### PR TITLE
[frontend] Fix 'Validation mode' tooltip in Import data pop-up

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
@@ -65,8 +65,19 @@ const ImportFilesOptions = ({
                 component={SelectField}
                 variant="standard"
                 name="validationMode"
-                label={t_i18n('Validation mode')}
-                containerstyle={{ marginTop: 16, width: '100%' }}
+                containerstyle={{ marginTop: 16, width: '100%', marginRight: 10 }}
+                label={<>
+                  {t_i18n('Validation mode')}
+                  <Tooltip
+                    title={t_i18n('Import all data into a new draft or an analyst workbench, to validate the data before ingestion. Note that creating a workbench is not possible when several files are selected.')}
+                  >
+                    <InformationOutline
+                      style={{ display: 'flex', marginTop: -22, marginLeft: 115 }}
+                      fontSize="small"
+                      color="primary"
+                    />
+                  </Tooltip>
+                </>}
               >
                 <MenuItem
                   key={'draft'}
@@ -82,15 +93,6 @@ const ImportFilesOptions = ({
                   {t_i18n('Workbench')}
                 </MenuItem>
               </Field>
-              <Tooltip
-                title={t_i18n('Import all data into a new draft or an analyst workbench, to validate the data before ingestion. Note that creating a workbench is not possible when several files are selected.')}
-              >
-                <InformationOutline
-                  style={{ position: 'absolute', marginLeft: 16, marginTop: 40 }}
-                  fontSize="small"
-                  color="primary"
-                />
-              </Tooltip>
             </div>
             {optionsFormikContext.values.validationMode === 'draft' && (
               <>


### PR DESCRIPTION
### Proposed changes
In 'import data' pop-up, in the 'import options' step, there is a tooltip moving when we scroll down

- Before changes
https://filigranio.sharepoint.com/:v:/s/team-opencti/EfW3EnIpWkdAuAn_77uu3WkBIIO5ZunlZTq3XiNA14DY8w?e=euu4oC

<img width="1226" height="723" alt="image" src="https://github.com/user-attachments/assets/3d78ef38-96ee-4065-b59f-376eed38efb8" />


- After changes
Tooltip is fixed
<img width="1452" height="646" alt="image" src="https://github.com/user-attachments/assets/1107aa75-43a7-4b3f-9628-84fdc2f5f1a4" />
