### PR TITLE
[backend] Fix child lock memory issue with callbacks (#12249)

### DIFF
--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -40,15 +40,19 @@ export const initLockFork = () => {
   }
 };
 
+const removeAllCallbacksForOperation = (operation) => {
+  lockProcess.callbacks.delete(`${operation}-lock`);
+  lockProcess.callbacks.delete(`${operation}-unlock`);
+  lockProcess.callbacks.delete(`${operation}-abort`);
+};
+
 // Unlock definition
 const childUnlockResources = async (operation) => {
   return new Promise((resolve, reject) => {
     // Set up the unlock callback
     lockProcess.callbacks.set(`${operation}-unlock`, (msg) => {
       // Cleanup the callback map
-      lockProcess.callbacks.delete(`${operation}-lock`);
-      lockProcess.callbacks.delete(`${operation}-unlock`);
-      lockProcess.callbacks.delete(`${operation}-abort`);
+      removeAllCallbacksForOperation(operation);
       // Resolve or reject depending on the unlock result
       if (msg.success) {
         resolve(msg);
@@ -80,6 +84,8 @@ const childLockResources = async (ids, args = {}) => {
         const unlock = () => childUnlockResources(msg.operation);
         resolve({ operation, signal, unlock, result: msg });
       } else {
+        // Cleanup the callback map
+        removeAllCallbacksForOperation(operation);
         reject(msg.error);
       }
     });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* clear callbacks when receiving error on lock

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12249

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
To test locally:
- Add a log to see the lockProcess.callbacks map (you can log the size or the keys) at the begining of childLockResources function
- Start the backend as usual -> you should see at some point the log, everytime we try to take a lock (by managers), and the callbacks map is stable (it grows when managers start, then it stays the same)
- Start a second backend on cluster mode ("Backend start cluster (second platform)" configuration) -> you should see the map growing and growing, as the managers try to take the lock and fail (since the first platform has the locks)
