### PR TITLE
[backend] pir_information should not be in Csv mapper available attributes (#12634)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
@@ -65,6 +65,7 @@ export const INTERNAL_ATTRIBUTES = [
   'pattern_version',
   'connections',
   'i_attributes',
+  'pir_information',
   // X - Mitre
   'x_mitre_permissions_required',
   'x_mitre_detection',


### PR DESCRIPTION
### Proposed changes
'pir information' should not be available in the csv mapper attributes

### Related issues
#12634