### PR TITLE
[frontend](feat) Use tabbed view for composer log (#7328)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "Keine Importverbindungen auf dieser Plattform",
   "No import works for this file": "Für diese Datei funktioniert kein Import",
   "No label": "Kein Label",
+  "No logs available": "Keine Protokolle verfügbar",
   "No Malware analysis on this observable.": "Keine Malware-Analyse zu dieser Beobachtungseinheit.",
   "No malware analysis on this observable.": "Keine Malware-Analyse für diese Beobachtungsgröße.",
   "No mapping": "Kein Mapping",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "No import connectors on this platform",
   "No import works for this file": "No import works for this file",
   "No label": "No label",
+  "No logs available": "No logs available",
   "No Malware analysis on this observable.": "No Malware analysis on this observable.",
   "No malware analysis on this observable.": "No malware analysis on this observable.",
   "No mapping": "No mapping",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "Ningún conector de importación en esta plataforma",
   "No import works for this file": "No funciona la importación de este archivo",
   "No label": "Sin etiquetas",
+  "No logs available": "No hay registros disponibles",
   "No Malware analysis on this observable.": "Ningún análisis de malware sobre esta observable.",
   "No malware analysis on this observable.": "No hay análisis de malware en este observable.",
   "No mapping": "Sin mapeo",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "Aucun connecteur d'import sur cette plateforme",
   "No import works for this file": "Pas d'executions d'import pour ce fichier",
   "No label": "Aucun label",
+  "No logs available": "Aucun journal disponible",
   "No Malware analysis on this observable.": "Aucune analyse de code malveillant sur cet observable.",
   "No malware analysis on this observable.": "Pas d'analyse de logiciels malveillants sur cet observable.",
   "No mapping": "Aucune correspondance",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "Nessun connettore di importazione su questa piattaforma",
   "No import works for this file": "Nessuna importazione funziona per questo file",
   "No label": "Nessuna etichetta",
+  "No logs available": "Nessun registro disponibile",
   "No Malware analysis on this observable.": "Nessuna analisi del malware su questo osservabile.",
   "No malware analysis on this observable.": "Nessuna analisi del malware su questo osservabile.",
   "No mapping": "Nessuna mappatura",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "有効なインポート用コネクタがありません",
   "No import works for this file": "このファイルはインポートできません",
   "No label": "ラベルなし",
+  "No logs available": "過去ログなし",
   "No Malware analysis on this observable.": "この観測点では、マルウェアの解析は行われていません。",
   "No malware analysis on this observable.": "この観測値に関するマルウェア解析はありません。",
   "No mapping": "マッピングなし",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "이 플랫폼에서 가져오기 커넥터가 없습니다",
   "No import works for this file": "이 파일에는 가져오기가 작동하지 않습니다",
   "No label": "라벨 없음",
+  "No logs available": "사용 가능한 로그 없음",
   "No Malware analysis on this observable.": "이 관찰 가능 항목에 대한 악성 소프트웨어 분석 없음.",
   "No malware analysis on this observable.": "이 관찰 가능 항목에 대한 악성 소프트웨어 분석 없음.",
   "No mapping": "매핑 없음",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "На этой платформе нет коннекторов для импорта",
   "No import works for this file": "Импорт не работает для этого файла",
   "No label": "Без этикетки",
+  "No logs available": "Журналы отсутствуют",
   "No Malware analysis on this observable.": "Анализ вредоносного ПО на этом наблюдаемом объекте не проводился.",
   "No malware analysis on this observable.": "Анализ вредоносных программ для этого объекта наблюдения не проводился.",
   "No mapping": "Нет отображения",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2367,6 +2367,7 @@
   "No import connectors on this platform": "此平台没有导入连接器",
   "No import works for this file": "该文件无法导入",
   "No label": "无标签",
+  "No logs available": "没有日志",
   "No Malware analysis on this observable.": "没有对这个可观察到的恶意软件进行分析。",
   "No malware analysis on this observable.": "未对该观测值进行恶意软件分析。",
   "No mapping": "无映射",

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -26,6 +26,8 @@ import UpdateIcon from '@mui/icons-material/Update';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import DialogTitle from '@mui/material/DialogTitle';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
 import ManagedConnectorEdition from './ManagedConnectorEdition';
 import DangerZoneBlock from '../../common/danger_zone/DangerZoneBlock';
 import Filters from '../../common/lists/Filters';
@@ -148,6 +150,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
   const [displayClearWorks, setDisplayClearWorks] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [editionOpen, setEditionOpen] = useState(false);
+  const [tabValue, setTabValue] = useState(0);
 
   // API mutations - defined early to avoid use-before-define errors
   const [commitUpdateStatus] = useApiMutation<ConnectorUpdateStatusMutation>(updateRequestedStatus);
@@ -288,152 +291,14 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
 
   const computeConnectorStatus = useComputeConnectorStatus();
 
-  return (
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setTabValue(newValue);
+  };
+
+  // Component for Overview content
+  const ConnectorOverview = () => (
     <>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          width: '100%',
-          marginBottom: theme.spacing(2),
-        }}
-      >
-        <Typography
-          variant="h1"
-          gutterBottom={true}
-          style={{
-            textTransform: 'uppercase',
-            alignItems: 'center',
-            display: 'flex',
-            gap: theme.spacing(1),
-            margin: 0,
-          }}
-        >
-          {connector.name}
-          <div style={{ display: 'inline-block' }}>
-            {computeConnectorStatus(connector).render}
-          </div>
-          {connector.is_managed && (
-            <div>
-              <Button
-                variant="outlined"
-                size="small"
-                disabled={computeConnectorStatus(connector).processing}
-                color={connector.manager_current_status === 'started' ? 'error' : 'primary'}
-                onClick={() => commitUpdateStatus({
-                  variables: {
-                    input: {
-                      id: connector.id,
-                      status: connector.manager_current_status === 'started' ? 'stopping' : 'starting',
-                    },
-                  },
-                })}
-              >
-                {t_i18n(connector.manager_current_status === 'started' ? 'Stop' : 'Start')}
-              </Button>
-            </div>
-          )}
-        </Typography>
-        <div style={{
-          float: 'right',
-          display: 'flex',
-          alignItems: 'center',
-          gap: theme.spacing(1),
-        }}
-        >
-          <Security needs={[MODULES_MODMANAGE]}>
-            <>
-              {isSensitive && (
-                <div style={{ position: 'relative', display: 'inline-block' }}>
-                  <DangerZoneBlock
-                    type="connector_reset"
-                    sx={{
-                      root: { border: 'none', padding: 0, margin: 0 },
-                      title: { position: 'absolute', zIndex: 1, left: 4, top: 9, fontSize: 8 },
-                    }}
-                  >
-                    {({ disabled = false }: { disabled?: boolean }) => (
-                      <Button
-                        color="error"
-                        variant="outlined"
-                        disabled={disabled || !!connector.built_in}
-                        onClick={handleOpenResetState}
-                        style={{
-                          minWidth: '6rem',
-                        }}
-                      >
-                        <span style={{ zIndex: 2 }}>
-                          {t_i18n('Reset')}
-                        </span>
-                      </Button>
-                    )}
-                  </DangerZoneBlock>
-                </div>
-              )}
-              <ToggleButtonGroup
-                size="small"
-              >
-                {!isSensitive && (
-                  <Tooltip title={t_i18n('Reset the connector state')}>
-                    <span>
-                      <ToggleButton
-                        onClick={handleOpenResetState}
-                        aria-haspopup="true"
-                        disabled={!!connector.built_in}
-                        value={t_i18n('Reset')}
-                      >
-                        <PlaylistRemoveOutlined
-                          color="primary"
-                        />
-                      </ToggleButton>
-                    </span>
-                  </Tooltip>
-                )}
-                <Tooltip title={t_i18n('Clear all works')}>
-                  <span>
-                    <ToggleButton
-                      onClick={handleOpenClearWorks}
-                      aria-haspopup="true"
-                      value={t_i18n('Clear')}
-                    >
-                      <DeleteSweepOutlined
-                        color="primary"
-                      />
-                    </ToggleButton>
-                  </span>
-                </Tooltip>
-                <Tooltip title={t_i18n('Clear this connector')}>
-                  <span>
-                    <ToggleButton
-                      onClick={handleOpenDelete}
-                      aria-haspopup="true"
-                      disabled={!!connector.active || !!connector.built_in}
-                      value={t_i18n('Delete')}
-                    >
-                      <DeleteOutlined
-                        color="primary"
-                      />
-                    </ToggleButton>
-                  </span>
-                </Tooltip>
-              </ToggleButtonGroup>
-              {connector.is_managed && (
-                <EditEntityControlledDial
-                  onOpen={() => setEditionOpen(true)}
-                  style={{}}
-                />
-              )}
-            </>
-          </Security>
-        </div>
-      </div>
-      {editionOpen
-          && (<ManagedConnectorEdition connector={connector} onClose={() => setEditionOpen(false)} />)}
-      <Grid
-        container={true}
-        spacing={3}
-        style={{ marginBottom: 20 }}
-      >
+      <Grid container={true} spacing={3} style={{ marginBottom: 20 }}>
         <Grid item xs={6}>
           <Typography variant="h4" gutterBottom={true}>
             {t_i18n('Basic information')}
