### PR TITLE
[frontend/backend] Bulk Search: Bulk actions on known entities (#7279)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
@@ -174,6 +174,7 @@ const SearchBulk = ({ inputValues, dataColumns }: SearchBulkProps) => {
           storageKey={BULK_SEARCH_LOCAL_STORAGE_KEY}
           initialValues={initialValues}
           toolbarFilters={queryFilters}
+          additionalFilters={queryFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           exportContext={{ entity_type: 'Stix-Core-Object' }}
           lineFragment={searchBulkLineFragment}

--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { graphql } from 'react-relay';
 import { SearchBulkQuery, SearchBulkQuery$variables } from './__generated__/SearchBulkQuery.graphql';
 import { SearchBulkQuery_data$data } from './__generated__/SearchBulkQuery_data.graphql';
-import { allEntitiesKeyList } from './common/bulk/utils/querySearchEntityByText';
 import DataTable from '../../components/dataGrid/DataTable';
 import { addFilter, emptyFilterGroup, useBuildEntityTypeBasedFilterContext } from '../../utils/filters/filtersUtils';
 import { usePaginationLocalStorage } from '../../utils/hooks/useLocalStorage';
@@ -130,9 +129,8 @@ interface SearchBulkProps {
 
 const SearchBulk = ({ inputValues, dataColumns }: SearchBulkProps) => {
   const buildSearchBulkFilters = (values: string[], filters: FilterGroup) => {
-    return values.length > 0
-      ? addFilter(filters, allEntitiesKeyList as unknown as string, values)
-      : filters;
+    if (values.length === 0) return filters;
+    return addFilter(filters, 'bulkSearchKeywords', values);
   };
 
   const initialValues = {

--- a/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulk.tsx
@@ -180,8 +180,6 @@ const SearchBulk = ({ inputValues, dataColumns }: SearchBulkProps) => {
           exportContext={{ entity_type: 'Stix-Core-Object' }}
           lineFragment={searchBulkLineFragment}
           hideSearch
-          disableToolBar
-          disableLineSelection
         />
       )}
     </>

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -3,7 +3,6 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { SearchBulkUnknownEntitiesQuery, SearchBulkUnknownEntitiesQuery$variables } from '@components/__generated__/SearchBulkUnknownEntitiesQuery.graphql';
 import DataTableWithoutFragment from '../../components/dataGrid/DataTableWithoutFragment';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
-import { useBuildEntityTypeBasedFilterContext } from '../../utils/filters/filtersUtils';
 import { usePaginationLocalStorage } from '../../utils/hooks/useLocalStorage';
 import Loader from '../../components/Loader';
 import type { DataTableProps } from '../../components/dataGrid/dataTableTypes';
@@ -12,13 +11,11 @@ const LOCAL_STORAGE_KEY = 'searchBulk_unknownEntities';
 
 const searchBulkUnknownEntitiesQuery = graphql`
   query SearchBulkUnknownEntitiesQuery(
-    $filters: FilterGroup
     $values: [String!]!
     $orderBy: UnknownStixCoreObjectsOrdering
     $orderMode: OrderingMode
   ) {
     unknownStixCoreObjects(
-      filters: $filters
       values: $values
       orderBy: $orderBy
       orderMode: $orderMode
@@ -74,19 +71,6 @@ interface SearchBulkUnknownEntitiesProps {
 }
 
 const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }: SearchBulkUnknownEntitiesProps) => {
-  const contextFilters = useBuildEntityTypeBasedFilterContext('Stix-Core-Object', undefined);
-
-  const queryFilters = values.length > 0
-    ? {
-      mode: 'and',
-      filters: [
-        { key: 'entity_type', values: ['Stix-Core-Object'] },
-        { key: 'bulkSearchKeywords', values },
-      ],
-      filterGroups: [],
-    }
-    : contextFilters;
-
   const initialValues = {
     sortBy: 'value',
     orderAsc: true,
@@ -98,7 +82,6 @@ const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }:
 
   const queryPaginationOptions = {
     ...paginationOptions,
-    filters: queryFilters,
     values,
   } as unknown as SearchBulkUnknownEntitiesQuery$variables;
 

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { allEntitiesKeyList } from '@components/common/bulk/utils/querySearchEntityByText';
 import { SearchBulkUnknownEntitiesQuery, SearchBulkUnknownEntitiesQuery$variables } from '@components/__generated__/SearchBulkUnknownEntitiesQuery.graphql';
 import DataTableWithoutFragment from '../../components/dataGrid/DataTableWithoutFragment';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
@@ -82,7 +81,7 @@ const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }:
       mode: 'and',
       filters: [
         { key: 'entity_type', values: ['Stix-Core-Object'] },
-        { key: allEntitiesKeyList, values },
+        { key: 'bulkSearchKeywords', values },
       ],
       filterGroups: [],
     }
@@ -101,7 +100,7 @@ const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }:
     ...paginationOptions,
     filters: queryFilters,
     values,
-  } as SearchBulkUnknownEntitiesQuery$variables;
+  } as unknown as SearchBulkUnknownEntitiesQuery$variables;
 
   const queryRef = useQueryLoading<SearchBulkUnknownEntitiesQuery>(searchBulkUnknownEntitiesQuery, queryPaginationOptions);
 

--- a/opencti-platform/opencti-front/src/private/components/common/bulk/dialog/BulkRelationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/bulk/dialog/BulkRelationDialog.tsx
@@ -25,7 +25,7 @@ import BulkTextModalButton from 'src/components/fields/BulkTextField/BulkTextMod
 import StixDomainObjectCreation from '@components/common/stix_domain_objects/StixDomainObjectCreation';
 import { PaginationOptions } from 'src/components/list_lines';
 import StixCyberObservableCreation from '@components/observations/stix_cyber_observables/StixCyberObservableCreation';
-import { allEntitiesKeyList, type StixCoreResultsType } from '../utils/querySearchEntityByText';
+import { type StixCoreResultsType } from '../utils/querySearchEntityByText';
 import { getRelationsFromOneEntityToAny, RelationsDataFromEntity, RelationsToEntity } from '../../../../../utils/Relation';
 
 export const searchStixCoreObjectsByRepresentativeQuery = graphql`
@@ -125,7 +125,7 @@ const querySearchEntityByText = async (text: string) => {
       mode: 'and',
       filters: [
         {
-          key: allEntitiesKeyList,
+          key: 'bulkSearchKeywords',
           values: [text],
         },
       ],

--- a/opencti-platform/opencti-front/src/private/components/common/bulk/utils/querySearchEntityByText.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/bulk/utils/querySearchEntityByText.ts
@@ -18,26 +18,3 @@ export type StixCoreEntityType = {
 export type StixRepresentative = {
   main: string;
 };
-
-export const allEntitiesKeyList = [
-  'name',
-  'aliases',
-  'x_opencti_aliases',
-  'x_mitre_id',
-  'value',
-  'subject',
-  'attribute_abstract',
-  'x_opencti_additional_names',
-  // observables
-  'iban',
-  'hashes.MD5',
-  'hashes.SHA-1',
-  'hashes.SHA-256',
-  'hashes.SHA-512',
-  'url',
-  'card_number',
-  'account_type',
-  'user_id',
-  'account_login',
-  'path',
-];

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8684,7 +8684,7 @@ type Query {
   stixCoreObjects(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   stixCoreObjectsRestricted(first: Int, after: ID, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
   globalSearch(first: Int, after: ID, search: String, types: [String], orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup): StixCoreObjectConnection
-  unknownStixCoreObjects(filters: FilterGroup, values: [String!]!, orderBy: UnknownStixCoreObjectsOrdering, orderMode: OrderingMode): [String!]!
+  unknownStixCoreObjects(values: [String!]!, orderBy: UnknownStixCoreObjectsOrdering, orderMode: OrderingMode): [String!]!
   stixCoreObjectsExportFiles(first: Int, exportContext: ExportContext!): FileConnection
   stixCoreObjectsTimeSeries(authorId: String, field: String!, operation: StatsOperation!, startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, types: [String], filters: FilterGroup, search: String): [TimeSeries]
   stixCoreObjectsMultiTimeSeries(startDate: DateTime!, endDate: DateTime, interval: String!, onlyInferred: Boolean, timeSeriesParameters: [StixCoreObjectsTimeSeriesParameters]): [MultiTimeSeries]

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -49,7 +49,7 @@ export const FiltersVariant = {
   dialog: 'dialog',
 };
 
-const NOT_CLEANABLE_FILTER_KEYS = ['entity_type', 'authorized_members.id', 'user_id', 'internal_id', 'entity_id', 'ids'];
+const NOT_CLEANABLE_FILTER_KEYS = ['entity_type', 'authorized_members.id', 'user_id', 'internal_id', 'entity_id', 'ids', 'bulkSearchKeywords'];
 
 const pirScoreFilterDefinition = (pirId: string) => ({
   filterKey: `pir_score.${pirId}`,

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -13740,7 +13740,6 @@ type Query {
     filters: FilterGroup
   ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
   unknownStixCoreObjects(
-    filters: FilterGroup
     values: [String!]!
     orderBy: UnknownStixCoreObjectsOrdering
     orderMode: OrderingMode

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -151,7 +151,8 @@ import { extractEntityRepresentativeName, extractRepresentative } from './entity
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 import { addFilter, checkAndConvertFilters, extractFiltersFromGroup, isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import {
-  ALIAS_FILTER, BULK_SEARCH_KEYWORDS_FILTER,
+  ALIAS_FILTER,
+  BULK_SEARCH_KEYWORDS_FILTER,
   BULK_SEARCH_KEYWORDS_FILTER_KEYS,
   COMPUTED_RELIABILITY_FILTER,
   ID_FILTER,

--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -151,7 +151,8 @@ import { extractEntityRepresentativeName, extractRepresentative } from './entity
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 import { addFilter, checkAndConvertFilters, extractFiltersFromGroup, isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import {
-  ALIAS_FILTER,
+  ALIAS_FILTER, BULK_SEARCH_KEYWORDS_FILTER,
+  BULK_SEARCH_KEYWORDS_FILTER_KEYS,
   COMPUTED_RELIABILITY_FILTER,
   ID_FILTER,
   IDS_FILTER,
@@ -3277,6 +3278,14 @@ const completeSpecialFilterKeys = async (context, user, inputFilters) => {
         } else {
           finalFilters.push(filter); // nothing to modify
         }
+      }
+
+      if (filterKey === BULK_SEARCH_KEYWORDS_FILTER) {
+        const newFilter = {
+          ...filter,
+          key: BULK_SEARCH_KEYWORDS_FILTER_KEYS,
+        };
+        finalFilters.push(newFilter);
       }
 
       if (isMetricsName(filterKey)) {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -196,7 +196,7 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
         return Array.isArray(stixObjectValue)
           ? stixObjectValue.includes(value)
           : stixObjectValue === value;
-      })
+      });
     }
     return representativeMatch;
   };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -190,14 +190,13 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
         if (hashMatch) return hashMatch;
       }
       // try to find in attributes of bulk search filter
-      for (let i = 0; i < BULK_SEARCH_KEYWORDS_FILTER_KEYS.length; i += 1) {
-        const key = BULK_SEARCH_KEYWORDS_FILTER_KEYS[i];
+      return BULK_SEARCH_KEYWORDS_FILTER_KEYS.some((key) => {
         const stixObjectValue = stixObject[key];
-        if (stixObjectValue) {
-          const keyMatch = Array.isArray(stixObjectValue) ? stixObjectValue.includes(value) : stixObjectValue === value;
-          if (keyMatch) return true;
-        }
-      }
+        if (!stixObjectValue) return false;
+        return Array.isArray(stixObjectValue)
+          ? stixObjectValue.includes(value)
+          : stixObjectValue === value;
+      })
     }
     return representativeMatch;
   };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -77,7 +77,7 @@ import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefR
 import { buildContextDataForFile, completeContextDataForEntity, publishUserAction } from '../listener/UserActionListener';
 import { extractEntityRepresentativeName, extractRepresentative } from '../database/entity-representative';
 import { addFilter, findFiltersFromKey } from '../utils/filtering/filtering-utils';
-import { INSTANCE_REGARDING_OF } from '../utils/filtering/filtering-constants';
+import { BULK_SEARCH_KEYWORDS_FILTER_KEYS, INSTANCE_REGARDING_OF } from '../utils/filtering/filtering-constants';
 import { getEntitiesMapFromCache } from '../database/cache';
 import { BYPASS, isBypassUser, isUserCanAccessStoreElement, isUserHasCapabilities, SYSTEM_USER, validateUserAccessOperation } from '../utils/access';
 import { uploadToStorage } from '../database/file-storage-helper';
@@ -181,7 +181,15 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
         const hashMatch = Object.values(stixObject.hashes).filter((h) => !!h).some((h) => h === value);
         if (hashMatch) return hashMatch;
       }
-      // complete? // TODO (try to find in aliases and x_opencti_aliases)
+      // try to find in attributes of bulk search filter
+      for (let i = 0; i < BULK_SEARCH_KEYWORDS_FILTER_KEYS.length; i += 1) {
+        const key = BULK_SEARCH_KEYWORDS_FILTER_KEYS[i];
+        const stixObjectValue = stixObject[key];
+        if (stixObjectValue) {
+          const keyMatch = Array.isArray(stixObjectValue) ? stixObjectValue.includes(value) : stixObjectValue === value;
+          if (keyMatch) return true;
+        }
+      }
     }
     return representativeMatch;
   };

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -77,7 +77,7 @@ import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefR
 import { buildContextDataForFile, completeContextDataForEntity, publishUserAction } from '../listener/UserActionListener';
 import { extractEntityRepresentativeName, extractRepresentative } from '../database/entity-representative';
 import { addFilter, findFiltersFromKey } from '../utils/filtering/filtering-utils';
-import { BULK_SEARCH_KEYWORDS_FILTER_KEYS, INSTANCE_REGARDING_OF } from '../utils/filtering/filtering-constants';
+import { BULK_SEARCH_KEYWORDS_FILTER, BULK_SEARCH_KEYWORDS_FILTER_KEYS, INSTANCE_REGARDING_OF } from '../utils/filtering/filtering-constants';
 import { getEntitiesMapFromCache } from '../database/cache';
 import { BYPASS, isBypassUser, isUserCanAccessStoreElement, isUserHasCapabilities, SYSTEM_USER, validateUserAccessOperation } from '../utils/access';
 import { uploadToStorage } from '../database/file-storage-helper';
@@ -165,11 +165,19 @@ export const globalSearchPaginated = async (context, user, args) => {
 };
 
 export const findUnknownStixCoreObjects = async (context, user, args) => {
-  const { values: inputValues, filters, orderBy, orderMode } = args;
+  const { values: inputValues, orderBy, orderMode } = args;
   if (inputValues.length === 0) {
     return [];
   }
   const values = R.uniq(inputValues);
+  const filters = {
+    mode: 'and',
+    filters: [
+      { key: 'entity_type', values: [ABSTRACT_STIX_CORE_OBJECT] },
+      { key: BULK_SEARCH_KEYWORDS_FILTER, values },
+    ],
+    filterGroups: [],
+  };
   const knownScos = await globalSearchPaginated(context, user, { filters, first: 5000 });
   const knownNodes = knownScos.edges.map((n) => n.node) ?? [];
 

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -181,14 +181,17 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
         const hashMatch = Object.values(stixObject.hashes).filter((h) => !!h).some((h) => h === value);
         if (hashMatch) return hashMatch;
       }
+      // complete? // TODO (try to find in aliases and x_opencti_aliases)
     }
     return representativeMatch;
   };
 
+  // post filtering
   const unknownValues = values.filter((value) => {
     const resolvedScos = knownNodes.filter((o) => isStixObjectMatchWithSearchValue(o, value)) ?? [];
     return resolvedScos.length === 0;
   });
+  // order unknown values
   if (orderBy && orderBy === 'value') {
     const orderFactor = orderMode === 'desc' ? -1 : 1;
     return unknownValues.sort((a, b) => orderFactor * a.localeCompare(b));

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -169,7 +169,7 @@ export const findUnknownStixCoreObjects = async (context, user, args) => {
   if (inputValues.length === 0) {
     return [];
   }
-  const values = R.uniq(inputValues);
+  const values = [...new Set(inputValues)]; // uniq values only
   const filters = {
     mode: 'and',
     filters: [

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -165,7 +165,11 @@ export const globalSearchPaginated = async (context, user, args) => {
 };
 
 export const findUnknownStixCoreObjects = async (context, user, args) => {
-  const { values, filters, orderBy, orderMode } = args;
+  const { values: inputValues, filters, orderBy, orderMode } = args;
+  if (inputValues.length === 0) {
+    return [];
+  }
+  const values = R.uniq(inputValues);
   const knownScos = await globalSearchPaginated(context, user, { filters, first: 5000 });
   const knownNodes = knownScos.edges.map((n) => n.node) ?? [];
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -24552,7 +24552,6 @@ export type QueryTriggersKnowledgeCountArgs = {
 
 
 export type QueryUnknownStixCoreObjectsArgs = {
-  filters?: InputMaybe<FilterGroup>;
   orderBy?: InputMaybe<UnknownStixCoreObjectsOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
   values: Array<Scalars['String']['input']>;

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -230,4 +230,6 @@ export const BULK_SEARCH_KEYWORDS_FILTER_KEYS = [
   'user_id',
   'account_login',
   'path',
+  'attribute_key',
+  'persona_name',
 ];

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -75,6 +75,7 @@ export const RULE_FILTER = 'rule';
 export const USER_ID_FILTER = 'user_id';
 export const SOURCE_RELIABILITY_FILTER = 'source_reliability';
 export const COMPUTED_RELIABILITY_FILTER = 'computed_reliability';
+export const BULK_SEARCH_KEYWORDS_FILTER = 'bulkSearchKeywords';
 
 // for opinions
 export const OPINIONS_METRICS_MEAN_FILTER = 'opinionsMetricsMean';
@@ -129,6 +130,7 @@ const COMPLEX_CONVERSION_FILTER_KEYS = [
   'authorized_members', // nested filter on restricted members => kept for retro compatibility (TODO remove after renaming)
   'authorized_members.id', // nested filter on restricted members => kept for retro compatibility (TODO remove after renaming)
   'restricted_members.id', // nested filter on restricted members
+  BULK_SEARCH_KEYWORDS_FILTER, // set of keywords used in bulk search
 ];
 
 export const isComplexConversionFilterKey = (filterKey: string) => {
@@ -204,4 +206,28 @@ export const FILTER_KEYS_WITH_ME_VALUE = [
   CREATOR_FILTER,
   CONTEXT_ENTITY_ID_FILTER,
   MEMBERS_USER_FILTER,
+];
+
+// special filter key
+export const BULK_SEARCH_KEYWORDS_FILTER_KEYS = [
+  'name',
+  'aliases',
+  'x_opencti_aliases',
+  'x_mitre_id',
+  'value',
+  'subject',
+  'attribute_abstract',
+  'x_opencti_additional_names',
+  // observables
+  'iban',
+  'hashes.MD5',
+  'hashes.SHA-1',
+  'hashes.SHA-256',
+  'hashes.SHA-512',
+  'url',
+  'card_number',
+  'account_type',
+  'user_id',
+  'account_login',
+  'path',
 ];

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -208,7 +208,7 @@ export const FILTER_KEYS_WITH_ME_VALUE = [
   MEMBERS_USER_FILTER,
 ];
 
-// special filter key
+// multi filter keys
 export const BULK_SEARCH_KEYWORDS_FILTER_KEYS = [
   'name',
   'aliases',

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/filterGroup-test.js
@@ -8,6 +8,7 @@ import { RELATION_OBJECT_MARKING } from '../../../src/schema/stixRefRelationship
 import { ABSTRACT_INTERNAL_OBJECT, ABSTRACT_STIX_CORE_OBJECT, ENTITY_TYPE_CONTAINER, ENTITY_TYPE_LOCATION, ID_INTERNAL } from '../../../src/schema/general';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_INTRUSION_SET, ENTITY_TYPE_MALWARE } from '../../../src/schema/stixDomainObject';
 import {
+  BULK_SEARCH_KEYWORDS_FILTER,
   COMPUTED_RELIABILITY_FILTER,
   IDS_FILTER,
   INSTANCE_RELATION_FILTER,
@@ -2433,6 +2434,22 @@ describe('Complex filters combinations for elastic queries', () => {
     queryResult = await queryAsAdmin({ query: READ_MARKING_QUERY, variables: { id: marking2StixId } });
     expect(queryResult).not.toBeNull();
     expect(queryResult.data.markingDefinition).toBeNull();
+  });
+
+  it('should list scos with bulk search keyword filter', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_QUERY,
+      variables: {
+        first: 25,
+        filters: {
+          mode: 'and',
+          filters: [{
+            key: BULK_SEARCH_KEYWORDS_FILTER,
+            values: ['france', 'test', 'azerty'],
+          }],
+          filterGroups: [],
+        },
+      } });
+    expect(queryResult.data.globalSearch.edges.length).toEqual(2); // one country with 'France' name + 1 observable with 'azerty' value
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreObject-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreObject-test.ts
@@ -15,6 +15,10 @@ describe('StixCoreObject resolver standard behavior', () => {
     unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: ['unknownValue', locationName, md5Hash] });
     expect(unknownValues.length).toEqual(1);
     expect(unknownValues[0]).toEqual('unknownValue');
+    // should be case insensitive
+    unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: ['unknownValue', locationName.toUpperCase(), md5Hash] });
+    expect(unknownValues.length).toEqual(1);
+    expect(unknownValues[0]).toEqual('unknownValue');
     // some values are aliases
     unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: ['unknownValue', organizationAlias] });
     expect(unknownValues.length).toEqual(1);

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreObject-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/stixCoreObject-test.ts
@@ -7,11 +7,16 @@ describe('StixCoreObject resolver standard behavior', () => {
     const md5Hash = '757a71f0fbd6b3d993be2a213338d1f2';
     const malwareName = 'Paradise Ransomware';
     const locationName = 'france';
+    const organizationAlias = 'Computer Incident';
     // no values provided
     let unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: [] });
     expect(unknownValues.length).toEqual(0);
     // some values are representative or hashes of a sco, some are unknown
     unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: ['unknownValue', locationName, md5Hash] });
+    expect(unknownValues.length).toEqual(1);
+    expect(unknownValues[0]).toEqual('unknownValue');
+    // some values are aliases
+    unknownValues = await findUnknownStixCoreObjects(testContext, ADMIN_USER, { values: ['unknownValue', organizationAlias] });
     expect(unknownValues.length).toEqual(1);
     expect(unknownValues[0]).toEqual('unknownValue');
     // values returned in alphabetical order


### PR DESCRIPTION
### Proposed changes
- Add bulk actions on known entities in Bulk Search
- Fix Unknown entities api: no duplicates
- Special filter key for bulk search keywords in backend
- Improve post filtering of unknown entities (example: if an alias is found, don't put the value in unknown values)

### Related issues
#7279 