### PR TITLE
[backend] add telemetry on human user login (#12807)(#12916)

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -17,6 +17,7 @@ import { isEmptyField, isNotEmptyField } from '../database/utils';
 import { DEFAULT_INVALID_CONF_VALUE, SYSTEM_USER } from '../utils/access';
 import { enrichWithRemoteCredentials } from './credentials';
 import { OPENCTI_ADMIN_UUID } from '../schema/general';
+import { addUserLoginCount } from '../manager/telemetryManager';
 
 // Admin user initialization
 export const initializeAdminUser = async (context) => {

--- a/opencti-platform/opencti-graphql/src/config/providers.js
+++ b/opencti-platform/opencti-graphql/src/config/providers.js
@@ -155,6 +155,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
         return login(username, password)
           .then((info) => {
             logApp.info('[LOCAL] Successfully logged', { username });
+            addUserLoginCount();
             return done(null, info);
           })
           .catch((err) => {
@@ -173,6 +174,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       const ldapOptions = { server: tlsConfig };
       const ldapStrategy = new LdapStrategy(ldapOptions, (user, done) => {
         logApp.info('[LDAP] Successfully logged', { user });
+        addUserLoginCount();
         const userMail = mappedConfig.mail_attribute ? user[mappedConfig.mail_attribute] : user.mail;
         const userName = mappedConfig.account_attribute ? user[mappedConfig.account_attribute] : user.givenName;
         const firstname = user[mappedConfig.firstname_attribute] || '';
@@ -232,6 +234,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       const samlOptions = { ...mappedConfig };
       const samlStrategy = new SamlStrategy(samlOptions, (profile, done) => {
         logApp.info('[SAML] Successfully logged', { profile });
+        addUserLoginCount();
         const { nameID, nameIDFormat } = profile;
         const samlAttributes = profile.attributes ? profile.attributes : profile;
         const roleAttributes = mappedConfig.roles_management?.role_attributes || ['roles'];
@@ -323,6 +326,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           const debugCallback = (message, meta) => logApp.info(message, meta);
           const openIDStrategy = new OpenIDStrategy(options, debugCallback, (_, tokenset, userinfo, done) => {
             logApp.info('[OPENID] Successfully logged', { userinfo });
+            addUserLoginCount();
             const isGroupMapping = (isNotEmptyField(mappedConfig.groups_management) && isNotEmptyField(mappedConfig.groups_management?.groups_mapping));
             logApp.info('[OPENID] Groups management configuration', { groupsManagement: mappedConfig.groups_management });
             // region groups mapping
@@ -417,6 +421,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
         (_, __, ___, profile, done) => {
           const data = profile._json;
           logApp.info('[FACEBOOK] Successfully logged', { profile: data });
+          addUserLoginCount();
           const { email } = data;
           providerLoginHandler({ email, name: data.first_name }, done);
         }
@@ -431,6 +436,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       const googleOptions = { passReqToCallback: true, ...mappedConfig, ...specificConfig };
       const googleStrategy = new GoogleStrategy(googleOptions, (_, __, ___, profile, done) => {
         logApp.info('[GOOGLE] Successfully logged', { profile });
+        addUserLoginCount();
         const email = R.head(profile.emails).value;
         const name = profile.displayName;
         let authorized = true;
@@ -454,6 +460,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       const githubOptions = { passReqToCallback: true, ...mappedConfig, scope };
       const githubStrategy = new GithubStrategy(githubOptions, async (_, token, __, profile, done) => {
         logApp.info('[GITHUB] Successfully logged', { profile });
+        addUserLoginCount();
         let authorized = true;
         if (organizations.length > 0) {
           const github = new GitHub({ token });
@@ -507,6 +514,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
         const debugCallback = (message, meta) => logApp.info(message, meta);
         const auth0Strategy = new OpenIDStrategy(options, debugCallback, (_, tokenset, userinfo, done) => {
           logApp.info('[AUTH0] Successfully logged', { userinfo });
+          addUserLoginCount();
           const { email, name } = userinfo;
           providerLoginHandler({ email, name }, done);
         });
@@ -575,6 +583,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
           autoCreateGroup: mappedConfig.auto_create_group ?? false,
         };
         const provider_metadata = { headers_audit: mappedConfig.headers_audit };
+        addUserLoginCount();
         return new Promise((resolve) => {
           providerLoginHandler({ email, name, firstname, provider_metadata, lastname }, (err, user) => {
             resolve(user);
@@ -603,6 +612,7 @@ for (let i = 0; i < providerKeys.length; i += 1) {
       }
       return login(username, password)
         .then((info) => {
+          addUserLoginCount();
           return done(null, info);
         })
         .catch((err) => {

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1640,12 +1640,6 @@ export const authenticateUserByTokenOrUserId = async (context, req, tokenOrId) =
       }
     }
     validateUser(authenticatedUser, settings);
-    if (tokenOrId === authenticatedUser.id) {
-      // On auth succeed - Increment telemetry for SSO and local login
-      // (we don't count token auth, only "humans")
-      await addUserLoginCount();
-    }
-    console.log(`[1] User authenticated with ${tokenOrId}`, authenticatedUser);
     return userWithOrigin(req, authenticatedUser);
   }
   throw FunctionalError(`Cant identify with ${tokenOrId}`);
@@ -1712,7 +1706,6 @@ export const sessionAuthenticateUser = async (context, req, user, provider) => {
   }
   const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   validateUser(logged, settings);
-  console.log(`[2] User authenticated ${user.id}`);
   // Build and save the session
   req.session.user = { id: user.id, session_creation: now(), otp_validated: false };
   req.session.session_provider = provider;

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -86,7 +86,7 @@ import { cleanMarkings } from '../utils/markingDefinition-utils';
 import { UnitSystem } from '../generated/graphql';
 import { DRAFT_STATUS_OPEN } from '../modules/draftWorkspace/draftStatuses';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
-import { addServiceAccountIntoUserCount, addUserEmailSendCount, addUserIntoServiceAccountCount, addUserLoginCount } from '../manager/telemetryManager';
+import { addServiceAccountIntoUserCount, addUserEmailSendCount, addUserIntoServiceAccountCount } from '../manager/telemetryManager';
 import { sendMail } from '../database/smtp';
 import { checkEnterpriseEdition } from '../enterprise-edition/ee';
 import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../modules/emailTemplate/emailTemplate-types';

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -63,6 +63,7 @@ export const TELEMETRY_FORM_INTAKE_CREATED = 'formIntakeCreatedCount';
 export const TELEMETRY_FORM_INTAKE_UPDATED = 'formIntakeUpdatedCount';
 export const TELEMETRY_FORM_INTAKE_DELETED = 'formIntakeDeletedCount';
 export const TELEMETRY_FORM_INTAKE_SUBMITTED = 'formIntakeSubmittedCount';
+export const TELEMETRY_USER_LOGIN = 'formIntakeSubmittedCount';
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -130,6 +131,11 @@ export const addForgotPasswordCount = async () => {
 
 export const addConnectorDeployedCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_CONNECTOR_DEPLOYED, 1);
+};
+
+export const addUserLoginCount = async () => {
+  console.log('ANGIE - ADD USER LOGIN');
+  await redisSetTelemetryAdd(TELEMETRY_USER_LOGIN, 1);
 };
 
 // End Region user event counters
@@ -283,9 +289,11 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setForgotPasswordCount(forgotPasswordCountInRedis);
     const connectorDeployedCountInRedis = await redisGetTelemetry(TELEMETRY_CONNECTOR_DEPLOYED);
     manager.setConnectorDeployedCount(connectorDeployedCountInRedis);
+    const userLoginCountInRedis = await redisGetTelemetry(TELEMETRY_USER_LOGIN);
+    manager.setConnectorDeployedCount(userLoginCountInRedis);
     // end region Telemetry user events
 
-    logApp.debug('[TELEMETRY] Fetching telemetry data successfully');
+    logApp.info('[TELEMETRY] Fetching telemetry data successfully');
   } catch (e) {
     logApp.error('[TELEMETRY] Error fetching platform information', { cause: e });
   }

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -13,8 +13,11 @@ export class TelemetryMeterManager {
   // Cluster number of instances
   instancesCount = 0;
 
-  // Number of users in the platform
+  // Number of users in the platform (except service account)
   usersCount = 0;
+
+  // Number of users in the platform
+  serviceAccountCount = 0;
 
   // Number of active connectors
   activeConnectorsCount = 0;
@@ -69,6 +72,9 @@ export class TelemetryMeterManager {
   // Number of connectors deployed
   connectorDeployedCount = 0;
 
+  // +1 when a user that login into application, does not count token authentication
+  userLoginCount = 0;
+
   constructor(meterProvider: MeterProvider) {
     this.meterProvider = meterProvider;
   }
@@ -87,6 +93,10 @@ export class TelemetryMeterManager {
 
   setUsersCount(n: number) {
     this.usersCount = n;
+  }
+
+  setServiceAccountsCount(n: number) {
+    this.serviceAccountCount = n;
   }
 
   setActiveConnectorsCount(n: number) {
@@ -169,6 +179,10 @@ export class TelemetryMeterManager {
     this.connectorDeployedCount = n;
   }
 
+  setUserLoginCount(n: number) {
+    this.userLoginCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: { unit?: string, valueType?: ValueType } = {}) {
     const meter = this.meterProvider.getMeter(TELEMETRY_SERVICE_NAME);
     const gaugeOptions = { description, unit: opts.unit ?? 'count', valueType: opts.valueType ?? ValueType.INT };
@@ -184,6 +198,7 @@ export class TelemetryMeterManager {
     // This kind of gauge count be synchronous, waiting for opentelemetry-js 3668
     // https://github.com/open-telemetry/opentelemetry-js/issues/3668
     this.registerGauge('total_users_count', 'number of users', 'usersCount');
+    this.registerGauge('total_service_account_count', 'number of service account', 'serviceAccountCount');
     this.registerGauge('total_instances_count', 'cluster number of instances', 'instancesCount');
     this.registerGauge('active_connectors_count', 'number of active connectors', 'activeConnectorsCount');
     this.registerGauge('is_enterprise_edition', 'enterprise Edition is activated', 'isEEActivated', { unit: 'boolean' });

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -221,5 +221,6 @@ export class TelemetryMeterManager {
     this.registerGauge('forgot_password_count', 'Number of clicks on Forgot Password', 'forgotPasswordCount');
     this.registerGauge('pir_count', 'number of PIRs', 'pirCount');
     this.registerGauge('connector_deployed_count', 'Number of connectors deployed via composer', 'connectorDeployedCount');
+    this.registerGauge('user_login_count', 'Number of user that logs-in into application', 'userLoginCount');
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a telemetry point when a user login into the platform
* Split in telemetry the count of user that are not service account from service account

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #12807 
* closes #12916

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
