### PR TITLE
[frontend/backend] handle authorized member in launch import with draft

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/FileManager.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileManager.jsx
@@ -69,6 +69,30 @@ export const fileManagerAskJobImportMutation = graphql`
   }
 `;
 
+export const fileManagerCreateDraftAskJobImportMutation = graphql`
+  mutation FileManagerCreateDraftAskJobImportMutation(
+    $fileName: ID!
+    $connectorId: String
+    $configuration: String
+    $bypassValidation: Boolean
+    $forceValidation: Boolean
+    $validationMode: ValidationMode
+    $authorized_members: [MemberAccessInput!]
+  ) {
+    createDraftAndAskJobImport(
+      fileName: $fileName
+      connectorId: $connectorId
+      configuration: $configuration
+      bypassValidation: $bypassValidation
+      forceValidation: $forceValidation
+      validationMode: $validationMode
+      authorized_members: $authorized_members
+    ) {
+      ...FileLine_file
+    }
+  }
+`;
+
 export const fileManagerExportMutation = graphql`
   mutation FileManagerExportMutation(
     $id: ID!

--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -9,7 +9,7 @@ import Button from '@mui/material/Button';
 import * as Yup from 'yup';
 import ObjectMarkingField from '@components/common/form/ObjectMarkingField';
 import ManageImportConnectorMessage from '@components/data/import/ManageImportConnectorMessage';
-import { fileManagerAskJobImportMutation } from '@components/common/files/FileManager';
+import { fileManagerAskJobImportMutation, fileManagerCreateDraftAskJobImportMutation } from '@components/common/files/FileManager';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { ImportWorksDrawerQuery, ImportWorksDrawerQuery$data } from '@components/common/files/__generated__/ImportWorksDrawerQuery.graphql';
 import { fileWorksQuery } from '@components/common/files/ImportWorksDrawer';
@@ -47,7 +47,6 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
   const showAllMembersLine = !settings.platform_organization?.id;
   const { connectorsForImport: connectors } = usePreloadedQuery<ImportWorksDrawerQuery>(fileWorksQuery, queryRef);
   const [selectedConnector, setSelectedConnector] = React.useState<ConnectorType | null>(null);
-  const [selectedMode, setSelectedMode] = React.useState<'draft' | 'workbench' | null>(null);
   const [hasUserChoiceCsvMapper, setHasUserChoiceCsvMapper] = React.useState(false);
 
   const handleSetCsvMapper = (_: UIEvent, csvMapper: string) => {
@@ -67,10 +66,6 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
   const handleSelectConnector = (_: UIEvent, value: string) => {
     const connector = connectors?.find((c) => c?.id === value);
     setSelectedConnector(connector);
-  };
-
-  const handleSelectMode = (_: UIEvent, value: 'draft' | 'workbench') => {
-    setSelectedMode(value);
   };
 
   const onSubmitImport = (
@@ -98,7 +93,7 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
 
     commitMutation({
       ...defaultCommitMutation,
-      mutation: fileManagerAskJobImportMutation,
+      mutation: validation_mode === 'draft' ? fileManagerCreateDraftAskJobImportMutation : fileManagerAskJobImportMutation,
       variables: {
         fileName: file.id,
         connectorId: connector_id,
@@ -156,7 +151,7 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
       onSubmit={onSubmitImport}
       onReset={onClose}
     >
-      {({ submitForm, handleReset, isSubmitting, setFieldValue, isValid }) => (
+      {({ submitForm, handleReset, isSubmitting, setFieldValue, isValid, values }) => (
         <Form>
           <Dialog
             open={open}
@@ -201,13 +196,12 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
                   fullWidth={true}
                   containerstyle={{ marginTop: 20, width: '100%' }}
                   setFieldValue={setFieldValue}
-                  onChange={handleSelectMode}
                 >
                   <MenuItem value="workbench">Workbench</MenuItem>
                   <MenuItem value="draft">Draft</MenuItem>
                 </Field>
               )}
-              {selectedMode === 'draft' && (
+              {values.validation_mode === 'draft' && (
                 <Field
                   name="authorizedMembers"
                   component={AuthorizedMembersField}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
@@ -16,7 +16,7 @@ import Button from '@mui/material/Button';
 import { InfoOutlined } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
 import DraftWorkspaceViewer from '../files/draftWorkspace/DraftWorkspaceViewer';
-import { CONTENT_MAX_MARKINGS_HELPERTEXT, CONTENT_MAX_MARKINGS_TITLE } from '../files/FileManager';
+import { CONTENT_MAX_MARKINGS_HELPERTEXT, CONTENT_MAX_MARKINGS_TITLE, fileManagerCreateDraftAskJobImportMutation } from '../files/FileManager';
 import ManageImportConnectorMessage from '../../data/import/ManageImportConnectorMessage';
 import ObjectMarkingField from '../form/ObjectMarkingField';
 import FileExportViewer from '../files/FileExportViewer';
@@ -30,6 +30,8 @@ import WorkbenchFileViewer from '../files/workbench/WorkbenchFileViewer';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';
+import useAuth from '../../../../utils/hooks/useAuth';
+import AuthorizedMembersField from '../form/AuthorizedMembersField';
 
 const styles = (theme) => ({
   container: {
@@ -137,6 +139,8 @@ const StixCoreObjectFilesAndHistory = ({
   bypassEntityId,
 }) => {
   const { t_i18n } = useFormatter();
+  const { me: owner, settings } = useAuth();
+  const showAllMembersLine = !settings.platform_organization?.id;
   const draftContext = useDraftContext();
   const [fileToImport, setFileToImport] = useState(null);
   const [openExport, setOpenExport] = useState(false);
@@ -158,7 +162,7 @@ const StixCoreObjectFilesAndHistory = ({
   const handleCloseExport = () => setOpenExport(false);
   const handleSelectedContentMaxMarkingsChange = (values) => setSelectedContentMaxMarkingsIds(values.map(({ value }) => value));
   const onSubmitImport = (values, { setSubmitting, resetForm }) => {
-    const { connector_id, configuration, objectMarking, validation_mode } = values;
+    const { connector_id, configuration, objectMarking, validation_mode, authorizedMembers } = values;
     let config = configuration;
     // Dynamically inject the markings chosen by the user into the csv mapper.
     const isCsvConnector = selectedConnector?.name === 'ImportCsv';
@@ -170,13 +174,24 @@ const StixCoreObjectFilesAndHistory = ({
       }
     }
     commitMutation({
-      mutation: stixCoreObjectFilesAndHistoryAskJobImportMutation,
+      mutation: validation_mode === 'draft' ? fileManagerCreateDraftAskJobImportMutation : stixCoreObjectFilesAndHistoryAskJobImportMutation,
       variables: {
         fileName: fileToImport.id,
         connectorId: connector_id,
         bypassEntityId: bypassEntityId ? id : null,
         configuration: config,
         validationMode: validation_mode,
+        authorized_members: !authorizedMembers
+          ? null
+          : authorizedMembers
+            .filter((v) => v.accessRight !== 'none')
+            .map((member) => ({
+              id: member.value,
+              access_right: member.accessRight,
+              groups_restriction_ids: member.groupsRestriction?.length > 0
+                ? member.groupsRestriction.map((group) => group.value)
+                : undefined,
+            })),
       },
       onCompleted: () => {
         setSubmitting(false);
@@ -295,7 +310,7 @@ const StixCoreObjectFilesAndHistory = ({
         onSubmit={onSubmitImport}
         onReset={handleCloseImport}
       >
-        {({ submitForm, handleReset, isSubmitting, setFieldValue, isValid }) => (
+        {({ submitForm, handleReset, isSubmitting, setFieldValue, isValid, values }) => (
           <Form style={{ margin: '0 0 20px 0' }}>
             <Dialog
               slotProps={{ paper: { elevation: 1 } }}
@@ -356,6 +371,19 @@ const StixCoreObjectFilesAndHistory = ({
                       {'Draft'}
                     </MenuItem>
                   </Field>
+                )}
+                {values.validation_mode === 'draft' && (
+                  <Field
+                    name="authorizedMembers"
+                    component={AuthorizedMembersField}
+                    owner={owner}
+                    showAllMembersLine={showAllMembersLine}
+                    canDeactivate
+                    addMeUserWithAdminRights
+                    enableAccesses
+                    applyAccesses
+                    style={fieldSpacingContainerStyle}
+                  />
                 )}
                 {selectedConnector?.configurations?.length > 0
                   ? <Field

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9463,6 +9463,7 @@ type Mutation {
   uploadAndAskJobImport(file: Upload!, fileMarkings: [String!], connectors: [ConnectorWithConfig!], validationMode: ValidationMode, draftId: String, noTriggerImport: Boolean): File
   uploadPending(file: Upload!, entityId: String, labels: [String], errorOnExisting: Boolean, file_markings: [String!], refreshEntity: Boolean): File
   askJobImport(fileName: ID!, connectorId: String, configuration: String, bypassEntityId: String, bypassValidation: Boolean, validationMode: ValidationMode, forceValidation: Boolean): File
+  createDraftAndAskJobImport(fileName: ID!, connectorId: String, configuration: String, bypassEntityId: String, bypassValidation: Boolean, validationMode: ValidationMode, forceValidation: Boolean, authorized_members: [MemberAccessInput!]): File
   resetFileIndexing: Boolean
   synchronizerAdd(input: SynchronizerAddInput!): Synchronizer
   synchronizerEdit(id: ID!): SynchronizerEditMutations

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -15147,8 +15147,8 @@ type Mutation {
   uploadImport(file: Upload!, fileMarkings: [String]): File @auth(for: [KNOWLEDGE_KNASKIMPORT])
   uploadAndAskJobImport(file: Upload!, fileMarkings: [String!], connectors: [ConnectorWithConfig!], validationMode: ValidationMode, draftId: String, noTriggerImport: Boolean): File @auth(for: [KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNASKIMPORT])
   uploadPending(file: Upload!, entityId: String, labels: [String], errorOnExisting: Boolean, file_markings: [String!], refreshEntity: Boolean): File @auth(for: [KNOWLEDGE_KNASKIMPORT])
-  askJobImport(fileName: ID!, connectorId: String, configuration: String, bypassEntityId: String, bypassValidation: Boolean, validationMode: ValidationMode, forceValidation: Boolean): File
-  @auth(for: [KNOWLEDGE_KNASKIMPORT])
+  askJobImport(fileName: ID!, connectorId: String, configuration: String, bypassEntityId: String, bypassValidation: Boolean, validationMode: ValidationMode, forceValidation: Boolean): File @auth(for: [KNOWLEDGE_KNASKIMPORT])
+  createDraftAndAskJobImport(fileName: ID!, connectorId: String, configuration: String, bypassEntityId: String, bypassValidation: Boolean, validationMode: ValidationMode, forceValidation: Boolean,  authorized_members: [MemberAccessInput!]): File @auth(for: [KNOWLEDGE_KNASKIMPORT])
   resetFileIndexing: Boolean @auth(for: [SETTINGS_FILEINDEXING])
 
   ### SYNC

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -14676,6 +14676,7 @@ export type Mutation = {
   countryEdit?: Maybe<CountryEditMutations>;
   courseOfActionAdd?: Maybe<CourseOfAction>;
   courseOfActionEdit?: Maybe<CourseOfActionEditMutations>;
+  createDraftAndAskJobImport?: Maybe<File>;
   csvMapperAdd?: Maybe<CsvMapper>;
   csvMapperDelete?: Maybe<Scalars['ID']['output']>;
   csvMapperFieldPatch?: Maybe<CsvMapper>;
@@ -15418,6 +15419,18 @@ export type MutationCourseOfActionAddArgs = {
 
 export type MutationCourseOfActionEditArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationCreateDraftAndAskJobImportArgs = {
+  authorized_members?: InputMaybe<Array<MemberAccessInput>>;
+  bypassEntityId?: InputMaybe<Scalars['String']['input']>;
+  bypassValidation?: InputMaybe<Scalars['Boolean']['input']>;
+  configuration?: InputMaybe<Scalars['String']['input']>;
+  connectorId?: InputMaybe<Scalars['String']['input']>;
+  fileName: Scalars['ID']['input'];
+  forceValidation?: InputMaybe<Scalars['Boolean']['input']>;
+  validationMode?: InputMaybe<ValidationMode>;
 };
 
 
@@ -41739,6 +41752,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   countryEdit?: Resolver<Maybe<ResolversTypes['CountryEditMutations']>, ParentType, ContextType, RequireFields<MutationCountryEditArgs, 'id'>>;
   courseOfActionAdd?: Resolver<Maybe<ResolversTypes['CourseOfAction']>, ParentType, ContextType, RequireFields<MutationCourseOfActionAddArgs, 'input'>>;
   courseOfActionEdit?: Resolver<Maybe<ResolversTypes['CourseOfActionEditMutations']>, ParentType, ContextType, RequireFields<MutationCourseOfActionEditArgs, 'id'>>;
+  createDraftAndAskJobImport?: Resolver<Maybe<ResolversTypes['File']>, ParentType, ContextType, RequireFields<MutationCreateDraftAndAskJobImportArgs, 'fileName'>>;
   csvMapperAdd?: Resolver<Maybe<ResolversTypes['CsvMapper']>, ParentType, ContextType, RequireFields<MutationCsvMapperAddArgs, 'input'>>;
   csvMapperDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationCsvMapperDeleteArgs, 'id'>>;
   csvMapperFieldPatch?: Resolver<Maybe<ResolversTypes['CsvMapper']>, ParentType, ContextType, RequireFields<MutationCsvMapperFieldPatchArgs, 'id' | 'input'>>;

--- a/opencti-platform/opencti-graphql/src/resolvers/file.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/file.js
@@ -3,7 +3,7 @@ import { deleteImport, filesMetrics, uploadAndAskJobImport, uploadImport, upload
 import { paginatedForPathWithEnrichment } from '../modules/internal/document/document-domain';
 import { buildDraftVersion } from '../modules/draftWorkspace/draftWorkspace-domain';
 import { getDraftContextFilesPrefix } from '../database/draft-utils';
-import { askJobImport } from '../domain/connector';
+import { askJobImport, createDraftAndAskJobImport } from '../domain/connector';
 
 const fileResolvers = {
   Query: {
@@ -33,6 +33,7 @@ const fileResolvers = {
     deleteImport: (_, { fileName }, context) => deleteImport(context, context.user, fileName),
     askJobImport: (_, args, context) => askJobImport(context, context.user, args),
     uploadAndAskJobImport: (_, args, context) => uploadAndAskJobImport(context, context.user, args),
+    createDraftAndAskJobImport: (_, args, context) => createDraftAndAskJobImport(context, context.user, args),
   },
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix **Authorised Members** in **Data > Import > Global > Launch an import** query
* Add missing **Authorised Members** in data entity (Ex: Report > Data > Launch an import)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/10981

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
