### PR TITLE
[backend] improve addedRefs and removedRefs compute time complexity

### DIFF
--- a/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
@@ -214,11 +214,13 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
       const previousPatch = event.context.reverse_patch;
       const previousData = jsonpatch.applyPatch<StixReport>(structuredClone(report), previousPatch).newDocument;
       const previousRefIds = [...(previousData.extensions[STIX_EXT_OCTI].object_refs_inferred ?? []), ...(previousData.object_refs ?? [])];
+      const previousRefIdsSet = new Set(previousRefIds);
       const newRefIds = [...(report.extensions[STIX_EXT_OCTI].object_refs_inferred ?? []), ...(report.object_refs ?? [])];
+      const newRefIdsSet = new Set(newRefIds);
       // AddedRefs are ids not includes in previous data
-      const addedRefs: Array<StixId> = await asyncFilter(newRefIds, (newId) => !previousRefIds.includes(newId));
+      const addedRefs: Array<StixId> = await asyncFilter(newRefIds, (newId) => !previousRefIdsSet.has(newId));
       // RemovedRefs are ids not includes in current data
-      const removedRefs: Array<StixId> = await asyncFilter(previousRefIds, (newId) => !newRefIds.includes(newId));
+      const removedRefs: Array<StixId> = await asyncFilter(previousRefIds, (newId) => !newRefIdsSet.has(newId));
       // Apply operations
       // For added identities
       const leftAddedRefs = addedRefs.filter(typeRefFilter);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* improve addedRefs and removedRefs compute time complexity. Was O(n²) before, now O(n)
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
