### PR TITLE
[backend] add authorized members when creating saved filters (#6044) 

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -1,17 +1,16 @@
-import { addFilter } from '../../utils/filtering/filtering-utils';
 import { type BasicStoreEntitySavedFilter, ENTITY_TYPE_SAVED_FILTER, type StoreEntitySavedFilter } from './savedFilter-types';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { listEntitiesPaginated } from '../../database/middleware-loader';
 import type { QuerySavedFiltersArgs, SavedFilterAddInput } from '../../generated/graphql';
 import { createInternalObject, deleteInternalObject } from '../../domain/internalObject';
+import { MEMBER_ACCESS_RIGHT_ADMIN } from '../../utils/access';
 
 export const findAll = (context: AuthContext, user: AuthUser, args: QuerySavedFiltersArgs) => {
-  const queryFilters = addFilter(args.filters, 'creator_id', user.id);
-  const queryArgs = { ...args, filters: queryFilters };
-  return listEntitiesPaginated<BasicStoreEntitySavedFilter>(context, user, [ENTITY_TYPE_SAVED_FILTER], queryArgs);
+  return listEntitiesPaginated<BasicStoreEntitySavedFilter>(context, user, [ENTITY_TYPE_SAVED_FILTER], args);
 };
 export const addSavedFilter = (context: AuthContext, user: AuthUser, input: SavedFilterAddInput) => {
-  return createInternalObject<StoreEntitySavedFilter>(context, user, input, ENTITY_TYPE_SAVED_FILTER);
+  const savedFiltersToCreate = { ...input, restricted_members: [{ id: user.id, access_right: MEMBER_ACCESS_RIGHT_ADMIN }] };
+  return createInternalObject<StoreEntitySavedFilter>(context, user, savedFiltersToCreate, ENTITY_TYPE_SAVED_FILTER);
 };
 export const deleteSavedFilter = (context: AuthContext, user: AuthUser, savedFilterId: string) => {
   return deleteInternalObject(context, user, savedFilterId, ENTITY_TYPE_SAVED_FILTER);

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/savedFilterResolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/savedFilterResolver-test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import gql from 'graphql-tag';
-import { ADMIN_USER, testContext } from '../../utils/testQuery';
-import { queryAsAdminWithSuccess } from '../../utils/testQueryHelper';
+import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
+import { queryAsAdminWithSuccess, queryAsUserWithSuccess } from '../../utils/testQueryHelper';
 import { elLoadById } from '../../../src/database/engine';
 
 const GET_SAVED_FILTERS_QUERY = gql`
@@ -90,7 +90,16 @@ describe('Saved Filter Resolver', () => {
         const savedFilters = result.data?.savedFilters.edges;
         expect(savedFilters).toBeDefined();
         expect(savedFilters.length).toEqual(1);
-        expect(savedFilters.length).toEqual(1);
+      });
+      it('gives the list of saved filters with restricted members', async () => {
+        const result = await queryAsUserWithSuccess(USER_EDITOR.client, {
+          query: GET_SAVED_FILTERS_QUERY,
+          variables: {},
+        });
+
+        const savedFilters = result.data?.savedFilters.edges;
+        expect(savedFilters).toBeDefined();
+        expect(savedFilters.length).toEqual(0);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add authorized members for the creation
* add saved filters resolver test for the creation

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #6044 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
