### PR TITLE
[frontend] fix connector deploy disabled button on first render (#12562)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -302,15 +302,16 @@ const IngestionCatalogConnectorCreation = ({
           initialValues={{
             name: connectorName,
             confidence_level: connector.max_confidence_level.toString(),
-            user_id: '',
+            user_id: { label: '', value: '' },
             automatic_user: true,
             ...configDefaults,
           }}
-          validateOnMount
           onSubmit={() => {}}
         >
           {({ values, isSubmitting, setSubmitting, resetForm, isValid, setValues }) => {
             const errors = compiledValidator?.validate(values)?.errors;
+
+            const disableCreate = !isValid || isSubmitting || !!errors?.[0];
 
             return (
               <Form>
@@ -419,7 +420,7 @@ const IngestionCatalogConnectorCreation = ({
                             resetForm,
                           });
                         }}
-                        disabled={!isValid || isSubmitting || !!errors?.[0]}
+                        disabled={disableCreate}
                       >
                         {t_i18n('Create')}
                       </Button>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The deploy button should now be activable on first render of the connector creation form

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12562 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
