### PR TITLE
[backend] removing too heavy cleanup migration script (#11273)

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1742823297618-fix-activity-group_ids.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1742823297618-fix-activity-group_ids.js
@@ -1,49 +1,55 @@
-import { logMigration } from '../config/conf';
-import { elUpdateByQueryForMigration } from '../database/engine';
-import { READ_INDEX_HISTORY } from '../database/utils';
-import { executionContext, SYSTEM_USER } from '../utils/access';
-import { getEntitiesMapFromCache } from '../database/cache';
-import { ENTITY_TYPE_USER } from '../schema/internalObject';
+// import { logMigration } from '../config/conf';
+// import { elUpdateByQueryForMigration } from '../database/engine';
+// import { READ_INDEX_HISTORY } from '../database/utils';
+// import { executionContext, SYSTEM_USER } from '../utils/access';
+// import { getEntitiesMapFromCache } from '../database/cache';
+// import { ENTITY_TYPE_USER } from '../schema/internalObject';
 
-const message = '[MIGRATION] adding missing group_ids in activity due to regression bug in 6.6';
+// const message = '[MIGRATION] adding missing group_ids in activity due to regression bug in 6.6';
 
 export const up = async (next) => {
-  logMigration.info(`${message} > started`);
-  const context = executionContext('migration');
+  // ----- Explanations ----------
+  // This migration has been removed
+  // because it might be too heavy for large platforms
+  // Prefer using a cleanup script that can be run while the platform is running.
+  // -----------------------------
 
-  const userGroupIdsMap = {};
-  const allUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-  allUsers.forEach((u) => { userGroupIdsMap[u.internal_id] = u.groups?.map((g) => g.internal_id) ?? []; });
-
-  // Since bug was introduced with 6.6 release, we filter history from the data of 6.6 release: 8th of April 2025
-  const activityUpdateQuery = {
-    script: {
-      params: { userGroupIdsMap },
-      source: 'if (params.userGroupIdsMap.containsKey(ctx._source.user_id)) { ctx._source.group_ids = params.userGroupIdsMap[ctx._source.user_id]; }',
-    },
-    query: {
-      bool: {
-        must_not: [{
-          exists: {
-            field: 'group_ids'
-          }
-        }],
-        must: [{
-          range: {
-            created_at: {
-              gte: '2025-04-08T00:00:00'
-            }
-          }
-        }]
-      },
-    }
-  };
-  await elUpdateByQueryForMigration(
-    '[MIGRATION] Missing group_ids in activity fix',
-    READ_INDEX_HISTORY,
-    activityUpdateQuery
-  );
-
-  logMigration.info(`${message} > done`);
+  // logMigration.info(`${message} > started`);
+  // const context = executionContext('migration');
+  //
+  // const userGroupIdsMap = {};
+  // const allUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  // allUsers.forEach((u) => { userGroupIdsMap[u.internal_id] = u.groups?.map((g) => g.internal_id) ?? []; });
+  //
+  // // Since bug was introduced with 6.6 release, we filter history from the data of 6.6 release: 8th of April 2025
+  // const activityUpdateQuery = {
+  //   script: {
+  //     params: { userGroupIdsMap },
+  //     source: 'if (params.userGroupIdsMap.containsKey(ctx._source.user_id)) { ctx._source.group_ids = params.userGroupIdsMap[ctx._source.user_id]; }',
+  //   },
+  //   query: {
+  //     bool: {
+  //       must_not: [{
+  //         exists: {
+  //           field: 'group_ids'
+  //         }
+  //       }],
+  //       must: [{
+  //         range: {
+  //           created_at: {
+  //             gte: '2025-04-08T00:00:00'
+  //           }
+  //         }
+  //       }]
+  //     },
+  //   }
+  // };
+  // await elUpdateByQueryForMigration(
+  //   '[MIGRATION] Missing group_ids in activity fix',
+  //   READ_INDEX_HISTORY,
+  //   activityUpdateQuery
+  // );
+  //
+  // logMigration.info(`${message} > done`);
   next();
 };


### PR DESCRIPTION
With the fix #11275 for #11273 , we introduced a migration script to clean up activity logs.
This migration is not mandatory for the platform to operate, it is a matter of having consistent activity logs that were missing some data.

However in very large platforms, this migration can be very long to run.
We are removing the migration script for the time being, and will address this operation in a non-blocking manner.

