### PR TITLE
[frontend] hide organization's Admin tab when it's empty in user editing (#12001)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserEdition.tsx
@@ -22,6 +22,7 @@ const UserEditionFragment = graphql`
   @argumentDefinitions(
     groupsOrderBy: { type: "GroupsOrdering", defaultValue: name }
     groupsOrderMode: { type: "OrderingMode", defaultValue: asc }
+    organizationsCount: { type: "Int", defaultValue: 500 }
     organizationsOrderBy: { type: "OrganizationsOrdering", defaultValue: name }
     organizationsOrderMode: { type: "OrderingMode", defaultValue: asc }
   ) {
@@ -52,6 +53,14 @@ const UserEditionFragment = graphql`
         object {
           ... on User { entity_type id name }
           ... on Group { entity_type id name }
+        }
+      }
+    }
+    objectAssignedOrganization(first: $organizationsCount, orderBy: $organizationsOrderBy, orderMode: $organizationsOrderMode) {
+      edges {
+        node {
+          id
+          name
         }
       }
     }
@@ -115,7 +124,6 @@ const UserEditionDrawer: FunctionComponent<UserEditionDrawerProps> = ({
   const handleChangeTab = (value: number) => {
     setCurrentTab(value);
   };
-
   return (
     <Drawer
       title={t_i18n('Update a user')}
@@ -134,7 +142,7 @@ const UserEditionDrawer: FunctionComponent<UserEditionDrawerProps> = ({
             <Tab disabled={!!user.external} label={t_i18n('Password')} />
             <Tab label={t_i18n('Groups')} />
             {hasSetAccess
-              && <Tab label={
+              && <Tab disabled={user.objectAssignedOrganization?.edges.length === 0 } label={
                 <div style={{ alignItems: 'center', display: 'flex' }}>
                   {t_i18n('Organizations admin')}<EEChip />
                 </div>}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* disabled tab org admin

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12001 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
