### PR TITLE
[frontend] prevent backdrop interaction when filter popover is open (#11594)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -401,6 +401,22 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
           onChange={(event) => handleChangeOperator(event, finalFilterDefinition)}
           style={{ marginBottom: 15 }}
           disabled={disabled}
+          MenuProps={{
+            // Force MUI to use a backdrop
+            hideBackdrop: false,
+            BackdropProps: {
+              style: {
+                // Make the backdrop invisible because we already have one
+                backgroundColor: 'rgba(0, 0, 0, 0)',
+              },
+              // Prevent clicks from going through
+              onClick: (e) => {
+                stopEvent(e);
+                handleClose();
+              },
+              onMouseDown: stopEvent,
+            },
+          }}
         >
           {availableOperators.map((value) => (
             <MenuItem key={value} value={value}>

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -37,6 +37,7 @@ import QuickRelativeDateFiltersButtons from './QuickRelativeDateFiltersButtons';
 import DateRangeFilter from './DateRangeFilter';
 // eslint-disable-next-line import/no-cycle
 import FilterFiltersInput from './FilterFiltersInput';
+import stopEvent from '../../utils/domEvent';
 
 interface FilterChipMenuProps {
   handleClose: () => void;
@@ -296,10 +297,14 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
           const actualFilterValues = subKey ? filterValues.filter((fVal) => fVal && fVal.key === subKey).at(0)?.values ?? [] : filterValues;
           const checked = actualFilterValues.includes(option.value);
           const disabledOptions = disabled && checked && actualFilterValues.length === 1;
+
+          // Extract key from props to avoid React warning
+          const { key, ...otherProps } = props;
+
           return (
-            <Tooltip title={option.label} key={option.label} followCursor>
+            <Tooltip title={option.label} key={key || option.value} followCursor>
               <li
-                {...props}
+                {...otherProps}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     e.stopPropagation();
@@ -416,15 +421,15 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
   let disableSubfilter1 = false;
   let disableSubfilter2 = false;
   if (filterDefinition?.subFilters
-      && filterDefinition.subFilters.length > 1
-      && filterDefinition?.subFilters[1].filterKey === 'dynamic'
-      && filter?.values.filter((f) => f.key === 'relationship_type').length === 0
+    && filterDefinition.subFilters.length > 1
+    && filterDefinition?.subFilters[1].filterKey === 'dynamic'
+    && filter?.values.filter((f) => f.key === 'relationship_type').length === 0
   ) {
     disableSubfilter2 = true;
   } else if (filterDefinition?.subFilters
-      && filterDefinition.subFilters.length > 1
-      && filterDefinition?.subFilters[1].filterKey === 'dynamic'
-      && (filter?.values.filter((f) => f.key === 'dynamic')?.length ?? 0) > 0) {
+    && filterDefinition.subFilters.length > 1
+    && filterDefinition?.subFilters[1].filterKey === 'dynamic'
+    && (filter?.values.filter((f) => f.key === 'dynamic')?.length ?? 0) > 0) {
     disableSubfilter1 = true;
   }
   return (
@@ -436,7 +441,26 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
         vertical: 'bottom',
         horizontal: 'left',
       }}
-      slotProps={{ paper: { elevation: 1, style: { marginTop: 10 } } }}
+      // Force MUI to use a backdrop
+      hideBackdrop={false}
+      slotProps={{
+        paper: {
+          elevation: 1,
+          style: { marginTop: 10 },
+        },
+        backdrop: {
+          style: {
+            // Make the backdrop invisible because we already have one
+            backgroundColor: 'rgba(0, 0, 0, 0)',
+          },
+          // Prevent clicks from going through
+          onClick: (e) => {
+            stopEvent(e);
+            handleClose();
+          },
+          onMouseDown: stopEvent,
+        },
+      }}
     >
       {filterDefinition?.subFilters && filterDefinition.subFilters.length > 1
         ? <div


### PR DESCRIPTION
### Proposed changes

* Fixed backdrop interaction issue in FilterChipPopover component where users could interact with elements behind the popup when the filter selection popup was open
* Resolved React warning about keys being passed through spread props in Autocomplete's renderOption

### Related issues

* #11594
* Fixes issue where focusing on the Autocomplete input field within the filter popup did not prevent interaction with backdrop elements
* Addresses nested popup behavior when FilterChipPopover is opened from within another modal/dialog

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The main issue was that the FilterChipPopover component, when opened from within another popup (nested popups scenario), was not properly blocking interactions with the backdrop. This allowed users to interact with elements behind the popup when clicking outside of it, particularly when the Autocomplete component was focused.

**Solution implemented:**
- Modified the Popover component to explicitly handle backdrop behavior using `hideBackdrop={false}` and custom backdrop props
- Added proper event handlers (`onClick` and `onMouseDown`) to the backdrop to prevent event propagation while maintaining the ability to close the popup
- Fixed a secondary issue where React keys were being passed through spread props in the Autocomplete's renderOption, which was causing React warnings
