### PR TITLE
Fix banner height adjustments on Knowledge and Investigation graphs

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
@@ -14,6 +14,7 @@ import GraphToolbarTimeRange from './components/GraphToolbarTimeRange';
 import { useGraphContext } from './GraphContext';
 import GraphToolbarCorrelationTools from './components/GraphToolbarCorrelationTools';
 import GraphToolbarExpandTools, { GraphToolbarExpandToolsProps } from './components/GraphToolbarExpandTools';
+import useAuth from '../../utils/hooks/useAuth';
 
 export type GraphToolbarProps = GraphToolbarContentToolsProps & GraphToolbarExpandToolsProps & GraphToolbarDisplayToolsProps;
 
@@ -24,6 +25,7 @@ const GraphToolbar = ({
   ...props
 }: GraphToolbarProps) => {
   const theme = useTheme<Theme>();
+  const { bannerSettings: { bannerHeightNumber } } = useAuth();
   const navOpen = localStorage.getItem('navOpen') === 'true';
   const { selectBySearch } = useGraphInteractions();
 
@@ -52,6 +54,7 @@ const GraphToolbar = ({
           height: showTimeRange ? 134 : 54,
           overflow: 'hidden',
           transition: 'height 0.2s ease',
+          marginBottom: bannerHeightNumber,
         },
       }}
     >

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -18,7 +18,6 @@ import StixCoreObjectFileExportButton from '../stix_core_objects/StixCoreObjectF
 import StixCoreObjectsSuggestions from '../stix_core_objects/StixCoreObjectsSuggestions';
 import { DraftChip } from '../draft/DraftChip';
 import { stixCoreObjectQuickSubscriptionContentQuery } from '../stix_core_objects/stixCoreObjectTriggersUtils';
-import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 import StixCoreObjectSubscribers from '../stix_core_objects/StixCoreObjectSubscribers';
 import FormAuthorizedMembersDialog from '../form/FormAuthorizedMembersDialog';
 import ExportButtons from '../../../../components/ExportButtons';
@@ -41,6 +40,7 @@ import { authorizedMembersToOptions, useGetCurrentUserAccessRight } from '../../
 import StixCoreObjectEnrichment from '../stix_core_objects/StixCoreObjectEnrichment';
 import { resolveLink } from '../../../../utils/Entity';
 import PopoverMenu from '../../../../components/PopoverMenu';
+import useAuth from '../../../../utils/hooks/useAuth';
 
 export const containerHeaderObjectsQuery = graphql`
   query ContainerHeaderObjectsQuery($id: String!) {
@@ -486,7 +486,7 @@ const ContainerHeader = (props) => {
     navigate(`${entityLink}/${targetTab}?${urlParams}`);
   };
 
-  const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
+  const { bannerSettings: { bannerHeightNumber } } = useAuth();
   // containerDefault style
   let containerStyle = {
     display: 'flex',
@@ -500,7 +500,7 @@ const ContainerHeader = (props) => {
     containerStyle = {
       position: 'absolute',
       display: 'flex',
-      top: 166 + settingsMessagesBannerHeight,
+      top: 166 + bannerHeightNumber,
       right: 24,
     };
   }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKnowledgeBar.tsx
@@ -408,6 +408,7 @@ const StixCoreObjectKnowledgeBar = ({
         component="nav"
         style={{
           marginTop: bannerSettings.bannerHeightNumber + settingsMessagesBannerHeight,
+          marginBottom: bannerSettings.bannerHeightNumber,
           paddingBottom: 0,
         }}
       >


### PR DESCRIPTION
### Proposed changes

* Adjusted bottom margin spacing for graph toolbars
* Fetching actual banner height value in container header for top-right button group

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12231 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
