### PR TITLE
[frontend] Bulk Search: Unknown entities bulk creation (#3360)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "Beziehungen in Massen erstellen",
   "Create relations in bulk for": "Erstellen von Relationen im Bulk für",
   "Create Relationship": "Beziehung erstellen",
+  "Create unknown entities": "Unbekannte Entitäten erstellen",
   "Create Widget": "Widget erstellen",
   "Create Workbench": "Workbench erstellen",
   "created": "Erstellt",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "Create relations in bulk",
   "Create relations in bulk for": "Create relations in bulk for",
   "Create Relationship": "Create Relationship",
+  "Create unknown entities": "Create unknown entities",
   "Create Widget": "Create Widget",
   "Create Workbench": "Create Workbench",
   "created": "Created",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "Crear relaciones en bloque",
   "Create relations in bulk for": "Crear relaciones en bloque para",
   "Create Relationship": "Nueva relación",
+  "Create unknown entities": "Crear entidades desconocidas",
   "Create Widget": "Crear Widget",
   "Create Workbench": "Crear banco de trabajo",
   "created": "Creado",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "Créer des relations en masse",
   "Create relations in bulk for": "Créer des relations en masse pour",
   "Create Relationship": "Créer une relation",
+  "Create unknown entities": "Créer des entités inconnues",
   "Create Widget": "Créer un widget",
   "Create Workbench": "Créer un espace de travail",
   "created": "Créé",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "Crea relazioni in bulk",
   "Create relations in bulk for": "Crea relazioni in bulk per",
   "Create Relationship": "Creare una relazione",
+  "Create unknown entities": "Creare entità sconosciute",
   "Create Widget": "Crea Widget",
   "Create Workbench": "Creare Workbench",
   "created": "Creato",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "リレーションの一括作成",
   "Create relations in bulk for": "リレーションシップの一括作成",
   "Create Relationship": "リレーションシップを作成",
+  "Create unknown entities": "未知のエンティティを作成する",
   "Create Widget": "ウィジェットの作成",
   "Create Workbench": "ワークベンチを作成",
   "created": "作成日時",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "대량으로 관계 만들기",
   "Create relations in bulk for": "다음에 대한 대량 관계 만들기",
   "Create Relationship": "관계 만들기",
+  "Create unknown entities": "알 수 없는 엔터티 만들기",
   "Create Widget": "위젯 만들기",
   "Create Workbench": "워크벤치 생성",
   "created": "생성됨",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "Создание отношений в массовом порядке",
   "Create relations in bulk for": "Создавайте отношения в массовом порядке для",
   "Create Relationship": "Создать отношения",
+  "Create unknown entities": "Создание неизвестных сущностей",
   "Create Widget": "Создать виджет",
   "Create Workbench": "Создание рабочего стола",
   "created": "создан",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -792,6 +792,7 @@
   "Create relations in bulk": "批量创建关系",
   "Create relations in bulk for": "批量创建关系",
   "Create Relationship": "创建关系",
+  "Create unknown entities": "创建未知实体",
   "Create Widget": "创建小工具",
   "Create Workbench": "创建工作台",
   "created": "创建",

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -77,9 +77,9 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps & {
       resolvePath={(a) => a}
       initialValues={{}}
       disableLineSelection={!taskScope}
-      dataTableToolBarComponent={taskScope
+      dataTableToolBarComponent={taskScope && Array.isArray(data) && data[0].has('id')
         ? <DataTableWithoutFragmentInternalToolbar
-            dataIds={(data as { id: string, value: string, entity_type: string }[]).map((d) => d.id)}
+            dataIds={data.map((d) => d.id)}
             taskScope={taskScope}
           />
         : undefined

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import DataTableToolBar from '@components/data/DataTableToolBar';
+import { useTheme } from '@mui/styles';
 import type { DataTableProps } from './dataTableTypes';
 import DataTableComponent from './components/DataTableComponent';
+import type { Theme } from '../Theme';
+import { useDataTableContext } from './components/DataTableContext';
 
 type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
 | 'storageKey'
@@ -23,8 +27,43 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
   globalCount: number
 };
 
-const DataTableWithoutFragment = (props: OCTIDataTableProps) => {
-  const { data } = props;
+const DataTableWithoutFragmentInternalToolbar = ({ taskScope }: { taskScope: string }) => {
+  const theme = useTheme<Theme>();
+
+  const {
+    useDataTableToggle: {
+      selectedElements,
+      deSelectedElements,
+      numberOfSelectedElements,
+      selectAll,
+      handleClearSelectedElements,
+    },
+  } = useDataTableContext();
+
+  return (
+    <div
+      style={{
+        background: theme.palette.background.accent,
+        flex: 1,
+      }}
+    >
+      <DataTableToolBar
+        selectedElements={selectedElements}
+        deSelectedElements={deSelectedElements}
+        numberOfSelectedElements={numberOfSelectedElements}
+        selectAll={selectAll}
+        types={['Stix-Core-Object']}
+        handleClearSelectedElements={handleClearSelectedElements}
+        taskScope={taskScope}
+      />
+    </div>
+  );
+};
+
+const DataTableWithoutFragment = (props: OCTIDataTableProps & {
+  taskScope?: string
+}) => {
+  const { data, taskScope } = props;
 
   return (
     <DataTableComponent
@@ -34,7 +73,11 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps) => {
       dataQueryArgs={(line: never) => line}
       resolvePath={(a) => a}
       initialValues={{}}
-      disableLineSelection={true}
+      disableLineSelection={!taskScope}
+      dataTableToolBarComponent={taskScope
+        ? <DataTableWithoutFragmentInternalToolbar taskScope={taskScope} />
+        : undefined
+      }
     />
   );
 };

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -68,6 +68,11 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps & {
 }) => {
   const { data, taskScope } = props;
 
+  const extractDataIds = () => {
+    if (!Array.isArray(data)) return [];
+    return data.map((d) => d?.id).filter((id): id is string => typeof id === 'string');
+  };
+
   return (
     <DataTableComponent
       {...props}
@@ -79,7 +84,7 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps & {
       disableLineSelection={!taskScope}
       dataTableToolBarComponent={taskScope && Array.isArray(data) && data[0].has('id')
         ? <DataTableWithoutFragmentInternalToolbar
-            dataIds={data.map((d) => d.id)}
+            dataIds={extractDataIds()}
             taskScope={taskScope}
           />
         : undefined

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -82,7 +82,7 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps & {
       resolvePath={(a) => a}
       initialValues={{}}
       disableLineSelection={!taskScope}
-      dataTableToolBarComponent={taskScope && Array.isArray(data) && data[0].has('id')
+      dataTableToolBarComponent={taskScope
         ? <DataTableWithoutFragmentInternalToolbar
             dataIds={extractDataIds()}
             taskScope={taskScope}

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import DataTableToolBar from '@components/data/DataTableToolBar';
 import { useTheme } from '@mui/styles';
+import DataTableWithoutFragmentToolBar from '@components/data/DataTableWithoutFragmentToolBar';
 import type { DataTableProps } from './dataTableTypes';
 import DataTableComponent from './components/DataTableComponent';
 import type { Theme } from '../Theme';
@@ -27,18 +27,25 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
   globalCount: number
 };
 
-const DataTableWithoutFragmentInternalToolbar = ({ taskScope }: { taskScope: string }) => {
+interface DataTableWithoutFragmentInternalToolBarProps {
+  taskScope: string,
+  dataIds: string[],
+}
+
+const DataTableWithoutFragmentInternalToolbar = ({ taskScope, dataIds }: DataTableWithoutFragmentInternalToolBarProps) => {
   const theme = useTheme<Theme>();
 
   const {
     useDataTableToggle: {
       selectedElements,
       deSelectedElements,
-      numberOfSelectedElements,
       selectAll,
       handleClearSelectedElements,
     },
   } = useDataTableContext();
+  const selectedValues = selectAll
+    ? dataIds.filter((v) => !Object.keys(deSelectedElements).includes(v))
+    : Object.keys(selectedElements);
 
   return (
     <div
@@ -47,12 +54,8 @@ const DataTableWithoutFragmentInternalToolbar = ({ taskScope }: { taskScope: str
         flex: 1,
       }}
     >
-      <DataTableToolBar
-        selectedElements={selectedElements}
-        deSelectedElements={deSelectedElements}
-        numberOfSelectedElements={numberOfSelectedElements}
-        selectAll={selectAll}
-        types={['Stix-Core-Object']}
+      <DataTableWithoutFragmentToolBar
+        selectedValues={selectedValues}
         handleClearSelectedElements={handleClearSelectedElements}
         taskScope={taskScope}
       />
@@ -75,7 +78,10 @@ const DataTableWithoutFragment = (props: OCTIDataTableProps & {
       initialValues={{}}
       disableLineSelection={!taskScope}
       dataTableToolBarComponent={taskScope
-        ? <DataTableWithoutFragmentInternalToolbar taskScope={taskScope} />
+        ? <DataTableWithoutFragmentInternalToolbar
+            dataIds={(data as { id: string, value: string, entity_type: string }[]).map((d) => d.id)}
+            taskScope={taskScope}
+          />
         : undefined
       }
     />

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
@@ -7,6 +7,7 @@ import MenuItem from '@mui/material/MenuItem';
 import { PopoverProps } from '@mui/material/Popover/Popover';
 import { useTheme } from '@mui/styles';
 import Box from '@mui/material/Box';
+import { UNKNOWN_ENTITIES_LOCAL_STORAGE_KEY } from '@components/SearchBulkUnknownEntities';
 import { DataTableColumn, DataTableColumns, DataTableHeadersProps } from '../dataTableTypes';
 import DataTableHeader, { SELECT_COLUMN_SIZE } from './DataTableHeader';
 import type { Theme } from '../../Theme';
@@ -37,6 +38,7 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
     useDataTablePaginationLocalStorage: {
       viewStorage: { sortBy, orderAsc },
     },
+    storageKey,
   } = useDataTableContext();
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -67,7 +69,8 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
     minWidth: startColumnWidth,
   };
 
-  const showToolbar = numberOfSelectedElements > 0 && !disableToolBar;
+  const showToolbar = (numberOfSelectedElements > 0 && !disableToolBar)
+    || (storageKey === UNKNOWN_ENTITIES_LOCAL_STORAGE_KEY && selectAll); // case of DataTableWithoutFragment
 
   return (
     <div ref={containerRef} style={{ display: 'flex', height: 42 }}>

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -7,7 +7,7 @@ import { usePaginationLocalStorage } from '../../utils/hooks/useLocalStorage';
 import Loader from '../../components/Loader';
 import type { DataTableProps } from '../../components/dataGrid/dataTableTypes';
 
-const LOCAL_STORAGE_KEY = 'searchBulk_unknownEntities';
+export const UNKNOWN_ENTITIES_LOCAL_STORAGE_KEY = 'searchBulk_unknownEntities';
 
 const searchBulkUnknownEntitiesQuery = graphql`
   query SearchBulkUnknownEntitiesQuery(
@@ -58,7 +58,7 @@ const SearchBulkUnknownEntitiesContent = ({ queryRef, setNumberOfEntities, isDis
           data={unknownEntities}
           globalCount={unknownEntities.length}
           dataColumns={dataColumns}
-          storageKey={LOCAL_STORAGE_KEY}
+          storageKey={UNKNOWN_ENTITIES_LOCAL_STORAGE_KEY}
           taskScope="UNKNOWN_ENTITIES"
            />}
     </>
@@ -77,7 +77,7 @@ const SearchBulkUnknownEntities = ({ values, setNumberOfEntities, isDisplayed }:
     orderAsc: true,
   };
   const { paginationOptions } = usePaginationLocalStorage<SearchBulkUnknownEntitiesQuery>(
-    LOCAL_STORAGE_KEY,
+    UNKNOWN_ENTITIES_LOCAL_STORAGE_KEY,
     initialValues,
   );
 

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -59,6 +59,7 @@ const SearchBulkUnknownEntitiesContent = ({ queryRef, setNumberOfEntities, isDis
           globalCount={unknownEntities.length}
           dataColumns={dataColumns}
           storageKey={LOCAL_STORAGE_KEY}
+          taskScope="UNKNOWN_ENTITIES"
            />}
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkUnknownEntities.tsx
@@ -60,6 +60,7 @@ const SearchBulkUnknownEntitiesContent = ({ queryRef, setNumberOfEntities, isDis
           dataColumns={dataColumns}
           storageKey={UNKNOWN_ENTITIES_LOCAL_STORAGE_KEY}
           taskScope="UNKNOWN_ENTITIES"
+          selectOnLineClick
            />}
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
@@ -157,6 +157,9 @@ export type UploadStatus = 'uploading' | 'success' | undefined;
 
 interface InitialValues {
   entityId?: string;
+  activeStep?: number;
+  importMode?: ImportMode;
+  initialFreeTextContent?: string;
 }
 
 type ImportFilesContextProps = InitialValues & {
@@ -187,8 +190,8 @@ export const ImportFilesProvider = ({ children, initialValue }: {
   const canSelectImportMode = useGranted(['KNOWLEDGE_KNASKIMPORT']); // Check capability to set connectors and validation mode
   const draftContext = useDraftContext();
 
-  const [activeStep, setActiveStep] = useState(canSelectImportMode ? 0 : 1);
-  const [importMode, setImportMode] = useState<ImportMode | undefined>(!canSelectImportMode ? 'auto' : undefined);
+  const [activeStep, setActiveStep] = useState(initialValue.activeStep ?? (canSelectImportMode ? 0 : 1));
+  const [importMode, setImportMode] = useState<ImportMode | undefined>(!canSelectImportMode ? 'auto' : initialValue.importMode);
   const [files, setFiles] = useState<FileWithConnectors[]>([]);
   const [uploadStatus, setUploadStatus] = useState<undefined | UploadStatus>();
   const [draftId, setDraftId] = useState<string | undefined>(draftContext?.id);

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
 import { FileWithConnectors } from '@components/common/files/import_files/ImportFilesUploader';
 import { graphql, PreloadedQuery } from 'react-relay';
 import { ImportFilesContextQuery } from '@components/common/files/import_files/__generated__/ImportFilesContextQuery.graphql';
@@ -208,11 +208,15 @@ export const ImportFilesProvider = ({ children, initialValue }: {
 
     return result?.guessMimeType || null;
   }, []);
+  useEffect(() => {
+    setActiveStep(initialValue.activeStep ?? (canSelectImportMode ? 0 : 1));
+  }, [initialValue]);
 
   return queryRef && (
     <React.Suspense>
       <ImportFilesContext.Provider
         value={{
+          ...initialValue,
           canSelectImportMode,
           activeStep,
           setActiveStep,
@@ -229,7 +233,6 @@ export const ImportFilesProvider = ({ children, initialValue }: {
           inDraftContext: !!draftContext?.id,
           guessMimeType,
           queryRef,
-          ...initialValue,
         }}
       >
         {children}

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -105,7 +105,7 @@ interface ImportFilesDialogProps {
   open: boolean;
   handleClose: () => void;
   entityId?: string;
-  draftId?: string;
+  initialFreeTextContent?: string;
 }
 
 export type OptionsFormValues = {
@@ -509,7 +509,9 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
               {activeStep === 1 && (
                 importMode === 'form'
                   ? <ImportFilesFormSelector />
-                  : <ImportFilesUploader connectorsForImport={connectorsForImport}/>
+                  : <ImportFilesUploader
+                      connectorsForImport={connectorsForImport}
+                    />
               )}
               {activeStep === 2 && (
                 importMode === 'form'
@@ -540,10 +542,13 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
   );
 };
 
-const ImportFilesDialog = ({ open, entityId, handleClose }: ImportFilesDialogProps) => {
+const ImportFilesDialog = ({ open, entityId, handleClose, initialFreeTextContent }: ImportFilesDialogProps) => {
+  const initialValue = initialFreeTextContent
+    ? { entityId, activeStep: 1, mode: 'manual', initialFreeTextContent }
+    : { entityId };
   return (
-    <ImportFilesProvider initialValue={{ entityId }}>
-      <ImportFiles open={open} handleClose={handleClose}></ImportFiles>
+    <ImportFilesProvider initialValue={initialValue}>
+      <ImportFiles open={open} handleClose={handleClose} ></ImportFiles>
     </ImportFilesProvider>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
@@ -11,12 +11,12 @@ import { now } from '../../../../../utils/Time';
 type FileFreeTextType = { content: string };
 
 interface ImportFilesFreeTextProps {
-  onSumbit: (file: File) => void;
+  onSubmit: (file: File) => void;
   onClose: () => void;
   initialContent?: string;
 }
 
-const ImportFilesFreeText = ({ onSumbit, onClose, initialContent }: ImportFilesFreeTextProps) => {
+const ImportFilesFreeText = ({ onSubmit, onClose, initialContent }: ImportFilesFreeTextProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
 
@@ -33,7 +33,7 @@ const ImportFilesFreeText = ({ onSumbit, onClose, initialContent }: ImportFilesF
         type: fileType === 'json' ? 'application/json' : 'text/plain',
       },
     ) as File;
-    onSumbit(file);
+    onSubmit(file);
     resetForm();
   };
 

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
@@ -10,7 +10,13 @@ import { now } from '../../../../../utils/Time';
 
 type FileFreeTextType = { content: string };
 
-const ImportFilesFreeText = ({ onSumbit, onClose }: { onSumbit: (file: File) => void; onClose: () => void }) => {
+interface ImportFilesFreeTextProps {
+  onSumbit: (file: File) => void;
+  onClose: () => void;
+  initialContent?: string;
+}
+
+const ImportFilesFreeText = ({ onSumbit, onClose, initialContent }: ImportFilesFreeTextProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
 
@@ -35,7 +41,7 @@ const ImportFilesFreeText = ({ onSumbit, onClose }: { onSumbit: (file: File) => 
     <Formik<FileFreeTextType>
       enableReinitialize={true}
       initialValues={{
-        content: '',
+        content: initialContent ?? '',
       }}
       onSubmit={createFileFreeText}
     >

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesUploader.tsx
@@ -14,11 +14,13 @@ export type FileWithConnectors = {
 
 interface ImportFilesUploaderProps {
   connectorsForImport: ImportFilesContextQuery$data['connectorsForImport'];
+  isTextViewInitialValue?: boolean;
+  initialFreeTextContent?: string;
 }
 
 const ImportFilesUploader = ({ connectorsForImport }: ImportFilesUploaderProps) => {
-  const { files, setFiles } = useImportFilesContext();
-  const [isTextView, setIsTextView] = useState(false);
+  const { files, setFiles, initialFreeTextContent } = useImportFilesContext();
+  const [isTextView, setIsTextView] = useState(!!initialFreeTextContent);
 
   const updateFiles = (newFiles: File[]) => {
     const extendedFiles: FileWithConnectors[] = newFiles.map((file) => {
@@ -45,11 +47,13 @@ const ImportFilesUploader = ({ connectorsForImport }: ImportFilesUploaderProps) 
             openFreeText={() => setIsTextView(true)}
           />
         ) : (
-          <ImportFilesFreeText onSumbit={(file) => {
-            updateFiles([file]);
-            setIsTextView(false);
-          }}
-            onClose={ () => setIsTextView(false) }
+          <ImportFilesFreeText
+            onSumbit={(file) => {
+              updateFiles([file]);
+              setIsTextView(false);
+            }}
+            onClose={() => setIsTextView(false)}
+            initialContent={initialFreeTextContent}
           />
         )}
       </Grid>

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesUploader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesUploader.tsx
@@ -48,7 +48,7 @@ const ImportFilesUploader = ({ connectorsForImport }: ImportFilesUploaderProps) 
           />
         ) : (
           <ImportFilesFreeText
-            onSumbit={(file) => {
+            onSubmit={(file) => {
               updateFiles([file]);
               setIsTextView(false);
             }}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -28,6 +28,7 @@ import TableRow from '@mui/material/TableRow';
 import IconButton from '@mui/material/IconButton';
 import {
   AddOutlined,
+  AddBoxOutlined,
   AutoFixHighOutlined,
   BrushOutlined,
   CancelOutlined,
@@ -99,6 +100,7 @@ import { getEntityTypeTwoFirstLevelsFilterValues, removeIdAndIncorrectKeysFromFi
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
 import EETooltip from '../common/entreprise_edition/EETooltip';
 import { killChainPhasesSearchQuery } from '../settings/KillChainPhases';
+import ImportFilesDialog from "@components/common/files/import_files/ImportFilesDialog";
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -412,6 +414,7 @@ class DataTableToolBar extends Component {
       killChainPhases: [],
       groups: [],
       displayEditButtons: true,
+      unknownEntities: undefined,
     };
   }
 
@@ -657,6 +660,12 @@ class DataTableToolBar extends Component {
     }
     this.setState({ actionsInputs });
   }
+  handleLaunchCreateUnknownEntities() {
+    this.setState({ unknownValues: Object.keys(this.props.selectedElements) });
+  }
+  handleCloseCreateUnknownEntities() {
+    this.setState({ unknownValues: undefined });
+  }
   handleLaunchRead(read) {
     const actions = [{
       type: 'REPLACE',
@@ -838,19 +847,17 @@ class DataTableToolBar extends Component {
 
     const finalActions = taskScope === 'USER'
       ? this.getUserDatatableFinalActions(actions)
-      : R.map(
+      : actions.map(
         (n) => ({
           type: n.type,
           context: n.context
             ? {
               ...n.context,
-              values: R.map((o) => o.id || o.value || o, n.context.values),
+              values: n.context.values.map((o) => o.id || o.value || o),
             }
             : null,
           containerId: n.type === 'PROMOTE' && promoteToContainer && container?.id ? container.id : null,
-        }),
-        actions,
-      );
+        }));
 
     if (selectAll) {
       commitMutation({
@@ -2607,6 +2614,21 @@ class DataTableToolBar extends Component {
                     )}
                   </div>
                 )}
+                {taskScope === 'UNKNOWN_ENTITIES' &&
+                  <Tooltip title={t('Create unknown entities')}>
+                    <span>
+                      <IconButton
+                        aria-label={t('Create unknown entities')}
+                        disabled={numberOfSelectedElements === 0 || this.state.processing}
+                        onClick={this.handleLaunchCreateUnknownEntities.bind(this)}
+                        color="primary"
+                        size="small"
+                      >
+                        <AddBoxOutlined fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                }
               </Toolbar>
               <Dialog
                 slotProps={{ paper: { elevation: 1 } }}
@@ -3438,6 +3460,10 @@ class DataTableToolBar extends Component {
                   </Button>
                 </DialogActions>
               </Dialog>
+              <ImportFilesDialog
+                open={this.state.unknownValues}
+                handleClose={this.handleCloseCreateUnknownEntities.bind(this)}
+              />
             </>
           );
         }}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -660,12 +660,6 @@ class DataTableToolBar extends Component {
     }
     this.setState({ actionsInputs });
   }
-  handleLaunchCreateUnknownEntities() {
-    this.setState({ unknownValues: Object.keys(this.props.selectedElements) });
-  }
-  handleCloseCreateUnknownEntities() {
-    this.setState({ unknownValues: undefined });
-  }
   handleLaunchRead(read) {
     const actions = [{
       type: 'REPLACE',
@@ -2151,6 +2145,7 @@ class DataTableToolBar extends Component {
       taskScope,
       displayEditButtons,
     } = this.props;
+    console.log('selecg all in toolbar', this.props.selectAll);
     const { actions, keptEntityId, mergingElement, actionsInputs, promoteToContainer } = this.state;
 
     const isUserDatatable = taskScope === 'USER';
@@ -2615,21 +2610,6 @@ class DataTableToolBar extends Component {
                     )}
                   </div>
                 )}
-                {taskScope === 'UNKNOWN_ENTITIES'
-                  && <Tooltip title={t('Create unknown entities')}>
-                    <span>
-                      <IconButton
-                        aria-label={t('Create unknown entities')}
-                        disabled={numberOfSelectedElements === 0 || this.state.processing}
-                        onClick={this.handleLaunchCreateUnknownEntities.bind(this)}
-                        color="primary"
-                        size="small"
-                      >
-                        <AddBoxOutlined fontSize="small" />
-                      </IconButton>
-                    </span>
-                  </Tooltip>
-                }
               </Toolbar>
               <Dialog
                 slotProps={{ paper: { elevation: 1 } }}
@@ -3461,11 +3441,6 @@ class DataTableToolBar extends Component {
                   </Button>
                 </DialogActions>
               </Dialog>
-              <ImportFilesDialog
-                open={this.state.unknownValues}
-                handleClose={this.handleCloseCreateUnknownEntities.bind(this)}
-                initialFreeTextContent={(this.state.unknownValues ?? []).join('\n')}
-              />
             </>
           );
         }}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -65,7 +65,7 @@ import Avatar from '@mui/material/Avatar';
 import { FormControlLabel, Switch } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import ImportFilesDialog from '@components/common/files/import_files/ImportFilesDialog';
+import ImportFilesDialog from '../common/files/import_files/ImportFilesDialog';
 import UserEmailSend from '../settings/users/UserEmailSend';
 import { objectParticipantFieldMembersSearchQuery } from '../common/form/ObjectParticipantField';
 import { objectAssigneeFieldMembersSearchQuery } from '../common/form/ObjectAssigneeField';

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -28,7 +28,6 @@ import TableRow from '@mui/material/TableRow';
 import IconButton from '@mui/material/IconButton';
 import {
   AddOutlined,
-  AddBoxOutlined,
   AutoFixHighOutlined,
   BrushOutlined,
   CancelOutlined,
@@ -65,7 +64,6 @@ import Avatar from '@mui/material/Avatar';
 import { FormControlLabel, Switch } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
-import ImportFilesDialog from '../common/files/import_files/ImportFilesDialog';
 import UserEmailSend from '../settings/users/UserEmailSend';
 import { objectParticipantFieldMembersSearchQuery } from '../common/form/ObjectParticipantField';
 import { objectAssigneeFieldMembersSearchQuery } from '../common/form/ObjectAssigneeField';
@@ -414,7 +412,6 @@ class DataTableToolBar extends Component {
       killChainPhases: [],
       groups: [],
       displayEditButtons: true,
-      unknownEntities: undefined,
     };
   }
 
@@ -2145,7 +2142,6 @@ class DataTableToolBar extends Component {
       taskScope,
       displayEditButtons,
     } = this.props;
-    console.log('selecg all in toolbar', this.props.selectAll);
     const { actions, keptEntityId, mergingElement, actionsInputs, promoteToContainer } = this.state;
 
     const isUserDatatable = taskScope === 'USER';

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -65,6 +65,7 @@ import Avatar from '@mui/material/Avatar';
 import { FormControlLabel, Switch } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import ImportFilesDialog from '@components/common/files/import_files/ImportFilesDialog';
 import UserEmailSend from '../settings/users/UserEmailSend';
 import { objectParticipantFieldMembersSearchQuery } from '../common/form/ObjectParticipantField';
 import { objectAssigneeFieldMembersSearchQuery } from '../common/form/ObjectAssigneeField';
@@ -100,7 +101,6 @@ import { getEntityTypeTwoFirstLevelsFilterValues, removeIdAndIncorrectKeysFromFi
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
 import EETooltip from '../common/entreprise_edition/EETooltip';
 import { killChainPhasesSearchQuery } from '../settings/KillChainPhases';
-import ImportFilesDialog from "@components/common/files/import_files/ImportFilesDialog";
 
 const styles = (theme) => ({
   drawerPaper: {
@@ -857,7 +857,8 @@ class DataTableToolBar extends Component {
             }
             : null,
           containerId: n.type === 'PROMOTE' && promoteToContainer && container?.id ? container.id : null,
-        }));
+        }),
+      );
 
     if (selectAll) {
       commitMutation({
@@ -2614,8 +2615,8 @@ class DataTableToolBar extends Component {
                     )}
                   </div>
                 )}
-                {taskScope === 'UNKNOWN_ENTITIES' &&
-                  <Tooltip title={t('Create unknown entities')}>
+                {taskScope === 'UNKNOWN_ENTITIES'
+                  && <Tooltip title={t('Create unknown entities')}>
                     <span>
                       <IconButton
                         aria-label={t('Create unknown entities')}
@@ -3463,6 +3464,7 @@ class DataTableToolBar extends Component {
               <ImportFilesDialog
                 open={this.state.unknownValues}
                 handleClose={this.handleCloseCreateUnknownEntities.bind(this)}
+                initialFreeTextContent={(this.state.unknownValues ?? []).join('\n')}
               />
             </>
           );

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableWithoutFragmentToolBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableWithoutFragmentToolBar.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
+import IconButton from '@mui/material/IconButton';
+import { AddBoxOutlined, ClearOutlined } from '@mui/icons-material';
+import ImportFilesDialog from '../common/files/import_files/ImportFilesDialog';
+import { useFormatter } from '../../../components/i18n';
+
+interface DataTableWithoutFragmentToolBarProps {
+  taskScope: string,
+  selectedValues: string[],
+  handleClearSelectedElements: () => void,
+}
+
+const DataTableWithoutFragmentToolBar = ({
+  taskScope,
+  selectedValues,
+  handleClearSelectedElements,
+}: DataTableWithoutFragmentToolBarProps) => {
+  const { t_i18n } = useFormatter();
+  const [unknownValues, setUnkownValues] = useState<string[]>([]);
+  const handleLaunchCreateUnknownEntities = () => {
+    setUnkownValues(selectedValues);
+  };
+  const handleCloseCreateUnknownEntities = () => {
+    setUnkownValues([]);
+  };
+  const numberOfElements = selectedValues.length;
+  return (
+    <>
+      <Toolbar style={{ minHeight: 40, display: 'flex', justifyContent: 'space-between', height: '100%', paddingRight: 12, paddingLeft: 8 }} data-testid='opencti-toolbar'>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <Typography
+            style={{
+              flex: '1 1 100%',
+              fontSize: '12px',
+              marginBottom: '1px',
+            }}
+            color="inherit"
+            variant="subtitle1"
+          >
+            <strong>{numberOfElements}</strong> {t_i18n('selected')}{' '}
+          </Typography>
+          <IconButton
+            aria-label="clear"
+            disabled={numberOfElements === 0}
+            onClick={handleClearSelectedElements}
+            size="small"
+            color="primary"
+          >
+            <ClearOutlined fontSize="small" />
+          </IconButton>
+        </div>
+        {taskScope === 'UNKNOWN_ENTITIES'
+          && <Tooltip title={t_i18n('Create unknown entities')}>
+            <span>
+              <IconButton
+                aria-label={t_i18n('Create unknown entities')}
+                disabled={numberOfElements === 0}
+                onClick={handleLaunchCreateUnknownEntities}
+                color="primary"
+                size="small"
+              >
+                <AddBoxOutlined fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        }
+      </Toolbar>
+      <ImportFilesDialog
+        open={unknownValues.length > 0}
+        handleClose={handleCloseCreateUnknownEntities}
+        initialFreeTextContent={(unknownValues ?? []).join('\n')}
+      />
+    </>
+  );
+};
+
+export default DataTableWithoutFragmentToolBar;

--- a/opencti-platform/opencti-front/vitest.config.ts
+++ b/opencti-platform/opencti-front/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      'src': path.resolve(__dirname, './src'),
       '@components': path.resolve(__dirname, './src/private/components'),
     },
   }


### PR DESCRIPTION
### Proposed changes
in Bulk Search, in the Unknown entities tab
- add toolbar with an icon to bulk create the entities
- when clicking on the icon, a pop up opens to create the selected unknown entities via the already existing workflow to import data

### Related issues
#7279
#3360 