### PR TITLE
[frontend] Can't create support package while in draft mode (#12246)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "Sie können Ihre Plattform so konfigurieren, dass sie OpenCTI-Streams konsumieren kann. Eine Liste öffentlicher und kommerzieller nativer Feeds finden Sie in der",
   "You can enable/disable default values for marking in the customization of each entity type.": "Sie können in der Anpassung jedes Entitätstyps Standardwerte für die Markierung aktivieren/deaktivieren.",
   "You can now set a new password for your account.": "Sie können nun ein neues Passwort für Ihr Konto festlegen.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "Im Entwurfsmodus können Sie kein Support-Paket erstellen. Vergewissern Sie sich, dass Sie sich nicht im Entwurfsmodus befinden, um ein Paket zu erstellen.",
   "You cannot have more than 500 e-mail addresses": "Sie können nicht mehr als 500 E-Mail-Adressen haben",
   "You currently do not have any connector manager registered into your platform.": "Sie haben derzeit keinen Verbindungsmanager in Ihrer Plattform registriert.",
   "You do not have any access to support packages of this OpenCTI instance.": "Sie haben keinen Zugriff auf die Support-Pakete dieser OpenCTI-Instanz.",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the",
   "You can enable/disable default values for marking in the customization of each entity type.": "You can enable/disable default values for marking in the customization of each entity type.",
   "You can now set a new password for your account.": "You can now set a new password for your account.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.",
   "You cannot have more than 500 e-mail addresses": "You cannot have more than 500 e-mail addresses",
   "You currently do not have any connector manager registered into your platform.": "You currently do not have any connector manager registered into your platform.",
   "You do not have any access to support packages of this OpenCTI instance.": "You do not have any access to support packages of this OpenCTI instance.",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "Puede configurar su plataforma para consumir OpenCTI Streams. Una lista de feeds nativos públicos y comerciales está disponible en la sección",
   "You can enable/disable default values for marking in the customization of each entity type.": "Puede activar/desactivar los valores por defecto para el marcado en la personalización de cada tipo de entidad.",
   "You can now set a new password for your account.": "Ya puedes establecer una nueva contraseña para tu cuenta.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "No se puede generar un paquete de soporte mientras se está en modo borrador. Asegúrate de estar fuera de borrador para generar uno.",
   "You cannot have more than 500 e-mail addresses": "No puede tener más de 500 direcciones de correo electrónico",
   "You currently do not have any connector manager registered into your platform.": "Actualmente no tienes ningún gestor de conectores registrado en tu plataforma.",
   "You do not have any access to support packages of this OpenCTI instance.": "No tiene acceso a los paquetes de soporte de esta instancia de OpenCTI.",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "Vous pouvez configurer votre plateforme pour consommer les flux OpenCTI. Une liste de flux natifs publics et commerciaux est disponible dans la section",
   "You can enable/disable default values for marking in the customization of each entity type.": "Vous pouvez activer/désactiver les valeurs par défaut pour le marquage dans la personnalisation de chaque type d'entité.",
   "You can now set a new password for your account.": "Vous pouvez maintenant définir un nouveau mot de passe pour votre compte.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "Vous ne pouvez pas générer de dossier de soutien lorsque vous êtes en mode brouillon. Assurez-vous de ne pas être en mode brouillon pour en générer un.",
   "You cannot have more than 500 e-mail addresses": "Vous ne pouvez pas avoir plus de 500 adresses électroniques",
   "You currently do not have any connector manager registered into your platform.": "Vous n'avez actuellement aucun gestionnaire de connecteur enregistré dans votre plateforme.",
   "You do not have any access to support packages of this OpenCTI instance.": "Vous n'avez pas accès au support de cette instance OpenCTI.",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "Puoi configurare la tua piattaforma per consumare gli OpenCTI Streams. Un elenco di feed pubblici e commerciali nativi è disponibile nel",
   "You can enable/disable default values for marking in the customization of each entity type.": "Puoi abilitare/disabilitare i valori predefiniti per la marcatura nella personalizzazione di ogni tipo di entità.",
   "You can now set a new password for your account.": "È ora possibile impostare una nuova password per il proprio account.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "Non è possibile generare un pacchetto di supporto mentre si è in modalità bozza. Assicuratevi di essere fuori dalla bozza per generarne uno.",
   "You cannot have more than 500 e-mail addresses": "Non puoi avere più di 500 indirizzi e-mail",
   "You currently do not have any connector manager registered into your platform.": "Al momento non è stato registrato alcun gestore di connettori nella piattaforma.",
   "You do not have any access to support packages of this OpenCTI instance.": "Non avete accesso ai pacchetti di supporto di questa istanza OpenCTI.",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "OpenCTIストリームを消費するようにプラットフォームを設定することができます。公開および商用ネイティブフィードのリストは",
   "You can enable/disable default values for marking in the customization of each entity type.": "各エンティティ・タイプのカスタマイズで、マーキングのデフォルト値の有効/無効を設定できます。",
   "You can now set a new password for your account.": "アカウントの新しいパスワードを設定できます。",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "ドラフトモードではサポートパッケージを作成できません。サポートパッケージを生成するには、ドラフトモードを解除してください。",
   "You cannot have more than 500 e-mail addresses": "500を超える電子メールアドレスを持つことはできません。",
   "You currently do not have any connector manager registered into your platform.": "現在、お客様のプラットフォームにはコネクタ・マネージャが登録されていません。",
   "You do not have any access to support packages of this OpenCTI instance.": "この OpenCTI インスタンスのサポートパッケージにはアクセスできません。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "OpenCTI 스트림을 사용하도록 플랫폼을 구성할 수 있습니다. 공개 및 상업용 네이티브 피드 목록은",
   "You can enable/disable default values for marking in the customization of each entity type.": "각 엔터티 유형의 맞춤 설정에서 마킹의 기본값을 활성화/비활성화할 수 있습니다.",
   "You can now set a new password for your account.": "이제 계정에 새 비밀번호를 설정할 수 있습니다.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "초안 모드에서는 지원 패키지를 생성할 수 없습니다. 초안을 생성하려면 초안 모드에서 벗어나야 합니다.",
   "You cannot have more than 500 e-mail addresses": "이메일 주소는 500개 이상 보유할 수 없습니다",
   "You currently do not have any connector manager registered into your platform.": "현재 플랫폼에 등록된 커넥터 관리자가 없습니다.",
   "You do not have any access to support packages of this OpenCTI instance.": "이 OpenCTI 인스턴스의 지원 패키지에 대한 액세스 권한이 없습니다.",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "Вы можете настроить свою платформу на потребление потоков OpenCTI. Список публичных и коммерческих нативных потоков доступен в разделе",
   "You can enable/disable default values for marking in the customization of each entity type.": "Вы можете включить/отключить значения по умолчанию для маркировки в настройке каждого типа сущности.",
   "You can now set a new password for your account.": "Теперь вы можете установить новый пароль для своей учетной записи.",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "Вы не можете сгенерировать пакет поддержки, находясь в режиме черновика. Чтобы сгенерировать пакет поддержки, необходимо выйти из режима черновика.",
   "You cannot have more than 500 e-mail addresses": "У вас не может быть более 500 адресов электронной почты",
   "You currently do not have any connector manager registered into your platform.": "В настоящее время в вашей платформе не зарегистрирован ни один менеджер коннекторов.",
   "You do not have any access to support packages of this OpenCTI instance.": "У вас нет доступа к пакетам поддержки этого экземпляра OpenCTI.",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -4379,6 +4379,7 @@
   "You can configure your platform to consume OpenCTI Streams. A list of public and commercial native feeds is available in the": "您可以对平台进行配置，以便使用 OpenCTI 流。公共和商业原生信息源列表可在",
   "You can enable/disable default values for marking in the customization of each entity type.": "您可以在定制每个实体类型时启用/禁用标记的默认值。",
   "You can now set a new password for your account.": "现在您可以为账户设置新密码了。",
