### PR TITLE
[frontend] Hide Hub button if XTMHub is unreachable #12002

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -19,6 +19,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 import { isNotEmptyField } from '../../../utils/utils';
 import GradientButton from '../../../components/GradientButton';
+import useNetworkCheck from '../../../utils/hooks/useCheckNetwork';
 
 const LOCAL_STORAGE_KEY = 'ingestionCsvs';
 
@@ -38,6 +39,7 @@ const IngestionCsv = () => {
     ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?opencti_platform_id=${settings.id}`
     : '';
 
+  const { isReachable } = useNetworkCheck(settings?.platform_xtmhub_url);
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
   setTitle(t_i18n('CSV Feeds | Ingestion | Data'));
@@ -89,6 +91,7 @@ const IngestionCsv = () => {
       ingestionCsvLinesQuery,
       paginationOptions,
     );
+
     return (
       <ListLines
         helpers={helpers}
@@ -108,7 +111,7 @@ const IngestionCsv = () => {
               <IngestionCsvImport
                 paginationOptions={paginationOptions}
               />
-              {isNotEmptyField(importFromHubUrl) && (
+              {isReachable && isNotEmptyField(importFromHubUrl) && (
                 <GradientButton
                   size="small"
                   sx={{ marginLeft: 1 }}

--- a/opencti-platform/opencti-front/src/private/components/settings/Experience.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Experience.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useContext, useState } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import Grid from '@mui/material/Grid';
 import XtmHubSettings from '@components/settings/xtm-hub/XtmHubSettings';
@@ -35,6 +35,8 @@ import type { Theme } from '../../../components/Theme';
 import { FieldOption } from '../../../utils/field';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
 import useGranted, { SETTINGS_SETPARAMETERS, SETTINGS_SUPPORT } from '../../../utils/hooks/useGranted';
+import { UserContext } from '../../../utils/hooks/useAuth';
+import useNetworkCheck from '../../../utils/hooks/useCheckNetwork';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
@@ -125,6 +127,8 @@ const ExperienceComponent: FunctionComponent<ExperienceComponentProps> = ({ quer
       })
       .catch(() => false);
   };
+  const { settings: userSettings } = useContext(UserContext);
+  const { isReachable } = useNetworkCheck(userSettings?.platform_xtmhub_url);
 
   return (
     <div className={classes.container}>
@@ -308,9 +312,12 @@ const ExperienceComponent: FunctionComponent<ExperienceComponentProps> = ({ quer
             </Paper>
           </Grid>
         )}
-        <Grid item xs={6}>
-          <XtmHubSettings />
-        </Grid>
+        {
+          isReachable && <Grid item xs={6}>
+            <XtmHubSettings />
+          </Grid>
+        }
+
         {isGrantedToSupport && (
           <Grid item xs={12} style={{ marginTop: 15 }}>
             <SupportPackages />

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -51,6 +51,7 @@ const XtmHubSettingsComponent = () => {
     {},
   );
   const isGrantedToXtmHub = useGranted([SETTINGS_SETMANAGEXTMHUB]);
+
   return (
     <>
       <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -21,6 +21,7 @@ import CreateEntityControlledDial from '../../../components/CreateEntityControll
 import { isNotEmptyField } from '../../../utils/utils';
 import GradientButton from '../../../components/GradientButton';
 import { UserContext } from '../../../utils/hooks/useAuth';
+import useNetworkCheck from '../../../utils/hooks/useCheckNetwork';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -63,6 +64,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
     ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?opencti_platform_id=${settings.id}`
     : '';
+  const { isReachable } = useNetworkCheck(settings?.platform_xtmhub_url);
 
   const [commitImportMutation] = useApiMutation(importMutation);
   const [commitCreationMutation] = useApiMutation(workspaceMutation);
@@ -125,7 +127,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
       >
         <FileUploadOutlined fontSize="small" color={'primary'} />
       </ToggleButton>
-      {isNotEmptyField(importFromHubUrl) && (
+      {isReachable && isNotEmptyField(importFromHubUrl) && (
         <GradientButton
           size="small"
           sx={{ marginLeft: theme.spacing(1) }}

--- a/opencti-platform/opencti-front/src/utils/hooks/useCheckNetwork.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useCheckNetwork.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+
+interface UseNetworkCheckResult {
+  isReachable: boolean | null;
+  isLoading: boolean;
+}
+
+const useNetworkCheck = (url?: string | null): UseNetworkCheckResult => {
+  if (!url) {
+    return {
+      isReachable: false,
+      isLoading: false,
+    };
+  }
+  const [isReachable, setIsReachable] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const checkNetwork = async () => {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+        await fetch(url, {
+          method: 'HEAD',
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+        setIsReachable(true);
+      } catch {
+        setIsReachable(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkNetwork();
+  }, []); // Empty dependency array - only runs on mount
+
+  return { isReachable, isLoading };
+};
+
+export default useNetworkCheck;

--- a/opencti-platform/opencti-front/src/utils/hooks/useCheckNetwork.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useCheckNetwork.tsx
@@ -23,6 +23,8 @@ const useNetworkCheck = (url?: string | null): UseNetworkCheckResult => {
 
         await fetch(url, {
           method: 'HEAD',
+          mode: 'no-cors',
+          cache: 'no-cache',
           signal: controller.signal,
         });
 

--- a/opencti-platform/opencti-front/src/utils/hooks/useXtmHubUserPlatformToken.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useXtmHubUserPlatformToken.ts
@@ -39,7 +39,7 @@ const useXtmHubUserPlatformToken = (): Return => {
     if (tokenFromStorage) {
       setToken(tokenFromStorage);
     } else {
-      window.opener.postMessage({ action: 'refresh-token' }, '*');
+      window.opener?.postMessage({ action: 'refresh-token' }, '*');
     }
   }, [token]);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a hook to test connection
* Hide import hub button
* Hide register instance button

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12002

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Screen without button :
<img width="1601" height="1033" alt="image" src="https://github.com/user-attachments/assets/698be096-c230-40f2-bc75-3d430df7f878" />
<img width="1602" height="1034" alt="image" src="https://github.com/user-attachments/assets/a5a6ac47-e255-4748-8c1e-d1545314e4b0" />
<img width="1910" height="1044" alt="image" src="https://github.com/user-attachments/assets/0f424068-d228-455a-84d8-7c6a78d7e997" />


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
