### PR TITLE
[frontend] adding column selection in data tables (#9647)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -123,17 +123,19 @@ const DataTableBody = ({
       defaultComputation();
     }
 
-    return () => { observer?.disconnect(); };
+    return () => {
+      observer?.disconnect();
+    };
   }, [settingsMessagesBannerHeight, rootRef, filters]);
 
-  const rowWidth = useMemo(() => (
-    Math.floor(columns.reduce((acc, col) => {
+  const rowWidth = useMemo(() => {
+    return Math.floor(columns.filter(({ visible }) => !!visible).reduce((acc, col) => {
       if (col.percentWidth) {
         return acc + tableWidth * (col.percentWidth / 100);
       }
       return acc + (col.id === 'icon' ? ICON_COLUMN_SIZE : SELECT_COLUMN_SIZE);
     }, actions ? SELECT_COLUMN_SIZE + 9 : 9)) // 9 is for scrollbar.
-  ), [columns, tableWidth]);
+  }, [columns, tableWidth]);
 
   const containerLinesStyle: CSSProperties = {
     overflow: 'hidden auto',

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -107,7 +107,7 @@ const DataTableComponent = ({
           ...column,
           // Override column config with what we have in local storage
           order: useLocalStorage && currentColumn?.index ? currentColumn?.index : index,
-          visible: useLocalStorage && currentColumn?.visible ? currentColumn?.visible : true,
+          visible: useLocalStorage && (currentColumn?.visible != null) ? currentColumn?.visible : true,
           percentWidth: useLocalStorage && currentColumn?.percentWidth ? currentColumn?.percentWidth : percentWidth,
         });
       }),

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
@@ -170,6 +170,7 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
           )}
 
           {columns
+            .filter(({ visible }) => !!visible)
             .filter(({ id }) => !['select', 'navigate', 'icon'].includes(id))
             .map((column) => (
               <DataTableHeader

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -197,7 +197,7 @@ const DataTableLine = ({
               width: startColumnWidth,
             }}
           >
-            { startsWithAction && (
+            {startsWithAction && (
               <Checkbox
                 onClick={handleSelectLine}
                 sx={{
@@ -209,10 +209,10 @@ const DataTableLine = ({
                   },
                 }}
                 checked={
-                (selectAll
-                  && !((data.id || 'id') in (deSelectedElements || {})))
-                || (data.id || 'id') in (selectedElements || {})
-              }
+                  (selectAll
+                    && !((data.id || 'id') in (deSelectedElements || {})))
+                  || (data.id || 'id') in (selectedElements || {})
+                }
               />
             )}
             {(startsWithIcon && icon) && (
@@ -223,13 +223,16 @@ const DataTableLine = ({
           </div>
         )}
 
-        {columns.slice(columnsOffset, (actions || disableNavigation) ? undefined : -1).map((column) => (
-          <DataTableCell
-            key={column.id}
-            cell={column}
-            data={data}
-          />
-        ))}
+        {columns
+          .slice(columnsOffset, (actions || disableNavigation) ? undefined : -1)
+          .filter(({ visible }) => !!visible)
+          .map((column) => (
+            <DataTableCell
+              key={column.id}
+              cell={column}
+              data={data}
+            />
+          ))}
 
         {endsWithAction && (
           <div

--- a/opencti-platform/opencti-front/src/components/nested_menu/NestedMenuButton.tsx
+++ b/opencti-platform/opencti-front/src/components/nested_menu/NestedMenuButton.tsx
@@ -41,6 +41,7 @@ type Option = {
   onClick?: () => void; // individual click handler
   selected?: boolean;
   nestedOptions? : Option[];
+  render?: () => React.ReactNode;
 };
 
 type NestedMenuProps = {
@@ -279,7 +280,7 @@ const NestedMenuButton: React.FC<NestedMenuProps> = ({
                             alignItems: 'center',
                           }}
                         >
-                          <Typography>{option.label ?? option.value}</Typography>
+                          {option.render ? (option.render()) : (<Typography>{option.label ?? option.value}</Typography>)}
                           {option.nestedOptions ? (
                             <ChevronRight fontSize="small" />
                           ) : null}


### PR DESCRIPTION
This PR is **not for merge** but a support for discussion.

First step for #9647.

### Proposed changes

Add new nested menu in the data table settings to select (hide/show) columns.

### Known issues

* Sizing computation might break : we try to keep a 100% total width while adding and removing columns. This has to be carefully tested.
* clicking on the name of the column in the menu closes the menu ; it should select/deselect properly like when we click on the checkbox itself 



