### PR TITLE
[backend] dynamic regardingOf filter default local mode after key conversion

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -2870,7 +2870,8 @@ const completeSpecialFilterKeys = async (context, user, inputFilters) => {
         }
         const types = type?.values;
         if (isEmptyField(ids)) {
-          const keys = isEmptyField(types) ? buildRefRelationKey('*', '*')
+          const keys = isEmptyField(types)
+            ? buildRefRelationKey('*', '*')
             : types.map((t) => buildRefRelationKey(t, '*'));
           keys.forEach((relKey) => {
             regardingFilters.push({ key: [relKey], operator, values: ['EXISTS'] });
@@ -2881,7 +2882,7 @@ const completeSpecialFilterKeys = async (context, user, inputFilters) => {
           regardingFilters.push({ key: keys, operator, values: ids });
         }
         finalFilterGroups.push({
-          mode: filter.mode,
+          mode: filter.mode ?? FilterMode.Or,
           filters: regardingFilters,
           filterGroups: []
         });


### PR DESCRIPTION
Default local mode between regarding of filter should be OR in special key conversion in engine.js
It prevents errors if the local mode is not specified in the dynamicRegardingOf filter