### PR TITLE
[frontend] display selected date attribute in timeline widget (#13064)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
@@ -19,10 +19,10 @@ import FieldOrEmpty from '../FieldOrEmpty';
 interface WidgetTimelineProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: { value: any, link?: string }[]
-  dateAttribute: string
+  dateAttribute?: string
 }
 
-const WidgetTimeline = ({ data, dateAttribute }: WidgetTimelineProps) => {
+const WidgetTimeline = ({ data, dateAttribute = 'created_at' }: WidgetTimelineProps) => {
   const { fldt } = useFormatter();
 
   return (

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetTimeline.tsx
@@ -14,13 +14,15 @@ import MarkdownDisplay from '../MarkdownDisplay';
 import ItemIcon from '../ItemIcon';
 import { itemColor } from '../../utils/Colors';
 import { useFormatter } from '../i18n';
+import FieldOrEmpty from '../FieldOrEmpty';
 
 interface WidgetTimelineProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: { value: any, link?: string }[]
+  dateAttribute: string
 }
 
-const WidgetTimeline = ({ data }: WidgetTimelineProps) => {
+const WidgetTimeline = ({ data, dateAttribute }: WidgetTimelineProps) => {
   const { fldt } = useFormatter();
 
   return (
@@ -40,7 +42,9 @@ const WidgetTimeline = ({ data }: WidgetTimelineProps) => {
                 sx={{ paddingTop: '18px' }}
                 color="text.secondary"
               >
-                {fldt(value.created_at)}
+                <FieldOrEmpty source={value[dateAttribute]}>
+                  {fldt(value[dateAttribute])}
+                </FieldOrEmpty>
               </TimelineOppositeContent>
               <TimelineSeparator>
                 {link ? (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTimeline.tsx
@@ -31,6 +31,15 @@ const stixCoreObjectsTimelineQuery = graphql`
           id
           entity_type
           created_at
+          updated_at
+          ... on StixDomainObject  {
+            modified
+            created
+          }
+          ... on Event {
+            start_time
+            stop_time
+          }
           createdBy {
             ... on Identity {
               id
@@ -105,7 +114,7 @@ const StixCoreObjectsTimeline = ({
                 link,
               };
             });
-            return <WidgetTimeline data={data} />;
+            return <WidgetTimeline data={data} dateAttribute={dateAttribute} />;
           }
           if (props) {
             return <WidgetNoData />;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -48,7 +48,10 @@ const stixRelationshipsTimelineStixRelationshipQuery = graphql`
           relationship_type
           confidence
           is_inferred
+          created_at
           created
+          modified
+          updated_at
           x_opencti_inferences {
             rule {
               id
@@ -1035,7 +1038,7 @@ const StixRelationshipsTimeline = ({
                 link,
               };
             });
-            return <WidgetTimeline data={data} />;
+            return <WidgetTimeline data={data} dateAttribute={dateAttribute} />;
           }
           if (props) {
             return <WidgetNoData />;

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsTimeline.tsx
@@ -66,10 +66,12 @@ const publicStixCoreObjectsTimelineQuery = graphql`
 
 interface PublicStixCoreObjectsTimelineComponentProps {
   queryRef: PreloadedQuery<PublicStixCoreObjectsTimelineQuery>
+  dateAttribute?: string
 }
 
 const PublicStixCoreObjectsTimelineComponent = ({
   queryRef,
+  dateAttribute,
 }: PublicStixCoreObjectsTimelineComponentProps) => {
   const { publicStixCoreObjects } = usePreloadedQuery(
     publicStixCoreObjectsTimelineQuery,
@@ -89,7 +91,7 @@ const PublicStixCoreObjectsTimelineComponent = ({
         value: stixCoreObject,
       };
     });
-    return <WidgetTimeline data={data} />;
+    return <WidgetTimeline data={data} dateAttribute={dateAttribute} />;
   }
   return <WidgetNoData />;
 };
@@ -102,7 +104,7 @@ const PublicStixCoreObjectsTimeline = ({
   title,
 }: PublicWidgetContainerProps) => {
   const { t_i18n } = useFormatter();
-  const { id, parameters } = widget;
+  const { id, parameters, dataSelection } = widget;
   const queryRef = useQueryLoading<PublicStixCoreObjectsTimelineQuery>(
     publicStixCoreObjectsTimelineQuery,
     {
@@ -112,6 +114,10 @@ const PublicStixCoreObjectsTimeline = ({
       endDate,
     },
   );
+  const selection = dataSelection[0];
+  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
+    ? selection.date_attribute
+    : 'created_at';
 
   return (
     <WidgetContainer
@@ -120,7 +126,7 @@ const PublicStixCoreObjectsTimeline = ({
     >
       {queryRef ? (
         <React.Suspense fallback={<Loader variant={LoaderVariant.inElement} />}>
-          <PublicStixCoreObjectsTimelineComponent queryRef={queryRef} />
+          <PublicStixCoreObjectsTimelineComponent queryRef={queryRef} dateAttribute={dateAttribute} />
         </React.Suspense>
       ) : (
         <Loader variant={LoaderVariant.inElement} />

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsTimeline.tsx
@@ -27,6 +27,7 @@ const publicStixCoreObjectsTimelineQuery = graphql`
           id
           entity_type
           created_at
+          updated_at
           createdBy {
             ... on Identity {
               id
@@ -54,6 +55,10 @@ const publicStixCoreObjectsTimelineQuery = graphql`
           ... on StixDomainObject {
             created
             modified
+          }
+          ... on Event {
+            start_time
+            stop_time
           }
           ... on StixCyberObservable {
             observable_value

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsTimeline.tsx
@@ -32,6 +32,9 @@ const publicStixRelationshipsTimelineQuery = graphql`
           confidence
           is_inferred
           created
+          created_at
+          updated_at
+          modified
           x_opencti_inferences {
             rule {
               id

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsTimeline.tsx
@@ -986,7 +986,11 @@ const PublicStixRelationshipsTimelineComponent = ({
         },
       };
     });
-    return <WidgetTimeline data={data} />;
+    const selection = dataSelection[0];
+    const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
+      ? selection.date_attribute
+      : 'created_at';
+    return <WidgetTimeline data={data} dateAttribute={dateAttribute} />;
   }
   return <WidgetNoData />;
 };


### PR DESCRIPTION
### Proposed changes
In timeline widgets, instead of always displaying the created_at date, display the date selected in the widget options : 

<img width="1132" height="800" alt="image" src="https://github.com/user-attachments/assets/1b68d59c-93a2-4fab-8e60-23f7616de7fc" />

<img width="1496" height="655" alt="image" src="https://github.com/user-attachments/assets/9c9e76ea-2597-411c-9764-f8e14d5cdb3a" />



### Related issues
#13064