### PR TITLE
[frontend] 'sighting' export from an entity exports all the sightings of the platform (#6761)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
@@ -148,7 +148,7 @@ const EntityStixSightingRelationships: FunctionComponent<EntityStixSightingRelat
             'x_opencti_negative',
           ]}
           openExports={openExports}
-          exportContext={{ entity_type: 'stix-sighting-relationship' }}
+          exportContext={{ entity_type: 'stix-sighting-relationship', entity_id: entityId }}
           availableEntityTypes={stixCoreObjectTypes}
           displayImport={true}
           secondaryAction={true}

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/EntityStixSightingRelationships.tsx
@@ -12,7 +12,7 @@ import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { FilterGroup, emptyFilterGroup, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
+import { FilterGroup, emptyFilterGroup, useRemoveIdAndIncorrectKeysFromFilterGroupObject, isFilterGroupNotEmpty } from '../../../../utils/filters/filtersUtils';
 
 export const LOCAL_STORAGE_KEY = 'sightings';
 
@@ -60,15 +60,27 @@ const EntityStixSightingRelationships: FunctionComponent<EntityStixSightingRelat
     filters,
     numberOfElements,
   } = viewStorage;
+
+  const userFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, ['stix-sighting-relationship']);
+
+  const contextFilters: FilterGroup = {
+    mode: 'and',
+    filters: [
+      { key: isTo ? 'toId' : 'fromId', values: [entityId], operator: 'eq' },
+      {
+        key: 'entity_type',
+        values: ['stix-sighting-relationship'],
+        operator: 'eq',
+        mode: 'or',
+      },
+    ],
+    filterGroups: userFilters && isFilterGroupNotEmpty(userFilters) ? [userFilters] : [],
+  };
   const finalPaginationOptions = {
     ...paginationOptions,
-    filters: useRemoveIdAndIncorrectKeysFromFilterGroupObject(paginationOptions.filters as unknown as FilterGroup, ['stix-core-relationship']),
-  } as EntityStixSightingRelationshipsLinesPaginationQuery$variables;
-  if (isTo) {
-    finalPaginationOptions.toId = entityId;
-  } else {
-    finalPaginationOptions.fromId = entityId;
-  }
+    filters: contextFilters,
+  } as unknown as EntityStixSightingRelationshipsLinesPaginationQuery$variables;
+
   const queryRef = useQueryLoading<EntityStixSightingRelationshipsLinesPaginationQuery>(
     entityStixSightingRelationshipsLinesQuery,
     finalPaginationOptions,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* filter added for sighting relations query
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6761
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
