### PR TITLE
[Frontend] Corrected padding for zoom when window height changes #12313

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
@@ -79,8 +79,17 @@ const useGraphInteractions = () => {
   const zoomToFit = () => {
     const nbOfNodes = graphData?.nodes.length ?? 0;
     let padding = 50;
-    if (nbOfNodes === 1) padding = 300;
-    else if (nbOfNodes < 4) padding = 200;
+    if (nbOfNodes === 1) {
+      if (window.innerHeight < 600) {
+        padding = 50;
+      } else if (window.innerHeight < 900) {
+        padding = 150;
+      } else if (window.innerHeight < 1100) {
+        padding = 300;
+      } else {
+        padding = 400;
+      }
+    } else if (nbOfNodes < 4) padding = 200;
     else if (nbOfNodes < 8) padding = 100;
     // Different padding depending on the number of nodes in the graph.
     graphRef2D.current?.zoomToFit(400, padding);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adapted zoom to window height for graph when there is only one node
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*https://github.com/OpenCTI-Platform/opencti/issues/12313
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
