### PR TITLE
[backend] tests for events with internal scope

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -304,6 +304,7 @@ const createSseMiddleware = () => {
     try {
       const { user, context } = req;
       const paramStartFrom = extractQueryParameter(req, 'from') || req.headers.from || req.headers['last-event-id'];
+      const withInternal = extractQueryParameter(req, 'withInternal') ?? undefined;
       const startStreamId = convertParameterToStreamId(paramStartFrom);
       // Generic stream only available for bypass users
       if (!isUserHasCapability(user, BYPASS)) {
@@ -312,7 +313,7 @@ const createSseMiddleware = () => {
         return;
       }
       const { client } = createSseChannel(req, res, startStreamId);
-      const opts = { autoReconnect: true };
+      const opts = { autoReconnect: true, withInternal };
       const processor = createStreamProcessor(user, user.user_email, async (elements, lastEventId) => {
         // Process the event messages
         for (let index = 0; index < elements.length; index += 1) {

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -18,6 +18,30 @@ export const dumpEventByTypeToFile = (eventTypeName, eventsByTypesRecords) => {
 };
 
 describe('Raw streams tests', () => {
+  it(
+    'Should stream withInternal (ie with scope=internal) correctly formatted',
+    async () => {
+      // Read all events from the beginning.
+      const events = await fetchStreamEvents(`http://localhost:${PORT}/stream?withInternal=true`, { from: '0' });
+      const internalEvents = events.filter((e) => e.scope === 'internal');
+      writeTestDataToFile(JSON.stringify(internalEvents), 'raw-test-internal-event.json');
+
+      // 00 - Check the number of events and dump information in test result files
+      const createEvents = internalEvents.filter((e) => e.type === EVENT_TYPE_CREATE);
+      const createEventsByTypes = R.groupBy((e) => e.data.data.type, createEvents);
+
+      const updateEvents = internalEvents.filter((e) => e.type === EVENT_TYPE_UPDATE);
+      const updateEventsByTypes = R.groupBy((e) => e.data.data.type, updateEvents);
+
+      const deleteEvents = internalEvents.filter((e) => e.type === EVENT_TYPE_DELETE);
+      const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
+
+      expect(createEventsByTypes['internal-relationship']).toEqual(14);
+      expect(updateEventsByTypes['internal-relationship']).toEqual(2);
+      expect(deleteEventsByTypes['internal-relationship']).toEqual(3);
+    }
+  );
+
   // We need to check the event format to be sure that everything is setup correctly
   it(
     'Should stream correctly formatted',

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -21,12 +21,12 @@ describe('Raw streams tests', () => {
   it(
     'Should stream withInternal (ie with scope=internal) correctly formatted',
     async () => {
-      // Read all events from the beginning.
+      // Read all events of scope internal from the beginning
       const events = await fetchStreamEvents(`http://localhost:${PORT}/stream?withInternal=true`, { from: '0' });
       const internalEvents = events.filter((e) => e.scope === 'internal');
       writeTestDataToFile(JSON.stringify(internalEvents), 'raw-test-internal-event.json');
 
-      // 00 - Check the number of events and dump information in test result files
+      // group events by type
       const createEvents = internalEvents.filter((e) => e.type === EVENT_TYPE_CREATE);
       const createEventsByTypes = R.groupBy((e) => e.data.data.type, createEvents);
 
@@ -36,6 +36,7 @@ describe('Raw streams tests', () => {
       const deleteEvents = internalEvents.filter((e) => e.type === EVENT_TYPE_DELETE);
       const deleteEventsByTypes = R.groupBy((e) => e.data.data.type, deleteEvents);
 
+      // check internal relationships events number (ie participate-to and in-pir relationships events)
       expect(createEventsByTypes['internal-relationship']).toEqual(14);
       expect(updateEventsByTypes['internal-relationship']).toEqual(2);
       expect(deleteEventsByTypes['internal-relationship']).toEqual(3);

--- a/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-streams/00-Raw/raw-test.js
@@ -26,6 +26,8 @@ describe('Raw streams tests', () => {
       const internalEvents = events.filter((e) => e.scope === 'internal');
       writeTestDataToFile(JSON.stringify(internalEvents), 'raw-test-internal-event.json');
 
+      expect(internalEvents).toEqual('test');
+
       // group events by type
       const createEvents = internalEvents.filter((e) => e.type === EVENT_TYPE_CREATE);
       const createEventsByTypes = R.groupBy((e) => e.data.data.type, createEvents);


### PR DESCRIPTION
### Proposed changes
Add backend tests with counters for events of scope internal

Following a modification in events scope with the PIR feature (participate-to and in-pir relationships events are of scope internal)