### PR TITLE
[frontend] remove Column customization for Timeline widget (#12398)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -789,7 +789,7 @@ const WidgetCreationParameters = () => {
             label={t_i18n('Display legend')}
           />
         )}
-        {getCurrentCategory(type) === 'list' && context !== 'fintelTemplate'
+        {type === 'list' && context !== 'fintelTemplate'
           && dataSelection.map(({ perspective, columns, filters }, index) => {
             if (perspective === 'relationships' || perspective === 'entities') {
               const getEntityTypeFromFilters = (filterGroup?: FilterGroup | null): string | undefined => {


### PR DESCRIPTION
### Proposed changes
- Customization columns should only be available in UI for list widgets, not for timeline widgets

### Related issues
#12398