### PR TITLE
[backend] Fix PIR manager saves too many audit logs (#12904)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/pirManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/pirManager.ts
@@ -181,7 +181,7 @@ const pirManagerHandler = async () => {
       );
       // Update pir last event id.
       if (lastEventId !== pir.lastEventId) {
-        await updatePir(context, PIR_MANAGER_USER, pir.id, [{ key: 'lastEventId', value: [lastEventId] }]);
+        await updatePir(context, PIR_MANAGER_USER, pir.id, [{ key: 'lastEventId', value: [lastEventId] }], { auditLogEnabled: false });
       }
     }, { concurrency: PIR_MANAGER_MAX_CONCURRENCY });
   } finally {

--- a/opencti-platform/opencti-graphql/src/modules/pir/pir-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/pir/pir-domain.ts
@@ -240,14 +240,14 @@ export const deletePir = async (context: AuthContext, user: AuthUser, pirId: str
   return deleteInternalObject(context, user, pirId, ENTITY_TYPE_PIR);
 };
 
-export const updatePir = async (context: AuthContext, user: AuthUser, pirId: string, input: EditInput[]) => {
+export const updatePir = async (context: AuthContext, user: AuthUser, pirId: string, input: EditInput[], opts: { auditLogEnabled?: boolean } = {}) => {
   await checkEnterpriseEdition(context);
   const allowedKeys = ['lastEventId', 'name', 'description'];
   const keys = input.map((i) => i.key);
   if (keys.some((k) => !allowedKeys.includes(k))) {
     throw FunctionalError('Error while updating the PIR, invalid or forbidden key.');
   }
-  return editInternalObject<StoreEntityPir>(context, user, pirId, ENTITY_TYPE_PIR, input);
+  return editInternalObject<StoreEntityPir>(context, user, pirId, ENTITY_TYPE_PIR, input, opts);
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add option auditLogEnabled and set it to false when updating lastEventId for PIR

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12904

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
