### PR TITLE
[frontend] fix dot on marking when limit is setted (#12090)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemMarkings.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemMarkings.tsx
@@ -171,7 +171,7 @@ const ItemMarkings = ({
     >
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <Badge
-          variant="dot"
+          variant={markings.length > limit ? 'dot' : 'standard'}
           color="primary"
           sx={{
             '& .MuiBadge-badge': {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* display dot on Marking only when length is over limit props
* Ex: In a report knowledge graph 
- 3 markings with limit at 2
<img width="801" height="229" alt="image" src="https://github.com/user-attachments/assets/84a6d58f-032b-41ab-a652-efcccc0677ec" />
- 2 marking with limit at 2
<img width="801" height="229" alt="image" src="https://github.com/user-attachments/assets/563d02c3-6162-4f53-84a4-44c280610ebc" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12090

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
