### PR TITLE
[frontend] forgot password : disable button onSubmit  (#11975)

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
+++ b/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
@@ -123,11 +123,10 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
     });
   };
 
-  const onSubmitAskOtp: FormikConfig<ResetFormValues>['onSubmit'] = async (
+  const onSubmitAskOtp: FormikConfig<ResetFormValues>['onSubmit'] = (
     values,
-    { setSubmitting, resetForm, setErrors },
+    { resetForm, setErrors },
   ) => {
-    setSubmitting(true);
     askSentOtpCommitMutation({
       variables: {
         input: {
@@ -137,22 +136,19 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
       onCompleted: (response) => {
         setTransactionId(response.askSendOtp ?? '');
         setEmail(values.email);
-        setSubmitting(false);
         resetForm();
         setStep(Step.VALIDATE_OTP);
       },
       onError: (error) => {
         handleErrorInForm(error, setErrors);
-        setSubmitting(false);
       },
     });
   };
 
-  const onSubmitValidateOtp: FormikConfig<ValidateOtpFormValues>['onSubmit'] = async (
+  const onSubmitValidateOtp: FormikConfig<ValidateOtpFormValues>['onSubmit'] = (
     values,
-    { setSubmitting, resetForm, setErrors },
+    { resetForm, setErrors },
   ) => {
-    setSubmitting(true);
     verifyOtpCommitMutation({
       variables: {
         input: {
@@ -164,23 +160,20 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
         const mfaActivated = response.verifyOtp?.mfa_activated;
         setOtpError(false);
         setOtp(values.otp);
-        setSubmitting(false);
         resetForm();
         setStep(mfaActivated ? Step.MFA : Step.RESET_PASSWORD);
       },
       onError: (error) => {
         handleErrorInForm(error, setErrors);
         setOtpError(true);
-        setSubmitting(false);
       },
     });
   };
 
-  const onSubmitValidatePassword: FormikConfig<ResetPasswordFormValues>['onSubmit'] = async (
+  const onSubmitValidatePassword: FormikConfig<ResetPasswordFormValues>['onSubmit'] = (
     values,
-    { setSubmitting, resetForm, setErrors },
+    { resetForm, setErrors },
   ) => {
-    setSubmitting(true);
     changePasswordCommitMutation({
       variables: {
         input: {
@@ -190,14 +183,12 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
         },
       },
       onCompleted: () => {
-        setSubmitting(false);
         resetForm();
         onCancel();
       },
       onError: (error) => {
         handleErrorInForm(error, setErrors);
         setChangePasswordError(true);
-        setSubmitting(false);
       },
     });
   };


### PR DESCRIPTION
### Proposed changes

* Remove async to fix the disable state
* Remove setSubmitting, default behaviour of Formik already set to true onSubmit and to false onError & onCompleted.

### Related issues

* #11975 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality