### PR TITLE
[backend] check multiple keys for meEdit mutation (#9739)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -833,28 +833,30 @@ const ME_USER_MODIFIABLE_ATTRIBUTES = [
   'draft_context',
 ];
 export const meEditField = async (context, user, userId, inputs, password = null) => {
-  const input = R.head(inputs);
-  const { key } = input;
-  // Check if field can be updated by the user
-  if (PROTECTED_USER_ATTRIBUTES.includes(key)) {
-    throw ForbiddenAccess();
-  }
-  // If the user is external, some extra attributes must be protected
-  if (user.external && PROTECTED_EXTERNAL_ATTRIBUTES.includes(key)) {
-    throw ForbiddenAccess();
-  }
-  // On MeUser only some fields are updatable
-  if (!ME_USER_MODIFIABLE_ATTRIBUTES.includes(key)) {
-    throw ForbiddenAccess();
-  }
-  // Check password confirmation in case of password change
-  if (key === 'password') {
-    const dbPassword = user.session_password;
-    const match = bcrypt.compareSync(password, dbPassword);
-    if (!match) {
-      throw FunctionalError('The current password you have provided is not valid');
+  inputs.forEach((input) => {
+    const { key } = input;
+    // Check if field can be updated by the user
+    if (PROTECTED_USER_ATTRIBUTES.includes(key)) {
+      throw ForbiddenAccess();
     }
-  }
+    // If the user is external, some extra attributes must be protected
+    if (user.external && PROTECTED_EXTERNAL_ATTRIBUTES.includes(key)) {
+      throw ForbiddenAccess();
+    }
+    // On MeUser only some fields are updatable
+    if (!ME_USER_MODIFIABLE_ATTRIBUTES.includes(key)) {
+      throw ForbiddenAccess();
+    }
+    // Check password confirmation in case of password change
+    if (key === 'password') {
+      const dbPassword = user.session_password;
+      const match = bcrypt.compareSync(password, dbPassword);
+      if (!match) {
+        throw FunctionalError('The current password you have provided is not valid');
+      }
+    }
+  });
+
   return userEditField(context, user, userId, inputs);
 };
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/user-test.ts
@@ -1031,17 +1031,6 @@ describe('meUser specific resolvers', async () => {
       }
     }
   `;
-  afterAll(async () => {
-    await queryAsUserWithSuccess(USER_EDITOR.client, {
-      query: ME_EDIT,
-      variables: {
-        password: USER_EDITOR.password,
-        input: [
-          { key: 'language', value: 'en-us' },
-        ]
-      },
-    });
-  });
 
   it('User should update authorized attribute', async () => {
     const variables = {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* check all keys of the input before action.
* Add test

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
