### PR TITLE
[frontend] notes header alignment (#12922)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NotePopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NotePopover.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent, useState } from 'react';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import IconButton from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
 import MoreVert from '@mui/icons-material/MoreVert';
 import { graphql } from 'react-relay';
@@ -37,27 +36,30 @@ interface NotePopoverProps {
   size?: 'medium' | 'large' | 'small' | undefined;
   note: StixCoreObjectOrStixCoreRelationshipNoteCard_node$data;
   paginationOptions?: StixCoreObjectOrStixCoreRelationshipNotesCardsQuery$variables;
-  variant?: string;
 }
 
 const NotePopover: FunctionComponent<NotePopoverProps> = ({
   id,
   handleOpenRemoveExternal,
-  size,
+  size = 'large',
   note,
   paginationOptions,
-  variant,
 }) => {
   const { t_i18n } = useFormatter();
   const navigate = useNavigate();
+
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [displayEdit, setDisplayEdit] = useState<boolean>(false);
   const [displayEnroll, setDisplayEnroll] = useState(false);
+
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => setAnchorEl(event.currentTarget);
   const handleClose = () => setAnchorEl(null);
+
   const [commit] = useApiMutation(NotePopoverDeletionMutation);
+
   const deletion = useDeletion({ handleClose });
   const { setDeleting, handleOpenDelete, handleCloseDelete } = deletion;
+
   const submitDelete = () => {
     setDeleting(true);
     commit({
@@ -80,46 +82,32 @@ const NotePopover: FunctionComponent<NotePopoverProps> = ({
       },
     });
   };
+
   const handleOpenEdit = () => {
     setDisplayEdit(true);
     handleClose();
   };
+
   const handleCloseEdit = () => setDisplayEdit(false);
+
   const handleOpenRemove = () => {
     if (handleOpenRemoveExternal) {
       handleOpenRemoveExternal();
     }
     handleClose();
   };
+
   const handleOpenEnroll = () => {
     setDisplayEnroll(true);
     handleClose();
   };
+
   const handleCloseEnroll = () => {
     setDisplayEnroll(false);
   };
 
   return (
     <>
-      {variant === 'inLine' ? (
-        <IconButton
-          onClick={handleOpen}
-          aria-haspopup="true"
-          size={size || 'large'}
-          style={{ marginTop: size === 'small' ? -3 : 3 }}
-          color="primary"
-        >
-          <MoreVert />
-        </IconButton>
-      ) : (
-        <ToggleButton
-          value="popover"
-          size="small"
-          onClick={handleOpen}
-        >
-          <MoreVert fontSize="small" color="primary" />
-        </ToggleButton>
-      )}
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
         <MenuItem onClick={handleOpenEdit}>{t_i18n('Update')}</MenuItem>
         {handleOpenRemoveExternal && (
@@ -140,10 +128,23 @@ const NotePopover: FunctionComponent<NotePopoverProps> = ({
           <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
         </CollaborativeSecurity>
       </Menu>
+
       <Security needs={[KNOWLEDGE_KNENRICHMENT]}>
         <StixCoreObjectEnrichment stixCoreObjectId={id} onClose={undefined} isOpen={undefined} />
       </Security>
+
       <StixCoreObjectEnrollPlaybook stixCoreObjectId={id} open={displayEnroll} handleClose={handleCloseEnroll} />
+
+      <ToggleButton
+        onClick={handleOpen}
+        aria-haspopup="true"
+        value="popover"
+        size={size}
+        color="primary"
+      >
+        <MoreVert fontSize="small" color="primary" />
+      </ToggleButton>
+
       <DeleteDialog
         deletion={deletion}
         submitDelete={submitDelete}

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
@@ -17,6 +17,7 @@ import makeStyles from '@mui/styles/makeStyles';
 import { useTheme } from '@mui/styles';
 import Chip from '@mui/material/Chip';
 import DialogTitle from '@mui/material/DialogTitle';
+import { Stack } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 import { noteMutationRelationDelete } from './AddNotesLines';
 import NotePopover from './NotePopover';
@@ -38,21 +39,6 @@ import useApiMutation from '../../../../utils/hooks/useApiMutation';
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
 const useStyles = makeStyles<Theme>((theme) => ({
-  card: {
-    width: '100%',
-    height: '100%',
-    marginBottom: 30,
-    borderRadius: 4,
-    padding: 0,
-    position: 'relative',
-  },
-  chipInList: {
-    fontSize: 12,
-    height: 20,
-    float: 'left',
-    width: 120,
-    marginRight: 10,
-  },
   external: {
     position: 'absolute',
     bottom: 0,
@@ -106,18 +92,23 @@ StixCoreObjectOrStixCoreRelationshipNoteCardComponentProps
   const { t_i18n, nsdt } = useFormatter();
   const classes = useStyles();
   const theme = useTheme<Theme>();
+
   const note = useFragment(
     StixCoreObjectOrStixCoreRelationshipNoteCardFragment,
     data,
   );
+
   const [displayDialog, setDisplayDialog] = useState<boolean>(false);
   const [removing, setRemoving] = useState<boolean>(false);
+
   const handleOpenDialog = () => setDisplayDialog(true);
   const handleCloseDialog = () => {
     setDisplayDialog(false);
     setRemoving(false);
   };
+
   const [commit] = useApiMutation(noteMutationRelationDelete);
+
   const removeNote = () => {
     commit({
       variables: {
@@ -134,23 +125,24 @@ StixCoreObjectOrStixCoreRelationshipNoteCardComponentProps
       },
     });
   };
+
   const handleRemoval = () => {
     setRemoving(true);
     removeNote();
   };
-  let authorName = null;
-  let authorLink = null;
-  if (note.createdBy) {
-    authorName = note.createdBy.name;
-    authorLink = `${resolveLink(note.createdBy.entity_type)}/${
-      note.createdBy.id
-    }`;
-  }
+
+  const authorName = note.createdBy ? note.createdBy.name : null;
+  const authorLink = note.createdBy ? `${resolveLink(note.createdBy.entity_type)}/${note.createdBy.id}` : null;
+
   return (
-    <Card classes={{ root: classes.card }} variant="outlined">
+    <Card
+      sx={{
+        marginBottom: 2,
+      }}
+      variant="outlined"
+    >
       <CardHeader
         style={{
-          padding: '15px 10px 10px 15px',
           borderBottom: `1px solid ${theme.palette.divider}`,
         }}
         action={
@@ -161,62 +153,47 @@ StixCoreObjectOrStixCoreRelationshipNoteCardComponentProps
               handleOpenRemoveExternal={handleOpenDialog}
               size="small"
               paginationOptions={paginationOptions}
-              variant="inLine"
             />
           </CollaborativeSecurity>
         }
         title={
-          <div>
-            <div
-              style={{
-                paddingTop: 2,
-                float: 'left',
-                textTransform: 'none',
-              }}
-            >
-              <strong>
-                {authorLink ? (
-                  <Link to={authorLink}>{authorName}</Link>
-                ) : (
-                  t_i18n('Unknown')
-                )}
-              </strong>{' '}
-              <span style={{ color: theme.palette.text?.secondary }}>
-                {t_i18n('added a note')} {t_i18n('on')} {nsdt(note.created)}
-              </span>
-            </div>
-            <div
-              style={{
-                float: 'left',
-                marginLeft: 20,
-                textTransform: 'none',
-              }}
-            >
-              {(note.note_types ?? [t_i18n('Unknown')]).map((type) => (
-                <Chip
-                  key={type}
-                  classes={{ root: classes.chipInList }}
-                  color="primary"
-                  variant="outlined"
-                  label={t_i18n(type)}
-                />
-              ))}
-            </div>
-            <div
-              style={{
-                float: 'right',
-                textTransform: 'none',
-              }}
-            >
-              <ItemMarkings
-                variant="inList"
-                markingDefinitions={note.objectMarking ?? []}
-                limit={1}
-              />
-            </div>
-          </div>
+          <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1} sx={{ marginTop: 0.5 }}>
+            <Stack direction="row" spacing={1}>
+              <Stack direction="row" spacing={0.5} sx={{ textTransform: 'none' }}>
+                <Typography variant='body2' sx={{ fontWeight: 800 }}>
+                  {authorLink ? <Link to={authorLink}>{authorName}</Link> : t_i18n('Unknown')}
+                </Typography>
+                <Typography variant='body2' sx={{ color: theme.palette.text?.secondary }}>
+                  {t_i18n('added a note')} {t_i18n('on')} {nsdt(note.created)}
+                </Typography>
+              </Stack>
+
+              <Stack direction="row" spacing={1}>
+                {(note.note_types ?? [t_i18n('Unknown')]).map((type) => (
+                  <Chip
+                    key={type}
+                    color="primary"
+                    variant="outlined"
+                    label={t_i18n(type)}
+                    sx={{
+                      fontSize: 12,
+                      height: 20,
+                      width: 120,
+                    }}
+                  />
+                ))}
+              </Stack>
+            </Stack>
+
+            <ItemMarkings
+              variant="inList"
+              markingDefinitions={note.objectMarking ?? []}
+              limit={1}
+            />
+          </Stack>
         }
       />
+
       <CardContent>
         <Grid container={true} spacing={3}>
           <Grid item xs={9}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
@@ -6,18 +6,18 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Typography from '@mui/material/Typography';
-import Grid from '@mui/material/Grid';
+import Grid from '@mui/material/Grid2';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import makeStyles from '@mui/styles/makeStyles';
 import { useTheme } from '@mui/styles';
 import Chip from '@mui/material/Chip';
 import DialogTitle from '@mui/material/DialogTitle';
-import { Stack } from '@mui/material';
+import { Stack, Box } from '@mui/material';
+import { isEmptyField } from 'src/utils/utils';
 import { useFormatter } from '../../../../components/i18n';
 import { noteMutationRelationDelete } from './AddNotesLines';
 import NotePopover from './NotePopover';
@@ -35,17 +35,6 @@ import ItemLikelihood from '../../../../components/ItemLikelihood';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  external: {
-    position: 'absolute',
-    bottom: 0,
-    right: 0,
-    color: theme.palette.text?.secondary,
-  },
-}));
 
 const StixCoreObjectOrStixCoreRelationshipNoteCardFragment = graphql`
   fragment StixCoreObjectOrStixCoreRelationshipNoteCard_node on Note {
@@ -90,7 +79,6 @@ const StixCoreObjectOrStixCoreRelationshipNoteCard: FunctionComponent<
 StixCoreObjectOrStixCoreRelationshipNoteCardComponentProps
 > = ({ data, stixCoreObjectOrStixCoreRelationshipId, paginationOptions }) => {
   const { t_i18n, nsdt } = useFormatter();
-  const classes = useStyles();
   const theme = useTheme<Theme>();
 
   const note = useFragment(
@@ -136,9 +124,7 @@ StixCoreObjectOrStixCoreRelationshipNoteCardComponentProps
 
   return (
     <Card
-      sx={{
-        marginBottom: 2,
-      }}
+      sx={{ marginBottom: 2 }}
       variant="outlined"
     >
       <CardHeader
@@ -194,71 +180,81 @@ StixCoreObjectOrStixCoreRelationshipNoteCardComponentProps
         }
       />
 
-      <CardContent>
-        <Grid container={true} spacing={3}>
-          <Grid item xs={9}>
-            <Typography variant="h3" gutterBottom={true}>
-              {t_i18n('Abstract')}
-            </Typography>
-            {note.attribute_abstract && (
-              <MarkdownDisplay
-                content={note.attribute_abstract}
-                remarkGfmPlugin={true}
-              />
-            )}
-            <Typography
-              variant="h3"
-              gutterBottom={true}
-              style={{ marginTop: 20 }}
-            >
-              {t_i18n('Content')}
-            </Typography>
-            {note.content && (
-              <MarkdownDisplay content={note.content} remarkGfmPlugin={true} />
-            )}
+      <CardContent sx={{ position: 'relative' }}>
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, md: 8, lg: 9 }}>
+            <Stack spacing={3}>
+              <Box>
+                <Typography variant="h3" gutterBottom={true}>
+                  {t_i18n('Abstract')}
+                </Typography>
+                {
+                  isEmptyField(note.attribute_abstract) ? '-' : (
+                    <MarkdownDisplay
+                      content={note.attribute_abstract}
+                      remarkGfmPlugin={true}
+                    />
+                  )
+                }
+              </Box>
+
+              <Box>
+                <Typography variant="h3" gutterBottom={true}>
+                  {t_i18n('Content')}
+                </Typography>
+                {
+                  isEmptyField(note.content) ? '-' : (
+                    <MarkdownDisplay content={note.content} remarkGfmPlugin={true} />
+                  )
+                }
+              </Box>
+            </Stack>
           </Grid>
-          <Grid item xs={3}>
-            <StixCoreObjectLabelsView
-              labels={note.objectLabel}
-              id={note.id}
-              entity_type={note.entity_type}
-            />
-            <Grid container={true} spacing={3}>
-              <Grid item xs={6}>
-                <Typography
-                  variant="h3"
-                  gutterBottom={true}
-                  style={{ marginTop: 20 }}
-                >
-                  {t_i18n('Confidence level')}
-                </Typography>
-                <ItemConfidence
-                  confidence={note.confidence}
-                  entityType={note.entity_type}
-                />
+
+          <Grid size={{ xs: 6, md: 3 }}>
+            <Stack spacing={3}>
+              {/* FIXME: remove style marginTop: 20px in StixCoreObjectLabelsView */}
+              <Grid size={{ xs: 10, md: 12 }}>
+                <Box sx={{ marginTop: '-20px!important' }}>
+                  <StixCoreObjectLabelsView
+                    labels={note.objectLabel}
+                    id={note.id}
+                    entity_type={note.entity_type}
+                  />
+                </Box>
               </Grid>
-              <Grid item xs={6}>
-                <Typography
-                  variant="h3"
-                  gutterBottom={true}
-                  style={{ marginTop: 20 }}
-                >
-                  {t_i18n('Likelihood')}
-                </Typography>
-                <ItemLikelihood likelihood={note.likelihood} />
+
+              <Grid container>
+                <Grid size={{ xs: 3, md: 6 }}>
+                  <Typography variant="h3" gutterBottom={true}>
+                    {t_i18n('Confidence level')}
+                  </Typography>
+                  <ItemConfidence
+                    confidence={note.confidence}
+                    entityType={note.entity_type}
+                  />
+                </Grid>
+                <Grid size={{ xs: 3, md: 6 }}>
+                  <Typography variant="h3" gutterBottom={true}>
+                    {t_i18n('Likelihood')}
+                  </Typography>
+                  <ItemLikelihood likelihood={note.likelihood} />
+                </Grid>
               </Grid>
-            </Grid>
+            </Stack>
           </Grid>
         </Grid>
+
         <IconButton
           component={Link}
           to={`/dashboard/analyses/notes/${note.id}`}
-          classes={{ root: classes.external }}
-          size="large"
+          sx={{ position: 'absolute', bottom: 8, right: 8 }}
+          size="small"
         >
           <OpenInNewOutlined fontSize="small" />
         </IconButton>
       </CardContent>
+
       <Dialog
         open={displayDialog}
         slotProps={{ paper: { elevation: 1 } }}

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -347,12 +347,12 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
   });
 
   const notes = data?.notes?.edges ?? [];
-  const accordionRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const [open, setOpen] = useState<boolean>(false);
 
   const scrollToBottom = () => {
-    const element = accordionRef.current;
+    const element = containerRef.current;
     if (!element) return;
 
     setTimeout(() => {
@@ -363,11 +363,27 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
         top: targetPosition,
         behavior: 'smooth',
       });
-    }, 300);
+    }, 200);
+  };
+
+  const scrollToTop = () => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    setTimeout(() => {
+      const rect = element.getBoundingClientRect();
+      const OFFSET_TITLE_BLOCK = 100; // arbitrary offset to see the title block
+      const targetPosition = rect.top + window.pageYOffset - marginTop - OFFSET_TITLE_BLOCK;
+
+      window.scrollTo({
+        top: targetPosition,
+        behavior: 'smooth',
+      });
+    }, 100);
   };
 
   useEffect(() => {
-    if (accordionRef.current) {
+    if (containerRef.current && open) {
       scrollToBottom();
     }
   }, [open]);
@@ -397,12 +413,13 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
       onCompleted: () => {
         setSubmitting(false);
         resetForm();
+        scrollToTop();
       },
     });
   };
 
   return (
-    <div style={{ marginTop, marginBottom: 20 }} ref={accordionRef}>
+    <div style={{ marginTop, marginBottom: 20 }} ref={containerRef}>
       <Header
         data={data}
         id={id}

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -402,7 +402,7 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
   };
 
   return (
-    <div style={{ marginTop }} ref={accordionRef}>
+    <div style={{ marginTop, marginBottom: 20 }} ref={accordionRef}>
       <Header
         data={data}
         id={id}
@@ -426,9 +426,15 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
 
       <Security needs={[KNOWLEDGE_KNPARTICIPATE]}>
         <Accordion
-          style={{ margin: `${notes.length > 0 ? '30' : '0'}px 0 0px 0` }}
           expanded={open}
           variant="outlined"
+          sx={{
+            spacing: 1,
+            borderBottomLeftRadius: '4px!important', // override mui theme accordion
+            borderBottomRightRadius: '4px!important',
+            borderRadius: 1,
+            '&:before': { backgroundColor: 'transparent' },
+          }}
         >
           <AccordionSummary
             expandIcon={<ExpandMoreOutlined />}
@@ -451,7 +457,6 @@ StixCoreObjectOrStixCoreRelationshipNotesCardsProps
           </AccordionDetails>
         </Accordion>
       </Security>
-
     </div>
   );
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* Enhance note card behaviour
* Invert vert dots button with enrichment button
* Update vert dots icon to match the style of the action buttons on each page
* Fix scroll window when expanding the accordion write a note 
* Scroll window when clicking on "more fields" so we can see the extra fields
* On created note, scroll up to the note created because when there are some notes, it was looking like it wasn't created but as the notes are ordered desc by date, we don't see the new one.
* Refactor code with grid2, remove deprecated makestyles, split components


https://github.com/user-attachments/assets/b40e64f7-ef37-4b8c-895d-44bdea571567



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12922 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
