### PR TITLE
[frontend/e2e] attempt to remove flake on backgroundTask test (#7378)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/backgroundTask/backgroundTask.spec.ts
@@ -80,5 +80,9 @@ test('Verify background tasks execution', { tag: ['@mutation', '@incident', '@ta
   await filter.removeLastFilter();
 
   await filter.addFilter('Label', 'background-task-search-add-label', true);
+  if (!await page.getByText('2 entitie(s)').isVisible({ timeout: 500 })) {
+    // Try to reload page in case it's a flake.
+    await entitiesPage.goto();
+  }
   await expect(page.getByText('2 entitie(s)')).toBeVisible(); // 1 by this test + 1 in stix imported data
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Force reload page when the expect fails one time (kind of retry = 1)

### Related issues
```
   [chromium] › backgroundTask/backgroundTask.spec.ts:24:5 › Verify background tasks execution ───
    
    Error: Timed out 60000ms waiting for expect(locator).toBeVisible()
    
    Locator: getByText('2 entitie(s)')
    Expected: visible
    Received: <element(s) not found>
    Call log:
    
    - expect.toBeVisible with timeout 60000ms
    - waiting for getByText('2 entitie(s)')
```

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
