### PR TITLE
[dev] Add remote debugging capabilities

### DIFF
--- a/opencti-platform/opencti-graphql/webpack.config.js
+++ b/opencti-platform/opencti-graphql/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const glob = require('glob');
-const { DefinePlugin, HotModuleReplacementPlugin } = require('webpack');
+const { DefinePlugin, HotModuleReplacementPlugin, SourceMapDevToolPlugin } = require('webpack');
 const nodeExternals = require('webpack-node-externals');
 const TerserPlugin = require('terser-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
@@ -78,7 +78,14 @@ module.exports = (env, argv) => {
         OPENCTI_BUILD_DATE: JSON.stringify(buildDate),
       }),
       new CleanWebpackPlugin(),
-      ...addIf(isDev, [new HotModuleReplacementPlugin(), new RunScriptWebpackPlugin()]),
+      ...addIf(isDev, [
+        new HotModuleReplacementPlugin(), 
+        new RunScriptWebpackPlugin({
+          // Add remote debugging capabilities while doing a `yarn start`.
+          // This argument can be changed to a `--inspect-brk` in order to wait for a debugger before running.
+          nodeArgs: ["--inspect"]
+        }), 
+      ]),
     ],
   };
 };


### PR DESCRIPTION
Add remote debugging capabilities to the dev' server running the opencti-graphql
project.

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Add remote-debugging capabilities to the developer server of the opencti-graphql project. This is currently the easiest approach found in order to have a debugger on the project.

### Related issues
None.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
