### PR TITLE
[backend] xtm-hub: add configuration to disable connectivity email notifications (#12988)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -233,7 +233,8 @@
     "opengrc_url": "",
     "opengrc_token": "",
     "xtmhub_url": "https://hub.filigran.io",
-    "xtmhub_to_email": "no-reply@filigran.io"
+    "xtmhub_to_email": "no-reply@filigran.io",
+    "xtmhub_connectivity_email_enabled": true
   },
   "data_sharing": {
     "max_csv_feed_result": 5000

--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -5,7 +5,7 @@ import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
 import { type AutoRegisterInput, XtmHubRegistrationStatus } from '../generated/graphql';
 import { updateAttribute } from '../database/middleware';
-import { BUS_TOPICS, PLATFORM_VERSION } from '../config/conf';
+import { booleanConf, BUS_TOPICS, PLATFORM_VERSION } from '../config/conf';
 import { HUB_REGISTRATION_MANAGER_USER } from '../utils/access';
 import { getSettings, settingsEditField } from './settings';
 import { notify } from '../database/redis';
@@ -33,9 +33,11 @@ export const checkXTMHubConnectivity = async (context: AuthContext, user: AuthUs
 
   const lastCheckDate = utcDate(settings.xtm_hub_last_connectivity_check);
   const are24HoursPassed = utcDate().diff(lastCheckDate, 'hours') >= 24;
+  const isEmailEnabled = booleanConf('xtm:xtmhub_connectivity_email_enabled', true);
   const shouldSendLostConnectivityEmail = !isConnectivityActive
     && are24HoursPassed
-    && settings.xtm_hub_should_send_connectivity_email;
+    && settings.xtm_hub_should_send_connectivity_email
+    && isEmailEnabled;
   if (shouldSendLostConnectivityEmail) {
     await sendAdministratorsLostConnectivityEmail(context, settings);
     attributeUpdates.push({ key: 'xtm_hub_should_send_connectivity_email', value: [false] });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/xtm-hub-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/xtm-hub-test.ts
@@ -13,6 +13,7 @@ import * as settingsModule from '../../../src/domain/settings';
 import * as redisModule from '../../../src/database/redis';
 import * as xtmHubEmail from '../../../src/modules/xtm/hub/xtm-hub-email';
 import * as licensingModule from '../../../src/modules/settings/licensing';
+import * as conf from '../../../src/config/conf';
 
 describe('XTM hub', () => {
   describe('checkXTMHubConnectivity', () => {
@@ -222,6 +223,23 @@ describe('XTM hub', () => {
         };
         getEntityFromCacheSpy.mockResolvedValue(settings);
         xtmHubClientRefreshStatusSpy.mockResolvedValue('active');
+
+        await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(sendAdministratorsLostConnectivityEmailSpy).not.toBeCalled();
+      });
+
+      it('should not send connectivity email when email sending is disabled via configuration', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.LostConnectivity,
+          xtm_hub_last_connectivity_check: new Date(new Date().getTime() - 1000 * 60 * 60 * 24),
+          xtm_hub_should_send_connectivity_email: true,
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientRefreshStatusSpy.mockResolvedValue('inactive');
+        vi.spyOn(conf, 'booleanConf').mockReturnValue(false);
 
         await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
 


### PR DESCRIPTION
### Proposed changes

* Add environment variable `xtmhub_connectivity_email_enabled` to control Hub connectivity lost email notifications
* Modify `checkXTMHubConnectivity()` to check configuration before sending emails
* Add unit test to verify emails are not sent when configuration is disabled
* Keep connectivity check and UI status display active regardless of email configuration

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/12988
* https://github.com/FiligranHQ/xtm-hub/issues/1175

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

**Context:**
On demo instances that are reset daily, the Hub connectivity check fails regularly because the registration state becomes invalid after each reset. This triggers automated emails to administrators every 24 hours, causing email spam.

**Solution:**
This PR adds a new environment variable `OPENCTI__XTM__XTMHUB_CONNECTIVITY_EMAIL_ENABLED` (default: `true`) to control email notifications while keeping all other functionality intact:

✅ **What continues to work:**
- Hub connectivity check runs every hour (via `hub_registration_manager`)
- Connection status is updated in the database
- Status remains visible in the UI
- Connectivity restoration triggers re-enable email notifications

❌ **What can be disabled:**
- Email notifications to administrators when connectivity is lost

**Usage for demo instances:**
Set environment variable: `OPENCTI__XTM__XTMHUB_CONNECTIVITY_EMAIL_ENABLED=false`

**Files changed:**
- `config/default.json` - Added configuration with default value `true`
- `src/domain/xtm-hub.ts` - Added configuration check before sending emails
- `tests/01-unit/domain/xtm-hub-test.ts` - Added test case for disabled emails scenario

**Backward compatibility:**
The default value is `true`, preserving the current behavior for all existing instances. Only instances that explicitly set the variable to `false` will have emails disabled.

**Testing:**
Added unit test `should not send connectivity email when email sending is disabled via configuration` that verifies:
- When configuration is set to `false`
- And all other conditions for sending email are met (24h passed, connectivity lost, settings flag true)
- Then no email is sent and no settings update occurs
