### PR TITLE
[backend] fix undefined user on public query (#12142)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
@@ -48,6 +48,7 @@ import { ES_MAX_CONCURRENCY } from '../../database/engine';
 import { findById as findMarkingDefinitionById } from '../../domain/markingDefinition';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { fromB64, toB64 } from '../../utils/base64';
+import { computeLoaders } from '../../http/httpAuthenticatedContext';
 
 export const findById = (
   context: AuthContext,
@@ -292,12 +293,19 @@ export const publicDashboardDelete = async (context: AuthContext, user: AuthUser
 };
 
 // region Widgets Public API
+const ensurePublicContext = async (context: AuthContext, uriKey: string, widgetId: string) => {
+  const { user, dataSelection, parameters } = await getWidgetArguments(context, uriKey, widgetId);
+  context.user = user;
+  context.user_inside_platform_organization = true;
+  context.batch = computeLoaders(context, user);
+
+  return { user, dataSelection, parameters };
+};
 
 // heatmap & vertical-bar & line & area
 export const publicStixCoreObjectsMultiTimeSeries = async (context: AuthContext, args: QueryPublicStixCoreObjectsMultiTimeSeriesArgs) => {
-  const { user, parameters, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection, parameters } = await ensurePublicContext(context, args.uriKey, args.widgetId);
+
   const timeSeriesParameters = dataSelection.map((selection) => {
     return { field: selection.date_attribute, filters: selection.filters };
   });
@@ -315,9 +323,7 @@ export const publicStixRelationshipsMultiTimeSeries = async (
   context: AuthContext,
   args: QueryPublicStixRelationshipsMultiTimeSeriesArgs,
 ) => {
-  const { user, parameters, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection, parameters } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const timeSeriesParameters = dataSelection.map((selection) => {
     const filters = {
@@ -348,9 +354,7 @@ export const publicStixCoreObjectsNumber = async (
   context: AuthContext,
   args: QueryPublicStixCoreObjectsNumberArgs
 ): Promise<NumberResult> => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const selection = dataSelection[0];
   const { filters } = selection;
@@ -373,9 +377,7 @@ export const publicStixRelationshipsNumber = async (
   context: AuthContext,
   args: QueryPublicStixRelationshipsNumberArgs
 ): Promise<NumberResult> => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const selection = dataSelection[0];
   const { filters } = selection;
@@ -398,9 +400,7 @@ export const publicStixCoreObjectsDistribution = async (
   context: AuthContext,
   args: QueryPublicStixCoreObjectsDistributionArgs
 ) => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const mainSelection = dataSelection[0];
   const breakdownSelection = dataSelection[1];
@@ -472,9 +472,7 @@ export const publicStixRelationshipsDistribution = async (
   context: AuthContext,
   args: QueryPublicStixRelationshipsDistributionArgs
 ) => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const mainSelection = dataSelection[0];
   const breakdownSelection = dataSelection[1];
@@ -567,9 +565,7 @@ export const publicBookmarks = async (
   context: AuthContext,
   args: QueryPublicBookmarksArgs
 ) => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const selection = dataSelection[0];
   const { filters } = selection;
@@ -587,9 +583,7 @@ export const publicStixCoreObjectsPaginated = async (
   context: AuthContext,
   args: QueryPublicStixCoreObjectsArgs
 ) => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user; // context.user is used in standard api
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const selection = dataSelection[0];
   const { filters } = selection;
@@ -614,9 +608,7 @@ export const publicStixRelationships = async (
   context: AuthContext,
   args: QueryPublicStixRelationshipsArgs
 ) => {
-  const { user, dataSelection } = await getWidgetArguments(context, args.uriKey, args.widgetId);
-  context.user = user;
-  context.user_inside_platform_organization = true;
+  const { user, dataSelection } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const selection = dataSelection[0];
   const { filters } = selection;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
The issue is some public dashboard widgets failed with cannot read properties of undefined because DataLoader are executing with user = undefined

The cause is because the user value is catpured in a closure when created in DataLoader.
```
  const dataLoader = new DataLoader(
    (elements) => {
      const elementsToLoad = elements.map((e) => e.elementToLoad);
      return loader(context, user, elementsToLoad);
    },
    { maxBatchSize: MAX_BATCH_SIZE, cache: false }
  );
 ```
 
So, in public dashboard queries, the loaders still references the user undefined from the middleware initialization from httpServer calling createAuthenticatedContext, which returns a user undefined.
 

### Proposed changes

* Recreate loaders with context.batch = computeLoaders(context, user) in each public dashboard query, to ensure DataLoaders uses the updated user value
* The impact should be minimal, since it only affects the public dashboard queries

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12142 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
