### PR TITLE
[worker] implement thread pool selector for push handlers in worker 

### DIFF
--- a/opencti-worker/src/message_queue_consumer.py
+++ b/opencti-worker/src/message_queue_consumer.py
@@ -1,9 +1,7 @@
 import functools
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from threading import Thread
 from typing import Any, Callable, Literal
-from thread_pool_selector import ThreadPoolSelector
 
 import pika
 
@@ -17,7 +15,6 @@ class MessageQueueConsumer:  # pylint: disable=too-many-instance-attributes
     submit_fn: Callable[[Callable[[int, str], None], int, str], Any]
     handle_message: Callable[[str], Literal["ack", "nack", "requeue"]]
     should_stop: bool = field(default=False, init=False)
-    is_realtime: bool = False
 
     def __post_init__(self) -> None:
         self.pika_connection = pika.BlockingConnection(self.pika_parameters)
@@ -81,9 +78,7 @@ class MessageQueueConsumer:  # pylint: disable=too-many-instance-attributes
                     },
                 )
                 task_future = self.submit_fn(
-                    self.consume_message,
-                    method.delivery_tag,
-                    body
+                    self.consume_message, method.delivery_tag, body
                 )
                 while task_future.running():  # Loop while the thread is processing
                     self.pika_connection.sleep(0.05)

--- a/opencti-worker/src/message_queue_consumer.py
+++ b/opencti-worker/src/message_queue_consumer.py
@@ -1,6 +1,7 @@
 import functools
 from dataclasses import dataclass, field
 from threading import Thread
+from concurrent.futures import Future
 from typing import Any, Callable, Literal
 
 import pika
@@ -12,7 +13,7 @@ class MessageQueueConsumer:  # pylint: disable=too-many-instance-attributes
     consumer_type: Literal["listen", "push"]
     queue_name: str
     pika_parameters: pika.ConnectionParameters
-    submit_fn: Callable[[Callable[[int, str], None]], Any]
+    submit_fn: Callable[[Callable[[], None]], Future[None]]
     handle_message: Callable[[str], Literal["ack", "nack", "requeue"]]
     should_stop: bool = field(default=False, init=False)
 

--- a/opencti-worker/src/message_queue_consumer.py
+++ b/opencti-worker/src/message_queue_consumer.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from threading import Thread
 from typing import Any, Callable, Literal
+from thread_pool_selector import ThreadPoolSelector
 
 import pika
 
@@ -13,7 +14,7 @@ class MessageQueueConsumer:  # pylint: disable=too-many-instance-attributes
     consumer_type: Literal["listen", "push"]
     queue_name: str
     pika_parameters: pika.ConnectionParameters
-    execution_pool: ThreadPoolExecutor
+    execution_pool: ThreadPoolExecutor | ThreadPoolSelector
     handle_message: Callable[[str], Literal["ack", "nack", "requeue"]]
     should_stop: bool = field(default=False, init=False)
 

