### PR TITLE
[backend] remove duplicates in elDataConverter refs if ref is unidirectional (#12257)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -163,12 +163,12 @@ import {
   INSTANCE_RELATION_FILTER,
   INSTANCE_RELATION_TYPES_FILTER,
   IS_INFERRED_FILTER,
-  RELATION_DYNAMIC_FROM_FILTER,
-  RELATION_DYNAMIC_TO_FILTER,
   isComplexConversionFilterKey,
   LAST_PIR_SCORE_DATE_FILTER_PREFIX,
   PIR_SCORE_FILTER_PREFIX,
   RELATION_DYNAMIC_FILTER,
+  RELATION_DYNAMIC_FROM_FILTER,
+  RELATION_DYNAMIC_TO_FILTER,
   RELATION_FROM_FILTER,
   RELATION_FROM_ROLE_FILTER,
   RELATION_FROM_TYPES_FILTER,
@@ -1563,7 +1563,8 @@ const elDataConverter = (esHit) => {
       // Rebuild rel to stix attributes
       const rel = key.substring(REL_INDEX_PREFIX.length);
       const [relType] = rel.split('.');
-      data[relType] = isSingleRelationsRef(data.entity_type, relType) ? R.head(val) : [...(data[relType] ?? []), ...val];
+      const relData = isSingleRelationsRef(data.entity_type, relType) ? R.head(val) : [...(data[relType] ?? []), ...val];
+      data[relType] = isStixRefUnidirectionalRelationship(relType) ? R.uniq(relData) : relData;
     } else {
       data[key] = val;
     }

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1563,8 +1563,12 @@ const elDataConverter = (esHit) => {
       // Rebuild rel to stix attributes
       const rel = key.substring(REL_INDEX_PREFIX.length);
       const [relType] = rel.split('.');
-      const relData = isSingleRelationsRef(data.entity_type, relType) ? R.head(val) : [...(data[relType] ?? []), ...val];
-      data[relType] = isStixRefUnidirectionalRelationship(relType) ? R.uniq(relData) : relData;
+      if (isSingleRelationsRef(data.entity_type, relType)) {
+        data[relType] = R.head(val);
+      } else {
+        const relData = [...(data[relType] ?? []), ...val];
+        data[relType] = isStixRefUnidirectionalRelationship(relType) ? R.uniq(relData) : relData;
+      }
     } else {
       data[key] = val;
     }

--- a/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixRefRelationship.ts
@@ -913,6 +913,7 @@ export const META_RELATIONS: RefAttribute[] = [
   // OCTI
   objectOrganization,
   objectAssignee,
+  objectParticipant,
 ];
 
 // Register


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove duplicates in elDataConverter refs if ref is unidirectional. This is used to prevent returning duplicate labels/markings/etc.. when the data in elastic is inconsistent on those fields
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12257 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
