### PR TITLE
[frontend] fix matrix export in image for domain objects (#11518)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
@@ -419,10 +419,11 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
               )}
             </>
           )}
-          {displayButtons && (<div style={{ float: 'right', margin: 0 }}>
-            <ToggleButtonGroup size="small" color="secondary" exclusive={true}>
-              {[...viewButtons]}
-              {typeof handleToggleExports === 'function' && (
+          {displayButtons
+            && (<div style={{ float: 'right', margin: 0 }} id="container-view-buttons">
+              <ToggleButtonGroup size="small" color="secondary" exclusive={true}>
+                {[...viewButtons]}
+                {typeof handleToggleExports === 'function' && (
                 <Tooltip
                   key="export"
                   title={
@@ -444,23 +445,23 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
                     />
                   </ToggleButton>
                 </Tooltip>
-              )}
-            </ToggleButtonGroup>
+                )}
+              </ToggleButtonGroup>
 
-            <div
-              style={{
-                float: 'right',
-                margin: '0 0 0 20px',
-              }}
-            >
-              <ExportButtons
-                domElementId="container"
-                name={t_i18n('Attack patterns kill chain')}
-                csvData={csvData}
-                csvFileName={`${t_i18n('Attack pattern courses of action')}.csv`}
-              />
-            </div>
-          </div>)}
+              <div
+                style={{
+                  float: 'right',
+                  margin: '0 0 0 20px',
+                }}
+              >
+                <ExportButtons
+                  domElementId="container"
+                  name={t_i18n('Attack patterns kill chain')}
+                  csvData={csvData}
+                  csvFileName={`${t_i18n('Attack pattern courses of action')}.csv`}
+                />
+              </div>
+            </div>)}
           <div className="clearfix"/>
         </div>
       )}


### PR DESCRIPTION
### Proposed changes
When in an attack pattern matrix of a stix domain object, export the matrix in image should generate the image instead of keeping loading

### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/11518#issuecomment-3083173551