### PR TITLE
[frontend] graph: apply forces at init + reset positions saved on unfix (#10581)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/Graph.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/Graph.tsx
@@ -92,10 +92,12 @@ const Graph = ({
   useEffect(() => {
     // A short timeout to be sure graph is ready.
     setTimeout(() => {
-      if (!isLoadingData) {if (zoom) setZoom(zoom);
-      else zoomToFit();
-      if (withForces) applyForces();
-    }}, 200);
+      if (!isLoadingData) {
+        if (zoom) setZoom(zoom);
+        else zoomToFit();
+        if (withForces) applyForces();
+      }
+    }, 200);
   }, [mode3D, isLoadingData]);
 
   const shouldDisplayLinks = graphData?.links.length ?? 0 < 200;

--- a/opencti-platform/opencti-front/src/components/graph/Graph.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/Graph.tsx
@@ -45,6 +45,7 @@ const Graph = ({
     setRawPositions,
     setZoom,
     zoomToFit,
+    applyForces,
     setIsExpandOpen,
   } = useGraphInteractions();
 
@@ -91,11 +92,10 @@ const Graph = ({
   useEffect(() => {
     // A short timeout to be sure graph is ready.
     setTimeout(() => {
-      if (!isLoadingData) {
-        if (zoom) setZoom(zoom);
-        else zoomToFit();
-      }
-    }, 200);
+      if (!isLoadingData) {if (zoom) setZoom(zoom);
+      else zoomToFit();
+      if (withForces) applyForces();
+    }}, 200);
   }, [mode3D, isLoadingData]);
 
   const shouldDisplayLinks = graphData?.links.length ?? 0 < 200;

--- a/opencti-platform/opencti-front/src/components/graph/GraphContainerCorrelation.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphContainerCorrelation.tsx
@@ -370,6 +370,7 @@ const GraphContainerCorrelationComponent = ({
     <div style={graphContainerStyle} ref={ref}>
       <Graph parentRef={ref} onPositionsChanged={onPositionsChanged}>
         <GraphToolbar
+          onUnfixNodes={() => onPositionsChanged({})}
           stixCoreObjectRefetchQuery={knowledgeCorrelationStixCoreObjectQuery}
           relationshipRefetchQuery={knowledgeCorrelationStixCoreRelationshipQuery}
         />

--- a/opencti-platform/opencti-front/src/components/graph/GraphContainerKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphContainerKnowledge.tsx
@@ -520,6 +520,7 @@ const GraphContainerKnowledgeComponent = ({
       />
       <Graph parentRef={ref} onPositionsChanged={onPositionsChanged}>
         <GraphToolbar
+          onUnfixNodes={() => onPositionsChanged({})}
           enableReferences={enableReferences}
           stixCoreObjectRefetchQuery={knowledgeGraphStixCoreObjectQuery}
           relationshipRefetchQuery={knowledgeGraphStixRelationshipQuery}

--- a/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
@@ -6,7 +6,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 import useGraphInteractions from './utils/useGraphInteractions';
 import SearchInput from '../SearchInput';
 import type { Theme } from '../Theme';
-import GraphToolbarDisplayTools from './components/GraphToolbarDisplayTools';
+import GraphToolbarDisplayTools, { GraphToolbarDisplayToolsProps } from './components/GraphToolbarDisplayTools';
 import GraphToolbarSelectTools from './components/GraphToolbarSelectTools';
 import GraphToolbarFilterTools from './components/GraphToolbarFilterTools';
 import GraphToolbarContentTools, { GraphToolbarContentToolsProps } from './components/GraphToolbarContentTools';
@@ -15,11 +15,12 @@ import { useGraphContext } from './GraphContext';
 import GraphToolbarCorrelationTools from './components/GraphToolbarCorrelationTools';
 import GraphToolbarExpandTools, { GraphToolbarExpandToolsProps } from './components/GraphToolbarExpandTools';
 
-export type GraphToolbarProps = GraphToolbarContentToolsProps & GraphToolbarExpandToolsProps;
+export type GraphToolbarProps = GraphToolbarContentToolsProps & GraphToolbarExpandToolsProps & GraphToolbarDisplayToolsProps;
 
 const GraphToolbar = ({
   onInvestigationExpand,
   onInvestigationRollback,
+  onUnfixNodes,
   ...props
 }: GraphToolbarProps) => {
   const theme = useTheme<Theme>();
@@ -72,7 +73,7 @@ const GraphToolbar = ({
         padding: `0 ${theme.spacing(1)}`,
       }}
       >
-        <GraphToolbarDisplayTools />
+        <GraphToolbarDisplayTools onUnfixNodes={onUnfixNodes} />
         <Divider sx={{ margin: 1, height: '80%' }} orientation="vertical" />
 
         <GraphToolbarSelectTools />

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarDisplayTools.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarDisplayTools.tsx
@@ -6,7 +6,13 @@ import { useFormatter } from '../../i18n';
 import { useGraphContext } from '../GraphContext';
 import useGraphInteractions from '../utils/useGraphInteractions';
 
-const GraphToolbarDisplayTools = () => {
+export interface GraphToolbarDisplayToolsProps {
+  onUnfixNodes: () => void
+}
+
+const GraphToolbarDisplayTools = ({
+  onUnfixNodes,
+}: GraphToolbarDisplayToolsProps) => {
   const { t_i18n } = useFormatter();
 
   const {
@@ -25,6 +31,11 @@ const GraphToolbarDisplayTools = () => {
     zoomToFit,
     unfixNodes,
   } = useGraphInteractions();
+
+  const resetLayout = () => {
+    unfixNodes();
+    onUnfixNodes();
+  };
 
   return (
     <>
@@ -69,7 +80,7 @@ const GraphToolbarDisplayTools = () => {
         Icon={<AutoFix />}
         disabled={!withForces}
         color="primary"
-        onClick={unfixNodes}
+        onClick={resetLayout}
         title={t_i18n('Unfix the nodes and re-apply forces')}
       />
     </>

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
@@ -92,6 +92,11 @@ const useGraphInteractions = () => {
     graphRef2D.current?.centerAt(zoomLevel.x, zoomLevel.y, 400);
   };
 
+  const applyForces = () => {
+    graphRef2D.current?.d3ReheatSimulation();
+    graphRef3D.current?.d3ReheatSimulation();
+  };
+
   /**
    * Remove fx and fy positions responsible for fixed positions when
    * mode forces is on and reapply forces.
@@ -101,8 +106,7 @@ const useGraphInteractions = () => {
       node.fx = undefined; // eslint-disable-line no-param-reassign
       node.fy = undefined; // eslint-disable-line no-param-reassign
     });
-    graphRef2D.current?.d3ReheatSimulation();
-    graphRef3D.current?.d3ReheatSimulation();
+    applyForces();
   };
 
   const toggleSelectFreeRectangle = () => {
@@ -480,6 +484,7 @@ const useGraphInteractions = () => {
     resetFilters,
     selectBySearch,
     addNode,
+    applyForces,
     removeNode,
     removeNodes,
     addLink,

--- a/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/StixCoreObjectOrStixCoreRelationshipContainersGraph.tsx
@@ -288,7 +288,7 @@ const StixCoreObjectOrStixCoreRelationshipContainersGraphComponent = ({
   return (
     <div style={graphContainerStyle} ref={ref}>
       <Graph parentRef={ref} onPositionsChanged={savePositions}>
-        <GraphToolbar />
+        <GraphToolbar onUnfixNodes={() => savePositions({})} />
       </Graph>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.tsx
@@ -511,6 +511,7 @@ const InvestigationGraphComponent = ({
       <div style={graphContainerStyle} ref={ref}>
         <Graph parentRef={ref} onPositionsChanged={savePositions}>
           <GraphToolbar
+            onUnfixNodes={() => savePositions({})}
             stixCoreObjectRefetchQuery={knowledgeGraphStixCoreObjectQuery}
             relationshipRefetchQuery={knowledgeGraphStixRelationshipQuery}
             entity={investigation}


### PR DESCRIPTION
### Proposed changes

* When loading graphs, apply forces if mode with force active
* On unfix nodes, reset positions

### Related issues

* #10581 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality