### PR TITLE
[frontend] fix navigation on notification click (#11582)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -152,8 +152,7 @@ const Notifications: FunctionComponent = () => {
     const firstEvent = events.at(0);
     const firstOperation = isDigest ? 'multiple' : (firstEvent?.operation ?? 'none');
     const isLinkAvailable = events.length === 1 && isNotEmptyField(firstEvent?.instance_id) && firstOperation !== 'delete';
-    if (!isLinkAvailable) return undefined;
-    if (firstEvent.instance_id) {
+    if (isLinkAvailable && firstEvent.instance_id) {
       navigate(`/dashboard/id/${firstEvent.instance_id}`);
     }
   };

--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -14,6 +14,7 @@ import { NotificationsLine_node$data } from '@components/profile/__generated__/N
 import { NotificationsLinesPaginationQuery, NotificationsLinesPaginationQuery$variables } from '@components/profile/__generated__/NotificationsLinesPaginationQuery.graphql';
 import { NotificationsLines_data$data } from '@components/profile/__generated__/NotificationsLines_data.graphql';
 import DigestNotificationDrawer from '@components/profile/notifications/DigestNotificationDrawer';
+import { useNavigate } from 'react-router-dom';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import useAuth from '../../../utils/hooks/useAuth';
@@ -129,7 +130,7 @@ const notificationLineNotificationDeleteMutation = graphql`
 const Notifications: FunctionComponent = () => {
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
-
+  const navigate = useNavigate();
   const [commitMarkRead] = useApiMutation(
     notificationLineNotificationMarkReadMutation,
   );
@@ -146,6 +147,14 @@ const Notifications: FunctionComponent = () => {
     const isDigest = events.length > 1;
     if (isDigest) {
       setNotificationDigestToOpen(data);
+    }
+
+    const firstEvent = events.at(0);
+    const firstOperation = isDigest ? 'multiple' : (firstEvent?.operation ?? 'none');
+    const isLinkAvailable = events.length === 1 && isNotEmptyField(firstEvent?.instance_id) && firstOperation !== 'delete';
+    if (!isLinkAvailable) return undefined;
+    if (firstEvent.instance_id) {
+      navigate(`/dashboard/id/${firstEvent.instance_id}`);
     }
   };
 
@@ -422,16 +431,6 @@ const Notifications: FunctionComponent = () => {
         availableEntityTypes={['Notification']}
         actions={renderActions}
         markAsReadEnabled={true}
-        useComputeLink={({ notification_content, notification_type }: NotificationsLine_node$data) => {
-          const events = notification_content.map((n) => n.events).flat();
-          const firstEvent = events.at(0);
-          const isDigest = notification_type === 'digest';
-          const firstOperation = isDigest ? 'multiple' : (firstEvent?.operation ?? 'none');
-          const isLinkAvailable = events.length === 1 && isNotEmptyField(firstEvent?.instance_id) && firstOperation !== 'delete';
-          if (!isLinkAvailable) return undefined;
-          return `/dashboard/id/${firstEvent.instance_id}`;
-        }}
-
       />
       )}
       {notificationToDelete && (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* From datatableline code here: https://github.com/OpenCTI-Platform/opencti/blob/a73f9154a49d9ef86b2c35359e8433a6b790f9aa/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx#L128C44-L128C55

If there is a onLineClick define, the navigation on useComputeLink is disable. It's one or the other. So I moved navigation code inside the onLineClick.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #11582 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
