### PR TITLE
[backend] replace ruleApply in background task to direct inferred creation (#11626)

### DIFF
--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -18,6 +18,7 @@ import requests
 from pycti import __version__
 from pycti.api.opencti_api_connector import OpenCTIApiConnector
 from pycti.api.opencti_api_draft import OpenCTIApiDraft
+from pycti.api.opencti_api_inferred import OpenCTIApiInferred
 from pycti.api.opencti_api_internal_file import OpenCTIApiInternalFile
 from pycti.api.opencti_api_notification import OpenCTIApiNotification
 from pycti.api.opencti_api_pir import OpenCTIApiPir
@@ -209,6 +210,7 @@ class OpenCTIApiClient:
         # Define the dependencies
         self.work = OpenCTIApiWork(self)
         self.notification = OpenCTIApiNotification(self)
+        self.inferred = OpenCTIApiInferred(self)
         self.trash = OpenCTIApiTrash(self)
         self.draft = OpenCTIApiDraft(self)
         self.workspace = OpenCTIApiWorkspace(self)

--- a/client-python/pycti/api/opencti_api_inferred.py
+++ b/client-python/pycti/api/opencti_api_inferred.py
@@ -1,0 +1,25 @@
+class OpenCTIApiInferred:
+    """OpenCTIApiInferred"""
+
+    def __init__(self, api):
+        self.api = api
+
+    def create_inferred_rel(self, **kwargs):
+        input = kwargs.get("input", None)
+        self.api.app_logger.info("Creating inferred rel", {"input": input})
+        query = """
+            mutation inferredRelationAdd($jsonInput: String!) {
+                inferredRelationAdd(jsonInput: $jsonInput)
+            }
+           """
+        self.api.query(query, {"jsonInput": input})
+
+    def create_inferred_entity(self, **kwargs):
+        input = kwargs.get("input", None)
+        self.api.app_logger.info("Creating inferred entity", {"input": input})
+        query = """
+            mutation inferredEntityAdd($jsonInput: String!) {
+                inferredEntityAdd(jsonInput: $jsonInput)
+            }
+           """
+        self.api.query(query, {"jsonInput": input})

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2807,6 +2807,20 @@ class OpenCTIStix2:
             self.opencti.pir.pir_unflag_element(id=id, input=input)
         elif operation == "rule_apply":
             self.rule_apply(item=item)
+        elif operation == "inferred_entity":
+            opencti_inferred_input = self.opencti.get_attribute_in_extension(
+                "opencti_inferred_input", item
+            )
+            if opencti_inferred_input is None:
+                opencti_inferred_input = item["opencti_inferred_input"]
+            self.opencti.inferred.create_inferred_entity(input=opencti_inferred_input)
+        elif operation == "inferred_rel":
+            opencti_inferred_input = self.opencti.get_attribute_in_extension(
+                "opencti_inferred_input", item
+            )
+            if opencti_inferred_input is None:
+                opencti_inferred_input = item["opencti_inferred_input"]
+            self.opencti.inferred.create_inferred_rel(input=opencti_inferred_input)
         elif operation == "rule_clear":
             self.rule_clear(item=item)
         elif operation == "rules_rescan":

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9756,6 +9756,8 @@ type Mutation {
   stixRefRelationshipEdit(id: ID!): StixRefRelationshipEditMutations
   stixSightingRelationshipAdd(input: StixSightingRelationshipAddInput!): StixSightingRelationship
   stixSightingRelationshipEdit(id: ID!): StixSightingRelationshipEditMutations
+  inferredRelationAdd(jsonInput: String!): ID
+  inferredEntityAdd(jsonInput: String!): ID
   channelAdd(input: ChannelAddInput!): Channel
   channelDelete(id: ID!): ID
   channelFieldPatch(id: ID!, input: [EditInput]!, commitMessage: String, references: [String]): Channel

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -15552,4 +15552,8 @@ type Mutation {
   stixSightingRelationshipAdd(input: StixSightingRelationshipAddInput!): StixSightingRelationship
   @auth(for: [KNOWLEDGE_KNUPDATE])
   stixSightingRelationshipEdit(id: ID!): StixSightingRelationshipEditMutations @auth(for: [KNOWLEDGE_KNUPDATE])
+
+  ######## INTERNAL INFERRED CREATION
+  inferredRelationAdd(jsonInput: String!): ID @auth(for: [KNOWLEDGE_KNUPDATE])
+  inferredEntityAdd(jsonInput: String!): ID @auth(for: [KNOWLEDGE_KNUPDATE])
 }

--- a/opencti-platform/opencti-graphql/src/domain/inferredObject.ts
+++ b/opencti-platform/opencti-graphql/src/domain/inferredObject.ts
@@ -8,7 +8,6 @@ export const createInternalInferredRelation = async (context: AuthContext, user:
   if (user.id !== RULE_MANAGER_USER.id) {
     throw ForbiddenAccess();
   }
-  // TODO: JSON input validation? Maybe we don't need it since it's only coming from task manager?
   const { input, ruleContent, opts } = JSON.parse(jsonInput);
   const createdInferredRelation = await createInferredRelation(context, input, ruleContent, opts);
   return createdInferredRelation.id;
@@ -18,7 +17,6 @@ export const createInternalInferredEntity = async (context: AuthContext, user: A
   if (user.id !== RULE_MANAGER_USER.id) {
     throw ForbiddenAccess();
   }
-  // TODO: JSON input validation? Maybe we don't need it since it's only coming from task manager?
   const { input, ruleContent, type } = JSON.parse(jsonInput);
   const createdInferredEntity = await createInferredEntity(context, input, ruleContent, type);
   return createdInferredEntity.id;

--- a/opencti-platform/opencti-graphql/src/domain/inferredObject.ts
+++ b/opencti-platform/opencti-graphql/src/domain/inferredObject.ts
@@ -1,0 +1,25 @@
+import { createInferredEntity, createInferredRelation } from '../database/middleware';
+import type { AuthContext, AuthUser } from '../types/user';
+import { RULE_MANAGER_USER } from '../utils/access';
+import { ForbiddenAccess } from '../config/errors';
+
+export const createInternalInferredRelation = async (context: AuthContext, user: AuthUser, jsonInput: string) => {
+  // This API should only be available to task manager user
+  if (user.id !== RULE_MANAGER_USER.id) {
+    throw ForbiddenAccess();
+  }
+  // TODO: JSON input validation? Maybe we don't need it since it's only coming from task manager?
+  const { input, ruleContent, opts } = JSON.parse(jsonInput);
+  const createdInferredRelation = await createInferredRelation(context, input, ruleContent, opts);
+  return createdInferredRelation.id;
+};
+export const createInternalInferredEntity = async (context: AuthContext, user: AuthUser, jsonInput: string) => {
+  // This API should only be available to task manager user
+  if (user.id !== RULE_MANAGER_USER.id) {
+    throw ForbiddenAccess();
+  }
+  // TODO: JSON input validation? Maybe we don't need it since it's only coming from task manager?
+  const { input, ruleContent, type } = JSON.parse(jsonInput);
+  const createdInferredEntity = await createInferredEntity(context, input, ruleContent, type);
+  return createdInferredEntity.id;
+};

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15152,6 +15152,8 @@ export type Mutation = {
   indicatorRelationDelete?: Maybe<Indicator>;
   individualAdd?: Maybe<Individual>;
   individualEdit?: Maybe<IndividualEditMutations>;
+  inferredEntityAdd?: Maybe<Scalars['ID']['output']>;
+  inferredRelationAdd?: Maybe<Scalars['ID']['output']>;
   infrastructureAdd?: Maybe<Infrastructure>;
   infrastructureEdit?: Maybe<InfrastructureEditMutations>;
   ingestionCsvAdd?: Maybe<IngestionCsv>;
@@ -16363,6 +16365,16 @@ export type MutationIndividualAddArgs = {
 
 export type MutationIndividualEditArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationInferredEntityAddArgs = {
+  jsonInput: Scalars['String']['input'];
+};
+
+
+export type MutationInferredRelationAddArgs = {
+  jsonInput: Scalars['String']['input'];
 };
 
 
@@ -43175,6 +43187,8 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   indicatorRelationDelete?: Resolver<Maybe<ResolversTypes['Indicator']>, ParentType, ContextType, RequireFields<MutationIndicatorRelationDeleteArgs, 'id' | 'relationship_type' | 'toId'>>;
   individualAdd?: Resolver<Maybe<ResolversTypes['Individual']>, ParentType, ContextType, RequireFields<MutationIndividualAddArgs, 'input'>>;
   individualEdit?: Resolver<Maybe<ResolversTypes['IndividualEditMutations']>, ParentType, ContextType, RequireFields<MutationIndividualEditArgs, 'id'>>;
+  inferredEntityAdd?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationInferredEntityAddArgs, 'jsonInput'>>;
+  inferredRelationAdd?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationInferredRelationAddArgs, 'jsonInput'>>;
   infrastructureAdd?: Resolver<Maybe<ResolversTypes['Infrastructure']>, ParentType, ContextType, RequireFields<MutationInfrastructureAddArgs, 'input'>>;
   infrastructureEdit?: Resolver<Maybe<ResolversTypes['InfrastructureEditMutations']>, ParentType, ContextType, RequireFields<MutationInfrastructureEditArgs, 'id'>>;
   ingestionCsvAdd?: Resolver<Maybe<ResolversTypes['IngestionCsv']>, ParentType, ContextType, RequireFields<MutationIngestionCsvAddArgs, 'input'>>;

--- a/opencti-platform/opencti-graphql/src/graphql/schema.js
+++ b/opencti-platform/opencti-graphql/src/graphql/schema.js
@@ -74,6 +74,7 @@ import stixMetaObjectResolvers from '../resolvers/stixMetaObject';
 import filterKeysSchemaResolver from '../resolvers/filterKeysSchema';
 import basicObjectResolvers from '../resolvers/basicObject';
 import { FunctionalError } from '../config/errors';
+import inferredObjectResolvers from '../resolvers/inferredObject';
 
 const schemaTypeDefs = [globalTypeDefs];
 
@@ -180,6 +181,7 @@ const schemaResolvers = [
   constraintDirectiveTypeDefs,
   // INTERNAL
   globalResolvers,
+  inferredObjectResolvers,
   taxiiResolvers,
   feedResolvers,
   streamResolvers,

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -6,7 +6,7 @@ import { createStreamProcessor } from '../database/stream/stream-handler';
 import { redisGetManagerEventState, redisSetManagerEventState } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
-import { createEntity, patchAttribute, stixLoadById, storeLoadByIdWithRefs } from '../database/middleware';
+import { createEntity, createInferredRelation, createInferredEntity, patchAttribute, stixLoadById, storeLoadByIdWithRefs } from '../database/middleware';
 import { EVENT_TYPE_CREATE, EVENT_TYPE_DELETE, EVENT_TYPE_MERGE, EVENT_TYPE_UPDATE, isEmptyField, isNotEmptyField, READ_DATA_INDICES } from '../database/utils';
 import { ABSTRACT_STIX_RELATIONSHIP, RULE_PREFIX } from '../schema/general';
 import { ENTITY_TYPE_RULE_MANAGER } from '../schema/internalObject';
@@ -15,7 +15,7 @@ import { getParentTypes } from '../schema/schemaUtils';
 import { isBasicRelationship, isStixRelationship } from '../schema/stixRelationship';
 import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
 import { internalLoadById, fullRelationsList } from '../database/middleware-loader';
-import type { RuleDefinition, RuleRuntime, RuleScope } from '../types/rules';
+import type { CreateInferredEntityCallbackFunction, CreateInferredRelationCallbackFunction, RuleDefinition, RuleRuntime, RuleScope } from '../types/rules';
 import type { BasicManagerEntity, BasicStoreBase, BasicStoreCommon, BasicStoreEntity, BasicStoreRelation, StoreObject } from '../types/store';
 import type { AuthContext, AuthUser } from '../types/user';
 import type { RuleManager } from '../generated/graphql';
@@ -81,7 +81,6 @@ const isAttributesImpactDependencies = (rule: RuleDefinition, operations: Operat
     .map((a) => a.name);
   const operationAttributes = R.uniq(operations.map((o) => {
     const parts = o.path.substring(1).split('/');
-
     return parts.filter((p) => isNaN(Number(p))).join('.');
   }));
   return operationAttributes.filter((f) => rulesAttributes.includes(f)).length > 0;
@@ -161,7 +160,14 @@ const applyCleanupOnDependencyIds = async (deletionIds: Array<string>, rules: Ar
   await elList(context, RULE_MANAGER_USER, READ_DATA_INDICES, opts);
 };
 
-export const rulesApplyHandler = async (context: AuthContext, user: AuthUser, events: Array<DataEvent>, forRules: Array<RuleRuntime> = []) => {
+export const rulesApplyHandler = async (
+  context: AuthContext,
+  user: AuthUser,
+  events: Array<DataEvent>,
+  forRules: Array<RuleRuntime> = [],
+  createInferredEntityCallback: CreateInferredEntityCallbackFunction = createInferredEntity,
+  createInferredRelationCallback: CreateInferredRelationCallbackFunction = createInferredRelation
+) => {
   if (isEmptyField(events) || events.length === 0) {
     return;
   }
@@ -175,8 +181,7 @@ export const rulesApplyHandler = async (context: AuthContext, user: AuthUser, ev
       if (type === EVENT_TYPE_MERGE) {
         const mergeEvent = event as MergeEvent;
         const mergeEvents = await ruleMergeHandler(mergeEvent);
-
-        await rulesApplyHandler(context, user, mergeEvents);
+        await rulesApplyHandler(context, user, mergeEvents, forRules, createInferredEntityCallback, createInferredRelationCallback);
       }
       // In case of deletion, call clean on every impacted elements
       if (type === EVENT_TYPE_DELETE) {
@@ -212,7 +217,7 @@ export const rulesApplyHandler = async (context: AuthContext, user: AuthUser, ev
           const rule = rules[ruleIndex];
           const isImpactedElement = isMatchRuleFilters(rule, data);
           if (isImpactedElement) {
-            await rule.insert(data);
+            await rule.insert(data, createInferredEntityCallback, createInferredRelationCallback);
           }
         }
       }
@@ -350,22 +355,36 @@ const initRuleManager = () => {
 };
 const ruleEngine = initRuleManager();
 
-export const executeRuleApply = async (context: AuthContext, user: AuthUser, rule: RuleRuntime, id: string) => {
+export const executeRuleApply = async (
+  context: AuthContext,
+  user: AuthUser,
+  rule: RuleRuntime,
+  id: string,
+  createInferredEntityCallback: CreateInferredEntityCallbackFunction,
+  createInferredRelationCallback: CreateInferredRelationCallbackFunction
+) => {
   // Execute rules over one element, act as element creation
   const instance = await storeLoadByIdWithRefs(context, user, id);
   if (!instance) {
     throw FunctionalError('Cant find element to scan', { id });
   }
   const event = buildCreateEvent(user, instance, '-');
-  await rulesApplyHandler(context, user, [event], [rule]);
+  await rulesApplyHandler(context, user, [event], [rule], createInferredEntityCallback, createInferredRelationCallback);
 };
 
-export const ruleApply = async (context: AuthContext, user: AuthUser, elementId: string, ruleId: string) => {
+export const ruleApply = async (
+  context: AuthContext,
+  user: AuthUser,
+  elementId: string,
+  ruleId: string,
+  createInferredEntityCallback: CreateInferredEntityCallbackFunction = createInferredEntity,
+  createInferredRelationCallback: CreateInferredRelationCallbackFunction = createInferredRelation,
+) => {
   const rule = await getRule(context, user, ruleId) as RuleRuntime;
   if (!rule) {
     throw FunctionalError('Cant find rule to scan', { id: ruleId });
   }
-  return executeRuleApply(context, user, rule, elementId);
+  return executeRuleApply(context, user, rule, elementId, createInferredEntityCallback, createInferredRelationCallback);
 };
 
 export const ruleClear = async (context: AuthContext, user: AuthUser, elementId: string, ruleId: string) => {
@@ -412,7 +431,9 @@ export const executeRuleElementRescan = async (context: AuthContext, user: AuthU
 export const rulesRescan = async (context: AuthContext, user: AuthUser, elementId: string) => {
   const elem = await internalLoadById(context, user, elementId, { baseData: true });
   if (elem) {
-    await executeRuleElementRescan(context, user, elem);
+    executeRuleElementRescan(context, user, elem).catch((e) => {
+      logApp.warn('RULE RESCAN - Unexpected error during rule rescan', { elementId, cause: e });
+    });
     return true;
   }
   return false;

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -166,7 +166,7 @@ export const rulesApplyHandler = async (
   events: Array<DataEvent>,
   forRules: Array<RuleRuntime> = [],
   createInferredEntityCallback: CreateInferredEntityCallbackFunction = createInferredEntity,
-  createInferredRelationCallback: CreateInferredRelationCallbackFunction = createInferredRelation
+  createInferredRelationCallback: CreateInferredRelationCallbackFunction = createInferredRelation,
 ) => {
   if (isEmptyField(events) || events.length === 0) {
     return;
@@ -361,7 +361,7 @@ export const executeRuleApply = async (
   rule: RuleRuntime,
   id: string,
   createInferredEntityCallback: CreateInferredEntityCallbackFunction,
-  createInferredRelationCallback: CreateInferredRelationCallbackFunction
+  createInferredRelationCallback: CreateInferredRelationCallbackFunction,
 ) => {
   // Execute rules over one element, act as element creation
   const instance = await storeLoadByIdWithRefs(context, user, id);

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -1,24 +1,24 @@
 /* eslint-disable camelcase */
-import { v4 as uuidv4 } from 'uuid';
-import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/dynamic';
+import {v4 as uuidv4} from 'uuid';
+import {clearIntervalAsync, setIntervalAsync} from 'set-interval-async/dynamic';
 import * as R from 'ramda';
-import { Promise as BluePromise } from 'bluebird';
-import { lockResources } from '../lock/master-lock';
-import { buildQueryFilters, findBackgroundTask, updateTask } from '../domain/backgroundTask';
-import conf, { booleanConf, logApp } from '../config/conf';
-import { resolveUserByIdFromCache } from '../domain/user';
-import { storeLoadByIdsWithRefs } from '../database/middleware';
-import { now } from '../utils/format';
-import { isEmptyField, READ_DATA_INDICES, READ_DATA_INDICES_WITHOUT_INFERRED } from '../database/utils';
-import { elList } from '../database/engine';
-import { FunctionalError, TYPE_LOCK_ERROR } from '../config/errors';
-import { ABSTRACT_STIX_CORE_RELATIONSHIP, INPUT_OBJECTS, RULE_PREFIX } from '../schema/general';
-import { executionContext, isUserInPlatformOrganization, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
-import { buildEntityFilters, internalFindByIds, internalLoadById, fullRelationsList } from '../database/middleware-loader';
-import { getRule } from '../domain/rules';
-import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
-import { isStixCyberObservable } from '../schema/stixCyberObservable';
-import { generateIndicatorFromObservable } from '../domain/stixCyberObservable';
+import {Promise as BluePromise} from 'bluebird';
+import {lockResources} from '../lock/master-lock';
+import {buildQueryFilters, findBackgroundTask, updateTask} from '../domain/backgroundTask';
+import conf, {booleanConf, logApp} from '../config/conf';
+import {resolveUserByIdFromCache} from '../domain/user';
+import {storeLoadByIdsWithRefs} from '../database/middleware';
+import {now} from '../utils/format';
+import {isEmptyField, READ_DATA_INDICES, READ_DATA_INDICES_WITHOUT_INFERRED} from '../database/utils';
+import {elList} from '../database/engine';
+import {FunctionalError, TYPE_LOCK_ERROR} from '../config/errors';
+import {ABSTRACT_STIX_CORE_RELATIONSHIP, INPUT_OBJECTS, RULE_PREFIX} from '../schema/general';
+import {executionContext, isUserInPlatformOrganization, RULE_MANAGER_USER, SYSTEM_USER} from '../utils/access';
+import { buildEntityFilters, fullRelationsList, internalFindByIds, internalLoadById } from '../database/middleware-loader';
+import {getRule} from '../domain/rules';
+import {ENTITY_TYPE_INDICATOR} from '../modules/indicator/indicator-types';
+import {isStixCyberObservable} from '../schema/stixCyberObservable';
+import {generateIndicatorFromObservable} from '../domain/stixCyberObservable';
 import {
   ACTION_TYPE_ADD,
   ACTION_TYPE_ADD_GROUPS,
@@ -48,23 +48,23 @@ import {
   TASK_TYPE_QUERY,
   TASK_TYPE_RULE,
 } from '../domain/backgroundTask-common';
-import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
-import { getDraftContext } from '../utils/draftContext';
-import { getBestBackgroundConnectorId, pushToWorkerForConnector } from '../database/rabbitmq';
-import { updateExpectationsNumber, updateProcessedTime } from '../domain/work';
-import { convertStoreToStix_2_1, convertTypeToStixType } from '../database/stix-2-1-converter';
-import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
-import { RELATION_BASED_ON } from '../schema/stixCoreRelationship';
-import { extractValidObservablesFromIndicatorPattern } from '../utils/syntax';
-import { generateStandardId } from '../schema/identifier';
-import { isBasicRelationship } from '../schema/stixRelationship';
-import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
-import { isStixDomainObjectContainer } from '../schema/stixDomainObject';
-import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
-import { getEntityFromCache } from '../database/cache';
-import { objects as getContainerObjects } from '../domain/container';
-import { ruleApply } from './ruleManager';
-import { doYield } from '../utils/eventloop-utils';
+import {schemaRelationsRefDefinition} from '../schema/schema-relationsRef';
+import {getDraftContext} from '../utils/draftContext';
+import {getBestBackgroundConnectorId, pushToWorkerForConnector} from '../database/rabbitmq';
+import {updateExpectationsNumber, updateProcessedTime} from '../domain/work';
+import {convertStoreToStix_2_1, convertTypeToStixType} from '../database/stix-2-1-converter';
+import {STIX_EXT_OCTI} from '../types/stix-2-1-extensions';
+import {RELATION_BASED_ON} from '../schema/stixCoreRelationship';
+import {extractValidObservablesFromIndicatorPattern} from '../utils/syntax';
+import {generateStandardId} from '../schema/identifier';
+import {isBasicRelationship} from '../schema/stixRelationship';
+import {isStixSightingRelationship} from '../schema/stixSightingRelationship';
+import {isStixDomainObjectContainer} from '../schema/stixDomainObject';
+import {ENTITY_TYPE_SETTINGS} from '../schema/internalObject';
+import {getEntityFromCache} from '../database/cache';
+import {objects as getContainerObjects} from '../domain/container';
+import {ruleApply} from './ruleManager';
+import {doYield} from '../utils/eventloop-utils';
 
 // Task manager responsible to execute long manual tasks
 // Each API will start is task manager.
@@ -287,12 +287,7 @@ const buildBaseBundleElement = (element, additionalOCTIExtensions, standard_id) 
 };
 const buildBundleElement = (element, actionType, operations) => {
   const additionalExtensions = baseOperationBuilder(actionType, operations, element);
-  const bundleObject = buildBaseBundleElement(element, additionalExtensions);
-  bundleObject.extensions[STIX_EXT_OCTI] = {
-    ...bundleObject.extensions[STIX_EXT_OCTI],
-    ...baseOperationBuilder(actionType, operations, element)
-  };
-  return bundleObject;
+  return buildBaseBundleElement(element, additionalExtensions);
 };
 
 const standardOperationCallback = async (context, user, task, actionType, operations) => {

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -1,24 +1,23 @@
-/* eslint-disable camelcase */
-import {v4 as uuidv4} from 'uuid';
-import {clearIntervalAsync, setIntervalAsync} from 'set-interval-async/dynamic';
+import { v4 as uuidv4 } from 'uuid';
+import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/dynamic';
 import * as R from 'ramda';
-import {Promise as BluePromise} from 'bluebird';
-import {lockResources} from '../lock/master-lock';
-import {buildQueryFilters, findBackgroundTask, updateTask} from '../domain/backgroundTask';
-import conf, {booleanConf, logApp} from '../config/conf';
-import {resolveUserByIdFromCache} from '../domain/user';
-import {storeLoadByIdsWithRefs} from '../database/middleware';
-import {now} from '../utils/format';
-import {isEmptyField, READ_DATA_INDICES, READ_DATA_INDICES_WITHOUT_INFERRED} from '../database/utils';
-import {elList} from '../database/engine';
-import {FunctionalError, TYPE_LOCK_ERROR} from '../config/errors';
-import {ABSTRACT_STIX_CORE_RELATIONSHIP, INPUT_OBJECTS, RULE_PREFIX} from '../schema/general';
-import {executionContext, isUserInPlatformOrganization, RULE_MANAGER_USER, SYSTEM_USER} from '../utils/access';
+import { Promise as BluePromise } from 'bluebird';
+import { lockResources } from '../lock/master-lock';
+import { buildQueryFilters, findBackgroundTask, updateTask } from '../domain/backgroundTask';
+import conf, { booleanConf, logApp } from '../config/conf';
+import { resolveUserByIdFromCache } from '../domain/user';
+import { storeLoadByIdsWithRefs } from '../database/middleware';
+import { now } from '../utils/format';
+import { isEmptyField, READ_DATA_INDICES, READ_DATA_INDICES_WITHOUT_INFERRED } from '../database/utils';
+import { elList } from '../database/engine';
+import { FunctionalError, TYPE_LOCK_ERROR } from '../config/errors';
+import { ABSTRACT_STIX_CORE_RELATIONSHIP, INPUT_OBJECTS, RULE_PREFIX } from '../schema/general';
+import { executionContext, isUserInPlatformOrganization, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
 import { buildEntityFilters, fullRelationsList, internalFindByIds, internalLoadById } from '../database/middleware-loader';
-import {getRule} from '../domain/rules';
-import {ENTITY_TYPE_INDICATOR} from '../modules/indicator/indicator-types';
-import {isStixCyberObservable} from '../schema/stixCyberObservable';
-import {generateIndicatorFromObservable} from '../domain/stixCyberObservable';
+import { getRule } from '../domain/rules';
+import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
+import { isStixCyberObservable } from '../schema/stixCyberObservable';
+import { generateIndicatorFromObservable } from '../domain/stixCyberObservable';
 import {
   ACTION_TYPE_ADD,
   ACTION_TYPE_ADD_GROUPS,
@@ -48,23 +47,23 @@ import {
   TASK_TYPE_QUERY,
   TASK_TYPE_RULE,
 } from '../domain/backgroundTask-common';
-import {schemaRelationsRefDefinition} from '../schema/schema-relationsRef';
-import {getDraftContext} from '../utils/draftContext';
-import {getBestBackgroundConnectorId, pushToWorkerForConnector} from '../database/rabbitmq';
-import {updateExpectationsNumber, updateProcessedTime} from '../domain/work';
-import {convertStoreToStix_2_1, convertTypeToStixType} from '../database/stix-2-1-converter';
-import {STIX_EXT_OCTI} from '../types/stix-2-1-extensions';
-import {RELATION_BASED_ON} from '../schema/stixCoreRelationship';
-import {extractValidObservablesFromIndicatorPattern} from '../utils/syntax';
-import {generateStandardId} from '../schema/identifier';
-import {isBasicRelationship} from '../schema/stixRelationship';
-import {isStixSightingRelationship} from '../schema/stixSightingRelationship';
-import {isStixDomainObjectContainer} from '../schema/stixDomainObject';
-import {ENTITY_TYPE_SETTINGS} from '../schema/internalObject';
-import {getEntityFromCache} from '../database/cache';
-import {objects as getContainerObjects} from '../domain/container';
-import {ruleApply} from './ruleManager';
-import {doYield} from '../utils/eventloop-utils';
+import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
+import { getDraftContext } from '../utils/draftContext';
+import { getBestBackgroundConnectorId, pushToWorkerForConnector } from '../database/rabbitmq';
+import { updateExpectationsNumber, updateProcessedTime } from '../domain/work';
+import { convertStoreToStix_2_1, convertTypeToStixType } from '../database/stix-2-1-converter';
+import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
+import { RELATION_BASED_ON } from '../schema/stixCoreRelationship';
+import { extractValidObservablesFromIndicatorPattern } from '../utils/syntax';
+import { generateStandardId } from '../schema/identifier';
+import { isBasicRelationship } from '../schema/stixRelationship';
+import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
+import { isStixDomainObjectContainer } from '../schema/stixDomainObject';
+import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
+import { getEntityFromCache } from '../database/cache';
+import { objects as getContainerObjects } from '../domain/container';
+import { ruleApply } from './ruleManager';
+import { doYield } from '../utils/eventloop-utils';
 
 // Task manager responsible to execute long manual tasks
 // Each API will start is task manager.
@@ -271,9 +270,9 @@ const buildBaseBundleElement = (element, additionalOCTIExtensions, standard_id) 
       [STIX_EXT_OCTI]: {
         id: element.internal_id,
         type: element.entity_type,
-        ...additionalOCTIExtensions
-      }
-    }
+        ...additionalOCTIExtensions,
+      },
+    },
   };
   // region Handle specific relationship attributes
   if (isStixSightingRelationship(element.entity_type)) {
@@ -528,7 +527,7 @@ const ruleApplyCallback = async (context, user, task, ruleId) => {
       const addObjectToBundle = async (input, isRel = false) => {
         const additionalExtensions = {
           opencti_operation: isRel ? 'inferred_rel' : 'inferred_entity',
-          opencti_inferred_input: JSON.stringify(input)
+          opencti_inferred_input: JSON.stringify(input),
         };
         const inferredEntityObject = buildBaseBundleElement(element, additionalExtensions, `${element.standard_id}_e_${inferredObjectsBundle.length}`);
         inferredObjectsBundle.push(inferredEntityObject);

--- a/opencti-platform/opencti-graphql/src/resolvers/inferredObject.ts
+++ b/opencti-platform/opencti-graphql/src/resolvers/inferredObject.ts
@@ -1,0 +1,11 @@
+import type { Resolvers } from '../generated/graphql';
+import { createInternalInferredEntity, createInternalInferredRelation } from '../domain/inferredObject';
+
+const inferredObjectResolvers: Resolvers = {
+  Mutation: {
+    inferredRelationAdd: (_, { jsonInput }, context) => createInternalInferredRelation(context, context.user, jsonInput),
+    inferredEntityAdd: (_, { jsonInput }, context) => createInternalInferredEntity(context, context.user, jsonInput),
+  },
+};
+
+export default inferredObjectResolvers;

--- a/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import * as jsonpatch from 'fast-json-patch';
 import * as R from 'ramda';
 import { createInferredRelation, deleteInferredRuleElement, generateUpdateMessage, stixLoadById } from '../database/middleware';
@@ -41,13 +40,13 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
     ];
   };
   type ArrayRefs = Array<{ partOfFromId: string; partOfId: string; partOfStandardId: StixId; partOfTargetId: string; partOfTargetStandardId: StixId }>;
-  // eslint-disable-next-line max-len
+
   const createObjectRefsInferences = async (
     context: AuthContext,
     data: StixReport,
     addedTargets: ArrayRefs,
     deletedTargets: Array<BasicStoreRelation>,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     if (addedTargets.length === 0 && deletedTargets.length === 0) {
       return;
@@ -125,7 +124,7 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
     report: StixReport,
     addedRefs: Array<string>,
     removedRefs: Array<string>,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     if (addedRefs.length > 0) {
       const identities = await internalFindByIds(context, RULE_MANAGER_USER, addedRefs) as Array<StoreObject>;
@@ -184,7 +183,7 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
   const handlePartOfRelationCreation = async (
     context: AuthContext,
     partOfRelation: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     let partOfTargetStandardId: StixId;
     const { id: partOfStandardId } = partOfRelation;
@@ -209,8 +208,8 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
   };
   const applyInsert = async (
     data: StixObject,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
-    // eslint-disable-next-line consistent-return
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
+
   ): Promise<void> => {
     const context = executionContext(ruleDefinition.name, RULE_MANAGER_USER);
     const entityType = generateInternalType(data);
@@ -260,7 +259,7 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyInsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
@@ -70,20 +70,12 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
         const ruleRelationContent = createRuleContent(id, dependencies, [reportId, partOfId], {});
         const inputForRelation = { fromId: reportId, toId: partOfId, relationship_type: RELATION_OBJECT };
         targetsToCreate.push({ i: inputForRelation, r: ruleRelationContent });
-        const inferredRelation = await createInferredRelationCallback(context, inputForRelation, ruleRelationContent, opts) as RelationCreation;
-        if (inferredRelation?.isCreation) {
-          createdTargets.push(inferredRelation.element[INPUT_DOMAIN_TO] as BasicStoreObject);
-        }
       }
       // -----------------------------------------------------------------------------------------------------------
       if (!reportObjectRefIds.includes(partOfTargetStandardId)) {
         const ruleIdentityContent = createRuleContent(id, dependencies, isSource ? [reportId, partOfTargetId] : [reportId, partOfFromId], {});
         const inputForIdentity = { fromId: reportId, toId: isSource ? partOfTargetId : partOfFromId, relationship_type: RELATION_OBJECT };
         targetsToCreate.push({ i: inputForIdentity, r: ruleIdentityContent });
-        const inferredTarget = await createInferredRelationCallback(context, inputForIdentity, ruleIdentityContent, opts) as RelationCreation;
-        if (inferredTarget?.isCreation) {
-          createdTargets.push(inferredTarget.element[INPUT_DOMAIN_TO] as BasicStoreObject);
-        }
       }
     }
     // endregion

--- a/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
@@ -79,18 +79,6 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
       }
     }
     // endregion
-    // region handle deletion
-    const deletedTargetRefs: Array<StoreObject> = [];
-    for (let indexDeletion = 0; indexDeletion < deletedTargets.length; indexDeletion += 1) {
-      const inferenceToDelete = deletedTargets[indexDeletion];
-      const isDeletion = await deleteInferredRuleElement(id, inferenceToDelete, [], opts);
-      if (isDeletion) {
-        // if delete really occurs (not simple upsert removing an explanation)
-        const deletedTarget = await internalLoadById(context, RULE_MANAGER_USER, inferenceToDelete.toId) as unknown as StoreObject;
-        deletedTargetRefs.push(deletedTarget);
-      }
-    }
-    // endregion
     // When current rule is called from taskManager, we need to generate an event on last inferred creation
     const isMiddlewareCreation = createInferredRelationCallback === createInferredRelation;
     for (let indexCreateTarget = 0; targetsToCreate.length; indexCreateTarget += 1) {
@@ -104,6 +92,18 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
         createdTargets.push(inferredTarget.element[INPUT_DOMAIN_TO] as BasicStoreObject);
       }
     }
+    // region handle deletion
+    const deletedTargetRefs: Array<StoreObject> = [];
+    for (let indexDeletion = 0; indexDeletion < deletedTargets.length; indexDeletion += 1) {
+      const inferenceToDelete = deletedTargets[indexDeletion];
+      const isDeletion = await deleteInferredRuleElement(id, inferenceToDelete, [], opts);
+      if (isDeletion) {
+        // if delete really occurs (not simple upsert removing an explanation)
+        const deletedTarget = await internalLoadById(context, RULE_MANAGER_USER, inferenceToDelete.toId) as unknown as StoreObject;
+        deletedTargetRefs.push(deletedTarget);
+      }
+    }
+    // endregion
     if (createdTargets.length > 0 || deletedTargetRefs.length > 0) {
       const updatedReport = structuredClone(report);
       const deletedTargetIds = deletedTargetRefs.map((d) => d.standard_id);

--- a/opencti-platform/opencti-graphql/src/rules/indicate-sighted/IndicateSightedRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/indicate-sighted/IndicateSightedRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import * as R from 'ramda';
 import def from './IndicateSightedDefinition';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
@@ -23,7 +22,7 @@ const indicateSightedRuleBuilder = (): RuleRuntime => {
   const applyFromStixRelation = async (
     context: AuthContext,
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     // **indicator A** `indicates` **Malware C**
     const createdId = data.extensions[STIX_EXT_OCTI].id;
@@ -67,7 +66,7 @@ const indicateSightedRuleBuilder = (): RuleRuntime => {
   const applyFromStixSighting = async (
     context: AuthContext,
     data: StixSighting,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     // **indicator A** `sighted` **identity/location B**
     const createdId = data.extensions[STIX_EXT_OCTI].id;
@@ -113,7 +112,7 @@ const indicateSightedRuleBuilder = (): RuleRuntime => {
   };
   const applyUpsert = async (
     data: StixRelation | StixSighting,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     if (data.extensions[STIX_EXT_OCTI].type === STIX_SIGHTING_RELATIONSHIP) {
@@ -130,7 +129,7 @@ const indicateSightedRuleBuilder = (): RuleRuntime => {
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/localization-of-targets/LocalizationOfTargetsRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/localization-of-targets/LocalizationOfTargetsRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { createInferredRelation, deleteInferredRuleElement } from '../../database/middleware';
 import { buildPeriodFromDates, computeRangeIntersection } from '../../utils/format';
 import { RELATION_TARGETS } from '../../schema/stixCoreRelationship';
@@ -17,7 +16,7 @@ const ruleLocalizationOfTargetsBuilder = () => {
   // Execution
   const applyUpsert = async (
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     const { extensions } = data;
@@ -57,7 +56,7 @@ const ruleLocalizationOfTargetsBuilder = () => {
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/observable-related/ObservableRelatedRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/observable-related/ObservableRelatedRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { createInferredRelation, deleteInferredRuleElement } from '../../database/middleware';
 import { buildPeriodFromDates, computeRangeIntersection } from '../../utils/format';
 import { RELATION_RELATED_TO } from '../../schema/stixCoreRelationship';
@@ -17,7 +16,7 @@ const ruleRelatedObservableBuilder = () => {
   // Execution
   const applyUpsert = async (
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     const { extensions } = data;
@@ -74,7 +73,7 @@ const ruleRelatedObservableBuilder = () => {
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/observed-sighting/ObserveSightingRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/observed-sighting/ObserveSightingRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { createInferredRelation, deleteInferredRuleElement, stixLoadById } from '../../database/middleware';
 import { RELATION_BASED_ON } from '../../schema/stixCoreRelationship';
 import def from './ObserveSightingDefinition';
@@ -48,7 +47,7 @@ const ruleObserveSightingBuilder = (): RuleRuntime => {
   const handleIndicatorUpsert = async (
     context: AuthContext,
     indicator: StixDomainObject,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const { id: indicatorId } = indicator.extensions[STIX_EXT_OCTI];
     const { object_marking_refs: indicatorMarkings } = indicator;
@@ -94,7 +93,7 @@ const ruleObserveSightingBuilder = (): RuleRuntime => {
   const handleObservedDataUpsert = async (
     context: AuthContext,
     observedData: StixObservedData,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const { created_by_ref: organizationId } = observedData;
     const { id: observedDataId } = observedData.extensions[STIX_EXT_OCTI];
@@ -141,7 +140,7 @@ const ruleObserveSightingBuilder = (): RuleRuntime => {
   const handleObservableRelationUpsert = async (
     context: AuthContext,
     baseOnRelation: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ) => {
     const { source_ref: indicatorId } = baseOnRelation.extensions[STIX_EXT_OCTI];
     const baseOnIndicator = (await stixLoadById(context, RULE_MANAGER_USER, indicatorId)) as unknown as StixIndicator;
@@ -151,7 +150,7 @@ const ruleObserveSightingBuilder = (): RuleRuntime => {
   };
   const applyUpsert = async (
     data: StixObject,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     const entityType = generateInternalType(data);
@@ -174,7 +173,7 @@ const ruleObserveSightingBuilder = (): RuleRuntime => {
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ): Promise<void> => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { buildPeriodFromDates, computeRangeIntersection } from '../utils/format';
 import { createInferredRelation, deleteInferredRuleElement } from '../database/middleware';
 import { createRuleContent } from './rules-utils';
@@ -17,7 +16,7 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
   // Execution
   const applyUpsert = async (
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(ruleDefinition.name, RULE_MANAGER_USER);
     const { extensions } = data;
@@ -96,7 +95,7 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
@@ -4,7 +4,7 @@ import { createInferredRelation, deleteInferredRuleElement } from '../database/m
 import { createRuleContent } from './rules-utils';
 import { computeAverage } from '../database/utils';
 import { fullRelationsList } from '../database/middleware-loader';
-import type { RelationTypes, RuleDefinition, RuleRuntime } from '../types/rules';
+import type { CreateInferredRelationCallbackFunction, RelationTypes, RuleDefinition, RuleRuntime } from '../types/rules';
 import type { BasicStoreRelation, StoreObject } from '../types/store';
 import type { StixRelation } from '../types/stix-2-1-sro';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
@@ -15,7 +15,10 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
   const { id } = ruleDefinition;
   const { leftType, rightType, creationType } = relationTypes;
   // Execution
-  const applyUpsert = async (data: StixRelation): Promise<void> => {
+  const applyUpsert = async (
+    data: StixRelation,
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+  ): Promise<void> => {
     const context = executionContext(ruleDefinition.name, RULE_MANAGER_USER);
     const { extensions } = data;
     const createdId = extensions[STIX_EXT_OCTI].id;
@@ -49,7 +52,7 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
             stop_time: range.end,
             objectMarking: elementMarkings,
           });
-          await createInferredRelation(context, input, ruleContent);
+          await createInferredRelationCallback(context, input, ruleContent);
         }
       };
       const listFromArgs = { toId: sourceRef, callback: listFromCallback };
@@ -79,7 +82,7 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
             stop_time: range.end,
             objectMarking: elementMarkings,
           });
-          await createInferredRelation(context, input, ruleContent);
+          await createInferredRelationCallback(context, input, ruleContent);
         }
       };
       const listToArgs = { fromId: targetRef, callback: listToCallback };
@@ -90,11 +93,15 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
   const clean = async (element: StoreObject, deletedDependencies: Array<string>): Promise<void> => {
     await deleteInferredRuleElement(id, element, deletedDependencies);
   };
-  const insert = async (element: StixRelation): Promise<void> => {
-    return applyUpsert(element);
+  const insert: RuleRuntime['insert'] = async (
+    element,
+    _createInferredEntityCallback,
+    createInferredRelationCallback
+  ) => {
+    return applyUpsert(element, createInferredRelationCallback);
   };
   const update = async (element: StixRelation): Promise<void> => {
-    return applyUpsert(element);
+    return applyUpsert(element, createInferredRelation);
   };
   return { ...ruleDefinition, insert, update, clean };
 };

--- a/opencti-platform/opencti-graphql/src/rules/relationWithRelationBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/relationWithRelationBuilder.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { createInferredRelation, deleteInferredRuleElement } from '../database/middleware';
 import { buildPeriodFromDates, computeRangeIntersection } from '../utils/format';
 import { createRuleContent } from './rules-utils';
@@ -18,7 +17,7 @@ const buildRelationWithRelationRule = (ruleDefinition: RuleDefinition, relationT
   // Execution
   const applyUpsert = async (
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(ruleDefinition.name, RULE_MANAGER_USER);
     const { extensions } = data;
@@ -67,7 +66,7 @@ const buildRelationWithRelationRule = (ruleDefinition: RuleDefinition, relationT
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/sighting-incident/SightingIncidentRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-incident/SightingIncidentRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { createInferredEntity, createInferredRelation, deleteInferredRuleElement, stixLoadById } from '../../database/middleware';
 import def from './SightingIncidentDefinition';
 import { ENTITY_TYPE_INCIDENT } from '../../schema/stixDomainObject';
@@ -39,7 +38,7 @@ const ruleSightingIncidentBuilder = () => {
     context: AuthContext,
     indicator: StixIndicator,
     createInferredEntityCallback: CreateInferredEntityCallbackFunction,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const { extensions } = indicator;
     const indicatorId = extensions[STIX_EXT_OCTI].id;
@@ -75,7 +74,7 @@ const ruleSightingIncidentBuilder = () => {
     context: AuthContext,
     sightingRelation: StixSighting,
     createInferredEntityCallback: CreateInferredEntityCallbackFunction,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ) => {
     const indicatorId = sightingRelation.extensions[STIX_EXT_OCTI].sighting_of_ref;
     const sightingIndicator = await stixLoadById(context, RULE_MANAGER_USER, indicatorId);
@@ -84,7 +83,7 @@ const ruleSightingIncidentBuilder = () => {
   const applyUpsert = async (
     data: StixIndicator | StixSighting,
     createInferredEntityCallback: CreateInferredEntityCallbackFunction,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     const entityType = generateInternalType(data);
@@ -102,7 +101,7 @@ const ruleSightingIncidentBuilder = () => {
   const insert: RuleRuntime['insert'] = async (
     element,
     createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredEntityCallback, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-indicator/SightingIndicatorRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import * as R from 'ramda';
 import def from './SightingIndicatorDefinition';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
@@ -28,7 +27,7 @@ const sightingIndicatorRuleBuilder = (): RuleRuntime => {
   const applyFromStixRelation = async (
     context: AuthContext,
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     // **indicator A** `based on` **observable C**
     const createdId = data.extensions[STIX_EXT_OCTI].id;
@@ -72,7 +71,7 @@ const sightingIndicatorRuleBuilder = (): RuleRuntime => {
   const applyFromStixSighting = async (
     context: AuthContext,
     data: StixSighting,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     // **indicator A** is `sighted` in **identity/location B**
     const createdId = data.extensions[STIX_EXT_OCTI].id;
@@ -116,7 +115,7 @@ const sightingIndicatorRuleBuilder = (): RuleRuntime => {
   };
   const applyUpsert = async (
     data: StixRelation | StixSighting,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     if (data.extensions[STIX_EXT_OCTI].type === STIX_SIGHTING_RELATIONSHIP) {
@@ -133,7 +132,7 @@ const sightingIndicatorRuleBuilder = (): RuleRuntime => {
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/rules/sighting-observable/SightingObservableRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/sighting-observable/SightingObservableRule.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import * as R from 'ramda';
 import def from './SightingObservableDefinition';
 import { STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
@@ -29,7 +28,7 @@ const sightingObservableRuleBuilder = (): RuleRuntime => {
   const applyFromStixRelation = async (
     context: AuthContext,
     data: StixRelation,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     // **indicator C** `based on` **observable A**
     const createdId = data.extensions[STIX_EXT_OCTI].id;
@@ -73,7 +72,7 @@ const sightingObservableRuleBuilder = (): RuleRuntime => {
   const applyFromStixSighting = async (
     context: AuthContext,
     data: StixSighting,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     // **observable A** is `sighted` in **identity/location B**
     const createdId = data.extensions[STIX_EXT_OCTI].id;
@@ -117,7 +116,7 @@ const sightingObservableRuleBuilder = (): RuleRuntime => {
   };
   const applyUpsert = async (
     data: StixRelation | StixSighting,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ): Promise<void> => {
     const context = executionContext(def.name, RULE_MANAGER_USER);
     if (data.extensions[STIX_EXT_OCTI].type === STIX_SIGHTING_RELATIONSHIP) {
@@ -134,7 +133,7 @@ const sightingObservableRuleBuilder = (): RuleRuntime => {
   const insert: RuleRuntime['insert'] = async (
     element,
     _createInferredEntityCallback,
-    createInferredRelationCallback
+    createInferredRelationCallback,
   ) => {
     return applyUpsert(element, createInferredRelationCallback);
   };

--- a/opencti-platform/opencti-graphql/src/types/rules.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/rules.d.ts
@@ -61,7 +61,7 @@ interface RuleRuntime extends RuleDefinition {
   insert: (
     element: StixEntities | StixRelation,
     createInferredEntityCallback: CreateInferredEntityCallbackFunction,
-    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction,
   ) => Promise<void>;
   update: (element: StixEntities | StixRelation, event: UpdateEvent) => Promise<void>;
   clean: (element: StoreObject, deletedDependencies: Array<string>) => Promise<void>;

--- a/opencti-platform/opencti-graphql/src/types/rules.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/rules.d.ts
@@ -2,6 +2,7 @@ import type { StixEntities } from './general';
 import type { StixRelation } from './stix-2-1-sro';
 import type { StoreObject } from './store';
 import type { UpdateEvent } from './event';
+import type { AuthContext } from './user';
 
 interface RuleFilters {
   types: Array<string>;
@@ -52,9 +53,16 @@ interface RuleDefinition {
   scopes: Array<RuleScope>;
 }
 
+type CreateInferredRelationCallbackFunction = (context: AuthContext, input: any, ruleContent: any, opts?: any | undefined) => Promise<any>;
+type CreateInferredEntityCallbackFunction = (context: AuthContext, input: any, ruleContent: any, type: string) => Promise<any>;
+
 interface RuleRuntime extends RuleDefinition {
   activated?: boolean;
-  insert: (element: StixEntities | StixRelation) => Promise<void>;
+  insert: (
+    element: StixEntities | StixRelation,
+    createInferredEntityCallback: CreateInferredEntityCallbackFunction,
+    createInferredRelationCallback: CreateInferredRelationCallbackFunction
+  ) => Promise<void>;
   update: (element: StixEntities | StixRelation, event: UpdateEvent) => Promise<void>;
   clean: (element: StoreObject, deletedDependencies: Array<string>) => Promise<void>;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* now send inferred creation operation to worker instead of rule apply

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fix #11626 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
