### PR TITLE
[backend] add noThrow opts in elLoadById (#12482)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1852,7 +1852,7 @@ export const elLoadById = async (context, user, id, opts = {}) => {
   const hits = await elFindByIds(context, user, id, { ...opts, withoutRels: false });
   //* v8 ignore if */
   if (hits.length > 1) {
-    if (opts.noThrow) {
+    if (opts.ignoreDuplicates) {
       logApp.warn('Id loading expect only one response', { id, hits: hits.length });
     } else {
       throw DatabaseError('Id loading expect only one response', { id, hits: hits.length });

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -1852,7 +1852,11 @@ export const elLoadById = async (context, user, id, opts = {}) => {
   const hits = await elFindByIds(context, user, id, { ...opts, withoutRels: false });
   //* v8 ignore if */
   if (hits.length > 1) {
-    throw DatabaseError('Id loading expect only one response', { id, hits: hits.length });
+    if (opts.noThrow) {
+      logApp.warn('Id loading expect only one response', { id, hits: hits.length });
+    } else {
+      throw DatabaseError('Id loading expect only one response', { id, hits: hits.length });
+    }
   }
   return R.head(hits);
 };

--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -150,7 +150,7 @@ export const deleteFile = async (context, user, id) => {
   // Delete associated works
   await deleteWorkForFile(context, user, id);
   // Delete index file
-  await deleteDocumentIndex(context, user, id);
+  await deleteDocumentIndex(context, user, up);
   // delete in index if file has been indexed
   const isFileIndexModuleActivated = await isModuleActivated('FILE_INDEX_MANAGER');
   if (isFileIndexModuleActivated && isAttachmentProcessorEnabled()) {
@@ -314,7 +314,7 @@ export const loadFile = async (context, user, fileS3Path, opts = {}) => {
       throw FunctionalError('File not found or restricted', { filename: fileS3Path });
     }
     // 02. Check if the referenced document is accessible
-    const document = await documentFindById(context, user, fileS3Path);
+    const document = await documentFindById(context, user, fileS3Path, { noThrow: true });
     if (!document) {
       throw FunctionalError('File not found or restricted', { filename: fileS3Path });
     }

--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -314,7 +314,7 @@ export const loadFile = async (context, user, fileS3Path, opts = {}) => {
       throw FunctionalError('File not found or restricted', { filename: fileS3Path });
     }
     // 02. Check if the referenced document is accessible
-    const document = await documentFindById(context, user, fileS3Path, { noThrow: true });
+    const document = await documentFindById(context, user, fileS3Path, { ignoreDuplicates: true });
     if (!document) {
       throw FunctionalError('File not found or restricted', { filename: fileS3Path });
     }

--- a/opencti-platform/opencti-graphql/src/database/file-storage.js
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.js
@@ -150,7 +150,7 @@ export const deleteFile = async (context, user, id) => {
   // Delete associated works
   await deleteWorkForFile(context, user, id);
   // Delete index file
-  await deleteDocumentIndex(context, user, up);
+  await deleteDocumentIndex(context, user, id);
   // delete in index if file has been indexed
   const isFileIndexModuleActivated = await isModuleActivated('FILE_INDEX_MANAGER');
   if (isFileIndexModuleActivated && isAttachmentProcessorEnabled()) {

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import moment from 'moment';
 import { generateFileIndexId } from '../../../schema/identifier';
 import { ENTITY_TYPE_INTERNAL_FILE } from '../../../schema/internalObject';
-import { elAggregationCount, elCount, elDeleteInstances, elIndex } from '../../../database/engine';
+import { elAggregationCount, elCount, elDeleteInstances, elFindByIds, elIndex } from '../../../database/engine';
 import { INDEX_DRAFT_OBJECTS, INDEX_INTERNAL_OBJECTS, isEmptyField, READ_INDEX_DRAFT_OBJECTS, READ_INDEX_INTERNAL_OBJECTS } from '../../../database/utils';
 import { type EntityOptions, type FilterGroupWithNested, internalLoadById, fullEntitiesList, pageEntitiesConnection, storeLoadById } from '../../../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../../../types/user';
@@ -75,13 +75,13 @@ export const indexFileToDocument = async (context: AuthContext, file: any) => {
 };
 
 export const deleteDocumentIndex = async (context: AuthContext, user: AuthUser, id: string) => {
-  const internalFile = await storeLoadById(context, user, id, ENTITY_TYPE_INTERNAL_FILE, { noThrow: true });
-  if (internalFile) {
-    await elDeleteInstances([internalFile]);
+  const internalFile = await elFindByIds(context, user, [id], { type: ENTITY_TYPE_INTERNAL_FILE }) as BasicStoreEntityDocument[];
+  if (internalFile.length > 0) {
+    await elDeleteInstances(internalFile);
   }
 };
 
-export const findById: DomainFindById<BasicStoreEntityDocument> = (context: AuthContext, user: AuthUser, fileId: string, opts: { noThrow?: boolean } = {}) => {
+export const findById: DomainFindById<BasicStoreEntityDocument> = (context: AuthContext, user: AuthUser, fileId: string, opts: { ignoreDuplicates?: boolean } = {}) => {
   return storeLoadById<BasicStoreEntityDocument>(context, user, fileId, ENTITY_TYPE_INTERNAL_FILE, opts);
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -75,14 +75,14 @@ export const indexFileToDocument = async (context: AuthContext, file: any) => {
 };
 
 export const deleteDocumentIndex = async (context: AuthContext, user: AuthUser, id: string) => {
-  const internalFile = await storeLoadById(context, user, id, ENTITY_TYPE_INTERNAL_FILE);
+  const internalFile = await storeLoadById(context, user, id, ENTITY_TYPE_INTERNAL_FILE, { noThrow: true });
   if (internalFile) {
     await elDeleteInstances([internalFile]);
   }
 };
 
-export const findById: DomainFindById<BasicStoreEntityDocument> = (context: AuthContext, user: AuthUser, fileId: string) => {
-  return storeLoadById<BasicStoreEntityDocument>(context, user, fileId, ENTITY_TYPE_INTERNAL_FILE);
+export const findById: DomainFindById<BasicStoreEntityDocument> = (context: AuthContext, user: AuthUser, fileId: string, opts: { noThrow?: boolean } = {}) => {
+  return storeLoadById<BasicStoreEntityDocument>(context, user, fileId, ENTITY_TYPE_INTERNAL_FILE, opts);
 };
 
 interface FilesOptions<T extends BasicStoreCommon> extends EntityOptions<T> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add noThrow option in elLoadById to still be able to load document even if there are multiple returned
* use noThrow option when deleting a file to still be able to delete in case of duplicates

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12482
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
