### PR TITLE
[frontend] Date is missing in timeline widget (#12987)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
@@ -40,7 +40,7 @@ const WidgetTimeline = ({ data }: WidgetTimelineProps) => {
                 sx={{ paddingTop: '18px' }}
                 color="text.secondary"
               >
-                {fldt(value.created)}
+                {fldt(value.created_at)}
               </TimelineOppositeContent>
               <TimelineSeparator>
                 {link ? (


### PR DESCRIPTION
### Proposed changes
- Add creation date in timeline widget display

Before:
<img width="1660" height="727" alt="image" src="https://github.com/user-attachments/assets/7817abf6-14dd-4a2f-a50d-6aeb0619f357" />


After: 
<img width="1685" height="755" alt="image" src="https://github.com/user-attachments/assets/729a0b1e-e16e-43ff-a71b-11f403adb371" />


### Related issues
#12987 