### PR TITLE
[CI] Skip api-test on PR build when only opencti-front files have changed (#12003)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,6 +86,7 @@ steps:
       SMTP__ENABLED: false
       PYTHONUNBUFFERED: 1
     commands:
+      - if [ -f ${WORKSPACE}/api-test.skip ]; then exit 0; fi
       - echo "$(ls /root/.yarn/berry/cache/ 2> /dev/null | wc -l || echo 0) packages in Yarn global cache"
       - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,7 +86,7 @@ steps:
       SMTP__ENABLED: false
       PYTHONUNBUFFERED: 1
     commands:
-      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then exit 0; fi
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - echo "$(ls /root/.yarn/berry/cache/ 2> /dev/null | wc -l || echo 0) packages in Yarn global cache"
       - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools
@@ -295,6 +295,7 @@ services:
       SMTP__ENABLED: false
     commands:
       - sleep 10
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - ls -lart
       - apk add build-base git libffi-dev cargo
       - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/raw-start-platform/
@@ -336,6 +337,7 @@ services:
       SMTP__ENABLED: false
     commands:
       - sleep 10
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - apk add build-base git libffi-dev cargo
       - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/live-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
@@ -376,6 +378,7 @@ services:
       SMTP__ENABLED: false
     commands:
       - sleep 10
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - apk add build-base git libffi-dev cargo
       - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/direct-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"
@@ -396,6 +399,7 @@ services:
       WORKER_LOG_LEVEL: info
     commands:
       - sleep 10
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - apk add build-base git libffi-dev cargo
       - cp -a opencti-worker /tmp/direct-start-worker
       - cd "$DRONE_WORKSPACE/client-python"
@@ -416,6 +420,7 @@ services:
       WORKER_LOG_LEVEL: info
     commands:
       - sleep 10
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - cp -a opencti-worker /tmp/opencti-test-worker
       - apk add build-base git libffi-dev cargo
       - cd "$DRONE_WORKSPACE/client-python"
@@ -455,6 +460,7 @@ services:
       SMTP__ENABLED: false
     commands:
       - sleep 10
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then echo "API TESTS ARE SKIPPED" ; exit 0; fi
       - apk add build-base git libffi-dev cargo
       - cp -a $DRONE_WORKSPACE/platform-reference/* /tmp/restore-start-platform/
       - cd "$DRONE_WORKSPACE/client-python"

--- a/.drone.yml
+++ b/.drone.yml
@@ -111,6 +111,7 @@ steps:
 
   - name: api-coverage
     image: plugins/codecov
+    failure: ignore
     settings:
       token:
         from_secret: codecov_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,7 +86,7 @@ steps:
       SMTP__ENABLED: false
       PYTHONUNBUFFERED: 1
     commands:
-      - if [ -f ${WORKSPACE}/api-test.skip ]; then exit 0; fi
+      - if [ -f $DRONE_WORKSPACE/api-test.skip ]; then exit 0; fi
       - echo "$(ls /root/.yarn/berry/cache/ 2> /dev/null | wc -l || echo 0) packages in Yarn global cache"
       - apk add build-base git libffi-dev cargo
       - pip3 install --upgrade setuptools

--- a/scripts/clone-dependencies.sh
+++ b/scripts/clone-dependencies.sh
@@ -85,6 +85,7 @@ clone_for_pr_build() {
         gh repo clone https://github.com/OpenCTI-Platform/client-python ${CLI_PYTHON_DIR} -- --branch ${PR_TARGET_BRANCH}  --depth=1
         gh repo clone https://github.com/OpenCTI-Platform/connectors ${CONNECTOR_DIR} -- --branch ${PR_TARGET_BRANCH}  --depth=1
 
+        cd ${WORKSPACE}
         CHANGES_OUSTIDE_FRONT_COUNT=$(gh pr diff ${PR_NUMBER} --name-only | grep -v "opencti-platform/opencti-front" | wc -l)
         if [[ ${CHANGES_OUSTIDE_FRONT_COUNT} -eq 0 ]]
         then

--- a/scripts/clone-dependencies.sh
+++ b/scripts/clone-dependencies.sh
@@ -13,7 +13,9 @@ PR_NUMBER=$4
 
 
 CLI_PYTHON_DIR="${WORKSPACE}/client-python"
+CONNECTOR_DIR="${WORKSPACE}/opencti-connectors"
 echo "CLI_PYTHON_DIR=${CLI_PYTHON_DIR}"
+echo "CONNECTOR_DIR=${CONNECTOR_DIR}"
 
 clone_for_pr_build() {
     cd ${WORKSPACE}
@@ -54,9 +56,33 @@ clone_for_pr_build() {
             # Repository already clone on PR_TARGET_BRANCH branch
         fi
         
+        # ------
+        # For connector, maybe one day we will refactor to a function.
+        echo "[CLONE-DEPS][CONNECTOR] Multi repository PR, looking for connectors related branch"
+        gh repo clone https://github.com/OpenCTI-Platform/connectors ${CONNECTOR_DIR}  -- --branch ${PR_TARGET_BRANCH}  --depth=1
+        cd ${CONNECTOR_DIR}
+
+        # search for the first opencti PR that matches OPENCTI_BRANCH
+        gh repo set-default https://github.com/OpenCTI-Platform/connectors
+        gh pr list --label "multi-repository" > multi-repo-connector-prs.txt
+
+        cat multi-repo-connector-prs.txt
+
+        CONNECTOR_PR_NUMBER=$(cat multi-repo-connector-prs.txt | grep "${TARGET_BRANCH}" | head -n 1 | sed 's/#//g' | awk '{print $1}')
+        echo "CONNECTOR_PR_NUMBER=${CONNECTOR_PR_NUMBER}"
+
+        if [[ "${CONNECTOR_PR_NUMBER}" != "" ]]
+        then
+            echo "[CLONE-DEPS][CONNECTOR] Found a PR in connectors with number ${CONNECTOR_PR_NUMBER}, using it."
+            gh pr checkout ${CONNECTOR_PR_NUMBER}
+        else
+            echo "[CLONE-DEPS][CONNECTOR] No PR found in connectors side, keeping connector:${PR_TARGET_BRANCH}"
+            # Repository already clone on PR_TARGET_BRANCH branch
+        fi
+
     else
 
-        echo "[CLONE-DEPS] NOT multi repo, cloning client-python:${PR_TARGET_BRANCH}"
+        echo "[CLONE-DEPS] NOT multi repo, cloning client-python:${PR_TARGET_BRANCH} and connector:${PR_TARGET_BRANCH}"
         
         gh repo clone https://github.com/OpenCTI-Platform/client-python ${CLI_PYTHON_DIR} -- --depth=1
         cd ${CLI_PYTHON_DIR}
@@ -68,6 +94,15 @@ clone_for_pr_build() {
             git switch $PR_TARGET_BRANCH
         elif [[ $EXIT_CODE == '2' ]]; then
             echo "Git branch '$PR_TARGET_BRANCH' does not exist in the remote repository, using default in ${CLI_PYTHON_DIR}"
+        fi
+
+        gh repo clone https://github.com/OpenCTI-Platform/connectors ${CONNECTOR_DIR} -- --depth=1
+        cd ${CONNECTOR_DIR}
+        if [[ $EXIT_CODE == '0' ]]; then
+            echo "Git branch '$PR_TARGET_BRANCH' exists in the remote repository ${CONNECTOR_DIR}"
+            git switch $PR_TARGET_BRANCH
+        elif [[ $EXIT_CODE == '2' ]]; then
+            echo "Git branch '$PR_TARGET_BRANCH' does not exist in the remote repository, using default in ${CONNECTOR_DIR}"
         fi
 
         cd ${WORKSPACE}
@@ -95,6 +130,16 @@ clone_for_push_build() {
         CLIENT_PYTHON_BRANCH=$([[ "$(echo "$(git ls-remote --heads https://github.com/OpenCTI-Platform/client-python.git refs/heads/opencti/$PR_BRANCH_NAME)")" != '' ]] && echo opencti/$PR_BRANCH_NAME || echo 'master')
     fi
     git clone -b $CLIENT_PYTHON_BRANCH https://github.com/OpenCTI-Platform/client-python.git ${CLI_PYTHON_DIR}
+
+    echo "[CLONE-DEPS][CONNECTOR] Build from a commit, checking if a dedicated branch is required."
+    if [[ "$(echo "$(git ls-remote --heads https://github.com/OpenCTI-Platform/connectors.git refs/heads/$PR_BRANCH_NAME)")" != '' ]]
+    then
+        CONNECTOR_BRANCH=${PR_BRANCH_NAME}
+    else
+        CONNECTOR_BRANCH=$([[ "$(echo "$(git ls-remote --heads https://github.com/OpenCTI-Platform/connectors.git refs/heads/opencti/$PR_BRANCH_NAME)")" != '' ]] && echo opencti/$PR_BRANCH_NAME || echo 'master')
+    fi
+
+    git clone -b $CONNECTOR_BRANCH https://github.com/OpenCTI-Platform/connectors.git ${CONNECTOR_DIR}
 }
 
 echo "[CLONE-DEPS] START; with PR_BRANCH_NAME=${PR_BRANCH_NAME},PR_TARGET_BRANCH=${PR_TARGET_BRANCH}, PR_NUMBER=${PR_NUMBER}, OPENCTI_DIR=${OPENCTI_DIR}."
@@ -120,6 +165,8 @@ else
     clone_for_pr_build
 fi
 
+cd ${CONNECTOR_DIR}
+echo "[CLONE-DEPS] END; Using connectors on branch:$(git branch --show-current)"
 cd ${CLI_PYTHON_DIR}
 echo "[CLONE-DEPS] END; Using client-python on branch:$(git branch --show-current)"
 

--- a/scripts/clone-dependencies.sh
+++ b/scripts/clone-dependencies.sh
@@ -84,6 +84,16 @@ clone_for_pr_build() {
         echo "[CLONE-DEPS] NOT multi repo, cloning client-python:${PR_TARGET_BRANCH} and connector:${PR_TARGET_BRANCH}"
         gh repo clone https://github.com/OpenCTI-Platform/client-python ${CLI_PYTHON_DIR} -- --branch ${PR_TARGET_BRANCH}  --depth=1
         gh repo clone https://github.com/OpenCTI-Platform/connectors ${CONNECTOR_DIR} -- --branch ${PR_TARGET_BRANCH}  --depth=1
+
+        CHANGES_OUSTIDE_FRONT_COUNT=$(gh pr diff ${PR_NUMBER} --name-only | grep -v "opencti-platform/opencti-front" | wc -l)
+        if [[ ${CHANGES_OUSTIDE_FRONT_COUNT} -eq 0 ]]
+        then
+            echo "[CLONE-DEPS][BUILD] Only frontend changes on this PR, api-test can be skipped."
+            touch "${WORKSPACE}/api-test.skip"
+        else
+            echo "[CLONE-DEPS][BUILD] There is more than frontend changes, api-test will be run."
+        fi
+        
     fi
 }
 

--- a/scripts/clone-dependencies.sh
+++ b/scripts/clone-dependencies.sh
@@ -93,7 +93,7 @@ clone_for_pr_build() {
             echo "Git branch '$PR_TARGET_BRANCH' exists in the remote repository in ${CLI_PYTHON_DIR}"
             git switch $PR_TARGET_BRANCH
         elif [[ $EXIT_CODE == '2' ]]; then
-            echo "Git branch '$BRANCH' does not exist in the remote repository, using default in ${CLI_PYTHON_DIR}"
+            echo "Git branch '$PR_TARGET_BRANCH' does not exist in the remote repository, using default in ${CLI_PYTHON_DIR}"
         fi
 
         gh repo clone https://github.com/OpenCTI-Platform/connectors ${CONNECTOR_DIR} -- --depth=1
@@ -102,7 +102,7 @@ clone_for_pr_build() {
             echo "Git branch '$PR_TARGET_BRANCH' exists in the remote repository ${CONNECTOR_DIR}"
             git switch $PR_TARGET_BRANCH
         elif [[ $EXIT_CODE == '2' ]]; then
-            echo "Git branch '$BRANCH' does not exist in the remote repository, using default in ${CONNECTOR_DIR}"
+            echo "Git branch '$PR_TARGET_BRANCH' does not exist in the remote repository, using default in ${CONNECTOR_DIR}"
         fi
 
         cd ${WORKSPACE}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Do not run api-test and all start-* when changes are only in `opencti-platform/opencti-front` folder; using a `api-test.skip` markerfile.
* Remove connector repository clone, we don't use it...
* Fix the fallback to master when base branch of PR is neither `master` not `release/current`
* Ignore failure on codecov step ; I couldn't find how to skip it in the drone plugin. May be back when https://github.com/OpenCTI-Platform/opencti/issues/9146 is implemented.

#### Tests
* testing with front only changes on PR https://github.com/OpenCTI-Platform/opencti/pull/12606
* backend : https://github.com/OpenCTI-Platform/opencti/pull/12618
* fork https://github.com/OpenCTI-Platform/opencti/pull/12619

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #12003 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
