### PR TITLE
[frontend] number of results in Knowledge List widgets (#12392)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.jsx
@@ -4537,7 +4537,7 @@ const StixRelationshipsList = ({
         <QueryRenderer
           query={stixRelationshipsListQuery}
           variables={{
-            first: 50,
+            first: selection.number ?? 50,
             orderBy: dateAttribute,
             orderMode: selection.sort_mode ?? 'desc',
             filters,


### PR DESCRIPTION
### Proposed changes
In list widgets of Knowledge perspective, take into account the number of results instead of always displaying 50 relationships.

### Related issues
#12392 