### PR TITLE
[frontend/backend] add playbook component for sending email templates to users (#12829)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "Duplizieren Sie das Dashboard",
   "Dynamic filter": "Dynamischer Filter",
   "Dynamic from the main entity triggering the playbook": "Dynamisch von der Hauptinstanz, die das Playbook auslöst",
+  "Dynamic from the objects in the bundle of the playbook": "Dynamisch aus den Objekten im Bündel des Spielbuchs",
   "Dynamic source filters": "Dynamische Quellfilter",
   "Dynamic target filters": "Dynamische Zielfilter",
   "Each line must contain a valid email address": "Jede Zeile muss eine gültige E-Mail Adresse enthalten",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "Duplicate the dashboard",
   "Dynamic filter": "Dynamic filter",
   "Dynamic from the main entity triggering the playbook": "Dynamic from the main entity triggering the playbook",
+  "Dynamic from the objects in the bundle of the playbook": "Dynamic from the objects in the bundle of the playbook",
   "Dynamic source filters": "Dynamic source filters",
   "Dynamic target filters": "Dynamic target filters",
   "Each line must contain a valid email address": "Each line must contain a valid email address",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "Duplicar el salpicadero",
   "Dynamic filter": "Filtro dinámico",
   "Dynamic from the main entity triggering the playbook": "Dinámica de la entidad principal que activa el libro de jugadas",
+  "Dynamic from the objects in the bundle of the playbook": "Dinámica de los objetos del paquete del libro de jugadas",
   "Dynamic source filters": "Filtros de fuente dinámicos",
   "Dynamic target filters": "Filtros dinámicos de destino",
   "Each line must contain a valid email address": "Cada línea debe contener una dirección de correo electrónico válida",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "Dupliquer le tableau de bord",
   "Dynamic filter": "Filtre dynamique",
   "Dynamic from the main entity triggering the playbook": "Dynamique de l'entité principale déclenchant le playbook",
+  "Dynamic from the objects in the bundle of the playbook": "Dynamique à partir des objets dans le bundle du playbook",
   "Dynamic source filters": "Filtres de source dynamique",
   "Dynamic target filters": "Filtres dynamiques cibles",
   "Each line must contain a valid email address": "Chaque ligne doit contenir une adresse électronique valide",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "Duplica la dashboard",
   "Dynamic filter": "Filtro dinamico",
   "Dynamic from the main entity triggering the playbook": "Dinamica dell'entità principale che attiva il playbook",
+  "Dynamic from the objects in the bundle of the playbook": "Dinamico dagli oggetti del bundle del playbook",
   "Dynamic source filters": "Filtri di origine dinamici",
   "Dynamic target filters": "Filtri di destinazione dinamici",
   "Each line must contain a valid email address": "Ogni riga deve contenere un indirizzo email valido",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "ダッシュボードの複製",
   "Dynamic filter": "ダイナミック・フィルター",
   "Dynamic from the main entity triggering the playbook": "プレイブックをトリガーする主体からの動的なもの",
+  "Dynamic from the objects in the bundle of the playbook": "再生ブックのバンドル内のオブジェクトから動的な",
   "Dynamic source filters": "ダイナミック・ソース・フィルタ",
   "Dynamic target filters": "動的ターゲットフィルタ",
   "Each line must contain a valid email address": "各行には有効なEメールアドレスを記載すること",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "대시보드 복제",
   "Dynamic filter": "동적 필터",
   "Dynamic from the main entity triggering the playbook": "플레이북을 트리거하는 주 엔터티에서 동적",
+  "Dynamic from the objects in the bundle of the playbook": "플레이북 번들의 오브젝트에서 동적으로 가져오기",
   "Dynamic source filters": "동적 소스 필터",
   "Dynamic target filters": "동적 대상 필터",
   "Each line must contain a valid email address": "각 줄에는 유효한 이메일 주소가 포함되어야 합니다",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "Дублировать дашборд",
   "Dynamic filter": "Динамический фильтр",
   "Dynamic from the main entity triggering the playbook": "Динамика от основной сущности, запускающей игровой блокнот",
+  "Dynamic from the objects in the bundle of the playbook": "Динамические из объектов в пакете игровой книги",
   "Dynamic source filters": "Динамические фильтры источников",
   "Dynamic target filters": "Динамические целевые фильтры",
   "Each line must contain a valid email address": "Каждая строка должна содержать действительный адрес электронной почты",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1256,6 +1256,7 @@
   "Duplicate the dashboard": "复制仪表板",
   "Dynamic filter": "动态过滤器",
   "Dynamic from the main entity triggering the playbook": "来自触发播放本的主体的动态",
+  "Dynamic from the objects in the bundle of the playbook": "从播放列表捆绑包中的对象动态生成",
   "Dynamic source filters": "动态源过滤器",
   "Dynamic target filters": "动态目标过滤器",
   "Each line must contain a valid email address": "每行必须包含一个有效的电子邮件地址",

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -577,6 +577,7 @@ const iconSelector = (
       return <PlaylistRemoveOutlined style={style} fontSize={fontSize} role="img" />;
     case 'disseminationlist':
       return <AlternateEmailOutlined style={style} fontSize={fontSize} role="img" />;
+    case 'email-template':
     case 'emailtemplate':
       return <EmailOutlined style={style} fontSize={fontSize} role="img" />;
     case 'finteldesign':

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -577,7 +577,6 @@ const iconSelector = (
       return <PlaylistRemoveOutlined style={style} fontSize={fontSize} role="img" />;
     case 'disseminationlist':
       return <AlternateEmailOutlined style={style} fontSize={fontSize} role="img" />;
-    case 'email-template':
     case 'emailtemplate':
       return <EmailOutlined style={style} fontSize={fontSize} role="img" />;
     case 'finteldesign':

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
@@ -95,6 +95,11 @@ const ObjectMembersField: FunctionComponent<ObjectMembersFieldProps> = ({
       value: 'PARTICIPANTS',
       label: t_i18n('Participants'),
     },
+    {
+      type: t_i18n('Dynamic from the objects in the bundle of the playbook'),
+      value: 'BUNDLE_ORGANIZATIONS',
+      label: t_i18n('Organizations'),
+    },
   ] : []);
   const searchMembers = (event: React.ChangeEvent<HTMLInputElement>) => {
     fetchQuery(objectMembersFieldSearchQuery, {

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -634,6 +634,18 @@ const PlaybookAddComponentsContent = ({
                       />
                     );
                   }
+                  if (k === 'targets') {
+                    return (
+                      <ObjectMembersField
+                        key={k}
+                        label={t_i18n('Targets')}
+                        style={{ marginTop: 20 }}
+                        multiple={true}
+                        name="targets"
+                        dynamicKeysForPlaybooks={true}
+                      />
+                    );
+                  }
                   if (k === 'caseTemplates') {
                     const isCaseContainer = values?.container_type && ['Case-Incident', 'Case-Rfi', 'Case-Rft'].includes(values?.container_type);
                     if (values?.caseTemplates && values?.caseTemplates.length > 0 && !isCaseContainer) {

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/PlaybookAddComponents.jsx
@@ -869,7 +869,7 @@ const PlaybookAddComponentsContent = ({
                       />
                     );
                   }
-                  if (v.type === 'string' && isNotEmptyField(v.oneOf)) {
+                  if (v.type === 'string' && v.oneOf) {
                     return (
                       <Field
                         key={k}

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -1,0 +1,95 @@
+import type { JSONSchemaType } from 'ajv';
+import * as R from 'ramda';
+import { type PlaybookComponent } from '../playbook-types';
+import { executionContext, SYSTEM_USER } from '../../../utils/access';
+import { fullEntitiesList } from '../../../database/middleware-loader';
+import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../../emailTemplate/emailTemplate-types';
+
+// const hackNotifierForTemplate = async (params: ExecutorParameters<NotifierConfiguration>) => {
+//   const { playbookId, playbookNode, bundle } = params;
+//   logApp.info('[PLAYBOOK EXEC] Notif component - EMAIL template');
+//   const context = executionContext('playbook_components');
+//   const { notifiers } = playbookNode.configuration;
+//
+//   for (let i = 0; i < bundle.objects.length; i += 1) {
+//     const bundleObject: StixObject = bundle.objects[i];
+//     if (bundleObject.extensions[STIX_EXT_OCTI].type === 'Organization') {
+//       const internalId = bundleObject.extensions[STIX_EXT_OCTI].id;
+//       const allMembers = await organizationMembersPaginated(context, SYSTEM_USER, internalId, {});
+//       logApp.info('[PLAYBOOK EXEC] ==> Send email to all member of org', { orgId: bundleObject.id, template: notifiers[0] });
+//       for (let j = 0; j < allMembers.edges.length; j += 1) {
+//         const currentMember: any = allMembers.edges[j].node;
+//         logApp.info('[PLAYBOOK EXEC] ==> Send email to user', { userId: currentMember.id, templateId: notifiers[0] });
+//         await sendEmailToUser(context, AUTOMATION_MANAGER_USER, { target_user_id: currentMember.id, email_template_id: notifiers[0] });
+//       }
+//     } else {
+//       logApp.info('[PLAYBOOK EXEC] NO EMAIL', { bundleObject });
+//     }
+//   }
+//   return { output_port: undefined, bundle };
+// };
+
+export interface SendEmailTemplateConfiguration {
+  email_template: string,
+  targets: object,
+}
+const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT_SCHEMA: JSONSchemaType<SendEmailTemplateConfiguration> = {
+  type: 'object',
+  properties: {
+    email_template: {
+      type: 'string', $ref: 'Email template', oneOf: [],
+    },
+    targets: { type: 'objet' },
+  },
+  required: ['email_template']
+};
+export const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT: PlaybookComponent<SendEmailTemplateConfiguration> = {
+  id: 'PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT',
+  name: 'Send email from template',
+  description: 'Send email from template to targets',
+  icon: 'email-template',
+  is_entry_point: false,
+  is_internal: true,
+  ports: [],
+  configuration_schema: PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT_SCHEMA,
+  schema: async () => {
+    const context = executionContext('playbook_components');
+    const emailTemplates = await fullEntitiesList(context, SYSTEM_USER, [ENTITY_TYPE_EMAIL_TEMPLATE]);
+    const elements = emailTemplates.map((c) => ({ const: c.id, title: c.name }));
+    const schemaElement = { properties: { email_template: { oneOf: elements } } };
+    return R.mergeDeepRight<JSONSchemaType<SendEmailTemplateConfiguration>, any>(PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT_SCHEMA, schemaElement);
+  },
+  executor: async ({ bundle }) => {
+    // const context = executionContext('playbook_components');
+    // const playbook = await storeLoadById<BasicStoreEntityPlaybook>(context, SYSTEM_USER,ENTITY_TYPE_PLAYBOOK);
+    // const { notifiers, authorized_members } = playbookNode.configuration;
+    // const targetUsers = await convertAuthorizedMemberToUsers(authorized_members as { value: string }[]);
+    // const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+    // const notificationsCall = [];
+    // for (let index = 0; index < targetUsers.length; index += 1) {
+    //   const targetUser = targetUsers[index];
+    //   const user_inside_platform_organization = isUserInPlatformOrganization(targetUser, settings);
+    //   const userContext = { ...context, user_inside_platform_organization };
+    //   const stixElements = bundle.objects.filter((o) => isUserCanAccessStixElement(userContext, targetUser, o));
+    //   const notificationEvent: DigestEvent = {
+    //     version: EVENT_NOTIFICATION_VERSION,
+    //     playbook_source: playbook.name,
+    //     notification_id: playbookNode.id,
+    //     target: convertToNotificationUser(targetUser, notifiers),
+    //     type: 'digest',
+    //     data: stixElements.map((stixObject) => ({
+    //       notification_id: playbookNode.id,
+    //       instance: stixObject,
+    //       type: 'create', // TODO Improve that with type event follow up
+    //       message: generateCreateMessage({
+    //       ...stixObject, entity_type: convertStixToInternalTypes(stixObject.type) }) === '-' ? playbookNode.name : generateCreateMessage({ ...stixObject, entity_type: convertStixToInternalTypes(stixObject.type) }),
+    //     }))
+    //   };
+    //   notificationsCall.push(storeNotificationEvent(context, notificationEvent));
+    // }
+    // if (notificationsCall.length > 0) {
+    //   await Promise.all(notificationsCall);
+    // }
+    return { output_port: undefined, bundle };
+  }
+};

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -7,8 +7,6 @@ import { fullEntitiesList } from '../../../database/middleware-loader';
 import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../../emailTemplate/emailTemplate-types';
 import { convertMembersToUsers, extractBundleBaseElement } from '../playbook-utils';
 import { sendEmailToUser } from '../../../domain/user';
-import { ES_MAX_CONCURRENCY, MAX_BULK_OPERATIONS } from '../../../database/engine';
-import { loadFile } from '../../../database/file-storage';
 
 export interface SendEmailTemplateConfiguration {
   email_template: string,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -7,6 +7,7 @@ import { fullEntitiesList } from '../../../database/middleware-loader';
 import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../../emailTemplate/emailTemplate-types';
 import { convertMembersToUsers, extractBundleBaseElement } from '../playbook-utils';
 import { sendEmailToUser } from '../../../domain/user';
+import { ACCOUNT_STATUS_ACTIVE } from '../../../config/conf';
 
 export interface SendEmailTemplateConfiguration {
   email_template: string,
@@ -46,7 +47,7 @@ export const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT: PlaybookComponent<SendEmail
     const sendEmailUserIds = [];
     for (let index = 0; index < targetUsers.length; index += 1) {
       const targetUser = targetUsers[index];
-      if (!targetUser.user_service_account) {
+      if (!targetUser.user_service_account && targetUser.account_status === ACCOUNT_STATUS_ACTIVE) {
         sendEmailUserIds.push(targetUser.id);
       }
     }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -34,7 +34,7 @@ export const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT: PlaybookComponent<SendEmail
   configuration_schema: PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT_SCHEMA,
   schema: async () => {
     const context = executionContext('playbook_components');
-    const emailTemplates = await fullEntitiesList(context, SYSTEM_USER, [ENTITY_TYPE_EMAIL_TEMPLATE]);
+    const emailTemplates = await fullEntitiesList(context, AUTOMATION_MANAGER_USER, [ENTITY_TYPE_EMAIL_TEMPLATE]);
     const elements = emailTemplates.map((c) => ({ const: c.id, title: c.name }));
     const schemaElement = { properties: { email_template: { oneOf: elements } } };
     return R.mergeDeepRight<JSONSchemaType<SendEmailTemplateConfiguration>, any>(PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT_SCHEMA, schemaElement);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -4,7 +4,7 @@ import { type PlaybookComponent } from '../playbook-types';
 import { AUTOMATION_MANAGER_USER, executionContext, SYSTEM_USER } from '../../../utils/access';
 import { fullEntitiesList } from '../../../database/middleware-loader';
 import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../../emailTemplate/emailTemplate-types';
-import { convertAuthorizedMemberToUsers, extractBundleBaseElement } from '../playbook-utils';
+import { convertMembersToUsers, extractBundleBaseElement } from '../playbook-utils';
 import { sendEmailToUser } from '../../../domain/user';
 
 export interface SendEmailTemplateConfiguration {
@@ -25,7 +25,7 @@ export const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT: PlaybookComponent<SendEmail
   id: 'PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT',
   name: 'Send email from template',
   description: 'Send email from template to targets',
-  icon: 'email-template',
+  icon: 'emailtemplate',
   is_entry_point: false,
   is_internal: true,
   ports: [],
@@ -41,7 +41,7 @@ export const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT: PlaybookComponent<SendEmail
     const context = executionContext('playbook_components');
     const { email_template, targets } = playbookNode.configuration;
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
-    const targetUsers = await convertAuthorizedMemberToUsers(targets as { value: string }[], baseData, bundle);
+    const targetUsers = await convertMembersToUsers(targets as { value: string }[], baseData, bundle);
     const sendEmailCall = [];
     for (let index = 0; index < targetUsers.length; index += 1) {
       const targetUser = targetUsers[index];

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -2,7 +2,7 @@ import type { JSONSchemaType } from 'ajv';
 import * as R from 'ramda';
 import { Promise as BluePromise } from 'bluebird';
 import { type PlaybookComponent } from '../playbook-types';
-import { AUTOMATION_MANAGER_USER, executionContext, SYSTEM_USER } from '../../../utils/access';
+import { AUTOMATION_MANAGER_USER, executionContext } from '../../../utils/access';
 import { fullEntitiesList } from '../../../database/middleware-loader';
 import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../../emailTemplate/emailTemplate-types';
 import { convertMembersToUsers, extractBundleBaseElement } from '../playbook-utils';

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/send-email-template-component.ts
@@ -45,7 +45,9 @@ export const PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT: PlaybookComponent<SendEmail
     const sendEmailCall = [];
     for (let index = 0; index < targetUsers.length; index += 1) {
       const targetUser = targetUsers[index];
-      sendEmailCall.push(sendEmailToUser(context, AUTOMATION_MANAGER_USER, { target_user_id: targetUser.id, email_template_id: email_template }));
+      if (!targetUser.user_service_account) {
+        sendEmailCall.push(sendEmailToUser(context, AUTOMATION_MANAGER_USER, { target_user_id: targetUser.id, email_template_id: email_template }));
+      }
     }
     if (sendEmailCall.length > 0) {
       await Promise.all(sendEmailCall);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -737,6 +737,12 @@ export const PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT: PlaybookComponent<AccessRes
         for (let index2 = 0; index2 < creators.length; index2 += 1) {
           finalAccessRestrictions.push({ ...accessRestriction, value: creators[index2] });
         }
+      } else if (accessRestriction.value === 'BUNDLE_ORGANIZATIONS') {
+        const bundleOrganizations = bundle.objects.filter((o) => o.extensions[STIX_EXT_OCTI].type === ENTITY_TYPE_IDENTITY_ORGANIZATION);
+        const bundleOrganizationsIds = bundleOrganizations.map((o) => o.extensions[STIX_EXT_OCTI].id);
+        for (let index2 = 0; index2 < bundleOrganizationsIds.length; index2 += 1) {
+          finalAccessRestrictions.push({ ...accessRestriction, value: bundleOrganizationsIds[index2] });
+        }
       } else {
         finalAccessRestrictions.push(accessRestriction);
       }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -95,7 +95,7 @@ import type { BasicStoreSettings } from '../../types/settings';
 import { AUTHORIZED_MEMBERS_SUPPORTED_ENTITY_TYPES, editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { removeOrganizationRestriction } from '../../domain/stix';
 import { PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT } from './components/send-email-template-component';
-import { convertAuthorizedMemberToUsers, extractBundleBaseElement } from './playbook-utils';
+import { convertMembersToUsers, extractBundleBaseElement } from './playbook-utils';
 
 // region built in playbook components
 interface LoggerConfiguration {
@@ -1206,7 +1206,7 @@ const PLAYBOOK_NOTIFIER_COMPONENT: PlaybookComponent<NotifierConfiguration> = {
     const playbook = await storeLoadById<BasicStoreEntityPlaybook>(context, SYSTEM_USER, playbookId, ENTITY_TYPE_PLAYBOOK);
     const { notifiers, authorized_members } = playbookNode.configuration;
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
-    const targetUsers = await convertAuthorizedMemberToUsers(authorized_members as { value: string }[], baseData, bundle);
+    const targetUsers = await convertMembersToUsers(authorized_members as { value: string }[], baseData, bundle);
     const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
     const notificationsCall = [];
     for (let index = 0; index < targetUsers.length; index += 1) {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -103,6 +103,7 @@ import type { BasicStoreEntityTaskTemplate } from '../task/task-template/task-te
 import type { BasicStoreSettings } from '../../types/settings';
 import { AUTHORIZED_MEMBERS_SUPPORTED_ENTITY_TYPES, editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { removeOrganizationRestriction } from '../../domain/stix';
+import { PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT } from './components/send-email-template-component';
 
 const extractBundleBaseElement = (instanceId: string, bundle: StixBundle): StixObject => {
   const baseData = bundle.objects.find((o) => o.id === instanceId);
@@ -1637,4 +1638,5 @@ export const PLAYBOOK_COMPONENTS: { [k: string]: PlaybookComponent<object> } = {
   [PLAYBOOK_CREATE_INDICATOR_COMPONENT.id]: PLAYBOOK_CREATE_INDICATOR_COMPONENT,
   [PLAYBOOK_REDUCING_COMPONENT.id]: PLAYBOOK_REDUCING_COMPONENT,
   [PLAYBOOK_CREATE_OBSERVABLE_COMPONENT.id]: PLAYBOOK_CREATE_OBSERVABLE_COMPONENT,
+  [PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT.id]: PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -1,0 +1,53 @@
+import * as R from 'ramda';
+import { isEmptyField } from '../../database/utils';
+import { executionContext, INTERNAL_USERS, SYSTEM_USER } from '../../utils/access';
+import { getEntitiesListFromCache } from '../../database/cache';
+import type { AuthUser } from '../../types/user';
+import { ENTITY_TYPE_USER } from '../../schema/internalObject';
+import type { StixBundle, StixObject } from '../../types/stix-2-1-common';
+import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
+import { FunctionalError } from '../../config/errors';
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
+
+export const extractBundleBaseElement = (instanceId: string, bundle: StixBundle): StixObject => {
+  const baseData = bundle.objects.find((o) => o.id === instanceId);
+  if (!baseData) throw FunctionalError('Playbook base element no longer accessible');
+  return baseData;
+};
+
+export const convertAuthorizedMemberToUsers = async (members: { value: string }[], baseData: StixObject, bundle: StixBundle) => {
+  if (isEmptyField(members)) {
+    return [];
+  }
+  const context = executionContext('playbook_components');
+  const platformUsers = await getEntitiesListFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
+
+  const membersIds: string[] = [];
+  members?.forEach((m) => {
+    if (m.value === 'AUTHOR') {
+      membersIds.push(baseData.extensions[STIX_EXT_OCTI].created_by_ref_id);
+    } else if (m.value === 'CREATORS') {
+      const creatorIds = baseData.extensions[STIX_EXT_OCTI].creator_ids;
+      membersIds.push(...creatorIds);
+    } else if (m.value === 'ASSIGNEES') {
+      const assigneeIds = baseData.extensions[STIX_EXT_OCTI].assignee_ids;
+      membersIds.push(...assigneeIds);
+    } else if (m.value === 'PARTICIPANTS') {
+      const participantIds = baseData.extensions[STIX_EXT_OCTI].participant_ids;
+      membersIds.push(...participantIds);
+    } else if (m.value === 'BUNDLE_ORGANIZATIONS') {
+      const bundleOrganizations = bundle.objects.filter((o) => o.extensions[STIX_EXT_OCTI].type === ENTITY_TYPE_IDENTITY_ORGANIZATION);
+      const bundleOrganizationsIds = bundleOrganizations.map((o) => o.extensions[STIX_EXT_OCTI].id);
+      membersIds.push(...bundleOrganizationsIds);
+    }
+  });
+
+  const usersFromGroups = platformUsers.filter((user) => user.groups.map((g) => g.internal_id)
+    .some((id: string) => membersIds.includes(id)));
+  const usersFromOrganizations = platformUsers.filter((user) => user.organizations.map((g) => g.internal_id)
+    .some((id: string) => membersIds.includes(id)));
+  const usersFromIds = platformUsers.filter((user) => membersIds.includes(user.id));
+  const withoutInternalUsers = [...usersFromOrganizations, ...usersFromGroups, ...usersFromIds]
+    .filter((u) => INTERNAL_USERS[u.id] === undefined);
+  return R.uniqBy(R.prop('id'), withoutInternalUsers);
+};

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -39,6 +39,8 @@ export const convertMembersToUsers = async (members: { value: string }[], baseDa
       const bundleOrganizations = bundle.objects.filter((o) => o.extensions[STIX_EXT_OCTI].type === ENTITY_TYPE_IDENTITY_ORGANIZATION);
       const bundleOrganizationsIds = bundleOrganizations.map((o) => o.extensions[STIX_EXT_OCTI].id);
       membersIds.push(...bundleOrganizationsIds);
+    } else {
+      membersIds.push(m.value);
     }
   });
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -15,7 +15,7 @@ export const extractBundleBaseElement = (instanceId: string, bundle: StixBundle)
   return baseData;
 };
 
-export const convertAuthorizedMemberToUsers = async (members: { value: string }[], baseData: StixObject, bundle: StixBundle) => {
+export const convertMembersToUsers = async (members: { value: string }[], baseData: StixObject, bundle: StixBundle) => {
   if (isEmptyField(members)) {
     return [];
   }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { isEmptyField } from '../../database/utils';
-import { AUTOMATION_MANAGER_USER, executionContext, INTERNAL_USERS, SYSTEM_USER } from '../../utils/access';
+import { AUTOMATION_MANAGER_USER, executionContext, INTERNAL_USERS } from '../../utils/access';
 import { getEntitiesListFromCache } from '../../database/cache';
 import type { AuthUser } from '../../types/user';
 import { ENTITY_TYPE_USER } from '../../schema/internalObject';

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { isEmptyField } from '../../database/utils';
-import { executionContext, INTERNAL_USERS, SYSTEM_USER } from '../../utils/access';
+import { AUTOMATION_MANAGER_USER, executionContext, INTERNAL_USERS, SYSTEM_USER } from '../../utils/access';
 import { getEntitiesListFromCache } from '../../database/cache';
 import type { AuthUser } from '../../types/user';
 import { ENTITY_TYPE_USER } from '../../schema/internalObject';
@@ -20,7 +20,7 @@ export const convertMembersToUsers = async (members: { value: string }[], baseDa
     return [];
   }
   const context = executionContext('playbook_components');
-  const platformUsers = await getEntitiesListFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  const platformUsers = await getEntitiesListFromCache<AuthUser>(context, AUTOMATION_MANAGER_USER, ENTITY_TYPE_USER);
 
   const membersIds: string[] = [];
   members?.forEach((m) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add playbook component for sending email templates to users
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12829 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
