### PR TITLE
[frontend] Use theme text color when rendering the letter security coverage (#13116)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageInformation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageInformation.tsx
@@ -101,7 +101,7 @@ const SecurityCoverageInformation: FunctionComponent<SecurityCoverageInformation
           <Chart options={options} series={series} type="donut" width={chartSize} height={chartSize}/>
           <Tooltip title={'Empty coverage'} placement="bottom">
             <Avatar className={classes.iconOverlay} sx={{ bgcolor: 'transparent', width: iconSize, height: iconSize }} style={{ top: iconPosition, left: iconPosition, fontSize: iconSize - 2 }}>
-              <span style={{ color: '#ffffff' }}>E</span>
+              <span style={{ color: theme.palette.text?.primary }}>E</span>
             </Avatar>
           </Tooltip>
         </div>
@@ -116,7 +116,7 @@ const SecurityCoverageInformation: FunctionComponent<SecurityCoverageInformation
               <Chart options={options} series={series} type="donut" width={chartSize} height={chartSize}/>
               <Tooltip title={`${coverageResult.coverage_name} ${coverageResult.coverage_score}/100`} placement="bottom">
                 <Avatar className={classes.iconOverlay} sx={{ bgcolor: 'transparent', width: iconSize, height: iconSize }} style={{ top: iconPosition, left: iconPosition, fontSize: iconSize - 2 }}>
-                  <span style={{ color: '#ffffff' }}>{coverageResult.coverage_name.charAt(0).toUpperCase()}</span>
+                  <span style={{ color: theme.palette.text?.primary }}>{coverageResult.coverage_name.charAt(0).toUpperCase()}</span>
                 </Avatar>
               </Tooltip>
             </div>
@@ -137,7 +137,7 @@ const SecurityCoverageInformation: FunctionComponent<SecurityCoverageInformation
               <Chart options={options} series={series} type="donut" width={70} height={70}/>
               <Tooltip title={'Empty coverage'} placement="top">
                 <Avatar className={classes.iconOverlay} sx={{ bgcolor: 'transparent', width: 24, height: 24 }}>
-                  <span style={{ color: '#ffffff', fontSize: 18 }}>E</span>
+                  <span style={{ color: theme.palette.text?.primary, fontSize: 18 }}>E</span>
                 </Avatar>
               </Tooltip>
             </div>
@@ -168,7 +168,7 @@ const SecurityCoverageInformation: FunctionComponent<SecurityCoverageInformation
                 <Chart options={options} series={series} type="donut" width={70} height={70}/>
                 <Tooltip title={coverageResult.coverage_name} placement="top">
                   <Avatar className={classes.iconOverlay} sx={{ bgcolor: 'transparent', width: 24, height: 24 }}>
-                    <span style={{ color: '#ffffff', fontSize: 18 }}>{coverageResult.coverage_name.charAt(0).toUpperCase()}</span>
+                    <span style={{ color: theme.palette.text?.primary, fontSize: 18 }}>{coverageResult.coverage_name.charAt(0).toUpperCase()}</span>
                   </Avatar>
                 </Tooltip>
               </div>


### PR DESCRIPTION
The issue in light theme, we cannot see the text in the donut 
<img width="283" height="106" alt="image" src="https://github.com/user-attachments/assets/6784cf1c-56e4-4ab8-9dbf-4dad20614793" />

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use theme text color to render the text in the donut gauge to avoid issue when changing theme
<img width="500" height="190" alt="image" src="https://github.com/user-attachments/assets/4f6f8a64-6c81-4e33-9e34-ecc880e603e4" />

<img width="300" height="105" alt="image" src="https://github.com/user-attachments/assets/9d2dc355-85af-47a1-a686-f668f886f615" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13116 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
