### PR TITLE
[backend] remove LIVE_CATALOGS feature flag (#12314)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -19,8 +19,8 @@ addFormats(ajv, ['password', 'uri', 'duration', 'email', 'date-time', 'date']);
 let catalogMap: Record<string, CatalogType>;
 // cache for contracts by image map
 let contractsByImageCache: Map<string, CatalogContract> | undefined;
-// Test mode flag - when enabled, catalogs are loaded without cache
-let testMode = false;
+// Bypass catalog cache flag - when enabled, catalogs are loaded without cache
+let bypassCatalogCache = false;
 
 // Build catalog map from files
 const buildCatalogMap = (): Record<string, CatalogType> => {
@@ -93,19 +93,19 @@ const buildCatalogMap = (): Record<string, CatalogType> => {
   return newCatalogMap;
 };
 
-// Enable test catalog mode - clears cache and enables live catalog loading for tests
-export const enableTestCatalogMode = () => {
+// Enable custom catalogs - clears cache and enables live catalog loading
+export const enableCustomCatalogs = () => {
   catalogMap = undefined as any;
   contractsByImageCache = undefined;
-  testMode = true;
+  bypassCatalogCache = true;
 };
 
 const getCatalogs = (): Record<string, CatalogType> => {
-  // Test mode: load catalogs without cache for testing purposes
-  const shouldBypassCache = testMode && CUSTOM_CATALOGS.length > 0;
+  // Bypass cache mode: load catalogs without cache for custom catalogs
+  const shouldBypassCache = bypassCatalogCache && CUSTOM_CATALOGS.length > 0;
 
   if (shouldBypassCache) {
-    // Test mode: no cache, only custom catalogs (excluding filigran catalog)
+    // Bypass cache mode: no cache, only custom catalogs (excluding filigran catalog)
     const liveCatalogMap: Record<string, CatalogType> = {};
     const catalogs = CUSTOM_CATALOGS.map((custom) => fs.readFileSync(custom, { encoding: 'utf8', flag: 'r' }));
     // Note: intentionally NOT adding filigranCatalog here

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-composer-test.ts
@@ -8,7 +8,7 @@ import { wait } from '../../../src/database/utils';
 import { XTMComposerMock } from '../../utils/XTMComposerMock';
 import type { ApiConnector } from '../../utils/XTMComposerMock';
 import { catalogHelper } from '../../utils/catalogHelper';
-import { enableTestCatalogMode } from '../../../src/modules/catalog/catalog-domain';
+import { enableCustomCatalogs } from '../../../src/modules/catalog/catalog-domain';
 
 const TEST_COMPOSER_ID = uuidv4();
 const TEST_USER_CONNECTOR_ID: string = USER_CONNECTOR.id; // Initialize with default value
@@ -164,8 +164,8 @@ describe('Connector Composer and Managed Connectors', () => {
     const testCatalogPath = path.join(__dirname, '../../utils/opencti-manifest.json');
     process.env.APP__CUSTOM_CATALOGS = JSON.stringify([testCatalogPath]);
 
-    // Enable test mode to ensure test catalog is loaded
-    enableTestCatalogMode();
+    // Enable custom catalogs to ensure test catalog is loaded
+    enableCustomCatalogs();
 
     // Validate that we're using the test catalog
     catalogHelper.validateTestCatalog();

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-composer-test.ts
@@ -8,7 +8,7 @@ import { wait } from '../../../src/database/utils';
 import { XTMComposerMock } from '../../utils/XTMComposerMock';
 import type { ApiConnector } from '../../utils/XTMComposerMock';
 import { catalogHelper } from '../../utils/catalogHelper';
-import { resetCatalogCache } from '../../../src/modules/catalog/catalog-domain';
+import { enableTestCatalogMode } from '../../../src/modules/catalog/catalog-domain';
 
 const TEST_COMPOSER_ID = uuidv4();
 const TEST_USER_CONNECTOR_ID: string = USER_CONNECTOR.id; // Initialize with default value
@@ -164,8 +164,8 @@ describe('Connector Composer and Managed Connectors', () => {
     const testCatalogPath = path.join(__dirname, '../../utils/opencti-manifest.json');
     process.env.APP__CUSTOM_CATALOGS = JSON.stringify([testCatalogPath]);
 
-    // Reset catalog cache to ensure test catalog is loaded
-    resetCatalogCache();
+    // Enable test mode to ensure test catalog is loaded
+    enableTestCatalogMode();
 
     // Validate that we're using the test catalog
     catalogHelper.validateTestCatalog();


### PR DESCRIPTION
### Proposed changes

* Removed the temporary `LIVE_CATALOGS` feature flag from catalog-domain.ts

### Related issues

* #12314

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This feature was initially implemented as a temporary hack for the connector testing sandbox. While it was planned for removal, the functionality proved valuable for maintaining consistent catalog behavior and reproducible test conditions. 

This refactor removes the feature flag dependency while preserving the essential test functionality through a cleaner internal mechanism. The test mode now explicitly controls catalog cache bypassing, making the code more maintainable and the intent clearer.

No breaking changes - all existing tests continue to work as before.
