### PR TITLE
[frontend] fixes for dynamic regardingOf filter (#11357)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/DisplayFilterGroup.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/DisplayFilterGroup.tsx
@@ -13,7 +13,6 @@ import Chip from '@mui/material/Chip';
 import { useFormatter } from '../i18n';
 import { FilterRepresentative } from './FiltersModel';
 import { Filter, FilterGroup } from '../../utils/filters/filtersHelpers-types';
-import TasksFilterValueContainer from '../TasksFilterValueContainer';
 
 interface DisplayFiltersValuesProps {
   filtersRepresentativesMap: Map<string, FilterRepresentative>,
@@ -56,133 +55,6 @@ const DisplayFiltersValues: FunctionComponent<DisplayFiltersValuesProps> = ({
   );
 };
 
-interface DisplayFiltersFiltersProps {
-  filtersRepresentativesMap: Map<string, FilterRepresentative>,
-  filters: Filter[],
-  parentMode: string,
-}
-
-const DisplayFiltersFilters: FunctionComponent<DisplayFiltersFiltersProps> = ({
-  filtersRepresentativesMap,
-  filters,
-  parentMode,
-}) => {
-  const { t_i18n } = useFormatter();
-  return filters.map((f, i) => {
-    const { key, operator, values, mode, id } = f;
-    return (
-      <Box
-        key={id ?? key}
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: 'auto 1fr',
-          gap: '8px',
-          alignItems: 'center',
-        }}
-      >
-        {i !== 0 && (
-          <Box
-            sx={{
-              textTransform: 'uppercase',
-              fontWeight: 'bold',
-              display: 'inline-block',
-              borderRadius: '24px',
-              padding: '8px 16px',
-              fontFamily: 'Consolas, monaco, monospace',
-              backgroundColor: '#01478d',
-            }}
-          >
-            {parentMode}
-          </Box>
-        )}
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '16px',
-            borderRadius: '24px',
-            padding: '0 16px',
-            backgroundColor: 'rgba(255, 255, 255, 0.16)',
-            width: 'fit-content',
-          }}
-        >
-          <span>{t_i18n(key)}</span>
-          <Box
-            sx={{
-              textTransform: 'uppercase',
-              fontFamily: 'Consolas, monaco, monospace',
-              backgroundColor: 'rgb(74 117 162)',
-              fontWeight: 'bold',
-              display: 'inline-block',
-              margin: '0 8px',
-              padding: '8px',
-            }}
-          >
-            {' '}
-            {operator}
-          </Box>
-          <Box sx={{ display: 'inline-block' }}>
-            {key === 'regardingOf' || key === 'dynamicRegardingOf'
-              ? <>
-                {values
-                  .filter((v) => v.key === 'relationship_type')
-                  .flat()
-                  .map((value) => {
-                    return (<span key={'relationship_type'}>
-                      <DisplayFiltersValues
-                        filtersRepresentativesMap={filtersRepresentativesMap}
-                        values={value.values}
-                      />
-                    </span>);
-                  })}
-                {values.filter((v) => v.key === 'id' || v.key === 'dynamic').length > 0
-                  && <Box
-                    sx={{
-                      paddingTop: 2,
-                      textTransform: 'uppercase',
-                      fontFamily: 'Consolas, monaco, monospace',
-                      backgroundColor: 'rgba(255, 255, 255, .1)',
-                      fontWeight: 'bold',
-                      display: 'inline-block',
-                      margin: '0 8px',
-                      padding: '8px',
-                    }}
-                     >
-                    {t_i18n('WITH')}
-                  </Box>
-                }
-                {values.filter((v) => v.key === 'id').flat().map((value) => {
-                  return (<span key={'id'}>
-                    <DisplayFiltersValues
-                      filtersRepresentativesMap={filtersRepresentativesMap}
-                      values={value.values}
-                    />
-                  </span>);
-                })}
-                {values.filter((v) => v.key === 'dynamic').flat().map((value) => {
-                  return (<span key={'id'}>
-                    {value.values.map((v: FilterGroup) => (
-                      <TasksFilterValueContainer
-                        key={value.values.indexOf(v)}
-                        filters={v}
-                      />))
-                    }
-                  </span>);
-                })}
-              </>
-              : <DisplayFiltersValues
-                  filtersRepresentativesMap={filtersRepresentativesMap}
-                  values={values}
-                  mode={mode ?? 'or'}
-                />
-            }
-          </Box>
-        </Box>
-      </Box>
-    );
-  });
-};
-
 interface DisplayFilterGroupsProps {
   filtersRepresentativesMap: Map<string, FilterRepresentative>,
   filterGroups: FilterGroup[],
@@ -194,6 +66,122 @@ const DisplayFiltersFilterGroups: FunctionComponent<DisplayFilterGroupsProps> = 
   filterGroups,
   filterMode,
 }) => {
+  const { t_i18n } = useFormatter();
+  const displayFilterFilters = (filters: Filter[], parentMode: string) => {
+    return filters.map((f, i) => {
+      const { key, operator, values, mode, id } = f;
+      return (
+        <Box
+          key={id ?? key}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'auto 1fr',
+            gap: '8px',
+            alignItems: 'center',
+          }}
+        >
+          {i !== 0 && (
+            <Box
+              sx={{
+                textTransform: 'uppercase',
+                fontWeight: 'bold',
+                display: 'inline-block',
+                borderRadius: '24px',
+                padding: '8px 16px',
+                fontFamily: 'Consolas, monaco, monospace',
+                backgroundColor: '#01478d',
+              }}
+            >
+              {parentMode}
+            </Box>
+          )}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '16px',
+              borderRadius: '24px',
+              padding: '0 16px',
+              backgroundColor: 'rgba(255, 255, 255, 0.16)',
+              width: 'fit-content',
+            }}
+          >
+            <span>{t_i18n(key)}</span>
+            <Box
+              sx={{
+                textTransform: 'uppercase',
+                fontFamily: 'Consolas, monaco, monospace',
+                backgroundColor: 'rgb(74 117 162)',
+                fontWeight: 'bold',
+                display: 'inline-block',
+                margin: '0 8px',
+                padding: '8px',
+              }}
+            >
+              {' '}
+              {operator}
+            </Box>
+            <Box sx={{ display: 'inline-block' }}>
+              {key === 'regardingOf' || key === 'dynamicRegardingOf'
+                ? <>
+                  {values
+                    .filter((v) => v.key === 'relationship_type')
+                    .flat()
+                    .map((value) => {
+                      return (<span key={'relationship_type'}>
+                        <DisplayFiltersValues
+                          filtersRepresentativesMap={filtersRepresentativesMap}
+                          values={value.values}
+                        />
+                      </span>);
+                    })}
+                  {values.filter((v) => v.key === 'id' || v.key === 'dynamic').length > 0
+                    && <Box
+                      sx={{
+                        paddingTop: 2,
+                        textTransform: 'uppercase',
+                        fontFamily: 'Consolas, monaco, monospace',
+                        backgroundColor: 'rgba(255, 255, 255, .1)',
+                        fontWeight: 'bold',
+                        display: 'inline-block',
+                        margin: '0 8px',
+                        padding: '8px',
+                      }}
+                       >
+                      {t_i18n('WITH')}
+                    </Box>
+                  }
+                  {values.filter((v) => v.key === 'id').flat().map((value) => {
+                    return (<span key={'id'}>
+                      <DisplayFiltersValues
+                        filtersRepresentativesMap={filtersRepresentativesMap}
+                        values={value.values}
+                      />
+                    </span>);
+                  })}
+                  {values.filter((v) => v.key === 'dynamic').flat().map((value) => {
+                    return (<span key={'id'}>
+                      <DisplayFiltersFilterGroups
+                        filterGroups={value.values}
+                        filtersRepresentativesMap={filtersRepresentativesMap}
+                        filterMode={'and'}
+                      />
+                    </span>);
+                  })}
+                </>
+                : <DisplayFiltersValues
+                    filtersRepresentativesMap={filtersRepresentativesMap}
+                    values={values}
+                    mode={mode ?? 'or'}
+                  />
+              }
+            </Box>
+          </Box>
+        </Box>
+      );
+    });
+  };
+
   return filterGroups.map((f, i) => {
     return (
       <Fragment key={i}>
@@ -222,11 +210,7 @@ const DisplayFiltersFilterGroups: FunctionComponent<DisplayFilterGroupsProps> = 
           }}
         >
           <Stack sx={{ gap: '8px', paddingBottom: '8px' }}>
-            <DisplayFiltersFilters
-              filtersRepresentativesMap={filtersRepresentativesMap}
-              filters={f.filters}
-              parentMode={f.mode}
-            />
+            {displayFilterFilters(f.filters, f.mode)}
           </Stack>
           {f.filterGroups.length > 0 && (
             <Stack direction="row">

--- a/opencti-platform/opencti-front/src/components/filters/DisplayFilterGroup.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/DisplayFilterGroup.tsx
@@ -13,6 +13,7 @@ import Chip from '@mui/material/Chip';
 import { useFormatter } from '../i18n';
 import { FilterRepresentative } from './FiltersModel';
 import { Filter, FilterGroup } from '../../utils/filters/filtersHelpers-types';
+import TasksFilterValueContainer from '../TasksFilterValueContainer';
 
 interface DisplayFiltersValuesProps {
   filtersRepresentativesMap: Map<string, FilterRepresentative>,
@@ -121,7 +122,7 @@ const DisplayFiltersFilters: FunctionComponent<DisplayFiltersFiltersProps> = ({
             {operator}
           </Box>
           <Box sx={{ display: 'inline-block' }}>
-            {key === 'regardingOf'
+            {key === 'regardingOf' || key === 'dynamicRegardingOf'
               ? <>
                 {values
                   .filter((v) => v.key === 'relationship_type')
@@ -134,7 +135,7 @@ const DisplayFiltersFilters: FunctionComponent<DisplayFiltersFiltersProps> = ({
                       />
                     </span>);
                   })}
-                {values.filter((v) => v.key === 'id').length > 0
+                {values.filter((v) => v.key === 'id' || v.key === 'dynamic').length > 0
                   && <Box
                     sx={{
                       paddingTop: 2,
@@ -156,6 +157,16 @@ const DisplayFiltersFilters: FunctionComponent<DisplayFiltersFiltersProps> = ({
                       filtersRepresentativesMap={filtersRepresentativesMap}
                       values={value.values}
                     />
+                  </span>);
+                })}
+                {values.filter((v) => v.key === 'dynamic').flat().map((value) => {
+                  return (<span key={'id'}>
+                    {value.values.map((v: FilterGroup) => (
+                      <TasksFilterValueContainer
+                        key={value.values.indexOf(v)}
+                        filters={v}
+                      />))
+                    }
                   </span>);
                 })}
               </>

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -343,7 +343,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
       return <BasicFilterDate value={computedValues.length > 0 ? computedValues[0] : undefined} />;
     }
     if (fDefinition?.type === 'filters') {
-      const finalComputedValues = computedValues.filter((v: object) => 'filters' in v);
+      const finalComputedValues = computedValues.filter((v: object) => 'filters' in v); // we keep values of type FilterGroup
       const values = finalComputedValues.length > 0 ? finalComputedValues[0] : emptyFilterGroup;
       return (
         <FilterFiltersInput

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -343,7 +343,8 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
       return <BasicFilterDate value={computedValues.length > 0 ? computedValues[0] : undefined} />;
     }
     if (fDefinition?.type === 'filters') {
-      const values = computedValues.length > 0 ? computedValues[0] : emptyFilterGroup;
+      const finalComputedValues = computedValues.filter((v: object) => 'filters' in v);
+      const values = finalComputedValues.length > 0 ? finalComputedValues[0] : emptyFilterGroup;
       return (
         <FilterFiltersInput
           filter={filter}

--- a/opencti-platform/opencti-front/src/components/filters/FilterFiltersInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterFiltersInput.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent, useEffect, useRef } from 'react';
 import Filters from '@components/common/lists/Filters';
 import Box from '@mui/material/Box';
 import { Filter, FilterGroup, handleFilterHelpers } from '../../utils/filters/filtersHelpers-types';
-import { emptyFilterGroup, sanitizeFiltersStructure, useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
+import { emptyFilterGroup, isFilterGroupNotEmpty, sanitizeFiltersStructure, useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
 import useFiltersState from '../../utils/filters/useFiltersState';
 // eslint-disable-next-line import/no-cycle
 import FilterIconButton from '../FilterIconButton';
@@ -29,8 +29,12 @@ const FilterFiltersInput: FunctionComponent<BasicFilterInputProps> = ({
         const childFilters = filter?.values.filter((val) => val.key === childKey) as Filter[];
         const childFilter = childFilters && childFilters.length > 0 ? childFilters[0] : undefined;
         const sanitizedCurrentFilter = sanitizeFiltersStructure(currentFilter);
-        const representation = { key: childKey, values: [sanitizedCurrentFilter] };
-        helpers?.handleChangeRepresentationFilter(filter?.id ?? '', childFilter, representation);
+        if (isFilterGroupNotEmpty(sanitizedCurrentFilter)) {
+          const representation = { key: childKey, values: [sanitizedCurrentFilter] };
+          helpers?.handleChangeRepresentationFilter(filter?.id ?? '', childFilter, representation);
+        } else {
+          helpers?.handleRemoveRepresentationFilter(filter?.id ?? '', childFilter);
+        }
       } else {
         const sanitizedCurrentFilter = sanitizeFiltersStructure(currentFilter);
         helpers?.handleReplaceFilterValues(filter?.id ?? '', [sanitizedCurrentFilter]);

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -9,11 +9,11 @@ import { WarningOutlined } from '@mui/icons-material';
 import { Link } from 'react-router-dom';
 import { useFormatter } from '../i18n';
 import type { Theme } from '../Theme';
-import { FiltersRestrictions, isFilterEditable, isRegardingOfFilterWarning, useFilterDefinition } from '../../utils/filters/filtersUtils';
+import { FiltersRestrictions, isFilterEditable, isFilterGroupNotEmpty, isRegardingOfFilterWarning, useFilterDefinition } from '../../utils/filters/filtersUtils';
 import { isDateIntervalTranslatable, translateDateInterval, truncate } from '../../utils/String';
 import FilterValuesContent from '../FilterValuesContent';
 import { FilterRepresentative } from './FiltersModel';
-import { Filter } from '../../utils/filters/filtersHelpers-types';
+import { Filter, FilterGroup } from '../../utils/filters/filtersHelpers-types';
 import useSchema from '../../utils/hooks/useSchema';
 
 // Deprecated - https://mui.com/system/styles/basics/
@@ -222,6 +222,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                 </>
               );
               if (subKey === 'dynamic') {
+                if (!val.values.every((v: FilterGroup) => isFilterGroupNotEmpty(v))) return <div key={val.key}/>;
                 return (
                   <Fragment key={val.key}>
                     <Tooltip

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -15,6 +15,7 @@ import FilterValuesContent from '../FilterValuesContent';
 import { FilterRepresentative } from './FiltersModel';
 import { Filter, FilterGroup } from '../../utils/filters/filtersHelpers-types';
 import useSchema from '../../utils/hooks/useSchema';
+import TasksFilterValueContainer from '../TasksFilterValueContainer';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -222,17 +223,17 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                 </>
               );
               if (subKey === 'dynamic') {
-                if (!val.values.every((v: FilterGroup) => isFilterGroupNotEmpty(v))) return <div key={val.key}/>;
+                const dynamicValues = val.values;
+                if (!dynamicValues.every((v: FilterGroup) => isFilterGroupNotEmpty(v))) return <div key={val.key}/>;
                 return (
                   <Fragment key={val.key}>
                     <Tooltip
                       title={
-                        <FilterValues
-                          label={keyLabel}
-                          tooltip={true}
-                          currentFilter={val}
-                          filtersRepresentativesMap={filtersRepresentativesMap}
-                        />
+                        dynamicValues.map((v: FilterGroup) => (
+                          <TasksFilterValueContainer
+                            key={dynamicValues.indexOf(v)}
+                            filters={v}
+                          />))
                         }
                     >
                       <Box

--- a/opencti-platform/opencti-front/src/utils/filters/filtersHelpers-types.ts
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersHelpers-types.ts
@@ -25,7 +25,7 @@ export type HandleOperatorFilter = (
 export interface handleFilterHelpers {
   handleSwitchGlobalMode: () => void;
   handleSwitchLocalMode: (filter: Filter) => void;
-  handleRemoveRepresentationFilter: (id: string, valueId: string) => void;
+  handleRemoveRepresentationFilter: (id: string, valueId: string | Filter | undefined) => void;
   handleRemoveFilterById: (id: string) => void;
   handleChangeOperatorFilters: HandleOperatorFilter;
   handleAddSingleValueFilter: (id: string, valueId?: string) => void;

--- a/opencti-platform/opencti-front/src/utils/filters/useFiltersState.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useFiltersState.tsx
@@ -88,7 +88,7 @@ const useFiltersState = (initFilters: FilterGroup | null = emptyFilterGroup, def
         latestAddFilterId: undefined,
       }));
     },
-    handleRemoveRepresentationFilter: (id: string, value: string) => {
+    handleRemoveRepresentationFilter: (id: string, value: string | Filter | undefined) => {
       setFiltersState((prevState) => ({
         ...prevState,
         filters: handleRemoveRepresentationFilterUtil({ filters: prevState.filters, id, value }),


### PR DESCRIPTION
Bug following this PR : https://github.com/OpenCTI-Platform/opencti/pull/11335

## Bug 1
don't display 'Dynamic filter' if there is no dynamic filter selected
![image](https://github.com/user-attachments/assets/6accf40e-9475-4534-b043-20f5a3061594)

![image](https://github.com/user-attachments/assets/6c2c85ee-b095-4aa5-9afb-9d228f2468fb)

## Bug 2
fix : when editing a dynamic filter with only a relationship type, the screen crashes
![image](https://github.com/user-attachments/assets/ad0781e9-6dc0-4109-bc82-628f6578dc6e)

## Bug 3
fix: when we add only a dynamic filter, then remove it, the screen crashes

## Bug 4
add a tooltip for 'dynamic filter' content

- before: 
![image](https://github.com/user-attachments/assets/a7052b77-66ee-4143-8f29-0543b0fb1c7c)

- after: 
![image](https://github.com/user-attachments/assets/24e449ce-010f-4da7-88a6-04ce1ae77e4c)


## Bug 5
Do a query background task with a dynamic regarding of filter
![image](https://github.com/user-attachments/assets/3d3a018e-5d21-41b4-bb63-dcadad296121)

In the opened pop up, click on the orange chip
![image](https://github.com/user-attachments/assets/026b2a3f-10de-4814-9b78-3c9b94caa94a)

An error occurs 
![image](https://github.com/user-attachments/assets/66165bca-e094-4425-b18c-dcd95fc30d7f)

## Bug 6

If the filter in 'dynamic' is targeting too many ids, the list of ids put in the final query is too long and the screen crashes
![image](https://github.com/user-attachments/assets/ab8c4f39-7eb1-44d9-a447-beda8eabd2c4)
