### PR TITLE
[frontend] remove form intake create button in draft with AM (#10981)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectForms.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectForms.tsx
@@ -6,6 +6,8 @@ import IconButton from '@mui/material/IconButton';
 import { AssignmentOutlined } from '@mui/icons-material';
 import StixCoreObjectFormSelector from '@components/common/stix_core_objects/StixCoreObjectFormSelector';
 import { useFormatter } from '../../../../components/i18n';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
+import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 
 // region types
 interface StixCoreObjectFormsProps {
@@ -73,7 +75,13 @@ const StixCoreObjectForms: FunctionComponent<StixCoreObjectFormsProps> = ({ enti
   useEffect(() => {
     loadQuery(formsPaginationOptions, { fetchPolicy: 'store-and-network' });
   }, []);
-  return (
+
+  // Remove create button in Draft context without the minimal right access "canEdit"
+  const draftContext = useDraftContext();
+  const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const canDisplayButton = !draftContext || currentAccessRight.canEdit;
+
+  return canDisplayButton && (
     <>
       {queryRef && (
         <Suspense>


### PR DESCRIPTION
### Proposed changes

* Remove form intake create button without right access to update in AM.

### Related issues

* #10981 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality