### PR TITLE
[ci] client-python build - fix init .pypirc step (#12446)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,7 @@ jobs:
           name: init .pypirc
           command: |
             cd client-python
-            printf "[pypi]\nusername = __token__\npassword = %s\n"
-            "${PYPI_PASSWORD}" >> ~/.pypirc
+            printf "[pypi]\nusername = __token__\npassword = %s\n" "${PYPI_PASSWORD}" >> ~/.pypirc
       - run:
           name: upload to pypi
           command: cd client-python && twine upload dist/*


### PR DESCRIPTION
Fix the circle CI pycti build step following client python migration [(](https://github.com/OpenCTI-Platform/opencti/commit/4405a0222ba2c73450207d477509c83bfd8e6f0e)https://github.com/OpenCTI-Platform/opencti/issues/12446) and partial fix in https://github.com/OpenCTI-Platform/opencti/pull/13208