### PR TITLE
[backend] Prevent users from seing other user's from different org than their own orgs in assignee & participant field  (#11964)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -180,7 +180,7 @@ import {
 } from '../schema/attribute-definition';
 import { connections as connectionsAttribute } from '../modules/attributes/basicRelationship-registrationAttributes';
 import { schemaTypesDefinition } from '../schema/schema-types';
-import { INTERNAL_RELATIONSHIPS, isInternalRelationship } from '../schema/internalRelationship';
+import { INTERNAL_RELATIONSHIPS, isInternalRelationship, RELATION_PARTICIPATE_TO } from '../schema/internalRelationship';
 import { isStixSightingRelationship, STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
 import { rule_definitions } from '../rules/rules-definition';
 import { buildElasticSortingForAttributeCriteria } from '../utils/sorting';
@@ -1652,6 +1652,7 @@ const REL_DEFAULT_FETCH = [
   `${REL_INDEX_PREFIX}${RELATION_BORN_IN}${REL_DEFAULT_SUFFIX}`,
   `${REL_INDEX_PREFIX}${RELATION_ETHNICITY}${REL_DEFAULT_SUFFIX}`,
   `${REL_INDEX_PREFIX}${RELATION_SAMPLE}${REL_DEFAULT_SUFFIX}`,
+  `${REL_INDEX_PREFIX}${RELATION_PARTICIPATE_TO}${REL_DEFAULT_SUFFIX}`,
 ];
 
 const REL_COUNT_SCRIPT_FIELD = {

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -207,17 +207,16 @@ export const findAll = async (context, user, args) => {
   return listEntities(context, user, [ENTITY_TYPE_USER], args);
 };
 
-export const findCreators = async (context, user, args) => {
+export const findCreators = (context, user, args) => {
   const { entityTypes = [] } = args;
   return listAllEntitiesForFilter(context, user, CREATOR_FILTER, ENTITY_TYPE_USER, { ...args, types: entityTypes });
 };
 
-export const findAssignees = async (context, user, args) => {
+export const findAssignees = (context, user, args) => {
   const { entityTypes = [] } = args;
   return listAllEntitiesForFilter(context, user, ASSIGNEE_FILTER, ENTITY_TYPE_USER, { ...args, types: entityTypes });
 };
-
-export const findParticipants = async (context, user, args) => {
+export const findParticipants = (context, user, args) => {
   const { entityTypes = [] } = args;
   return listAllEntitiesForFilter(context, user, PARTICIPANT_FILTER, ENTITY_TYPE_USER, { ...args, types: entityTypes });
 };

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -209,20 +209,17 @@ export const findAll = async (context, user, args) => {
 
 export const findCreators = async (context, user, args) => {
   const { entityTypes = [] } = args;
-  const restrictedArgs = await applyOrganizationRestriction(context, user, args);
-  return listAllEntitiesForFilter(context, user, CREATOR_FILTER, ENTITY_TYPE_USER, { ...restrictedArgs, types: entityTypes });
+  return listAllEntitiesForFilter(context, user, CREATOR_FILTER, ENTITY_TYPE_USER, { ...args, types: entityTypes });
 };
 
 export const findAssignees = async (context, user, args) => {
   const { entityTypes = [] } = args;
-  const restrictedArgs = await applyOrganizationRestriction(context, user, args);
-  return listAllEntitiesForFilter(context, user, ASSIGNEE_FILTER, ENTITY_TYPE_USER, { ...restrictedArgs, types: entityTypes });
+  return listAllEntitiesForFilter(context, user, ASSIGNEE_FILTER, ENTITY_TYPE_USER, { ...args, types: entityTypes });
 };
 
 export const findParticipants = async (context, user, args) => {
   const { entityTypes = [] } = args;
-  const restrictedArgs = await applyOrganizationRestriction(context, user, args);
-  return listAllEntitiesForFilter(context, user, PARTICIPANT_FILTER, ENTITY_TYPE_USER, { ...restrictedArgs, types: entityTypes });
+  return listAllEntitiesForFilter(context, user, PARTICIPANT_FILTER, ENTITY_TYPE_USER, { ...args, types: entityTypes });
 };
 
 export const findAllMembers = async (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/modules/case/case-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-resolvers.ts
@@ -6,6 +6,7 @@ import { caseTasksPaginated } from '../task/task-domain';
 import type { BasicStoreEntityTask } from '../task/task-types';
 import { loadThroughDenormalized } from '../../resolvers/stix';
 import { INPUT_PARTICIPANT } from '../../schema/general';
+import { filterMembersWithUsersOrgs } from '../../utils/access';
 
 const caseResolvers: Resolvers = {
   Query: {
@@ -22,7 +23,10 @@ const caseResolvers: Resolvers = {
       return 'Unknown';
     },
     tasks: (current, args, context) => caseTasksPaginated<BasicStoreEntityTask>(context, context.user, current.id, args),
-    objectParticipant: (container, _, context) => loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' }),
+    objectParticipant: async (container, _, context) => {
+      const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      return filterMembersWithUsersOrgs(context, context.user, participants);
+    }
   },
   CasesOrdering: {
     creator: 'creator_id',

--- a/opencti-platform/opencti-graphql/src/modules/case/case-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-resolvers.ts
@@ -25,6 +25,9 @@ const caseResolvers: Resolvers = {
     tasks: (current, args, context) => caseTasksPaginated<BasicStoreEntityTask>(context, context.user, current.id, args),
     objectParticipant: async (container, _, context) => {
       const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      if (!participants) {
+        return [];
+      }
       return filterMembersWithUsersOrgs(context, context.user, participants);
     }
   },

--- a/opencti-platform/opencti-graphql/src/modules/task/task-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/task/task-resolvers.ts
@@ -15,6 +15,9 @@ const taskResolvers: Resolvers = {
   Task: {
     objectParticipant: async (container, _, context) => {
       const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      if (!participants) {
+        return [];
+      }
       return filterMembersWithUsersOrgs(context, context.user, participants);
     }
   },

--- a/opencti-platform/opencti-graphql/src/modules/task/task-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/task/task-resolvers.ts
@@ -2,6 +2,7 @@ import type { Resolvers } from '../../generated/graphql';
 import { findAll, findById, taskAdd, taskAddRelation, taskContainsStixObjectOrStixRelationship, taskDelete, taskDeleteRelation, taskEdit } from './task-domain';
 import { loadThroughDenormalized } from '../../resolvers/stix';
 import { INPUT_PARTICIPANT } from '../../schema/general';
+import { filterMembersWithUsersOrgs } from '../../utils/access';
 
 const taskResolvers: Resolvers = {
   Query: {
@@ -12,7 +13,10 @@ const taskResolvers: Resolvers = {
     },
   },
   Task: {
-    objectParticipant: (container, _, context) => loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' }),
+    objectParticipant: async (container, _, context) => {
+      const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      return filterMembersWithUsersOrgs(context, context.user, participants);
+    }
   },
   Mutation: {
     taskAdd: (_, { input }, context) => taskAdd(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/resolvers/incident.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/incident.js
@@ -26,6 +26,9 @@ const incidentResolvers = {
   Incident: {
     objectParticipant: async (container, _, context) => {
       const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      if (!participants) {
+        return [];
+      }
       return filterMembersWithUsersOrgs(context, context.user, participants);
     }
   },

--- a/opencti-platform/opencti-graphql/src/resolvers/incident.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/incident.js
@@ -26,8 +26,7 @@ const incidentResolvers = {
   Incident: {
     objectParticipant: async (container, _, context) => {
       const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
-      const visibleParticipants = await filterMembersWithUsersOrgs(context, context.user, participants);
-      return visibleParticipants;
+      return filterMembersWithUsersOrgs(context, context.user, participants);
     }
   },
   IncidentsOrdering: {

--- a/opencti-platform/opencti-graphql/src/resolvers/report.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/report.js
@@ -25,6 +25,7 @@ import { distributionEntities } from '../database/middleware';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../schema/stixDomainObject';
 import { loadThroughDenormalized } from './stix';
 import { INPUT_PARTICIPANT } from '../schema/general';
+import { filterMembersWithUsersOrgs } from '../utils/access';
 
 const reportResolvers = {
   Query: {
@@ -60,7 +61,10 @@ const reportResolvers = {
   },
   Report: {
     deleteWithElementsCount: (report, _, context) => reportDeleteElementsCount(context, context.user, report.id),
-    objectParticipant: (container, _, context) => loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' }),
+    objectParticipant: async (container, _, context) => {
+      const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      return filterMembersWithUsersOrgs(context, context.user, participants);
+    }
   },
   Mutation: {
     reportEdit: (_, { id }, context) => ({

--- a/opencti-platform/opencti-graphql/src/resolvers/report.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/report.js
@@ -63,6 +63,9 @@ const reportResolvers = {
     deleteWithElementsCount: (report, _, context) => reportDeleteElementsCount(context, context.user, report.id),
     objectParticipant: async (container, _, context) => {
       const participants = await loadThroughDenormalized(context, context.user, container, INPUT_PARTICIPANT, { sortBy: 'user_email' });
+      if (!participants) {
+        return [];
+      }
       return filterMembersWithUsersOrgs(context, context.user, participants);
     }
   },

--- a/opencti-platform/opencti-graphql/src/resolvers/stix.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stix.js
@@ -4,7 +4,7 @@ import { stixLoadByIdStringify } from '../database/middleware';
 import { connectorsForEnrichment } from '../database/repository';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { INPUT_GRANTED_REFS } from '../schema/general';
-import { isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT, REDACTED_USER } from '../utils/access';
+import { filterMembersWithUsersOrgs, isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT, REDACTED_USER } from '../utils/access';
 import { ENABLED_DEMO_MODE } from '../config/conf';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
 
@@ -72,7 +72,13 @@ const stixResolvers = {
       /* v8 ignore next */
       return 'Unknown';
     },
-    creators: (stix, _, context) => context.batch.creatorsBatchLoader.load(stix.creator_id),
+    creators: async (stix, _, context) => {
+      const creators = await context.batch.creatorsBatchLoader.load(stix.creator_id);
+      if (!creators) {
+        return [];
+      }
+      return filterMembersWithUsersOrgs(context, context.user, creators);
+    },
   },
 };
 

--- a/opencti-platform/opencti-graphql/src/resolvers/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixDomainObject.js
@@ -63,6 +63,9 @@ const stixDomainObjectResolvers = {
     status: (stixDomainObject, _, context) => (stixDomainObject.x_opencti_workflow_id ? findStatusById(context, context.user, stixDomainObject.x_opencti_workflow_id) : null),
     objectAssignee: async (stixDomainObject, args, context) => {
       const assignees = await loadThroughDenormalized(context, context.user, stixDomainObject, INPUT_ASSIGNEE, { sortBy: 'user_email' });
+      if (!assignees) {
+        return [];
+      }
       return filterMembersWithUsersOrgs(context, context.user, assignees);
     },
     workflowEnabled: async (stixDomainObject, _, context) => {

--- a/opencti-platform/opencti-graphql/src/resolvers/stixDomainObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixDomainObject.js
@@ -26,6 +26,7 @@ import { stixDomainObjectOptions as StixDomainObjectsOptions } from '../schema/s
 import { stixCoreObjectExportPush, stixCoreObjectImportPush, stixCoreObjectsExportPush } from '../domain/stixCoreObject';
 import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { loadThroughDenormalized } from './stix';
+import { filterMembersWithUsersOrgs } from '../utils/access';
 
 const stixDomainObjectResolvers = {
   Query: {
@@ -60,7 +61,10 @@ const stixDomainObjectResolvers = {
     },
     avatar: (stixDomainObject) => stixDomainObjectAvatar(stixDomainObject),
     status: (stixDomainObject, _, context) => (stixDomainObject.x_opencti_workflow_id ? findStatusById(context, context.user, stixDomainObject.x_opencti_workflow_id) : null),
-    objectAssignee: (stixDomainObject, args, context) => loadThroughDenormalized(context, context.user, stixDomainObject, INPUT_ASSIGNEE, { sortBy: 'user_email' }),
+    objectAssignee: async (stixDomainObject, args, context) => {
+      const assignees = await loadThroughDenormalized(context, context.user, stixDomainObject, INPUT_ASSIGNEE, { sortBy: 'user_email' });
+      return filterMembersWithUsersOrgs(context, context.user, assignees);
+    },
     workflowEnabled: async (stixDomainObject, _, context) => {
       const statusesType = await findByType(context, context.user, stixDomainObject.entity_type);
       return statusesType.length > 0;

--- a/opencti-platform/opencti-graphql/src/resolvers/user.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/user.js
@@ -59,7 +59,7 @@ import { publishUserAction } from '../listener/UserActionListener';
 import { findById as findDraftById } from '../modules/draftWorkspace/draftWorkspace-domain';
 import { findById as findWorskpaceById } from '../modules/workspace/workspace-domain';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
-import { executionContext, REDACTED_USER } from '../utils/access';
+import { executionContext, filterMembersWithUsersOrgs, REDACTED_USER } from '../utils/access';
 import { getNotifiers } from '../modules/notifier/notifier-domain';
 
 const userResolvers = {
@@ -70,7 +70,13 @@ const userResolvers = {
     users: (_, args, context) => findAll(context, context.user, args),
     role: (_, { id }, context) => findRoleById(context, context.user, id),
     roles: (_, args, context) => findRoles(context, context.user, args),
-    creators: (_, args, context) => findCreators(context, context.user, args),
+    creators: async (_, args, context) => {
+      const creators = await findCreators(context, context.user, args);
+      if (!creators) {
+        return [];
+      }
+      return filterMembersWithUsersOrgs(context, context.user, creators);
+    },
     assignees: (_, args, context) => findAssignees(context, context.user, args),
     participants: (_, args, context) => findParticipants(context, context.user, args),
     members: (_, args, context) => findAllMembers(context, context.user, args),

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -927,7 +927,7 @@ export const applyOrganizationRestriction = async (
     const userMembersFilter = {
       mode: FilterMode.Or,
       filters: [membersFilters, userTypeFilters],
-      filterGroup: [],
+      filterGroups: [],
     };
     const filters = {
       mode: FilterMode.And,

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -875,6 +875,9 @@ export const filterMembersWithUsersOrgs = async (
   if (!userInPlatformOrg) {
     const userOrgIds = (user.organizations || []).map((org) => org.id);
     return members.map((member) => {
+      if (member.id === user.id) {
+        return member;
+      }
       const memberOrgIds = member[RELATION_PARTICIPATE_TO] ?? [];
       const sameOrg = memberOrgIds.some((id) => userOrgIds.includes(id));
       if (!sameOrg) {

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -868,12 +868,18 @@ export const filterMembersWithUsersOrgs = async (
 ): Promise<ParticipantWithOrgIds[]> => {
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   const userInPlatformOrg = isUserInPlatformOrganization(user, settings);
-
   if (!userInPlatformOrg) {
     const userOrgIds = (user.organizations || []).map((org) => org.id);
-    return members.filter((member) => {
-      const memberOrgIds = member[RELATION_PARTICIPATE_TO] || [];
-      return memberOrgIds.some((id) => userOrgIds.includes(id));
+    return members.map((member) => {
+      const memberOrgIds = member[RELATION_PARTICIPATE_TO] ?? [];
+      const sameOrg = memberOrgIds.some((id) => userOrgIds.includes(id));
+      if (!sameOrg) {
+        return {
+          ...member,
+          name: 'Restricted'
+        };
+      }
+      return member;
     });
   }
   return members;

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -858,6 +858,10 @@ export const isUserInPlatformOrganization = (user: AuthUser, settings: BasicStor
 };
 
 type ParticipantWithOrgIds = Participant & {
+  representative?: {
+    main: string,
+    secondary: string
+  }
   [RELATION_PARTICIPATE_TO]?: string[];
 };
 
@@ -878,7 +882,10 @@ export const filterMembersWithUsersOrgs = async (
           ...member,
           name: REDACTED_USER.name,
           user_email: REDACTED_USER.user_email,
-          id: uuidv4()
+          representative: {
+            main: REDACTED_USER.name,
+            secondary: REDACTED_USER.name
+          }
         };
       }
       return member;

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -854,3 +854,19 @@ export const isUserInPlatformOrganization = (user: AuthUser, settings: BasicStor
   const userOrganizationIds = (user.organizations ?? []).map((organization) => organization.internal_id);
   return settings.platform_organization ? userOrganizationIds.includes(settings.platform_organization) : true;
 };
+
+export const filterMembersWithUsersOrgs = async (context: AuthContext, user: AuthUser, members) => {
+  const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+  const userInPlatformOrg = isUserInPlatformOrganization(user, settings);
+
+  if (!userInPlatformOrg) {
+    const userOrgIds = (user.organizations || []).map((org) => org.id);
+    const reducedMembers = members.filter((member) => {
+      const memberOrgIds = (member.organizations || []).map((org) => org.id);
+      return memberOrgIds.some((id) => userOrgIds.includes(id));
+    });
+
+    return reducedMembers;
+  }
+  return members;
+};

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -23,7 +23,7 @@ import { isStixObject } from '../schema/stixCoreObject';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import type { UpdateEvent } from '../types/event';
 import { RELATION_PARTICIPATE_TO } from '../schema/internalRelationship';
-import type { Participant } from '../generated/graphql';
+import type { Creator, Participant } from '../generated/graphql';
 
 export const DEFAULT_INVALID_CONF_VALUE = 'ChangeMe';
 
@@ -857,7 +857,7 @@ export const isUserInPlatformOrganization = (user: AuthUser, settings: BasicStor
   return settings.platform_organization ? userOrganizationIds.includes(settings.platform_organization) : true;
 };
 
-type ParticipantWithOrgIds = Participant & {
+type ParticipantWithOrgIds = Participant & Creator & {
   representative?: {
     main: string,
     secondary: string

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -23,6 +23,7 @@ import { isStixObject } from '../schema/stixCoreObject';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import type { UpdateEvent } from '../types/event';
 import { RELATION_PARTICIPATE_TO } from '../schema/internalRelationship';
+import type { Participant } from '../generated/graphql';
 
 export const DEFAULT_INVALID_CONF_VALUE = 'ChangeMe';
 
@@ -856,7 +857,15 @@ export const isUserInPlatformOrganization = (user: AuthUser, settings: BasicStor
   return settings.platform_organization ? userOrganizationIds.includes(settings.platform_organization) : true;
 };
 
-export const filterMembersWithUsersOrgs = async (context: AuthContext, user: AuthUser, members: { [RELATION_PARTICIPATE_TO]: string[] }[]) => {
+type ParticipantWithOrgIds = Participant & {
+  [RELATION_PARTICIPATE_TO]?: string[];
+};
+
+export const filterMembersWithUsersOrgs = async (
+  context: AuthContext,
+  user: AuthUser,
+  members: ParticipantWithOrgIds[]
+): Promise<ParticipantWithOrgIds[]> => {
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   const userInPlatformOrg = isUserInPlatformOrganization(user, settings);
 

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -876,7 +876,8 @@ export const filterMembersWithUsersOrgs = async (
       if (!sameOrg) {
         return {
           ...member,
-          name: 'Restricted'
+          name: REDACTED_USER.name,
+          user_email: REDACTED_USER.user_email
         };
       }
       return member;

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -877,7 +877,8 @@ export const filterMembersWithUsersOrgs = async (
         return {
           ...member,
           name: REDACTED_USER.name,
-          user_email: REDACTED_USER.user_email
+          user_email: REDACTED_USER.user_email,
+          id: uuidv4()
         };
       }
       return member;

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -6,7 +6,7 @@ import { context as telemetryContext, trace } from '@opentelemetry/api';
 import { OPENCTI_SYSTEM_UUID } from '../schema/general';
 import { RELATION_GRANTED_TO, RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
 import { getEntitiesMapFromCache, getEntityFromCache } from '../database/cache';
-import { ENTITY_TYPE_SETTINGS, isInternalObject } from '../schema/internalObject';
+import { ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER, isInternalObject } from '../schema/internalObject';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import type { AuthContext, AuthUser, UserRole } from '../types/user';
 import type { BasicStoreCommon } from '../types/store';
@@ -919,10 +919,20 @@ export const applyOrganizationRestriction = async (
       values: userOrgIds,
       operator: 'eq',
     };
+    const userTypeFilters = {
+      key: ['entity_type'],
+      values: [ENTITY_TYPE_USER],
+      operator: 'not_eq',
+    };
+    const userMembersFilter = {
+      mode: FilterMode.Or,
+      filters: [membersFilters, userTypeFilters],
+      filterGroup: [],
+    };
     const filters = {
       mode: FilterMode.And,
-      filters: [membersFilters],
-      filterGroups: argsFilters ? [argsFilters] : [],
+      filters: [],
+      filterGroups: argsFilters ? [argsFilters, userMembersFilter] : [userMembersFilter],
     };
     return {
       ...args,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Filter members by user orgs if platform org active and user outside

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/11964

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
