### PR TITLE
[backend] fetch connector manifest from rolling or tag (#7328)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
           command: yarn install
       - run:
           working_directory: ~/opencti/opencti-platform/opencti-graphql
+          environment:
+            TAG_VERSION: $CIRCLE_TAG
           command: yarn build
       - slack/notify:
           event: fail

--- a/opencti-platform/opencti-graphql/script/get-connectors-manifest.js
+++ b/opencti-platform/opencti-graphql/script/get-connectors-manifest.js
@@ -18,18 +18,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function getConnectorManifest() {
+  console.info('📝 Getting connectors manifest');
   const schemaUrl = getSchemaURL();
-  console.info(`Fetching manifest from: ${schemaUrl}`);
   try {
     // fetch file
+    console.info(`➡️ Fetching manifest from: ${schemaUrl}`);
     const res = await fetch(schemaUrl);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.text();
 
     // try to parse as json
+    console.info('➡️ Parsing manifest...');
     JSON.parse(data);
 
     // save file
+    console.info('➡️ Writing manifest file...');
     const fullDir = path.resolve(__dirname, OUTPUT_DIR);
     fs.mkdirSync(fullDir, { recursive: true });
     const fullPath = path.join(fullDir, OUTPUT_FILE);

--- a/opencti-platform/opencti-graphql/script/get-connectors-manifest.js
+++ b/opencti-platform/opencti-graphql/script/get-connectors-manifest.js
@@ -2,7 +2,14 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const SCHEMA_URL = 'https://raw.githubusercontent.com/OpenCTI-Platform/connectors/refs/heads/master/manifest.json';
+const getSchemaURL = () => {
+  if (process.env.TAG_VERSION) {
+    return `https://raw.githubusercontent.com/OpenCTI-Platform/connectors/refs/tags/${process.env.TAG_VERSION}/manifest.json`;
+  }
+  // rolling
+  return 'https://raw.githubusercontent.com/OpenCTI-Platform/connectors/refs/heads/master/manifest.json';
+};
+// use tags instead of master if env from circle TAG is set
 
 const OUTPUT_DIR = '../src/__generated__';
 const OUTPUT_FILE = 'opencti-manifest.json';
@@ -11,14 +18,18 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 async function getConnectorManifest() {
+  const schemaUrl = getSchemaURL();
+  console.info(`Fetching manifest from: ${schemaUrl}`);
   try {
-    console.info(`Fetching manifest from: ${SCHEMA_URL}`);
-    const res = await fetch(SCHEMA_URL);
+    // fetch file
+    const res = await fetch(schemaUrl);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.text();
 
+    // try to parse as json
     JSON.parse(data);
 
+    // save file
     const fullDir = path.resolve(__dirname, OUTPUT_DIR);
     fs.mkdirSync(fullDir, { recursive: true });
     const fullPath = path.join(fullDir, OUTPUT_FILE);
@@ -26,7 +37,8 @@ async function getConnectorManifest() {
 
     console.info(`✅ Manifest saved to: ${fullPath}`);
   } catch (err) {
-    console.error(`❌ Error: ${err.message}`);
+    console.error(`❌ Error: ${err.message}`, err);
+    console.error(err);
     process.exit(1);
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

When building the platform, the script `get-connectors-manifest.js` fetched the manifest from master only.
With these changes, it now fetches from tagged version if the environment variable TAG_VERSION is set.
In Circle CI jobs, we set the variable so tagged build matches tagged manifest.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #7328

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


