### PR TITLE
[frontend/backend] 'Type of related entity' filter values according to context (#12833)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -14,7 +14,7 @@ import { FilterIconButtonProps } from '../FilterIconButton';
 import { isNotEmptyField } from '../../utils/utils';
 import type { Theme } from '../Theme';
 import { useDataTableContext } from './components/DataTableContext';
-import { useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
+import { FilterSearchContext, useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
 
 type DataTableInternalFiltersProps = Pick<DataTableProps,
 | 'additionalFilters'
@@ -24,7 +24,7 @@ type DataTableInternalFiltersProps = Pick<DataTableProps,
   availableRelationFilterTypes?: FilterIconButtonProps['availableRelationFilterTypes']
   availableEntityTypes?: string[]
   availableRelationshipTypes?: string[]
-  searchContextFinal?: { entityTypes: string[]; elementId?: string[] }
+  searchContextFinal?: FilterSearchContext
   additionalHeaderButtons?: ReactNode[]
   currentView?: string
   exportContext?: { entity_type: string, entity_id?: string }
@@ -98,6 +98,7 @@ const DataTableInternalFilters = ({
           availableRelationFilterTypes={availableRelationFilterTypes}
           availableEntityTypes={availableEntityTypes}
           entityTypes={computedEntityTypes}
+          searchContext={searchContextFinal}
         />
       )}
     </>

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -27,6 +27,7 @@ export const DataTableDisplayFilters = ({
   availableRelationFilterTypes,
   availableEntityTypes,
   entityTypes,
+  searchContext,
 }: DataTableDisplayFiltersProps) => {
   const {
     useDataTablePaginationLocalStorage: {
@@ -49,6 +50,7 @@ export const DataTableDisplayFilters = ({
         entityTypes={entityTypes}
         hasSavedFilters={!!savedFilters}
         redirection
+        searchContext={searchContext}
       />
     </div>
   );

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -8,6 +8,7 @@ import { OperationType } from 'relay-runtime';
 import type { LocalStorage } from '../../utils/hooks/useLocalStorageModel';
 import { NumberOfElements, PaginationLocalStorage, UseLocalStorageHelpers } from '../../utils/hooks/useLocalStorage';
 import { FilterGroup } from '../../utils/filters/filtersHelpers-types';
+import { FilterSearchContext } from '../../utils/filters/filtersUtils';
 
 export type LocalStorageColumn = { percentWidth: number, visible?: boolean, index?: number };
 export type LocalStorageColumns = Record<string, LocalStorageColumn>;
@@ -166,7 +167,8 @@ export interface DataTableDisplayFiltersProps {
   entityTypes?: string[]
   availableRelationFilterTypes?: Record<string, string[]> | undefined
   availableFilterKeys?: string[] | undefined;
-  availableEntityTypes?: string[]
+  availableEntityTypes?: string[];
+  searchContext?: FilterSearchContext;
 }
 
 export interface DataTableFiltersProps {

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_history/PirHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_history/PirHistory.tsx
@@ -214,7 +214,7 @@ const PirHistory = ({ data }: PirHistoryProps) => {
         useComputeLink={({ context_data }: PirHistoryLogFragment$data) => {
           return pirLogRedirectUri(context_data);
         }}
-        searchContextFinal={{ entityTypes: ['History'] }}
+        searchContextFinal={{ entityTypes: ['History'], elementType: 'Pir' }}
         availableFilterKeys={[
           'timestamp',
           'contextObjectLabel',
@@ -222,7 +222,6 @@ const PirHistory = ({ data }: PirHistoryProps) => {
           'contextCreator',
           'contextCreatedBy',
           'contextEntityType',
-          'contextEntityId',
         ]}
         resolvePath={(d: PirHistoryLogsFragment$data) => {
           return d.pirLogs?.edges?.map((e) => e?.node);

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
@@ -104,7 +104,6 @@ const Audit = () => {
     [SETTINGS_SECURITYACTIVITY, KNOWLEDGE],
     true,
   );
-  const knowledgeCapability = useGranted([KNOWLEDGE], true);
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
   setTitle(t_i18n('Events | Activity | Settings'));
@@ -252,7 +251,7 @@ const Audit = () => {
         paginationOptions={paginationOptions}
         numberOfElements={numberOfElements}
         handleExportCsv={handleExportCsv}
-        entityTypes={knowledgeCapability ? ['History'] : ['Activity']}
+        entityTypes={types}
       >
         {queryRef && (
           <React.Suspense

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -19,6 +19,7 @@ export interface FilterSearchContext {
   entityTypes: string[]
   elementId?: string[]
   connectorsScope?: boolean
+  elementType?: string
 }
 
 export type FiltersRestrictions = {

--- a/opencti-platform/opencti-graphql/src/domain/filterKeysSchema.ts
+++ b/opencti-platform/opencti-graphql/src/domain/filterKeysSchema.ts
@@ -40,7 +40,7 @@ import { ABSTRACT_STIX_CORE_OBJECT, INPUT_GRANTED_REFS, isAbstract } from '../sc
 import { getEntityFromCache } from '../database/cache';
 import type { BasicStoreSettings } from '../types/settings';
 import { executionContext, SYSTEM_USER } from '../utils/access';
-import { ENTITY_TYPE_GROUP, ENTITY_TYPE_HISTORY, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS_TEMPLATE, ENTITY_TYPE_USER } from '../schema/internalObject';
+import { ENTITY_TYPE_ACTIVITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_HISTORY, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS_TEMPLATE, ENTITY_TYPE_USER } from '../schema/internalObject';
 import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../schema/stixCyberObservable';
 import { ENTITY_TYPE_IDENTITY_INDIVIDUAL, ENTITY_TYPE_IDENTITY_SECTOR, ENTITY_TYPE_IDENTITY_SYSTEM, isStixObjectAliased } from '../schema/stixDomainObject';
 import { ENTITY_TYPE_MALWARE_ANALYSIS } from '../modules/malwareAnalysis/malwareAnalysis-types';
@@ -311,7 +311,7 @@ const completeFilterDefinitionMapWithSpecialKeys = (
       elementsForFilterValuesSearch: [],
     });
   }
-  if (type === ENTITY_TYPE_HISTORY) {
+  if (type === ENTITY_TYPE_HISTORY || type === ENTITY_TYPE_ACTIVITY) {
     // add context filters
     filterDefinitionsMap.set(CONTEXT_OBJECT_LABEL_FILTER, {
       filterKey: CONTEXT_OBJECT_LABEL_FILTER,


### PR DESCRIPTION
### Proposed changes
- refacto for useSearchEntities part of code concerning type filters
- in 'type of related entity' filter in Pir > Activities: add relationship type values, remove internal types values
- remove 'related entity' filter in Pir > Activities

### Related issues
#12833