### PR TITLE
[backend] Fix file indexing when no file mime types selected (#12050)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/file.js
+++ b/opencti-platform/opencti-graphql/src/domain/file.js
@@ -30,13 +30,6 @@ export const buildOptionsFromFileManager = async (context) => {
   const excludedPaths = ['import/pending/']; // always exclude pending
   const managerConfiguration = await getManagerConfigurationFromCache(context, SYSTEM_USER, 'FILE_INDEX_MANAGER');
   const configMimetypes = managerConfiguration.manager_setting?.accept_mime_types;
-  if (isEmptyField(configMimetypes)) {
-    return {
-      globalCount: 0,
-      globalSize: 0,
-      metricsByMimeType: [],
-    };
-  }
   const includeGlobal = managerConfiguration.manager_setting?.include_global_files || false;
   const onlyForEntityTypes = managerConfiguration.manager_setting?.entity_types;
   if (isNotEmptyField(onlyForEntityTypes)) {
@@ -56,6 +49,13 @@ export const filesMetrics = async (context, user) => {
   const metrics = await getStats([READ_INDEX_FILES]);
   const indexedFilesCount = metrics.docs.count;
   const fileOptions = await buildOptionsFromFileManager(context);
+  if (isEmptyField(fileOptions.opts.prefixMimeTypes)) {
+    return {
+      globalCount: 0,
+      globalSize: 0,
+      metricsByMimeType: [],
+    };
+  }
   const filesMimeTypesDistribution = await allFilesMimeTypeDistribution(context, user, fileOptions.paths, fileOptions.opts);
   const remainingFilesCount = await allRemainingFilesCount(context, user, fileOptions.paths, fileOptions.opts);
   const metricsByMimeType = [];

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -17,7 +17,7 @@ import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from
 import { Promise as BluePromise } from 'bluebird';
 import * as R from 'ramda';
 import type { BasicStoreSettings } from '../types/settings';
-import { EVENT_TYPE_UPDATE, waitInSec } from '../database/utils';
+import { EVENT_TYPE_UPDATE, isEmptyField, waitInSec } from '../database/utils';
 import conf, { ENABLED_FILE_INDEX_MANAGER, logApp } from '../config/conf';
 import { createStreamProcessor, type StreamProcessor, } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
@@ -64,6 +64,9 @@ const loadFilesToIndex = async (file: FileToIndexObject) => {
 
 export const indexImportedFiles = async (context: AuthContext, indexFromDate: string | null) => {
   const fileOptions = await buildOptionsFromFileManager(context);
+  if (isEmptyField(fileOptions.opts.prefixMimeTypes)) {
+    return; // no mimetype prefix selected, should return 0 files
+  }
   const opts = { ...fileOptions.opts, modifiedSince: indexFromDate };
   const allFiles = await allFilesForPaths(context, SYSTEM_USER, fileOptions.paths ?? [], opts);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix previous refactoring : return empty when no mime type selected

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
To reproduce the issue, you just need to unselect all file types in file indexing configuration screen
* #12050

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
