### PR TITLE
[backend] allow to set/update platform id (#11188)

### DIFF
--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -42,6 +42,7 @@
       "token": "d434ce02-e58e-4cac-8b4c-42bf16748e84"
     }
   },
+  "platform_id": "7992a4b1-128c-4656-bf97-2018b6f1f395",
   "http_proxy": "http://proxy.opencti.io:2000",
   "https_proxy": "https://proxy.opencti.io:2100",
   "no_proxy": "127.0.0.1,127.0.0.0/8,internal.opencti.io,rabbitmq",

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -402,7 +402,7 @@ export const patchPlatformId = async (context) => {
 
     const platformSettings = await loadEntity(context, SYSTEM_USER, [ENTITY_TYPE_SETTINGS]);
     if (platformSettings.id !== platformId) {
-      logApp.info(`[INIT] Switching platform identifier from [${platformSettings.id}] to [${platformId}]`);
+      logApp.warn(`[INIT] Switching platform identifier from [${platformSettings.id}] to [${platformId}]`);
       // to change the id in elastic, we have no choice but to create a patched copy and delete the old document
       const response = await elRawGet({
         index: INDEX_INTERNAL_OBJECTS,

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -369,7 +369,7 @@ export const initializeData = async (context, withMarkings = true) => {
   // Create default elements
   const platformId = conf.get('platform_id') || undefined;
   if (isNotEmptyField(platformId)) {
-    logApp.info(`[INIT] Platform identifier forced to [${platformId}]`);
+    logApp.warn(`[INIT] Platform identifier forced to [${platformId}]`);
   }
 
   await addSettings(context, SYSTEM_USER, {
@@ -393,8 +393,7 @@ export const initializeData = async (context, withMarkings = true) => {
   return true;
 };
 
-export const patchPlatformId = async (context) => {
-  const platformId = conf.get('platform_id') || undefined;
+export const setPlatformId = async (context, platformId) => {
   if (isNotEmptyField((platformId))) {
     if (!validator.isUUID(platformId)) {
       throw ConfigurationError('Cannot switch platform identifier: platform_id is not a valid UUID', { platform_id: platformId });
@@ -425,4 +424,9 @@ export const patchPlatformId = async (context) => {
       });
     }
   }
+};
+
+export const patchPlatformId = async (context) => {
+  const platformId = conf.get('platform_id') || undefined;
+  await setPlatformId(context, platformId);
 };

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -413,6 +413,10 @@ export const elRawSearch = (context, user, types, query) => {
     [SEMATTRS_DB_STATEMENT]: JSON.stringify(query),
   }, elRawSearchFn);
 };
+
+export const elRawGet = (args) => engine.get(args).then((r) => oebp(r));
+export const elRawIndex = (args) => engine.index(args).then((r) => oebp(r));
+export const elRawDelete = (args) => engine.delete(args).then((r) => oebp(r));
 export const elRawDeleteByQuery = (query) => engine.deleteByQuery(query).then((r) => oebp(r));
 export const elRawBulk = (args) => engine.bulk(args).then((r) => oebp(r));
 export const elRawUpdateByQuery = (query) => engine.updateByQuery(query).then((r) => oebp(r));

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -18,7 +18,7 @@ import { smtpIsAlive } from './database/smtp';
 import { initCreateEntitySettings } from './modules/entitySetting/entitySetting-domain';
 import { initDecayRules } from './modules/decayRule/decayRule-domain';
 import { initManagerConfigurations } from './modules/managerConfiguration/managerConfiguration-domain';
-import { initializeData } from './database/data-initialization';
+import { initializeData, patchPlatformId } from './database/data-initialization';
 import { initExclusionListCache } from './database/exclusionListCache';
 import { initFintelTemplates } from './modules/fintelTemplate/fintelTemplate-domain';
 import { lockResources } from './lock/master-lock';
@@ -118,6 +118,7 @@ const platformInit = async (withMarkings = true) => {
         // noinspection ExceptionCaughtLocallyJS
         throw ConfigurationError('Internal option internal_init_mapping_migration is only available for new platform init');
       }
+      await patchPlatformId(context);
       await refreshMappingsAndIndices();
       await initializeInternalQueues();
       await enforceQueuesConsistency(context, SYSTEM_USER);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/data-initialization-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/data-initialization-test.ts
@@ -17,6 +17,14 @@ describe('Data initialization test', () => {
     await setPlatformId(testContext, '74cc0eba-b0c6-4822-8db6-6ddbdf49498f');
     const platformSettings = await loadEntity(testContext, ADMIN_USER, [ENTITY_TYPE_SETTINGS]);
     expect(platformSettings?.id).toEqual('74cc0eba-b0c6-4822-8db6-6ddbdf49498f');
+    // restore initial id
+    await setPlatformId(testContext, '7992a4b1-128c-4656-bf97-2018b6f1f395');
+  });
+
+  it('should not be able to set a platform_id that is not a valid uuid', async () => {
+    await expect(async () => {
+      await setPlatformId(testContext, 'wrong-id');
+    }).rejects.toThrowError('Cannot switch platform identifier: platform_id is not a valid UUID');
   });
 
   it('should create all capabilities', async () => {

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/data-initialization-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/data-initialization-test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import { listAllEntities } from '../../../src/database/middleware-loader';
-import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE } from '../../../src/schema/internalObject';
+import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE, ENTITY_TYPE_SETTINGS } from '../../../src/schema/internalObject';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import type { BasicStoreEntity } from '../../../src/types/store';
+import { loadEntity } from '../../../src/database/middleware';
+import { setPlatformId } from '../../../src/database/data-initialization';
 
 describe('Data initialization test', () => {
+  it('should have a specific platform_id from config file', async () => {
+    const platformSettings = await loadEntity(testContext, ADMIN_USER, [ENTITY_TYPE_SETTINGS]);
+    // as configured in test.json
+    expect(platformSettings?.id).toEqual('7992a4b1-128c-4656-bf97-2018b6f1f395');
+  });
+
+  it('should be able to set another platform_id', async () => {
+    await setPlatformId(testContext, '74cc0eba-b0c6-4822-8db6-6ddbdf49498f');
+    const platformSettings = await loadEntity(testContext, ADMIN_USER, [ENTITY_TYPE_SETTINGS]);
+    expect(platformSettings?.id).toEqual('74cc0eba-b0c6-4822-8db6-6ddbdf49498f');
+  });
+
   it('should create all capabilities', async () => {
     const capabilities = await listAllEntities<BasicStoreEntity>(testContext, ADMIN_USER, [ENTITY_TYPE_CAPABILITY]);
     expect(capabilities.length).toEqual(41);


### PR DESCRIPTION
This feature allows to set a platform identifier instead of using the default uuid v4.
Note that technically, the platform id is the id of the Platform Settings object in elastic.

### Proposed changes

* new config token `platform_id`
* When booting a brand new platform, if `platform_id` is defined in the configuration, we use it instead of a random uuid
* When booting an existing platform, we change the platform identifier during startup, by patching the platform settings document in elastic.

### Related issues
* #11188 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

To test this feature I suggest to:
* set a new `elasticsearch.index_prefix` if you do not want to pollute your main dev index
* set `platform_id` to a fixed uuidv4 of your choice
* start the platform
* checkout the platform identifier in the app settings (or with a quick query in ES, get the only doc with `Settings` as entityType)
* stop the platform
* change the setting `platform_id` with another value
* restart the backend
* checkout the platform identifier once again
* delete your ES indices to remove your test data
