### PR TITLE
[frontend] Allow immediate deletion of managed connectors after stop request (#12474)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
@@ -162,7 +162,22 @@ const ConnectorPopover = ({ connector, onRefreshData }: ConnectorPopoverProps) =
           <MenuItem onClick={handleOpenResetState}>{t_i18n('Reset the connector state')}</MenuItem>
         )}
         <MenuItem onClick={handleOpenClearWorks}>{t_i18n('Clear all works')}</MenuItem>
-        <MenuItem onClick={handleOpenDelete} disabled={!!connector.active || !!connector.built_in}>{t_i18n('Delete')}</MenuItem>
+        <MenuItem
+          onClick={handleOpenDelete}
+          disabled={(() => {
+            if (connector.built_in) return true;
+            if (connector.is_managed) {
+              // Allow deletion once stop has been requested or connector is stopped
+              const canDelete = connector.manager_requested_status === 'stopping'
+                             || connector.manager_requested_status === 'stopped'
+                             || connector.manager_current_status === 'stopped';
+              return !canDelete;
+            }
+            return !!connector.active;
+          })()}
+        >
+          {t_i18n('Delete')}
+        </MenuItem>
       </Menu>
 
       {

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
@@ -27,6 +27,7 @@ import DeleteDialog from '../../../../components/DeleteDialog';
 import { useFormatter } from '../../../../components/i18n';
 import useDeletion from '../../../../utils/hooks/useDeletion';
 import stopEvent from '../../../../utils/domEvent';
+import canDeleteConnector from './utils/canDeleteConnector';
 
 interface ConnectorPopoverProps {
   connector: Connector_connector$data;
@@ -164,17 +165,7 @@ const ConnectorPopover = ({ connector, onRefreshData }: ConnectorPopoverProps) =
         <MenuItem onClick={handleOpenClearWorks}>{t_i18n('Clear all works')}</MenuItem>
         <MenuItem
           onClick={handleOpenDelete}
-          disabled={(() => {
-            if (connector.built_in) return true;
-            if (connector.is_managed) {
-              // Allow deletion once stop has been requested or connector is stopped
-              const canDelete = connector.manager_requested_status === 'stopping'
-                             || connector.manager_requested_status === 'stopped'
-                             || connector.manager_current_status === 'stopped';
-              return !canDelete;
-            }
-            return !!connector.active;
-          })()}
+          disabled={!canDeleteConnector(connector)}
         >
           {t_i18n('Delete')}
         </MenuItem>

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorsStatus.tsx
@@ -27,6 +27,7 @@ import ConnectorsList, { connectorsListQuery } from '@components/data/connectors
 import ConnectorsState, { connectorsStateQuery } from '@components/data/connectors/ConnectorsState';
 import { ConnectorsListQuery } from '@components/data/connectors/__generated__/ConnectorsListQuery.graphql';
 import { ConnectorsStateQuery } from '@components/data/connectors/__generated__/ConnectorsStateQuery.graphql';
+import { Connector_connector$data } from '@components/data/connectors/__generated__/Connector_connector.graphql';
 import { getConnectorMetadata, IngestionConnectorType } from '@components/data/IngestionCatalog/utils/ingestionConnectorTypeMetadata';
 import Transition from '../../../../components/Transition';
 import { FIVE_SECONDS } from '../../../../utils/Time';
@@ -41,6 +42,7 @@ import type { Theme } from '../../../../components/Theme';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import SortConnectorsHeader from './SortConnectorsHeader';
 import useSensitiveModifications from '../../../../utils/hooks/useSensitiveModifications';
+import canDeleteConnector from './utils/canDeleteConnector';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -377,7 +379,7 @@ const ConnectorsStatusContent: FunctionComponent<ConnectorsStatusContentProps> =
                                   }}
                                   aria-haspopup="true"
                                   color="primary"
-                                  disabled={!!connector.active || !!connector.built_in}
+                                  disabled={!canDeleteConnector(connector as unknown as Connector_connector$data)}
                                   size="large"
                                 >
                                   <DeleteOutlined />

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/utils/canDeleteConnector.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/utils/canDeleteConnector.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { Connector_connector$data } from '@components/data/connectors/__generated__/Connector_connector.graphql';
+import canDeleteConnector from './canDeleteConnector';
+
+describe('canDeleteConnector', () => {
+  it('should return false for built-in connectors', () => {
+    const connector = {
+      built_in: true,
+      is_managed: false,
+      active: false,
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(false);
+  });
+
+  it('should return false for active non-managed connectors', () => {
+    const connector = {
+      built_in: false,
+      is_managed: false,
+      active: true,
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(false);
+  });
+
+  it('should return true for inactive non-managed connectors', () => {
+    const connector = {
+      built_in: false,
+      is_managed: false,
+      active: false,
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(true);
+  });
+
+  it('should return true for managed connectors with stopping requested status', () => {
+    const connector = {
+      built_in: false,
+      is_managed: true,
+      manager_requested_status: 'stopping',
+      manager_current_status: 'started',
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(true);
+  });
+
+  it('should return true for managed connectors with stopped requested status', () => {
+    const connector = {
+      built_in: false,
+      is_managed: true,
+      manager_requested_status: 'stopped',
+      manager_current_status: 'started',
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(true);
+  });
+
+  it('should return true for managed connectors with stopped current status', () => {
+    const connector = {
+      built_in: false,
+      is_managed: true,
+      manager_requested_status: null,
+      manager_current_status: 'stopped',
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(true);
+  });
+
+  it('should return false for managed connectors that are running without stop request', () => {
+    const connector = {
+      built_in: false,
+      is_managed: true,
+      manager_requested_status: 'started',
+      manager_current_status: 'started',
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(false);
+  });
+
+  it('should return false for managed built-in connectors even if stopped', () => {
+    const connector = {
+      built_in: true,
+      is_managed: true,
+      manager_requested_status: 'stopped',
+      manager_current_status: 'stopped',
+    } as Connector_connector$data;
+
+    expect(canDeleteConnector(connector)).toBe(false);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/utils/canDeleteConnector.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/utils/canDeleteConnector.ts
@@ -1,0 +1,26 @@
+import { Connector_connector$data } from '@components/data/connectors/__generated__/Connector_connector.graphql';
+
+/**
+ * Determines if a connector can be deleted based on its state.
+ *
+ * @param connector - The connector to check
+ * @returns true if the connector can be deleted, false otherwise
+ */
+const canDeleteConnector = (connector: Connector_connector$data): boolean => {
+  // Built-in connectors cannot be deleted
+  if (connector.built_in) {
+    return false;
+  }
+
+  // For managed connectors, allow deletion only after stop has been requested or connector is stopped
+  if (connector.is_managed) {
+    return connector.manager_requested_status === 'stopping'
+      || connector.manager_requested_status === 'stopped'
+      || connector.manager_current_status === 'stopped';
+  }
+
+  // For non-managed connectors, cannot delete if active
+  return !connector.active;
+};
+
+export default canDeleteConnector;


### PR DESCRIPTION
### Proposed changes

* Modified the deletion button logic in `ConnectorPopover.tsx` to enable deletion of managed connectors as soon as stop has been requested
* Previously, users had to wait for the composer to detect the process was dead before deletion was allowed

### Related issues

* #12474 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

This is a UX improvement that eliminates unnecessary waiting time. The change is minimal and focused:
- Built-in connectors: deletion remains disabled (unchanged)
- Managed connectors: deletion enabled immediately when stop is requested
- Non-managed connectors: original behavior preserved

The backend/composer will handle cleanup of stopping/stopped containers appropriately.
