### PR TITLE
[frontend] Fix workspace duplication dialog closing unexpectedly on internal clicks (#11010)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -24,7 +24,7 @@ interface WorkspaceDuplicationDialogProps {
   workspace: Dashboard_workspace$data | InvestigationGraph_fragment$data;
   displayDuplicate: boolean;
   duplicating: boolean;
-  handleCloseDuplicate: (event: UIEvent) => void;
+  handleCloseDuplicate: () => void;
   setDuplicating: (value: boolean) => void;
   updater?: (
     store: RecordSourceSelectorProxy<WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation$data>,
@@ -86,7 +86,7 @@ WorkspaceDuplicationDialogProps
         handleError(error);
       },
       onCompleted: (data) => {
-        handleCloseDuplicate(e);
+        handleCloseDuplicate();
         const isDashboardView = !paginationOptions;
         if (isDashboardView) {
           MESSAGING$.notifySuccess(
@@ -113,7 +113,12 @@ WorkspaceDuplicationDialogProps
   return (
     <Dialog
       open={displayDuplicate}
-      slotProps={{ paper: { elevation: 1 } }}
+      slotProps={{
+        paper: {
+          elevation: 1,
+          onClick: (e: React.MouseEvent) => stopEvent(e),
+        },
+      }}
       slots={{ transition: Transition }}
       onClose={handleCloseDuplicate}
       fullWidth={true}
@@ -139,7 +144,7 @@ WorkspaceDuplicationDialogProps
         />
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCloseDuplicate}>{t_i18n('Cancel')}</Button>
+        <Button onClick={() => handleCloseDuplicate()}>{t_i18n('Cancel')}</Button>
         <Button
           color="secondary"
           onClick={(e) => handleSubmitDuplicate(e, newName)}


### PR DESCRIPTION
### Proposed changes

* Fixed dialog closing unexpectedly when clicking inside the workspace duplication popup
* Updated event handling to properly manage dialog closure behavior while maintaining backdrop click functionality
* Prevented event propagation from dialog content to avoid unintended closures

### Related issues

* Fixes issue where the workspace duplication dialog would close when clicking inside the dialog content (title, text field, etc.)
* Preserves the expected behavior of closing the dialog when clicking on the backdrop
* #11010 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The issue was caused by improper event handling in the MUI Dialog component. Click events inside the dialog were bubbling up and triggering the dialog's close mechanism.

**Solution implemented:**
- Modified the `handleCloseDuplicate` function signature to remove the UIEvent parameter as it wasn't compatible with MUI's onClose callback
- Updated the Dialog's `onClose` handler to properly handle both backdrop clicks and escape key events
- Added `stopPropagation()` on the Paper component through `slotProps` to prevent click events inside the dialog from bubbling up
