### PR TITLE
[frontend/backend] Bulk Search: Unknown entities API (#7279)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
@@ -131,7 +131,7 @@ interface SearchBulkProps {
 const SearchBulk = ({ inputValues, dataColumns }: SearchBulkProps) => {
   const buildSearchBulkFilters = (values: string[], filters: FilterGroup) => {
     return values.length > 0
-      ? addFilter(filters, allEntitiesKeyList as unknown as string, values) // TODO INVALID TYPE
+      ? addFilter(filters, allEntitiesKeyList as unknown as string, values)
       : filters;
   };
 
@@ -155,8 +155,7 @@ const SearchBulk = ({ inputValues, dataColumns }: SearchBulkProps) => {
   const queryPaginationOptions = {
     ...paginationOptions,
     filters: queryFilters,
-    count: 5000,
-  } as SearchBulkQuery$variables;
+  } as unknown as SearchBulkQuery$variables;
 
   const queryRef = useQueryLoading<SearchBulkQuery>(searchBulkQuery, queryPaginationOptions);
 

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -48,10 +48,11 @@ const SearchBulkUnknownEntitiesContent = ({ queryRef, setNumberOfEntities, isDis
   const dataColumns: DataTableProps['dataColumns'] = {
     entity_type: {
       percentWidth: 15,
+      isSortable: true,
     },
     value: {
       percentWidth: 85,
-      isSortable: false,
+      isSortable: true,
     },
   };
   return (

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -7,85 +7,35 @@ import useQueryLoading from '../../utils/hooks/useQueryLoading';
 import { useBuildEntityTypeBasedFilterContext } from '../../utils/filters/filtersUtils';
 import { usePaginationLocalStorage } from '../../utils/hooks/useLocalStorage';
 import Loader from '../../components/Loader';
-import { getMainRepresentative } from '../../utils/defaultRepresentatives';
 import type { DataTableProps } from '../../components/dataGrid/dataTableTypes';
 
 const LOCAL_STORAGE_KEY = 'searchBulk_unknownEntities';
 
 const searchBulkUnknownEntitiesQuery = graphql`
   query SearchBulkUnknownEntitiesQuery(
-    $count: Int!
-    $cursor: ID
-    $types: [String]
     $filters: FilterGroup
-    $search: String
-    $orderBy: StixCoreObjectsOrdering
+    $values: [String!]!
+    $orderBy: UnknownStixCoreObjectsOrdering
     $orderMode: OrderingMode
   ) {
-    globalSearch(
-      first: $count
-      after: $cursor
-      types: $types,
-      search: $search,
+    unknownStixCoreObjects(
       filters: $filters
+      values: $values
       orderBy: $orderBy
       orderMode: $orderMode
     )
-    @connection(key: "Pagination_globalSearch") {
-      edges {
-        node {
-          id
-          entity_type
-          ... on StixObject {
-            representative {
-              main
-            }
-          }
-          ... on HashedObservable {
-            hashes {
-              algorithm
-              hash
-            }
-          }
-        }
-      }
-    }
   }
 `;
 
 interface SearchBulkUnknownEntitiesContentProps {
-  values: string[],
   queryRef: PreloadedQuery<SearchBulkUnknownEntitiesQuery>,
   setNumberOfEntities: (n: number) => void,
   isDisplayed: boolean,
 }
 
-const SearchBulkUnknownEntitiesContent = ({ values, queryRef, setNumberOfEntities, isDisplayed }: SearchBulkUnknownEntitiesContentProps) => {
-  const matchStixObjectWithSearchValue = (
-    stixObject: {
-      representative?: { main: string },
-      hashes?: readonly ({ readonly algorithm: string, readonly hash?: string | null } | null | undefined)[] | null,
-    },
-    value: string,
-  ) => {
-    const representativeMatch = value.toLowerCase() === getMainRepresentative(stixObject).toLowerCase();
-    if (!representativeMatch) {
-      // try to find in hashes
-      if (stixObject.hashes) {
-        const hashMatch = stixObject.hashes.some((h) => h?.hash === value);
-        if (hashMatch) return hashMatch;
-      }
-      // other cases ?
-    }
-    return representativeMatch;
-  };
-
+const SearchBulkUnknownEntitiesContent = ({ queryRef, setNumberOfEntities, isDisplayed }: SearchBulkUnknownEntitiesContentProps) => {
   const data = usePreloadedQuery(searchBulkUnknownEntitiesQuery, queryRef);
-  const nodes = data.globalSearch?.edges.map((n) => n.node) ?? [];
-  const unknownValues = values.filter((value) => {
-    const resolvedStixCoreObjects = nodes.filter((o) => matchStixObjectWithSearchValue(o, value)) ?? [];
-    return resolvedStixCoreObjects.length === 0;
-  });
+  const unknownValues = data.unknownStixCoreObjects;
   useEffect(() => {
     setNumberOfEntities(unknownValues.length ?? 0);
   }, [unknownValues.length]);
@@ -149,7 +99,7 @@ const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }:
   const queryPaginationOptions = {
     ...paginationOptions,
     filters: queryFilters,
-    count: 5000,
+    values,
   } as SearchBulkUnknownEntitiesQuery$variables;
 
   const queryRef = useQueryLoading<SearchBulkUnknownEntitiesQuery>(searchBulkUnknownEntitiesQuery, queryPaginationOptions);
@@ -158,7 +108,6 @@ const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }:
     <>
       {queryRef && <React.Suspense fallback={<Loader />}>
         <SearchBulkUnknownEntitiesContent
-          values={values}
           queryRef={queryRef}
           setNumberOfEntities={setNumberOfEntities}
           isDisplayed={isDisplayed}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8647,7 +8647,7 @@ type Query {
   stixCoreObjects(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   stixCoreObjectsRestricted(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   globalSearch(first: Int, after: ID, search: String, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup): StixCoreObjectConnection
-  unknownStixCoreObjects(filters: FilterGroup, values: [String!]!, orderBy: UnknownStixCoreObjectsOrdering, ordreMode: FilterGroup): [String!]!
+  unknownStixCoreObjects(filters: FilterGroup, values: [String!]!, orderBy: UnknownStixCoreObjectsOrdering, orderMode: OrderingMode): [String!]!
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection
   stixCoreObjectsTimeSeries(authorId: String, field: String!, operation: StatsOperation!, startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, types: [String], filters: FilterGroup, search: String): [TimeSeries]
   stixCoreObjectsMultiTimeSeries(startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, timeSeriesParameters: [StixCoreObjectsTimeSeriesParameters]): [MultiTimeSeries]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2765,6 +2765,11 @@ type Representative {
   secondary: String
 }
 
+enum UnknownStixCoreObjectsOrdering {
+  _score
+  value
+}
+
 enum StixCoreObjectsOrdering {
   name
   entity_type
@@ -8642,6 +8647,7 @@ type Query {
   stixCoreObjects(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   stixCoreObjectsRestricted(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   globalSearch(first: Int, after: ID, search: String, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup): StixCoreObjectConnection
+  unknownStixCoreObjects(filters: FilterGroup, values: [String!]!, orderBy: UnknownStixCoreObjectsOrdering, ordreMode: FilterGroup): [String!]!
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection
   stixCoreObjectsTimeSeries(authorId: String, field: String!, operation: StatsOperation!, startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, types: [String], filters: FilterGroup, search: String): [TimeSeries]
   stixCoreObjectsMultiTimeSeries(startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, timeSeriesParameters: [StixCoreObjectsTimeSeriesParameters]): [MultiTimeSeries]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2766,8 +2766,8 @@ type Representative {
 }
 
 enum UnknownStixCoreObjectsOrdering {
-  _score
   value
+  entity_type
 }
 
 enum StixCoreObjectsOrdering {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -13628,7 +13628,7 @@ type Query {
     filters: FilterGroup
     values: [String!]!
     orderBy: UnknownStixCoreObjectsOrdering
-    ordreMode: FilterGroup
+    orderMode: OrderingMode
   ): [String!]! @auth(for: [KNOWLEDGE])
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection @auth(for: [KNOWLEDGE_KNGETEXPORT])
   stixCoreObjectsTimeSeries(

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2698,6 +2698,11 @@ type Representative {
   secondary: String
 }
 
+enum UnknownStixCoreObjectsOrdering {
+  _score
+  value
+}
+
 enum StixCoreObjectsOrdering {
   name
   entity_type
@@ -13619,6 +13624,12 @@ type Query {
     orderMode: OrderingMode
     filters: FilterGroup
   ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
+  unknownStixCoreObjects(
+    filters: FilterGroup
+    values: [String!]!
+    orderBy: UnknownStixCoreObjectsOrdering
+    ordreMode: FilterGroup
+  ): [String!]! @auth(for: [KNOWLEDGE])
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection @auth(for: [KNOWLEDGE_KNGETEXPORT])
   stixCoreObjectsTimeSeries(
     authorId: String

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2699,8 +2699,8 @@ type Representative {
 }
 
 enum UnknownStixCoreObjectsOrdering {
-  _score
   value
+  entity_type
 }
 
 enum StixCoreObjectsOrdering {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -155,7 +155,7 @@ export const globalSearchPaginated = async (context, user, args) => {
 
 export const findUnknownStixCoreObjects = async (context, user, args) => {
   const { values, filters, orderBy, orderMode } = args;
-  const knownScos = await globalSearchPaginated(context, user, { filters, first: 10000 });
+  const knownScos = await globalSearchPaginated(context, user, { filters, first: 5000 });
   const knownNodes = knownScos.edges.map((n) => n.node) ?? [];
 
   const isStixObjectMatchWithSearchValue = (stixObject, value) => {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -163,7 +163,7 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
     if (!representativeMatch) {
       // try to find in hashes
       if (stixObject.hashes) {
-        const hashMatch = stixObject.hashes.some((h) => h?.hash === value);
+        const hashMatch = Object.values(stixObject.hashes).filter((h) => !!h).some((h) => h === value);
         if (hashMatch) return hashMatch;
       }
     }

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -174,7 +174,10 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
     const resolvedScos = knownNodes.filter((o) => isStixObjectMatchWithSearchValue(o, value)) ?? [];
     return resolvedScos.length === 0;
   });
-  // return unknownValues.sort((a, b) => a.localCompare(b));
+  if (orderBy && orderBy === 'value') {
+    const orderFactor = orderMode === 'desc' ? -1 : 1;
+    return unknownValues.sort((a, b) => orderFactor * a.localeCompare(b));
+  }
   return unknownValues;
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -155,7 +155,7 @@ export const globalSearchPaginated = async (context, user, args) => {
 
 export const findUnknownStixCoreObjects = async (context, user, args) => {
   const { values, filters, orderBy, orderMode } = args;
-  const knownScos = await globalSearchPaginated(context, user, { filters });
+  const knownScos = await globalSearchPaginated(context, user, { filters, first: 10000 });
   const knownNodes = knownScos.edges.map((n) => n.node) ?? [];
 
   const isStixObjectMatchWithSearchValue = (stixObject, value) => {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -21659,6 +21659,7 @@ export type Query = {
   triggersActivity?: Maybe<TriggerConnection>;
   triggersKnowledge?: Maybe<TriggerConnection>;
   triggersKnowledgeCount?: Maybe<Scalars['Int']['output']>;
+  unknownStixCoreObjects: Array<Scalars['String']['output']>;
   user?: Maybe<User>;
   userAlreadyExists?: Maybe<Scalars['Boolean']['output']>;
   users?: Maybe<UserConnection>;
@@ -24512,6 +24513,14 @@ export type QueryTriggersKnowledgeCountArgs = {
   filters?: InputMaybe<FilterGroup>;
   includeAuthorities?: InputMaybe<Scalars['Boolean']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryUnknownStixCoreObjectsArgs = {
+  filters?: InputMaybe<FilterGroup>;
+  orderBy?: InputMaybe<UnknownStixCoreObjectsOrdering>;
+  ordreMode?: InputMaybe<FilterGroup>;
+  values: Array<Scalars['String']['input']>;
 };
 
 
@@ -31562,6 +31571,11 @@ export enum UnitSystem {
   Auto = 'auto'
 }
 
+export enum UnknownStixCoreObjectsOrdering {
+  Score = '_score',
+  Value = 'value'
+}
+
 export type UpdateConnectorManagerStatusInput = {
   id: Scalars['ID']['input'];
 };
@@ -34877,6 +34891,7 @@ export type ResolversTypes = ResolversObject<{
   TriggersOrdering: TriggersOrdering;
   TypeAttribute: ResolverTypeWrapper<TypeAttribute>;
   UnitSystem: UnitSystem;
+  UnknownStixCoreObjectsOrdering: UnknownStixCoreObjectsOrdering;
   UpdateConnectorManagerStatusInput: UpdateConnectorManagerStatusInput;
   Upload: ResolverTypeWrapper<Scalars['Upload']['output']>;
   Url: ResolverTypeWrapper<Omit<Url, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<ResolversTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, indicators?: Maybe<ResolversTypes['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
@@ -43265,6 +43280,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   triggersActivity?: Resolver<Maybe<ResolversTypes['TriggerConnection']>, ParentType, ContextType, Partial<QueryTriggersActivityArgs>>;
   triggersKnowledge?: Resolver<Maybe<ResolversTypes['TriggerConnection']>, ParentType, ContextType, Partial<QueryTriggersKnowledgeArgs>>;
   triggersKnowledgeCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType, Partial<QueryTriggersKnowledgeCountArgs>>;
+  unknownStixCoreObjects?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QueryUnknownStixCoreObjectsArgs, 'values'>>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
   userAlreadyExists?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryUserAlreadyExistsArgs, 'name'>>;
   users?: Resolver<Maybe<ResolversTypes['UserConnection']>, ParentType, ContextType, Partial<QueryUsersArgs>>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -24519,7 +24519,7 @@ export type QueryTriggersKnowledgeCountArgs = {
 export type QueryUnknownStixCoreObjectsArgs = {
   filters?: InputMaybe<FilterGroup>;
   orderBy?: InputMaybe<UnknownStixCoreObjectsOrdering>;
-  ordreMode?: InputMaybe<FilterGroup>;
+  orderMode?: InputMaybe<OrderingMode>;
   values: Array<Scalars['String']['input']>;
 };
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -31572,7 +31572,7 @@ export enum UnitSystem {
 }
 
 export enum UnknownStixCoreObjectsOrdering {
-  Score = '_score',
+  EntityType = 'entity_type',
   Value = 'value'
 }
 

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
@@ -44,7 +44,8 @@ import {
   stixCoreObjectsNumber,
   stixCoreObjectsTimeSeries,
   stixCoreObjectsTimeSeriesByAuthor,
-  stixCoreRelationshipsPaginated, findUnknownStixCoreObjects
+  stixCoreRelationshipsPaginated,
+  findUnknownStixCoreObjects,
 } from '../domain/stixCoreObject';
 import { fetchEditContext } from '../database/redis';
 import { distributionRelations, stixLoadByIdStringify } from '../database/middleware';

--- a/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixCoreObject.js
@@ -44,7 +44,7 @@ import {
   stixCoreObjectsNumber,
   stixCoreObjectsTimeSeries,
   stixCoreObjectsTimeSeriesByAuthor,
-  stixCoreRelationshipsPaginated
+  stixCoreRelationshipsPaginated, findUnknownStixCoreObjects
 } from '../domain/stixCoreObject';
 import { fetchEditContext } from '../database/redis';
 import { distributionRelations, stixLoadByIdStringify } from '../database/middleware';
@@ -63,6 +63,7 @@ import { loadThroughDenormalized } from './stix';
 const stixCoreObjectResolvers = {
   Query: {
     globalSearch: (_, args, context) => globalSearchPaginated(context, context.user, args),
+    unknownStixCoreObjects: (_, args, context) => findUnknownStixCoreObjects(context, context.user, args),
     stixCoreObject: (_, { id }, context) => findById(context, context.user, id),
     stixCoreObjectRaw: (_, { id }, context) => stixLoadByIdStringify(context, context.user, id),
     stixCoreObjects: (_, args, context) => findStixCoreObjectPaginated(context, context.user, args),

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreObject-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreObject-test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { findUnknownStixCoreObjects } from '../../../src/domain/stixCoreObject';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+
+describe('StixCoreObject resolver standard behavior', () => {
+  it('findUnknownStixCoreObjects: should return unknown entities', async () => {
+    const md5Hash = '757a71f0fbd6b3d993be2a213338d1f2';
+    const malwareName = 'Paradise Ransomware';
+    const locationName = 'france';
+    // no values provided
+    let unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: [] });
+    expect(unknownValues.length).toEqual(0);
+    // some values are representative or hashes of a sco, some are unknown
+    unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: ['unknownValue', locationName, md5Hash] });
+    expect(unknownValues.length).toEqual(1);
+    expect(unknownValues[0]).toEqual('unknownValue');
+    // values returned in alphabetical order
+    unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: [malwareName, 'aa', locationName, 'cc', 'bb'], orderBy: 'value', orderMode: 'asc' });
+    expect(unknownValues.length).toEqual(3);
+    expect(unknownValues).toEqual(['aa', 'bb', 'cc']);
+  });
+});


### PR DESCRIPTION
### Proposed changes
In Bulk Search context
- API for unknown entities instead of post filtering logic in frontend
- possibility to order unknown entities by value

### Related issues
#7279 