### PR TITLE
[backend] remove pagination in elFindByIds (#12810)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1732,7 +1732,7 @@ const findElementsDuplicateIds = (elements) => {
   const elementIds = new Set();
   const checkCurrentIds = (id) => {
     if (!id) return;
-    if (elementIds.has(id)) {
+    if (elementIds.has(id) && !duplicatedIds.includes(id)) {
       duplicatedIds.push(id);
     } else {
       elementIds.add(id);

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1739,8 +1739,6 @@ export const elFindByIds = async (context, user, ids, opts = {}) => {
     mapWithAllIds = false,
     type = null,
     relCount = false,
-    orderBy = null,
-    orderMode = 'asc',
   } = opts;
   const idsArray = Array.isArray(ids) ? ids : [ids];
   const types = (Array.isArray(type) || isEmptyField(type)) ? type : [type];
@@ -1807,9 +1805,6 @@ export const elFindByIds = async (context, user, ids, opts = {}) => {
       body.script_fields = {
         script_field_denormalization_count: REL_COUNT_SCRIPT_FIELD
       };
-    }
-    if (isNotEmptyField(orderBy)) {
-      body.sort = [{ [orderBy]: orderMode }];
     }
     const _source = { excludes: [] };
     if (withoutRels) _source.excludes.push(`${REL_INDEX_PREFIX}*`);

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1730,10 +1730,18 @@ const REL_COUNT_SCRIPT_FIELD = {
 // elFindByIds is not defined to use ordering or sorting (ordering is forced by creation date)
 // It's a way to load a bunch of ids and use in list or map
 export const elFindByIds = async (context, user, ids, opts = {}) => {
-  const { indices, baseData = false, baseFields = [] } = opts;
-  const { withoutRels = true, toMap = false, mapWithAllIds = false, type = null } = opts;
-  const { relCount = false } = opts;
-  const { orderBy = null, orderMode = 'asc' } = opts;
+  const {
+    indices,
+    baseData = false,
+    baseFields = [],
+    withoutRels = true,
+    toMap = false,
+    mapWithAllIds = false,
+    type = null,
+    relCount = false,
+    orderBy = null,
+    orderMode = 'asc',
+  } = opts;
   const idsArray = Array.isArray(ids) ? ids : [ids];
   const types = (Array.isArray(type) || isEmptyField(type)) ? type : [type];
   const processIds = R.filter((id) => isNotEmptyField(id), idsArray);

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1728,12 +1728,12 @@ const REL_COUNT_SCRIPT_FIELD = {
 };
 
 const findElementsDuplicateIds = (elements) => {
-  const duplicatedIds = [];
+  const duplicatedIds = new Set();
   const elementIds = new Set();
   const checkCurrentIds = (id) => {
     if (!id) return;
-    if (elementIds.has(id) && !duplicatedIds.includes(id)) {
-      duplicatedIds.push(id);
+    if (elementIds.has(id) && !duplicatedIds.has(id)) {
+      duplicatedIds.add(id);
     } else {
       elementIds.add(id);
     }
@@ -1746,7 +1746,7 @@ const findElementsDuplicateIds = (elements) => {
     otherStixIds?.map((id) => checkCurrentIds(id));
     aliasIds?.map((id) => checkCurrentIds(id));
   }
-  return duplicatedIds;
+  return Array.from(duplicatedIds);
 };
 
 // elFindByIds is not defined to use ordering or sorting (ordering is forced by creation date)

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -49,7 +49,6 @@ import {
   TASK_TYPE_RULE
 } from '../domain/backgroundTask-common';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
-import { BackgroundTaskScope } from '../generated/graphql';
 import { getDraftContext } from '../utils/draftContext';
 import { getBestBackgroundConnectorId, pushToWorkerForConnector } from '../database/rabbitmq';
 import { updateExpectationsNumber, updateProcessedTime } from '../domain/work';
@@ -118,15 +117,12 @@ export const taskQuery = async (context, user, task, callback) => {
 };
 
 export const taskList = async (context, user, task, callback) => {
-  const { task_position, task_ids, scope, task_order_mode } = task;
+  const { task_position, task_ids } = task;
   // task_position is no longer used, but we still handle it to properly process task that were processing before task migrated to worker
   const isUndefinedPosition = R.isNil(task_position) || R.isEmpty(task_position);
   const startIndex = isUndefinedPosition ? 0 : task_ids.findIndex((id) => task_position === id) + 1;
   const ids = task_ids.slice(startIndex);
   const options = {
-    orderMode: task_order_mode || 'desc',
-    // processing elements in descending order makes possible restoring from trash elements with dependencies
-    orderBy: scope === BackgroundTaskScope.Import ? 'lastModified' : 'created_at',
     baseData: true,
     includeDeletedInDraft: true,
   };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove pagination in elFindByIds. Instead, use the already in place system of splitting the query in multiple sub queries with a maximum of ids lower than ES_MAX_PAGINATION.
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12810 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