--- a/opencti-worker/src/thread_pool_selector.py
+++ b/opencti-worker/src/thread_pool_selector.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+
+from numpy import number
+
+
+@dataclass(unsafe_hash=True)
+class ThreadPoolSelector:  # pylint: disable=too-many-instance-attributes
+    default_pool_size: int
+    default_execution_pool: ThreadPoolExecutor
+    realtime_pool_size: int
+    realtime_execution_pool: ThreadPoolExecutor
+
+    def __post_init__(self) -> None:
+        self.default_active_threads = set()
+        self.realtime_active_threads = set()
+
+    def submit_to_default_pool(self, consume_message_fn, delivery_tag, body):
+        task_future = self.default_execution_pool.submit(
+            consume_message_fn, delivery_tag, body
+        )
+        self.default_active_threads.add(task_future)
+        task_future.add_done_callback(self.default_active_threads.remove)
+        return task_future
+
+    def submit_to_realtime_pool(self, consume_message_fn, delivery_tag, body):
+        task_future = self.realtime_execution_pool.submit(
+            consume_message_fn, delivery_tag, body
+        )
+        self.realtime_active_threads.add(task_future)
+        task_future.add_done_callback(self.realtime_active_threads.remove)
+        return task_future
+
+    def submit(self, is_realtime, consume_message_fn, delivery_tag, body):
+        if is_realtime:
+            if (
+                len(self.default_active_threads) <= self.default_pool_size
+                and len(self.realtime_active_threads) > self.realtime_pool_size
+            ):
+                return self.submit_to_default_pool(
+                    consume_message_fn, delivery_tag, body
+                )
+            else:
+                return self.submit_to_realtime_pool(
+                    consume_message_fn, delivery_tag, body
+                )
+        else:
+            if (
+                len(self.realtime_active_threads) <= self.realtime_pool_size
+                and len(self.default_active_threads) > self.default_pool_size
+            ):
+                return self.submit_to_realtime_pool(
+                    consume_message_fn, delivery_tag, body
+                )
+            else:
+                return self.submit_to_default_pool(
+                    consume_message_fn, delivery_tag, body
+                )

--- a/opencti-worker/src/thread_pool_selector.py
+++ b/opencti-worker/src/thread_pool_selector.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
 import threading
-from typing import Any, Callable
+from typing import Callable
 
 
 @dataclass(unsafe_hash=True)
@@ -24,21 +24,21 @@ class ThreadPoolSelector:  # pylint: disable=too-many-instance-attributes
         with self.count_lock:
             self.realtime_active_threads_count -= 1
 
-    def submit_to_default_pool(self, consume_message_fn):
+    def submit_to_default_pool(self, consume_message_fn: Callable[[], None]):
         task_future = self.default_execution_pool.submit(consume_message_fn)
         with self.count_lock:
             self.default_active_threads_count += 1
         task_future.add_done_callback(self.decrement_default_count)
         return task_future
 
-    def submit_to_realtime_pool(self, consume_message_fn):
+    def submit_to_realtime_pool(self, consume_message_fn: Callable[[], None]):
         task_future = self.realtime_execution_pool.submit(consume_message_fn)
         with self.count_lock:
             self.realtime_active_threads_count += 1
         task_future.add_done_callback(self.decrement_realtime_count)
         return task_future
 
-    def submit(self, is_realtime, consume_message_fn):
+    def submit(self, is_realtime: bool, consume_message_fn: Callable[[], None]):
         is_default_pool_full = (
             self.default_active_threads_count >= self.default_pool_size
         )

--- a/opencti-worker/src/thread_pool_selector.py
+++ b/opencti-worker/src/thread_pool_selector.py
@@ -33,9 +33,9 @@ class ThreadPoolSelector:  # pylint: disable=too-many-instance-attributes
         task_future.add_done_callback(self.decrement_default_count)
         return task_future
 
-    def submit_to_realtime_pool(self, consume_message_fn, delivery_tag, body):
+    def submit_to_realtime_pool(self, fn: Callable[..., Any], *args: Any, **kwargs: Any):
         task_future = self.realtime_execution_pool.submit(
-            consume_message_fn, delivery_tag, body
+            fn, args, kwargs
         )
         with self.count_lock:
             self.realtime_active_threads_count += 1

--- a/opencti-worker/src/thread_pool_selector.py
+++ b/opencti-worker/src/thread_pool_selector.py
@@ -33,10 +33,10 @@ class ThreadPoolSelector:  # pylint: disable=too-many-instance-attributes
         task_future.add_done_callback(self.decrement_default_count)
         return task_future
 
-    def submit_to_realtime_pool(self, fn: Callable[..., Any], *args: Any, **kwargs: Any):
-        task_future = self.realtime_execution_pool.submit(
-            fn, args, kwargs
-        )
+    def submit_to_realtime_pool(
+        self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+    ):
+        task_future = self.realtime_execution_pool.submit(fn, args, kwargs)
         with self.count_lock:
             self.realtime_active_threads_count += 1
         task_future.add_done_callback(self.decrement_realtime_count)

--- a/opencti-worker/src/thread_pool_selector.py
+++ b/opencti-worker/src/thread_pool_selector.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor
 
-from numpy import number
-
 
 @dataclass(unsafe_hash=True)
 class ThreadPoolSelector:  # pylint: disable=too-many-instance-attributes

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -182,7 +182,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
         self.worker_logger = self.api.logger_class("worker")
 
     def build_pika_parameters(
-            self, connector_config: Dict[str, Any]
+        self, connector_config: Dict[str, Any]
     ) -> pika.ConnectionParameters:
         ssl_options = None
         if connector_config["connection"]["use_ssl"]:
@@ -234,7 +234,9 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                 # Telemetry
                 max_ingestion_units_count.set(self.opencti_pool_size)
                 running_ingestion_units_gauge.set(
-                    len(push_execution_pool._threads) + len(realtime_push_execution_pool._threads))
+                    len(push_execution_pool._threads)
+                    + len(realtime_push_execution_pool._threads)
+                )
 
                 # Fetch queue configuration from API
                 queues: List[Any] = []
@@ -272,10 +274,16 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             bundles_processing_time_gauge,
                             self.objects_max_refs,
                         )
-                        is_realtime = is_priority_connector(connector["connector_priority_group"])
+                        is_realtime = is_priority_connector(
+                            connector["connector_priority_group"]
+                        )
 
-                        def selector_submit_consume(consume_message_fn, delivery_tag, body):
-                            return push_thread_pool_selector.submit(is_realtime, consume_message_fn, delivery_tag, body)
+                        def selector_submit_consume(
+                            consume_message_fn, delivery_tag, body
+                        ):
+                            return push_thread_pool_selector.submit(
+                                is_realtime, consume_message_fn, delivery_tag, body
+                            )
 
                         self.consumers[push_queue] = MessageQueueConsumer(
                             self.worker_logger,
@@ -284,7 +292,6 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             pika_parameters,
                             selector_submit_consume,
                             push_handler.handle_message,
-                            is_realtime
                         )
 
                     # Listen for webhook message
@@ -330,10 +337,8 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
 if __name__ == "__main__":
     worker: Worker = Worker()
 
-
     def exit_handler(_signum, _frame):
         worker.stop()
-
 
     signal.signal(signal.SIGINT, exit_handler)
     signal.signal(signal.SIGTERM, exit_handler)

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -278,11 +278,9 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             connector["connector_priority_group"]
                         )
 
-                        def selector_submit_consume(
-                            consume_message_fn, delivery_tag, body
-                        ):
+                        def selector_submit_consume(consume_message_fn):
                             return push_thread_pool_selector.submit(
-                                is_realtime, consume_message_fn, delivery_tag, body
+                                is_realtime, consume_message_fn
                             )
 
                         self.consumers[push_queue] = MessageQueueConsumer(

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -271,8 +271,9 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             bundles_processing_time_gauge,
                             self.objects_max_refs,
                         )
+                        is_realtime = False
                         if is_priority_connector(connector["connector_priority_group"]):
-                            execution_pool = realtime_push_execution_pool
+                            is_realtime = True
                         self.consumers[push_queue] = MessageQueueConsumer(
                             self.worker_logger,
                             "push",
@@ -280,6 +281,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
                             pika_parameters,
                             push_thread_pool_selector,
                             push_handler.handle_message,
+                            is_realtime
                         )
 
                     # Listen for webhook message


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* to keep total workers count low, but keep realtime connector priority handling, a new thread pool selector is added. The selector enables realtime work to run on default pool if no default work is ongoing, or enables default work to run on realtime pool if no realtime work is ongoing
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
