### PR TITLE
[backend] feat: send hub lost connectivity email only after 24 hours

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "Status der XTM-Hub-Registrierung",
   "XTM Hub registration User ID": "XTM-Hub-Registrierung Benutzer-ID",
   "XTM Hub registration User name": "XTM-Hub-Registrierung Benutzername",
+  "XTM Hub should send connectivity email": "XTM Hub sollte Konnektivitäts-E-Mails senden",
   "XTM Hub Token": "XTM-Hub-Token"
 }

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "XTM Hub registration status",
   "XTM Hub registration User ID": "XTM Hub registration User ID",
   "XTM Hub registration User name": "XTM Hub registration User name",
+  "XTM Hub should send connectivity email": "XTM Hub should send connectivity email",
   "XTM Hub Token": "XTM Hub Token"
 }

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "Estado de registro en XTM Hub",
   "XTM Hub registration User ID": "XTM Hub registro ID de usuario",
   "XTM Hub registration User name": "XTM Hub registro Nombre de usuario",
+  "XTM Hub should send connectivity email": "El eje de XTM debe enviar el email de la conectividad",
   "XTM Hub Token": "Token del concentrador XTM"
 }

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "Statut de l'inscription au XTM Hub",
   "XTM Hub registration User ID": "ID de l'utilisateur de l'enregistrement du XTM Hub",
   "XTM Hub registration User name": "Nom de l'utilisateur pour l'enregistrement du XTM Hub",
+  "XTM Hub should send connectivity email": "XTM Hub doit envoyer un e-mail de connectivité",
   "XTM Hub Token": "Token XTM Hub"
 }

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "Stato di registrazione XTM Hub",
   "XTM Hub registration User ID": "ID utente registrazione XTM Hub",
   "XTM Hub registration User name": "Registrazione XTM Hub Nome utente",
+  "XTM Hub should send connectivity email": "XTM Hub dovrebbe inviare un'e-mail di connettività",
   "XTM Hub Token": "Token XTM Hub"
 }

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "XTMハブ登録状況",
   "XTM Hub registration User ID": "XTMハブ登録ユーザーID",
   "XTM Hub registration User name": "XTMハブ登録ユーザー名",
+  "XTM Hub should send connectivity email": "XTM Hubは接続性の電子メールを送信する必要があります。",
   "XTM Hub Token": "XTM ハブ・トークン"
 }

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "XTM Hub 등록 상태",
   "XTM Hub registration User ID": "XTM Hub 등록 사용자 ID",
   "XTM Hub registration User name": "XTM Hub 등록 사용자 이름",
+  "XTM Hub should send connectivity email": "XTM 허브가 연결 이메일을 보내야 합니다",
   "XTM Hub Token": "XTM 허브 토큰"
 }

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "Статус регистрации XTM Hub",
   "XTM Hub registration User ID": "Идентификатор пользователя при регистрации концентратора XTM",
   "XTM Hub registration User name": "Регистрация концентратора XTM Имя пользователя",
+  "XTM Hub should send connectivity email": "Концентратор XTM должен отправить электронное сообщение о возможности подключения",
   "XTM Hub Token": "Токен концентратора XTM"
 }

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -952,5 +952,6 @@
   "XTM Hub registration status": "XTM Hub 注册状态",
   "XTM Hub registration User ID": "XTM Hub 注册用户 ID",
   "XTM Hub registration User name": "XTM Hub 注册用户名",
+  "XTM Hub should send connectivity email": "XTM 中枢应发送连接电子邮件",
   "XTM Hub Token": "XTM 中枢令牌"
 }

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "Möchten Sie diese Abklingregel löschen?",
   "Do you want to delete this dissemination list?": "Möchten Sie diese Verbreitungsliste löschen?",
   "Do you want to delete this draft?": "Möchten Sie diesen Entwurf löschen?",
-  "Do you want to delete this Email template?": "Möchten Sie diese E-Mail-Vorlage löschen?",
+  "Do you want to delete this email template?": "Möchten Sie diese E-Mail-Vorlage löschen?",
   "Do you want to delete this entity?": "Möchten Sie diese Entität löschen?",
   "Do you want to delete this event?": "Möchten Sie dieses Ereignis löschen?",
   "Do you want to delete this exclusion list?": "Möchten Sie diese Ausschlussliste löschen?",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "¿Desea eliminar esta regla de decaimiento?",
   "Do you want to delete this dissemination list?": "¿Desea eliminar esta lista de difusión?",
   "Do you want to delete this draft?": "¿Desea eliminar este borrador?",
