### PR TITLE
[ci] client-python build - fix init .pypirc step (#12446) 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           command: cd client-python && pip3 install twine
       - run:
           name: init .pypirc
-          command: >
+          command: |
             cd client-python
             printf "[pypi]\nusername = __token__\npassword = %s\n"
             "${PYPI_PASSWORD}" >> ~/.pypirc


### PR DESCRIPTION
Fix the circle CI pycti build step following client python migration [(](https://github.com/OpenCTI-Platform/opencti/commit/4405a0222ba2c73450207d477509c83bfd8e6f0e)https://github.com/OpenCTI-Platform/opencti/issues/12446)