### PR TITLE
[frontend] temporary fix for hidden controlled dial button

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -846,6 +846,8 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
               speeddial={undefined}
               handleClose={undefined}
               onCompleted={undefined}
+              // TODO: remove with release 6.9
+              controlledDialStyles={{ position: 'fixed', top: 16, right: 16 }}
             />
           )}
           {targetEntities.length === 0 && isOnlySCOs && (
@@ -906,6 +908,8 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                 isFromBulkRelation={undefined}
                 defaultMarkingDefinitions={undefined}
                 stixDomainObjectTypes={undefined}
+                // TODO: remove with release 6.9
+                controlledDialStyles={{ position: 'fixed', top: 16, right: 16 }}
               />
               <StixCyberObservableCreation
                 display={open}
@@ -918,6 +922,8 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                 handleClose={handleCloseCreateObservable}
                 type={undefined}
                 defaultCreatedBy={undefined}
+                // TODO: remove with release 6.9
+                controlledDialStyles={{ position: 'fixed', top: 16, right: 16 }}
               />
             </>
           )}


### PR DESCRIPTION
This bug is already fixed in PR https://github.com/OpenCTI-Platform/opencti/pull/10870 which is merged in release/current, so this is just to fix this bug for clients until the next release

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix the `Create <entity>` button on the Create Relationship view. I kept the fix super minimal as this is quite urgent and to minimize conflicts when we will merge the next release, as this bug has already been fixed in https://github.com/OpenCTI-Platform/opencti/pull/10870 with a pretty big refacto, so this will reduce the conflicts scope

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes https://github.com/OpenCTI-Platform/opencti/issues/13007

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
