### PR TITLE
[frontend] Disable deploy form during connector deployment (#12499)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -130,6 +130,7 @@ const IngestionCatalogConnectorCreation = ({
     setSubmitting,
     resetForm,
   }: Partial<FormikHelpers<ManagedConnectorValues>>) => {
+    setSubmitting?.(true);
     const input = {
       name: values.display_name,
       catalog_id: catalogId,


### PR DESCRIPTION
### Proposed changes

* Added `setSubmitting(true)` call at the start of `submitConnectorManagementCreation` function to immediately disable the form when deployment begins
* This prevents users from clicking the "Deploy" button multiple times during the deployment process
* The button is re-enabled automatically once deployment completes (success or error) through existing `setSubmitting(false)` calls

### Related issues

* #12499

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

