### PR TITLE
[frontend] update authorized members add button style

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -4,8 +4,7 @@ import ObjectMembersField, { OptionMember } from '@components/common/form/Object
 import FormHelperText from '@mui/material/FormHelperText';
 import { Field, FieldArray, FieldProps, Formik } from 'formik';
 import MenuItem from '@mui/material/MenuItem';
-import IconButton from '@mui/material/IconButton';
-import { Add } from '@mui/icons-material';
+import { Button } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import List from '@mui/material/List';
 import React, { CSSProperties, useEffect, useState } from 'react';
@@ -432,7 +431,7 @@ const AuthorizedMembersField = ({
                       </MenuItem>
                     ))}
                   </Field>
-                  <IconButton
+                  <Button
                     color="primary"
                     aria-label="More"
                     onClick={() => handleSubmit()}
@@ -444,8 +443,8 @@ const AuthorizedMembersField = ({
                     }
                     style={{ marginTop: 10 }}
                   >
-                    <Add fontSize="small" />
-                  </IconButton>
+                    {t_i18n('Add')}
+                  </Button>
                 </div>
                 {values.newAccessMember && values.newAccessMember.type === 'Organization' && (
                   <div style={fieldSpacingContainerStyle}>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* improve UX by making the + icon button a regular Add button
<img width="496" height="130" alt="Capture d’écran 2025-11-04 à 10 10 28" src="https://github.com/user-attachments/assets/81d15caa-e4e2-4bdb-8ff9-053efb1c933b" />

(how it looks on hover)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13055

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