-  "Do you want to delete this Email template?": "¿Desea eliminar esta plantilla de correo electrónico?",
+  "Do you want to delete this email template?": "¿Desea eliminar esta plantilla de correo electrónico?",
   "Do you want to delete this entity?": "¿Quieres borrar esta entidad?",
   "Do you want to delete this event?": "¿Desea eliminar este evento?",
   "Do you want to delete this exclusion list?": "¿Desea eliminar esta lista de exclusión?",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "Souhaitez-vous supprimer cette règle de déclin ?",
   "Do you want to delete this dissemination list?": "Voulez-vous supprimer cette liste de diffusion ?",
   "Do you want to delete this draft?": "Voulez-vous supprimer ce brouillon ?",
-  "Do you want to delete this Email template?": "Souhaitez-vous supprimer ce modèle d'e-mail ?",
+  "Do you want to delete this email template?": "Souhaitez-vous supprimer ce modèle de courrier électronique ?",
   "Do you want to delete this entity?": "Souhaitez-vous supprimer cette entité ?",
   "Do you want to delete this event?": "Voulez-vous supprimer cet événement ?",
   "Do you want to delete this exclusion list?": "Voulez-vous supprimer cette liste d'exclusion ?",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "Si desidera eliminare questa regola di decadimento?",
   "Do you want to delete this dissemination list?": "Vuoi eliminare questa lista di diffusione?",
   "Do you want to delete this draft?": "Vuoi eliminare questa bozza?",
-  "Do you want to delete this Email template?": "Volete cancellare questo modello di e-mail?",
+  "Do you want to delete this email template?": "Volete cancellare questo modello di e-mail?",
   "Do you want to delete this entity?": "Vuoi eliminare questa entità?",
   "Do you want to delete this event?": "Vuoi eliminare questo evento?",
   "Do you want to delete this exclusion list?": "Vuoi eliminare questa lista di esclusione?",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "この減衰ルールを削除しますか？",
   "Do you want to delete this dissemination list?": "この配信リストを削除しますか？",
   "Do you want to delete this draft?": "この下書きを削除しますか？",
-  "Do you want to delete this Email template?": "このメールテンプレートを削除しますか？",
+  "Do you want to delete this email template?": "このメールテンプレートを削除しますか？",
   "Do you want to delete this entity?": "このエンティティを削除しますか？",
   "Do you want to delete this event?": "このイベントを削除しますか？",
   "Do you want to delete this exclusion list?": "この除外リストを削除しますか？",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "이 소멸 규칙을 삭제하시겠습니까?",
   "Do you want to delete this dissemination list?": "이 배포 목록을 삭제하시겠습니까?",
   "Do you want to delete this draft?": "이 초안을 삭제하시겠습니까?",
-  "Do you want to delete this Email template?": "이 이메일 템플릿을 삭제하시겠습니까?",
+  "Do you want to delete this email template?": "이 이메일 템플릿을 삭제하시겠습니까?",
   "Do you want to delete this entity?": "이 엔터티를 삭제하시겠습니까?",
   "Do you want to delete this event?": "이 이벤트를 삭제하시겠습니까?",
   "Do you want to delete this exclusion list?": "이 제외 목록을 삭제하시겠습니까?",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "Хотите ли вы удалить это правило распада?",
   "Do you want to delete this dissemination list?": "Хотите ли вы удалить этот список распространения?",
   "Do you want to delete this draft?": "Вы хотите удалить этот черновик?",
-  "Do you want to delete this Email template?": "Хотите ли вы удалить этот шаблон электронной почты?",
+  "Do you want to delete this email template?": "Вы хотите удалить этот шаблон электронной почты?",
   "Do you want to delete this entity?": "Вы хотите удалить эту сущность?",
   "Do you want to delete this event?": "Вы хотите удалить это событие?",
   "Do you want to delete this exclusion list?": "Хотите ли вы удалить этот список исключений?",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1010,7 +1010,7 @@
   "Do you want to delete this decay rule?": "您想删除这条衰减规则吗？",
   "Do you want to delete this dissemination list?": "你想删除这个传播列表吗？",
   "Do you want to delete this draft?": "要删除此草稿吗？",
-  "Do you want to delete this Email template?": "您想删除此电子邮件模板吗？",
+  "Do you want to delete this email template?": "您想删除此电子邮件模板吗？",
   "Do you want to delete this entity?": "是否要删除此实体？",
   "Do you want to delete this event?": "您想删除此事件吗？",
   "Do you want to delete this exclusion list?": "要删除此排除列表吗？",

--- a/opencti-platform/opencti-graphql/src/domain/settings.js
+++ b/opencti-platform/opencti-graphql/src/domain/settings.js
@@ -169,7 +169,8 @@ const ACCESS_SETTINGS_MANAGE_XTMHUB_KEYS = [
   'xtm_hub_last_connectivity_check',
   'xtm_hub_registration_date',
   'xtm_hub_registration_user_name',
-  'xtm_hub_registration_status'
+  'xtm_hub_registration_status',
+  'xtm_hub_should_send_connectivity_email'
 ];
 
 export const settingsEditField = async (context, user, settingsId, input) => {

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -213,6 +213,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'xtm_hub_registration_user_id', label: 'XTM Hub registration User ID', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_USER], mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'xtm_hub_registration_user_name', label: 'XTM Hub registration User name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'xtm_hub_last_connectivity_check', label: 'XTM Hub last connectivity check', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'xtm_hub_should_send_connectivity_email', label: 'XTM Hub should send connectivity email', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'xtm_hub_registration_date', label: 'XTM Hub registration date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'xtm_hub_registration_status', label: 'XTM Hub registration status', type: 'string', format: 'enum', values: ['registered', 'unregistered', 'lost_connectivity'], editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: false },
   ],

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-email.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-email.ts
@@ -1,0 +1,48 @@
+import ejs from 'ejs';
+import conf, { getBaseUrl, logApp } from '../../../config/conf';
+import type { AuthContext, AuthUser } from '../../../types/user';
+import { findUserWithCapabilities } from '../../../domain/user';
+import { BYPASS, HUB_REGISTRATION_MANAGER_USER, SETTINGS_SETMANAGEXTMHUB } from '../../../utils/access';
+import type { BasicStoreSettings } from '../../../types/settings';
+import { OCTI_EMAIL_TEMPLATE } from '../../../utils/emailTemplates/octiEmailTemplate';
+import type { SendMailArgs } from '../../../types/smtp';
+import { sendMail } from '../../../database/smtp';
+
+const MAX_EMAIL_LIST_SIZE = conf.get('smtp:email_max_cc_size') || 500;
+const TO_EMAIL = conf.get('xtm:xtmhub_to_email') || 'no-reply@filigran.io';
+const EMAIL_BODY = `
+  <p>We wanted to inform you that the connectivity between OpenCTI and the XTM Hub has been lost. As a result, the integration is currently inactive.</p>
+  <p>To restore functionality, please navigate to the <strong>Settings</strong> section and re-initiate the registration process for the OpenCTI platform. This will re-establish the connection and allow continued use of the integrated features.</p>
+  <p>If you need assistance during the process, don’t hesitate to reach out.</p>
+  <p>
+    <a href="${getBaseUrl()}">Access OpenCTI</a><br />
+    Best,<br />
+    Filigran Team<br />
+  </p>
+`;
+
+const loadAdministratorsList = async (context: AuthContext) => {
+  const administrators = (await findUserWithCapabilities(context, HUB_REGISTRATION_MANAGER_USER, [BYPASS, SETTINGS_SETMANAGEXTMHUB])) as AuthUser[];
+  if (administrators.length > MAX_EMAIL_LIST_SIZE) {
+    logApp.warn(`Administrators list too large, loading only ${MAX_EMAIL_LIST_SIZE} first administrators.`);
+    return administrators.slice(0, MAX_EMAIL_LIST_SIZE);
+  }
+
+  return administrators;
+};
+
+export const sendAdministratorsLostConnectivityEmail = async (context: AuthContext, settings: BasicStoreSettings) => {
+  const administrators = await loadAdministratorsList(context);
+  const subject = 'Action Required: Re-register OpenCTI Platform Due to Lost Connectivity with XTM Hub';
+  const html = ejs.render(OCTI_EMAIL_TEMPLATE, { settings, body: EMAIL_BODY });
+
+  const sendMailArgs: SendMailArgs = {
+    from: `${settings.platform_title} <${settings.platform_email}>`,
+    to: TO_EMAIL,
+    bcc: administrators.map((administrator) => administrator.user_email),
+    subject,
+    html,
+  };
+
+  await sendMail(sendMailArgs, { category: 'hub-registration' });
+};

--- a/opencti-platform/opencti-graphql/src/types/settings.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/settings.d.ts
@@ -25,4 +25,6 @@ export interface BasicStoreSettings extends BasicStoreEntity {
   xtm_hub_registration_user_id?: string
   xtm_hub_registration_user_name?: string
   xtm_hub_registration_date?: Date
+  xtm_hub_last_connectivity_check?: Date
+  xtm_hub_should_send_connectivity_email?: boolean
 }

--- a/opencti-platform/opencti-graphql/src/utils/settings.helper.ts
+++ b/opencti-platform/opencti-graphql/src/utils/settings.helper.ts
@@ -23,6 +23,10 @@ export const completeXTMHubDataForRegistration = (user: AuthUser, input: InputSe
       {
         key: 'xtm_hub_last_connectivity_check',
         value: [new Date()]
+      },
+      {
+        key: 'xtm_hub_should_send_connectivity_email',
+        value: [true]
       }
     ];
   }

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/xtm-hub-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/xtm-hub-test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import * as cache from '../../../src/database/cache';
+import { checkXTMHubConnectivity } from '../../../src/domain/xtm-hub';
+import { testContext } from '../../utils/testQuery';
+import { HUB_REGISTRATION_MANAGER_USER } from '../../../src/utils/access';
+import { XtmHubRegistrationStatus } from '../../../src/generated/graphql';
+import { xtmHubClient } from '../../../src/modules/xtm/hub/xtm-hub-client';
+import type { BasicStoreSettings } from '../../../src/types/settings';
+import * as middleware from '../../../src/database/middleware';
+import { ENTITY_TYPE_SETTINGS } from '../../../src/schema/internalObject';
+import * as settingsModule from '../../../src/domain/settings';
+import * as redisModule from '../../../src/database/redis';
+import * as xtmHubEmail from '../../../src/modules/xtm/hub/xtm-hub-email';
+
+describe('XTM hub', () => {
+  describe('checkXTMHubConnectivity', () => {
+    const xtm_hub_token = 'fake-token';
+    let getEntityFromCacheSpy: MockInstance;
+    let xtmHubClientSpy: MockInstance;
+    let updateAttributeSpy: MockInstance;
+    let sendAdministratorsLostConnectivityEmailSpy: MockInstance;
+
+    beforeEach(() => {
+      getEntityFromCacheSpy = vi.spyOn(cache, 'getEntityFromCache');
+      xtmHubClientSpy = vi.spyOn(xtmHubClient, 'loadRegistrationStatus');
+      updateAttributeSpy = vi.spyOn(middleware, 'updateAttribute').mockResolvedValue({});
+      sendAdministratorsLostConnectivityEmailSpy = vi.spyOn(xtmHubEmail, 'sendAdministratorsLostConnectivityEmail').mockResolvedValue({} as any);
+      vi.spyOn(settingsModule, 'getSettings').mockResolvedValue({} as any);
+      vi.spyOn(redisModule, 'notify').mockResolvedValue({});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return the unregistered status when platform is not registered', async () => {
+      const settings = {};
+      getEntityFromCacheSpy.mockResolvedValue(settings);
+
+      const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+      expect(result.status).toBe(XtmHubRegistrationStatus.Unregistered);
+    });
+
+    it('should update registration status when connectivity is lost', async () => {
+      const settings: Partial<BasicStoreSettings> = {
+        id: 'id',
+        xtm_hub_token,
+        xtm_hub_registration_status: XtmHubRegistrationStatus.Registered
+      };
+      getEntityFromCacheSpy.mockResolvedValue(settings);
+      xtmHubClientSpy.mockResolvedValue('inactive');
+
+      const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+      expect(result.status).toBe(XtmHubRegistrationStatus.LostConnectivity);
+      expect(updateAttributeSpy).toBeCalledWith(
+        testContext,
+        HUB_REGISTRATION_MANAGER_USER,
+        'id',
+        ENTITY_TYPE_SETTINGS,
+        [{ key: 'xtm_hub_registration_status', value: [XtmHubRegistrationStatus.LostConnectivity] }]
+      );
+    });
+
+    it('should update registration status when connectivity is back up again', async () => {
+      const settings: Partial<BasicStoreSettings> = {
+        id: 'id',
+        xtm_hub_token,
+        xtm_hub_registration_status: XtmHubRegistrationStatus.LostConnectivity,
+        xtm_hub_should_send_connectivity_email: false
+      };
+      getEntityFromCacheSpy.mockResolvedValue(settings);
+      xtmHubClientSpy.mockResolvedValue('active');
+
+      const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+      expect(result.status).toBe(XtmHubRegistrationStatus.Registered);
+      expect(updateAttributeSpy).toBeCalledWith(
+        testContext,
+        HUB_REGISTRATION_MANAGER_USER,
+        'id',
+        ENTITY_TYPE_SETTINGS,
+        [
+          { key: 'xtm_hub_registration_status', value: [XtmHubRegistrationStatus.Registered] },
+          { key: 'xtm_hub_last_connectivity_check', value: [expect.any(Date)] },
+          { key: 'xtm_hub_should_send_connectivity_email', value: [true] }
+        ]
+      );
+    });
+
+    it('should not update registration status when connectivity stays inactive', async () => {
+      const settings: Partial<BasicStoreSettings> = {
+        id: 'id',
+        xtm_hub_token,
+        xtm_hub_registration_status: XtmHubRegistrationStatus.LostConnectivity
+      };
+      getEntityFromCacheSpy.mockResolvedValue(settings);
+      xtmHubClientSpy.mockResolvedValue('inactive');
+
+      const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+      expect(result.status).toBe(XtmHubRegistrationStatus.LostConnectivity);
+      expect(updateAttributeSpy).not.toBeCalled();
+    });
+
+    it('should only update last connectivity check when connection stays active', async () => {
+      const settings: Partial<BasicStoreSettings> = {
+        id: 'id',
+        xtm_hub_token,
+        xtm_hub_registration_status: XtmHubRegistrationStatus.Registered,
+        xtm_hub_should_send_connectivity_email: true
+      };
+      getEntityFromCacheSpy.mockResolvedValue(settings);
+      xtmHubClientSpy.mockResolvedValue('active');
+
+      const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+      expect(result.status).toBe(XtmHubRegistrationStatus.Registered);
+      expect(updateAttributeSpy).toBeCalledWith(
+        testContext,
+        HUB_REGISTRATION_MANAGER_USER,
+        'id',
+        ENTITY_TYPE_SETTINGS,
+        [{ key: 'xtm_hub_last_connectivity_check', value: [expect.any(Date)] }]
+      );
+    });
+
+    describe('lost connectivity email send', () => {
+      it('should send connectivity email when 24 hours passed and connectivity is lost', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.LostConnectivity,
+          xtm_hub_last_connectivity_check: new Date(new Date().getTime() - 1000 * 60 * 60 * 24),
+          xtm_hub_should_send_connectivity_email: true
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientSpy.mockResolvedValue('inactive');
+
+        await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(sendAdministratorsLostConnectivityEmailSpy).toBeCalled();
+        expect(updateAttributeSpy).toBeCalledWith(
+          testContext,
+          HUB_REGISTRATION_MANAGER_USER,
+          'id',
+          ENTITY_TYPE_SETTINGS,
+          [{ key: 'xtm_hub_should_send_connectivity_email', value: [false] }]
+        );
+      });
+
+      it('should not send connectivity email when connectivity is lost and 24 hours did not pass', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.LostConnectivity,
+          xtm_hub_last_connectivity_check: new Date(new Date().getTime() - 1000 * 60 * 60 * 23),
+          xtm_hub_should_send_connectivity_email: true
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientSpy.mockResolvedValue('inactive');
+
+        await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(sendAdministratorsLostConnectivityEmailSpy).not.toBeCalled();
+      });
+
+      it('should not send connectivity email when email was already sent', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.LostConnectivity,
+          xtm_hub_last_connectivity_check: new Date(new Date().getTime() - 1000 * 60 * 60 * 24),
+          xtm_hub_should_send_connectivity_email: false
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientSpy.mockResolvedValue('inactive');
+
+        await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(sendAdministratorsLostConnectivityEmailSpy).not.toBeCalled();
+      });
+
+      it('should not send connectivity email when connectivity is active', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.Registered
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientSpy.mockResolvedValue('active');
+
+        await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(sendAdministratorsLostConnectivityEmailSpy).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/settings-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/settings-test.ts
@@ -20,7 +20,8 @@ describe('XTM Hub settings helper', () => {
     const userName = data.find((item) => item.key === 'xtm_hub_registration_user_name');
     const registrationDate = data.find((item) => item.key === 'xtm_hub_registration_date');
     const lastConnectivityCheck = data.find((item) => item.key === 'xtm_hub_last_connectivity_check');
-    expect(data.length).toEqual(7);
+    const shouldSendConnectivityEmail = data.find((item) => item.key === 'xtm_hub_should_send_connectivity_email');
+    expect(data.length).toEqual(8);
     expect(xtmHubToken).toBeTruthy();
     expect(registrationStatus).toBeTruthy();
     expect(userId).toBeTruthy();
@@ -29,6 +30,7 @@ describe('XTM Hub settings helper', () => {
     expect(userName?.value).toEqual([ADMIN_USER.name]);
     expect(registrationDate).toBeTruthy();
     expect(lastConnectivityCheck).toBeTruthy();
+    expect(shouldSendConnectivityEmail).toBeTruthy();
   });
   it('should not complete XTM Data', () => {
     const mockInput: InputSettingsData[] = [


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* move email send to its own file
* add unit tests on connectivity check function
* send lost connectivity email only after 24 hours

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12111 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
