### PR TITLE
[backend/frontend] Integration Manager warning banner not reappearing when inactive (#12895) 

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -31,7 +31,7 @@ import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 interface IngestionCatalogComponentProps {
   catalogsData: IngestionConnectorsCatalogsQuery['response'];
   deploymentData: IngestionConnectorsQuery['response'];
-  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasRegisteredManagers: boolean, deploymentCount: number) => void;
+  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasRegisteredManagers: boolean, hasActiveManagers: boolean, deploymentCount: number) => void;
 }
 
 type IngestionTypeMap = {
@@ -136,7 +136,7 @@ const IngestionCatalogComponent = ({
   const { setTitle } = useConnectedDocumentModifier();
   const [searchParams] = useSearchParams();
 
-  const { hasRegisteredManagers } = useConnectorManagerStatus();
+  const { hasRegisteredManagers, hasActiveManagers } = useConnectorManagerStatus();
 
   setTitle(t_i18n('Connector catalog | Ingestion | Data'));
 
@@ -168,7 +168,7 @@ const IngestionCatalogComponent = ({
       <IngestionMenu />
       <PageContainer withRightMenu withGap>
         <Breadcrumbs elements={[{ label: t_i18n('Data') }, { label: t_i18n('Ingestion') }, { label: t_i18n('Connector catalog'), current: true }]} />
-        <ConnectorDeploymentBanner hasRegisteredManagers={hasRegisteredManagers} />
+        <ConnectorDeploymentBanner hasActiveManagers={hasActiveManagers} />
         <Stack flexDirection="row">
           <IngestionCatalogFilters
             contracts={allContracts}
@@ -191,7 +191,7 @@ const IngestionCatalogComponent = ({
                     node={contract}
                     dataListId={catalog.id}
                     isEnterpriseEdition={isEnterpriseEdition}
-                    onClickDeploy={() => onClickDeploy(contract, catalog.id, hasRegisteredManagers, deploymentCount)}
+                    onClickDeploy={() => onClickDeploy(contract, catalog.id, hasRegisteredManagers, hasActiveManagers, deploymentCount)}
                     deploymentCount={deploymentCount}
                   />
                 </Grid>
@@ -252,7 +252,7 @@ const IngestionCatalog = () => {
           connector={catalogState.selectedConnector}
           onClose={handleCloseDeployDialog}
           catalogId={catalogState.selectedCatalogId}
-          hasRegisteredManagers={catalogState.hasRegisteredManagers}
+          hasActiveManagers={catalogState.hasActiveManagers}
           onCreate={handleCreate}
           deploymentCount={catalogState.deploymentCount}
         />

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -31,7 +31,7 @@ import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 interface IngestionCatalogComponentProps {
   catalogsData: IngestionConnectorsCatalogsQuery['response'];
   deploymentData: IngestionConnectorsQuery['response'];
-  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasRegisteredManagers: boolean, hasActiveManagers: boolean, deploymentCount: number) => void;
+  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasActiveManagers: boolean, deploymentCount: number) => void;
 }
 
 type IngestionTypeMap = {
@@ -136,7 +136,7 @@ const IngestionCatalogComponent = ({
   const { setTitle } = useConnectedDocumentModifier();
   const [searchParams] = useSearchParams();
 
-  const { hasRegisteredManagers, hasActiveManagers } = useConnectorManagerStatus();
+  const { hasActiveManagers } = useConnectorManagerStatus();
 
   setTitle(t_i18n('Connector catalog | Ingestion | Data'));
 
@@ -191,7 +191,7 @@ const IngestionCatalogComponent = ({
                     node={contract}
                     dataListId={catalog.id}
                     isEnterpriseEdition={isEnterpriseEdition}
-                    onClickDeploy={() => onClickDeploy(contract, catalog.id, hasRegisteredManagers, hasActiveManagers, deploymentCount)}
+                    onClickDeploy={() => onClickDeploy(contract, catalog.id, hasActiveManagers, deploymentCount)}
                     deploymentCount={deploymentCount}
                   />
                 </Grid>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnector.tsx
@@ -37,7 +37,7 @@ const ingestionCatalogConnectorQuery = graphql`
 
 interface IngestionCatalogConnectorComponentProps {
   queryRef: PreloadedQuery<IngestionCatalogConnectorQuery>;
-  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasRegisteredManagers: boolean, deploymentCount: number) => void;
+  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasRegisteredManagers: boolean, hasActiveManagers: boolean, deploymentCount: number) => void;
   openConfig?: boolean;
 }
 
@@ -50,7 +50,7 @@ const IngestionCatalogConnectorComponent = ({
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
 
-  const { hasRegisteredManagers } = useConnectorManagerStatus();
+  const { hasRegisteredManagers, hasActiveManagers } = useConnectorManagerStatus();
 
   const { contract, connectors } = usePreloadedQuery(
     ingestionCatalogConnectorQuery,
@@ -66,7 +66,7 @@ const IngestionCatalogConnectorComponent = ({
 
   useEffect(() => {
     if (openConfig && contract && connector) {
-      onClickDeploy(connector, contract.catalog_id, hasRegisteredManagers, deploymentCount);
+      onClickDeploy(connector, contract.catalog_id, hasRegisteredManagers, hasActiveManagers, deploymentCount);
     }
   }, [openConfig, contract]);
 
@@ -84,13 +84,13 @@ const IngestionCatalogConnectorComponent = ({
       />
 
       <Stack gap={2}>
-        <ConnectorDeploymentBanner hasRegisteredManagers={hasRegisteredManagers} />
+        <ConnectorDeploymentBanner hasActiveManagers={hasActiveManagers} />
 
         <Stack gap={4}>
           <IngestionCatalogConnectorHeader
             connector={connector}
             isEnterpriseEdition={isEnterpriseEdition}
-            onClickDeploy={() => onClickDeploy(connector, contract?.catalog_id, hasRegisteredManagers, deploymentCount)}
+            onClickDeploy={() => onClickDeploy(connector, contract?.catalog_id, hasRegisteredManagers, hasActiveManagers, deploymentCount)}
           />
           <IngestionCatalogConnectorOverview connector={connector} />
         </Stack>
@@ -131,7 +131,7 @@ const IngestionCatalogConnector = () => {
             connector={catalogState.selectedConnector}
             onClose={handleCloseDeployDialog}
             catalogId={catalogState.selectedCatalogId}
-            hasRegisteredManagers={catalogState.hasRegisteredManagers}
+            hasActiveManagers={catalogState.hasActiveManagers}
             onCreate={handleCreate}
             deploymentCount={catalogState.deploymentCount}
           />

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnector.tsx
@@ -37,7 +37,7 @@ const ingestionCatalogConnectorQuery = graphql`
 
 interface IngestionCatalogConnectorComponentProps {
   queryRef: PreloadedQuery<IngestionCatalogConnectorQuery>;
-  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasRegisteredManagers: boolean, hasActiveManagers: boolean, deploymentCount: number) => void;
+  onClickDeploy: (connector: IngestionConnector, catalogId: string, hasActiveManagers: boolean, deploymentCount: number) => void;
   openConfig?: boolean;
 }
 
@@ -50,7 +50,7 @@ const IngestionCatalogConnectorComponent = ({
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
 
-  const { hasRegisteredManagers, hasActiveManagers } = useConnectorManagerStatus();
+  const { hasActiveManagers } = useConnectorManagerStatus();
 
   const { contract, connectors } = usePreloadedQuery(
     ingestionCatalogConnectorQuery,
@@ -66,7 +66,7 @@ const IngestionCatalogConnectorComponent = ({
 
   useEffect(() => {
     if (openConfig && contract && connector) {
-      onClickDeploy(connector, contract.catalog_id, hasRegisteredManagers, hasActiveManagers, deploymentCount);
+      onClickDeploy(connector, contract.catalog_id, hasActiveManagers, deploymentCount);
     }
   }, [openConfig, contract]);
 
@@ -90,7 +90,7 @@ const IngestionCatalogConnectorComponent = ({
           <IngestionCatalogConnectorHeader
             connector={connector}
             isEnterpriseEdition={isEnterpriseEdition}
-            onClickDeploy={() => onClickDeploy(connector, contract?.catalog_id, hasRegisteredManagers, hasActiveManagers, deploymentCount)}
+            onClickDeploy={() => onClickDeploy(connector, contract?.catalog_id, hasActiveManagers, deploymentCount)}
           />
           <IngestionCatalogConnectorOverview connector={connector} />
         </Stack>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -88,7 +88,7 @@ interface IngestionCatalogConnectorCreationProps {
   open: boolean;
   onClose: () => void;
   catalogId: string;
-  hasRegisteredManagers: boolean
+  hasActiveManagers: boolean;
   deploymentCount?: number;
   onCreate?: (connectorId: string) => void;
 }
@@ -111,7 +111,7 @@ const validationSchema = Yup.object().shape({
 });
 
 const IngestionCatalogConnectorCreation = ({
-  connector, open, onClose, catalogId, hasRegisteredManagers, deploymentCount = 0, onCreate,
+  connector, open, onClose, catalogId, hasActiveManagers, deploymentCount = 0, onCreate,
 }: IngestionCatalogConnectorCreationProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
@@ -296,7 +296,7 @@ const IngestionCatalogConnectorCreation = ({
       }
     >
       <Stack gap={1}>
-        <ConnectorDeploymentBanner hasRegisteredManagers={hasRegisteredManagers} />
+        <ConnectorDeploymentBanner hasActiveManagers={hasActiveManagers} />
 
         <Formik<ManagedConnectorValues>
           onReset={onClose}
@@ -319,11 +319,11 @@ const IngestionCatalogConnectorCreation = ({
             return (
               <Form>
                 <fieldset
-                  disabled={!hasRegisteredManagers}
+                  disabled={!hasActiveManagers}
                   style={{
                     border: 'none',
                     padding: 0,
-                    ...(!hasRegisteredManagers && { opacity: 0.5, pointerEvents: 'none' }),
+                    ...(!hasActiveManagers && { opacity: 0.5, pointerEvents: 'none' }),
                   }}
                 >
                   <Field
@@ -425,7 +425,7 @@ const IngestionCatalogConnectorCreation = ({
                     {t_i18n('Cancel')}
                   </Button>
                   {
-                    hasRegisteredManagers && (
+                    hasActiveManagers && (
                       <Button
                         variant="contained"
                         color="secondary"

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/hooks/useConnectorDeployDialog.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/hooks/useConnectorDeployDialog.ts
@@ -7,6 +7,7 @@ interface CatalogState {
   selectedConnector: IngestionConnector | null;
   selectedCatalogId: string;
   hasRegisteredManagers: boolean;
+  hasActiveManagers: boolean;
   deploymentCount: number
 }
 
@@ -17,6 +18,7 @@ const useConnectorDeployDialog = () => {
     selectedConnector: null,
     selectedCatalogId: '',
     hasRegisteredManagers: false,
+    hasActiveManagers: false,
     deploymentCount: 0,
   });
 
@@ -24,6 +26,7 @@ const useConnectorDeployDialog = () => {
     connector: IngestionConnector,
     catalogId: string,
     registeredManagers: boolean,
+    activeManagers: boolean,
     deploymentCount: number,
   ) => {
     setCatalogState((prev) => ({
@@ -31,6 +34,7 @@ const useConnectorDeployDialog = () => {
       selectedConnector: connector,
       selectedCatalogId: catalogId,
       hasRegisteredManagers: registeredManagers,
+      hasActiveManagers: activeManagers,
       deploymentCount,
     }));
   };

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/hooks/useConnectorDeployDialog.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/hooks/useConnectorDeployDialog.ts
@@ -6,7 +6,6 @@ import { resolveLink } from '../../../../../utils/Entity';
 interface CatalogState {
   selectedConnector: IngestionConnector | null;
   selectedCatalogId: string;
-  hasRegisteredManagers: boolean;
   hasActiveManagers: boolean;
   deploymentCount: number
 }
@@ -17,7 +16,6 @@ const useConnectorDeployDialog = () => {
   const [catalogState, setCatalogState] = useState<CatalogState>({
     selectedConnector: null,
     selectedCatalogId: '',
-    hasRegisteredManagers: false,
     hasActiveManagers: false,
     deploymentCount: 0,
   });
@@ -25,7 +23,6 @@ const useConnectorDeployDialog = () => {
   const handleOpenDeployDialog = (
     connector: IngestionConnector,
     catalogId: string,
-    registeredManagers: boolean,
     activeManagers: boolean,
     deploymentCount: number,
   ) => {
@@ -33,7 +30,6 @@ const useConnectorDeployDialog = () => {
       ...prev,
       selectedConnector: connector,
       selectedCatalogId: catalogId,
-      hasRegisteredManagers: registeredManagers,
       hasActiveManagers: activeManagers,
       deploymentCount,
     }));

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorDeploymentBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorDeploymentBanner.tsx
@@ -8,18 +8,18 @@ import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 const URL = 'https://docs.opencti.io/latest/deployment/integration-manager/';
 
 type ConnectorDeploymentBannerProps = {
-  hasRegisteredManagers: boolean;
+  hasActiveManagers: boolean;
 };
 
-const ConnectorDeploymentBanner: FunctionComponent<ConnectorDeploymentBannerProps> = ({ hasRegisteredManagers }) => {
+const ConnectorDeploymentBanner: FunctionComponent<ConnectorDeploymentBannerProps> = ({ hasActiveManagers }) => {
   const { t_i18n } = useFormatter();
   const isEnterpriseEdition = useEnterpriseEdition();
 
-  if (isEnterpriseEdition && hasRegisteredManagers) {
+  if (isEnterpriseEdition && hasActiveManagers) {
     return null;
   }
 
-  if (isEnterpriseEdition && !hasRegisteredManagers) {
+  if (isEnterpriseEdition && !hasActiveManagers) {
     return (
       <Alert severity="warning">
         <Typography>

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
@@ -17,6 +17,7 @@ export const connectorManagerStatusQuery = graphql`
 interface ConnectorManagerStatusContextValue {
   connectorManagers: readonly { id: string; active: boolean }[] | null;
   hasRegisteredManagers: boolean;
+  hasActiveManagers: boolean;
 }
 
 const ConnectorManagerStatusContext = createContext<ConnectorManagerStatusContextValue | null>(null);
@@ -49,10 +50,12 @@ export const ConnectorManagerStatusProvider: React.FC<ConnectorManagerStatusProv
 
   const connectorManagers = data?.connectorManagers || null;
   const hasRegisteredManagers = connectorManagers ? connectorManagers.length > 0 : false;
+  const hasActiveManagers = connectorManagers ? connectorManagers.some((cm) => cm.active) : false;
 
   const contextValue: ConnectorManagerStatusContextValue = {
     connectorManagers,
     hasRegisteredManagers,
+    hasActiveManagers,
   };
 
   return (

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -114,7 +114,7 @@ const connectorResolvers = {
     connector_user: (cn, _, context) => connectorUser(context, context.user, cn.connector_user_id),
   },
   ConnectorManager: {
-    active: (cm) => sinceNowInMinutes(cm.updated_at) < 5,
+    active: (cm) => sinceNowInMinutes(cm.last_sync_execution) < 5,
     about_version: () => PLATFORM_VERSION
   },
   Work: {


### PR DESCRIPTION
### Proposed changes

* Updated frontend logic to check `hasActiveManagers` instead of `hasRegisteredManagers` 
* Warning banner now correctly reappears when Integration Manager stops responding (~5-6 min after XTM-Composer stops)
* Added `hasActiveManagers` computed property to ConnectorManagerStatusContext
* Updated ConnectorDeploymentBanner and related components to use active status
* Form fields now disabled when no active managers available

### Related issues

* #12895

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Root Cause**: The frontend was checking if any connector managers existed in the database (`hasRegisteredManagers`) instead of checking if they were actively responding (`hasActiveManagers`).

**Solution**: Frontend-only fix. The backend already correctly computes the `active` status via `sinceNowInMinutes(cm.updated_at) < 5` and the frontend already polls for it every 30 seconds. We simply needed to use the correct boolean flag.

