### PR TITLE
[ci] Disable child lock for api-tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ steps:
     environment:
       APP__BASE_URL: http://api-tests:4010/
       APP__ADMIN__PASSWORD: admin
-      APP__CHILD_LOCKING_PROCESS__ENABLED: true
+      APP__CHILD_LOCKING_PROCESS__ENABLED: false
       APP__ENTERPRISE_EDITION_LICENSE:
         from_secret: ee_license
       APP__SYNC_RAW_START_REMOTE_URI: http://opencti-raw-start:4100/graphql


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Until we fix vite setup, childlock need to be swicth to false for api-tests only.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
