### PR TITLE
[frontend] avoid unnecessary re-renders with computeLink

### DIFF
--- a/opencti-platform/opencti-front/src/private/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/Root.tsx
@@ -414,7 +414,7 @@ const RootComponent: FunctionComponent<RootComponentProps> = ({ queryRef }) => {
       <StyledEngineProvider injectFirst={true}>
         <ConnectedThemeProvider settings={settings}>
           <ConnectedIntlProvider settings={settings}>
-            <ComputeLinkProvider>
+            <ComputeLinkProvider isPublicRoute={false}>
               <AnalyticsProvider instance={Analytics(platformAnalyticsConfiguration)}>
                 <Index settings={settings} />
               </AnalyticsProvider>

--- a/opencti-platform/opencti-front/src/public/PublicRoot.tsx
+++ b/opencti-platform/opencti-front/src/public/PublicRoot.tsx
@@ -28,12 +28,13 @@ const PublicRoot = () => {
     queryRef,
   );
   const isPlaygroundEnabled = settings.playground_enabled;
+
   return (
     <PublicSettingsProvider settings={settings}>
       <StyledEngineProvider injectFirst={true}>
         <ConnectedThemeProvider settings={settings}>
           <ConnectedIntlProvider settings={settings}>
-            <ComputeLinkProvider>
+            <ComputeLinkProvider isPublicRoute={true}>
               <CssBaseline />
               <Message />
               <Routes>

--- a/opencti-platform/opencti-front/src/utils/hooks/useComputeLink.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useComputeLink.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, createContext, useContext } from 'react';
-import { useLocation } from 'react-router-dom';
 import { resolveLink } from '../Entity';
 import useSchema from './useSchema';
 
@@ -64,10 +63,7 @@ const PrivateComputeLinkProvider: React.FC<{ children: ReactNode }> = ({ childre
   );
 };
 
-export const ComputeLinkProvider = ({ children }: { children: ReactNode }) => {
-  const location = useLocation();
-
-  const isPublicRoute = location.pathname.startsWith('/public/');
+export const ComputeLinkProvider = ({ isPublicRoute, children }: { isPublicRoute: boolean, children: ReactNode }) => {
   if (isPublicRoute) {
     return (
       <ComputeLinkContext.Provider value={() => ''}>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove unnecessary usage of useLocation. now that we useComputeLink's provider is at the top level we can rely on a prop instead of useLocation


### Related issues

- https://github.com/OpenCTI-Platform/opencti/issues/12887

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
