### PR TITLE
[backend] ensure getConsolidatedUpdatePatch doesn't fail in case of null values in input value or in previous value (#12643)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/draft-utils.js
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.js
@@ -124,7 +124,7 @@ export const buildUpdateFieldPatch = (rawUpdatePatch) => {
 export const getConsolidatedUpdatePatch = (currentUpdatePatch, updatedInputsResolved) => {
   const newUpdatePatch = currentUpdatePatch;
   const nonResolvedInput = updatedInputsResolved
-    .map((i) => { return { key: i.key, value: i.value?.map((v) => v.standard_id ?? v), operation: i.operation ?? UPDATE_OPERATION_REPLACE, previous: i.previous ?? [] }; });
+    .map((i) => { return { key: i.key, value: i.value?.map((v) => v?.standard_id ?? v), operation: i.operation ?? UPDATE_OPERATION_REPLACE, previous: i.previous ?? [] }; });
   for (let i = 0; i < nonResolvedInput.length; i += 1) {
     const currentNonResolvedInput = nonResolvedInput[i];
     const currentUpdates = currentUpdatePatch[currentNonResolvedInput.key];
@@ -158,7 +158,7 @@ export const getConsolidatedUpdatePatch = (currentUpdatePatch, updatedInputsReso
       const replaced_value = currentNonResolvedInput.operation === UPDATE_OPERATION_REPLACE ? currentNonResolvedInput.value : [];
       const added_value = currentNonResolvedInput.operation === UPDATE_OPERATION_ADD ? currentNonResolvedInput.value : [];
       const removed_value = currentNonResolvedInput.operation === UPDATE_OPERATION_REMOVE ? currentNonResolvedInput.value : [];
-      const initial_value = currentNonResolvedInput.previous?.map((p) => p.standard_id ?? p);
+      const initial_value = currentNonResolvedInput.previous?.map((p) => p?.standard_id ?? p);
       newUpdatePatch[currentNonResolvedInput.key] = { replaced_value, added_value, removed_value, initial_value };
     }
   }


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* ensure getConsolidatedUpdatePatch doesn't fail in case of null values in input value or in previous value
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12643
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
