### PR TITLE
[frontend] Open draft imported files in new tab (11840)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/import/ImportFilesContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ImportFilesContent.tsx
@@ -220,7 +220,7 @@ const ImportFilesContent = ({ inDraftOverview }: ImportFilesContentProps) => {
             const { id, metaData, uploadStatus } = file;
             const isProgress = uploadStatus === 'progress' || uploadStatus === 'wait';
             if (!isProgress && !(metaData?.errors && metaData?.errors.length > 0)) {
-              window.location.pathname = getFileUri(id);
+              window.open(getFileUri(id), '_blank', 'noopener');
             }
           }}
           createButton={<UploadImport variant="contained"/>}

--- a/opencti-platform/opencti-front/src/private/components/data/import/ImportFilesContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ImportFilesContent.tsx
@@ -220,7 +220,7 @@ const ImportFilesContent = ({ inDraftOverview }: ImportFilesContentProps) => {
             const { id, metaData, uploadStatus } = file;
             const isProgress = uploadStatus === 'progress' || uploadStatus === 'wait';
             if (!isProgress && !(metaData?.errors && metaData?.errors.length > 0)) {
-              window.open(getFileUri(id), '_blank', 'noopener');
+              window.open(getFileUri(id), '_blank', 'noreferrer');
             }
           }}
           createButton={<UploadImport variant="contained"/>}


### PR DESCRIPTION
Use case

Drafts : At the moment when users upload new files (E.g. PDF, JSON, TXT) to OpenCTI, after the document is uploaded, the import will appear on the screen, in the relevant import page, as per below. When users click on the imported file to view it, the file opens on the ‘working’ tab and the OpenCTI application is momentarily inactive. To bring the OpenCTI tab back, users are required to press the browser "back" button.

### Proposed changes
- Open draft imported files in new tab instead of the current window.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11840

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