@@ -506,36 +371,36 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                 ))}
               </Grid>
               {connectorFiltersEnabled && (
-                <Grid item xs={6}>
-                  <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                    <Typography variant="h3" gutterBottom={true}>
-                      {t_i18n('Trigger filters')}
-                    </Typography>
-                    <Tooltip title={t_i18n('Trigger filters can be used to trigger automatically this connector on entities matching the filters and scope.')}>
-                      <span>
-                        <InformationOutline fontSize="small" color="primary" />
-                      </span>
-                    </Tooltip>
-                  </Box>
-                  <Box sx={{ display: 'flex', gap: 1, paddingTop: '4px' }}>
-                    <Filters
-                      availableFilterKeys={connectorAvailableFilterKeys}
+              <Grid item xs={6}>
+                <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                  <Typography variant="h3" gutterBottom={true}>
+                    {t_i18n('Trigger filters')}
+                  </Typography>
+                  <Tooltip title={t_i18n('Trigger filters can be used to trigger automatically this connector on entities matching the filters and scope.')}>
+                    <span>
+                      <InformationOutline fontSize="small" color="primary" />
+                    </span>
+                  </Tooltip>
+                </Box>
+                <Box sx={{ display: 'flex', gap: 1, paddingTop: '4px' }}>
+                  <Filters
+                    availableFilterKeys={connectorAvailableFilterKeys}
+                    helpers={helpers}
+                    searchContext={filtersSearchContext}
+                  />
+                </Box>
+                {filters && (
+                  <Box sx={{ overflow: 'hidden' }}>
+                    <FilterIconButton
+                      filters={filters}
                       helpers={helpers}
+                      styleNumber={2}
                       searchContext={filtersSearchContext}
+                      entityTypes={connectorFiltersScope}
                     />
                   </Box>
-                  {filters && (
-                    <Box sx={{ overflow: 'hidden' }}>
-                      <FilterIconButton
-                        filters={filters}
-                        helpers={helpers}
-                        styleNumber={2}
-                        searchContext={filtersSearchContext}
-                        entityTypes={connectorFiltersScope}
-                      />
-                    </Box>
-                  )}
-                </Grid>
+                )}
+              </Grid>
               )}
               <Security needs={[SETTINGS_SETACCESSES]}>
                 <>
