### PR TITLE
[backend] Fix publicStixRelationshipsMultiTimeSeries with dynamic filters (#13027)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
@@ -334,6 +334,8 @@ export const publicStixRelationshipsMultiTimeSeries = async (
     return {
       field: selection.date_attribute,
       filters,
+      dynamicFrom: selection.dynamicFrom,
+      dynamicTo: selection.dynamicTo,
     };
   });
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/publicDashboard-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/publicDashboard-test.js
@@ -796,7 +796,7 @@ describe('PublicDashboard resolver', () => {
           const { publicStixRelationshipsMultiTimeSeries } = data;
           const attacksData = publicStixRelationshipsMultiTimeSeries[0].data;
           expect(attacksData.length).toEqual(1);
-          expect(attacksData[0].value).toEqual(5);
+          expect(attacksData[0].value).toEqual(4); // same result as for '6dbb6564-3e4a-4a28-85b1-e2ac479e38e7' widget
         });
 
         it('should return the data for API: SCO Distribution', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix dynamicFrom & dynamicTo that were forgotten in publicStixRelationshipsMultiTimeSeries 
* Fix the test which was wrong (it was expecting 5 relationships instead of 4 that should match the widget filters with dynamicFrom)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13027 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->
