### PR TITLE
[backend] fix diffTargets compute complexity

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2861,25 +2861,26 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
       if (!isOutDatedModification) {
         if (relDef.multiple) {
           const currentData = resolvedElement[relDef.databaseName] ?? [];
+          const currentDataSet = new Set(currentData);
           const isCurrentWithData = isNotEmptyField(currentData);
-          const targetData = (patchInputData ?? []).map((n) => n.internal_id);
+          const fullPatchInputData = patchInputData ?? [];
           // Specific case for organization restriction, has EE must be activated.
           // If not supported, upsert of organization is not applied
           const isUserCanManipulateGrantedRefs = isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && settings.valid_enterprise_edition === true;
           const allowedOperation = relDef.databaseName !== RELATION_GRANTED_TO || (relDef.databaseName === RELATION_GRANTED_TO && isUserCanManipulateGrantedRefs);
           // If expected data is different from current data
-          const diffTargets = R.symmetricDifference(currentData, targetData);
-          if (allowedOperation && diffTargets.length > 0) {
+          const dataDiff = fullPatchInputData.filter((target) => !currentDataSet.has(target.internal_id));
+          if (allowedOperation && dataDiff.length > 0) {
             // In full synchro, just replace everything
             if (isUpsertSynchro) {
-              inputs.push({ key: inputField, value: patchInputData ?? [], operation: UPDATE_OPERATION_REPLACE });
+              inputs.push({ key: inputField, value: fullPatchInputData, operation: UPDATE_OPERATION_REPLACE });
             } else if ((isCurrentWithData && isInputWithData && isConfidenceMatch)
                 || (isInputWithData && !isCurrentWithData)
             ) {
               // If data is provided, different from existing data, and of higher confidence
               // OR if existing data is empty and data is provided (even if lower confidence, it's better than nothing),
               // --> apply an add operation
-              inputs.push({ key: inputField, value: diffTargets, operation: UPDATE_OPERATION_ADD });
+              inputs.push({ key: inputField, value: dataDiff, operation: UPDATE_OPERATION_ADD });
             }
           }
         } else { // not multiple

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2868,12 +2868,12 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
           const isUserCanManipulateGrantedRefs = isUserHasCapability(user, KNOWLEDGE_ORGANIZATION_RESTRICT) && settings.valid_enterprise_edition === true;
           const allowedOperation = relDef.databaseName !== RELATION_GRANTED_TO || (relDef.databaseName === RELATION_GRANTED_TO && isUserCanManipulateGrantedRefs);
           // If expected data is different from current data
-          if (allowedOperation && R.symmetricDifference(currentData, targetData).length > 0) {
-            const diffTargets = (patchInputData ?? []).filter((target) => !currentData.includes(target.internal_id));
+          const diffTargets = R.symmetricDifference(currentData, targetData);
+          if (allowedOperation && diffTargets.length > 0) {
             // In full synchro, just replace everything
             if (isUpsertSynchro) {
               inputs.push({ key: inputField, value: patchInputData ?? [], operation: UPDATE_OPERATION_REPLACE });
-            } else if ((isCurrentWithData && isInputWithData && diffTargets.length > 0 && isConfidenceMatch)
+            } else if ((isCurrentWithData && isInputWithData && isConfidenceMatch)
                 || (isInputWithData && !isCurrentWithData)
             ) {
               // If data is provided, different from existing data, and of higher confidence


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix diffTargets compute complexity: in case of a big report, diff compute could cause event loop lag spike due to diff computation being O(n²) (if input had the same amount of object refs as current data). Time complexity is now O(n) using a Set for current data values
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
