### PR TITLE
[worker] add connector_type filtering in worker 

### DIFF
--- a/opencti-worker/src/config.yml.sample
+++ b/opencti-worker/src/config.yml.sample
@@ -7,3 +7,4 @@ opencti:
 worker:
   log_level: 'info'
   telemetry_enabled: false
+  targeted_connector_types: ['ANY'] # If not configured, or configured with 'ANY', all connectors will be targeted. Otherwise, only target connector types will be processed

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -596,6 +596,12 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             config,
             default="",
         )
+        self.targeted_connector_types = get_config_variable(
+            "WORKER_TARGETED_CONNECTOR_TYPES",
+            ["worker", "targeted_connector_types"],
+            config,
+            default=None,
+        )
         # Telemetry
         self.telemetry_enabled = get_config_variable(
             "WORKER_TELEMETRY_ENABLED",
@@ -672,6 +678,16 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                 self.connectors = self.api.connector.list()
                 # Check if all queues are consumed
                 for connector in self.connectors:
+                    # Apply connector type filter if needed
+                    if (
+                        self.targeted_connector_types is not None
+                        and "ANY" not in self.targeted_connector_types
+                    ):
+                        if (
+                            connector["connector_type"]
+                            not in self.targeted_connector_types
+                        ):
+                            continue
                     # Push to ingest message
                     push_queue = connector["config"]["push"]
                     self.queues.append(push_queue)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add ability to filter connectors to handle in worker: this could enable deploying workers only used for draft, or other workers only used for tasks etc...
*
Linked to https://github.com/OpenCTI-Platform/client-python/pull/991
Linked to https://github.com/OpenCTI-Platform/docs/pull/362
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
