### PR TITLE
[backend] trim decay history size (#11985)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -344,6 +344,22 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
   return notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC, created, user);
 };
 
+const MAX_DECAY_HISTORY_POINTS = 50;
+const computeIndicatorDecayHistory = (indicator: BasicStoreEntityIndicator, newHistoryPoint: DecayHistory) => {
+  const newHistory = [...(indicator.decay_history ?? [])];
+  newHistory.push(newHistoryPoint);
+  // If decay history length is too large, we need to trim it to keep it at a manageable size in ES
+  // we want to keep part of the start of the history, and part of the end of the history
+  if (newHistory.length > MAX_DECAY_HISTORY_POINTS) {
+    const startPointsToKeep = MAX_DECAY_HISTORY_POINTS / 2;
+    const endPointsToKeep = MAX_DECAY_HISTORY_POINTS - startPointsToKeep;
+    const startPoints = newHistory.slice(0, startPointsToKeep);
+    const endPoints = newHistory.slice(-endPointsToKeep);
+    return [...startPoints, ...endPoints];
+  }
+  return newHistory;
+};
+
 /**
  * Compute decay data when it's needed from indicator updates.
  * Return keys for 'decay_history', 'decay_next_reaction_date', 'valid_until'
@@ -357,11 +373,8 @@ export const restartDecayComputationOnEdit = (fromScore: number, indicatorBefore
   const updateDate = utcDate();
   inputToAdd.push({ key: 'decay_base_score', value: [fromScore] });
   inputToAdd.push({ key: 'decay_base_score_date', value: [updateDate.toISOString()] });
-  const decayHistory: DecayHistory[] = [...(indicatorBeforeUpdate.decay_history ?? [])];
-  decayHistory.push({
-    updated_at: nowDate,
-    score: fromScore,
-  });
+  const newDecayHistoryPoint = { updated_at: nowDate, score: fromScore };
+  const decayHistory = computeIndicatorDecayHistory(indicatorBeforeUpdate, newDecayHistoryPoint);
   inputToAdd.push({ key: 'decay_history', value: decayHistory });
   const nextScoreReactionDate = computeNextScoreReactionDate(fromScore, fromScore, indicatorDecayRule, updateDate);
   if (nextScoreReactionDate) {
@@ -450,11 +463,8 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
         finalInput.push({ key: X_DETECTION, value: [false] });
         finalInput.push({ key: VALID_UNTIL, value: [nowDate.toISOString()] });
 
-        const decayHistory: DecayHistory[] = [...(indicatorBeforeUpdate.decay_history ?? [])];
-        decayHistory.push({
-          updated_at: nowDate,
-          score: revokeScore,
-        });
+        const newDecayHistoryPoint = { updated_at: nowDate, score: revokeScore };
+        const decayHistory = computeIndicatorDecayHistory(indicatorBeforeUpdate, newDecayHistoryPoint);
         finalInput.push({ key: 'decay_history', value: decayHistory });
       }
 
@@ -519,11 +529,8 @@ export const computeIndicatorDecayPatch = (indicator: BasicStoreEntityIndicator)
   }
   const newStableScore = model.decay_points.find((p) => (p || indicator.x_opencti_score) < indicator.x_opencti_score) || model.decay_revoke_score;
   if (newStableScore) {
-    const decayHistory: DecayHistory[] = [...(indicator.decay_history ?? [])];
-    decayHistory.push({
-      updated_at: new Date(),
-      score: newStableScore,
-    });
+    const newDecayHistoryPoint = { updated_at: new Date(), score: newStableScore };
+    const decayHistory = computeIndicatorDecayHistory(indicator, newDecayHistoryPoint);
     patch = {
       x_opencti_score: newStableScore,
       decay_history: decayHistory,

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/decayRule-test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import moment from 'moment';
-import { computeIndicatorDecayPatch, computeLivePoints, computeLiveScore, type IndicatorPatch } from '../../../src/modules/indicator/indicator-domain';
+import {
+  computeIndicatorDecayHistory,
+  computeIndicatorDecayPatch,
+  computeLivePoints,
+  computeLiveScore,
+  type IndicatorPatch,
+  MAX_DECAY_HISTORY_POINTS
+} from '../../../src/modules/indicator/indicator-domain';
 import type { BasicStoreEntityIndicator, IndicatorDecayRule } from '../../../src/modules/indicator/indicator-types';
 import {
   type DecayRuleConfiguration,
@@ -323,6 +330,25 @@ describe('Decay update testing', () => {
 
     // THEN
     expect(patchResult, 'No database operation should be done.').toBeNull();
+  });
+});
+
+describe('Decay history trimming testing', () => {
+  it('should only keep MAX_DECAY_HISTORY_POINTS entries in decay history', () => {
+    const currentDecayHistory = [];
+    const nowDate = new Date();
+    for (let i = 0; i < 1000; i += 1) {
+      const decayHistoryPoint = { updated_at: nowDate, score: i };
+      currentDecayHistory.push(decayHistoryPoint);
+    }
+    const newDecayHistoryPoint = { updated_at: nowDate, score: -1 };
+    const trimmedDecayHistory = computeIndicatorDecayHistory(currentDecayHistory, newDecayHistoryPoint);
+
+    expect(trimmedDecayHistory.length).toBe(MAX_DECAY_HISTORY_POINTS);
+    const firstDecayPoint = trimmedDecayHistory[0];
+    expect(firstDecayPoint.score).toBe(0);
+    const lastTrimmedDecayHistoryPoint = trimmedDecayHistory[trimmedDecayHistory.length - 1];
+    expect(lastTrimmedDecayHistoryPoint.score).toBe(-1);
   });
 });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* trim decay history size to only keep 50 points max
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11985 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
