### PR TITLE
Update redis Docker tag to v8.0.4

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -249,7 +249,7 @@ steps:
 
 services:
   - name: redis
-    image: redis:8.0.3
+    image: redis:8.0.4
   - name: elastic
     image: docker.elastic.co/elasticsearch/elasticsearch:8.19.2
     environment:

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   opencti-dev-redis:
     container_name: opencti-dev-redis
-    image: redis:8.0.3
+    image: redis:8.0.4
     restart: unless-stopped
     ports:
       - 6379:6379


### PR DESCRIPTION
### Proposed changes
Update redis docker from 8.0.3 to 8.0.4

to align with the Saas version