@@ -663,10 +528,10 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                                 <ItemIcon
                                   type="Organization"
                                   color={
-                                    (organizationEdge.node.authorized_authorities ?? []).includes(connector.connector_user?.id ?? '')
-                                      ? theme.palette.dangerZone
-                                      : theme.palette.primary.main
-                                  }
+                                  (organizationEdge.node.authorized_authorities ?? []).includes(connector.connector_user?.id ?? '')
+                                    ? theme.palette.dangerZone
+                                    : theme.palette.primary.main
+                                }
                                 />
                               </ListItemIcon>
                               <ListItemText primary={organizationEdge.node.name} />
@@ -681,7 +546,6 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                 </>
               </Security>
             </Grid>
-
           </Paper>
         </Grid>
         <Grid item xs={6}>
@@ -696,14 +560,14 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
           >
             <Grid container={true} spacing={3}>
               {connector.connector_info?.buffering && (
-                <Grid item xs={12}>
-                  <Alert severity="warning" icon={<UpdateIcon color="warning" />} style={{ alignItems: 'center' }}>
-                    <div>
-                      <strong>{t_i18n('Buffering: ')}</strong>
-                      {t_i18n('Server ingestion is not accepting new work, waiting for current messages in ingestion to be processed until message count go back under threshold')}
-                    </div>
-                  </Alert>
-                </Grid>
+              <Grid item xs={12}>
+                <Alert severity="warning" icon={<UpdateIcon color="warning" />} style={{ alignItems: 'center' }}>
+                  <div>
+                    <strong>{t_i18n('Buffering: ')}</strong>
+                    {t_i18n('Server ingestion is not accepting new work, waiting for current messages in ingestion to be processed until message count go back under threshold')}
+                  </div>
+                </Alert>
+              </Grid>
               )}
               <Grid item={true} xs={12}>
                 <Typography variant="h3" gutterBottom={true}>
