### PR TITLE
[frontend] adjust catalog card and description ui (#12652)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogCard.tsx
@@ -59,6 +59,7 @@ const ConnectorTitle = ({ title }: ConnectorTitleProps) => {
           fontWeight: 800,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
+          display: '-webkit-box',
           WebkitLineClamp: 2,
           WebkitBoxOrient: 'vertical',
           opacity: 0.9,
@@ -71,7 +72,7 @@ const ConnectorTitle = ({ title }: ConnectorTitleProps) => {
 };
 
 interface ConnectorActionsProps {
-  connectorMetadata: { label: string; color?: 'primary' | 'secondary' | 'error' | 'warning' | 'success' };
+  connectorMetadata: { label: string; color?: 'primary' | 'secondary' | 'error' | 'warning' | 'success' | string };
   isEnterpriseEdition: boolean;
   deploymentCount: number;
   onClickDeploy: () => void;
@@ -92,17 +93,16 @@ const ConnectorActions = ({
         gap: 1,
         alignItems: 'flex-end',
       }}
-      onClick={(e) => e.stopPropagation()}
     >
       <IngestionCatalogChip
         label={connectorMetadata.label}
         color={connectorMetadata.color}
       />
       <Stack
-        sx={{
-          marginLeft: '0!important',
-        }}
-        direction="row" gap={1}
+        sx={{ marginLeft: '0!important' }}
+        direction="row"
+        gap={1}
+        onClick={(e) => e.stopPropagation()}
       >
         <Security needs={[INGESTION_SETINGESTIONS]}>
           {isEnterpriseEdition ? (
@@ -199,6 +199,7 @@ const IngestionCatalogCard = ({
             WebkitLineClamp: 5,
             WebkitBoxOrient: 'vertical',
             lineHeight: 1.5,
+            opacity: 0.8,
           }}
         >
           {connector.short_description}

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnector.tsx
@@ -74,13 +74,14 @@ const IngestionCatalogConnectorComponent = ({
       <Stack gap={2}>
         <ConnectorDeploymentBanner hasRegisteredManagers={hasRegisteredManagers} />
 
-        <IngestionCatalogConnectorHeader
-          connector={connector}
-          isEnterpriseEdition={isEnterpriseEdition}
-          onClickDeploy={() => onClickDeploy(connector, contract?.catalog_id, hasRegisteredManagers, deploymentCount)}
-        />
-
-        <IngestionCatalogConnectorOverview connector={connector} />
+        <Stack gap={4}>
+          <IngestionCatalogConnectorHeader
+            connector={connector}
+            isEnterpriseEdition={isEnterpriseEdition}
+            onClickDeploy={() => onClickDeploy(connector, contract?.catalog_id, hasRegisteredManagers, deploymentCount)}
+          />
+          <IngestionCatalogConnectorOverview connector={connector} />
+        </Stack>
       </Stack>
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorHeader.tsx
@@ -7,6 +7,7 @@ import IngestionCatalogChip from '@components/data/IngestionCatalog/IngestionCat
 import { IngestionConnector } from '@components/data/IngestionCatalog';
 import EnterpriseEditionButton from '@components/common/entreprise_edition/EnterpriseEditionButton';
 import { getConnectorMetadata } from '@components/data/IngestionCatalog/utils/ingestionConnectorTypeMetadata';
+import { Stack } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import { INGESTION_SETINGESTIONS } from '../../../../utils/hooks/useGranted';
@@ -26,52 +27,79 @@ const IngestionCatalogConnectorHeader = ({ connector, isEnterpriseEdition, onCli
   const connectorMetadata = getConnectorMetadata(connector.container_type, t_i18n);
 
   return (
-    <>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: theme.spacing(2) }}>
-        <div style={{ display: 'flex', gap: 20 }}>
-          <img style={{ height: 70, width: 70, objectFit: 'cover', borderRadius: 4 }} src={connector.logo} alt={connector.title} />
-          <div>
-            <div style={{ display: 'flex', gap: 20 }}>
-              <Typography variant="h1" style={{ fontSize: 30, textTransform: 'uppercase' }}>{connector.title}</Typography>
-              {
-                connector.verified && (
-                  <ItemBoolean
-                    status={true}
-                    label={
-                      <div style={{ display: 'flex', alignItems: 'center', gap: theme.spacing(1) }}>
-                        <VerifiedOutlined color="success" fontSize="small" />
-                        {t_i18n('Verified')}
-                      </div>
-                    }
-                  />
-                )
-              }
-            </div>
-            <div style={{ display: 'flex' }}>
-              <IngestionCatalogChip
-                isInlist
-                label={connectorMetadata.label}
-                color={connectorMetadata.color}
-              />
-              {connector.use_cases.map((useCase: string) => <IngestionCatalogChip key={useCase} label={useCase} isInlist />)}
-            </div>
-          </div>
-        </div>
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+    >
+      <Stack direction="row" gap={2}>
+        <img
+          src={connector.logo}
+          alt={connector.title}
+          style={{
+            height: 96,
+            width: 96,
+            objectFit: 'cover',
+            borderRadius: 4,
+          }}
+        />
 
-        <div>
-          <Security needs={[INGESTION_SETINGESTIONS]}>
+        <Stack gap={1}>
+          <Stack direction="row" gap={2} alignItems="center">
+            <Typography
+              variant="h1"
+              sx={{
+                fontWeight: 800,
+                fontSize: 30,
+                opacity: 0.9,
+                marginBottom: 0,
+                textTransform: 'uppercase',
+              }}
+            >
+              {connector.title}
+            </Typography>
             {
-              isEnterpriseEdition ? (
-                <Button variant="contained" onClick={onClickDeploy} style={{ marginLeft: theme.spacing(1) }}>{t_i18n('Deploy')}</Button>
-              ) : (
-                <EnterpriseEditionButton title="Deploy" />
+              connector.verified && (
+                <ItemBoolean
+                  status
+                  label={
+                    <Stack direction="row" alignItems="center" gap={theme.spacing(1)}>
+                      <VerifiedOutlined color="success" fontSize="small" />
+                      {t_i18n('Verified')}
+                    </Stack>
+                  }
+                />
               )
             }
-          </Security>
-        </div>
+          </Stack>
 
+          <Stack direction="row">
+            <IngestionCatalogChip
+              isInlist
+              label={connectorMetadata.label}
+              color={connectorMetadata.color}
+            />
+
+            {
+              connector.use_cases.map((useCase: string) => (
+                <IngestionCatalogChip key={useCase} label={useCase} isInlist color="primary" />
+              ))
+            }
+          </Stack>
+        </Stack>
+      </Stack>
+
+      <div>
+        <Security needs={[INGESTION_SETINGESTIONS]}>
+          {
+            isEnterpriseEdition ? (
+              <Button variant="contained" onClick={onClickDeploy} style={{ marginLeft: theme.spacing(1) }}>{t_i18n('Deploy')}</Button>
+            ) : (
+              <EnterpriseEditionButton title="Deploy" />
+            )
+          }
+        </Security>
       </div>
-    </>
+    </Stack>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorOverview.tsx
@@ -3,7 +3,7 @@ import Button from '@mui/material/Button';
 import { Launch } from 'mdi-material-ui';
 import React from 'react';
 import { useTheme } from '@mui/styles';
-import Grid from '@mui/material/Grid';
+import Grid from '@mui/material/Grid2';
 import Paper from '@mui/material/Paper';
 import { IngestionConnector } from '@components/data/IngestionCatalog';
 import { LibraryBooksOutlined } from '@mui/icons-material';
@@ -16,56 +16,58 @@ const IngestionCatalogConnectorOverview = ({ connector }: { connector: Ingestion
   const theme = useTheme<Theme>();
 
   return (
-    <Grid container={true} spacing={3} style={{ marginBottom: 20 }}>
-
-      <Grid item xs={8}>
+    <Grid container spacing={3} sx={{ marginBottom: 20 }}>
+      <Grid size={{ xs: 12, md: 8 }}>
         <Typography variant="h4" gutterBottom={true}>{t_i18n('Overview')}</Typography>
         <Paper
-          style={{ marginTop: theme.spacing(1), padding: '15px', borderRadius: 4 }}
+          sx={{ marginTop: theme.spacing(1), padding: 2, borderRadius: 1 }}
           variant="outlined"
         >
           <MarkdownDisplay content={connector.description} />
         </Paper>
       </Grid>
 
-      <Grid item xs={4}>
+      <Grid size={{ xs: 12, md: 4 }}>
         <Typography variant="h4" gutterBottom={true}>{t_i18n('Basic information')}</Typography>
         <Paper
           style={{ marginTop: theme.spacing(1), padding: '15px', borderRadius: 4 }}
           variant="outlined"
         >
-          <Grid item xs={12}>
-            <Typography variant="h3" gutterBottom={true}>{t_i18n('Integration documentation and code')}</Typography>
-            <Button
-              size="large"
-              startIcon={<LibraryBooksOutlined />}
-              href={connector.source_code}
-              target="blank"
-              rel="noopener noreferrer"
-            >
-              {connector.title}
-            </Button>
-          </Grid>
-          <Grid item xs={12} style={{ marginTop: 20 }}>
-            <Typography variant="h3" gutterBottom={true}>{t_i18n('Visit the vendor\'s page to learn more and get in touch')}</Typography>
-            <Button
-              size="large"
-              startIcon={<Launch />}
-              href={connector.subscription_link}
-              target="blank"
-              rel="noopener noreferrer"
-              disabled={!connector.subscription_link}
-            >
-              {t_i18n('Vendor contact')}
-            </Button>
-          </Grid>
-          <Grid item xs={12} style={{ marginTop: 20 }}>
-            <Typography variant="h3" gutterBottom={true}>{t_i18n('Last verified')}</Typography>
-            {connector.last_verified_date || '-' }
+          <Grid container spacing={2.5}>
+            <Grid size={12}>
+              <Typography variant="h3" gutterBottom={true}>{t_i18n('Integration documentation and code')}</Typography>
+              <Button
+                size="large"
+                startIcon={<LibraryBooksOutlined />}
+                href={connector.source_code}
+                target="blank"
+                rel="noopener noreferrer"
+              >
+                {connector.title}
+              </Button>
+            </Grid>
+
+            <Grid size={12}>
+              <Typography variant="h3" gutterBottom={true}>{t_i18n('Visit the vendor\'s page to learn more and get in touch')}</Typography>
+              <Button
+                size="large"
+                startIcon={<Launch />}
+                href={connector.subscription_link}
+                target="blank"
+                rel="noopener noreferrer"
+                disabled={!connector.subscription_link}
+              >
+                {t_i18n('Vendor contact')}
+              </Button>
+            </Grid>
+
+            <Grid size={12}>
+              <Typography variant="h3" gutterBottom={true}>{t_i18n('Last verified')}</Typography>
+              {connector.last_verified_date || '-' }
+            </Grid>
           </Grid>
         </Paper>
       </Grid>
-
     </Grid>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogUseCaseChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogUseCaseChip.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from '@mui/material';
-import Chip from '@mui/material/Chip';
+import Chip, { ChipProps } from '@mui/material/Chip';
 import React from 'react';
 import { useTheme } from '@mui/material/styles';
 import type { Theme } from '../../../../components/Theme';
@@ -8,11 +8,34 @@ interface IngestionCatalogChipProps {
   label: string;
   tooltipLabel?: string;
   variant?: 'outlined' | 'filled';
-  color?: 'primary' | 'secondary' | 'error' | 'success' | 'warning';
+  color?: 'primary' | 'secondary' | 'error' | 'success' | 'warning' | string;
   withTooltip?: boolean;
   isInTooltip?: boolean;
   isInlist?: boolean;
 }
+
+interface CustomChipProps extends Omit<ChipProps, 'color'> {
+  color?: 'primary' | 'secondary' | 'error' | 'warning' | 'success' | 'info' | 'default' | string;
+}
+
+const CustomChip = ({ color, ...props }: CustomChipProps) => {
+  const validMuiColors = ['primary', 'secondary', 'error', 'warning', 'success', 'info', 'default'];
+  const isMuiColor = color && validMuiColors.includes(color);
+
+  return (
+    <Chip
+      {...props}
+      color={isMuiColor ? (color as ChipProps['color']) : undefined}
+      sx={{
+        ...(color && !isMuiColor && {
+          borderColor: color,
+          color,
+        }),
+        ...props.sx,
+      }}
+    />
+  );
+};
 
 const IngestionCatalogChip = ({
   label,
@@ -28,7 +51,7 @@ const IngestionCatalogChip = ({
 
   return (
     <Tooltip title={tooltipContent}>
-      <Chip
+      <CustomChip
         variant={variant ?? 'outlined'}
         size="small"
         color={color ?? 'default'}
@@ -39,6 +62,7 @@ const IngestionCatalogChip = ({
           marginRight: isInlist ? theme.spacing(1) : 0,
           border: `1px solid ${color || theme.palette.chip.main}`,
           backgroundColor: 'rgba(0, 0, 0, 0.1)',
+          color,
         }}
         label={label}
       />

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/ingestionConnectorTypeMetadata.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/ingestionConnectorTypeMetadata.ts
@@ -14,38 +14,38 @@ export const getConnectorMetadata = (
     case 'EXTERNAL_IMPORT':
       return {
         label: t_i18n('External import'),
-        color: 'primary' as const,
+        color: 'secondary' as const,
       };
     case 'INTERNAL_ENRICHMENT':
       return {
         label: t_i18n('Internal enrichment'),
-        color: 'secondary' as const,
+        color: 'warning' as const,
       };
     case 'INTERNAL_EXPORT_FILE':
       return {
         label: t_i18n('Internal export file'),
-        color: 'error' as const,
+        color: 'warning' as const,
       };
     case 'INTERNAL_IMPORT_FILE':
       return {
         label: t_i18n('Internal import file'),
-        color: 'success' as const,
+        color: 'warning' as const,
       };
     case 'INTERNAL_INGESTION':
       return {
         label: t_i18n('Internal ingestion'),
-        color: 'success' as const,
+        color: 'warning' as const,
       };
     case 'STREAM':
       return {
         label: t_i18n('Stream'),
-        color: 'warning' as const,
+        color: '#ff78ffff',
       };
     default:
       // return raw type if type not handled
       return {
         label: containerType,
-        color: 'primary' as const,
+        color: 'default' as const,
       };
   }
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* Catalog card title on 2 line max
* Lower card body text color
* Fix clicking on the card when mouse is on the left of Deploy button
<img width="1502" height="764" alt="Screenshot 2025-10-15 at 16 45 57" src="https://github.com/user-attachments/assets/32db8ca7-028e-4f7d-8e79-079bf5c1c943" />


* Change use case label chip color to match the one in catalog cards
* Center title with verified chip
* Refactor the component 
<img width="1496" height="750" alt="image" src="https://github.com/user-attachments/assets/7d8016e1-825f-4a46-8add-3718947c253d" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12652 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
