### PR TITLE
[backend] now keep description & content from baseData in container wrapper (#12870)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -553,7 +553,7 @@ export const PLAYBOOK_CONTAINER_WRAPPER_COMPONENT: PlaybookComponent<ContainerWr
         (container as StixReport).extensions[STIX_EXT_OCTI].content = (baseData as StixReport).extensions[STIX_EXT_OCTI].content;
       }
       if ((baseData as StixCaseIncident).content) {
-        (container as StixReport).extensions[STIX_EXT_OCTI].content = (baseData as StixReport).extensions[STIX_EXT_OCTI].content;
+        (container as StixCaseIncident).content = (baseData as StixCaseIncident).content;
       }
       if (baseData.object_marking_refs) {
         container.object_marking_refs = baseData.object_marking_refs;

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -537,7 +537,7 @@ export const PLAYBOOK_CONTAINER_WRAPPER_COMPONENT: PlaybookComponent<ContainerWr
         parent_types: getParentTypes(container_type),
         ...containerData
       } as StoreCommon;
-      const container = convertStoreToStix(storeContainer) as StixContainer;
+      const container = convertStoreToStix(storeContainer) as StixReport | StixCaseIncident;
       // add all objects in the container if requested in the playbook config
       if (all) {
         container.object_refs = bundle.objects.map((o: StixObject) => o.id);
@@ -545,7 +545,16 @@ export const PLAYBOOK_CONTAINER_WRAPPER_COMPONENT: PlaybookComponent<ContainerWr
         container.object_refs = [baseData.id];
       }
       // Specific remapping of some attributes, waiting for a complete binding solution in the UI
-      // Following attributes are the same as the base instance: markings, labels, created_by, assignees, participants
+      // Following attributes are the same as the base instance: description, content, markings, labels, created_by, assignees, participants
+      if ((baseData as StixReport).description) {
+        container.description = (baseData as StixReport).description;
+      }
+      if ((baseData as StixReport).extensions[STIX_EXT_OCTI].content) {
+        (container as StixReport).extensions[STIX_EXT_OCTI].content = (baseData as StixReport).extensions[STIX_EXT_OCTI].content;
+      }
+      if ((baseData as StixCaseIncident).content) {
+        (container as StixReport).extensions[STIX_EXT_OCTI].content = (baseData as StixReport).extensions[STIX_EXT_OCTI].content;
+      }
       if (baseData.object_marking_refs) {
         container.object_marking_refs = baseData.object_marking_refs;
       }
@@ -566,7 +575,7 @@ export const PLAYBOOK_CONTAINER_WRAPPER_COMPONENT: PlaybookComponent<ContainerWr
         (<StixCaseIncident>container).severity = (<StixIncident>baseData).severity;
       }
       if (STIX_DOMAIN_OBJECT_CONTAINER_CASES.includes(container_type) && caseTemplates.length > 0) {
-        const tasks = await addTaskFromCaseTemplates(caseTemplates, container);
+        const tasks = await addTaskFromCaseTemplates(caseTemplates, (container as StixContainer));
         bundle.objects.push(...tasks);
       }
       bundle.objects.push(container);


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* now keep description & content from baseData in container wrapper
*

related client PR: https://github.com/OpenCTI-Platform/client-python/pull/1020

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12870
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
