### PR TITLE
[worker] Worker performance increase (#11889)

### DIFF
--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import json
+import threading
 from dataclasses import dataclass
 from typing import Any, Dict, Union, Literal
 
@@ -29,13 +30,19 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
     objects_max_refs: int
 
     def __post_init__(self) -> None:
-        self.api = OpenCTIApiClient(
-            url=self.opencti_url,
-            token=self.opencti_token,
-            log_level=self.log_level,
-            json_logging=self.json_logging,
-            ssl_verify=self.ssl_verify,
+        self.local_api = threading.local()
+
+    # OpenCTIClient is not thread safe, use a thread local to ensure to work on a dedicated client when creating and sending a request
+    def get_api_client(self) -> OpenCTIApiClient:
+        if not hasattr(self.local_api, "client"):
+            self.local_api.client = OpenCTIApiClient(
+                url=self.opencti_url,
+                token=self.opencti_token,
+                log_level=self.log_level,
+                json_logging=self.json_logging,
+                ssl_verify=self.ssl_verify,
         )
+        return self.local_api.client
 
     def send_bundle_to_specific_queue(
         self,
@@ -76,17 +83,18 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
         imported_items = []
         start_processing = datetime.datetime.now()
         try:
+            api = self.get_api_client()
             # Set the API headers
-            self.api.set_applicant_id_header(data.get("applicant_id"))
-            self.api.set_playbook_id_header(data.get("playbook_id"))
-            self.api.set_event_id(data.get("event_id"))
-            self.api.set_draft_id(data.get("draft_id"))
-            self.api.set_synchronized_upsert_header(data.get("synchronized", False))
-            self.api.set_previous_standard_header(data.get("previous_standard"))
+            api.set_applicant_id_header(data.get("applicant_id"))
+            api.set_playbook_id_header(data.get("playbook_id"))
+            api.set_event_id(data.get("event_id"))
+            api.set_draft_id(data.get("draft_id"))
+            api.set_synchronized_upsert_header(data.get("synchronized", False))
+            api.set_previous_standard_header(data.get("previous_standard"))
             work_id = data.get("work_id")
             # Check if work is still valid
             if work_id is not None:
-                is_work_alive = self.api.work.get_is_work_alive(work_id)
+                is_work_alive = api.work.get_is_work_alive(work_id)
                 # If work no longer exists, bundle can be acked without doing anything
                 if not is_work_alive:
                     return "ack"
@@ -107,7 +115,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                 if len(content["objects"]) == 1 or data.get("no_split", False):
                     update = data.get("update", False)
                     imported_items, too_large_items_bundles = (
-                        self.api.stix2.import_bundle_from_json(
+                        api.stix2.import_bundle_from_json(
                             raw_content, update, types, work_id, self.objects_max_refs
                         )
                     )
@@ -159,7 +167,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                             )
                             # Add expectations to the work
                             if work_id is not None:
-                                self.api.work.add_expectations(work_id, expectations)
+                                api.work.add_expectations(work_id, expectations)
                             # For each split bundle, send it to the same queue
                             for bundle in bundles:
                                 self.send_bundle_to_specific_queue(
@@ -179,7 +187,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                             "type": "bundle",
                             "objects": [content["data"]],
                         }
-                        imported_items = self.api.stix2.import_bundle(
+                        imported_items = api.stix2.import_bundle(
                             bundle, True, types, work_id
                         )
                     # Specific knowledge merge
@@ -200,7 +208,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                             "type": "bundle",
                             "objects": [merge_object],
                         }
-                        imported_items = self.api.stix2.import_bundle(
+                        imported_items = api.stix2.import_bundle(
                             bundle, True, types, work_id
                         )
                     # All standard operations
@@ -223,7 +231,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                             "type": "bundle",
                             "objects": [data_object],
                         }
-                        imported_items = self.api.stix2.import_bundle(
+                        imported_items = api.stix2.import_bundle(
                             bundle, True, types, work_id
                         )
                     case _:

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -146,6 +146,14 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             True,
             0,
         )
+        self.worker_queue_concurrency_enabled = get_config_variable(
+            "WORKER_QUEUE_CONCURRENCY_ENABLED",
+            ["worker", "queue_concurrency_enabled"],
+            config,
+            False,
+            False,
+        )
+
         # Telemetry
         if self.telemetry_enabled:
             self.prom_httpd, self.prom_t = start_http_server(
@@ -257,6 +265,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             pika_parameters,
                             push_execution_pool,
                             push_handler.handle_message,
+                            self.worker_queue_concurrency_enabled,
                         )
 
                     # Listen for webhook message
@@ -281,6 +290,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                                 self.build_pika_parameters(connector_config),
                                 listen_execution_pool,
                                 listen_handler.handle_message,
+                                self.worker_queue_concurrency_enabled,
                             )
 
                 # Check if some consumer must be stopped


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Align AMQP prefetch with requested worker thread pool size
* Removed busy polling for thread termination. Instead, the above [AMQP prefetch limits](https://www.rabbitmq.com/docs/consumer-prefetch) will limit the throughput.

Those two changes does allow having better utilization of resources, limiting the need of running multiple worker processes.

Remaining ideas to implement in another PR:

* [Raise pycti Requests module maximum connections, to allow more than 10 connections in parallel](https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter)
* Finer prefetch adjustment for additional performance

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #4936
* https://github.com/OpenCTI-Platform/opencti/issues/11889

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

This PR may increase the load on the OpenCTI API and backends, up to 5 times on single RabbitMQ active queue workloads (Only one queue has messages), down to ~5-10% on systems with more than 5 active queues

Fixes #11889