### PR TITLE
[backend] Check valid from/ valid until order only if one of them is changes (#11667)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -404,7 +404,7 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   });
 
   if (validUntilEditInput || validFromEditInput) {
-    if (new Date(valid_until) <= new Date(valid_from)) {
+    if (new Date(valid_until) < new Date(valid_from)) {
       throw ValidationError('The valid until date must be greater than the valid from date', VALID_FROM, { input, valid_from, valid_until });
     }
   }
@@ -476,7 +476,7 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
       }
 
       if (hasRevokedChangedToFalse) {
-        logApp.info('ANGIE - revoked moved to false');
+        logApp.debug('ANGIE - revoked moved to false');
         // Restart decay as if the score has been put to decay_base_score manually.
         const newScore = indicatorBeforeUpdate.decay_base_score;
         const allChanges = restartDecayComputationOnEdit(newScore, indicatorBeforeUpdate);

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -395,13 +395,20 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   }
   // validation check because according to STIX 2.1 specification the valid_until must be greater than the valid_from
   let { valid_from, valid_until } = indicatorBeforeUpdate;
+  const validUntilEditInput = input.find((e) => e.key === VALID_UNTIL);
+  const validFromEditInput = input.find((e) => e.key === VALID_FROM);
+
   input.forEach((e) => {
     if (e.key === VALID_FROM) [valid_from] = e.value;
     if (e.key === VALID_UNTIL) [valid_until] = e.value;
   });
-  if (new Date(valid_until) <= new Date(valid_from)) {
-    throw ValidationError('The valid until date must be greater than the valid from date', VALID_FROM, { input, valid_from, valid_until });
+
+  if (validUntilEditInput || validFromEditInput) {
+    if (new Date(valid_until) <= new Date(valid_from)) {
+      throw ValidationError('The valid until date must be greater than the valid from date', VALID_FROM, { input, valid_from, valid_until });
+    }
   }
+
   // check indicator pattern syntax
   const patternEditInput = input.find((e) => e.key === 'pattern');
   if (patternEditInput) {
@@ -419,7 +426,7 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   const finalInput = input.filter((editInput) => { return editInput.key !== VALID_UNTIL && editInput.key !== X_SCORE && editInput.key !== REVOKED; });
 
   const isDecayEnabledOnIndicator: boolean = indicatorBeforeUpdate.decay_applied_rule !== undefined && indicatorBeforeUpdate.decay_applied_rule.decay_revoke_score !== undefined;
-  const validUntilEditInput = input.find((e) => e.key === VALID_UNTIL);
+
   const revokedEditInput = input.find((e) => e.key === REVOKED);
   const nowDate = new Date();
   let hasRevokedChangedToTrue: boolean = false;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Check that valid until / valid from are correct only if one of them is change. Can't block to change other fields of indicators if some indicators already exists like that for some reason in the platform.
* This bug occurs when valid_until === valid_from, throwing exception only when valid_until strictly lower than valid_from.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #11667

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
