### PR TITLE
[backend] add stream type managers state tracking & state recovery (#13254)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -689,6 +689,18 @@ export const redisClearTelemetry = async () => {
 };
 // endregion - telemetry gauges
 
+// region - manager stream state
+const MANAGER_EVENT_STATE_KEY = 'manager_stream_state_';
+export const redisSetManagerEventState = async (managerName: string, event_state_id: string) => {
+  const managerEventStateKey = MANAGER_EVENT_STATE_KEY + managerName;
+  await getClientBase().set(managerEventStateKey, event_state_id);
+};
+export const redisGetManagerEventState = async (managerName: string) => {
+  const managerEventStateKey = MANAGER_EVENT_STATE_KEY + managerName;
+  return getClientBase().get(managerEventStateKey);
+};
+// endregion
+
 // region connector logs
 export const redisSetConnectorLogs = async (connectorId: string, logs: string[]) => {
   const data = JSON.stringify(logs);

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -21,6 +21,7 @@ import { EVENT_TYPE_UPDATE, isEmptyField, waitInSec } from '../database/utils';
 import conf, { ENABLED_FILE_INDEX_MANAGER, logApp } from '../config/conf';
 import { createStreamProcessor } from '../database/stream/stream-handler';
 import { type StreamProcessor } from '../database/stream/stream-utils';
+import { redisGetManagerEventState, redisSetManagerEventState } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { getEntityFromCache } from '../database/cache';
@@ -42,6 +43,7 @@ const FILE_INDEX_MANAGER_KEY = conf.get('file_index_manager:lock_key');
 const SCHEDULE_TIME = conf.get('file_index_manager:interval') || 60000; // 1 minute
 const STREAM_SCHEDULE_TIME = 10000;
 const FILE_INDEX_MANAGER_STREAM_KEY = conf.get('file_index_manager:stream_lock_key');
+const FILE_INDEX_MANAGER_NAME = 'file_index_manager';
 
 interface FileToIndexObject {
   id: string;
@@ -103,13 +105,12 @@ export const indexImportedFiles = async (context: AuthContext, indexFromDate: st
     }
   }
 };
