### PR TITLE
[frontend] add margin between each input in connector config (#13085)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -38,6 +38,7 @@ import { type FieldOption, fieldSpacingContainerStyle } from '../../../../utils/
 import TextField from '../../../../components/TextField';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import { resolveLink } from '../../../../utils/Entity';
+import { JsonFormVerticalLayout, jsonFormVerticalLayoutTester } from './utils/JsonFormVerticalLayout';
 
 const ingestionCatalogConnectorCreationMutation = graphql`
   mutation IngestionCatalogConnectorCreationMutation($input: AddManagedConnectorInput) {
@@ -78,6 +79,7 @@ const sanitizeContainerName = (label: string): string => {
 
 const customRenderers = [
   ...materialRenderers,
+  { tester: jsonFormVerticalLayoutTester, renderer: JsonFormVerticalLayout },
   { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
   { tester: jsonFormArrayTester, renderer: JsonFormArrayRenderer },
   { tester: jsonFormUnsupportedTypeTester, renderer: JsonFormUnsupportedType },
@@ -398,7 +400,7 @@ const IngestionCatalogConnectorCreation = ({
                             <AccordionSummary id="accordion-panel">
                               <Typography>{t_i18n('Advanced options')}</Typography>
                             </AccordionSummary>
-                            <AccordionDetails>
+                            <AccordionDetails sx={{ paddingTop: 2 }}>
                               <JsonForms
                                 data={configDefaults}
                                 schema={optionalProperties}

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/JsonFormVerticalLayout.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/JsonFormVerticalLayout.tsx
@@ -1,0 +1,37 @@
+import { Layout, LayoutProps, rankWith, uiTypeIs } from '@jsonforms/core';
+import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react';
+import { Box } from '@mui/material';
+import React from 'react';
+
+const VerticalLayoutWithSpacingRenderer = (props: LayoutProps) => {
+  const layout = props.uischema as Layout;
+  const { renderers, cells, schema, path, enabled, visible } = props;
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    layout.elements.map((child, index) => (
+      <Box key={index} sx={{ marginTop: index === 0 ? 0 : '20px' }}>
+        <JsonFormsDispatch
+          uischema={child}
+          schema={schema}
+          path={path}
+          enabled={enabled}
+          renderers={renderers}
+          cells={cells}
+        />
+      </Box>
+    ))
+  );
+};
+
+export const JsonFormVerticalLayout = withJsonFormsLayoutProps(
+  VerticalLayoutWithSpacingRenderer,
+);
+
+export const jsonFormVerticalLayoutTester = rankWith(
+  1000, // very high rank to ensure it uses this custom renderer
+  uiTypeIs('VerticalLayout'),
+);

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
@@ -28,6 +28,7 @@ import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import { MESSAGING$ } from '../../../../relay/environment';
+import { JsonFormVerticalLayout, jsonFormVerticalLayoutTester } from '../IngestionCatalog/utils/JsonFormVerticalLayout';
 
 type ManagerContractProperty = [string, IngestionTypedProperty];
 
@@ -53,6 +54,7 @@ interface ManagedConnectorValues {
 
 const customRenderers = [
   ...materialRenderers,
+  { tester: jsonFormVerticalLayoutTester, renderer: JsonFormVerticalLayout },
   { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
   { tester: jsonFormArrayTester, renderer: JsonFormArrayRenderer },
   { tester: jsonFormUnsupportedTypeTester, renderer: JsonFormUnsupportedType },
@@ -269,7 +271,7 @@ const ManagedConnectorEdition = ({ connector, open, onClose }: ManagedConnectorE
                         <AccordionSummary id="accordion-panel">
                           <Typography>{t_i18n('Advanced options')}</Typography>
                         </AccordionSummary>
-                        <AccordionDetails>
+                        <AccordionDetails sx={{ paddingTop: 2 }}>
                           <JsonForms
                             data={values}
                             schema={optionalProperties}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add margin 20px on each input generated by JsonForms
<img width="1458" height="1057" alt="image" src="https://github.com/user-attachments/assets/aea5fa1a-d172-4454-9996-3006de4de6f5" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13085 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
