### PR TITLE
[frontend] feat(filters): add keyboard navigation support for filter autocomplete (#8430)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/BasicFilterInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/BasicFilterInput.tsx
@@ -9,6 +9,7 @@ interface BasicFilterInputProps {
   filterValues: string[];
   label: string;
   type?: string;
+  handleClose?: () => void;
 }
 
 const BasicFilterInput: FunctionComponent<BasicFilterInputProps> = ({
@@ -18,6 +19,7 @@ const BasicFilterInput: FunctionComponent<BasicFilterInputProps> = ({
   filterValues,
   label,
   type,
+  handleClose,
 }) => {
   return (
     <TextField
@@ -31,10 +33,15 @@ const BasicFilterInput: FunctionComponent<BasicFilterInputProps> = ({
       autoFocus={true}
       onKeyDown={(event) => {
         if (event.key === 'Enter') {
+          event.preventDefault();
+          event.stopPropagation();
           helpers?.handleAddSingleValueFilter(
             filter?.id ?? '',
             (event.target as HTMLInputElement).value,
           );
+          setTimeout(() => {
+            handleClose?.();
+          }, 0);
         }
       }}
       onBlur={(event) => {

--- a/opencti-platform/opencti-front/src/components/filters/FilterAutocompleteSimple.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterAutocompleteSimple.tsx
@@ -1,0 +1,177 @@
+import React, { FunctionComponent, useState, useEffect, useRef } from 'react';
+import { Autocomplete, TextField, Chip, Box, Checkbox, Tooltip } from '@mui/material';
+import { FilterOptionValue } from '@components/common/lists/FilterAutocomplete';
+import ItemIcon from '../ItemIcon';
+import { useFormatter } from '../i18n';
+
+interface FilterAutocompleteSimpleProps {
+  fLabel?: string;
+  selectedOptions: FilterOptionValue[];
+  options: FilterOptionValue[];
+  handleChange: (checked: boolean, value: string | null, childKey?: string) => void;
+  searchEntities: (event: React.SyntheticEvent) => void;
+  renderSearchScope?: React.ReactNode;
+  groupBy: (option: FilterOptionValue) => string;
+  subKey?: string;
+  disabled?: boolean;
+}
+
+const FilterAutocompleteSimple: FunctionComponent<FilterAutocompleteSimpleProps> = ({
+  fLabel,
+  selectedOptions,
+  options,
+  handleChange,
+  searchEntities,
+  renderSearchScope,
+  groupBy,
+  subKey,
+  disabled = false,
+}) => {
+  const { t_i18n } = useFormatter();
+  const [inputValue, setInputValue] = useState('');
+  const lastReasonRef = useRef<string>('');
+
+  useEffect(() => {
+    if (lastReasonRef.current === 'input' && inputValue) {
+      const timer = setTimeout(() => {
+        setInputValue(inputValue);
+      }, 0);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [inputValue]);
+
+  return (
+    <Autocomplete
+      multiple
+      value={selectedOptions}
+      options={options}
+      inputValue={inputValue}
+      getOptionLabel={(option) => option.label ?? ''}
+      noOptionsText={t_i18n('No available options')}
+      disableCloseOnSelect
+      groupBy={groupBy}
+      freeSolo={false}
+      autoHighlight
+      onChange={(event, newValue, reason) => {
+        if (reason === 'clear') {
+          selectedOptions.forEach((option) => {
+            handleChange(false, option.value, subKey);
+          });
+          setInputValue('');
+          return;
+        }
+
+        if (reason === 'selectOption') {
+          setInputValue('');
+        }
+
+        const currentValues = selectedOptions.map((o) => o.value);
+        const newValues = newValue.map((o) => o.value);
+
+        currentValues.forEach((value) => {
+          if (!newValues.includes(value)) {
+            handleChange(false, value, subKey);
+          }
+        });
+
+        newValues.forEach((value) => {
+          if (!currentValues.includes(value)) {
+            handleChange(true, value, subKey);
+          }
+        });
+      }}
+      onInputChange={(event, newInputValue, reason) => {
+        lastReasonRef.current = reason;
+
+        if (reason === 'input') {
+          setInputValue(newInputValue);
+          if (event && event.type !== 'click') {
+            searchEntities(event);
+          }
+        } else if (reason === 'reset') {
+          if (newInputValue === '' && inputValue !== '') {
+            const currentValue = inputValue;
+            setTimeout(() => {
+              setInputValue(currentValue);
+            }, 0);
+            return;
+          }
+          setInputValue(newInputValue);
+        } else if (reason === 'clear') {
+          setInputValue('');
+        }
+      }}
+      isOptionEqualToValue={(option, value) => option.value === value.value}
+      renderTags={(tagValue, getTagProps) => (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {tagValue.map((option, index) => {
+            const { key, ...chipProps } = getTagProps({ index });
+            return (
+              <Chip
+                key={key}
+                label={option.label}
+                {...chipProps}
+                size="small"
+              />
+            );
+          })}
+        </Box>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={t_i18n(fLabel)}
+          variant="outlined"
+          size="small"
+          fullWidth
+          autoFocus
+          onFocus={searchEntities}
+          inputProps={{
+            ...params.inputProps,
+          }}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {renderSearchScope}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+      renderOption={(props, option) => {
+        const checked = selectedOptions.some((o) => o.value === option.value);
+        const disabledOption = disabled && checked && selectedOptions.length === 1;
+        const { key, ...otherProps } = props;
+        const tooltipKey = [key, option.value, option.type, option.group].filter(Boolean).join('-');
+        return (
+          <Tooltip title={option.label} key={tooltipKey} followCursor>
+            <li
+              {...otherProps}
+              style={{
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                padding: 0,
+                margin: 0,
+              }}
+            >
+              <Checkbox
+                checked={checked}
+                disabled={disabledOption}
+              />
+              <ItemIcon type={option.type} color={option.color} />
+              <span style={{ padding: '0 4px 0 4px' }}>
+                {option.label}
+              </span>
+            </li>
+          </Tooltip>
+        );
+      }}
+    />
+  );
+};
+
+export default FilterAutocompleteSimple;

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -262,17 +262,20 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     // State to track the input value and highlighted option
     const [inputValue, setInputValue] = useState('');
     const [highlightedOption, setHighlightedOption] = useState<FilterOptionValue | null>(null);
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
     return (
       <Autocomplete
         multiple
         key={fKey}
-        value={selectedOptions} // Ajouter cette ligne
+        value={selectedOptions}
         getOptionLabel={(option) => option.label ?? ''}
         noOptionsText={t_i18n('No available options')}
         options={options}
         inputValue={inputValue}
         groupBy={(option) => groupByEntities(option, fLabel)}
+        onOpen={() => setIsDropdownOpen(true)}
+        onClose={() => setIsDropdownOpen(false)}
         onInputChange={(event, newInputValue, reason) => {
           // Update input value state
           setInputValue(newInputValue);
@@ -290,12 +293,11 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
           if (event.key === 'Enter' && event.ctrlKey === false && event.shiftKey === false) {
             stopEvent(event);
 
-            if (inputValue.trim() === '') {
+            if (!isDropdownOpen) {
               handleClose();
               return;
             }
 
-            // If there's a highlighted option, select/deselect it
             if (highlightedOption) {
               const actualFilterValues = subKey
                 ? filterValues.filter((fVal) => fVal && fVal.key === subKey).at(0)?.values ?? []
@@ -343,8 +345,10 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
           // Extract key from props to avoid React warning
           const { key, ...otherProps } = props;
 
+          // Create a unique key combining multiple properties to avoid duplicates
+          const tooltipKey = [key, option.value, option.type, option.group].filter(Boolean).join('-');
           return (
-            <Tooltip title={option.label} key={key || option.value} followCursor>
+            <Tooltip title={option.label} key={tooltipKey} followCursor>
               <li
                 {...otherProps}
                 onKeyDown={(e) => {

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -184,7 +184,10 @@ const ListFilters = ({
                 required={required}
               />
             )}
-            renderOption={(props, option) => <li {...props}>{option.label}</li>}
+            renderOption={(props, option) => {
+              const { key, ...otherProps } = props;
+              return <li key={key} {...otherProps}>{option.label}</li>;
+            }}
           />
           {isDatatable && variant === 'default' && (
             <SavedFilters


### PR DESCRIPTION
### Proposed changes

* Add keyboard navigation support for filter autocomplete component
* Enable Enter key to validate current highlighted option in autocomplete dropdown
* Allow closing the filter popup by pressing Enter when autocomplete options list is closed
* Improve user experience by reducing the need to use mouse for filter selection

### Related issues

* Closes #8430

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This PR enhances the keyboard accessibility of the filter autocomplete component. The main improvements are:

1. **Enter key validation**: Users can now press Enter to select/deselect the currently highlighted option while navigating with arrow keys
2. **Quick popup closing**: Pressing Enter with an empty input field now closes the filter popup, providing a quick way to exit
3. **State management**: Added state tracking for input value and highlighted option to enable proper keyboard interaction

The solution maintains backward compatibility with existing mouse interactions while adding keyboard shortcuts that follow common UI patterns. 