### PR TITLE
[frontend/backend] PIR in Playbooks: detect entities update (#12362)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/listenPirEventsUtils.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/listenPirEventsUtils.ts
@@ -9,9 +9,9 @@ import { isStixRelation } from '../../schema/stixRelationship';
 import type { SseEvent, StreamDataEvent } from '../../types/event';
 import type { StixBundle, StixObject } from '../../types/stix-2-1-common';
 import type { AuthContext } from '../../types/user';
-import { AUTOMATION_MANAGER_USER, SYSTEM_USER } from '../../utils/access';
+import { AUTOMATION_MANAGER_USER } from '../../utils/access';
 import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/stix-filtering';
-import { isEventInPirRelationship, isEventUpdateOnEntity, isValidEventType, StreamDataEventTypeEnum } from './playbookManagerUtils';
+import { isEventInPirRelationship, isEventUpdateOnEntity, isValidEventType } from './playbookManagerUtils';
 import { STIX_SPEC_VERSION } from '../../database/stix';
 import { playbookExecutor } from './playbookExecutor';
 import { storeLoadById } from '../../database/middleware-loader';
@@ -77,6 +77,7 @@ export const isEventMatchesPir = async (
   // Else if it's an update of an entity, we check if this entity is flagged in PIR.
   if (isEventUpdateOnEntity(eventData)) {
     const entityPirList = await listOfPirInEntity(context, eventData.data.id);
+
     if (entityPirList.length > 0) {
       // If entity is flagged and no PIR filtering set, it matches.
       if (!pirList || pirList.length === 0) return true;

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -109,6 +109,7 @@ const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEven
                     // Data
                     previousStepBundle: null,
                     bundle,
+                    event: streamEvent.data
                   });
                 }
               }

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManagerUtils.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManagerUtils.ts
@@ -1,6 +1,10 @@
-import { RELATION_IN_PIR } from '../../schema/internalRelationship';
-import { isStixRelation } from '../../schema/stixRelationship';
-import type { StreamDataEvent } from '../../types/event';
+import type { StreamDataEventType } from '../../types/event';
+
+export enum StreamDataEventTypeEnum {
+  UPDATE = 'update',
+  DELETE = 'delete',
+  CREATE = 'create'
+}
 
 interface EventConfig {
   create?: boolean
@@ -8,7 +12,7 @@ interface EventConfig {
   delete?: boolean
 }
 
-export const isValidEventType = (eventType: string, configuration: EventConfig) => {
+export const isValidEventType = (eventType: StreamDataEventType, configuration: EventConfig) => {
   const {
     update,
     create,
@@ -16,14 +20,9 @@ export const isValidEventType = (eventType: string, configuration: EventConfig) 
   } = configuration;
 
   let validEventType = false;
-  if (eventType === 'create' && create === true) validEventType = true;
-  if (eventType === 'update' && update === true) validEventType = true;
-  if (eventType === 'delete' && deletion === true) validEventType = true;
+  if (eventType === StreamDataEventTypeEnum.CREATE && create === true) validEventType = true;
+  if (eventType === StreamDataEventTypeEnum.UPDATE && update === true) validEventType = true;
+  if (eventType === StreamDataEventTypeEnum.DELETE && deletion === true) validEventType = true;
 
   return validEventType;
-};
-
-export const isEventInPir = (streamEvent : StreamDataEvent) => {
-  const { data, scope } = streamEvent;
-  return scope === 'internal' && isStixRelation(data) && data.relationship_type === RELATION_IN_PIR;
 };

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManagerUtils.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManagerUtils.ts
@@ -1,4 +1,6 @@
-import type { StreamDataEventType } from '../../types/event';
+import type { StreamDataEvent, StreamDataEventType } from '../../types/event';
+import { RELATION_IN_PIR } from '../../schema/internalRelationship';
+import { isStixRelation } from '../../schema/stixRelationship';
 
 export enum StreamDataEventTypeEnum {
   UPDATE = 'update',
@@ -25,4 +27,24 @@ export const isValidEventType = (eventType: StreamDataEventType, configuration: 
   if (eventType === StreamDataEventTypeEnum.DELETE && deletion === true) validEventType = true;
 
   return validEventType;
+};
+
+/**
+ * Checks if an event is about a relationship in-pir.
+ * @param eventData The event.
+ * @returns True if the event concerns a relationship in-pir.
+ */
+export const isEventInPirRelationship = (eventData : StreamDataEvent) => {
+  const { data, scope } = eventData;
+  return scope === 'internal' && isStixRelation(data) && data.relationship_type === RELATION_IN_PIR;
+};
+
+/**
+ * Checks if an event is an update on an entity.
+ * @param eventData The event.
+ * @returns True if the event is an update of entity.
+ */
+export const isEventUpdateOnEntity = (eventData : StreamDataEvent) => {
+  const { data, type } = eventData;
+  return type === StreamDataEventTypeEnum.UPDATE && !isStixRelation(data);
 };

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -23,7 +23,7 @@ import { FilterMode, FilterOperator } from '../generated/graphql';
 import type { StixCoreObject } from '../types/stix-2-1-common';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import type { StixRelation, StixSighting } from '../types/stix-2-1-sro';
-import type { BaseEvent, DataEvent, DeleteEvent, MergeEvent, SseEvent, StreamDataEvent, UpdateEvent } from '../types/event';
+import type { BaseEvent, DataEvent, DeleteEvent, MergeEvent, SseEvent, StreamDataEvent, StreamDataEventType, UpdateEvent } from '../types/event';
 import { getActivatedRules, getRule } from '../domain/rules';
 import { executionContext, RULE_MANAGER_USER, SYSTEM_USER } from '../utils/access';
 import { isModuleActivated } from '../database/cluster-module';
@@ -43,7 +43,7 @@ export const getManagerInfo = async (context: AuthContext, user: AuthUser): Prom
   return { activated: isRuleEngineActivated, ...ruleStatus };
 };
 
-export const buildInternalEvent = (type: 'update' | 'create' | 'delete', stix: StixCoreObject): StreamDataEvent => {
+export const buildInternalEvent = (type: StreamDataEventType, stix: StixCoreObject): StreamDataEvent => {
   return {
     version: EVENT_CURRENT_VERSION,
     type,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/data-stream-pir-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/data-stream-pir-component.ts
@@ -19,8 +19,8 @@ const PLAYBOOK_DATA_STREAM_PIR_SCHEMA: JSONSchemaType<PirStreamConfiguration> = 
       items: { type: 'string', oneOf: [] }
     },
     create: { type: 'boolean', default: true, $ref: 'A new entity enters a selected PIR' },
-    // update: { type: 'boolean', default: false, $ref: 'An entity from a selected PIR has been updated' },
     delete: { type: 'boolean', default: false, $ref: 'An entity has left a selected PIR' },
+    update: { type: 'boolean', default: false, $ref: 'An entity from a selected PIR has been updated' },
     filters: { type: 'string' },
   },
   required: ['create', 'delete'],

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/notifier-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/notifier-component.ts
@@ -13,6 +13,7 @@ import { convertStixToInternalTypes } from '../../../schema/schemaUtils';
 import { storeNotificationEvent } from '../../../database/redis';
 import { convertMembersToUsers, extractBundleBaseElement } from '../playbook-utils';
 import { isEventInPirRelationship } from '../../../manager/playbookManager/playbookManagerUtils';
+import { extractEntityRepresentativeName } from '../../../database/entity-representative';
 
 export interface NotifierConfiguration {
   notifiers: string[]
@@ -83,8 +84,10 @@ export const PLAYBOOK_NOTIFIER_COMPONENT: PlaybookComponent<NotifierConfiguratio
             entity_type: convertStixToInternalTypes(stixObject.type)
           });
           if (event) {
-            if (isEventInPirRelationship(event) || event.type === 'update') {
+            if (isEventInPirRelationship(event)) {
               message = event.message;
+            } else if (event.type === 'update') {
+              message = `${event.message} in \`${extractEntityRepresentativeName(stixObject)}\``;
             } else if (event.type === 'delete') {
               message = generateDeleteMessage({
                 ...stixObject,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/notifier-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/notifier-component.ts
@@ -87,7 +87,7 @@ export const PLAYBOOK_NOTIFIER_COMPONENT: PlaybookComponent<NotifierConfiguratio
             if (isEventInPirRelationship(event)) {
               message = event.message;
             } else if (event.type === 'update') {
-              message = `${event.message} in \`${extractEntityRepresentativeName(stixObject)}\``;
+              message = `${event.message} in \`${extractEntityRepresentativeName(stixObject)}\` ${event.data.type}`;
             } else if (event.type === 'delete') {
               message = generateDeleteMessage({
                 ...stixObject,

--- a/opencti-platform/opencti-graphql/src/types/event.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/event.d.ts
@@ -42,9 +42,11 @@ interface StreamNotifEvent extends BaseEvent {
   type: 'live' | 'digest' | 'action';
 }
 
+export type StreamDataEventType = 'update' | 'create' | 'delete';
+
 interface StreamDataEvent extends BaseEvent {
   scope: 'internal' | 'external';
-  type: 'update' | 'create' | 'delete';
+  type: StreamDataEventType;
   origin: Partial<UserOrigin>;
   message: string;
   data: StixCoreObject

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/listenPirEventsUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/listenPirEventsUtils-test.ts
@@ -46,12 +46,10 @@ describe('listenPirEventsUtils', () => {
     data: {
       id: 'internal-relationship--id-3',
       scope: 'internal',
-      // spec_version: '2.1',
       type: 'create',
       data: { relationship_type: RELATION_IN_PIR, },
       extensions: { 'extension-definition--id-4':
         {
-          // extension_type: 'new-sro',
           id: 'id-5',
           type: 'in-pir',
           source_ref_pir_refs: ['id-1'],

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/listenPirEventsUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/listenPirEventsUtils-test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildPirFilters, isEventInPir, isEventMatchesPir, listenPirEvents } from '../../../../src/manager/playbookManager/listenPirEventsUtils';
+import { buildPirFilters, isEventInPirRelationship, isEventMatchesPir, listenPirEvents } from '../../../../src/manager/playbookManager/listenPirEventsUtils';
 import type { AuthContext } from '../../../../src/types/user';
 import type { SseEvent, StreamDataEvent } from '../../../../src/types/event';
 import type { BasicStoreEntityPlaybook } from '../../../../src/modules/playbook/playbook-types';
@@ -287,7 +287,7 @@ describe('listenPirEventsUtils', () => {
             relationship_type: RELATION_IN_PIR
           }
         } as unknown as StreamDataEvent;
-        const result = isEventInPir(streamEventMock);
+        const result = isEventInPirRelationship(streamEventMock);
         expect(result).toBeTruthy();
       });
     });
@@ -301,7 +301,7 @@ describe('listenPirEventsUtils', () => {
             relationship_type: RELATION_IN_PIR
           }
         } as unknown as StreamDataEvent;
-        const result = await isEventInPir(streamEventMock);
+        const result = await isEventInPirRelationship(streamEventMock);
         expect(result).toBeFalsy();
       });
     });
@@ -315,7 +315,7 @@ describe('listenPirEventsUtils', () => {
             relationship_type: 'random-relationship-type'
           }
         } as unknown as StreamDataEvent;
-        const result = await isEventInPir(streamEventMock);
+        const result = await isEventInPirRelationship(streamEventMock);
         expect(result).toBeFalsy();
       });
     });
@@ -329,7 +329,7 @@ describe('listenPirEventsUtils', () => {
             relationship_type: RELATION_IN_PIR
           }
         } as unknown as StreamDataEvent;
-        const result = await isEventInPir(streamEventMock);
+        const result = await isEventInPirRelationship(streamEventMock);
         expect(result).toBeFalsy();
       });
     });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/listenPirEventsUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/listenPirEventsUtils-test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildPirFilters, isEventInPirRelationship, isEventMatchesPir, listenPirEvents } from '../../../../src/manager/playbookManager/listenPirEventsUtils';
