### PR TITLE
[frontend] The “CREATOR” column in Advanced Search should be “CREATORS” (#12696)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -197,7 +197,7 @@ const Search = () => {
       isSortable: isRuntimeSort,
     },
     creator: {
-      label: 'Creator',
+      label: 'Creators',
       percentWidth: 12,
       isSortable: isRuntimeSort,
     },


### PR DESCRIPTION
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/12696