### PR TITLE
[backend] Fix widget export with regardingOf filter (#13028)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-utils.ts
@@ -1,12 +1,12 @@
 import * as R from 'ramda';
 import type { AuthContext, AuthUser } from '../../types/user';
-import { isNotEmptyField } from '../../database/utils';
 import type { Filter, FilterGroup } from '../../generated/graphql';
 import type { BasicStoreObject } from '../../types/store';
 import { internalFindByIds } from '../../database/middleware-loader';
 import { INSTANCE_REGARDING_OF } from '../../utils/filtering/filtering-constants';
 import { isInternalId, isStixId } from '../../schema/schemaUtils';
 import { idsValuesRemap } from '../../database/stix-2-1-converter';
+import { isFilterGroupNotEmpty } from '../../utils/filtering/filtering-utils';
 
 // workspace ids converter_2_1
 // Export => Dashboard filter ids must be converted to standard id
@@ -65,37 +65,37 @@ const replaceFiltersIds = (filter: FilterGroup, resolvedMap: { [k: string]: Basi
 };
 
 export const convertWidgetsIds = async (context: AuthContext, user: AuthUser, widgetDefinitions: any[], from: 'internal' | 'stix') => {
-  // First iteration to resolve all ids to translate
+  // First iteration: resolve all the ids to translate
   const resolvingIds: string[] = [];
   widgetDefinitions.forEach((widgetDefinition: any) => {
     widgetDefinition.dataSelection.forEach((selection: any) => {
-      if (isNotEmptyField(selection.filters)) {
+      if (isFilterGroupNotEmpty(selection.filters)) {
         const filterIds = extractFiltersIds(selection.filters as FilterGroup, from);
         resolvingIds.push(...filterIds);
       }
-      if (isNotEmptyField(selection.dynamicFrom)) {
+      if (isFilterGroupNotEmpty(selection.dynamicFrom)) {
         const dynamicFromIds = extractFiltersIds(selection.dynamicFrom as FilterGroup, from);
         resolvingIds.push(...dynamicFromIds);
       }
-      if (isNotEmptyField(selection.dynamicTo)) {
+      if (isFilterGroupNotEmpty(selection.dynamicTo)) {
         const dynamicToIds = extractFiltersIds(selection.dynamicTo as FilterGroup, from);
         resolvingIds.push(...dynamicToIds);
       }
     });
   });
-  // Resolve then second iteration to replace the ids
+  // Second iteration: replace the ids
   const resolveOpts = { baseData: true, toMap: true, mapWithAllIds: true };
   const resolvedMap = await internalFindByIds(context, user, resolvingIds, resolveOpts);
   const idsMap = resolvedMap as unknown as { [k: string]: BasicStoreObject };
   widgetDefinitions.forEach((widgetDefinition: any) => {
     widgetDefinition.dataSelection.forEach((selection: any) => {
-      if (isNotEmptyField(selection.filters)) {
+      if (isFilterGroupNotEmpty(selection.filters)) {
         replaceFiltersIds(selection.filters as FilterGroup, idsMap, from);
       }
-      if (isNotEmptyField(selection.dynamicFrom)) {
+      if (isFilterGroupNotEmpty(selection.dynamicFrom)) {
         replaceFiltersIds(selection.dynamicFrom as FilterGroup, idsMap, from);
       }
-      if (isNotEmptyField(selection.dynamicTo)) {
+      if (isFilterGroupNotEmpty(selection.dynamicTo)) {
         replaceFiltersIds(selection.dynamicTo as FilterGroup, idsMap, from);
       }
     });

--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-utils.ts
@@ -48,7 +48,7 @@ const replaceFiltersIds = (filter: FilterGroup, resolvedMap: { [k: string]: Basi
         idInnerFilter.values = filterValuesRemap(idInnerFilter, resolvedMap, from);
         regardingOfValues.push(idInnerFilter);
       }
-      const typeInnerFilter = f.values.find((v) => toKeys(v.key).includes('type'));
+      const typeInnerFilter = f.values.find((v) => toKeys(v.key).includes('relationship_type'));
       if (typeInnerFilter) { // Type is not mandatory
         regardingOfValues.push(typeInnerFilter);
       }

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/workspace-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/workspace-utils-test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { convertWidgetsIds } from '../../../src/modules/workspace/workspace-utils';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { INSTANCE_REGARDING_OF, TYPE_FILTER } from '../../../src/utils/filtering/filtering-constants';
+import { emptyFilterGroup } from '../../../src/utils/filtering/filtering-utils';
+import { internalFindByIds } from '../../../src/database/middleware-loader';
+import type { BasicStoreObject } from '../../../src/types/store';
+
+describe('Workspace utils', () => {
+  it('should convert widget filters ids', async () => {
+    // find internal ids associated to standard ids
+    const reportStandardId = 'report--a445d22a-db0c-4b5d-9ec8-e9ad0b6dbdd7';
+    const malwareStandardId = 'malware--faa5b705-cf44-4e50-8472-29e5fec43c3c';
+    const softwareStandardId = 'software--b0debdba-74e7-4463-ad2a-34334ee66d8d';
+    const resolveOpts = { baseData: true, toMap: true, mapWithAllIds: true };
+    const objects = await internalFindByIds(testContext, ADMIN_USER, [reportStandardId, malwareStandardId, softwareStandardId], resolveOpts);
+    const objectsMap = objects as unknown as { [k: string]: BasicStoreObject };
+    console.log('objectsMap[reportStandardId]', objectsMap[reportStandardId]);
+    console.log('map', objectsMap);
+    const reportInternalId = objectsMap[reportStandardId].internal_id;
+    const malwareInternalId = objectsMap[malwareStandardId].internal_id;
+    const softwareInternalId = objectsMap[softwareStandardId].internal_id;
+
+    // construct the filters (with standard ids) to test
+    const filters1 = {
+      mode: 'and',
+      filters: [
+        { key: TYPE_FILTER, values: ['Report', 'Malware'], operator: 'not_eq' },
+        { key: INSTANCE_REGARDING_OF,
+          values: [
+            { key: 'relationship_type', values: ['related-to', 'located-at'] },
+            { key: 'id', values: [reportInternalId, malwareInternalId] },
+          ] },
+      ],
+      filterGroups: [
+        {
+          mode: 'or',
+          filters: [
+            { key: 'object', values: [softwareInternalId, 'fakeId'], mode: 'and' },
+            { key: 'objectMarking', values: ['markingId1'] },
+          ],
+          filterGroups: [],
+        }
+      ],
+    };
+    const filters2 = emptyFilterGroup;
+    const input = [
+      {
+        type: 'list',
+        perspective: 'entities',
+        parameters: {},
+        dataSelection: [{
+          number: 10,
+          attribute: 'entity_type',
+          date_attribute: 'created_at',
+          filters: filters1,
+          dynamicFrom: filters2,
+          dynamicTo: undefined,
+        }],
+      }
+    ];
+
+    // construct the expected result (filters with internal ids)
+
+    // check the result
+    const result = await convertWidgetsIds(testContext, ADMIN_USER, input, 'internal');
+    expect(result).toEqual('test');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/workspace-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/workspace-utils-test.ts
@@ -55,7 +55,6 @@ describe('Workspace utils', () => {
           date_attribute: 'created_at',
           filters,
           dynamicFrom: emptyFilterGroup,
-          dynamicTo: undefined,
         }],
       }
     ];
@@ -93,7 +92,6 @@ describe('Workspace utils', () => {
           date_attribute: 'created_at',
           filters: convertedFilters,
           dynamicFrom: emptyFilterGroup,
-          dynamicTo: undefined,
         }],
       }
     ];

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/workspace-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/workspace-utils-test.ts
@@ -15,6 +15,8 @@ describe('Workspace utils', () => {
     const softwareId = 'software--b0debdba-74e7-4463-ad2a-34334ee66d8d';
     const resolveOpts = { baseData: true, mapWithAllIds: true };
     const objects = await internalFindByIds(testContext, ADMIN_USER, [reportId, malwareId, softwareId], resolveOpts);
+    expect(objects).toEqual('test');
+    expect(objects.length).toEqual(3);
     const reportInternalId = objects.find((o) => o.entity_type === ENTITY_TYPE_CONTAINER_REPORT)?.internal_id;
     const reportStandardId = objects.find((o) => o.entity_type === ENTITY_TYPE_CONTAINER_REPORT)?.standard_id;
     const malwareInternalId = objects.find((o) => o.entity_type === ENTITY_TYPE_MALWARE)?.internal_id;

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/workspace-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/workspace-utils-test.ts
@@ -15,8 +15,6 @@ describe('Workspace utils', () => {
     const softwareId = 'software--b0debdba-74e7-4463-ad2a-34334ee66d8d';
     const resolveOpts = { baseData: true, mapWithAllIds: true };
     const objects = await internalFindByIds(testContext, ADMIN_USER, [reportId, malwareId, softwareId], resolveOpts);
-    expect(objects).toEqual('test');
-    expect(objects.length).toEqual(3);
     const reportInternalId = objects.find((o) => o.entity_type === ENTITY_TYPE_CONTAINER_REPORT)?.internal_id;
     const reportStandardId = objects.find((o) => o.entity_type === ENTITY_TYPE_CONTAINER_REPORT)?.standard_id;
     const malwareInternalId = objects.find((o) => o.entity_type === ENTITY_TYPE_MALWARE)?.internal_id;


### PR DESCRIPTION
### Proposed changes
- Fix widget export with regardingOf filter: when exporting a widget that includes a regardingOf filter, the result of the export should not remove the 'relationship_type' part of the regardingOf filter
- add backend tests for the function convertWidgetsIds

### Related issues
#13028 