### PR TITLE
[frontend] use the indicator score default value (#11035)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -96,7 +96,7 @@ interface IndicatorAddInput {
   objectLabel: FieldOption[]
   externalReferences: { value: string }[]
   x_opencti_detection: boolean
-  x_opencti_score: number
+  x_opencti_score: number | undefined;
   file: File | undefined
 }
 
@@ -224,7 +224,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
       externalReferences: [],
       x_opencti_detection: false,
       createObservables: false,
-      x_opencti_score: 50,
+      x_opencti_score: undefined,
       file: undefined,
     },
   );


### PR DESCRIPTION
### Proposed changes

* display default value on score field

### Related issues

* #11035 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality