### PR TITLE
[frontend] Narrative views buttons inconsistancy (#10964)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ViewSwitchingButtons.tsx
+++ b/opencti-platform/opencti-front/src/components/ViewSwitchingButtons.tsx
@@ -1,11 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
-import { LibraryBooksOutlined, ViewModuleOutlined } from '@mui/icons-material';
+import { LibraryBooksOutlined, ViewListOutlined, ViewModuleOutlined } from '@mui/icons-material';
 import { FormatListGroup, Group, RelationManyToMany, VectorPolygon } from 'mdi-material-ui';
 import { ToggleButtonGroup } from '@mui/material';
-import { ListViewIcon, SublistViewIcon } from 'filigran-icon';
-import FiligranIcon from '@components/common/FiligranIcon';
+import SegmentOutlinedIcon from '@mui/icons-material/SegmentOutlined';
 import { useFormatter } from './i18n';
 
 interface ViewSwitchingButtonsProps {
@@ -84,7 +83,7 @@ const ViewSwitchingButtons: FunctionComponent<ViewSwitchingButtonsProps> = ({
           onClick={() => handleChangeView('lines')}
           aria-label="lines"
         >
-          <FiligranIcon icon={ListViewIcon} color="primary" size="small" />
+          <ViewListOutlined color="primary" fontSize="small" />
         </ToggleButton>
       </Tooltip>
       )}
@@ -93,9 +92,8 @@ const ViewSwitchingButtons: FunctionComponent<ViewSwitchingButtonsProps> = ({
         <ToggleButton
           value="subEntityLines"
           aria-label="subEntityLines"
-          style={{ height: 36 }}
         >
-          <FiligranIcon icon={SublistViewIcon} color="secondary" size="small" />
+          <SegmentOutlinedIcon color="primary" fontSize="small" />
         </ToggleButton>
       </Tooltip>
       )}

--- a/opencti-platform/opencti-front/src/components/ViewSwitchingButtons.tsx
+++ b/opencti-platform/opencti-front/src/components/ViewSwitchingButtons.tsx
@@ -1,10 +1,11 @@
 import React, { FunctionComponent } from 'react';
 import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
-import { LibraryBooksOutlined, ViewListOutlined, ViewModuleOutlined } from '@mui/icons-material';
+import { LibraryBooksOutlined, ViewModuleOutlined } from '@mui/icons-material';
 import { FormatListGroup, Group, RelationManyToMany, VectorPolygon } from 'mdi-material-ui';
 import { ToggleButtonGroup } from '@mui/material';
-import SegmentOutlinedIcon from '@mui/icons-material/SegmentOutlined';
+import FiligranIcon from '@components/common/FiligranIcon';
+import { ListViewIcon, SublistViewIcon } from 'filigran-icon';
 import { useFormatter } from './i18n';
 
 interface ViewSwitchingButtonsProps {
@@ -83,7 +84,7 @@ const ViewSwitchingButtons: FunctionComponent<ViewSwitchingButtonsProps> = ({
           onClick={() => handleChangeView('lines')}
           aria-label="lines"
         >
-          <ViewListOutlined color="primary" fontSize="small" />
+          <FiligranIcon icon={ListViewIcon} color="primary" size="small" />
         </ToggleButton>
       </Tooltip>
       )}
@@ -93,7 +94,7 @@ const ViewSwitchingButtons: FunctionComponent<ViewSwitchingButtonsProps> = ({
           value="subEntityLines"
           aria-label="subEntityLines"
         >
-          <SegmentOutlinedIcon color="primary" fontSize="small" />
+          <FiligranIcon icon={SublistViewIcon} color="secondary" size="small" />
         </ToggleButton>
       </Tooltip>
       )}

--- a/opencti-platform/opencti-front/src/private/components/techniques/Narratives.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/Narratives.tsx
@@ -1,13 +1,12 @@
 import React, { FunctionComponent } from 'react';
 import { NarrativeWithSubnarrativeLineDummy } from '@components/techniques/narratives/NarrativeWithSubnarrativeLine';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import FiligranIcon from '@components/common/FiligranIcon';
-import { SublistViewIcon } from 'filigran-icon';
 import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
 import { NarrativesLines_data$data } from '@components/techniques/narratives/__generated__/NarrativesLines_data.graphql';
 import { ViewListOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/styles';
+import SegmentOutlinedIcon from '@mui/icons-material/SegmentOutlined';
 import ExportContextProvider from '../../../utils/ExportContextProvider';
 import { narrativeLineFragment } from './narratives/NarrativeLine';
 import { narrativesLinesFragment, narrativesLinesQuery } from './narratives/NarrativesLines';
@@ -196,7 +195,7 @@ const Narratives: FunctionComponent = () => {
                     value="subEntityLines"
                     aria-label="subEntityLines"
                   >
-                    <FiligranIcon icon={SublistViewIcon} color="primary" size="small" />
+                    <SegmentOutlinedIcon color="primary" fontSize="small" />
                   </ToggleButton>
                 </Tooltip>
               )]}

--- a/opencti-platform/opencti-front/src/private/components/techniques/Narratives.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/Narratives.tsx
@@ -4,9 +4,9 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ToggleButton from '@mui/material/ToggleButton';
 import Tooltip from '@mui/material/Tooltip';
 import { NarrativesLines_data$data } from '@components/techniques/narratives/__generated__/NarrativesLines_data.graphql';
-import { ViewListOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/styles';
-import SegmentOutlinedIcon from '@mui/icons-material/SegmentOutlined';
+import { ListViewIcon, SublistViewIcon } from 'filigran-icon';
+import FiligranIcon from '@components/common/FiligranIcon';
 import ExportContextProvider from '../../../utils/ExportContextProvider';
 import { narrativeLineFragment } from './narratives/NarrativeLine';
 import { narrativesLinesFragment, narrativesLinesQuery } from './narratives/NarrativesLines';
@@ -185,7 +185,7 @@ const Narratives: FunctionComponent = () => {
                     value="lines"
                     aria-label="lines"
                   >
-                    <ViewListOutlined color="primary" fontSize="small" />
+                    <FiligranIcon icon={ListViewIcon} color="primary" size="small" />
                   </ToggleButton>
                 </Tooltip>
               ),
@@ -195,7 +195,7 @@ const Narratives: FunctionComponent = () => {
                     value="subEntityLines"
                     aria-label="subEntityLines"
                   >
-                    <SegmentOutlinedIcon color="primary" fontSize="small" />
+                    <FiligranIcon icon={SublistViewIcon} color="primary" size="small" />
                   </ToggleButton>
                 </Tooltip>
               )]}


### PR DESCRIPTION
### Proposed changes

* I took the liberty to change the icon for subentities view as I think it was awful and not coherent to what we use in the platform.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10964