### PR TITLE
[backend/frontend](fix) path support via APP__BASE_PATH env var (#11790)

### DIFF
--- a/opencti-platform/opencti-front/src/relay/environment.jsx
+++ b/opencti-platform/opencti-front/src/relay/environment.jsx
@@ -49,7 +49,13 @@ const isEmptyPath = R.isNil(window.BASE_PATH) || R.isEmpty(window.BASE_PATH);
 const contextPath = isEmptyPath || window.BASE_PATH === '/' ? '' : window.BASE_PATH;
 export const APP_BASE_PATH = isEmptyPath || contextPath.startsWith('/') ? contextPath : `/${contextPath}`;
 
-export const fileUri = (fileImport) => `${APP_BASE_PATH}${fileImport}`; // No slash here, will be replace by the builder
+export const fileUri = (fileImport) => {
+  // If the import already starts with the base path (from Vite), don't add it again
+  if (APP_BASE_PATH && fileImport.startsWith(APP_BASE_PATH)) {
+    return fileImport;
+  }
+  return `${APP_BASE_PATH}${fileImport}`;
+};
 
 // Create Network
 let subscriptionClient;

--- a/opencti-platform/opencti-front/vite.config.mts
+++ b/opencti-platform/opencti-front/vite.config.mts
@@ -180,7 +180,14 @@ logger.error = (msg, options) => {
   loggerError(msg, options)
 };
 
-const basePath = "";
+// Read base path from environment variable
+const getBasePath = () => {
+  const basePath = process.env.APP__BASE_PATH || '';
+  // Normalize the base path
+  return basePath.startsWith('/') ? basePath : basePath ? `/${basePath}` : '';
+};
+
+const basePath = getBasePath();
 
 const backProxy = (ws = false) => ({
   target: process.env.BACK_END_URL ?? 'http://localhost:4000',
@@ -190,6 +197,7 @@ const backProxy = (ws = false) => ({
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: basePath || '/',
   build: {
     target: ['chrome58'],
   },
@@ -240,15 +248,15 @@ export default defineConfig({
       clientFiles: ['./lang/front/*', './src/static/*', './src/app.tsx', './src/front.tsx', './src/util/hooks/*']
     },
     proxy: {
-      '/logout': backProxy(),
-      '/stream': backProxy(),
-      '/storage': backProxy(),
-      '^/.*/embedded/.*': backProxy(),
-      '/taxii2': backProxy(),
-      '/feeds': backProxy(),
-      '/graphql': backProxy(true),
-      '/auth': backProxy(),
-      '/static/flags': backProxy(),
+      [`${basePath}/logout`]: backProxy(),
+      [`${basePath}/stream`]: backProxy(),
+      [`${basePath}/storage`]: backProxy(),
+      [`^${basePath}/.*/embedded/.*`]: backProxy(),
+      [`${basePath}/taxii2`]: backProxy(),
+      [`${basePath}/feeds`]: backProxy(),
+      [`${basePath}/graphql`]: backProxy(true),
+      [`${basePath}/auth`]: backProxy(),
+      [`${basePath}/static/flags`]: backProxy(),
     },
   },
 });

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -327,7 +327,7 @@ const createApp = async (app) => {
   app.get(`${basePath}/auth/cert`, (req, res) => {
     try {
       const context = executionContext('cert_strategy');
-      const redirect = extractRefererPathFromReq(req) ?? '/';
+      const redirect = extractRefererPathFromReq(req) ?? (basePath || '/');
       const isActivated = isStrategyActivated(STRATEGY_CERT);
       if (!isActivated) {
         setCookieError(res, 'Cert authentication is not available');
@@ -366,7 +366,7 @@ const createApp = async (app) => {
   // Logout
   app.get(`${basePath}/logout`, async (req, res) => {
     try {
-      const referer = extractRefererPathFromReq(req) ?? '/';
+      const referer = extractRefererPathFromReq(req) ?? (basePath || '/');
       const provider = req.session.session_provider;
       const { user } = req.session;
       if (user) {
@@ -415,6 +415,9 @@ const createApp = async (app) => {
             }
           }
         });
+      } else {
+        // If no user in session, redirect to base path
+        res.redirect(basePath || '/');
       }
     } catch (e) {
       setCookieError(res, e.message);
@@ -470,7 +473,7 @@ const createApp = async (app) => {
       logApp.error('Error auth provider callback', { cause: e, provider });
       setCookieError(res, 'Invalid authentication, please ask your administrator');
     } finally {
-      res.redirect(referer ?? '/');
+      res.redirect(referer ?? (basePath || '/'));
     }
   });
 


### PR DESCRIPTION
### Proposed changes

* Add support for base path configuration using environment variable `APP__BASE_PATH` in frontend development
* Fix logout redirect to respect configured base path instead of redirecting to root `/`

### Related issues

* #11790 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

**Usage:**

Development (frontend):
```bash
export APP__BASE_PATH=mybasepath
yarn dev
```

Production (after frontend & backend build):
```bash
export APP__BASE_PATH=mybasepath
yarn serv
```

**Key changes:**
- Frontend reads `APP__BASE_PATH` environment variable in `vite.config.mts`
- Logout redirects now respect the configured base path