-
 const handleStreamEvents = async (streamEvents: Array<SseEvent<StreamDataEvent>>) => {
   try {
     if (streamEvents.length === 0) {
       return;
     }
-    const context = executionContext('file_index_manager');
+    const context = executionContext(FILE_INDEX_MANAGER_NAME);
     for (let index = 0; index < streamEvents.length; index += 1) {
       const event = streamEvents[index];
       if (event.data.type === EVENT_TYPE_UPDATE) {
@@ -127,6 +128,7 @@ const handleStreamEvents = async (streamEvents: Array<SseEvent<StreamDataEvent>>
           await elUpdateFilesWithEntityRestrictions(entity);
         }
       }
+      await redisSetManagerEventState(FILE_INDEX_MANAGER_NAME, event.id);
     }
   } catch (e) {
     logApp.error('[OPENCTI-MODULE] File index manager handling error', { cause: e, manager: 'FILE_INDEX_MANAGER' });
@@ -146,7 +148,7 @@ const initFileIndexManager = () => {
     });
   };
   const fileIndexHandler = async () => {
-    const context = executionContext('file_index_manager');
+    const context = executionContext(FILE_INDEX_MANAGER_NAME);
     const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
     if (settings.valid_enterprise_edition === true) {
       let lock;
@@ -177,7 +179,7 @@ const initFileIndexManager = () => {
     }
   };
   const fileIndexStreamHandler = async () => {
-    const context = executionContext('file_index_manager');
+    const context = executionContext(FILE_INDEX_MANAGER_NAME);
     const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
     if (settings.valid_enterprise_edition === true) {
       let lock;
@@ -187,7 +189,8 @@ const initFileIndexManager = () => {
         running = true;
         logApp.info('[OPENCTI-MODULE] Running file index manager stream handler');
         streamProcessor = createStreamProcessor('File index manager', handleStreamEvents, { bufferTime: 5000 });
-        await streamProcessor.start('live');
+        const lastEventState = await redisGetManagerEventState(FILE_INDEX_MANAGER_NAME);
+        await streamProcessor.start(lastEventState ?? 'live');
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
           await wait(WAIT_TIME_ACTION);

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -4,10 +4,7 @@ import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from
 import type { Moment } from 'moment';
 import { type StreamProcessor } from '../database/stream/stream-utils';
 import { fetchRangeNotifications, storeNotificationEvent, createStreamProcessor } from '../database/stream/stream-handler';
-import {
-  redisGetManagerEventState,
-  redisSetManagerEventState,
-} from '../database/redis';
+import { redisGetManagerEventState, redisSetManagerEventState } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { FunctionalError, TYPE_LOCK_ERROR } from '../config/errors';

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -265,7 +265,7 @@ export const isRelationFromOrToMatchFilters = (
   } else if (instance.type === STIX_TYPE_RELATION) {
     stixIdsToSearch.push((instance as StixRelation).source_ref, (instance as StixRelation).target_ref);
   }
-  // eslint-disable-next-line no-restricted-syntax
+
   for (const value of listenedInstanceIdsMap.values()) {
     if (stixIdsToSearch.includes(value.id)) {
       return true;
@@ -516,7 +516,6 @@ export const buildTargetEvents = async (
               targets.push({ user: notificationUser, type: translatedType, message });
             }
         } else { // useSideEventMatching = true: Case side events for instance triggers
-          // eslint-disable-next-line no-lonely-if
           if (isPreviousMatch || isCurrentlyMatch) { // we keep events if : was visible and/or is visible
             const listenedInstanceIdsMap = await resolveFiltersMapForUser(userContext, user, finalFilters);
             // eslint-disable-next-line max-len

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -241,7 +241,6 @@ export const internalProcessNotification = async (
   notificationData: NotificationData[],
   triggerList: BasicStoreEntityTrigger[],
   usersMap: Map<string, AuthUser>,
-  // eslint-disable-next-line consistent-return
 ): Promise<void> => {
   if (notificationUser.user_service_account) {
     throw UnsupportedError('Cannot send notification to service account user');

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -1,12 +1,17 @@
-/* eslint-disable camelcase */
+ 
 import * as R from 'ramda';
 import type { Operation } from 'fast-json-patch';
 import * as jsonpatch from 'fast-json-patch';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import { createStreamProcessor } from '../database/stream/stream-handler';
 import {
-  buildCreateEvent, createStreamProcessor, EVENT_CURRENT_VERSION, REDIS_STREAM_NAME, redisGetManagerEventState,
-  redisSetManagerEventState, type StreamProcessor
+  buildCreateEvent,
+  createStreamProcessor,
+  EVENT_CURRENT_VERSION,
+  REDIS_STREAM_NAME,
+  redisGetManagerEventState,
+  redisSetManagerEventState,
+  type StreamProcessor
 } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
@@ -85,7 +90,7 @@ const isAttributesImpactDependencies = (rule: RuleDefinition, operations: Operat
     .map((a) => a.name);
   const operationAttributes = R.uniq(operations.map((o) => {
     const parts = o.path.substring(1).split('/');
-    // eslint-disable-next-line no-restricted-globals
+     
     return parts.filter((p) => isNaN(Number(p))).join('.');
   }));
   return operationAttributes.filter((f) => rulesAttributes.includes(f)).length > 0;
@@ -158,7 +163,7 @@ const applyCleanupOnDependencyIds = async (deletionIds: Array<string>, rules: Ar
     filterGroups: [],
   };
   const callback = async (elements: Array<BasicStoreCommon>) => {
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+     
     await rulesCleanHandler(context, RULE_MANAGER_USER, elements, rules, deletionIds);
     return true;
   };
@@ -180,7 +185,7 @@ export const rulesApplyHandler = async (context: AuthContext, user: AuthUser, ev
       if (type === EVENT_TYPE_MERGE) {
         const mergeEvent = event as MergeEvent;
         const mergeEvents = await ruleMergeHandler(mergeEvent);
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+         
         await rulesApplyHandler(context, user, mergeEvents);
       }
       // In case of deletion, call clean on every impacted elements

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -1,4 +1,3 @@
- 
 import * as R from 'ramda';
 import type { Operation } from 'fast-json-patch';
 import * as jsonpatch from 'fast-json-patch';
@@ -11,7 +10,7 @@ import {
   REDIS_STREAM_NAME,
   redisGetManagerEventState,
   redisSetManagerEventState,
-  type StreamProcessor
+  type StreamProcessor,
 } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
@@ -90,7 +89,7 @@ const isAttributesImpactDependencies = (rule: RuleDefinition, operations: Operat
     .map((a) => a.name);
   const operationAttributes = R.uniq(operations.map((o) => {
     const parts = o.path.substring(1).split('/');
-     
+
     return parts.filter((p) => isNaN(Number(p))).join('.');
   }));
   return operationAttributes.filter((f) => rulesAttributes.includes(f)).length > 0;
@@ -163,7 +162,6 @@ const applyCleanupOnDependencyIds = async (deletionIds: Array<string>, rules: Ar
     filterGroups: [],
   };
   const callback = async (elements: Array<BasicStoreCommon>) => {
-     
     await rulesCleanHandler(context, RULE_MANAGER_USER, elements, rules, deletionIds);
     return true;
   };
@@ -185,7 +183,7 @@ export const rulesApplyHandler = async (context: AuthContext, user: AuthUser, ev
       if (type === EVENT_TYPE_MERGE) {
         const mergeEvent = event as MergeEvent;
         const mergeEvents = await ruleMergeHandler(mergeEvent);
-         
+
         await rulesApplyHandler(context, user, mergeEvents);
       }
       // In case of deletion, call clean on every impacted elements

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -317,7 +317,7 @@ const initRuleManager = () => {
       // Start the stream listening
       const opts = { withInternal: true, streamName: LIVE_STREAM_NAME };
       streamProcessor = createStreamProcessor('Rule manager', ruleStreamHandler, opts);
-      await streamProcessor.start(lastEventDateTouse);
+      await streamProcessor.start(lastEventDateTouse ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
         await wait(WAIT_TIME_ACTION);

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -3,15 +3,7 @@ import type { Operation } from 'fast-json-patch';
 import * as jsonpatch from 'fast-json-patch';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import { createStreamProcessor } from '../database/stream/stream-handler';
-import {
-  buildCreateEvent,
-  createStreamProcessor,
-  EVENT_CURRENT_VERSION,
-  REDIS_STREAM_NAME,
-  redisGetManagerEventState,
-  redisSetManagerEventState,
-  type StreamProcessor,
-} from '../database/redis';
+import { redisGetManagerEventState, redisSetManagerEventState } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { createEntity, patchAttribute, stixLoadById, storeLoadByIdWithRefs } from '../database/middleware';

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -309,6 +309,11 @@ const initRuleManager = () => {
       const lastEventState = await redisGetManagerEventState(RULE_MANAGER_NAME);
       const lastEventDateTouse = lastEventState ?? lastEventId;
       logApp.info(`[OPENCTI-MODULE] Running rule manager from ${lastEventDateTouse ?? 'start'}`);
+      // Cleaning previous lastEventId value from stored manager: we now rely on redis state instead of ES state
+      if (lastEventId) {
+        const context = executionContext(RULE_MANAGER_NAME, RULE_MANAGER_USER);
+        await patchAttribute(context, RULE_MANAGER_USER, RULE_ENGINE_ID, ENTITY_TYPE_RULE_MANAGER, { lastEventId: null });
+      }
       // Start the stream listening
       const opts = { withInternal: true, streamName: LIVE_STREAM_NAME };
       streamProcessor = createStreamProcessor('Rule manager', ruleStreamHandler, opts);

--- a/opencti-platform/opencti-graphql/tests/utils/rule-utils.js
+++ b/opencti-platform/opencti-graphql/tests/utils/rule-utils.js
@@ -9,6 +9,7 @@ import { queryAsAdmin, testContext } from './testQuery';
 import { fetchStreamInfo } from '../../src/database/stream/stream-handler';
 import { logApp } from '../../src/config/conf';
 import { TASK_TYPE_RULE } from '../../src/domain/backgroundTask-common';
+import { getManagerInfo } from '../../src/manager/ruleManager';
 
 export const inferenceLookup = async (inferences, fromStandardId, toStandardId, type) => {
   for (let index = 0; index < inferences.length; index += 1) {
@@ -73,10 +74,10 @@ export const changeRule = async (ruleId, active) => {
   let stableCount = 1;
   while (stableCount < 3) {
     const innerInfo = await fetchStreamInfo();
-    const ruleManager = await internalLoadById(testContext, SYSTEM_USER, 'rule_engine_settings');
+    const ruleManagerInfo = await getManagerInfo(testContext, SYSTEM_USER);
     await wait(2000);
     const lastEventDate = new Date(parseInt(innerInfo.lastEventId.split('-').at(0), 10));
-    const managerEventDate = new Date(parseInt(ruleManager.lastEventId.split('-').at(0), 10));
+    const managerEventDate = new Date(parseInt(ruleManagerInfo.lastEventId.split('-').at(0), 10));
     if (managerEventDate >= lastEventDate) {
       stableCount += 1;
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* stream type managers could potentially miss some events, either at startup or in case of a node failure. To prevent this, we now keep track of the state of the stream events handling by the managers, so that this state can be reused at manager startup to continue where the last run left off
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13254 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
