### PR TITLE
[backend] improve task work status tracking and activeTasks retrieval 

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -956,6 +956,7 @@
   "Window title": "Fenstertitel",
   "Windows registry values": "Windows-Registrierungswerte",
   "Work": "Arbeit",
+  "Work completion status": "Status des Arbeitsabschlusses",
   "Work status": "Arbeitsstatus",
   "Workbench labels": "Workbench-Etiketten",
   "Workflow activated": "Workflow aktiviert",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -956,6 +956,7 @@
   "Window title": "Window title",
   "Windows registry values": "Windows registry values",
   "Work": "Work",
+  "Work completion status": "Work completion status",
   "Work status": "Work status",
   "Workbench labels": "Workbench labels",
   "Workflow activated": "Workflow activated",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -956,6 +956,7 @@
   "Window title": "Título de la ventana",
   "Windows registry values": "Valores del registro de Windows",
   "Work": "Trabajo",
+  "Work completion status": "Estado de finalización de los trabajos",
   "Work status": "Situación laboral",
   "Workbench labels": "Etiquetas del Workbench",
   "Workflow activated": "Flujo de trabajo activado",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -956,6 +956,7 @@
   "Window title": "Titre de la fenêtre",
   "Windows registry values": "Valeurs du registre Windows",
   "Work": "Travail",
+  "Work completion status": "État d'avancement du travail",
   "Work status": "Statut du travail",
   "Workbench labels": "Étiquettes de l'atelier",
   "Workflow activated": "Flux de travail activé",

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -956,6 +956,7 @@
   "Window title": "Titolo della finestra",
   "Windows registry values": "Valori del registro di Windows",
   "Work": "Lavoro",
+  "Work completion status": "Stato di completamento del lavoro",
   "Work status": "Stato del lavoro",
   "Workbench labels": "Etichette della workbench",
   "Workflow activated": "Workflow attivato",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -956,6 +956,7 @@
   "Window title": "ウィンドウタイトル",
   "Windows registry values": "Windowsレジストリ値",
   "Work": "作業内容",
+  "Work completion status": "作業完了状況",
   "Work status": "勤務状況",
   "Workbench labels": "ラベル",
   "Workflow activated": "イベントの種類",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -956,6 +956,7 @@
   "Window title": "창 제목",
   "Windows registry values": "윈도우 레지스트리 값",
   "Work": "작업",
+  "Work completion status": "작업 완료 상태",
   "Work status": "작업 상태",
   "Workbench labels": "작업대 라벨",
   "Workflow activated": "워크플로우 활성화됨",

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -956,6 +956,7 @@
   "Window title": "Заголовок окна",
   "Windows registry values": "Значения реестра Windows",
   "Work": "Работа",
+  "Work completion status": "Статус завершения работ",
   "Work status": "Статус работы",
   "Workbench labels": "Наклейки на верстак",
   "Workflow activated": "Активирован рабочий процесс",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -956,6 +956,7 @@
   "Window title": "窗口标题",
   "Windows registry values": "Windows 注册表值",
   "Work": "工作",
+  "Work completion status": "工作完成情况",
   "Work status": "工作状态",
   "Workbench labels": "工作台标签",
   "Workflow activated": "已激活的工作流程",

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1743,7 +1743,7 @@ export const elFindByIds = async (context, user, ids, opts = {}) => {
   const queryIndices = computeQueryIndices(indices, types);
   const computedIndices = getIndicesToQuery(context, user, queryIndices);
   const hits = [];
-  const groupIds = R.splitEvery(MAX_TERMS_SPLIT, idsArray);
+  const groupIds = R.splitEvery(MAX_TERMS_SPLIT, processIds);
   for (let index = 0; index < groupIds.length; index += 1) {
     const mustTerms = [];
     const workingIds = groupIds[index];

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask-common.js
@@ -330,6 +330,7 @@ export const createDefaultTask = async (context, user, input, taskType, taskExpe
     completed: false,
     // Associated job
     work_id,
+    work_completed: false,
     connector_id,
     // Task related
     type: taskType,

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -5,7 +5,6 @@ import {
   createRelationRaw,
   deleteElementById,
   distributionEntities,
-  stixLoadById,
   storeLoadByIdWithRefs,
   timeSeriesEntities
 } from '../database/middleware';
@@ -66,7 +65,6 @@ import {
   isEmptyField,
   isNotEmptyField,
   READ_ENTITIES_INDICES,
-  READ_INDEX_HISTORY,
   READ_INDEX_INFERRED_ENTITIES,
   READ_INDEX_INTERNAL_OBJECTS,
   UPDATE_OPERATION_ADD,

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -1,13 +1,5 @@
 import * as R from 'ramda';
-import {
-  buildRestrictedEntity,
-  createEntity,
-  createRelationRaw,
-  deleteElementById,
-  distributionEntities,
-  storeLoadByIdWithRefs,
-  timeSeriesEntities
-} from '../database/middleware';
+import { buildRestrictedEntity, createEntity, createRelationRaw, deleteElementById, distributionEntities, storeLoadByIdWithRefs, timeSeriesEntities } from '../database/middleware';
 import {
   fullEntitiesList,
   internalFindByIds,

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import * as R from 'ramda';
-import { elDeleteInstances, elFindByIds, elIndex, elLoadById, elPaginate, elRawDeleteByQuery, elUpdate, ES_MINIMUM_FIXED_PAGINATION } from '../database/engine';
+import { elDeleteInstances, elIndex, elLoadById, elPaginate, elRawDeleteByQuery, elUpdate, ES_MINIMUM_FIXED_PAGINATION } from '../database/engine';
 import { generateWorkId } from '../schema/identifier';
 import { INDEX_HISTORY, isNotEmptyField, READ_INDEX_HISTORY } from '../database/utils';
 import { isWorkCompleted, redisDeleteWorks, redisUpdateActionExpectation, redisUpdateWorkFigures } from '../database/redis';
@@ -14,7 +14,6 @@ import { IMPORT_CSV_CONNECTOR, IMPORT_CSV_CONNECTOR_ID } from '../connector/impo
 import { RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
 import { DRAFT_VALIDATION_CONNECTOR, DRAFT_VALIDATION_CONNECTOR_ID } from '../modules/draftWorkspace/draftWorkspace-connector';
 import { logApp } from '../config/conf';
-import { stixLoadById } from '../database/middleware';
 import { internalLoadById } from '../database/middleware-loader';
 
 export const workToExportFile = (work) => {

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -536,6 +536,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'completed', label: 'Completed', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'initiator_id', label: 'Initiator', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'work_id', label: 'Work', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'work_completed', label: 'Work complete status', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'connector_id', label: 'Connector ID', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     draftContext,
     { name: 'task_filters', label: 'Task filters', type: 'string', format: 'json', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: false },

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -536,7 +536,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition> } = {
     { name: 'completed', label: 'Completed', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'initiator_id', label: 'Initiator', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'work_id', label: 'Work', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'work_completed', label: 'Work complete status', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'work_completed', label: 'Work completion status', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'connector_id', label: 'Connector ID', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     draftContext,
     { name: 'task_filters', label: 'Task filters', type: 'string', format: 'json', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: false },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix elFindByIds potentially failing when using null values
* add work_completed attribute to task to keep track of work completion
* modify stixCoreBackgroundActiveOperations to not use any post filtering but instead use work_completed value in filter to retrieve relevant tasks

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
