### PR TITLE
[frontend] break long text on affected software list (12035)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilitySoftwaresHas.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilitySoftwaresHas.jsx
@@ -81,7 +81,7 @@ class VulnerabilitySoftwaresHasComponent extends Component {
                   <IconButton
                     aria-label="Remove"
                     onClick={this.removeSoftware.bind(this, softwareEdge)}
-                    size="large"
+                    size="small"
                   >
                     <LinkOff />
                   </IconButton>
@@ -97,6 +97,12 @@ class VulnerabilitySoftwaresHasComponent extends Component {
                     </ListItemIcon>
                   </ListItemIcon>
                   <ListItemText
+                    sx={{
+                      '& .MuiListItemText-primary, .MuiListItemText-secondary': {
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      },
+                    }}
                     primary={`${software.name} ${
                       software.version && software.version.length > 0
                         ? `(${software.version})`


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* break word on long line with text ellipsis

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12035 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