+import { buildPirFilters, isEventMatchesPir, listenPirEvents } from '../../../../src/manager/playbookManager/listenPirEventsUtils';
 import type { AuthContext } from '../../../../src/types/user';
 import type { SseEvent, StreamDataEvent } from '../../../../src/types/event';
 import type { BasicStoreEntityPlaybook } from '../../../../src/modules/playbook/playbook-types';
@@ -273,64 +273,6 @@ describe('listenPirEventsUtils', () => {
         expect(playbookUtils.isValidEventType).toHaveBeenCalled();
         expect(middleware.stixLoadById).not.toHaveBeenCalled();
         expect(playbookExecutor.playbookExecutor).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('isEventInPir', () => {
-    describe('When scope is internal, data relationship type is relation in pir, and isStixRelation is true', () => {
-      it('should return true', () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = isEventInPirRelationship(streamEventMock);
-        expect(result).toBeTruthy();
-      });
-    });
-
-    describe('When scope is not internal, but the rest is correct', () => {
-      it('should return false', async () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'external',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = await isEventInPirRelationship(streamEventMock);
-        expect(result).toBeFalsy();
-      });
-    });
-
-    describe('When data relationship type is not a relation in pir, but the rest is correct', () => {
-      it('should return false', async () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: 'random-relationship-type'
-          }
-        } as unknown as StreamDataEvent;
-        const result = await isEventInPirRelationship(streamEventMock);
-        expect(result).toBeFalsy();
-      });
-    });
-
-    describe('When isStixRelation is false, but the rest is correct', () => {
-      it('should return false', async () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = await isEventInPirRelationship(streamEventMock);
-        expect(result).toBeFalsy();
       });
     });
   });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/playbookManagerUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/playbookManagerUtils-test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { isValidEventType } from '../../../../src/manager/playbookManager/playbookManagerUtils';
