### PR TITLE
[frontend] better alignment on overview (#10206)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreObjectExternalReferences.jsx
@@ -20,6 +20,9 @@ const styles = (theme) => ({
     padding: 0,
     borderRadius: 4,
   },
+  container: {
+    height: 60,
+  },
   avatar: {
     width: 24,
     height: 24,
@@ -68,6 +71,7 @@ class StixCoreObjectExternalReferences extends Component {
                       key={i}
                       dense={true}
                       divider={true}
+                      classes={classes.container}
                     >
                       <ListItemIcon>
                         <Avatar classes={{ root: classes.avatarDisabled }}>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
@@ -32,7 +32,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 
 const styles = () => ({
   container: {
-    marginBottom: 5,
+    height: 60,
   },
   line: {
     content: ' ',
@@ -286,7 +286,7 @@ class StixCoreObjectHistoryLineComponent extends Component {
   render() {
     const { nsdt, classes, node, isRelation, t } = this.props;
     return (
-      <div className={classes.container}>
+      <ListItem className={classes.container}>
         <div className={classes.avatar}>
           <Badge
             color="secondary"
@@ -463,7 +463,7 @@ class StixCoreObjectHistoryLineComponent extends Component {
             </Button>
           </DialogActions>
         </Dialog>
-      </div>
+      </ListItem>
     );
   }
 }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLines.tsx
@@ -6,6 +6,7 @@ import {
   StixCoreObjectHistoryLinesQuery$variables,
 } from '@components/common/stix_core_objects/__generated__/StixCoreObjectHistoryLinesQuery.graphql';
 import { StixCoreObjectHistoryLines_data$key } from '@components/common/stix_core_objects/__generated__/StixCoreObjectHistoryLines_data.graphql';
+import List from '@mui/material/List';
 import { useFormatter } from '../../../../components/i18n';
 import StixCoreObjectHistoryLine from './StixCoreObjectHistoryLine';
 import { FIVE_SECONDS } from '../../../../utils/Time';
@@ -67,48 +68,52 @@ const StixCoreObjectHistoryLines: FunctionComponent<StixCoreObjectHistoryLinesPr
   }, FIVE_SECONDS);
 
   const logs = data?.logs?.edges ?? [];
+
   return (
     <Paper
       style={{
         marginTop: 6,
-        padding: 15,
+        padding: '0 15px',
         borderRadius: 4,
       }}
       className={'paper-for-grid'}
       variant="outlined"
     >
       {logs.length > 0 ? (
-        logs.filter((l) => !!l).map((logEdge) => {
-          const log = logEdge.node;
-          return (
-            <StixCoreObjectHistoryLine
-              key={log.id}
-              node={log}
-              isRelation={isRelationLog}
-            />
-          );
-        })
-      ) : (
-        <div
-          style={{
-            display: 'table',
-            height: '100%',
-            width: '100%',
-          }}
-        >
-          <span
+        <List>
+          {logs.filter((l) => !!l).map((logEdge) => {
+            const log = logEdge.node;
+            return (
+              <StixCoreObjectHistoryLine
+                key={log.id}
+                node={log}
+                isRelation={isRelationLog}
+              />
+            );
+          })}
+        </List>
+      )
+        : (
+          <div
             style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
+              display: 'table',
+              height: '100%',
+              width: '100%',
             }}
           >
-            {isRelationLog
-              ? t_i18n('No relations history about this entity.')
-              : t_i18n('No history about this entity.')}
-          </span>
-        </div>
-      )}
+            <span
+              style={{
+                display: 'table-cell',
+                verticalAlign: 'middle',
+                textAlign: 'center',
+              }}
+            >
+              {isRelationLog
+                ? t_i18n('No relations history about this entity.')
+                : t_i18n('No history about this entity.')}
+            </span>
+          </div>
+        )}
     </Paper>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipHistoryLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipHistoryLines.jsx
@@ -10,7 +10,7 @@ import inject18n from '../../../../components/i18n';
 const styles = (theme) => ({
   paperHistory: {
     marginTop: theme.spacing(1),
-    padding: 15,
+    padding: '0 15px',
     borderRadius: 4,
   },
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* style updated to have a better alignment between external refs and history lines on overview 

<img width="1703" height="498" alt="image" src="https://github.com/user-attachments/assets/129e7aa8-2094-40c3-8ed2-53849621fb6f" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10206 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
