### PR TITLE
[backend] Avoid refs duplication during rels update (#7535)

### DIFF
--- a/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
@@ -923,6 +923,8 @@ schemaTypesDefinition.register(
 
 export const isStixRefRelationship = (type: string) => schemaTypesDefinition.isTypeIncludedIn(type, ABSTRACT_STIX_REF_RELATIONSHIP) || type === ABSTRACT_STIX_REF_RELATIONSHIP;
 
+export const isStixMetaRelationship = (type: string) => META_RELATIONS.some((ref) => ref.databaseName === type);
+
 export const buildRelationRef = (relationRef: Omit<RefAttribute, 'isRefExistingForTypes'>, isRefExistingForTypes: Checker): RefAttribute => {
   return {
     ...relationRef,

--- a/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
@@ -923,7 +923,9 @@ schemaTypesDefinition.register(
 
 export const isStixRefRelationship = (type: string) => schemaTypesDefinition.isTypeIncludedIn(type, ABSTRACT_STIX_REF_RELATIONSHIP) || type === ABSTRACT_STIX_REF_RELATIONSHIP;
 
-export const isStixMetaRelationship = (type: string) => META_RELATIONS.some((ref) => ref.databaseName === type);
+const isStixMetaRelationship = (type: string) => META_RELATIONS.some((ref) => ref.databaseName === type);
+
+export const isStixRefUnidirectionalRelationship = (type: string) => isStixMetaRelationship(type) && type !== RELATION_OBJECT;
 
 export const buildRelationRef = (relationRef: Omit<RefAttribute, 'isRefExistingForTypes'>, isRefExistingForTypes: Checker): RefAttribute => {
   return {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

I couldn't reproduce the issue, I could only guess that it happens because of "retry on conflict" (update is run again on elastic if there is a version conflict)

* change denormalized rels update script for refs to avoid duplicates if conflict during script execution
* split bulk operations

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7535 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