+import { describe, expect, it, vi } from 'vitest';
+import { isEventInPirRelationship, isValidEventType } from '../../../../src/manager/playbookManager/playbookManagerUtils';
+import * as stixRelationship from '../../../../src/schema/stixRelationship';
+import { RELATION_IN_PIR } from '../../../../src/schema/internalRelationship';
+import type { StreamDataEvent } from '../../../../src/types/event';
 
 describe('playbookManagerUtils', () => {
   describe('isValidEventType', () => {
@@ -13,6 +16,64 @@ describe('playbookManagerUtils', () => {
     describe('When evenType is correct but corresponding event in configuration is false', () => {
       it('should return false', () => {
         const result = isValidEventType('create', { create: false });
+        expect(result).toBeFalsy();
+      });
+    });
+  });
+
+  describe('isEventInPirRelationship', () => {
+    describe('When scope is internal, data relationship type is relation in pir, and isStixRelation is true', () => {
+      it('should return true', () => {
+        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+        const streamEventMock = {
+          scope: 'internal',
+          data: {
+            relationship_type: RELATION_IN_PIR
+          }
+        } as unknown as StreamDataEvent;
+        const result = isEventInPirRelationship(streamEventMock);
+        expect(result).toBeTruthy();
+      });
+    });
+
+    describe('When scope is not internal, but the rest is correct', () => {
+      it('should return false', async () => {
+        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+        const streamEventMock = {
+          scope: 'external',
+          data: {
+            relationship_type: RELATION_IN_PIR
+          }
+        } as unknown as StreamDataEvent;
+        const result = await isEventInPirRelationship(streamEventMock);
+        expect(result).toBeFalsy();
+      });
+    });
+
+    describe('When data relationship type is not a relation in pir, but the rest is correct', () => {
+      it('should return false', async () => {
+        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+        const streamEventMock = {
+          scope: 'internal',
+          data: {
+            relationship_type: 'random-relationship-type'
+          }
+        } as unknown as StreamDataEvent;
+        const result = await isEventInPirRelationship(streamEventMock);
+        expect(result).toBeFalsy();
+      });
+    });
+
+    describe('When isStixRelation is false, but the rest is correct', () => {
+      it('should return false', async () => {
+        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
+        const streamEventMock = {
+          scope: 'internal',
+          data: {
+            relationship_type: RELATION_IN_PIR
+          }
+        } as unknown as StreamDataEvent;
+        const result = await isEventInPirRelationship(streamEventMock);
         expect(result).toBeFalsy();
       });
     });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/playbookManagerUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/playbookManagerUtils-test.ts
@@ -1,8 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { isEventInPir, isValidEventType } from '../../../../src/manager/playbookManager/playbookManagerUtils';
-import type { StreamDataEvent } from '../../../../src/types/event';
-import { RELATION_IN_PIR } from '../../../../src/schema/internalRelationship';
-import * as stixRelationship from '../../../../src/schema/stixRelationship';
+import { describe, expect, it } from 'vitest';
+import { isValidEventType } from '../../../../src/manager/playbookManager/playbookManagerUtils';
 
 describe('playbookManagerUtils', () => {
   describe('isValidEventType', () => {
@@ -16,74 +13,6 @@ describe('playbookManagerUtils', () => {
     describe('When evenType is correct but corresponding event in configuration is false', () => {
       it('should return false', () => {
         const result = isValidEventType('create', { create: false });
-        expect(result).toBeFalsy();
-      });
-
-      describe('When evenType is not correct, even if all events in configuration are true', () => {
-        it('should return false', () => {
-          const result = isValidEventType('random-event-type', {
-            update: true,
-            create: true,
-            delete: true });
-          expect(result).toBeFalsy();
-        });
-      });
-    });
-  });
-
-  describe('isEventInPir', () => {
-    describe('When scope is internal, data relationship type is relation in pir, and isStixRelation is true', () => {
-      it('should return true', () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = isEventInPir(streamEventMock);
-        expect(result).toBeTruthy();
-      });
-    });
-
-    describe('When scope is not internal, but the rest is correct', () => {
-      it('should return false', () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'external',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = isEventInPir(streamEventMock);
-        expect(result).toBeFalsy();
-      });
-    });
-
-    describe('When data relationship type is not a relation in pir, but the rest is correct', () => {
-      it('should return false', () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: 'random-relationship-type'
-          }
-        } as unknown as StreamDataEvent;
-        const result = isEventInPir(streamEventMock);
-        expect(result).toBeFalsy();
-      });
-    });
-
-    describe('When isStixRelation is false, but the rest is correct', () => {
-      it('should return false', () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = isEventInPir(streamEventMock);
         expect(result).toBeFalsy();
       });
     });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/playbookManagerUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/playbookManager/playbookManagerUtils-test.ts
@@ -1,81 +1,101 @@
 import { describe, expect, it, vi } from 'vitest';
-import { isEventInPirRelationship, isValidEventType } from '../../../../src/manager/playbookManager/playbookManagerUtils';
+import { isEventInPirRelationship, isEventUpdateOnEntity, isValidEventType } from '../../../../src/manager/playbookManager/playbookManagerUtils';
 import * as stixRelationship from '../../../../src/schema/stixRelationship';
 import { RELATION_IN_PIR } from '../../../../src/schema/internalRelationship';
 import type { StreamDataEvent } from '../../../../src/types/event';
 
 describe('playbookManagerUtils', () => {
   describe('isValidEventType', () => {
-    describe('When evenType is correct and corresponding event in configuration is true', () => {
-      it('should return true', () => {
-        const result = isValidEventType('create', { create: true });
-        expect(result).toBeTruthy();
-      });
+    it('should return true when evenType is correct and corresponding event in configuration is true', () => {
+      const result = isValidEventType('create', { create: true });
+      expect(result).toBeTruthy();
     });
 
-    describe('When evenType is correct but corresponding event in configuration is false', () => {
-      it('should return false', () => {
-        const result = isValidEventType('create', { create: false });
-        expect(result).toBeFalsy();
-      });
+    it('should return false when evenType is correct but corresponding event in configuration is false', () => {
+      const result = isValidEventType('create', { create: false });
+      expect(result).toBeFalsy();
     });
   });
 
   describe('isEventInPirRelationship', () => {
-    describe('When scope is internal, data relationship type is relation in pir, and isStixRelation is true', () => {
-      it('should return true', () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = isEventInPirRelationship(streamEventMock);
-        expect(result).toBeTruthy();
-      });
+    it('should return true when scope is internal, data relationship type is relation in pir, and isStixRelation is true', () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+      const streamEventMock = {
+        scope: 'internal',
+        data: {
+          relationship_type: RELATION_IN_PIR
+        }
+      } as unknown as StreamDataEvent;
+      const result = isEventInPirRelationship(streamEventMock);
+      expect(result).toBeTruthy();
     });
 
-    describe('When scope is not internal, but the rest is correct', () => {
-      it('should return false', async () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'external',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = await isEventInPirRelationship(streamEventMock);
-        expect(result).toBeFalsy();
-      });
+    it('should return false when scope is not internal, but the rest is correct', async () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+      const streamEventMock = {
+        scope: 'external',
+        data: {
+          relationship_type: RELATION_IN_PIR
+        }
+      } as unknown as StreamDataEvent;
+      const result = await isEventInPirRelationship(streamEventMock);
+      expect(result).toBeFalsy();
     });
 
-    describe('When data relationship type is not a relation in pir, but the rest is correct', () => {
-      it('should return false', async () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: 'random-relationship-type'
-          }
-        } as unknown as StreamDataEvent;
-        const result = await isEventInPirRelationship(streamEventMock);
-        expect(result).toBeFalsy();
-      });
+    it('should return false when data relationship type is not a relation in pir, but the rest is correct', async () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+      const streamEventMock = {
+        scope: 'internal',
+        data: {
+          relationship_type: 'random-relationship-type'
+        }
+      } as unknown as StreamDataEvent;
+      const result = await isEventInPirRelationship(streamEventMock);
+      expect(result).toBeFalsy();
     });
 
-    describe('When isStixRelation is false, but the rest is correct', () => {
-      it('should return false', async () => {
-        vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
-        const streamEventMock = {
-          scope: 'internal',
-          data: {
-            relationship_type: RELATION_IN_PIR
-          }
-        } as unknown as StreamDataEvent;
-        const result = await isEventInPirRelationship(streamEventMock);
-        expect(result).toBeFalsy();
-      });
+    it('should return false when isStixRelation is false, but the rest is correct', async () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
+      const streamEventMock = {
+        scope: 'internal',
+        data: {
+          relationship_type: RELATION_IN_PIR
+        }
+      } as unknown as StreamDataEvent;
+      const result = await isEventInPirRelationship(streamEventMock);
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('isEventUpdateOnEntity', () => {
+    it('should return true when event type is update and data is not a stix relation', () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
+      const streamEventMock = {
+        type: 'update',
+        data: {}
+      } as unknown as StreamDataEvent;
+      const result = isEventUpdateOnEntity(streamEventMock);
+      expect(result).toBeTruthy();
+    });
+
+    it('should return false when event type is not update, but data is not a stix relation', () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(false);
+      const streamEventMock = {
+        type: 'create',
+        data: {}
+      } as unknown as StreamDataEvent;
+      const result = isEventUpdateOnEntity(streamEventMock);
+      expect(result).toBeFalsy();
+    });
+
+    it('should return false when data is a stix relation, but event type is update', () => {
+      vi.spyOn(stixRelationship, 'isStixRelation').mockReturnValue(true);
+      const streamEventMock = {
+        type: 'update',
+        data: {}
+      } as unknown as StreamDataEvent;
+      const result = isEventUpdateOnEntity(streamEventMock);
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/notifier-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/notifier-component-test.ts
@@ -51,7 +51,7 @@ describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
     });
 
     it('should call storeNotificationEvent with correct message when event is a PIR', async () => {
-      vi.spyOn(playbookManagerUtils, 'isEventInPir').mockResolvedValue(true);
+      vi.spyOn(playbookManagerUtils, 'isEventInPirRelationship').mockResolvedValue(true);
 
       const mockEventPirDelete = { type: 'delete', message: 'PIR message' } as unknown as StreamDataEvent;
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/notifier-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/notifier-component-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as middlewareLoader from '../../../../src/database/middleware-loader';
 import * as cache from '../../../../src/database/cache';
 import * as utils from '../../../../src/utils/access';
@@ -8,6 +8,7 @@ import * as notificationManager from '../../../../src/manager/notificationManage
 import * as schemaUtils from '../../../../src/schema/schemaUtils';
 import * as generateMessage from '../../../../src/database/generate-message';
 import * as playbookManagerUtils from '../../../../src/manager/playbookManager/playbookManagerUtils';
+import * as entityRepresentative from '../../../../src/database/entity-representative';
 import type { AuthContext, AuthUser } from '../../../../src/types/user';
 import type { BasicStoreIdentifier } from '../../../../src/types/store';
 import type { StixBundle, StixObject } from '../../../../src/types/stix-2-1-common';
@@ -16,42 +17,44 @@ import type { BasicStoreEntityPlaybook, ExecutorParameters, NodeInstance } from 
 import type { StreamDataEvent } from '../../../../src/types/event';
 
 describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockContext = { id: 'context' } as unknown as AuthContext;
+  const mockPlaybook = { id: 'playbook-id', name: 'Test Playbook' } as unknown as BasicStoreEntityPlaybook;
+  const mockSettings = { id: 'settings-id' } as unknown as BasicStoreIdentifier;
+  const mockBundle = { objects: [{ id: 'obj1', type: 'indicator' } as unknown as StixObject] } as unknown as StixBundle;
+  const mockUser = { id: 'user-1', name: 'Alice' } as unknown as AuthUser;
+  const mockNotificationUser = { id: 'notif-user' } as unknown as notificationManager.NotificationUser;
+  const playbookNode = {
+    id: 'playbook-node-id',
+    name: 'Notifier Node',
+    configuration: {
+      notifiers: ['notifier-1'],
+      authorized_members: [{ value: 'group-1' }]
+    }
+  } as unknown as NodeInstance<NotifierConfiguration>;
+
+  beforeEach(() => {
+    vi.spyOn(utils, 'executionContext').mockReturnValue(mockContext);
+    vi.spyOn(middlewareLoader, 'storeLoadById').mockResolvedValue(mockPlaybook);
+    vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue(mockSettings);
+    vi.spyOn(playbookUtils, 'extractBundleBaseElement').mockReturnValue(mockBundle.objects[0]);
+    vi.spyOn(playbookUtils, 'convertMembersToUsers').mockResolvedValue([mockUser]);
+    vi.spyOn(utils, 'isUserInPlatformOrganization').mockReturnValue(true);
+    vi.spyOn(utils, 'isUserCanAccessStixElement').mockResolvedValue(true);
+    vi.spyOn(notificationManager, 'convertToNotificationUser').mockReturnValue(mockNotificationUser);
+    vi.spyOn(schemaUtils, 'convertStixToInternalTypes').mockReturnValue('Indicator');
+    vi.spyOn(generateMessage, 'generateCreateMessage').mockReturnValue('generated create message');
+    vi.spyOn(generateMessage, 'generateDeleteMessage').mockReturnValue('generated delete message');
+    vi.spyOn(redis, 'storeNotificationEvent').mockResolvedValue(undefined);
+    vi.spyOn(entityRepresentative, 'extractEntityRepresentativeName').mockReturnValue('name');
   });
 
   describe('executor', () => {
-    const mockContext = { id: 'context' } as unknown as AuthContext;
-    const mockPlaybook = { id: 'playbook-id', name: 'Test Playbook' } as unknown as BasicStoreEntityPlaybook;
-    const mockSettings = { id: 'settings-id' } as unknown as BasicStoreIdentifier;
-    const mockBundle = { objects: [{ id: 'obj1', type: 'indicator' } as unknown as StixObject] } as unknown as StixBundle;
-    const mockUser = { id: 'user-1', name: 'Alice' } as unknown as AuthUser;
-    const mockNotificationUser = { id: 'notif-user' } as unknown as notificationManager.NotificationUser;
-    const playbookNode = {
-      id: 'playbook-node-id',
-      name: 'Notifier Node',
-      configuration: {
-        notifiers: ['notifier-1'],
-        authorized_members: [{ value: 'group-1' }]
-      }
-    } as unknown as NodeInstance<NotifierConfiguration>;
-
-    beforeEach(() => {
-      vi.spyOn(utils, 'executionContext').mockReturnValue(mockContext);
-      vi.spyOn(middlewareLoader, 'storeLoadById').mockResolvedValue(mockPlaybook);
-      vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue(mockSettings);
-      vi.spyOn(playbookUtils, 'extractBundleBaseElement').mockReturnValue(mockBundle.objects[0]);
-      vi.spyOn(playbookUtils, 'convertMembersToUsers').mockResolvedValue([mockUser]);
-      vi.spyOn(utils, 'isUserInPlatformOrganization').mockReturnValue(true);
-      vi.spyOn(utils, 'isUserCanAccessStixElement').mockResolvedValue(true);
-      vi.spyOn(notificationManager, 'convertToNotificationUser').mockReturnValue(mockNotificationUser);
-      vi.spyOn(schemaUtils, 'convertStixToInternalTypes').mockReturnValue('Indicator');
-      vi.spyOn(generateMessage, 'generateCreateMessage').mockReturnValue('genereted message');
-      vi.spyOn(redis, 'storeNotificationEvent').mockResolvedValue(undefined);
-    });
-
-    it('should call storeNotificationEvent with correct message when event is a PIR', async () => {
-      vi.spyOn(playbookManagerUtils, 'isEventInPirRelationship').mockResolvedValue(true);
+    it('should call storeNotificationEvent with correct message when executor is called with an event in a PIR', async () => {
+      vi.spyOn(playbookManagerUtils, 'isEventInPirRelationship').mockReturnValue(true);
 
       const mockEventPirDelete = { type: 'delete', message: 'PIR message' } as unknown as StreamDataEvent;
 
@@ -83,6 +86,102 @@ describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
       expect(result).toEqual({ output_port: undefined, bundle: mockBundle });
     });
 
+    it('should call storeNotificationEvent with correct message when event is an update when executor is called with an update event', async () => {
+      vi.spyOn(playbookManagerUtils, 'isEventInPirRelationship').mockReturnValue(false);
+      const mockEventUpdate = { type: 'update', message: 'update message', data: { type: 'entity type' } } as unknown as StreamDataEvent;
+
+      const expectedNotificationEvent: notificationManager.DigestEvent = {
+        version: notificationManager.EVENT_NOTIFICATION_VERSION,
+        playbook_source: mockPlaybook.name,
+        notification_id: playbookNode.id,
+        target: mockNotificationUser,
+        type: 'digest',
+        data: [
+          {
+            notification_id: playbookNode.id,
+            instance: mockBundle.objects[0],
+            message: `${mockEventUpdate.message} in \`name\` ${mockEventUpdate.data.type}`,
+            type: mockEventUpdate.type,
+          },
+        ],
+      } as unknown as notificationManager.DigestEvent;
+
+      const result = await PLAYBOOK_NOTIFIER_COMPONENT.executor({
+        dataInstanceId: 'instance-id',
+        playbookId: 'playbook-id',
+        playbookNode,
+        bundle: mockBundle,
+        event: mockEventUpdate
+      } as unknown as ExecutorParameters<NotifierConfiguration>);
+
+      expect(redis.storeNotificationEvent).toHaveBeenCalledWith(mockContext, expectedNotificationEvent);
+      expect(result).toEqual({ output_port: undefined, bundle: mockBundle });
+    });
+
+    it('should call storeNotificationEvent with generetad create message if event type is created and not in pir', async () => {
+      vi.spyOn(playbookManagerUtils, 'isEventInPirRelationship').mockReturnValue(false);
+
+      const mockEventCreate = { type: 'create', message: 'update message', data: { type: 'entity type' } } as unknown as StreamDataEvent;
+
+      const expectedNotificationEvent: notificationManager.DigestEvent = {
+        version: notificationManager.EVENT_NOTIFICATION_VERSION,
+        playbook_source: mockPlaybook.name,
+        notification_id: playbookNode.id,
+        target: mockNotificationUser,
+        type: 'digest',
+        data: [
+          {
+            notification_id: playbookNode.id,
+            instance: mockBundle.objects[0],
+            message: 'generated create message',
+            type: 'create',
+          },
+        ],
+      } as unknown as notificationManager.DigestEvent;
+
+      await PLAYBOOK_NOTIFIER_COMPONENT.executor({
+        dataInstanceId: 'instance-id',
+        playbookId: 'playbook-id',
+        playbookNode,
+        bundle: mockBundle,
+        event: mockEventCreate
+      } as unknown as ExecutorParameters<NotifierConfiguration>);
+
+      expect(redis.storeNotificationEvent).toHaveBeenCalledWith(mockContext, expectedNotificationEvent);
+    });
+
+    it('should call storeNotificationEvent with generetad delete message if event type is deleted and not in pir', async () => {
+      vi.spyOn(playbookManagerUtils, 'isEventInPirRelationship').mockReturnValue(false);
+
+      const mockEventDelete = { type: 'delete', message: 'update message', data: { type: 'entity type' } } as unknown as StreamDataEvent;
+
+      const expectedNotificationEvent: notificationManager.DigestEvent = {
+        version: notificationManager.EVENT_NOTIFICATION_VERSION,
+        playbook_source: mockPlaybook.name,
+        notification_id: playbookNode.id,
+        target: mockNotificationUser,
+        type: 'digest',
+        data: [
+          {
+            notification_id: playbookNode.id,
+            instance: mockBundle.objects[0],
+            message: 'generated delete message',
+            type: 'delete',
+          },
+        ],
+      } as unknown as notificationManager.DigestEvent;
+
+      await PLAYBOOK_NOTIFIER_COMPONENT.executor({
+        dataInstanceId: 'instance-id',
+        playbookId: 'playbook-id',
+        playbookNode,
+        bundle: mockBundle,
+        event: mockEventDelete
+      } as unknown as ExecutorParameters<NotifierConfiguration>);
+
+      expect(redis.storeNotificationEvent).toHaveBeenCalledWith(mockContext, expectedNotificationEvent);
+    });
+
     it('should call storeNotificationEvent with generetad message if event in undefined', async () => {
       const expectedNotificationEvent: notificationManager.DigestEvent = {
         version: notificationManager.EVENT_NOTIFICATION_VERSION,
@@ -94,7 +193,7 @@ describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
           {
             notification_id: playbookNode.id,
             instance: mockBundle.objects[0],
-            message: 'genereted message',
+            message: 'generated create message',
             type: 'create',
           },
         ],

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/notifier-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/notifier-component-test.ts
@@ -51,7 +51,7 @@ describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
     });
 
     it('should call storeNotificationEvent with correct message when event is a PIR', async () => {
-      vi.spyOn(playbookManagerUtils, 'isEventInPir').mockReturnValue(true);
+      vi.spyOn(playbookManagerUtils, 'isEventInPir').mockResolvedValue(true);
 
       const mockEventPirDelete = { type: 'delete', message: 'PIR message' } as unknown as StreamDataEvent;
 
@@ -83,23 +83,7 @@ describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
       expect(result).toEqual({ output_port: undefined, bundle: mockBundle });
     });
 
-    it('should skip notification if event is in PIR and type is update', async () => {
-      vi.spyOn(playbookManagerUtils, 'isEventInPir').mockReturnValue(true);
-
-      await PLAYBOOK_NOTIFIER_COMPONENT.executor({
-        dataInstanceId: 'instance-id',
-        playbookId: 'playbook-id',
-        playbookNode,
-        bundle: mockBundle,
-        event: { type: 'update' } as unknown as StreamDataEvent
-      } as unknown as ExecutorParameters<NotifierConfiguration>);
-
-      expect(redis.storeNotificationEvent).not.toHaveBeenCalled();
-    });
-
-    it('should call storeNotificationEvent with generetad message is event is not a PIR', async () => {
-      vi.spyOn(playbookManagerUtils, 'isEventInPir').mockReturnValue(false);
-
+    it('should call storeNotificationEvent with generetad message if event in undefined', async () => {
       const expectedNotificationEvent: notificationManager.DigestEvent = {
         version: notificationManager.EVENT_NOTIFICATION_VERSION,
         playbook_source: mockPlaybook.name,
@@ -121,7 +105,7 @@ describe('PLAYBOOK_NOTIFIER_COMPONENT', () => {
         playbookId: 'playbook-id',
         playbookNode,
         bundle: mockBundle,
-        event: {} as unknown as StreamDataEvent
+        event: undefined
       } as unknown as ExecutorParameters<NotifierConfiguration>);
 
       expect(redis.storeNotificationEvent).toHaveBeenCalledWith(mockContext, expectedNotificationEvent);


### PR DESCRIPTION
### Proposed changes

FF: PIR_IN_PLAYBOOKS

This PR allows playbooks to listen to updates of flagged entities in a Pir
We changed the default message for notifier when an update is made on an entity to match the event message instead of a create message
We made the listen Pir Utils to listen to external events so that it can get an update of an entity and not only the pir relationship, and from that update, we added logic to know if the updated entity is in one of the selected Pir in the playbook
When it is the case then the entity is sent in the playbookExecutor

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/12362

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality