### PR TITLE
[frontend] Store information of XTM Hub accessible in the context #12002 #12130

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -17,6 +17,7 @@ import generateAnalyticsConfig from './Analytics';
 import { RootMe_data$key } from './__generated__/RootMe_data.graphql';
 import { RootPrivateQuery } from './__generated__/RootPrivateQuery.graphql';
 import { RootSettings$data, RootSettings$key } from './__generated__/RootSettings.graphql';
+import useNetworkCheck from '../utils/hooks/useCheckNetwork';
 
 const rootSettingsFragment = graphql`
   fragment RootSettings on Settings {
@@ -379,6 +380,7 @@ const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
   const platformModuleHelpers = platformModuleHelper(settings);
   const platformAnalyticsConfiguration = generateAnalyticsConfig(settings);
 
+  const { isReachable } = useNetworkCheck(settings?.platform_xtmhub_url);
   return (
     <UserContext.Provider
       value={{
@@ -388,6 +390,7 @@ const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
         entitySettings,
         platformModuleHelpers,
         schema,
+        isXTMHubAccessible: isReachable,
       }}
     >
       <StyledEngineProvider injectFirst={true}>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -19,7 +19,6 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 import { isNotEmptyField } from '../../../utils/utils';
 import GradientButton from '../../../components/GradientButton';
-import useNetworkCheck from '../../../utils/hooks/useCheckNetwork';
 
 const LOCAL_STORAGE_KEY = 'ingestionCsvs';
 
@@ -34,12 +33,11 @@ const useStyles = makeStyles(() => ({
 
 const IngestionCsv = () => {
   const classes = useStyles();
-  const { settings } = useContext(UserContext);
+  const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
     ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?opencti_platform_id=${settings.id}`
     : '';
 
-  const { isReachable } = useNetworkCheck(settings?.platform_xtmhub_url);
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
   setTitle(t_i18n('CSV Feeds | Ingestion | Data'));
@@ -111,7 +109,7 @@ const IngestionCsv = () => {
               <IngestionCsvImport
                 paginationOptions={paginationOptions}
               />
-              {isReachable && isNotEmptyField(importFromHubUrl) && (
+              {isXTMHubAccessible && isNotEmptyField(importFromHubUrl) && (
                 <GradientButton
                   size="small"
                   sx={{ marginLeft: 1 }}

--- a/opencti-platform/opencti-front/src/private/components/settings/Experience.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Experience.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext, useState } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import Grid from '@mui/material/Grid';
 import XtmHubSettings from '@components/settings/xtm-hub/XtmHubSettings';
@@ -35,8 +35,6 @@ import type { Theme } from '../../../components/Theme';
 import { FieldOption } from '../../../utils/field';
 import useApiMutation from '../../../utils/hooks/useApiMutation';
 import useGranted, { SETTINGS_SETPARAMETERS, SETTINGS_SUPPORT } from '../../../utils/hooks/useGranted';
-import { UserContext } from '../../../utils/hooks/useAuth';
-import useNetworkCheck from '../../../utils/hooks/useCheckNetwork';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
@@ -127,8 +125,6 @@ const ExperienceComponent: FunctionComponent<ExperienceComponentProps> = ({ quer
       })
       .catch(() => false);
   };
-  const { settings: userSettings } = useContext(UserContext);
-  const { isReachable } = useNetworkCheck(userSettings?.platform_xtmhub_url);
 
   return (
     <div className={classes.container}>
@@ -313,7 +309,7 @@ const ExperienceComponent: FunctionComponent<ExperienceComponentProps> = ({ quer
           </Grid>
         )}
         {
-          isReachable && <Grid item xs={6}>
+          <Grid item xs={6}>
             <XtmHubSettings />
           </Grid>
         }

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -1,17 +1,18 @@
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import Paper from '@mui/material/Paper';
 import { List, ListItem, ListItemText, Typography } from '@mui/material';
 import { Theme } from '@mui/material/styles/createTheme';
 import XtmHubTab from '@components/settings/xtm-hub/XtmHubTab';
 import makeStyles from '@mui/styles/makeStyles';
-import Skeleton from '@mui/material/Skeleton';
 import { useFormatter } from '../../../../components/i18n';
 import { XtmHubSettingsQuery } from './__generated__/XtmHubSettingsQuery.graphql';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import useGranted, { SETTINGS_SETMANAGEXTMHUB } from '../../../../utils/hooks/useGranted';
 import GradientButton from '../../../../components/GradientButton';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import { UserContext } from '../../../../utils/hooks/useAuth';
+import Loader, { LoaderVariant } from '../../../../components/Loader';
 
 const useStyles = makeStyles<Theme>((theme) => ({
   paper: {
@@ -51,13 +52,13 @@ const XtmHubSettingsComponent = () => {
     {},
   );
   const isGrantedToXtmHub = useGranted([SETTINGS_SETMANAGEXTMHUB]);
-
+  const { isXTMHubAccessible } = useContext(UserContext);
   return (
     <>
       <Typography variant="h4" gutterBottom={true} style={{ float: 'left' }}>
         {t_i18n('XTM Hub')}
       </Typography>
-      {isGrantedToXtmHub && (<XtmHubTab registrationStatus={xtmHubSettings.xtm_hub_registration_status || undefined} />)}
+      {isGrantedToXtmHub && isXTMHubAccessible && (<XtmHubTab registrationStatus={xtmHubSettings.xtm_hub_registration_status || undefined} />)}
       <div className="clearfix" />
       <Paper
         classes={{ root: classes.paper }}
@@ -76,9 +77,11 @@ const XtmHubSettingsComponent = () => {
               <li>{t_i18n('stay informed of new resources and key threat events with an exclusive news feed')} <i>({t_i18n('coming soon')})</i></li>
               <li>{t_i18n('monitor key metrics of the platform and health status')} <i>({t_i18n('coming soon')})</i></li>
             </List>
+
             <GradientButton variant="outlined" component="a" href="https://filigran.io/platforms/xtm-hub/" target="_blank" rel="noreferrer" style={{ marginTop: 10, marginBottom: 10 }}>
               {t_i18n('Discover the Hub')}
             </GradientButton>
+
           </>
         )}
         <List style={{ marginTop: -10 }}>
@@ -148,12 +151,7 @@ const XtmHubSettings: React.FC = () => {
   }, []);
 
   if (!isCheckDone) {
-    return <Skeleton
-      animation="wave"
-      variant="rectangular"
-      width="100%"
-      height="100%"
-           />;
+    return <Loader variant={LoaderVariant.inElement} />;
   }
 
   return <XtmHubSettingsComponent />;

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.jsx
@@ -21,7 +21,6 @@ import CreateEntityControlledDial from '../../../components/CreateEntityControll
 import { isNotEmptyField } from '../../../utils/utils';
 import GradientButton from '../../../components/GradientButton';
 import { UserContext } from '../../../utils/hooks/useAuth';
-import useNetworkCheck from '../../../utils/hooks/useCheckNetwork';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -60,11 +59,10 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
   const theme = useTheme();
   const { t_i18n } = useFormatter();
   const inputRef = useRef();
-  const { settings } = useContext(UserContext);
+  const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
     ? `${settings.platform_xtmhub_url}/redirect/octi_custom_dashboards?opencti_platform_id=${settings.id}`
     : '';
-  const { isReachable } = useNetworkCheck(settings?.platform_xtmhub_url);
 
   const [commitImportMutation] = useApiMutation(importMutation);
   const [commitCreationMutation] = useApiMutation(workspaceMutation);
@@ -127,7 +125,7 @@ const WorkspaceCreation = ({ paginationOptions, type }) => {
       >
         <FileUploadOutlined fontSize="small" color={'primary'} />
       </ToggleButton>
-      {isReachable && isNotEmptyField(importFromHubUrl) && (
+      {isXTMHubAccessible && isNotEmptyField(importFromHubUrl) && (
         <GradientButton
           size="small"
           sx={{ marginLeft: theme.spacing(1) }}

--- a/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAuth.ts
@@ -40,6 +40,7 @@ export interface UserContextType {
   entitySettings: RootPrivateQuery$data['entitySettings'] | undefined;
   platformModuleHelpers: ModuleHelper | undefined;
   schema: SchemaType | undefined;
+  isXTMHubAccessible: boolean | null | undefined;
 }
 
 const defaultContext = {
@@ -49,6 +50,7 @@ const defaultContext = {
   entitySettings: undefined,
   platformModuleHelpers: undefined,
   schema: undefined,
+  isXTMHubAccessible: undefined,
 };
 export const UserContext = React.createContext<UserContextType>(defaultContext);
 
@@ -60,11 +62,12 @@ const useAuth = () => {
     entitySettings,
     platformModuleHelpers,
     schema,
+    isXTMHubAccessible,
   } = useContext(UserContext);
   if (!me || !settings || !bannerSettings || !entitySettings || !platformModuleHelpers || !schema) {
     throw new Error('Invalid user context !');
   }
-  return { me, settings, bannerSettings, entitySettings, platformModuleHelpers, schema };
+  return { me, settings, bannerSettings, entitySettings, platformModuleHelpers, schema, isXTMHubAccessible };
 };
 
 export default useAuth;

--- a/opencti-platform/opencti-front/src/utils/hooks/useCheckNetwork.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useCheckNetwork.tsx
@@ -24,7 +24,6 @@ const useNetworkCheck = (url?: string | null): UseNetworkCheckResult => {
         await fetch(url, {
           method: 'HEAD',
           mode: 'no-cors',
-          cache: 'no-cache',
           signal: controller.signal,
         });
 

--- a/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
@@ -55,6 +55,7 @@ export const createMockUserContext = (options?: CreateUserContextOptions): UserC
     entitySettings: (entitySettings ?? {}) as UserContextType['entitySettings'],
     platformModuleHelpers: (platformModuleHelpers ?? {}) as UserContextType['platformModuleHelpers'],
     schema: (schema ?? {}) as UserContextType['schema'],
+    isXTMHubAccessible: true,
   };
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Replace Skeleton by Filigran Loader
* Hide button in Filigran experience instead of the card
* Store information of XTM Hub accessible in the context

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12002
* #12130 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
