### PR TITLE
[frontend] Handle authorized members on draft (#10981)

### DIFF
--- a/opencti-platform/opencti-front/src/components/CreateEntityControlledDial.tsx
+++ b/opencti-platform/opencti-front/src/components/CreateEntityControlledDial.tsx
@@ -35,7 +35,7 @@ const CreateEntityControlledDial: FunctionComponent<CreateEntityControlledDialPr
   const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
   const canDisplayButton = !draftContext || currentAccessRight.canEdit;
 
-  return canDisplayButton && (
+  return canDisplayButton ? (
     <Button
       onClick={onOpen}
       color={color}
@@ -48,6 +48,8 @@ const CreateEntityControlledDial: FunctionComponent<CreateEntityControlledDialPr
     >
       {buttonValue}
     </Button>
+  ) : (
+    <></>
   );
 };
 

--- a/opencti-platform/opencti-front/src/components/CreateEntityControlledDial.tsx
+++ b/opencti-platform/opencti-front/src/components/CreateEntityControlledDial.tsx
@@ -4,6 +4,8 @@ import { useTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles/createTheme';
 import { DrawerControlledDialProps } from '../private/components/common/drawer/Drawer';
 import { useFormatter } from './i18n';
+import useDraftContext from '../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../utils/authorizedMembers';
 
 interface CreateEntityControlledDialProps extends DrawerControlledDialProps {
   entityType: string;
@@ -28,7 +30,12 @@ const CreateEntityControlledDial: FunctionComponent<CreateEntityControlledDialPr
     id: 'Create ...',
     values: { entity_type: valueString },
   });
-  return (
+  // Remove create button in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canDisplayButton = !draftContext || currentAccessRight.canEdit;
+
+  return canDisplayButton && (
     <Button
       onClick={onOpen}
       color={color}

--- a/opencti-platform/opencti-front/src/components/EditEntityControlledDial.tsx
+++ b/opencti-platform/opencti-front/src/components/EditEntityControlledDial.tsx
@@ -4,6 +4,8 @@ import { DrawerControlledDialProps } from '@components/common/drawer/Drawer';
 import { CommonProps } from '@mui/material/OverridableComponent';
 import { ButtonOwnProps } from '@mui/material/Button/Button';
 import { useFormatter } from './i18n';
+import useDraftContext from '../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../utils/authorizedMembers';
 
 const EditEntityControlledDial = ({
   onOpen,
@@ -15,7 +17,12 @@ const EditEntityControlledDial = ({
 }: ButtonOwnProps & CommonProps & DrawerControlledDialProps) => {
   const { t_i18n } = useFormatter();
   const buttonLabel = t_i18n('Update');
-  return (
+  // Remove create button in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canDisplayButton = !draftContext || currentAccessRight.canEdit;
+
+  return canDisplayButton && (
     <Button
       onClick={onOpen}
       color={color}

--- a/opencti-platform/opencti-front/src/components/EditEntityControlledDial.tsx
+++ b/opencti-platform/opencti-front/src/components/EditEntityControlledDial.tsx
@@ -22,7 +22,7 @@ const EditEntityControlledDial = ({
   const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
   const canDisplayButton = !draftContext || currentAccessRight.canEdit;
 
-  return canDisplayButton && (
+  return canDisplayButton ? (
     <Button
       onClick={onOpen}
       color={color}
@@ -34,6 +34,8 @@ const EditEntityControlledDial = ({
     >
       {buttonLabel}
     </Button>
+  ) : (
+    <></>
   );
 };
 

--- a/opencti-platform/opencti-front/src/components/EditEntityControlledDial.tsx
+++ b/opencti-platform/opencti-front/src/components/EditEntityControlledDial.tsx
@@ -17,7 +17,7 @@ const EditEntityControlledDial = ({
 }: ButtonOwnProps & CommonProps & DrawerControlledDialProps) => {
   const { t_i18n } = useFormatter();
   const buttonLabel = t_i18n('Update');
-  // Remove create button in Draft context without the minimal right access "canEdit"
+  // Remove Update button in Draft context without the minimal right access "canEdit"
   const draftContext = useDraftContext();
   const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
   const canDisplayButton = !draftContext || currentAccessRight.canEdit;

--- a/opencti-platform/opencti-front/src/components/UploadImport.tsx
+++ b/opencti-platform/opencti-front/src/components/UploadImport.tsx
@@ -7,6 +7,8 @@ import { UploadFileOutlined } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import ImportFilesDialog from '@components/common/files/import_files/ImportFilesDialog';
 import { useFormatter } from './i18n';
+import useDraftContext from '../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../utils/authorizedMembers';
 
 interface UploadImportProps {
   color?: 'primary' | 'inherit' | 'secondary' | 'success' | 'error' | 'info' | 'warning';
@@ -31,8 +33,12 @@ const UploadImport = ({
   const { t_i18n } = useFormatter();
   const title = t_i18n('Import data');
   const [openImportFilesDialog, setOpenImportFilesDialog] = useState(false);
+  // Remove import button in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canDisplayButton = !draftContext || currentAccessRight.canEdit;
 
-  return (
+  return canDisplayButton && (
     <>
       {openImportFilesDialog && (
         <ImportFilesDialog

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -116,7 +116,7 @@ type DataTableInternalToolbarProps = Pick<DataTableProps,
 > & {
   taskScope?: string
   globalSearch?: string;
-  displayEditButtons: boolean
+  displayEditButtons?: boolean
 };
 
 const DataTableInternalToolbar = ({

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -15,6 +15,8 @@ import { isNotEmptyField } from '../../utils/utils';
 import type { Theme } from '../Theme';
 import { useDataTableContext } from './components/DataTableContext';
 import { useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
+import useDraftContext from '../../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../../utils/authorizedMembers';
 
 type DataTableInternalFiltersProps = Pick<DataTableProps,
 | 'additionalFilters'
@@ -114,6 +116,7 @@ type DataTableInternalToolbarProps = Pick<DataTableProps,
 > & {
   taskScope?: string
   globalSearch?: string;
+  displayEditButtons: boolean
 };
 
 const DataTableInternalToolbar = ({
@@ -125,6 +128,7 @@ const DataTableInternalToolbar = ({
   removeFromDraftEnabled,
   markAsReadEnabled,
   entityTypes,
+  displayEditButtons,
 }: DataTableInternalToolbarProps) => {
   const theme = useTheme<Theme>();
 
@@ -163,6 +167,7 @@ const DataTableInternalToolbar = ({
         removeAuthMembersEnabled={removeAuthMembersEnabled}
         removeFromDraftEnabled={removeFromDraftEnabled}
         markAsReadEnabled={markAsReadEnabled}
+        displayEditButtons={displayEditButtons}
       />
     </div>
   );
@@ -239,6 +244,11 @@ const DataTable = (props: OCTIDataTableProps) => {
     availableFilterKeys = availableFilterKeys.concat(additionalFilterKeys);
   }
 
+  // Remove toolbar in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const hasAuthorizedMembersCanEdit = !draftContext || currentAccessRight.canEdit;
+
   return (
     <>
       <DataTableComponent
@@ -261,7 +271,7 @@ const DataTable = (props: OCTIDataTableProps) => {
             exportContext={exportContext}
             searchContextFinal={computedSearchContextFinal}
           />
-      )}
+        )}
         dataTableToolBarComponent={(
           <DataTableInternalToolbar
             entityTypes={entityTypes}
@@ -272,6 +282,7 @@ const DataTable = (props: OCTIDataTableProps) => {
             removeAuthMembersEnabled={removeAuthMembersEnabled}
             removeFromDraftEnabled={removeFromDraftEnabled}
             markAsReadEnabled={markAsReadEnabled}
+            displayEditButtons={hasAuthorizedMembersCanEdit}
           />
       )}
       />

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -41,6 +41,7 @@ import StixCoreObjectEnrichment from '../stix_core_objects/StixCoreObjectEnrichm
 import { resolveLink } from '../../../../utils/Entity';
 import PopoverMenu from '../../../../components/PopoverMenu';
 import useAuth from '../../../../utils/hooks/useAuth';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
 
 export const containerHeaderObjectsQuery = graphql`
   query ContainerHeaderObjectsQuery($id: String!) {
@@ -459,7 +460,11 @@ const ContainerHeader = (props) => {
   const [openSharing, setOpenSharing] = useState(false);
   const [openAccessRestriction, setOpenAccessRestriction] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
-  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]);
+
+  const draftContext = useDraftContext();
+  const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+
+  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]) && (!draftContext || currentDraftAccessRight.canEdit);
 
   const handleCloseEnrollPlaybook = () => {
     setOpenEnrollPlaybook(false);

--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -16,15 +16,14 @@ import { fileWorksQuery } from '@components/common/files/ImportWorksDrawer';
 import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import { ImportWorkbenchesContentFileLine_file$data } from '@components/data/import/__generated__/ImportWorkbenchesContentFileLine_file.graphql';
 import { ImportFilesContentFileLine_file$data } from '@components/data/import/__generated__/ImportFilesContentFileLine_file.graphql';
+import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import { commitMutation, defaultCommitMutation } from '../../../../relay/environment';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
 import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
-import useAuth from '../../../../utils/hooks/useAuth';
 import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import useAuth from '../../../../utils/hooks/useAuth';
-import Switch from '@mui/material/Switch';
 
 interface LaunchImportDialogProps {
   file: ImportWorkbenchesContentFileLine_file$data | ImportFilesContentFileLine_file$data;

--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -13,7 +13,6 @@ import { fileManagerAskJobImportMutation } from '@components/common/files/FileMa
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { ImportWorksDrawerQuery, ImportWorksDrawerQuery$data } from '@components/common/files/__generated__/ImportWorksDrawerQuery.graphql';
 import { fileWorksQuery } from '@components/common/files/ImportWorksDrawer';
-import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import { ImportWorkbenchesContentFileLine_file$data } from '@components/data/import/__generated__/ImportWorkbenchesContentFileLine_file.graphql';
 import { ImportFilesContentFileLine_file$data } from '@components/data/import/__generated__/ImportFilesContentFileLine_file.graphql';
 import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
@@ -22,7 +21,6 @@ import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
 import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
-import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import useAuth from '../../../../utils/hooks/useAuth';
 
 interface LaunchImportDialogProps {

--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -22,6 +22,9 @@ import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapper
 import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
 import useAuth from '../../../../utils/hooks/useAuth';
+import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
+import useAuth from '../../../../utils/hooks/useAuth';
+import Switch from '@mui/material/Switch';
 
 interface LaunchImportDialogProps {
   file: ImportWorkbenchesContentFileLine_file$data | ImportFilesContentFileLine_file$data;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -59,6 +59,7 @@ import PopoverMenu from '../../../../components/PopoverMenu';
 import { resolveLink } from '../../../../utils/Entity';
 import { authorizedMembersToOptions, CAN_USE_ENTITY_TYPES, useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import useHelper from '../../../../utils/hooks/useHelper';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
 
 export const stixDomainObjectMutation = graphql`
   mutation StixDomainObjectHeaderFieldMutation(
@@ -303,6 +304,11 @@ const StixDomainObjectHeader = (props) => {
   const enableManageAuthorizedMembers = currentAccessRight.canManage && enableAuthorizedMembers;
   const { isFeatureEnable } = useHelper();
 
+  // Remove CRUD button in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canEdit = !draftContext || currentDraftAccessRight.canEdit;
+
   const openAliasesCreate = false;
   const [openAlias, setOpenAlias] = useState(false);
   const [openAliases, setOpenAliases] = useState(false);
@@ -311,9 +317,9 @@ const StixDomainObjectHeader = (props) => {
   const [openAccessRestriction, setOpenAccessRestriction] = useState(false);
   const [newAlias, setNewAlias] = useState('');
   const [aliasToDelete, setAliasToDelete] = useState(null);
-  const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]);
-  const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]);
-  const isKnowledgeDeleter = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]);
+  const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]) && canEdit;
+  const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]) && canEdit;
+  const isKnowledgeDeleter = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]) && canEdit;
 
   const [isEnrollPlaybookOpen, setEnrollPlaybookOpen] = useState(false);
   const [isSharingOpen, setIsSharingOpen] = useState(false);

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -2537,6 +2537,7 @@ class DataTableToolBar extends Component {
                               disabled={
                                 numberOfSelectedElements === 0
                                 || this.state.processing
+                                || selectedElementsList.find((element) => element.currentUserAccessRight === 'view')
                               }
                               onClick={this.handleLaunchDelete.bind(this)}
                               color={warning ? 'warning' : 'primary'}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -410,6 +410,7 @@ class DataTableToolBar extends Component {
       participants: [],
       killChainPhases: [],
       groups: [],
+      displayEditButtons: true,
     };
   }
 
@@ -2139,6 +2140,7 @@ class DataTableToolBar extends Component {
       warning,
       warningMessage,
       taskScope,
+      displayEditButtons,
     } = this.props;
     const { actions, keptEntityId, mergingElement, actionsInputs, promoteToContainer } = this.state;
 
@@ -2273,333 +2275,335 @@ class DataTableToolBar extends Component {
                     <ClearOutlined fontSize="small" />
                   </IconButton>
                 </div>
-                <div>
-                  {markAsReadEnabled && (
-                    <>
-                      <Tooltip title={t('Mark as read')}>
-                        <span>
-                          <IconButton
-                            aria-label={t('Mark as read')}
-                            disabled={numberOfSelectedElements === 0 || this.state.processing}
-                            onClick={this.handleLaunchRead.bind(this, true)}
-                            color="success"
-                            size="small"
-                          >
-                            <CheckCircleOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                      <Tooltip title={t('Mark as unread')}>
-                        <span>
-                          <IconButton
-                            aria-label={t('Mark as unread')}
-                            disabled={numberOfSelectedElements === 0 || this.state.processing}
-                            onClick={this.handleLaunchRead.bind(this, false)}
-                            color="warning"
-                            size="small"
-                          >
-                            <UnpublishedOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </>
-                  )}
-                  {removeAuthMembersEnabled && (
-                    <Security needs={[BYPASS]}>
-                      <Tooltip title={t('Remove access restriction')}>
-                        <IconButton
-                          color="primary"
-                          aria-label="input"
-                          onClick={this.handleLaunchRemoveAuthMembers.bind(this)}
-                          size="small"
-                          disabled={
-                            numberOfSelectedElements === 0
-                            || this.state.processing
-                          }
-                        >
-                          <LockOpenOutlined fontSize="small" color={'primary'} />
-                        </IconButton>
-                      </Tooltip>
-                    </Security>
-                  )}
-                  <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                    {!typesAreNotUpdatable && !removeAuthMembersEnabled && (
-                      <Tooltip title={t('Update')}>
-                        <span>
-                          <IconButton
-                            aria-label="update"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                            onClick={this.handleOpenUpdate.bind(this)}
-                            color="primary"
-                            size="small"
-                          >
-                            <BrushOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                {displayEditButtons && (
+                  <div>
+                    {markAsReadEnabled && (
+                      <>
+                        <Tooltip title={t('Mark as read')}>
+                          <span>
+                            <IconButton
+                              aria-label={t('Mark as read')}
+                              disabled={numberOfSelectedElements === 0 || this.state.processing}
+                              onClick={this.handleLaunchRead.bind(this, true)}
+                              color="success"
+                              size="small"
+                            >
+                              <CheckCircleOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title={t('Mark as unread')}>
+                          <span>
+                            <IconButton
+                              aria-label={t('Mark as unread')}
+                              disabled={numberOfSelectedElements === 0 || this.state.processing}
+                              onClick={this.handleLaunchRead.bind(this, false)}
+                              color="warning"
+                              size="small"
+                            >
+                              <UnpublishedOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </>
                     )}
-                    {isUserDatatable && isEnterpriseEdition && (
-                      <UserEmailSend
-                        isOpen={this.state.displaySendEmail}
-                        onClose={this.handleCloseSendEmail.bind(this)}
-                        onSubmit={this.handleSubmitEmailTemplate.bind(this)}
-                      />
-                    )}
-                    {!removeAuthMembersEnabled && !removeFromDraftEnabled && !isInDraft && !isUserDatatable && (
-                    <UserContext.Consumer>
-                      {({ platformModuleHelpers }) => {
-                        const label = platformModuleHelpers.isRuleEngineEnable()
-                          ? 'Rule rescan'
-                          : 'Rule rescan (engine is disabled)';
-                        const buttonDisable = typesAreNotScannable
-                          || !platformModuleHelpers.isRuleEngineEnable()
-                          || numberOfSelectedElements === 0
-                          || this.state.processing;
-                        return typesAreNotScannable ? undefined : (
-                          <Tooltip title={t(label)}>
-                            <span>
-                              <IconButton
-                                aria-label="update"
-                                disabled={buttonDisable}
-                                onClick={this.handleOpenRescan.bind(this)}
-                                color="primary"
-                                size="small"
-                              >
-                                <AutoFixHighOutlined fontSize="small" />
-                              </IconButton>
-                            </span>
-                          </Tooltip>
-                        );
-                      }}
-                    </UserContext.Consumer>
-                    )}
-                    {this.props.handleCopy && (
-                      <Tooltip title={titleCopy}>
-                        <span>
-                          <IconButton
-                            aria-label="copy"
-                            disabled={
-                              numberOfSelectedElements
-                              > maxNumberOfObservablesToCopy
-                            }
-                            onClick={this.props.handleCopy}
-                            color="primary"
-                            size="small"
-                          >
-                            <ContentCopyOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                    {!enrichDisable && !removeAuthMembersEnabled && !isUserDatatable && (
-                      <Tooltip title={t('Enrichment')}>
-                        <span>
-                          <IconButton
-                            aria-label="enrichment"
-                            disabled={this.state.processing}
-                            onClick={this.handleOpenEnrichment.bind(this, stixCyberObservableSubTypes, stixDomainObjectSubTypes)}
-                            color="primary"
-                            size="small"
-                          >
-                            <CloudRefreshOutline fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                    {promoteEnabled && (
-                      <Tooltip title={t('Indicators/observables generation')}>
-                        <span>
-                          <IconButton
-                            aria-label="promote"
-                            disabled={this.state.processing}
-                            onClick={this.handleOpenPromote.bind(this)}
-                            color="primary"
-                            size="small"
-                          >
-                            <TransformOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                  </Security>
-                  <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-                    {enableMerge && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isInDraft && !isUserDatatable && (
-                      <Tooltip title={t('Merge')}>
-                        <span>
-                          <IconButton
-                            aria-label="merge"
-                            disabled={
-                              typesAreDifferent
-                              || numberOfSelectedElements < 2
-                              || numberOfSelectedElements > 4
-                              || preventMerge
-                              || selectAll
-                              || this.state.processing
-                            }
-                            onClick={this.handleOpenMerge.bind(this)}
-                            color="primary"
-                            size="small"
-                          >
-                            <MergeOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    )}
-                  </Security>
-                  {!typesAreNotAddableInContainer && !removeAuthMembersEnabled && !isUserDatatable && (
-                    <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                      <Tooltip title={t('Add in container')}>
-                        <span>
-                          <IconButton
-                            aria-label="input"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                            onClick={this.handleOpenAddInContainer.bind(this)}
-                            color="primary"
-                            size="small"
-                          >
-                            <MoveToInboxOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </Security>
-                  )}
-                  {container && (
-                    <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                      <Tooltip title={t('Remove from the container')}>
-                        <span>
-                          <IconButton
-                            aria-label="remove"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                            onClick={this.handleLaunchRemove.bind(this)}
-                            color="primary"
-                            size="small"
-                          >
-                            <LinkOffOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </Security>
-                  )}
-                  {!deleteOperationEnabled && isShareableType && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isInDraft && !isUserDatatable && (
-                    <>
-                      <Security needs={[KNOWLEDGE_KNUPDATE_KNORGARESTRICT]}>
-                        <EETooltip title={t('Share with organizations')}>
+                    {removeAuthMembersEnabled && (
+                      <Security needs={[BYPASS]}>
+                        <Tooltip title={t('Remove access restriction')}>
                           <IconButton
                             color="primary"
                             aria-label="input"
-                            onClick={isEnterpriseEdition ? this.handleOpenShare.bind(this) : null}
+                            onClick={this.handleLaunchRemoveAuthMembers.bind(this)}
                             size="small"
                             disabled={
                               numberOfSelectedElements === 0
                               || this.state.processing
                             }
                           >
-                            <BankPlus fontSize="small" color={isEnterpriseEdition ? 'primary' : 'disabled'} />
+                            <LockOpenOutlined fontSize="small" color={'primary'} />
                           </IconButton>
-                        </EETooltip>
+                        </Tooltip>
                       </Security>
-                      <Security needs={[KNOWLEDGE_KNUPDATE_KNORGARESTRICT]}>
-                        <EETooltip title={t('Unshare with organizations')}>
-                          <IconButton
-                            color="primary"
-                            aria-label="input"
-                            onClick={isEnterpriseEdition ? this.handleOpenUnshare.bind(this) : null}
-                            size="small"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                          >
-                            <BankMinus fontSize="small" color={isEnterpriseEdition ? 'primary' : 'disabled'} />
-                          </IconButton>
-                        </EETooltip>
-                      </Security>
-                    </>
-                  )}
-                  {deleteDisable !== true && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isUserDatatable && (
-                    <Security needs={[deleteCapability]}>
-                      <Tooltip title={warningMessage || t('Delete')}>
-                        <span>
-                          <IconButton
-                            aria-label="delete"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                            onClick={this.handleLaunchDelete.bind(this)}
-                            color={warning ? 'warning' : 'primary'}
-                            size="small"
-                          >
-                            <DeleteOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    </Security>
-                  )}
-                  {removeFromDraftEnabled && (
+                    )}
                     <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                      <Tooltip title={t('Remove from draft')}>
-                        <IconButton
-                          color="primary"
-                          aria-label="input"
-                          onClick={this.handleLaunchRemoveFromDraft.bind(this)}
-                          size="small"
-                          disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                          }
-                        >
-                          <DeleteSweepOutlined fontSize="small" color={'primary'} />
-                        </IconButton>
-                      </Tooltip>
+                      {!typesAreNotUpdatable && !removeAuthMembersEnabled && (
+                        <Tooltip title={t('Update')}>
+                          <span>
+                            <IconButton
+                              aria-label="update"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                              onClick={this.handleOpenUpdate.bind(this)}
+                              color="primary"
+                              size="small"
+                            >
+                              <BrushOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
+                      {isUserDatatable && isEnterpriseEdition && (
+                        <UserEmailSend
+                          isOpen={this.state.displaySendEmail}
+                          onClose={this.handleCloseSendEmail.bind(this)}
+                          onSubmit={this.handleSubmitEmailTemplate.bind(this)}
+                        />
+                      )}
+                      {!removeAuthMembersEnabled && !removeFromDraftEnabled && !isInDraft && !isUserDatatable && (
+                        <UserContext.Consumer>
+                          {({ platformModuleHelpers }) => {
+                            const label = platformModuleHelpers.isRuleEngineEnable()
+                              ? 'Rule rescan'
+                              : 'Rule rescan (engine is disabled)';
+                            const buttonDisable = typesAreNotScannable
+                              || !platformModuleHelpers.isRuleEngineEnable()
+                              || numberOfSelectedElements === 0
+                              || this.state.processing;
+                            return typesAreNotScannable ? undefined : (
+                              <Tooltip title={t(label)}>
+                                <span>
+                                  <IconButton
+                                    aria-label="update"
+                                    disabled={buttonDisable}
+                                    onClick={this.handleOpenRescan.bind(this)}
+                                    color="primary"
+                                    size="small"
+                                  >
+                                    <AutoFixHighOutlined fontSize="small" />
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                            );
+                          }}
+                        </UserContext.Consumer>
+                      )}
+                      {this.props.handleCopy && (
+                        <Tooltip title={titleCopy}>
+                          <span>
+                            <IconButton
+                              aria-label="copy"
+                              disabled={
+                                numberOfSelectedElements
+                                > maxNumberOfObservablesToCopy
+                              }
+                              onClick={this.props.handleCopy}
+                              color="primary"
+                              size="small"
+                            >
+                              <ContentCopyOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
+                      {!enrichDisable && !removeAuthMembersEnabled && !isUserDatatable && (
+                        <Tooltip title={t('Enrichment')}>
+                          <span>
+                            <IconButton
+                              aria-label="enrichment"
+                              disabled={this.state.processing}
+                              onClick={this.handleOpenEnrichment.bind(this, stixCyberObservableSubTypes, stixDomainObjectSubTypes)}
+                              color="primary"
+                              size="small"
+                            >
+                              <CloudRefreshOutline fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
+                      {promoteEnabled && (
+                        <Tooltip title={t('Indicators/observables generation')}>
+                          <span>
+                            <IconButton
+                              aria-label="promote"
+                              disabled={this.state.processing}
+                              onClick={this.handleOpenPromote.bind(this)}
+                              color="primary"
+                              size="small"
+                            >
+                              <TransformOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
                     </Security>
-                  )}
-                  {deleteOperationEnabled && (
                     <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
-                      <Tooltip title={warningMessage || t('Restore')}>
-                        <span>
-                          <IconButton
-                            aria-label="restore"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                            onClick={this.handleLaunchRestore.bind(this)}
-                            color={warning ? 'warning' : 'primary'}
-                            size="small"
-                          >
-                            <RestoreOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                      <Tooltip title={warningMessage || t('Confirm delete')}>
-                        <span>
-                          <IconButton
-                            aria-label="completeDelete"
-                            disabled={
-                              numberOfSelectedElements === 0
-                              || this.state.processing
-                            }
-                            onClick={this.handleLaunchCompleteDelete.bind(this)}
-                            color={warning ? 'warning' : 'primary'}
-                            size="small"
-                          >
-                            <DeleteOutlined fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
+                      {enableMerge && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isInDraft && !isUserDatatable && (
+                        <Tooltip title={t('Merge')}>
+                          <span>
+                            <IconButton
+                              aria-label="merge"
+                              disabled={
+                                typesAreDifferent
+                                || numberOfSelectedElements < 2
+                                || numberOfSelectedElements > 4
+                                || preventMerge
+                                || selectAll
+                                || this.state.processing
+                              }
+                              onClick={this.handleOpenMerge.bind(this)}
+                              color="primary"
+                              size="small"
+                            >
+                              <MergeOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      )}
                     </Security>
-                  )}
-                </div>
+                    {!typesAreNotAddableInContainer && !removeAuthMembersEnabled && !isUserDatatable && (
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <Tooltip title={t('Add in container')}>
+                          <span>
+                            <IconButton
+                              aria-label="input"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                              onClick={this.handleOpenAddInContainer.bind(this)}
+                              color="primary"
+                              size="small"
+                            >
+                              <MoveToInboxOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Security>
+                    )}
+                    {container && (
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <Tooltip title={t('Remove from the container')}>
+                          <span>
+                            <IconButton
+                              aria-label="remove"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                              onClick={this.handleLaunchRemove.bind(this)}
+                              color="primary"
+                              size="small"
+                            >
+                              <LinkOffOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Security>
+                    )}
+                    {!deleteOperationEnabled && isShareableType && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isInDraft && !isUserDatatable && (
+                      <>
+                        <Security needs={[KNOWLEDGE_KNUPDATE_KNORGARESTRICT]}>
+                          <EETooltip title={t('Share with organizations')}>
+                            <IconButton
+                              color="primary"
+                              aria-label="input"
+                              onClick={isEnterpriseEdition ? this.handleOpenShare.bind(this) : null}
+                              size="small"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                            >
+                              <BankPlus fontSize="small" color={isEnterpriseEdition ? 'primary' : 'disabled'} />
+                            </IconButton>
+                          </EETooltip>
+                        </Security>
+                        <Security needs={[KNOWLEDGE_KNUPDATE_KNORGARESTRICT]}>
+                          <EETooltip title={t('Unshare with organizations')}>
+                            <IconButton
+                              color="primary"
+                              aria-label="input"
+                              onClick={isEnterpriseEdition ? this.handleOpenUnshare.bind(this) : null}
+                              size="small"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                            >
+                              <BankMinus fontSize="small" color={isEnterpriseEdition ? 'primary' : 'disabled'} />
+                            </IconButton>
+                          </EETooltip>
+                        </Security>
+                      </>
+                    )}
+                    {deleteDisable !== true && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isUserDatatable && (
+                      <Security needs={[deleteCapability]}>
+                        <Tooltip title={warningMessage || t('Delete')}>
+                          <span>
+                            <IconButton
+                              aria-label="delete"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                              onClick={this.handleLaunchDelete.bind(this)}
+                              color={warning ? 'warning' : 'primary'}
+                              size="small"
+                            >
+                              <DeleteOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Security>
+                    )}
+                    {removeFromDraftEnabled && (
+                      <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                        <Tooltip title={t('Remove from draft')}>
+                          <IconButton
+                            color="primary"
+                            aria-label="input"
+                            onClick={this.handleLaunchRemoveFromDraft.bind(this)}
+                            size="small"
+                            disabled={
+                              numberOfSelectedElements === 0
+                              || this.state.processing
+                            }
+                          >
+                            <DeleteSweepOutlined fontSize="small" color={'primary'} />
+                          </IconButton>
+                        </Tooltip>
+                      </Security>
+                    )}
+                    {deleteOperationEnabled && (
+                      <Security needs={[KNOWLEDGE_KNUPDATE_KNDELETE]}>
+                        <Tooltip title={warningMessage || t('Restore')}>
+                          <span>
+                            <IconButton
+                              aria-label="restore"
+                              disabled={
+                                numberOfSelectedElements === 0
+                                || this.state.processing
+                              }
+                              onClick={this.handleLaunchRestore.bind(this)}
+                              color={warning ? 'warning' : 'primary'}
+                              size="small"
+                            >
+                              <RestoreOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title={warningMessage || t('Confirm delete')}>
+                          <span>
+                            <IconButton
+                              aria-label="completeDelete"
+                              disabled={
+                              numberOfSelectedElements === 0
+                              || this.state.processing
+                            }
+                              onClick={this.handleLaunchCompleteDelete.bind(this)}
+                              color={warning ? 'warning' : 'primary'}
+                              size="small"
+                            >
+                              <DeleteOutlined fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Security>
+                    )}
+                  </div>
+                )}
               </Toolbar>
               <Dialog
                 slotProps={{ paper: { elevation: 1 } }}
@@ -2630,7 +2634,7 @@ class DataTableToolBar extends Component {
                   {numberOfSelectedElements > 1000 && (
                     <Alert severity="warning">
                       {t(
-                        "You're targeting more than 1000 entities with this background task, be sure of what you're doing!",
+                        'You\'re targeting more than 1000 entities with this background task, be sure of what you\'re doing!',
                       )}
                     </Alert>
                   )}
@@ -2898,10 +2902,10 @@ class DataTableToolBar extends Component {
                         secondaryAction={
                           <Radio
                             checked={
-                                      keptEntityId
-                                        ? keptEntityId === element.id
-                                        : R.head(selectedElementsList).id === element.id
-                                  }
+                              keptEntityId
+                                ? keptEntityId === element.id
+                                : R.head(selectedElementsList).id === element.id
+                            }
                             onChange={this.handleChangeKeptEntityId.bind(
                               this,
                               element.id,
@@ -2910,7 +2914,7 @@ class DataTableToolBar extends Component {
                             name="keptEntityID"
                             inputProps={{ 'aria-label': 'keptEntityID' }}
                           />
-                          }
+                        }
                       >
                         <ListItemIcon>
                           <ItemIcon type={element.entity_type} />

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
@@ -24,8 +24,7 @@ import { MESSAGING$ } from '../../../relay/environment';
 import Transition from '../../../components/Transition';
 import { TEN_SECONDS } from '../../../utils/Time';
 import ErrorNotFound from '../../../components/ErrorNotFound';
-import { authorizedMembersToOptions } from '../../../utils/authorizedMembers';
-import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight, authorizedMembersToOptions } from '../../../utils/authorizedMembers';
 
 const interval$ = interval(TEN_SECONDS * 3);
 

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
@@ -230,7 +230,7 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
             {t_i18n('Exit draft')}
           </Button>
         </div>
-        {currentAccessRight.canManage && (
+        {currentAccessRight.canEdit && (
           <div style={{ padding: '0 12px' }}>
             <Button
               variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
@@ -130,7 +130,6 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
     entity_id,
     creators,
     authorizedMembers,
-    currentUserAccessRight,
   } = useFragment<DraftContextBanner_data$key>(draftContextBannerFragment, draftWorkspace);
   const currentlyProcessing = processingCount > 0;
   const handleExitDraft = () => {
@@ -189,7 +188,7 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
     <div style={{ padding: '0 12px', flex: 1 }}>
       <div style={{ display: 'flex', width: '100%', alignItems: 'center' }}>
         <div style={{ padding: '0 12px' }}>
-          {currentUserAccessRight === 'admin' && (
+          {currentAccessRight.canManage && (
             <Tooltip title={t_i18n('Authorized members')}>
               <IconButton
                 onClick={() => {

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
@@ -25,6 +25,7 @@ import Transition from '../../../components/Transition';
 import { TEN_SECONDS } from '../../../utils/Time';
 import ErrorNotFound from '../../../components/ErrorNotFound';
 import { authorizedMembersToOptions } from '../../../utils/authorizedMembers';
+import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
 
 const interval$ = interval(TEN_SECONDS * 3);
 
@@ -115,6 +116,7 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
   const [displayAuthorizeMembersDialog, setDisplayAuthorizeMembersDialog] = useState(false);
   const navigate = useNavigate();
   const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
 
   const { draftWorkspace } = usePreloadedQuery<DraftContextBannerQuery>(draftContextBannerQuery, queryRef);
   if (!draftWorkspace) {
@@ -228,47 +230,49 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
             {t_i18n('Exit draft')}
           </Button>
         </div>
-        <div style={{ padding: '0 12px' }}>
-          <Button
-            variant="contained"
-            color="primary"
-            style={{ width: '100%' }}
-            onClick={() => setDisplayApprove(true)}
-            disabled={objectsCount.totalCount < 1}
-          >
-            {t_i18n('Approve draft')}
-          </Button>
-          <Dialog
-            open={displayApprove}
-            slotProps={{ paper: { elevation: 1 } }}
-            keepMounted={true}
-            slots={{ transition: Transition }}
-            onClose={() => setDisplayApprove(false)}
-          >
-            <DialogTitle>
-              {t_i18n('Are you sure?')}
-            </DialogTitle>
-            <DialogContent>
-              <DialogContentText>
-                {t_i18n('Do you want to approve this draft and send it to ingestion?')}
-                {currentlyProcessing && (
+        {currentAccessRight.canManage && (
+          <div style={{ padding: '0 12px' }}>
+            <Button
+              variant="contained"
+              color="primary"
+              style={{ width: '100%' }}
+              onClick={() => setDisplayApprove(true)}
+              disabled={objectsCount.totalCount < 1}
+            >
+              {t_i18n('Approve draft')}
+            </Button>
+            <Dialog
+              open={displayApprove}
+              slotProps={{ paper: { elevation: 1 } }}
+              keepMounted={true}
+              slots={{ transition: Transition }}
+              onClose={() => setDisplayApprove(false)}
+            >
+              <DialogTitle>
+                {t_i18n('Are you sure?')}
+              </DialogTitle>
+              <DialogContent>
+                <DialogContentText>
+                  {t_i18n('Do you want to approve this draft and send it to ingestion?')}
+                  {currentlyProcessing && (
                   <Alert style={{ marginTop: 10 }} severity={'warning'}>
                     <AlertTitle>{t_i18n('Ongoing processes')}</AlertTitle>
                     {t_i18n('There are processes still running that could impact the data of the draft. '
                       + 'By approving the draft now, the remaining changes that would have been applied by those processes will be ignored.')}
                   </Alert>)}
-              </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setDisplayApprove(false)} disabled={approving}>
-                {t_i18n('Cancel')}
-              </Button>
-              <Button color="secondary" onClick={handleValidateDraft} disabled={approving}>
-                {t_i18n('Approve')}
-              </Button>
-            </DialogActions>
-          </Dialog>
-        </div>
+                </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={() => setDisplayApprove(false)} disabled={approving}>
+                  {t_i18n('Cancel')}
+                </Button>
+                <Button color="secondary" onClick={handleValidateDraft} disabled={approving}>
+                  {t_i18n('Approve')}
+                </Button>
+              </DialogActions>
+            </Dialog>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftPopover.tsx
@@ -27,6 +27,7 @@ import { RelayError } from '../../../relay/relayTypes';
 import stopEvent from '../../../utils/domEvent';
 import DeleteDialog from '../../../components/DeleteDialog';
 import useDeletion from '../../../utils/hooks/useDeletion';
+import { useGetCurrentUserAccessRight } from '../../../utils/authorizedMembers';
 
 const draftPopoverDeleteMutation = graphql`
     mutation DraftPopoverDeleteMutation($id: ID!) {
@@ -41,6 +42,7 @@ interface DraftPopoverProps {
   updater?: (
     store: RecordSourceSelectorProxy<DraftContextBannerMutation$data>,
   ) => void;
+  currentUserAccessRight?: string;
 }
 
 const DraftPopover: React.FC<DraftPopoverProps> = ({
@@ -48,12 +50,14 @@ const DraftPopover: React.FC<DraftPopoverProps> = ({
   draftLocked,
   paginationOptions,
   updater,
+  currentUserAccessRight,
 }) => {
   const { t_i18n } = useFormatter();
   const [anchorEl, setAnchorEl] = useState<PopoverProps['anchorEl']>();
   const [openSwitch, setOpenSwitch] = useState(false);
   const [switchToDraft, setSwitchToDraft] = useState(false);
   const [commitSwitchToDraft] = useApiMutation<DraftContextBannerMutation>(draftContextBannerMutation);
+  const currentAccessRight = useGetCurrentUserAccessRight(currentUserAccessRight);
   const deleteSuccessMessage = t_i18n('', {
     id: '... successfully deleted',
     values: { entity_type: t_i18n('entity_DraftWorkspace') },
@@ -149,7 +153,7 @@ const DraftPopover: React.FC<DraftPopoverProps> = ({
           open={Boolean(anchorEl)}
           onClose={handleClose}
         >
-          <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
+          <MenuItem onClick={handleOpenDelete} disabled={!currentAccessRight.canEdit}>{t_i18n('Delete')}</MenuItem>
           <MenuItem onClick={handleOpenSwitch} disabled={draftLocked}>{t_i18n('Switch to Draft')}</MenuItem>
         </Menu>
         <DeleteDialog

--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -257,6 +257,7 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
                 draftId={row.id}
                 draftLocked={row.draft_status !== 'open'}
                 paginationOptions={queryPaginationOptions}
+                currentUserAccessRight={row.currentUserAccessRight}
               />
             )}
           />

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipHeader.tsx
@@ -9,6 +9,8 @@ import Security from '../../../../utils/Security';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 
 interface StixSightingRelationshipHeaderProps {
   headerName?: string,
@@ -21,9 +23,13 @@ const StixSightingRelationshipHeader = ({
   onOpenDelete,
   onOpenEdit,
 }: StixSightingRelationshipHeaderProps) => {
-  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]);
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
+  // Remove CRUD button in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canEdit = !draftContext || currentAccessRight.canEdit;
+  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]) && canEdit;
 
   return (
     <div style={{
@@ -62,7 +68,7 @@ const StixSightingRelationshipHeader = ({
             )}
           </PopoverMenu>
         )}
-        {(
+        {canEdit && (
           <Security needs={[KNOWLEDGE_KNUPDATE]}>
             <Button
               variant='contained'

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -16,15 +16,20 @@ import Security from '../../../../utils/Security';
 import PopoverMenu from '../../../../components/PopoverMenu';
 import StixCoreObjectMenuItemUnderEE from '../../common/stix_core_objects/StixCoreObjectMenuItemUnderEE';
 import { useFormatter } from '../../../../components/i18n';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 
 const StixCyberObservableHeaderComponent = ({ stixCyberObservable, DeleteComponent }) => {
   const [openSharing, setOpenSharing] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
   const { t_i18n } = useFormatter();
+  const draftContext = useDraftContext();
+  const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canEdit = !draftContext || currentDraftAccessRight.canEdit;
 
-  const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]);
-  const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]);
-  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]);
+  const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]) && canEdit;
+  const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]) && canEdit;
+  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]) && canEdit;
 
   const handleOpenDelete = () => setOpenDelete(true);
 

--- a/opencti-platform/opencti-front/src/utils/hooks/useDraftContext.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDraftContext.ts
@@ -5,6 +5,7 @@ export interface DraftContext {
   name: string;
   draft_status: string;
   processingCount: number;
+  currentUserAccessRight: string | null | undefined;
 }
 
 const useDraftContext = (): DraftContext | null | undefined => {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15597,18 +15597,6 @@ export type MutationDraftWorkspaceDeleteArgs = {
 
 export type MutationDraftWorkspaceEditAuthorizedMembersArgs = {
   id: Scalars['ID']['input'];
-  input: Array<MemberAccessInput>;
-};
-
-
-export type MutationDraftWorkspaceFieldPatchArgs = {
-  id: Scalars['ID']['input'];
-  input: Array<EditInput>;
-};
-
-
-export type MutationDraftWorkspaceEditAuthorizedMembersArgs = {
-  id: Scalars['ID']['input'];
   input?: InputMaybe<Array<MemberAccessInput>>;
 };
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15597,6 +15597,18 @@ export type MutationDraftWorkspaceDeleteArgs = {
 
 export type MutationDraftWorkspaceEditAuthorizedMembersArgs = {
   id: Scalars['ID']['input'];
+  input: Array<MemberAccessInput>;
+};
+
+
+export type MutationDraftWorkspaceFieldPatchArgs = {
+  id: Scalars['ID']['input'];
+  input: Array<EditInput>;
+};
+
+
+export type MutationDraftWorkspaceEditAuthorizedMembersArgs = {
+  id: Scalars['ID']['input'];
   input?: InputMaybe<Array<MemberAccessInput>>;
 };
 


### PR DESCRIPTION
### Proposed changes

* Hide buttons without right access

### Related issues

* #10981 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Without CanEdit
- Hide `Approve draft`
- Hide `create` / `update` buttons
- Disable `delete` draft buttons