### PR TITLE
[frontend] prevent adding coverage already selected (#13118)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
@@ -169,6 +169,11 @@ export const CoverageInformationFieldEdit: FunctionComponent<CoverageInformation
   const { t_i18n } = useFormatter();
   const coverageInformationMutation = mode === 'entity'
     ? coverageEntityInformationMutation : coverageRelationInformationMutation;
+
+  const disabledOptions = values
+    ?.map((v) => v.coverage_name)
+    .filter((coverageName) => coverageName !== '');
+
   return (
     <div style={{ ...fieldSpacingContainerStyle, ...containerStyle }}>
       <Typography variant="h4" gutterBottom>
@@ -195,6 +200,7 @@ export const CoverageInformationFieldEdit: FunctionComponent<CoverageInformation
                       type="coverage_ov"
                       name={`${name}.${index}.coverage_name`}
                       required={true}
+                      disabledOptions={disabledOptions}
                       onChange={(_: string, value) => {
                         const isCreation = isEmptyField(values?.[index]?.coverage_name);
                         if (isNotEmptyField(value)) {

--- a/opencti-platform/opencti-front/src/private/components/common/form/OpenVocabField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/OpenVocabField.tsx
@@ -25,6 +25,7 @@ interface OpenVocabProps {
   onChange?: (name: string, value: string | string[]) => void;
   onSubmit?: (name: string, value: string | string[]) => void;
   multiple?: boolean;
+  disabledOptions?: string[]
 }
 
 export const vocabularyQuery = graphql`
@@ -65,6 +66,7 @@ Omit<OpenVocabProps, 'type'>
   editContext,
   queryRef,
   disabled = false,
+  disabledOptions = [],
 }) => {
   const { vocabularies } = usePreloadedQuery<OpenVocabFieldQuery>(
     vocabularyQuery,
@@ -123,6 +125,7 @@ Omit<OpenVocabProps, 'type'>
         disabled={disabled}
         options={openVocabList}
         renderOption={renderOption}
+        getOptionDisabled={(option: FieldOption) => disabledOptions.includes(option.value)}
         isOptionEqualToValue={(option: FieldOption, value: string) => option.value === value
         }
         textfieldprops={{
@@ -146,6 +149,7 @@ Omit<OpenVocabProps, 'type'>
       style={containerStyle}
       options={openVocabList}
       renderOption={renderOption}
+      getOptionDisabled={(option: FieldOption) => disabledOptions.includes(option.value)}
       isOptionEqualToValue={(option: FieldOption, value: string) => option.value === value
       }
       textfieldprops={{


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Disable option coverage if already set

https://github.com/user-attachments/assets/6e6c547f-0b76-456e-a0ca-27eb2652f870



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13118 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
