### PR TITLE
[backend] fix manual & auto enrichment (#13008)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -544,10 +544,10 @@ export const stixLoadByIds = async (context, user, ids, opts = {}) => {
 };
 export const stixBundleByIdStringify = async (context, user, type, id) => {
   const resolver = modules.get(type)?.bundleResolver;
-  if (resolver) {
-    return await resolver(context, user, id);
+  if (!resolver) {
+    return null;
   }
-  return null;
+  return await resolver(context, user, id);
 };
 
 export const stixLoadByIdStringify = async (context, user, id) => {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -544,8 +544,10 @@ export const stixLoadByIds = async (context, user, ids, opts = {}) => {
 };
 export const stixBundleByIdStringify = async (context, user, type, id) => {
   const resolver = modules.get(type)?.bundleResolver;
-  if (resolver) return await resolver(context, user, id);
-  throw UnsupportedError('No bundle resolver for type', { type });
+  if (resolver) {
+    return await resolver(context, user, id);
+  }
+  return null;
 };
 
 export const stixLoadByIdStringify = async (context, user, id) => {

--- a/opencti-platform/opencti-graphql/src/domain/enrichment.js
+++ b/opencti-platform/opencti-graphql/src/domain/enrichment.js
@@ -94,14 +94,10 @@ export const filterConnectorsForElementEnrichment = async (context, connectors, 
     const conn = activeConnectors[i];
     const scopeMatch = scope ? (conn.connector_scope ?? []).some((s) => s.toLowerCase() === scope.toLowerCase()) : true;
     let autoTrigger = false;
-    let connectorFiltersMatching = true;
-    if (conn.connector_trigger_filters) {
-      connectorFiltersMatching = await isStixMatchConnectorFilter(context, element, conn.connector_trigger_filters);
-    }
     if (mode === 'creation') {
-      autoTrigger = conn.auto && connectorFiltersMatching;
+      autoTrigger = conn.connector_trigger_filters ? await isStixMatchConnectorFilter(context, element, conn.connector_trigger_filters) : conn.auto === true;
     } else if (mode === 'update') {
-      autoTrigger = conn.auto_update && connectorFiltersMatching;
+      autoTrigger = conn.auto_update;
     }
     if (scopeMatch && autoTrigger) {
       targetConnectors.push(conn);

--- a/opencti-platform/opencti-graphql/src/domain/enrichment.js
+++ b/opencti-platform/opencti-graphql/src/domain/enrichment.js
@@ -94,12 +94,14 @@ export const filterConnectorsForElementEnrichment = async (context, connectors, 
     const conn = activeConnectors[i];
     const scopeMatch = scope ? (conn.connector_scope ?? []).some((s) => s.toLowerCase() === scope.toLowerCase()) : true;
     let autoTrigger = false;
+    let connectorFiltersMatching = true;
     if (conn.connector_trigger_filters) {
-      autoTrigger = await isStixMatchConnectorFilter(context, element, conn.connector_trigger_filters);
-    } else if (mode === 'creation') {
-      autoTrigger = conn.auto === true;
-    } else {
-      autoTrigger = conn.auto_update === true;
+      connectorFiltersMatching = await isStixMatchConnectorFilter(context, element, conn.connector_trigger_filters);
+    }
+    if (mode === 'creation') {
+      autoTrigger = conn.auto && connectorFiltersMatching;
+    } else if (mode === 'update') {
+      autoTrigger = conn.auto_update && connectorFiltersMatching;
     }
     if (scopeMatch && autoTrigger) {
       targetConnectors.push(conn);

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -329,7 +329,7 @@ export const askElementEnrichmentForConnectors = async (context, user, enrichedI
   const contextOutOfDraft = { ...context, draft_context: '' };
   let stix_objects;
   const workMessage = draftContext ? `Manual enrichment in draft ${draftContext}` : 'Manual enrichment';
-  const stix_entity = convertStoreToStix(element);
+  const stix_entity = JSON.stringify(convertStoreToStix(element));
   const works = [];
   for (let index = 0; index < connectors.length; index += 1) {
     const connector = connectors[index];

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -327,13 +327,16 @@ export const askElementEnrichmentForConnectors = async (context, user, enrichedI
   // If we are in a draft, specify it in work message and send draft_id in message
   const draftContext = getDraftContext(context, user);
   const contextOutOfDraft = { ...context, draft_context: '' };
-  const stix_objects = await stixBundleByIdStringify(context, user, element.entity_type, element.internal_id);
+  let stix_objects;
   const workMessage = draftContext ? `Manual enrichment in draft ${draftContext}` : 'Manual enrichment';
   const stix_entity = convertStoreToStix(element);
   const works = [];
   for (let index = 0; index < connectors.length; index += 1) {
     const connector = connectors[index];
     const stixResolutionMode = connector.enrichment_resolution ?? 'stix_bundle';
+    if (stixResolutionMode === 'stix_bundle' && stix_objects === undefined) {
+      stix_objects = await stixBundleByIdStringify(context, user, element.entity_type, element.internal_id);
+    }
     const work = await createWork(contextOutOfDraft, user, connector, workMessage, element.standard_id, { draftContext });
     const message = {
       internal: {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix an issue in askElementEnrichmentForConnectors with the introduction of stixBundleByIdStringify
* => now only compute stix_objects if required by the connector
* => now return null instead of throwing an error in stixBundleByIdStringify if no bundleResolver is defined for entity type
* fix an issue in filterConnectorsForElementEnrichment where autoTrigger could be computed to true even if connectors are not configured with auto_update = true
* => changed autoTrigger to match previous behavior

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13008
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
