### PR TITLE
[client] fix usage of mapping_cache in draft (#13226)

### DIFF
--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -258,6 +258,9 @@ class OpenCTIApiClient:
         self.user = User(self)
         self.settings = Settings(self)
 
+        # Keep track of draft context
+        self.draft_id = ""
+
         # Check if openCTI is available
         if perform_health_check and not self.health_check():
             raise ValueError(
@@ -414,7 +417,11 @@ class OpenCTIApiClient:
     def set_event_id(self, event_id):
         self.request_headers["opencti-event-id"] = event_id
 
+    def get_draft_id(self):
+        return self.draft_id
+
     def set_draft_id(self, draft_id):
+        self.draft_id = draft_id
         self.request_headers["opencti-draft-id"] = draft_id
 
     def set_synchronized_upsert_header(self, synchronized):

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -418,6 +418,8 @@ class OpenCTIApiClient:
         self.request_headers["opencti-event-id"] = event_id
 
     def get_draft_id(self):
+        if self.draft_id is None:
+            return ""
         return self.draft_id
 
     def set_draft_id(self, draft_id):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* mapping_cache was being used independently of draft context in opencti_stix2. This means that it could try to use ids of label/entities created in an other draft, that have a different internal_id. 
* we now suffix all items inserted in mapping_cache with current draft_id
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13226 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
