### PR TITLE
[frontend] remove duplicate tooltip of connector state (#12717)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -544,24 +544,20 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                 <Typography variant="h3" gutterBottom={true}>
                   {t_i18n('State')}
                 </Typography>
-                {
-                  connector.connector_state ? (
-                    <Tooltip title={connector.connector_state || ''}>
-                      <pre>
-                        <ItemCopy
-                          content={connector.connector_state || ''}
-                          limit={200}
-                        />
-                      </pre>
-                    </Tooltip>
-                  ) : '-'
-                }
+                <FieldOrEmpty source={connector.connector_state}>
+                  <pre>
+                    <ItemCopy
+                      content={connector.connector_state || ''}
+                      limit={200}
+                    />
+                  </pre>
+                </FieldOrEmpty>
               </Grid>
 
               <Grid item xs={6}>
                 {!connector.connector_info && (
                   connector.connector_state
-                && connectorStateConverted !== null
+                  && connectorStateConverted !== null
                 && checkLastRunExistingInState && checkLastRunIsNumber ? (
                   <>
                     <Typography variant="h3" gutterBottom={true}>


### PR DESCRIPTION
### Proposed changes
remove duplicate tooltip when mouse hovers the state in connector overview

### Related issues
#12717 remove duplicate tooltip of connector state 