### PR TITLE
[frontend] display as password input when manifest describes this field (#12588)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -29,6 +29,8 @@ import Tooltip from '@mui/material/Tooltip';
 import JsonFormArrayRenderer, { jsonFormArrayTester } from '@components/data/IngestionCatalog/utils/JsonFormArrayRenderer';
 import buildContractConfiguration from '@components/data/connectors/utils/buildContractConfiguration';
 import JsonFormUnsupportedType, { jsonFormUnsupportedTypeTester } from '@components/data/IngestionCatalog/utils/JsonFormUnsupportedType';
+import { JsonFormPasswordRenderer, jsonFormPasswordTester } from '@components/data/IngestionCatalog/utils/JsonFormPasswordRenderer';
+import Box from '@mui/material/Box';
 import { MESSAGING$ } from '../../../../relay/environment';
 import { RelayError } from '../../../../relay/relayTypes';
 import type { Theme } from '../../../../components/Theme';
@@ -86,6 +88,7 @@ const k8sNameSchema = (t_i18n: (key: string) => string) => Yup.string()
 
 const customRenderers = [
   ...materialRenderers,
+  { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
   { tester: jsonFormArrayTester, renderer: JsonFormArrayRenderer },
   { tester: jsonFormUnsupportedTypeTester, renderer: JsonFormUnsupportedType },
 ];
@@ -366,6 +369,7 @@ const IngestionCatalogConnectorCreation = ({
                               },
                             }}
                           >
+
                             <JsonForms
                               data={configDefaults}
                               schema={requiredProperties}

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -30,7 +30,6 @@ import JsonFormArrayRenderer, { jsonFormArrayTester } from '@components/data/Ing
 import buildContractConfiguration from '@components/data/connectors/utils/buildContractConfiguration';
 import JsonFormUnsupportedType, { jsonFormUnsupportedTypeTester } from '@components/data/IngestionCatalog/utils/JsonFormUnsupportedType';
 import { JsonFormPasswordRenderer, jsonFormPasswordTester } from '@components/data/IngestionCatalog/utils/JsonFormPasswordRenderer';
-import Box from '@mui/material/Box';
 import { MESSAGING$ } from '../../../../relay/environment';
 import { RelayError } from '../../../../relay/relayTypes';
 import type { Theme } from '../../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/JsonFormPasswordRenderer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/JsonFormPasswordRenderer.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { and, ControlProps, isStringControl, RankedTester, rankWith, schemaMatches } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import Box from '@mui/material/Box';
+import PasswordTextField from '../../../../../components/PasswordTextField';
+
+export const JsonFormPasswordRenderer = ({ uischema, schema }: ControlProps) => {
+  const scope = uischema?.scope || ''; // eg: uischema?.scope: '#/properties/SOME_KEY';
+  const fieldName = scope.split('/').pop();
+
+  let fieldLabel = '';
+  if (fieldName && schema.properties) {
+    fieldLabel = schema.properties[fieldName].description ?? '';
+  }
+
+  return (
+    <Box
+      sx={{
+        // override the PasswordTextField position icon button
+        '& button[aria-label*="Show"], & button[aria-label*="Hide"]': {
+          top: '50% !important',
+          transform: 'translateY(-50%)',
+        },
+        // override the PasswordTextField container style
+        '& > div > div': {
+          margin: '0 !important',
+        },
+      }}
+    >
+      <PasswordTextField name={fieldName} label={fieldLabel} />
+    </Box>
+  );
+};
+
+export const jsonFormPasswordTester: RankedTester = rankWith(
+  10,
+  and(
+    isStringControl,
+    schemaMatches((schema) => {
+      return schema.type === 'string' && schema.format === 'password';
+    }),
+  ),
+);
+export default withJsonFormsControlProps(JsonFormPasswordRenderer);

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
@@ -20,6 +20,7 @@ import reconcileManagedConnectorContractDataWithSchema from '@components/data/co
 import buildContractConfiguration from '@components/data/connectors/utils/buildContractConfiguration';
 import JsonFormUnsupportedType, { jsonFormUnsupportedTypeTester } from '@components/data/IngestionCatalog/utils/JsonFormUnsupportedType';
 import { Connector_connector$data } from '@components/data/connectors/__generated__/Connector_connector.graphql';
+import { JsonFormPasswordRenderer, jsonFormPasswordTester } from '@components/data/IngestionCatalog/utils/JsonFormPasswordRenderer';
 import TextField from '../../../../components/TextField';
 import { type FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -51,6 +52,7 @@ interface ManagedConnectorValues {
 
 const customRenderers = [
   ...materialRenderers,
+  { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
   { tester: jsonFormArrayTester, renderer: JsonFormArrayRenderer },
   { tester: jsonFormUnsupportedTypeTester, renderer: JsonFormUnsupportedType },
 ];


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Display password field when manifest describes a password format field

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12588

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
