### PR TITLE
[frontend] Add bulk edit of object markings from list toolbar

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -74,8 +74,7 @@ import inject18n from '../../../components/i18n';
 import { truncate } from '../../../utils/String';
 import { commitMutation, fetchQuery, MESSAGING$ } from '../../../relay/environment';
 import ItemIcon from '../../../components/ItemIcon';
-import { objectMarkingFieldAllowedMarkingsQuery } from '../common/form/ObjectMarkingField';
-import ObjectMarkingField from '../common/form/ObjectMarkingField';
+import ObjectMarkingField, { objectMarkingFieldAllowedMarkingsQuery } from '../common/form/ObjectMarkingField';
 import { identitySearchIdentitiesSearchQuery } from '../common/identities/IdentitySearch';
 import { labelsSearchQuery } from '../settings/LabelsQuery';
 import Security from '../../../utils/Security';
@@ -514,7 +513,7 @@ class DataTableToolBar extends Component {
   handleBulkEditMarkings() {
     const { t } = this.props;
     const { bulkMarkings } = this.state;
-    const { selectedElements, selectAll, filters } = this.props;
+    const { selectedElements, selectAll } = this.props;
 
     if (!bulkMarkings || bulkMarkings.length === 0) {
       MESSAGING$.notifyError(t('Please select at least one marking'));
@@ -531,9 +530,8 @@ class DataTableToolBar extends Component {
       MESSAGING$.notifyError(t('Bulk edit markings for all entities requires a background task. Please select specific entities.'));
       this.handleCloseEditMarkings();
       return;
-    } else {
-      entitiesToProcess = Object.values(selectedElements || {});
     }
+    entitiesToProcess = Object.values(selectedElements || {});
 
     if (entitiesToProcess.length === 0) {
       MESSAGING$.notifyError(t('Please select at least one entity'));
@@ -546,7 +544,7 @@ class DataTableToolBar extends Component {
     let errorCount = 0;
     const total = entitiesToProcess.length;
 
-    const processEntity = (entity, index) => {
+    const processEntity = (entity) => {
       return new Promise((resolve) => {
         // Determine which mutation to use based on entity type
         const isStixCyberObservable = entity.entity_type && entity.entity_type.includes('Stix-Cyber-Observable');
@@ -580,7 +578,7 @@ class DataTableToolBar extends Component {
             }
             resolve();
           },
-          onError: (error) => {
+          onError: () => {
             errorCount += 1;
             if (successCount + errorCount === total) {
               this.setState({ processing: false });
@@ -598,8 +596,8 @@ class DataTableToolBar extends Component {
     };
 
     // Process entities sequentially to avoid overwhelming the server
-    entitiesToProcess.reduce((promise, entity, index) => {
-      return promise.then(() => processEntity(entity, index));
+    entitiesToProcess.reduce((promise, entity) => {
+      return promise.then(() => processEntity(entity));
     }, Promise.resolve());
   }
 

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -284,17 +284,6 @@ const toolBarBulkEditMarkingsDomainMutation = graphql`
     stixDomainObjectEdit(id: $id) {
       fieldPatch(input: $input) {
         id
-        objectMarking {
-          edges {
-            node {
-              id
-              definition_type
-              definition
-              x_opencti_color
-              x_opencti_order
-            }
-          }
-        }
       }
     }
   }
@@ -305,17 +294,6 @@ const toolBarBulkEditMarkingsCyberObservableMutation = graphql`
     stixCyberObservableEdit(id: $id) {
       fieldPatch(input: $input) {
         id
-        objectMarking {
-          edges {
-            node {
-              id
-              definition_type
-              definition
-              x_opencti_color
-              x_opencti_order
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

**Summary**
This PR adds a bulk edit flow to replace object markings across multiple selected entities directly from the list toolbar.

**What’s included**
- New toolbar action “Edit markings” in `DataTableToolBar.jsx`.
- Dialog using `ObjectMarkingField` to select target markings.
- Sequential mutation dispatch:
  - Uses `stixDomainObjectEdit.fieldPatch` for domain objects.
  - Uses `stixCyberObservableEdit.fieldPatch` for cyber observables.
- User feedback on success/error with MESSAGING$.

**Backward compatibility**
No breaking changes; new UI action added behind capability `KNOWLEDGE_KNUPDATE`.
<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
closes: https://github.com/OpenCTI-Platform/opencti/issues/13073

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
