### PR TITLE
[frontend] Improve managing of widgets positioning in Dashboards (#10730)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Dashboard.jsx
@@ -525,7 +525,7 @@ const WorkspaceDashboardComponent = ({ queryRef, timeField }) => {
   if (data.workspace) {
     return (
       <DashboardView
-        workspace={data.workspace}
+        data={data.workspace}
         noToolbar={true}
         timeField={timeField}
       />

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Dashboard.jsx
@@ -157,6 +157,13 @@ const DashboardComponent = ({ data, noToolbar }) => {
     saveManifest(newManifest);
   };
 
+  const getNextRow = () => {
+    return Object.values(widgetsArray).reduce((max, { layout }) => {
+      const widgetEndRow = layout.y + layout.h;
+      return widgetEndRow > max ? widgetEndRow : max;
+    }, 0);
+  };
+
   const handleAddWidget = (widgetConfig) => {
     saveManifest({
       ...manifest,
@@ -167,7 +174,7 @@ const DashboardComponent = ({ data, noToolbar }) => {
           layout: {
             i: widgetConfig.id,
             x: 0,
-            y: 1000, // 1000 will be replaced automatically by a new row at the end of existing ones.
+            y: getNextRow(),
             w: 4,
             h: 2,
           },

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Dashboard.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Dashboard.jsx
@@ -95,12 +95,13 @@ const DashboardComponent = ({ data, noToolbar }) => {
     return widgets;
   }, [manifest]);
 
-  const saveManifest = (newManifest, noRefresh = false) => {
+  const saveManifest = (newManifest, opts = { layouts: widgetsLayouts, noRefresh: false }) => {
+    const { layouts, noRefresh } = opts;
     // Need to sync manifest with local layouts before sending for update.
     // A desync occurs when resizing or moving a widget because in those cases
     // we skip a complete reload to avoid performance issue.
     const syncWidgets = Object.values(newManifest.widgets).reduce((res, widget) => {
-      const localLayout = widgetsLayouts[widget.id];
+      const localLayout = layouts[widget.id];
       res[widget.id] = {
         ...widget,
         layout: localLayout || widget.layout,
@@ -210,7 +211,7 @@ const DashboardComponent = ({ data, noToolbar }) => {
       // Triggering a manifest save with the same manifest.
       // As this function makes a sync between manifest and local layouts
       // it will make the update of layouts modification.
-      saveManifest(manifest, true);
+      saveManifest(manifest, { layouts: newLayouts, noRefresh: true });
     }
   };
 

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
@@ -66,7 +66,7 @@ const RootDashboard = () => {
                     path="/"
                     element={
                       <Dashboard
-                        workspace={props.workspace}
+                        data={props.workspace}
                         settings={props.settings}
                       />
                         }


### PR DESCRIPTION
### Proposed changes

* Refactor some code
* Always add a new widget in a new line

### Related issues

* #10730 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The code might seem a bit over-engineered, the issue we face is that we save in the same object the config for the Chart that is displayed inside the grid and the config of the grid position itself. But for performance issue we do not want to recompute all charts when we just moved or resized an element in the grid. So we need to separate the case of updating the widget and the case of modifying the grid. That's why we have a local state containing the grid layout that complicate a bit the code.