### PR TITLE
[frontend] change StixCyberObservableNestedEntitiesTable ref link (#12612)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
@@ -19,7 +19,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { StixCyberObservableNestedEntitiesTable_node$data } from './__generated__/StixCyberObservableNestedEntitiesTable_node.graphql';
 import { useBuildEntityTypeBasedFilterContext } from '../../../../utils/filters/filtersUtils';
 import stopEvent from '../../../../utils/domEvent';
-import { computeLink } from '../../../../utils/Entity';
+import { computeLink, ComputeLinkNode } from '../../../../utils/Entity';
 
 const LOCAL_STORAGE_KEY = 'StixCyberObservableNestedEntitiesTable';
 
@@ -342,8 +342,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
   const getRedirectionLink = (stixObject: StixCyberObservableNestedEntitiesTable_node$data) => {
     const targetObject = stixObject.from?.id === stixCyberObservableId ? stixObject.to : stixObject.from;
     if (targetObject) {
-      const reconstructedTarget = { ...targetObject, id: targetObject.id ?? '', entity_type: targetObject.entity_type ?? '' };
-      return computeLink(reconstructedTarget);
+      return computeLink(targetObject as ComputeLinkNode);
     }
     return undefined;
   };

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
@@ -19,6 +19,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { StixCyberObservableNestedEntitiesTable_node$data } from './__generated__/StixCyberObservableNestedEntitiesTable_node.graphql';
 import { useBuildEntityTypeBasedFilterContext } from '../../../../utils/filters/filtersUtils';
 import stopEvent from '../../../../utils/domEvent';
+import { computeLink } from '../../../../utils/Entity';
 
 const LOCAL_STORAGE_KEY = 'StixCyberObservableNestedEntitiesTable';
 
@@ -338,6 +339,15 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
     },
   };
 
+  const getRedirectionLink = (stixObject: StixCyberObservableNestedEntitiesTable_node$data) => {
+    const targetObject = stixObject.from?.id === stixCyberObservableId ? stixObject.to : stixObject.from;
+    if (targetObject) {
+      const reconstructedTarget = { ...targetObject, id: targetObject.id ?? '', entity_type: targetObject.entity_type ?? '' };
+      return computeLink(reconstructedTarget);
+    }
+    return undefined;
+  };
+
   return (
     <Box style={{
       marginBlockStart: isInLine ? 0 : -25,
@@ -356,6 +366,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
           hideSearch
           hideHeaders={isInLine}
           disableLineSelection
+          useComputeLink={getRedirectionLink}
           icon={(data: StixCyberObservableNestedEntitiesTable_node$data) => <ItemIcon type={data.to?.entity_type}/>}
           actions={(data: StixCyberObservableNestedEntitiesTable_node$data) => {
             return (

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
@@ -19,7 +19,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { StixCyberObservableNestedEntitiesTable_node$data } from './__generated__/StixCyberObservableNestedEntitiesTable_node.graphql';
 import { useBuildEntityTypeBasedFilterContext } from '../../../../utils/filters/filtersUtils';
 import stopEvent from '../../../../utils/domEvent';
-import { computeLink, ComputeLinkNode } from '../../../../utils/Entity';
+import useComputeLink, { ComputeLinkNode } from '../../../../utils/hooks/useComputeLink';
 
 const LOCAL_STORAGE_KEY = 'StixCyberObservableNestedEntitiesTable';
 
@@ -264,7 +264,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
       symbol: '',
     },
   };
-
+  const computeLink = useComputeLink();
   const { viewStorage, helpers } = usePaginationLocalStorage<StixCyberObservableNestedEntitiesTablePaginationQuery>(
     LOCAL_STORAGE_KEY,
     initialValues,
@@ -365,7 +365,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
           hideSearch
           hideHeaders={isInLine}
           disableLineSelection
-          useComputeLink={getRedirectionLink}
+          getComputeLink={getRedirectionLink}
           icon={(data: StixCyberObservableNestedEntitiesTable_node$data) => <ItemIcon type={data.to?.entity_type}/>}
           actions={(data: StixCyberObservableNestedEntitiesTable_node$data) => {
             return (

--- a/opencti-platform/opencti-front/src/utils/hooks/useComputeLink.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useComputeLink.ts
@@ -1,16 +1,18 @@
 import { resolveLink } from '../Entity';
 import useSchema from './useSchema';
 
+export type ComputeLinkNode = {
+  id: string;
+  entity_type: string;
+  relationship_type?: string;
+  from?: { entity_type: string; id: string };
+  to?: { entity_type: string; id: string };
+  type?: string;
+};
+
 const useComputeLink = () => {
   const { isRelationship } = useSchema();
-  const computeLink = (node: {
-    id: string;
-    entity_type: string;
-    relationship_type?: string;
-    from?: { entity_type: string; id: string };
-    to?: { entity_type: string; id: string };
-    type?: string;
-  }): string | undefined => {
+  const computeLink = (node: ComputeLinkNode): string | undefined => {
     let redirectLink;
     if (node.relationship_type === 'stix-sighting-relationship' && node.from) {
       redirectLink = `${resolveLink(node.from.entity_type)}/${


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* clicking on a nested ref in observables now redirects to the targeted entity instead of trying to target the relation that can't be displayed in a page
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12612
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
