### PR TITLE
[fix] Empty variable exception

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/loggerPlugin.js
+++ b/opencti-platform/opencti-graphql/src/graphql/loggerPlugin.js
@@ -44,15 +44,16 @@ export default {
         if (!isCallError && !perfLog) {
           return;
         }
-        const size = Buffer.byteLength(JSON.stringify(context.request.variables));
+        const contextVariables = context.request.variables || {}
+        const size = Buffer.byteLength(JSON.stringify(contextVariables));
         const isWrite = context.operation && context.operation.operation === 'mutation';
         const contextUser = context.context.user;
         const origin = contextUser ? contextUser.origin : undefined;
-        const [variables] = await tryResolveKeyPromises(context.request.variables);
+        const [variables] = await tryResolveKeyPromises(contextVariables);
         // Compute inner relations
         let innerRelationCount = 0;
         if (isWrite) {
-          const { input } = context.request.variables;
+          const { input } = contextVariables;
           if (input) {
             if (!isNil(input.createdBy) && !isEmpty(input.createdBy)) innerRelationCount += 1;
             if (!isNil(input.markingDefinitions)) innerRelationCount += innerCompute(input.markingDefinitions);


### PR DESCRIPTION
This MR is about fixing an exception raised in the `loggerPlugin`. More
specifically, when `context.request.variables` is undefined, then computing its
size raises an exception. This behavior used to happen with
unauthenticated GraphQL request.

### Proposed changes
If the `context.request.variables` is undefined, then the variables' size is assumed to be `0`.

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/1653 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

