### PR TITLE
[client] move pythonjsonlogger.jsonlogger to pythonjsonlogger.json (#13114)

### DIFF
--- a/client-python/pycti/utils/opencti_logger.py
+++ b/client-python/pycti/utils/opencti_logger.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import datetime, timezone
 
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger import json
 
 
-class CustomJsonFormatter(jsonlogger.JsonFormatter):
+class CustomJsonFormatter(json.JsonFormatter):
     """Custom JSON formatter for structured logging."""
 
     def add_fields(self, log_record, record, message_dict):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* move pythonjsonlogger.jsonlogger to pythonjsonlogger.json per the [docs](https://nhairs.github.io/python-json-logger/latest/changelog/#deprecated)
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes #13114
* [#1028](https://github.com/OpenCTI-Platform/client-python/pull/1028)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
