### PR TITLE
[frontend] date filters value display in date selector for lte and gt operators (#11916)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/lists/FilterDate.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FilterDate.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useState, KeyboardEvent } from 'react';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { buildDate } from '../../../../utils/Time';
+import { buildDate, dateFiltersValueForDisplay } from '../../../../utils/Time';
 
 interface FilterDateProps {
   defaultHandleAddFilter: (
@@ -26,7 +26,7 @@ const FilterDate: FunctionComponent<FilterDateProps> = ({
   filterLabel,
   filterValue,
 }) => {
-  const [dateState, setDateState] = useState<Date | null>(filterValue ? new Date(filterValue) : null);
+  const [dateState, setDateState] = useState<Date | null>(filterValue ? new Date(dateFiltersValueForDisplay(filterValue, operator)) : null);
 
   const findFilterFromKey = (filters: {
     key: string,

--- a/opencti-platform/opencti-front/src/utils/Time.js
+++ b/opencti-platform/opencti-front/src/utils/Time.js
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone';
+import { subDays } from 'date-fns';
 import { isNone } from '../components/i18n';
 
 const defaultDateFormat = 'YYYY-MM-DD';
@@ -198,4 +199,18 @@ export const formatUptime = (uptimeInSeconds, t_i18n) => {
   }
 
   return parts.join(', ');
+};
+
+/**
+ * Convert a date value stored in filters to a date value displayed in frontend according to the operator
+ *
+ * @param dateValue - The date value stored in filters
+ * @param operator - The associated filter operator
+ * @returns The date value to be displayed
+ */
+export const dateFiltersValueForDisplay = (dateFilterValue, filterOperator) => {
+  if (filterOperator && dateFilterValue && ['lte', 'gt'].includes(filterOperator)) {
+    return subDays(dateFilterValue, 1);
+  }
+  return dateFilterValue;
 };

--- a/opencti-platform/opencti-front/src/utils/Time.test.ts
+++ b/opencti-platform/opencti-front/src/utils/Time.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { dateFiltersValueForDisplay } from './Time';
+
+describe('Time utils', () => {
+  describe('dateFiltersValueForDisplay', () => {
+    it('should convert a date filter value to a date value for display', () => {
+      expect(dateFiltersValueForDisplay('2025-10-02T22:00:00.000Z', 'lt')).toEqual('2025-10-02T22:00:00.000Z');
+      expect(dateFiltersValueForDisplay('2025-10-02T22:00:00.000Z', 'lte')).toEqual(new Date('2025-10-01T22:00:00.000Z'));
+      expect(dateFiltersValueForDisplay('2025-10-02T22:00:00.000Z', 'gte')).toEqual('2025-10-02T22:00:00.000Z');
+      expect(dateFiltersValueForDisplay('2025-10-02T22:00:00.000Z', 'gt')).toEqual(new Date('2025-10-01T22:00:00.000Z'));
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -2,14 +2,14 @@ import * as R from 'ramda';
 import { v4 as uuid } from 'uuid';
 import { FilterOptionValue } from '@components/common/lists/FilterAutocomplete';
 import React from 'react';
-import { subDays } from 'date-fns';
 import { useFormatter } from '../../components/i18n';
 import type { FilterGroup as GqlFilterGroup } from './__generated__/useSearchEntitiesStixCoreObjectsSearchQuery.graphql';
 import useAuth, { FilterDefinition } from '../hooks/useAuth';
 import { capitalizeFirstLetter, displayEntityTypeForTranslation, isValidDate } from '../String';
 import { FilterRepresentative } from '../../components/filters/FiltersModel';
-import { uniqueArray, isEmptyField } from '../utils';
+import { isEmptyField, uniqueArray } from '../utils';
 import { Filter, FilterGroup, FilterValue, handleFilterHelpers } from './filtersHelpers-types';
+import { dateFiltersValueForDisplay } from '../Time';
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -400,10 +400,7 @@ export const filterValue = (filterKey: string, value?: string | null, filterType
       return value;
     }
     const dateConvertor = filterOperator === 'within' ? smhd : nsd;
-    if (filterOperator && value && ['lte', 'gt'].includes(filterOperator)) {
-      return dateConvertor(subDays(value, 1));
-    }
-    return dateConvertor(value);
+    return dateConvertor(dateFiltersValueForDisplay(value, filterOperator));
   }
   if (filterKey === 'relationship_type' || filterKey === 'type') {
     return t_i18n(`relationship_${value}`);


### PR DESCRIPTION
### Proposed changes
- Align date filter values display between filter icon button and date selection calendar
- Frontend utils function to convert a filter date value in a date value displayed in frontend, depending on the operator.

### Related issues
#11916 