### PR TITLE
[backend] fix elPaginate hasNextPage compute when elements are post filtered (#11885)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.js
+++ b/opencti-platform/opencti-graphql/src/database/engine.js
@@ -3865,10 +3865,10 @@ const buildRegardingOfFilter = async (context, user, elements, filters) => {
   return undefined;
 };
 
-const buildSearchResult = (elements, first, searchAfter, globalCount, connectionFormat) => {
+const buildSearchResult = (elements, first, searchAfter, globalCount, filterCount, connectionFormat) => {
   if (connectionFormat) {
     const nodeHits = elements.map((n) => ({ node: n, sort: n.sort, types: n.regardingOfTypes }));
-    return buildPagination(first, searchAfter, nodeHits, globalCount);
+    return buildPagination(first, searchAfter, nodeHits, globalCount, filterCount);
   }
   return elements;
 };
@@ -3910,11 +3910,11 @@ export const elPaginate = async (context, user, indexName, options = {}) => {
     // If filters contains an "in regards of" filter a post-security filtering is needed
     const regardingOfFilter = elements.length === 0 ? undefined : await buildRegardingOfFilter(context, user, elements, filters);
     const filteredElements = regardingOfFilter ? await asyncFilter(elements, regardingOfFilter) : elements;
-    const result = buildSearchResult(filteredElements, first, body.search_after, globalCount, connectionFormat);
+    const filterCount = elements.length - filteredElements.length;
+    const result = buildSearchResult(filteredElements, first, body.search_after, globalCount, filterCount, connectionFormat);
     if (withResultMeta) {
       const lastProcessedSort = R.last(elements)?.sort;
       const endCursor = lastProcessedSort ? offsetToCursor(lastProcessedSort) : null;
-      const filterCount = elements.length - filteredElements.length;
       return { elements: result, endCursor, total: globalCount, filterCount };
     }
     return result;

--- a/opencti-platform/opencti-graphql/src/database/utils.js
+++ b/opencti-platform/opencti-graphql/src/database/utils.js
@@ -249,10 +249,10 @@ export const emptyPaginationResult = () => {
   };
 };
 
-export const buildPaginationFromEdges = (limit, searchAfter, edges, globalCount) => {
+export const buildPaginationFromEdges = (limit, searchAfter, edges, globalCount, filteredCount = 0) => {
   // Because of stateless approach its difficult to know if its finish
   // this test could lead to an extra round trip sometimes
-  const hasNextPage = edges.length === limit;
+  const hasNextPage = (edges.length + filteredCount) === limit;
   // For same reason its difficult to know if a previous page exists.
   // Considering for now that if user specific an offset, it should exists a previous page.
   const hasPreviousPage = searchAfter !== undefined && searchAfter !== null;
@@ -268,14 +268,14 @@ export const buildPaginationFromEdges = (limit, searchAfter, edges, globalCount)
   return { edges, pageInfo };
 };
 
-export const buildPagination = (limit, searchAfter, instances, globalCount) => {
+export const buildPagination = (limit, searchAfter, instances, globalCount, filteredCount = 0) => {
   // TODO Make this transformation async
   const edges = instances.map((record) => {
     const { node, sort, types } = record;
     const cursor = sort ? offsetToCursor(sort) : '';
     return { node, cursor, types };
   });
-  return buildPaginationFromEdges(limit, searchAfter, edges, globalCount);
+  return buildPaginationFromEdges(limit, searchAfter, edges, globalCount, filteredCount);
 };
 
 export const inferIndexFromConceptType = (conceptType, inferred = false) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* reverted change on hasNextPage compute from https://github.com/OpenCTI-Platform/opencti/pull/12325
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #11885
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

The hasNextPage value was incorrect as soon as an element was post filtered: to check if there is a nextPage, we verified that the postFilteredElements count was equal to the query size. But if an element is post filtered, this condition can never be met

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
