### PR TITLE
[frontend/backend] Change dashboard widget import logic to not break existing layout (#12085)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/Root.jsx
@@ -52,6 +52,7 @@ const RootDashboard = () => {
         marginRight: -20,
         paddingRight: 20,
         paddingTop: 5,
+        height: '100%',
       }}
     >
       <QueryRenderer

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WorkspaceWidgetConfig.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/WorkspaceWidgetConfig.tsx
@@ -1,74 +1,29 @@
 import React, { useRef, useState } from 'react';
-import { graphql, useFragment } from 'react-relay';
 import Button from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
 import { Widget } from 'src/utils/widget/widget';
 import VisuallyHiddenInput from '../../common/VisuallyHiddenInput';
 import WidgetConfig from '../../widgets/WidgetConfig';
-import { toB64 } from '../../../../utils/String';
-import { handleError } from '../../../../relay/environment';
-import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import Security from '../../../../utils/Security';
 import { EXPLORE_EXUPDATE } from '../../../../utils/hooks/useGranted';
 import { useFormatter } from '../../../../components/i18n';
-import { WorkspaceWidgetConfigFragment$key } from './__generated__/WorkspaceWidgetConfigFragment.graphql';
-
-const workspaceWidgetConfigFragment = graphql`
-  fragment WorkspaceWidgetConfigFragment on Workspace {
-    id
-    manifest
-  }
-`;
-
-const workspaceImportWidgetMutation = graphql`
-  mutation WorkspaceWidgetConfigImportMutation(
-    $id: ID!
-    $input: ImportConfigurationInput!
-  ) {
-    workspaceWidgetConfigurationImport(id: $id, input: $input) {
-      manifest
-      ...Dashboard_workspace
-    }
-  }
-`;
 
 type WorkspaceWidgetConfigProps = {
-  data: WorkspaceWidgetConfigFragment$key;
+  handleImportWidget: (widgetFile: File) => void
   widget?: Widget,
   onComplete: (value: Widget, variableName?: string) => void,
   closeMenu?: () => void;
 };
 
-const WorkspaceWidgetConfig = ({ data, widget, onComplete, closeMenu }: WorkspaceWidgetConfigProps) => {
+const WorkspaceWidgetConfig = ({ widget, onComplete, closeMenu, handleImportWidget }: WorkspaceWidgetConfigProps) => {
   const { t_i18n } = useFormatter();
-  const workspace = useFragment(workspaceWidgetConfigFragment, data);
-
   const [isWidgetConfigOpen, setIsWidgetConfigOpen] = useState<boolean>(false);
-
-  const [commitWidgetImportMutation] = useApiMutation(workspaceImportWidgetMutation);
   const inputRef: React.MutableRefObject<HTMLInputElement | null> = useRef(null);
 
   const handleWidgetImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const importedWidgetConfiguration = event.target.files?.[0];
-    const emptyDashboardManifest = toB64(JSON.stringify({ widgets: {}, config: {} }));
-    const dashboardManifest = workspace.manifest ?? emptyDashboardManifest;
-    commitWidgetImportMutation({
-      variables: {
-        id: workspace.id,
-        input: {
-          importType: 'widget',
-          file: importedWidgetConfiguration,
-          dashboardManifest,
-        },
-      },
-      updater: () => {
-        if (inputRef.current) inputRef.current.value = ''; // Reset the input uploader ref
-      },
-      onError: (error) => {
-        if (inputRef.current) inputRef.current.value = ''; // Reset the input uploader ref
-        handleError(error);
-      },
-    });
+    if (importedWidgetConfiguration) handleImportWidget(importedWidgetConfiguration);
+    if (inputRef.current) inputRef.current.value = ''; // Reset the input uploader ref
   };
 
   const handleOpenWidgetConfig = () => setIsWidgetConfigOpen(true);
@@ -93,24 +48,22 @@ const WorkspaceWidgetConfig = ({ data, widget, onComplete, closeMenu }: Workspac
           />
           <Security needs={[EXPLORE_EXUPDATE]}>
             <>
-              <>
-                <Button
-                  variant='outlined'
-                  disableElevation
-                  sx={{ marginLeft: 1 }}
-                  onClick={handleImportWidgetButtonClick}
-                >
-                  {t_i18n('Import Widget')}
-                </Button>
-                <Button
-                  variant='outlined'
-                  disableElevation
-                  sx={{ marginLeft: 1 }}
-                  onClick={handleOpenWidgetConfig}
-                >
-                  {t_i18n('Create Widget')}
-                </Button>
-              </>
+              <Button
+                variant='outlined'
+                disableElevation
+                sx={{ marginLeft: 1 }}
+                onClick={handleImportWidgetButtonClick}
+              >
+                {t_i18n('Import Widget')}
+              </Button>
+              <Button
+                variant='outlined'
+                disableElevation
+                sx={{ marginLeft: 1 }}
+                onClick={handleOpenWidgetConfig}
+              >
+                {t_i18n('Create Widget')}
+              </Button>
             </>
           </Security>
         </>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeader.tsx
@@ -28,7 +28,6 @@ const workspaceHeaderFragment = graphql`
     type
     currentUserAccessRight
     ...WorkspaceKebabMenuFragment
-    ...WorkspaceWidgetConfigFragment
     ...WorkspaceEditionContainer_workspace
   }
 `;
@@ -52,6 +51,7 @@ type WorkspaceHeaderProps = {
     relativeDate: string | null
   },
   handleAddWidget?: () => void;
+  handleImportWidget?: (widgetFile: File) => void
 };
 
 const WorkspaceHeader = ({
@@ -59,6 +59,7 @@ const WorkspaceHeader = ({
   variant,
   adjust = () => {},
   handleAddWidget = () => {},
+  handleImportWidget = () => {},
 }: WorkspaceHeaderProps) => {
   const { t_i18n } = useFormatter();
   const workspace = useFragment(workspaceHeaderFragment, data);
@@ -120,7 +121,7 @@ const WorkspaceHeader = ({
             >
               <WorkspaceWidgetConfig
                 onComplete={handleAddWidget}
-                data={workspace}
+                handleImportWidget={handleImportWidget}
               />
             </Security>
           </>)}

--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -44,7 +44,7 @@ import { ENTITY_TYPE_MANAGER_CONFIGURATION } from '../modules/managerConfigurati
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from '../modules/playbook/playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
 import { ENTITY_TYPE_DECAY_RULE } from '../modules/decayRule/decayRule-types';
-import { fromBase64, isNotEmptyField } from '../database/utils';
+import { isNotEmptyField } from '../database/utils';
 import { type BasicStoreEntityPublicDashboard, ENTITY_TYPE_PUBLIC_DASHBOARD, type PublicDashboardCached } from '../modules/publicDashboard/publicDashboard-types';
 import { getAllowedMarkings } from '../modules/publicDashboard/publicDashboard-domain';
 import type { BasicStoreEntityConnector } from '../types/connector';
@@ -53,6 +53,7 @@ import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWork
 import { emptyFilterGroup } from '../utils/filtering/filtering-utils';
 import { FunctionalError } from '../config/errors';
 import { type BasicStoreEntityPir, ENTITY_TYPE_PIR } from '../modules/pir/pir-types';
+import { fromB64 } from '../utils/base64';
 
 const ADDS_TOPIC = `${TOPIC_PREFIX}*ADDED_TOPIC`;
 const EDITS_TOPIC = `${TOPIC_PREFIX}*EDIT_TOPIC`;
@@ -281,7 +282,7 @@ const platformPublicDashboards = (context: AuthContext) => {
           internal_id: dash.internal_id,
           uri_key: dash.uri_key,
           dashboard_id: dash.dashboard_id,
-          private_manifest: JSON.parse(fromBase64(dash.private_manifest) ?? ''),
+          private_manifest: fromB64(dash.private_manifest ?? ''),
           user_id: dash.user_id,
           allowed_markings_ids: dash.allowed_markings_ids,
           allowed_markings: markings,

--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
@@ -4,7 +4,7 @@ import { internalLoadById, listEntitiesPaginated, storeLoadById } from '../../da
 import { type BasicStoreEntityPublicDashboard, ENTITY_TYPE_PUBLIC_DASHBOARD, type PublicDashboardCached } from './publicDashboard-types';
 import { createEntity, deleteElementById, loadEntity, updateAttribute } from '../../database/middleware';
 import { type BasicStoreEntityWorkspace } from '../workspace/workspace-types';
-import { fromBase64, isNotEmptyField, toBase64 } from '../../database/utils';
+import { isNotEmptyField } from '../../database/utils';
 import { notify } from '../../database/redis';
 import { BUS_TOPICS, logApp } from '../../config/conf';
 import {
@@ -47,6 +47,7 @@ import { isStixCoreObject } from '../../schema/stixCoreObject';
 import { ES_MAX_CONCURRENCY } from '../../database/engine';
 import { findById as findMarkingDefinitionById } from '../../domain/markingDefinition';
 import { addFilter } from '../../utils/filtering/filtering-utils';
+import { fromB64, toB64 } from '../../utils/base64';
 
 export const findById = (
   context: AuthContext,
@@ -179,7 +180,7 @@ export const addPublicDashboard = async (
     throw FunctionalError(`Cannot publish this dashboard, uri key ${uriKey} already used.`);
   }
 
-  const parsedManifest = JSON.parse(fromBase64(dashboard.manifest) ?? '{}');
+  const parsedManifest = fromB64(dashboard.manifest ?? '{}');
   if (parsedManifest && isNotEmptyField(parsedManifest.widgets)) {
     Object.keys(parsedManifest.widgets).forEach((widgetId) => {
       parsedManifest.widgets[widgetId].dataSelection = parsedManifest
@@ -200,7 +201,7 @@ export const addPublicDashboard = async (
   }
 
   // Create public manifest
-  const publicManifest = toBase64(JSON.stringify(parsedManifest) ?? '{}');
+  const publicManifest = toB64(parsedManifest ?? '{}');
 
   // Create publicDashboard
   const publicDashboardToCreate = {

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
@@ -25,7 +25,7 @@ import { publishUserAction } from '../../listener/UserActionListener';
 import { editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { elFindByIds, elRawDeleteByQuery } from '../../database/engine';
 import type { BasicStoreEntity } from '../../types/store';
-import { buildPagination, fromBase64, isEmptyField, isNotEmptyField, READ_DATA_INDICES_WITHOUT_INTERNAL, READ_INDEX_INTERNAL_OBJECTS, toBase64 } from '../../database/utils';
+import { buildPagination, isEmptyField, isNotEmptyField, READ_DATA_INDICES_WITHOUT_INTERNAL, READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { extractContentFrom } from '../../utils/fileToContent';
 import { isCompatibleVersionWithMinimal } from '../../utils/version';
@@ -336,13 +336,13 @@ export const checkConfigurationImport = (type: string, parsedData: ConfigImportD
 // Export => Dashboard filter ids must be converted to standard id
 // Import => Dashboards filter ids must be converted back to internal id
 const convertWorkspaceManifestIds = async (context: AuthContext, user: AuthUser, manifest: string, from: 'internal' | 'stix'): Promise<string> => {
-  const parsedManifest = JSON.parse(fromBase64(manifest) ?? '{}');
+  const parsedManifest = fromB64(manifest ?? '{}');
   // Regeneration for dashboards
   if (parsedManifest && isNotEmptyField(parsedManifest.widgets)) {
     const { widgets } = parsedManifest;
     const widgetDefinitions = Object.values(widgets);
     await convertWidgetsIds(context, user, widgetDefinitions, from);
-    return toBase64(JSON.stringify(parsedManifest)) as string;
+    return toB64(parsedManifest) as string;
   }
   return manifest;
 };
@@ -368,7 +368,7 @@ export const generateWidgetExportConfiguration = async (context: AuthContext, us
   if (workspace.type !== 'dashboard') {
     throw FunctionalError('WORKSPACE_EXPORT_INCOMPATIBLE_TYPE', { type: workspace.type });
   }
-  const parsedManifest = JSON.parse(fromBase64(workspace.manifest) ?? '{}');
+  const parsedManifest = fromB64(workspace.manifest ?? '{}');
   if (parsedManifest && isNotEmptyField(parsedManifest.widgets) && parsedManifest.widgets[widgetId]) {
     const widgetDefinition = parsedManifest.widgets[widgetId];
     delete widgetDefinition.id; // Remove current widget id
@@ -376,7 +376,7 @@ export const generateWidgetExportConfiguration = async (context: AuthContext, us
     const exportConfigration = {
       openCTI_version: pjson.version,
       type: 'widget',
-      configuration: toBase64(JSON.stringify(widgetDefinition)) as string
+      configuration: toB64(widgetDefinition) as string
     };
     return JSON.stringify(exportConfigration);
   }

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-domain.ts
@@ -6,7 +6,7 @@ import { createEntity, deleteElementById, listThings, paginateAllThings, updateA
 import { listEntitiesPaginated, storeLoadById } from '../../database/middleware-loader';
 import { BUS_TOPICS } from '../../config/conf';
 import { delEditContext, notify, setEditContext } from '../../database/redis';
-import { ENTITY_TYPE_WORKSPACE, type BasicStoreEntityWorkspace } from './workspace-types';
+import { ENTITY_TYPE_WORKSPACE, type BasicStoreEntityWorkspace, type WidgetConfiguration } from './workspace-types';
 import { DatabaseError, FunctionalError } from '../../config/errors';
 import type { AuthContext, AuthUser } from '../../types/user';
 import type {
@@ -32,13 +32,13 @@ import { isCompatibleVersionWithMinimal } from '../../utils/version';
 import { getEntitiesListFromCache } from '../../database/cache';
 import { ENTITY_TYPE_PUBLIC_DASHBOARD, type PublicDashboardCached } from '../publicDashboard/publicDashboard-types';
 import { convertWidgetsIds } from './workspace-utils';
+import { fromB64, toB64 } from '../../utils/base64';
 
 export const PLATFORM_DASHBOARD = 'cf093b57-713f-404b-a210-a1c5c8cb3791';
 
 export const sanitizeElementForPublishAction = (element: BasicStoreEntityWorkspace) => {
   // Because manifest can be huge we remove this data from activity logs.
-  const sanitizeElement = { ...element, manifest: undefined };
-  return sanitizeElement;
+  return { ...element, manifest: undefined };
 };
 
 export const findById = (
@@ -312,7 +312,12 @@ configurationImportTypeValidation.set(
   'Invalid type. Please import OpenCTI widget-type only',
 );
 
-export const checkConfigurationImport = (type: string, parsedData: any) => {
+interface ConfigImportData {
+  type: string
+  openCTI_version: string
+}
+
+export const checkConfigurationImport = (type: string, parsedData: ConfigImportData) => {
   if (configurationImportTypeValidation.has(type) && parsedData.type !== type) {
     throw FunctionalError(configurationImportTypeValidation.get(type), {
       reason: parsedData.type,
@@ -426,31 +431,49 @@ export const duplicateWorkspace = async (context: AuthContext, user: AuthUser, i
   return notify(BUS_TOPICS[ENTITY_TYPE_WORKSPACE].ADDED_TOPIC, created, user);
 };
 
+interface WidgetConfigImportData extends ConfigImportData {
+  configuration?: string // widget definition in base64.
+}
+
 export const workspaceImportWidgetConfiguration = async (
   context: AuthContext,
   user: AuthUser,
   workspaceId: string,
   input: ImportWidgetInput,
 ) => {
-  const parsedData = await extractContentFrom(input.file);
+  const parsedData = await extractContentFrom<WidgetConfigImportData>(input.file);
   checkConfigurationImport('widget', parsedData);
-  const widgetDefinition = JSON.parse(fromBase64(parsedData.configuration) || '{}');
+  const widgetDefinition = fromB64(parsedData.configuration);
   await convertWidgetsIds(context, user, [widgetDefinition], 'stix');
-  const mappedData = {
-    type: parsedData.type,
-    openCTI_version: parsedData.openCTI_version,
-    widget: widgetDefinition,
-  };
   const importedWidgetId = uuidv4();
-  const dashboardManifestObjects = JSON.parse(fromBase64(input.dashboardManifest) || '{}');
+  const dashboardManifestObjects = fromB64(input.dashboardManifest ?? undefined);
+
+  // When importing a widget, change its position to not break
+  // the current layout of the dashboard.
+  // It is moved on a new line.
+  const widgetsArray = Object.values(dashboardManifestObjects.widgets ?? [])
+    .map((widget) => widget) as WidgetConfiguration[];
+  const nextRow = widgetsArray.reduce((max, { layout }) => {
+    const widgetEndRow = layout.y + layout.h;
+    return widgetEndRow > max ? widgetEndRow : max;
+  }, 0);
+
   const updatedObjects = {
     ...dashboardManifestObjects,
     widgets: {
       ...dashboardManifestObjects.widgets,
-      [`${importedWidgetId}`]: { id: importedWidgetId, ...mappedData.widget },
+      [importedWidgetId]: {
+        id: importedWidgetId,
+        ...widgetDefinition,
+        layout: {
+          ...widgetDefinition.layout,
+          x: 0,
+          y: nextRow,
+        }
+      },
     },
   };
-  const updatedManifest = toBase64(JSON.stringify(updatedObjects));
+  const updatedManifest = toB64(updatedObjects);
   const { element } = await updateAttribute(
     context,
     user,
@@ -458,6 +481,7 @@ export const workspaceImportWidgetConfiguration = async (
     ENTITY_TYPE_WORKSPACE,
     [{ key: 'manifest', value: [updatedManifest] }],
   );
+
   await publishUserAction({
     user,
     event_type: 'mutation',

--- a/opencti-platform/opencti-graphql/src/utils/base64.ts
+++ b/opencti-platform/opencti-graphql/src/utils/base64.ts
@@ -1,0 +1,4 @@
+import { fromBase64, toBase64 } from '../database/utils';
+
+export const toB64 = (data: unknown): string | undefined => toBase64(JSON.stringify(data));
+export const fromB64 = <T = any>(data?: string): T | undefined => JSON.parse(fromBase64(data) || '{}');

--- a/opencti-platform/opencti-graphql/src/utils/base64.ts
+++ b/opencti-platform/opencti-graphql/src/utils/base64.ts
@@ -1,4 +1,4 @@
 import { fromBase64, toBase64 } from '../database/utils';
 
 export const toB64 = (data: unknown): string | undefined => toBase64(JSON.stringify(data));
-export const fromB64 = <T = any>(data?: string): T | undefined => JSON.parse(fromBase64(data) || '{}');
+export const fromB64 = <T = any>(data?: string): T => JSON.parse(fromBase64(data) || '{}');

--- a/opencti-platform/opencti-graphql/src/utils/fileToContent.ts
+++ b/opencti-platform/opencti-graphql/src/utils/fileToContent.ts
@@ -1,9 +1,9 @@
 import type { FileHandle } from 'fs/promises';
 import { streamToString } from '../database/file-storage';
 
-export async function extractContentFrom(file: Promise<FileHandle>) {
+export async function extractContentFrom<T = any>(file: Promise<FileHandle>) {
   const uploadedFile = await file;
   const readStream = uploadedFile.createReadStream();
   const fileContent = await streamToString(readStream);
-  return JSON.parse(fileContent.toString());
+  return JSON.parse(fileContent.toString()) as T;
 }

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/publicDashboard-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/publicDashboard-test.js
@@ -1,11 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
 import { ADMIN_USER, editorQuery, getUserIdByEmail, participantQuery, queryAsAdmin, USER_EDITOR, USER_PARTICIPATE } from '../../utils/testQuery';
-import { toBase64 } from '../../../src/database/utils';
 import { PRIVATE_DASHBOARD_MANIFEST } from './publicDashboard-data';
 import { resetCacheForEntity } from '../../../src/database/cache';
 import { ENTITY_TYPE_PUBLIC_DASHBOARD } from '../../../src/modules/publicDashboard/publicDashboard-types';
 import { queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
+import { toB64 } from '../../../src/utils/base64';
 
 const LIST_QUERY = gql`
   query publicDashboards(
@@ -233,7 +233,7 @@ describe('PublicDashboard resolver', () => {
   describe('Tests with manifest', () => {
     beforeAll(async () => {
       // Add manifest to Private dashboard as empty dashboard should not be published
-      const manifest = toBase64(JSON.stringify(PRIVATE_DASHBOARD_MANIFEST));
+      const manifest = toB64(PRIVATE_DASHBOARD_MANIFEST);
       await queryAsAdmin({
         query: UPDATE_PRIVATE_DASHBOARD_QUERY,
         variables: {

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/workspace-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/workspace-test.js
@@ -3,8 +3,8 @@ import gql from 'graphql-tag';
 import { ADMIN_USER, editorQuery, getUserIdByEmail, queryAsAdmin, testContext, USER_EDITOR } from '../../utils/testQuery';
 import { elLoadById } from '../../../src/database/engine';
 import { MEMBER_ACCESS_ALL } from '../../../src/utils/access';
-import { toBase64 } from '../../../src/database/utils';
 import { createUploadFromTestDataFile, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
+import { toB64 } from '../../../src/utils/base64';
 
 const LIST_QUERY = gql`
   query workspaces(
@@ -308,7 +308,7 @@ describe('Workspace resolver standard behavior', () => {
     expect(workspaceWidget.data.workspaceAdd.name).toEqual(workspaceWidgetName);
     const workspaceId = workspaceWidget.data.workspaceAdd.id;
     const upload = await createUploadFromTestDataFile('20231123_octi_widget_list.json', 'valid.json', 'application/json');
-    const emptyDashboardManifest = toBase64(JSON.stringify({ widgets: {}, config: {} }));
+    const emptyDashboardManifest = toB64({ widgets: {}, config: {} });
 
     const queryResult = await queryAsAdmin({
       query: gql`
@@ -340,7 +340,7 @@ describe('Workspace resolver standard behavior', () => {
 
   it('can not import widget, given invalid widget type import', async () => {
     const upload = await createUploadFromTestDataFile('20231123_invalid_type_octi_widget_list.json', 'invalid-type.json', 'application/json');
-    const emptyDashboardManifest = toBase64(JSON.stringify({ widgets: {}, config: {} }));
+    const emptyDashboardManifest = toB64({ widgets: {}, config: {} });
 
     const queryResult = await queryAsAdmin({
       query: gql`
@@ -367,7 +367,7 @@ describe('Workspace resolver standard behavior', () => {
 
   it('can not import widget, given invalid widget version import', async () => {
     const upload = await createUploadFromTestDataFile('20231123_invalid_version_octi_widget_list.json', 'invalid-version.json', 'application/json', 'utf8');
-    const emptyDashboardManifest = toBase64(JSON.stringify({ widgets: {}, config: {} }));
+    const emptyDashboardManifest = toB64({ widgets: {}, config: {} });
 
     const queryResult = await queryAsAdmin({
       query: gql`


### PR DESCRIPTION
### Proposed changes

* Front: take in account layout changes when importing widget
* Back: change imported widget position to move it on a new line at the end of dashboard (to not break existing layout)

How to reproduce bug on master:
- create a dashboard
- add some widgets
- modify their size and position
- import a widget
- _the layout rollback_

In the branch, the layout stays and the imported widget goes at the end of the layout

### Related issues

* #12085

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality