### PR TITLE
[frontend] Remove Reliability in Organization details (#11073)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Organization.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Organization.tsx
@@ -85,7 +85,7 @@ const Organization: React.FC<OrganizationProps> = ({ organizationData, viewAs })
         style={{ marginBottom: 20 }}
       >
         <Grid item xs={6}>
-          <OrganizationDetails organization={organization} />
+          <OrganizationDetails organizationData={organization} />
         </Grid>
         <Grid item xs={6}>
           <StixDomainObjectOverview

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -1,24 +1,42 @@
 import React, { FunctionComponent } from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { graphql, useFragment } from 'react-relay';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
-import { OrganizationDetails_organization$data } from '@components/entities/organizations/__generated__/OrganizationDetails_organization.graphql';
 import { useTheme } from '@mui/material/styles';
+import { Organization_organization$data } from '@components/entities/organizations/__generated__/Organization_organization.graphql';
+import { OrganizationDetails_organization$key } from '@components/entities/organizations/__generated__/OrganizationDetails_organization.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ItemScore from '../../../../components/ItemScore';
 
+const organizationDetailsFragment = graphql`
+  fragment OrganizationDetails_organization on Organization {
+    id
+    description
+    contact_information
+    x_opencti_score
+    x_opencti_organization_type
+    objectLabel {
+      id
+      value
+      color
+    }
+  }
+`;
+
 interface OrganizationDetailsComponentProps {
-  organization: OrganizationDetails_organization$data;
+  organizationData: Organization_organization$data;
 }
 
-const OrganizationDetailsComponent: FunctionComponent<OrganizationDetailsComponentProps> = ({ organization }) => {
+const OrganizationDetails: FunctionComponent<OrganizationDetailsComponentProps> = ({ organizationData }) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme();
+  const organization = useFragment<OrganizationDetails_organization$key>(organizationDetailsFragment, organizationData);
+
   return (
     <div style={{ height: '100%' }}>
       <Typography variant="h4" gutterBottom={true}>
@@ -89,25 +107,5 @@ const OrganizationDetailsComponent: FunctionComponent<OrganizationDetailsCompone
     </div>
   );
 };
-
-const OrganizationDetails = createFragmentContainer(
-  OrganizationDetailsComponent,
-  {
-    organization: graphql`
-        fragment OrganizationDetails_organization on Organization {
-            id
-            description
-            contact_information
-            x_opencti_score
-            x_opencti_organization_type
-            objectLabel {
-                id
-                value
-                color
-            }
-        }
-    `,
-  },
-);
 
 export default OrganizationDetails;

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -4,56 +4,51 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
-import makeStyles from '@mui/styles/makeStyles';
 import { OrganizationDetails_organization$data } from '@components/entities/organizations/__generated__/OrganizationDetails_organization.graphql';
+import { useTheme } from '@mui/material/styles';
 import { useFormatter } from '../../../../components/i18n';
-import ItemOpenVocab from '../../../../components/ItemOpenVocab';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import type { Theme } from '../../../../components/Theme';
 import ItemScore from '../../../../components/ItemScore';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  paper: {
-    marginTop: theme.spacing(1),
-    padding: '15px',
-    borderRadius: 6,
-  },
-  chip: {
-    fontSize: 12,
-    height: 25,
-    marginRight: 7,
-    textTransform: 'uppercase',
-    borderRadius: 4,
-    width: 150,
-    backgroundColor: 'rgba(229,152,137, 0.08)',
-    color: '#e59889',
-  },
-}));
 
 interface OrganizationDetailsComponentProps {
   organization: OrganizationDetails_organization$data;
 }
 
 const OrganizationDetailsComponent: FunctionComponent<OrganizationDetailsComponentProps> = ({ organization }) => {
-  const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const theme = useTheme();
   return (
     <div style={{ height: '100%' }}>
       <Typography variant="h4" gutterBottom={true}>
         {t_i18n('Details')}
       </Typography>
-      <Paper classes={{ root: classes.paper }} className={'paper-for-grid'} variant="outlined">
+      <Paper
+        style={{
+          marginTop: theme.spacing(1),
+          padding: '15px',
+          borderRadius: 6,
+        }}
+        className={'paper-for-grid'}
+        variant="outlined"
+      >
         <Grid container={true} spacing={3}>
           <Grid item xs={6}>
             <Typography variant="h3" gutterBottom={true}>
               {t_i18n('Organization type')}
             </Typography>
             <Chip
-              classes={{ root: classes.chip }}
+              style={{
+                fontSize: 12,
+                height: 25,
+                marginRight: 7,
+                textTransform: 'uppercase',
+                borderRadius: 4,
+                width: 150,
+                backgroundColor: 'rgba(229,152,137, 0.08)',
+                color: '#e59889',
+              }}
               label={organization.x_opencti_organization_type || t_i18n('Unknown')}
             />
             <Typography
@@ -67,28 +62,11 @@ const OrganizationDetailsComponent: FunctionComponent<OrganizationDetailsCompone
               source={organization.description}
               limit={400}
             />
-            <Typography
-              variant="h3"
-              gutterBottom={true}
-              style={{ marginTop: 20 }}
-            >
-              {t_i18n('Score')}
-            </Typography>
-            <ItemScore score={organization.x_opencti_score} />
           </Grid>
           <Grid item xs={6}>
-            <Typography variant="h3" gutterBottom={true}>
-              {t_i18n('Reliability')}
-            </Typography>
-            <ItemOpenVocab
-              displayMode="chip"
-              type="reliability_ov"
-              value={organization.x_opencti_reliability}
-            />
             <Typography
               variant="h3"
               gutterBottom={true}
-              style={fieldSpacingContainerStyle}
             >
               {t_i18n('Contact information')}
             </Typography>
@@ -97,6 +75,14 @@ const OrganizationDetailsComponent: FunctionComponent<OrganizationDetailsCompone
               remarkGfmPlugin={true}
               commonmark={true}
             />
+            <Typography
+              variant="h3"
+              gutterBottom={true}
+              style={{ marginTop: 20 }}
+            >
+              {t_i18n('Score')}
+            </Typography>
+            <ItemScore score={organization.x_opencti_score} />
           </Grid>
         </Grid>
       </Paper>
@@ -113,7 +99,6 @@ const OrganizationDetails = createFragmentContainer(
             description
             contact_information
             x_opencti_score
-            x_opencti_reliability
             x_opencti_organization_type
             objectLabel {
                 id

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -5,7 +5,6 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import { useTheme } from '@mui/material/styles';
-import { Organization_organization$data } from '@components/entities/organizations/__generated__/Organization_organization.graphql';
 import { OrganizationDetails_organization$key } from '@components/entities/organizations/__generated__/OrganizationDetails_organization.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
@@ -29,13 +28,13 @@ const organizationDetailsFragment = graphql`
 `;
 
 interface OrganizationDetailsComponentProps {
-  organizationData: Organization_organization$data;
+  organizationData: OrganizationDetails_organization$key;
 }
 
 const OrganizationDetails: FunctionComponent<OrganizationDetailsComponentProps> = ({ organizationData }) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme();
-  const organization = useFragment<OrganizationDetails_organization$key>(organizationDetailsFragment, organizationData);
+  const organization = useFragment(organizationDetailsFragment, organizationData);
 
   return (
     <div style={{ height: '100%' }}>


### PR DESCRIPTION
### Proposed changes
- Remove 'reliability' in organization details, since it's already displayed in 'basic information'

<img width="1848" height="813" alt="image" src="https://github.com/user-attachments/assets/e4acda01-37f6-4c6b-be07-39bcc171b19a" />


### Related issues
#11073