### PR TITLE
[backend] Set a limit to playbook bundle_or_patch data  (#12889)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -291,7 +291,8 @@
     "lock_key": "playbook_manager_lock",
     "lock_cron_key": "playbook_cron_manager_lock",
     "interval": 60000,
-    "cron_max_size": 500
+    "cron_max_size": 500,
+    "log_max_size": 10000
   },
   "hub_registration_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -40,6 +40,7 @@ import type { ExclusionListCacheItem } from './exclusionListCache';
 import { refreshLocalCacheForEntity } from './cache';
 import { asyncMap } from '../utils/data-processing';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
+import { PLAYBOOK_LOG_MAX_SIZE } from '../manager/playbookManager';
 
 const USE_SSL = booleanConf('redis:use_ssl', false);
 const REDIS_CA = conf.get('redis:ca').map((path: string) => loadCert(path));
@@ -944,9 +945,8 @@ export const getLastPlaybookExecutions = async (playbookId: string) => {
     const steps = Object.entries(e).filter(([k, _]) => k.startsWith('step_')).map(([k, v]) => {
       const fullData = v.bundle ? JSON.stringify([v.bundle], null, 2) : JSON.stringify(v.patch, null, 2);
 
-      const MAX_LENGTH = 10000;
-      const bundle_or_patch = fullData.length > MAX_LENGTH
-        ? `${fullData.substring(0, MAX_LENGTH)}\n\n... (displaying ${MAX_LENGTH} on ${fullData.length - MAX_LENGTH} chars)`
+      const bundle_or_patch = fullData.length > PLAYBOOK_LOG_MAX_SIZE
+        ? `${fullData.substring(0, PLAYBOOK_LOG_MAX_SIZE)}\n\n... (displaying ${PLAYBOOK_LOG_MAX_SIZE} on ${fullData.length - PLAYBOOK_LOG_MAX_SIZE} chars)`
         : fullData;
 
       // beware, step key is the same for every execution, and we need to avoid id collision in Relay

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -40,11 +40,11 @@ import type { ExclusionListCacheItem } from './exclusionListCache';
 import { refreshLocalCacheForEntity } from './cache';
 import { asyncMap } from '../utils/data-processing';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
-import { PLAYBOOK_LOG_MAX_SIZE } from '../manager/playbookManager';
 
 const USE_SSL = booleanConf('redis:use_ssl', false);
 const REDIS_CA = conf.get('redis:ca').map((path: string) => loadCert(path));
 export const REDIS_STREAM_NAME = `${REDIS_PREFIX}stream.opencti`;
+const PLAYBOOK_LOG_MAX_SIZE = conf.get('playbook_manager:log_max_size') || 10000;
 
 export const EVENT_CURRENT_VERSION = '4';
 

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -942,7 +942,13 @@ export const getLastPlaybookExecutions = async (playbookId: string) => {
   const executions = await keysFromList(`playbook_executions_${playbookId}`, 5 * 60) as ExecutionEnvelop[];
   return executions.map((e) => {
     const steps = Object.entries(e).filter(([k, _]) => k.startsWith('step_')).map(([k, v]) => {
-      const bundle_or_patch = v.bundle ? JSON.stringify([v.bundle], null, 2) : JSON.stringify(v.patch, null, 2);
+      const fullData = v.bundle ? JSON.stringify([v.bundle], null, 2) : JSON.stringify(v.patch, null, 2);
+
+      const MAX_LENGTH = 10000;
+      const bundle_or_patch = fullData.length > MAX_LENGTH
+        ? `${fullData.substring(0, MAX_LENGTH)}\n\n... (displaying ${MAX_LENGTH} on ${fullData.length - MAX_LENGTH} chars)`
+        : fullData;
+
       // beware, step key is the same for every execution, and we need to avoid id collision in Relay
       const id = `${e.playbook_execution_id}-${k.split('step_')[1]}`;
       return ({ id, bundle_or_patch, ...v });

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -45,6 +45,7 @@ import { convertRelationRefsFilterKeys } from '../utils/filtering/filtering-util
 import type { ExecutionEnvelop, ExecutionEnvelopStep } from '../types/playbookExecution';
 import { isEnterpriseEdition } from '../enterprise-edition/ee';
 
+export const PLAYBOOK_LOG_MAX_SIZE = conf.get('playbook_manager:log_max_size') || 10000;
 const PLAYBOOK_LIVE_KEY = conf.get('playbook_manager:lock_key');
 const PLAYBOOK_CRON_KEY = conf.get('playbook_manager:lock_cron_key');
 const PLAYBOOK_CRON_MAX_SIZE = conf.get('playbook_manager:cron_max_size') || 500;

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager.ts
@@ -45,7 +45,6 @@ import { convertRelationRefsFilterKeys } from '../utils/filtering/filtering-util
 import type { ExecutionEnvelop, ExecutionEnvelopStep } from '../types/playbookExecution';
 import { isEnterpriseEdition } from '../enterprise-edition/ee';
 
-export const PLAYBOOK_LOG_MAX_SIZE = conf.get('playbook_manager:log_max_size') || 10000;
 const PLAYBOOK_LIVE_KEY = conf.get('playbook_manager:lock_key');
 const PLAYBOOK_CRON_KEY = conf.get('playbook_manager:lock_cron_key');
 const PLAYBOOK_CRON_MAX_SIZE = conf.get('playbook_manager:cron_max_size') || 500;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes


* Set a limit to the playbook last_executions bundle_or_patch resolver to prevent memory crash on browser

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12889 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