+  "You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.": "在草稿模式下无法生成支持软件包。请确保在草稿模式下生成支持软件包。",
   "You cannot have more than 500 e-mail addresses": "电子邮件地址不能超过 500 个",
   "You currently do not have any connector manager registered into your platform.": "您目前没有在平台上注册任何连接器管理器。",
   "You do not have any access to support packages of this OpenCTI instance.": "您没有访问此 OpenCTI 实例支持包的权限。",

--- a/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackages.tsx
@@ -18,6 +18,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import ListLines from '../../../../components/list_lines/ListLines';
 import { insertNode } from '../../../../utils/store';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
 
 const LOCAL_STORAGE_KEY = 'support-packages';
 
@@ -36,6 +37,8 @@ export const supportPackageAddMutation = graphql`
 
 const SupportPackages = () => {
   const { t_i18n, nsdt } = useFormatter();
+  const draftContext = useDraftContext();
+  const disabledInDraft = !!draftContext;
   const [commitSupportPackageAdd] = useApiMutation(supportPackageAddMutation);
   const { viewStorage, helpers, paginationOptions } = usePaginationLocalStorage<SupportPackageLinesPaginationQuery$variables>(
     LOCAL_STORAGE_KEY,
@@ -123,25 +126,34 @@ const SupportPackages = () => {
       <Typography variant="h4" gutterBottom={true}>
         {t_i18n('Support packages')}
       </Typography>
-      <Tooltip title={
-        <Alert
-          severity="warning"
-          variant="outlined"
-          style={{ position: 'relative', marginTop: 20, marginBottom: 20 }}
-        >
-          {t_i18n('We are doing our best to remove any sensitive information from support packages but we encourage you to check the content before sharing a support package depending on your security policy.')}
-        </Alert>
-        }
+      <Tooltip title={disabledInDraft
+        ? <Alert
+            severity="warning"
+            variant="outlined"
+            style={{ position: 'relative', marginTop: 20, marginBottom: 20 }}
+          >
+          {t_i18n('You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.')}
+        </Alert> : (
+          <Alert
+            severity="warning"
+            variant="outlined"
+            style={{ position: 'relative', marginTop: 20, marginBottom: 20 }}
+          >
+            {t_i18n('We are doing our best to remove any sensitive information from support packages but we encourage you to check the content before sharing a support package depending on your security policy.')}
+          </Alert>
+        )}
       >
-        <Button
-          style={{ float: 'right', marginTop: '-34px' }}
-          onClick={generateSupportPackage}
-          size="small"
-          variant="outlined"
-          color="primary"
-        >
-          {t_i18n('Generate Support Package')}
-        </Button>
+        <span style={{ float: 'right', marginTop: '-34px', display: 'inline-block' }}>
+          <Button
+            onClick={generateSupportPackage}
+            size="small"
+            variant="outlined"
+            color="primary"
+            disabled={disabledInDraft}
+          >
+            {t_i18n('Generate Support Package')}
+          </Button>
+        </span>
       </Tooltip>
       <div className="clearfix"/>
       <Paper className="paper-for-grid" variant="outlined" sx={{

--- a/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackages.tsx
@@ -126,22 +126,17 @@ const SupportPackages = () => {
       <Typography variant="h4" gutterBottom={true}>
         {t_i18n('Support packages')}
       </Typography>
-      <Tooltip title={disabledInDraft
-        ? <Alert
-            severity="warning"
-            variant="outlined"
-            style={{ position: 'relative', marginTop: 20, marginBottom: 20 }}
-          >
-          {t_i18n('You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.')}
-        </Alert> : (
-          <Alert
-            severity="warning"
-            variant="outlined"
-            style={{ position: 'relative', marginTop: 20, marginBottom: 20 }}
-          >
-            {t_i18n('We are doing our best to remove any sensitive information from support packages but we encourage you to check the content before sharing a support package depending on your security policy.')}
-          </Alert>
-        )}
+      <Tooltip title={
+        <Alert
+          severity="warning"
+          variant="outlined"
+          style={{ position: 'relative', marginTop: 20, marginBottom: 20 }}
+        >
+          {disabledInDraft
+            ? t_i18n('You cannot generate a support package while in draft mode. Make sure to be out of draft to generate one.')
+            : t_i18n('We are doing our best to remove any sensitive information from support packages but we encourage you to check the content before sharing a support package depending on your security policy.')}
+        </Alert>
+        }
       >
         <span style={{ float: 'right', marginTop: '-34px', display: 'inline-block' }}>
           <Button


### PR DESCRIPTION
### Proposed changes

* Change the method to explain user that it's not possible to generate a support package while in draft. It was checked before in the Error component with the useDraftContext, but the useDraftContext using the useAuth it created a conflict for public dashboards.
I've decided to disable the button to generate a support package instead with an alert to explain why.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/12246