### PR TITLE
[backend] set granted refs on input (#10095)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/data-builder.js
+++ b/opencti-platform/opencti-graphql/src/database/data-builder.js
@@ -49,17 +49,6 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
     R.dissoc('file'),
     R.omit(schemaRelationsRefDefinition.getInputNames(input.entity_type)),
   )(input);
-  // Apply default granted refs
-  const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(data.entity_type).includes(o))
-    || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === data.entity_type || getParentTypes(data.entity_type).includes(o));
-  if (isSegregationEntity) {
-    if (isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && isGrantedRefsValid(input[INPUT_GRANTED_REFS])) {
-      // ok!
-    } else if (!context.user_inside_platform_organization) {
-      // If user is not part of the platform organization, put its own organizations
-      input[INPUT_GRANTED_REFS] = user.organizations;
-    }
-  }
   if (inferred) {
     // Simply add the rule
     // start/stop confidence was computed by the rule directly
@@ -127,6 +116,8 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
   }
   // Create the meta relationships (ref, refs)
   const relToCreate = [];
+  const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(data.entity_type).includes(o))
+    || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === data.entity_type || getParentTypes(data.entity_type).includes(o));
   const appendMetaRelationships = async (inputField, relType) => {
     if (input[inputField]) {
       // For organizations management
@@ -192,13 +183,6 @@ export const buildRelationData = async (context, user, input, opts = {}) => {
   data.creator_id = [user.internal_id];
   data.created_at = today;
   data.updated_at = today;
-  // Apply default granted refs
-  if (isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && isGrantedRefsValid(input[INPUT_GRANTED_REFS])) {
-    // ok!
-  } else if (!context.user_inside_platform_organization) {
-    // If user is not part of the platform organization, put its own organizations
-    input[INPUT_GRANTED_REFS] = user.organizations;
-  }
   // region re-work data
   // stix-relationship
   if (isStixRelationshipExceptRef(relationshipType)) {

--- a/opencti-platform/opencti-graphql/src/database/data-builder.js
+++ b/opencti-platform/opencti-graphql/src/database/data-builder.js
@@ -27,10 +27,6 @@ import { getEntitiesListFromCache } from './cache';
 import { isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT } from '../utils/access';
 import { cleanMarkings } from '../utils/markingDefinition-utils';
 
-const isGrantedRefsValid = (input) => {
-  return input && (!Array.isArray(input) || input.length > 0);
-};
-
 export const buildEntityData = async (context, user, input, type, opts = {}) => {
   const { fromRule } = opts;
   const internalId = input.internal_id || generateInternalId();
@@ -122,7 +118,8 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
     if (input[inputField]) {
       // For organizations management
       if (relType === RELATION_GRANTED_TO && isSegregationEntity) {
-        if (isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && isGrantedRefsValid(input[inputField])) {
+        if (isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && input[inputField]
+            && (!Array.isArray(input[inputField]) || input[inputField].length > 0)) {
           relToCreate.push(...buildInnerRelation(data, input[inputField], RELATION_GRANTED_TO));
         }
       } else if (relType === RELATION_OBJECT_MARKING) {
@@ -270,7 +267,8 @@ export const buildRelationData = async (context, user, input, opts = {}) => {
   const relToCreate = [];
   if (isStixRelationshipExceptRef(relationshipType)) {
     // We need to link the data to organization sharing, only for core and sightings.
-    if (isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && isGrantedRefsValid(input[INPUT_GRANTED_REFS])) {
+    if (isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && input[INPUT_GRANTED_REFS]
+        && (!Array.isArray(input[INPUT_GRANTED_REFS]) || input[INPUT_GRANTED_REFS].length > 0)) {
       relToCreate.push(...buildInnerRelation(data, input[INPUT_GRANTED_REFS], RELATION_GRANTED_TO));
     }
     const markingsFiltered = await cleanMarkings(context, input.objectMarking);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2987,7 +2987,7 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
     }
     if (!existingRelationship) {
       // We do not use default values on upsert.
-      resolvedInput = fillDefaultValues(user, resolvedInput, entitySetting);
+      resolvedInput = fillDefaultValues(context, user, resolvedInput, entitySetting);
       resolvedInput = await inputResolveRefs(context, user, resolvedInput, relationshipType, entitySetting);
     }
     await validateEntityAndRelationCreation(context, user, resolvedInput, relationshipType, entitySetting, opts);
@@ -3176,7 +3176,7 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
     existingEntities.push(...R.uniqBy((e) => e.internal_id, [...existingByIds, ...existingByHashed]));
     // region - Pre-Check
     if (existingEntities.length === 0) { // We do not use default values on upsert.
-      resolvedInput = fillDefaultValues(user, resolvedInput, entitySetting);
+      resolvedInput = fillDefaultValues(context, user, resolvedInput, entitySetting);
       resolvedInput = await inputResolveRefs(context, user, resolvedInput, type, entitySetting);
     }
     await validateEntityAndRelationCreation(context, user, resolvedInput, type, entitySetting, opts);

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
@@ -5,6 +5,7 @@ import {
   ABSTRACT_STIX_DOMAIN_OBJECT,
   ENTITY_TYPE_CONTAINER,
   INPUT_AUTHORIZED_MEMBERS,
+  INPUT_GRANTED_REFS,
   INPUT_MARKINGS
 } from '../../schema/general';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
@@ -143,52 +144,54 @@ export const getDefaultValues = (attributeConfiguration: AttributeConfiguration,
   return undefined;
 };
 
-export const fillDefaultValues = (user: any, input: any, entitySetting: any) => {
-  const attributesConfiguration = getAttributesConfiguration(entitySetting);
-  if (!attributesConfiguration) {
-    return input;
-  }
+export const fillDefaultValues = (context: AuthContext, user: any, input: any, entitySetting: any) => {
   const filledValues = new Map();
-  attributesConfiguration.filter((attr) => attr.default_values)
-    .forEach((attr) => {
-      // Do not compute default value if we already have a value in the input.
-      // Empty is a valid value (i.e. [] for arrays or "" for strings).
-      if (input[attr.name] === undefined || input[attr.name] === null) {
-        const attributeDef = schemaAttributesDefinition.getAttribute(entitySetting.target_type, attr.name);
-        const refDef = schemaRelationsRefDefinition.getRelationRef(entitySetting.target_type, attr.name);
-        let isMultiple = false;
-        if (attributeDef) {
-          isMultiple = attributeDef.multiple;
-        } else if (refDef) {
-          isMultiple = refDef.multiple;
-        }
-        const defaultValue = getDefaultValues(attr, isMultiple);
-
-        const isNumeric = isNumericAttribute(attr.name);
-        const isBoolean = isBooleanAttribute(attr.name);
-        let parsedValue: any = defaultValue;
-        if (isNumeric) parsedValue = Number(defaultValue);
-        if (isBoolean) parsedValue = defaultValue === 'true';
-
-        if (attr.name === INPUT_AUTHORIZED_MEMBERS && parsedValue) {
-          const defaultAuthorizedMembers = (parsedValue as string[]).map((v) => JSON.parse(v));
-          // Replace dynamic creator rule with the id of the user making the query.
-          const creatorRule = defaultAuthorizedMembers.find((v) => v.id === MEMBER_ACCESS_CREATOR);
-          if (creatorRule) {
-            creatorRule.id = user.id;
+  if (!context.user_inside_platform_organization) {
+    filledValues.set(INPUT_GRANTED_REFS, user.organizations);
+  }
+  const attributesConfiguration = getAttributesConfiguration(entitySetting);
+  if (attributesConfiguration) {
+    attributesConfiguration.filter((attr) => attr.default_values)
+      .forEach((attr) => {
+        // Do not compute default value if we already have a value in the input.
+        // Empty is a valid value (i.e. [] for arrays or "" for strings).
+        if (input[attr.name] === undefined || input[attr.name] === null) {
+          const attributeDef = schemaAttributesDefinition.getAttribute(entitySetting.target_type, attr.name);
+          const refDef = schemaRelationsRefDefinition.getRelationRef(entitySetting.target_type, attr.name);
+          let isMultiple = false;
+          if (attributeDef) {
+            isMultiple = attributeDef.multiple;
+          } else if (refDef) {
+            isMultiple = refDef.multiple;
           }
-          filledValues.set(attr.name, defaultAuthorizedMembers);
-        } else if (attr.name === INPUT_MARKINGS && parsedValue) {
-          const defaultMarkings = user?.default_marking ?? [];
-          const globalDefaultMarking = (defaultMarkings.find((entry: any) => entry.entity_type === 'GLOBAL')?.values ?? []).map((m: any) => m.id);
-          if (!isEmptyField(globalDefaultMarking)) {
-            filledValues.set(INPUT_MARKINGS, globalDefaultMarking);
+          const defaultValue = getDefaultValues(attr, isMultiple);
+
+          const isNumeric = isNumericAttribute(attr.name);
+          const isBoolean = isBooleanAttribute(attr.name);
+          let parsedValue: any = defaultValue;
+          if (isNumeric) parsedValue = Number(defaultValue);
+          if (isBoolean) parsedValue = defaultValue === 'true';
+
+          if (attr.name === INPUT_AUTHORIZED_MEMBERS && parsedValue) {
+            const defaultAuthorizedMembers = (parsedValue as string[]).map((v) => JSON.parse(v));
+            // Replace dynamic creator rule with the id of the user making the query.
+            const creatorRule = defaultAuthorizedMembers.find((v) => v.id === MEMBER_ACCESS_CREATOR);
+            if (creatorRule) {
+              creatorRule.id = user.id;
+            }
+            filledValues.set(attr.name, defaultAuthorizedMembers);
+          } else if (attr.name === INPUT_MARKINGS && parsedValue) {
+            const defaultMarkings = user?.default_marking ?? [];
+            const globalDefaultMarking = (defaultMarkings.find((entry: any) => entry.entity_type === 'GLOBAL')?.values ?? []).map((m: any) => m.id);
+            if (!isEmptyField(globalDefaultMarking)) {
+              filledValues.set(INPUT_MARKINGS, globalDefaultMarking);
+            }
+          } else {
+            filledValues.set(attr.name, parsedValue);
           }
-        } else {
-          filledValues.set(attr.name, parsedValue);
         }
-      }
-    });
+      });
+  }
 
   return { ...input, ...Object.fromEntries(filledValues) };
 };

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
@@ -9,7 +9,14 @@ import {
   INPUT_MARKINGS
 } from '../../schema/general';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
-import { ENTITY_TYPE_CONTAINER_NOTE, ENTITY_TYPE_CONTAINER_OPINION, isStixDomainObject, isStixDomainObjectContainer } from '../../schema/stixDomainObject';
+import {
+  ENTITY_TYPE_CONTAINER_NOTE,
+  ENTITY_TYPE_CONTAINER_OPINION,
+  isStixDomainObject,
+  isStixDomainObjectContainer,
+  STIX_ORGANIZATIONS_RESTRICTED,
+  STIX_ORGANIZATIONS_UNRESTRICTED
+} from '../../schema/stixDomainObject';
 import { UnsupportedError } from '../../config/errors';
 import type { AttributeConfiguration, BasicStoreEntityEntitySetting } from './entitySetting-types';
 import { ENTITY_TYPE_ENTITY_SETTING } from './entitySetting-types';
@@ -26,6 +33,7 @@ import type { MandatoryType } from '../../schema/attribute-definition';
 import { schemaRelationsRefDefinition } from '../../schema/schema-relationsRef';
 import { ENTITY_TYPE_EXTERNAL_REFERENCE } from '../../schema/stixMetaObject';
 import { ENTITY_TYPE_CONTAINER_CASE_RFI } from '../case/case-rfi/case-rfi-types';
+import { getParentTypes } from '../../schema/schemaUtils';
 
 export type typeAvailableSetting = boolean | string;
 
@@ -146,7 +154,9 @@ export const getDefaultValues = (attributeConfiguration: AttributeConfiguration,
 
 export const fillDefaultValues = (context: AuthContext, user: any, input: any, entitySetting: any) => {
   const filledValues = new Map();
-  if (!context.user_inside_platform_organization) {
+  const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(entitySetting.target_type).includes(o))
+      || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === entitySetting.target_type || getParentTypes(entitySetting.target_type).includes(o));
+  if (isSegregationEntity && !context.user_inside_platform_organization) {
     filledValues.set(INPUT_GRANTED_REFS, user.organizations);
   }
   const attributesConfiguration = getAttributesConfiguration(entitySetting);

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
@@ -154,10 +154,12 @@ export const getDefaultValues = (attributeConfiguration: AttributeConfiguration,
 
 export const fillDefaultValues = (context: AuthContext, user: any, input: any, entitySetting: any) => {
   const filledValues = new Map();
-  const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(entitySetting.target_type).includes(o))
-      || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === entitySetting.target_type || getParentTypes(entitySetting.target_type).includes(o));
-  if (isSegregationEntity && !context.user_inside_platform_organization) {
-    filledValues.set(INPUT_GRANTED_REFS, user.organizations);
+  if (entitySetting) {
+    const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(entitySetting.target_type).includes(o))
+        || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === entitySetting.target_type || getParentTypes(entitySetting.target_type).includes(o));
+    if (isSegregationEntity && !context.user_inside_platform_organization) {
+      filledValues.set(INPUT_GRANTED_REFS, user.organizations);
+    }
   }
   const attributesConfiguration = getAttributesConfiguration(entitySetting);
   if (attributesConfiguration) {

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
@@ -154,7 +154,7 @@ export const getDefaultValues = (attributeConfiguration: AttributeConfiguration,
 
 export const fillDefaultValues = (context: AuthContext, user: any, input: any, entitySetting: any) => {
   const filledValues = new Map();
-  if (entitySetting?.target_type) {
+  if (!input[INPUT_GRANTED_REFS] && entitySetting?.target_type) {
     const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(entitySetting.target_type).includes(o))
         || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === entitySetting.target_type || getParentTypes(entitySetting.target_type).includes(o));
     if (isSegregationEntity && !context.user_inside_platform_organization && user?.organizations?.length > 0) {

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-utils.ts
@@ -154,10 +154,10 @@ export const getDefaultValues = (attributeConfiguration: AttributeConfiguration,
 
 export const fillDefaultValues = (context: AuthContext, user: any, input: any, entitySetting: any) => {
   const filledValues = new Map();
-  if (entitySetting) {
+  if (entitySetting?.target_type) {
     const isSegregationEntity = !STIX_ORGANIZATIONS_UNRESTRICTED.some((o) => getParentTypes(entitySetting.target_type).includes(o))
         || STIX_ORGANIZATIONS_RESTRICTED.some((o) => o === entitySetting.target_type || getParentTypes(entitySetting.target_type).includes(o));
-    if (isSegregationEntity && !context.user_inside_platform_organization) {
+    if (isSegregationEntity && !context.user_inside_platform_organization && user?.organizations?.length > 0) {
       filledValues.set(INPUT_GRANTED_REFS, user.organizations);
     }
   }

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-utils.ts
@@ -133,7 +133,7 @@ export const validateCsvMapper = async (context: AuthContext, user: AuthUser, ma
 
     // Validate required attributes
     const entitySetting = await getEntitySettingFromCache(context, representation.target.entity_type);
-    const defaultValues = fillDefaultValues(user, {}, entitySetting);
+    const defaultValues = fillDefaultValues(context, user, {}, entitySetting);
     const attributesDefs = [
       ...schemaAttributesDefinition.getAttributes(representation.target.entity_type).values(),
     ].map((def) => ({

--- a/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-utils.ts
@@ -139,7 +139,7 @@ export const validateJsonMapper = async (context: AuthContext, user: AuthUser, m
 
     // Validate required attributes
     const entitySetting = await getEntitySettingFromCache(context, representation.target.entity_type);
-    const defaultValues = fillDefaultValues(user, {}, entitySetting);
+    const defaultValues = fillDefaultValues(context, user, {}, entitySetting);
     const attributesDefs = [
       ...schemaAttributesDefinition.getAttributes(representation.target.entity_type).values(),
     ].map((def) => ({

--- a/opencti-platform/opencti-graphql/src/parser/csv-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/csv-mapper.ts
@@ -334,7 +334,7 @@ const mapRecord = async (
   const entitySetting = await getEntitySettingFromCache(context, entity_type);
   handleDefaultMarkings(entitySetting, representation, input, refEntities, chosenMarkings, user);
 
-  const filledInput = fillDefaultValues(user, input, entitySetting);
+  const filledInput = fillDefaultValues(context, user, input, entitySetting);
   if (!isValidInput(filledInput)) {
     return null;
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
The problem is that if the user does not specify an `INPUT_GRANTED_REFS`, then the backend automatically computes the default value without updating it on the original input object. This means that ElasticSearch and Redis see two different objects:
- ElasticSearch stores the entity and the relationships separately and merges them every read, so the relationships are always correct
- Redis will only see the original input without considering the relationship objects

The end result is that Redis streams are not aware of the default-applied `INPUT_GRANTED_REFS`. This PR updates the calculation so that the default value is applied on the input, instead of being passed straight into `relsToCreate`.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10095
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
I'm not really sure how to write a test for this

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