@@ -718,20 +582,19 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                   </pre>
                 </Tooltip>
               </Grid>
-
               <Grid item xs={6}>
                 {!connector.connector_info && (
                   connector.connector_state
-                  && connectorStateConverted !== null
-                  && checkLastRunExistingInState && checkLastRunIsNumber ? (
-                    <>
-                      <Typography variant="h3" gutterBottom={true}>
-                        {t_i18n('Last run (from State)')}
-                      </Typography>
-                      <Typography variant="body1" gutterBottom={true}>
-                        {nsdt(lastRunConverted)}
-                      </Typography>
-                    </>
+                && connectorStateConverted !== null
+                && checkLastRunExistingInState && checkLastRunIsNumber ? (
+                  <>
+                    <Typography variant="h3" gutterBottom={true}>
+                      {t_i18n('Last run (from State)')}
+                    </Typography>
+                    <Typography variant="body1" gutterBottom={true}>
+                      {nsdt(lastRunConverted)}
+                    </Typography>
+                  </>
                     ) : (
                       <>
                         <Typography variant="h3" gutterBottom={true}>
@@ -744,7 +607,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                     )
                 )}
                 {connector.connector_info && (
-                  // eslint-disable-next-line no-nested-ternary
+                // eslint-disable-next-line no-nested-ternary
                   connector.connector_info.last_run_datetime ? (
                     <>
                       <Typography variant="h3" gutterBottom={true}>
@@ -754,15 +617,15 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                         {nsdt(connector.connector_info?.last_run_datetime)}
                       </Typography>
                     </>) : (connector.connector_state
-                    && connectorStateConverted !== null
-                    && checkLastRunExistingInState && checkLastRunIsNumber ? (<>
-                      <Typography variant="h3" gutterBottom={true}>
-                        {t_i18n('Last run (from State)')}
-                      </Typography>
-                      <Typography variant="body1" gutterBottom={true}>
-                        {nsdt(lastRunConverted)}
-                      </Typography>
-                    </>)
+                  && connectorStateConverted !== null
+                  && checkLastRunExistingInState && checkLastRunIsNumber ? (<>
+                    <Typography variant="h3" gutterBottom={true}>
+                      {t_i18n('Last run (from State)')}
+                    </Typography>
+                    <Typography variant="body1" gutterBottom={true}>
+                      {nsdt(lastRunConverted)}
+                    </Typography>
+                  </>)
                     : (<>
                       <Typography variant="h3" gutterBottom={true}>
                         {t_i18n('Last run')}
@@ -774,13 +637,12 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                   )
                 )}
               </Grid>
-
               <Grid item xs={6}>
                 <Typography variant="h3" gutterBottom={true}>
                   {t_i18n('Next run')}
                 </Typography>
                 {connector.connector_info && (
-                  // eslint-disable-next-line no-nested-ternary
+                // eslint-disable-next-line no-nested-ternary
                   connector.connector_info.run_and_terminate ? (
                     <Typography variant="body1" gutterBottom={true}>
                       {t_i18n('External schedule')}
@@ -798,9 +660,9 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                   )
                 )}
                 {!connector.connector_info && (
-                  <Typography variant="body1" gutterBottom={true}>
-                    {t_i18n('Not provided')}
-                  </Typography>
+                <Typography variant="body1" gutterBottom={true}>
+                  {t_i18n('Not provided')}
+                </Typography>
                 )}
               </Grid>
               <Grid item xs={6}>
@@ -808,39 +670,233 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                   {t_i18n('Server capacity')}
                 </Typography>
                 {connector.connector_info && (connector.connector_info.queue_messages_size !== 0
-                  || connector.connector_info.last_run_datetime) ? (
-                    <FieldOrEmpty source={connector.connector_info?.queue_messages_size}>
-                      <span style={isBuffering() ? { color: theme.palette.dangerZone.main } : {}}>{connector.connector_info?.queue_messages_size.toFixed(2)}</span>
-                      <span> / {connector.connector_info?.queue_threshold} Mo</span>
-                    </FieldOrEmpty>
+                || connector.connector_info.last_run_datetime) ? (
+                  <FieldOrEmpty source={connector.connector_info?.queue_messages_size}>
+                    <span style={isBuffering() ? { color: theme.palette.dangerZone.main } : {}}>{connector.connector_info?.queue_messages_size.toFixed(2)}</span>
+                    <span> / {connector.connector_info?.queue_threshold} Mo</span>
+                  </FieldOrEmpty>
                   ) : (
                     <Typography variant="body1" gutterBottom={true}>
                       {t_i18n('Not provided')}
                     </Typography>
                   )
-                }
+              }
               </Grid>
-              { isComposerEnable && (
-                <Grid item xs={12}>
-                  <Typography variant="h3" gutterBottom={true}>
-                    {t_i18n('Logs')}
-                  </Typography>
-                  <pre
-                    style={{
-                      height: '100%',
-                      maxHeight: 400,
-                      overflowX: 'scroll',
-                      paddingBottom: theme.spacing(2),
-                    }}
-                  >
-                    {connector.manager_connector_logs?.join('\n')}
-                  </pre>
-                </Grid>
-              )}
             </Grid>
           </Paper>
         </Grid>
       </Grid>
+      <QueryRenderer
+        query={connectorWorksQuery}
+        variables={optionsInProgress}
+        render={({ props }: { props: ConnectorWorksQuery$data | null }) => (
+          <>
+            {props ? (
+              <ConnectorWorks data={props} options={[optionsInProgress]} inProgress={true} />
+            ) : (
+              <Loader variant={LoaderVariant.inElement} />
+            )}
+          </>
+        )}
+      />
+
+      <QueryRenderer
+        query={connectorWorksQuery}
+        variables={optionsFinished}
+        render={({ props }: { props: ConnectorWorksQuery$data | null }) => (
+          <>
+            {props ? (
+              <ConnectorWorks data={props} options={[optionsFinished]} />
+            ) : (
+              <Loader variant={LoaderVariant.inElement} />
+            )}
+          </>
+        )}
+      />
+    </>
+  );
+
+  // Component for Logs content
+  const ConnectorLogs = () => (
+    <Box sx={{ marginBottom: '20px' }}>
+      <pre
+        style={{
+          height: '100%',
+          overflowX: 'scroll',
+          paddingBottom: theme.spacing(2),
+          backgroundColor: theme.palette.background.paper,
+          padding: theme.spacing(2),
+          borderRadius: 4,
+          border: `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        {connector.manager_connector_logs?.join('\n') || t_i18n('No logs available')}
+      </pre>
+    </Box>
+  );
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          width: '100%',
+          marginBottom: theme.spacing(2),
+        }}
+      >
+        <Typography
+          variant="h1"
+          gutterBottom={true}
+          style={{
+            textTransform: 'uppercase',
+            alignItems: 'center',
+            display: 'flex',
+            gap: theme.spacing(1),
+            margin: 0,
+          }}
+        >
+          {connector.name}
+          <div style={{ display: 'inline-block' }}>
+            {computeConnectorStatus(connector).render}
+          </div>
+        </Typography>
+        <div style={{
+          float: 'right',
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing(1),
+        }}
+        >
+          <Security needs={[MODULES_MODMANAGE]}>
+            <>
+              {connector.is_managed && (
+              <Button
+                variant="contained"
+                disabled={computeConnectorStatus(connector).processing}
+                color={connector.manager_current_status === 'started' ? 'error' : 'primary'}
+                onClick={() => commitUpdateStatus({
+                  variables: {
+                    input: {
+                      id: connector.id,
+                      status: connector.manager_current_status === 'started' ? 'stopping' : 'starting',
+                    },
+                  },
+                })}
+              >
+                {t_i18n(connector.manager_current_status === 'started' ? 'Stop' : 'Start')}
+              </Button>
+              )}
+              {isSensitive && (
+                <div style={{ position: 'relative', display: 'inline-block' }}>
+                  <DangerZoneBlock
+                    type="connector_reset"
+                    sx={{
+                      root: { border: 'none', padding: 0, margin: 0 },
+                      title: { position: 'absolute', zIndex: 1, left: 4, top: 9, fontSize: 8 },
+                    }}
+                  >
+                    {({ disabled = false }: { disabled?: boolean }) => (
+                      <Button
+                        color="error"
+                        variant="outlined"
+                        disabled={disabled || !!connector.built_in}
+                        onClick={handleOpenResetState}
+                        style={{
+                          minWidth: '6rem',
+                        }}
+                      >
+                        <span style={{ zIndex: 2 }}>
+                          {t_i18n('Reset')}
+                        </span>
+                      </Button>
+                    )}
+                  </DangerZoneBlock>
+                </div>
+              )}
+              <ToggleButtonGroup
+                size="small"
+              >
+                {!isSensitive && (
+                  <Tooltip title={t_i18n('Reset the connector state')}>
+                    <span>
+                      <ToggleButton
+                        onClick={handleOpenResetState}
+                        aria-haspopup="true"
+                        disabled={!!connector.built_in}
+                        value={t_i18n('Reset')}
+                      >
+                        <PlaylistRemoveOutlined
+                          color="primary"
+                        />
+                      </ToggleButton>
+                    </span>
+                  </Tooltip>
+                )}
+                <Tooltip title={t_i18n('Clear all works')}>
+                  <span>
+                    <ToggleButton
+                      onClick={handleOpenClearWorks}
+                      aria-haspopup="true"
+                      value={t_i18n('Clear')}
+                    >
+                      <DeleteSweepOutlined
+                        color="primary"
+                      />
+                    </ToggleButton>
+                  </span>
+                </Tooltip>
+                <Tooltip title={t_i18n('Clear this connector')}>
+                  <span>
+                    <ToggleButton
+                      onClick={handleOpenDelete}
+                      aria-haspopup="true"
+                      disabled={!!connector.active || !!connector.built_in}
+                      value={t_i18n('Delete')}
+                    >
+                      <DeleteOutlined
+                        color="primary"
+                      />
+                    </ToggleButton>
+                  </span>
+                </Tooltip>
+              </ToggleButtonGroup>
+              {connector.is_managed && (
+                <EditEntityControlledDial
+                  onOpen={() => setEditionOpen(true)}
+                  variant='outlined'
+                  style={{}}
+                />
+              )}
+            </>
+          </Security>
+        </div>
+      </div>
+      {editionOpen
+          && (<ManagedConnectorEdition connector={connector} onClose={() => setEditionOpen(false)} />)}
+
+      {isComposerEnable ? (
+        <>
+          <Box
+            sx={{
+              borderBottom: 1,
+              borderColor: 'divider',
+              marginBottom: 3,
+            }}
+          >
+            <Tabs value={tabValue} onChange={handleTabChange}>
+              <Tab label={t_i18n('Overview')} />
+              <Tab label={t_i18n('Logs')} />
+            </Tabs>
+          </Box>
+          <Box>
+            {tabValue === 0 && <ConnectorOverview />}
+            {tabValue === 1 && <ConnectorLogs />}
+          </Box>
+        </>
+      ) : (
+        <ConnectorOverview />
+      )}
       <DeleteDialog
         deletion={deletion}
         submitDelete={submitDelete}
@@ -922,33 +978,6 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
         </DialogActions>
       </Dialog>
 
-      <QueryRenderer
-        query={connectorWorksQuery}
-        variables={optionsInProgress}
-        render={({ props }: { props: ConnectorWorksQuery$data | null }) => (
-          <>
-            {props ? (
-              <ConnectorWorks data={props} options={[optionsInProgress]} inProgress={true} />
-            ) : (
-              <Loader variant={LoaderVariant.inElement} />
-            )}
-          </>
-        )}
-      />
-
-      <QueryRenderer
-        query={connectorWorksQuery}
-        variables={optionsFinished}
-        render={({ props }: { props: ConnectorWorksQuery$data | null }) => (
-          <>
-            {props ? (
-              <ConnectorWorks data={props} options={[optionsFinished]} />
-            ) : (
-              <Loader variant={LoaderVariant.inElement} />
-            )}
-          </>
-        )}
-      />
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -58,12 +58,18 @@ import useDeletion from '../../../../utils/hooks/useDeletion';
 import useSensitiveModifications from '../../../../utils/hooks/useSensitiveModifications';
 import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
-import useHelper from '../../../../utils/hooks/useHelper';
 import type { Theme } from '../../../../components/Theme';
 import { Connector_connector$data } from './__generated__/Connector_connector.graphql';
 import { ConnectorUpdateTriggerMutation, EditInput } from './__generated__/ConnectorUpdateTriggerMutation.graphql';
 import { ConnectorUpdateStatusMutation } from './__generated__/ConnectorUpdateStatusMutation.graphql';
 import { ConnectorWorksQuery$variables, ConnectorWorksQuery$data } from './__generated__/ConnectorWorksQuery.graphql';
+
+// Type extension for organization node with authorized_authorities
+interface OrganizationNodeWithAuthorities {
+  id: string;
+  name: string;
+  authorized_authorities?: ReadonlyArray<string>;
+}
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -118,9 +124,6 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
   const { t_i18n, nsdt } = useFormatter();
   const navigate = useNavigate();
   const theme = useTheme<Theme>();
-
-  const { isFeatureEnable } = useHelper();
-  const isComposerEnable = isFeatureEnable('COMPOSER');
 
   // Helper function to create connector configuration
   const getConnectorConfig = () => ({
@@ -528,7 +531,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                                 <ItemIcon
                                   type="Organization"
                                   color={
-                                  (organizationEdge.node.authorized_authorities ?? []).includes(connector.connector_user?.id ?? '')
+                                  ((organizationEdge.node as OrganizationNodeWithAuthorities).authorized_authorities ?? []).includes(connector.connector_user?.id ?? '')
                                     ? theme.palette.dangerZone
                                     : theme.palette.primary.main
                                 }
@@ -875,7 +878,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
       {editionOpen
           && (<ManagedConnectorEdition connector={connector} onClose={() => setEditionOpen(false)} />)}
 
-      {isComposerEnable ? (
+      {connector.is_managed ? (
         <>
           <Box
             sx={{


### PR DESCRIPTION
### Proposed changes

* Add tab navigation to Connector detail page when COMPOSER feature is enabled
* Split connector information into two tabs: Overview and Logs
* Move connector logs from Details section to dedicated Logs tab for better organization
* Relocate Start/Stop button from header to action buttons group for UI consistency
* Update Start/Stop button styling from outlined to contained variant (main action btn)
* Move ConnectorWorks components inside Overview tab for better content grouping
* Add conditional rendering: display tabs only when connector.is_managed=true, otherwise show Overview content without tabs

### Related issues
* #7328 
* Feature: Improve connector page organization for COMPOSER-enabled instances
* UX: Better separation of concerns between connector information and logs

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments


**Key implementation details:**
- The tab functionality is only visible when `connector.is_managed=true`, ensuring backward compatibility
- The Overview tab contains all existing connector information (Basic information, Details, and ConnectorWorks)
- The Logs tab displays only the connector logs with improved styling
- The Start/Stop button has been moved to align with other action buttons, creating a more consistent UI pattern

This PR is essentially just UI/UX changes.
The changes are non-breaking and maintain the existing behavior for connector not managed by the Composer.
