### PR TITLE
[frontend] Fix closing PIR creation form (13096)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreation.tsx
@@ -48,6 +48,9 @@ const PirCreation = ({ paginationOptions }: PirCreationProps) => {
     { successMessage: `${t_i18n('entity_Pir')} ${t_i18n('successfully created')}` },
   );
 
+  const handleOpenDialog = () => setDialogOpen(true);
+  const handleCloseDialog = () => setDialogOpen(false);
+
   const submit = (data: PirCreationFormData) => {
     const input = pirFormDataToMutationInput(data);
     createMutation({
@@ -71,7 +74,7 @@ const PirCreation = ({ paginationOptions }: PirCreationProps) => {
     <>
       <CreateEntityControlledDial
         entityType='Pir'
-        onOpen={() => setDialogOpen(true)}
+        onOpen={handleOpenDialog}
       />
 
       <Dialog
@@ -84,9 +87,10 @@ const PirCreation = ({ paginationOptions }: PirCreationProps) => {
             style: { minWidth: '950px' },
           },
         }}
+        onClose={handleCloseDialog}
       >
         <PirCreationForm
-          onCancel={() => setDialogOpen(false)}
+          onClose={handleCloseDialog}
           onSubmit={submit}
         />
       </Dialog>

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreation.tsx
@@ -90,7 +90,7 @@ const PirCreation = ({ paginationOptions }: PirCreationProps) => {
         onClose={handleCloseDialog}
       >
         <PirCreationForm
-          onClose={handleCloseDialog}
+          onCancel={handleCloseDialog}
           onSubmit={submit}
         />
       </Dialog>

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreationForm.tsx
@@ -17,6 +17,7 @@ import { Button, DialogActions, DialogContent, DialogTitle } from '@mui/material
 import React, { useState } from 'react';
 import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
+import Dialog from '@mui/material/Dialog';
 import { PirCreationFormData } from './pir-form-utils';
 import PirCreationFormGeneralSettings, { redisStreamQuery } from './PirCreationFormGeneralSettings';
 import PirCreationFormStepper from './PirCreationFormStepper';
@@ -27,11 +28,11 @@ import { PirCreationFormGeneralSettingsRedisStreamQuery } from './__generated__/
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
 interface PirCreationFormProps {
-  onCancel: () => void
+  onClose: () => void
   onSubmit: (data: PirCreationFormData) => void
 }
 
-const PirCreationForm = ({ onCancel, onSubmit }: PirCreationFormProps) => {
+const PirCreationForm = ({ onClose, onSubmit }: PirCreationFormProps) => {
   const { t_i18n } = useFormatter();
   const [step, setStep] = useState(0);
 
@@ -107,7 +108,7 @@ const PirCreationForm = ({ onCancel, onSubmit }: PirCreationFormProps) => {
             </DialogContent>
 
             <DialogActions>
-              <Button onClick={onCancel}>
+              <Button onClick={onClose}>
                 {t_i18n('Cancel')}
               </Button>
               {step !== 1 && (

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreationForm.tsx
@@ -17,7 +17,6 @@ import { Button, DialogActions, DialogContent, DialogTitle } from '@mui/material
 import React, { useState } from 'react';
 import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import Dialog from '@mui/material/Dialog';
 import { PirCreationFormData } from './pir-form-utils';
 import PirCreationFormGeneralSettings, { redisStreamQuery } from './PirCreationFormGeneralSettings';
 import PirCreationFormStepper from './PirCreationFormStepper';
@@ -28,11 +27,11 @@ import { PirCreationFormGeneralSettingsRedisStreamQuery } from './__generated__/
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 
 interface PirCreationFormProps {
-  onClose: () => void
+  onCancel: () => void
   onSubmit: (data: PirCreationFormData) => void
 }
 
-const PirCreationForm = ({ onClose, onSubmit }: PirCreationFormProps) => {
+const PirCreationForm = ({ onCancel, onSubmit }: PirCreationFormProps) => {
   const { t_i18n } = useFormatter();
   const [step, setStep] = useState(0);
 
@@ -108,7 +107,7 @@ const PirCreationForm = ({ onClose, onSubmit }: PirCreationFormProps) => {
             </DialogContent>
 
             <DialogActions>
-              <Button onClick={onClose}>
+              <Button onClick={onCancel}>
                 {t_i18n('Cancel')}
               </Button>
               {step !== 1 && (


### PR DESCRIPTION
### Proposed changes
When clicking outside the PIR creation form, the form should close.

<img width="1838" height="838" alt="image" src="https://github.com/user-attachments/assets/c42fa2ff-6db2-424f-8804-7b0491382900" />


### Related issues
#13096