### PR TITLE
Revert "[frontend] Can't create support package while in draft mode (#12246)"

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "Zusammenfassung des Berichts",
   "Sunday": "Sonntag",
   "support package": "unterstützungspaket",
-  "support package when out of draft": "unterstützungspaket, wenn der Entwurf nicht vorliegt",
   "Support packages": "Unterstützungspakete",
   "Support Packages | Settings": "Support-Pakete | Einstellungen",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "Summary of the report",
   "Sunday": "Sunday",
   "support package": "support package",
-  "support package when out of draft": "support package when out of draft",
   "Support packages": "Support packages",
   "Support Packages | Settings": "Support Packages | Settings",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "Resumen del informe",
   "Sunday": "Domingo",
   "support package": "paquete de apoyo",
-  "support package when out of draft": "paquete de apoyo cuando se está fuera de servicio",
   "Support packages": "Paquetes de soporte",
   "Support Packages | Settings": "Paquetes de asistencia | Configuración",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "Résumé du rapport",
   "Sunday": "Dimanche",
   "support package": "paquet de support",
-  "support package when out of draft": "paquet de soutien en cas d'absence de projet",
   "Support packages": "Paquets de support",
   "Support Packages | Settings": "Packs Support | Paramètres",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "Riassunto del report",
   "Sunday": "Domenica",
   "support package": "packages di supporto",
-  "support package when out of draft": "pacchetto di supporto quando si è fuori dal progetto",
   "Support packages": "Packages di supporto",
   "Support Packages | Settings": "Packages di supporto | Impostazioni",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "レポートのまとめ",
   "Sunday": "日曜日",
   "support package": "サポートパッケージ",
-  "support package when out of draft": "ドラフト外でのサポートパッケージ",
   "Support packages": "サポートパッケージ",
   "Support Packages | Settings": "設定",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "보고서 요약",
   "Sunday": "일요일",
   "support package": "지원 패키지",
-  "support package when out of draft": "초안이 없을 때 지원 패키지",
   "Support packages": "지원 패키지",
   "Support Packages | Settings": "지원 패키지 | 설정",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "Краткое содержание доклада",
   "Sunday": "Воскресенье",
   "support package": "пакет поддержки",
-  "support package when out of draft": "пакет поддержки при увольнении из армии",
   "Support packages": "Пакеты поддержки",
   "Support Packages | Settings": "Пакеты поддержки | Настройки",
   "suricata": "суриката",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3613,7 +3613,6 @@
   "Summary of the report": "报告摘要",
   "Sunday": "星期日",
   "support package": "支持包",
-  "support package when out of draft": "退役时的一揽子支援计划",
   "Support packages": "支持软件包",
   "Support Packages | Settings": "支持包|设置",
   "suricata": "Suricata",

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -9,7 +9,6 @@ import ErrorNotFound from '../../components/ErrorNotFound';
 import { useFormatter } from '../../components/i18n';
 import { commitMutation } from '../../relay/environment';
 import withRouter from '../../utils/compat_router/withRouter';
-import useDraftContext from '../../utils/hooks/useDraftContext';
 
 // Highest level of error catching, do not rely on any tierce (intl, theme, ...) pure fallback
 export const HighLevelError = () => (
@@ -19,8 +18,6 @@ export const HighLevelError = () => (
 // Really simple error display
 export const SimpleError = () => {
   const { t_i18n } = useFormatter();
-  const draftContext = useDraftContext();
-  const disabledInDraft = !!draftContext;
 
   return (
     <div style={{ paddingTop: 10 }}>
@@ -30,7 +27,7 @@ export const SimpleError = () => {
             '',
             {
               id: 'An unknown error occurred. Please provide a support package to your administrator or OpenCTI maintainers',
-              values: { link_support_package: disabledInDraft ? t_i18n('support package when out of draft') : <Link to="/dashboard/settings/experience">{t_i18n('support package')}</Link> },
+              values: { link_support_package: <Link to="/dashboard/settings/experience">{t_i18n('support package')}</Link> },
             },
           )}
         </span>


### PR DESCRIPTION
This reverts commit 18b8b6ec2672c8b46bb48c28e6af8f2ab7f38bca.

### Proposed changes

* We cannot call `useDraftContext` in component Error. This hook need an authenticated user, which is not compatible with public dashboards.

### Related issues

* #12969

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality