### PR TITLE
[frontend]fix(FilterChipPopover): prevent background interaction (#11281)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -463,6 +463,9 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
         paper: {
           elevation: 1,
           style: { marginTop: 10 },
+          onMouseDown: (e) => e.stopPropagation(),
+          onPointerDown: (e) => e.stopPropagation(),
+          onClick: (e) => e.stopPropagation(),
         },
         backdrop: {
           style: {


### PR DESCRIPTION
### Proposed changes

* Fix mouse event propagation issue in FilterChipPopover component
* Add event handlers (onMouseDown, onPointerDown, onClick) to Paper component to prevent interaction with elements behind the backdrop
* use e.stopPropagation() (not stopEvent) to allow text selection while preventing event bubbling

### Related issues

* Fixes issue where mouse events (mousedown, click) on the popover would interact with elements beneath the backdrop
* #11281

### Checklist

- [ ] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

The issue was that the FilterChipPopover component allowed mouse events to pass through to elements beneath it. The solution adds event handlers to the Paper component that stop propagation without preventing default behaviors, allowing users to select text while blocking unwanted interactions with background elements.