### PR TITLE
[frontend] fix manage access restriction component not saving form (#13161)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -109,7 +109,8 @@ const AuthorizedMembersField = ({
   // Value in sync with internal Formik field 'applyAccesses'.
   // Require to use a state in addition to the Formik field because
   // we use the value outside the scope of the internal Formik form.
-  const [applyAccesses, setApplyAccesses] = useState(enableAccesses || (value && Array.isArray(value) && value.length > 0));
+  const hasValue = value && Array.isArray(value) && value.length > 0;
+  const [applyAccesses, setApplyAccesses] = useState(enableAccesses || hasValue);
   const accessForAllMembers = (value ?? []).find(
     (o) => o.value === ALL_MEMBERS_AUTHORIZED_CONFIG.id,
   );
@@ -148,7 +149,7 @@ const AuthorizedMembersField = ({
 
   // Initialize the field with owner and/or current on enableAccesses truthly.
   useEffect(() => {
-    if (enableAccesses) {
+    if (enableAccesses && !hasValue) {
       const values: AuthorizedMemberOption[] = [];
       if (owner) {
         values.push({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* frontend:  fix manage access restriction component not saving form => add missing condition in useEffect if enableAccesses
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/13161
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
