### PR TITLE
[Front] Graph names display after update of some elements (#2835)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analysis/groupings/GroupingKnowledgeGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/analysis/groupings/GroupingKnowledgeGraph.js
@@ -112,82 +112,120 @@ const groupingKnowledgeGraphStixCoreObjectQuery = graphql`
         }
       }
       ... on StixDomainObject {
-        created
+          created
       }
       ... on AttackPattern {
-        name
-        x_mitre_id
+          name
+          x_mitre_id
       }
       ... on Campaign {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on CourseOfAction {
-        name
+          name
+      }
+      ... on Channel {
+          name
+      }
+      ... on Note {
+          attribute_abstract
+          content
+      }
+      ... on ObservedData {
+          name
+          first_observed
+          last_observed
+      }
+      ... on Opinion {
+          opinion
+      }
+      ... on Report {
+          name
+          published
+      }
+      ... on Grouping {
+          name
+          description
       }
       ... on Individual {
-        name
+          name
       }
       ... on Organization {
-        name
+          name
       }
       ... on Sector {
-        name
+          name
+      }
+      ... on System {
+          name
       }
       ... on Indicator {
-        name
-        valid_from
+          name
+          valid_from
       }
       ... on Infrastructure {
-        name
+          name
       }
       ... on IntrusionSet {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on Position {
-        name
+          name
       }
       ... on City {
-        name
+          name
       }
       ... on AdministrativeArea {
-        name
+          name
       }
       ... on Country {
-        name
+          name
       }
       ... on Region {
-        name
+          name
       }
       ... on Malware {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on ThreatActor {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on Tool {
-        name
+          name
       }
       ... on Vulnerability {
-        name
+          name
       }
       ... on Incident {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on StixCyberObservable {
-        observable_value
+          observable_value
       }
       ... on StixFile {
-        observableName: name
+          observableName: name
+      }
+      ... on Event {
+          name
+      }
+      ... on Case {
+          name
+      }
+      ... on Narrative {
+          name
+      }
+      ... on DataComponent {
+          name
       }
     }
   }

--- a/opencti-platform/opencti-front/src/private/components/analysis/groupings/GroupingKnowledgeGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/analysis/groupings/GroupingKnowledgeGraph.js
@@ -227,6 +227,12 @@ const groupingKnowledgeGraphStixCoreObjectQuery = graphql`
       ... on DataComponent {
           name
       }
+      ... on DataSource {
+          name
+      }
+      ... on Language {
+          name
+      }
     }
   }
 `;
@@ -1498,112 +1504,150 @@ const GroupingKnowledgeGraph = createFragmentContainer(
                 }
               }
               ... on StixDomainObject {
-                is_inferred
-                created
+                  is_inferred
+                  created
               }
               ... on AttackPattern {
-                name
-                x_mitre_id
+                  name
+                  x_mitre_id
               }
               ... on Campaign {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on ObservedData {
-                name
+                  name
               }
               ... on CourseOfAction {
-                name
+                  name
+              }
+              ... on Note {
+                  attribute_abstract
+                  content
+              }
+              ... on Opinion {
+                  opinion
+              }
+              ... on Report {
+                  name
+                  published
+              }
+              ... on Grouping {
+                  name
               }
               ... on Individual {
-                name
+                  name
               }
               ... on Organization {
-                name
+                  name
               }
               ... on Sector {
-                name
+                  name
               }
               ... on System {
-                name
+                  name
               }
               ... on Indicator {
-                name
-                valid_from
+                  name
+                  valid_from
               }
               ... on Infrastructure {
-                name
+                  name
               }
               ... on IntrusionSet {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Position {
-                name
+                  name
               }
               ... on City {
-                name
+                  name
               }
               ... on AdministrativeArea {
-                name
+                  name
               }
               ... on Country {
-                name
+                  name
               }
               ... on Region {
-                name
+                  name
               }
               ... on Malware {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on ThreatActor {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Tool {
-                name
+                  name
               }
               ... on Vulnerability {
-                name
+                  name
               }
               ... on Incident {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Event {
-                name
-                start_time
-                stop_time
+                  name
+                  description
+                  start_time
+                  stop_time
               }
               ... on Channel {
-                name
+                  name
+                  description
               }
               ... on Narrative {
-                name
+                  name
+                  description
               }
               ... on Language {
-                name
+                  name
               }
               ... on DataComponent {
-                name
+                  name
               }
               ... on DataSource {
-                name
+                  name
               }
               ... on Case {
-                name
+                  name
               }
               ... on StixCyberObservable {
-                observable_value
+                  observable_value
               }
               ... on StixFile {
-                observableName: name
+                  observableName: name
+              }
+              ... on Label {
+                  value
+                  color
+              }
+              ... on MarkingDefinition {
+                  definition
+                  x_opencti_color
+              }
+              ... on KillChainPhase {
+                  kill_chain_name
+                  phase_name
+              }
+              ... on ExternalReference {
+                  url
+                  source_name
+              }
+              ... on BasicRelationship {
+                  id
+                  entity_type
+                  parent_types
               }
               ... on BasicRelationship {
                 id

--- a/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeGraph.js
@@ -246,6 +246,12 @@ const reportKnowledgeGraphStixCoreObjectQuery = graphql`
       ... on DataComponent {
           name
       }
+      ... on DataSource {
+          name
+      }
+      ... on Language {
+          name
+      }
     }
   }
 `;
@@ -1549,118 +1555,150 @@ const ReportKnowledgeGraph = createFragmentContainer(
                 }
               }
               ... on StixDomainObject {
-                is_inferred
-                created
+                  is_inferred
+                  created
               }
               ... on AttackPattern {
-                name
-                x_mitre_id
+                  name
+                  x_mitre_id
               }
               ... on Campaign {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on ObservedData {
-                name
+                  name
+              }
+              ... on CourseOfAction {
+                  name
+              }
+              ... on Note {
+                  attribute_abstract
+                  content
+              }
+              ... on Opinion {
+                  opinion
+              }
+              ... on Report {
+                  name
+                  published
               }
               ... on Grouping {
-                name
-              }              
-              ... on CourseOfAction {
-                name
-              }
-              ... on Channel {
                   name
               }
               ... on Individual {
-                name
+                  name
               }
               ... on Organization {
-                name
+                  name
               }
               ... on Sector {
-                name
+                  name
               }
               ... on System {
-                name
+                  name
               }
               ... on Indicator {
-                name
-                valid_from
+                  name
+                  valid_from
               }
               ... on Infrastructure {
-                name
+                  name
               }
               ... on IntrusionSet {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Position {
-                name
+                  name
               }
               ... on City {
-                name
+                  name
               }
               ... on AdministrativeArea {
-                name
+                  name
               }
               ... on Country {
-                name
+                  name
               }
               ... on Region {
-                name
+                  name
               }
               ... on Malware {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on ThreatActor {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Tool {
-                name
+                  name
               }
               ... on Vulnerability {
-                name
+                  name
               }
               ... on Incident {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Event {
-                name
-                start_time
-                stop_time
+                  name
+                  description
+                  start_time
+                  stop_time
               }
               ... on Channel {
-                name
+                  name
+                  description
               }
               ... on Narrative {
-                name
+                  name
+                  description
               }
               ... on Language {
-                name
+                  name
               }
               ... on DataComponent {
-                name
+                  name
               }
               ... on DataSource {
-                name
+                  name
               }
               ... on Case {
-                name
+                  name
               }
               ... on StixCyberObservable {
-                observable_value
+                  observable_value
               }
               ... on StixFile {
-                observableName: name
+                  observableName: name
+              }
+              ... on Label {
+                  value
+                  color
+              }
+              ... on MarkingDefinition {
+                  definition
+                  x_opencti_color
+              }
+              ... on KillChainPhase {
+                  kill_chain_name
+                  phase_name
+              }
+              ... on ExternalReference {
+                  url
+                  source_name
+              }
+              ... on BasicRelationship {
+                  id
+                  entity_type
+                  parent_types
               }
               ... on BasicRelationship {
                 id

--- a/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/analysis/reports/ReportKnowledgeGraph.js
@@ -134,82 +134,117 @@ const reportKnowledgeGraphStixCoreObjectQuery = graphql`
         }
       }
       ... on StixDomainObject {
-        created
+          created
       }
       ... on AttackPattern {
-        name
-        x_mitre_id
+          name
+          x_mitre_id
       }
       ... on Campaign {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on CourseOfAction {
-        name
+          name
+      }
+      ... on Note {
+          attribute_abstract
+          content
+      }
+      ... on ObservedData {
+          name
+          first_observed
+          last_observed
+      }
+      ... on Opinion {
+          opinion
+      }
+      ... on Report {
+          name
+          published
+      }
+      ... on Grouping {
+          name
+          description
       }
       ... on Individual {
-        name
+          name
       }
       ... on Organization {
-        name
+          name
       }
       ... on Sector {
-        name
+          name
+      }
+      ... on System {
+          name
       }
       ... on Indicator {
-        name
-        valid_from
+          name
+          valid_from
       }
       ... on Infrastructure {
-        name
+          name
       }
       ... on IntrusionSet {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on Position {
-        name
+          name
       }
       ... on City {
-        name
+          name
       }
       ... on AdministrativeArea {
-        name
+          name
       }
       ... on Country {
-        name
+          name
       }
       ... on Region {
-        name
+          name
       }
       ... on Malware {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on ThreatActor {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on Tool {
-        name
+          name
       }
       ... on Vulnerability {
-        name
+          name
       }
       ... on Incident {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on StixCyberObservable {
-        observable_value
+          observable_value
       }
       ... on StixFile {
-        observableName: name
+          observableName: name
+      }
+      ... on Event {
+          name
+      }
+      ... on Case {
+          name
+      }
+      ... on Narrative {
+          name
+      }
+      ... on DataComponent {
+          name
       }
     }
   }
@@ -1534,6 +1569,9 @@ const ReportKnowledgeGraph = createFragmentContainer(
               }              
               ... on CourseOfAction {
                 name
+              }
+              ... on Channel {
+                  name
               }
               ... on Individual {
                 name

--- a/opencti-platform/opencti-front/src/private/components/cases/incidents/IncidentKnowledgeGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/cases/incidents/IncidentKnowledgeGraph.js
@@ -249,6 +249,12 @@ const incidentKnowledgeGraphStixCoreObjectQuery = graphql`
       ... on DataComponent {
           name
       }
+      ... on DataSource {
+          name
+      }
+      ... on Language {
+          name
+      }
     }
   }
 `;
@@ -1552,115 +1558,150 @@ const IncidentKnowledgeGraph = createFragmentContainer(
                 }
               }
               ... on StixDomainObject {
-                is_inferred
-                created
+                  is_inferred
+                  created
               }
               ... on AttackPattern {
-                name
-                x_mitre_id
+                  name
+                  x_mitre_id
               }
               ... on Campaign {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on ObservedData {
-                name
-              }
-              ... on Grouping {
-                name
+                  name
               }
               ... on CourseOfAction {
-                name
+                  name
+              }
+              ... on Note {
+                  attribute_abstract
+                  content
+              }
+              ... on Opinion {
+                  opinion
+              }
+              ... on Report {
+                  name
+                  published
+              }
+              ... on Grouping {
+                  name
               }
               ... on Individual {
-                name
+                  name
               }
               ... on Organization {
-                name
+                  name
               }
               ... on Sector {
-                name
+                  name
               }
               ... on System {
-                name
+                  name
               }
               ... on Indicator {
-                name
-                valid_from
+                  name
+                  valid_from
               }
               ... on Infrastructure {
-                name
+                  name
               }
               ... on IntrusionSet {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Position {
-                name
+                  name
               }
               ... on City {
-                name
+                  name
               }
               ... on AdministrativeArea {
-                name
+                  name
               }
               ... on Country {
-                name
+                  name
               }
               ... on Region {
-                name
+                  name
               }
               ... on Malware {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on ThreatActor {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Tool {
-                name
+                  name
               }
               ... on Vulnerability {
-                name
+                  name
               }
               ... on Incident {
-                name
-                first_seen
-                last_seen
+                  name
+                  first_seen
+                  last_seen
               }
               ... on Event {
-                name
-                start_time
-                stop_time
+                  name
+                  description
+                  start_time
+                  stop_time
               }
               ... on Channel {
-                name
+                  name
+                  description
               }
               ... on Narrative {
-                name
+                  name
+                  description
               }
               ... on Language {
-                name
+                  name
               }
               ... on DataComponent {
-                name
+                  name
               }
               ... on DataSource {
-                name
+                  name
               }
               ... on Case {
-                name
+                  name
               }
               ... on StixCyberObservable {
-                observable_value
+                  observable_value
               }
               ... on StixFile {
-                observableName: name
+                  observableName: name
+              }
+              ... on Label {
+                  value
+                  color
+              }
+              ... on MarkingDefinition {
+                  definition
+                  x_opencti_color
+              }
+              ... on KillChainPhase {
+                  kill_chain_name
+                  phase_name
+              }
+              ... on ExternalReference {
+                  url
+                  source_name
+              }
+              ... on BasicRelationship {
+                  id
+                  entity_type
+                  parent_types
               }
               ... on BasicRelationship {
                 id

--- a/opencti-platform/opencti-front/src/private/components/cases/incidents/IncidentKnowledgeGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/cases/incidents/IncidentKnowledgeGraph.js
@@ -134,82 +134,120 @@ const incidentKnowledgeGraphStixCoreObjectQuery = graphql`
         }
       }
       ... on StixDomainObject {
-        created
+          created
       }
       ... on AttackPattern {
-        name
-        x_mitre_id
+          name
+          x_mitre_id
       }
       ... on Campaign {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on CourseOfAction {
-        name
+          name
+      }
+      ... on Channel {
+          name
+      }
+      ... on Note {
+          attribute_abstract
+          content
+      }
+      ... on ObservedData {
+          name
+          first_observed
+          last_observed
+      }
+      ... on Opinion {
+          opinion
+      }
+      ... on Report {
+          name
+          published
+      }
+      ... on Grouping {
+          name
+          description
       }
       ... on Individual {
-        name
+          name
       }
       ... on Organization {
-        name
+          name
       }
       ... on Sector {
-        name
+          name
+      }
+      ... on System {
+          name
       }
       ... on Indicator {
-        name
-        valid_from
+          name
+          valid_from
       }
       ... on Infrastructure {
-        name
+          name
       }
       ... on IntrusionSet {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on Position {
-        name
+          name
       }
       ... on City {
-        name
+          name
       }
       ... on AdministrativeArea {
-        name
+          name
       }
       ... on Country {
-        name
+          name
       }
       ... on Region {
-        name
+          name
       }
       ... on Malware {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on ThreatActor {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on Tool {
-        name
+          name
       }
       ... on Vulnerability {
-        name
+          name
       }
       ... on Incident {
-        name
-        first_seen
-        last_seen
+          name
+          first_seen
+          last_seen
       }
       ... on StixCyberObservable {
-        observable_value
+          observable_value
       }
       ... on StixFile {
-        observableName: name
+          observableName: name
+      }
+      ... on Event {
+          name
+      }
+      ... on Case {
+          name
+      }
+      ... on Narrative {
+          name
+      }
+      ... on DataComponent {
+          name
       }
     }
   }

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.js
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.js
@@ -164,6 +164,20 @@ export const containerHeaderObjectsQuery = graphql`
             ... on CourseOfAction {
               name
             }
+            ... on Note {
+                attribute_abstract
+                content
+            }
+            ... on Opinion {
+                opinion
+            }
+            ... on Report {
+                name
+                published
+            }
+            ... on Grouping {
+                name
+            }
             ... on Individual {
               name
             }
@@ -255,6 +269,27 @@ export const containerHeaderObjectsQuery = graphql`
             }
             ... on StixFile {
               observableName: name
+            }
+            ... on Label {
+                value
+                color
+            }
+            ... on MarkingDefinition {
+                definition
+                x_opencti_color
+            }
+            ... on KillChainPhase {
+                kill_chain_name
+                phase_name
+            }
+            ... on ExternalReference {
+                url
+                source_name
+            }
+            ... on BasicRelationship {
+                id
+                entity_type
+                parent_types
             }
             ... on BasicRelationship {
               id

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.js
@@ -89,6 +89,9 @@ const investigationGraphStixCoreObjectQuery = graphql`
       ... on CourseOfAction {
         name
       }
+      ... on Channel {
+          name
+      }
       ... on Note {
         attribute_abstract
         content
@@ -174,6 +177,18 @@ const investigationGraphStixCoreObjectQuery = graphql`
       }
       ... on StixFile {
         observableName: name
+      }
+      ... on Event {
+          name
+      }
+      ... on Case {
+          name
+      }
+      ... on Narrative {
+          name
+      }
+      ... on DataComponent {
+          name
       }
     }
   }

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.js
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.js
@@ -190,6 +190,12 @@ const investigationGraphStixCoreObjectQuery = graphql`
       ... on DataComponent {
           name
       }
+      ... on DataSource {
+          name
+      }
+      ... on Language {
+          name
+      }
     }
   }
 `;
@@ -2154,6 +2160,32 @@ const InvestigationGraph = createFragmentContainer(
                 name
                 first_seen
                 last_seen
+              }
+              ... on Event {
+                  name
+                  description
+                  start_time
+                  stop_time
+              }
+              ... on Channel {
+                  name
+                  description
+              }
+              ... on Narrative {
+                  name
+                  description
+              }
+              ... on Language {
+                  name
+              }
+              ... on DataComponent {
+                  name
+              }
+              ... on DataSource {
+                  name
+              }
+              ... on Case {
+                  name
               }
               ... on StixCyberObservable {
                 observable_value


### PR DESCRIPTION
When editing some elements in a graph, they appear as 'Unknown' after edition, except if we refresh the page.

Reproducible Steps (example) :
Go to Reports > Knowledge > view Graph
Select a node of type Grouping or Event.
Edit the node.
The node appears as 'Unknown'.
Refresh the page.
The correct name of the node appears.

Same behaviors for other entities.

### Other bug to fix
other bug to fix: when openning the graph bar, Report and Cases are marked unknown until we do something with them (update/expand/etc)

### Related issues

https://github.com/OpenCTI-Platform/opencti/issues/2835

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
