### PR TITLE
[frontend/backend] Dynamic PIR filters format refacto to handle several PIR ids (#13344)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/pir/pir_knowledge/PirKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_knowledge/PirKnowledge.tsx
@@ -34,12 +34,12 @@ interface PirKnowledgeProps {
 const PirKnowledge = ({ data }: PirKnowledgeProps) => {
   const pir = useFragment(knowledgeFragment, data);
   const pirId = pir.id;
-  const LOCAL_STORAGE_KEY = `PirSourcesFlaggedList-${pirId}`;
+  const LOCAL_STORAGE_KEY = `Pir-SourcesFlaggedList-${pirId}`;
 
   const initialValues = {
     filters: {
       ...emptyFilterGroup,
-      filters: useGetDefaultFilterObject([`pir_score.${pirId}`, `last_pir_score_date.${pirId}`], ['Stix-Domain-Object']),
+      filters: useGetDefaultFilterObject(['pir_score', 'last_pir_score_date'], ['Stix-Domain-Object']),
     },
     searchTerm: '',
     sortBy: 'pir_score',

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_knowledge/PirKnowledgeEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_knowledge/PirKnowledgeEntities.tsx
@@ -23,7 +23,7 @@ import {
   PirKnowledgeEntitiesSourcesFlaggedListQuery$variables,
 } from './__generated__/PirKnowledgeEntitiesSourcesFlaggedListQuery.graphql';
 import { PirKnowledgeEntities_SourceFlaggedFragment$data } from './__generated__/PirKnowledgeEntities_SourceFlaggedFragment.graphql';
-import { isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
+import { formatFiltersInPirContext, isFilterGroupNotEmpty, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 import { PaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { DataTableProps } from '../../../../components/dataGrid/dataTableTypes';
@@ -176,7 +176,7 @@ const PirKnowledgeEntities = ({ pirId, localStorage, initialValues, additionalHe
       },
     ],
     filterGroups: filters && isFilterGroupNotEmpty(filters)
-      ? [filters]
+      ? [formatFiltersInPirContext(filters, pirId)]
       : [],
   };
   const queryPaginationOptions = {
@@ -262,7 +262,7 @@ const PirKnowledgeEntities = ({ pirId, localStorage, initialValues, additionalHe
             return computeLink(e);
           }}
           additionalHeaderButtons={additionalHeaderButtons}
-          additionalFilterKeys={[`pir_score.${pirId}`, `last_pir_score_date.${pirId}`]}
+          additionalFilterKeys={['pir_score', 'last_pir_score_date']}
         />
       )}
     </>

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/listenPirEventsUtils.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/listenPirEventsUtils.ts
@@ -14,7 +14,7 @@ import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/sti
 import { isEventCreateRelationship, isEventInPirRelationship, isEventUpdateOnEntity, isValidEventType } from './playbookManagerUtils';
 import { STIX_SPEC_VERSION } from '../../database/stix';
 import { playbookExecutor } from './playbookExecutor';
-import { PIR_SCORE_FILTER } from '../../utils/filtering/filtering-constants';
+import { PIR_IDS_SUBFILTER, PIR_SCORE_FILTER, PIR_SCORE_SUBFILTER } from '../../utils/filtering/filtering-constants';
 import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
 
 /**
@@ -138,8 +138,8 @@ export const formatFiltersForPirPlaybookComponent = (sourceFilters: string, inPi
       return {
         key: [PIR_SCORE_FILTER],
         values: [
-          { ...filter, key: 'score' },
-          { key: 'pir_ids', values: (inPirFilters ?? []).map((pir) => pir.value) },
+          { ...filter, key: PIR_SCORE_SUBFILTER },
+          { key: PIR_IDS_SUBFILTER, values: (inPirFilters ?? []).map((pir) => pir.value) },
         ],
       };
     }
@@ -174,7 +174,7 @@ export const listenPirEvents = async (
         AUTOMATION_MANAGER_USER,
         data.source_ref,
         ABSTRACT_STIX_CORE_OBJECT,
-      ) as unknown as StixObject; ;
+      ) as unknown as StixObject;
     } else if (isUpdateEvent) {
       // Event update on flagged entity.
       stixEntity = data;
@@ -185,7 +185,7 @@ export const listenPirEvents = async (
         AUTOMATION_MANAGER_USER,
         stixIdLinked,
         ABSTRACT_STIX_CORE_OBJECT,
-      ) as unknown as StixObject; ;
+      ) as unknown as StixObject;
     }
 
     // Having an entity means we have a matched PIR.

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
@@ -14,7 +14,10 @@ import {
   IS_INFERRED_FILTER,
   isComplexConversionFilterKey,
   LAST_PIR_SCORE_DATE_FILTER,
+  LAST_PIR_SCORE_DATE_SUBFILTER,
+  PIR_IDS_SUBFILTER,
   PIR_SCORE_FILTER,
+  PIR_SCORE_SUBFILTER,
   RELATION_DYNAMIC_FROM_FILTER,
   RELATION_DYNAMIC_SUBFILTER,
   RELATION_DYNAMIC_TO_FILTER,
@@ -524,14 +527,14 @@ const adaptFilterToIsInferredFilterKey = (filter: Filter) => {
 };
 
 const adaptFilterToPirFilterKeys = async (context: AuthContext, user: AuthUser, filterKey: string, filter: Filter) => {
-  const pirIds: string[] = filter.values.find((v) => v.key === 'pir_ids')?.values ?? [];
+  const pirIds: string[] = filter.values.find((v) => v.key === PIR_IDS_SUBFILTER)?.values ?? [];
   if (pirIds.length === 0) {
     throw FunctionalError('This filter should be related to at least 1 Pir', { filter });
   }
   // check the user has access to the PIR
   await Promise.all(pirIds.map((pirId) => getPirWithAccessCheck(context, user, pirId)));
   // push the nested pir filter associated to the given PIR IDs
-  const subKey = filterKey === PIR_SCORE_FILTER ? 'score' : 'date';
+  const subKey = filterKey === PIR_SCORE_FILTER ? PIR_SCORE_SUBFILTER : LAST_PIR_SCORE_DATE_SUBFILTER;
   const subFilter = filter.values.find((v) => v.key === subKey);
   const newFilter = {
     key: ['pir_information'],

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -101,9 +101,8 @@ export const ALIAS_FILTER = 'alias'; // handle both 'aliases' and 'x_opencti_ali
 export const IS_INFERRED_FILTER = 'is_inferred'; // if an entity or relationship is inferred
 
 // for PIR
-export const PIR_SCORE_FILTER = 'pir_score'; // used in stix filtering
-export const PIR_SCORE_FILTER_PREFIX = 'pir_score'; // used in dynamic filtering
-export const LAST_PIR_SCORE_DATE_FILTER_PREFIX = 'last_pir_score_date';
+export const PIR_SCORE_FILTER = 'pir_score';
+export const LAST_PIR_SCORE_DATE_FILTER = 'last_pir_score_date';
 
 // for users
 export const USER_SERVICE_ACCOUNT_FILTER = 'user_service_account';
@@ -136,12 +135,12 @@ const COMPLEX_CONVERSION_FILTER_KEYS = [
   'authorized_members.id', // nested filter on restricted members => kept for retro compatibility (TODO remove after renaming)
   'restricted_members.id', // nested filter on restricted members
   BULK_SEARCH_KEYWORDS_FILTER, // set of keywords used in bulk search
+  PIR_SCORE_FILTER, // should be associated to Pir Ids
+  LAST_PIR_SCORE_DATE_FILTER, // should be associated to Pir Ids
 ];
 
 export const isComplexConversionFilterKey = (filterKey: string) => {
   return COMPLEX_CONVERSION_FILTER_KEYS.includes(filterKey)
-    || filterKey.startsWith(PIR_SCORE_FILTER_PREFIX)
-    || filterKey.startsWith(LAST_PIR_SCORE_DATE_FILTER_PREFIX)
     || isMetricsName(filterKey);
 };
 

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -103,6 +103,9 @@ export const IS_INFERRED_FILTER = 'is_inferred'; // if an entity or relationship
 // for PIR
 export const PIR_SCORE_FILTER = 'pir_score';
 export const LAST_PIR_SCORE_DATE_FILTER = 'last_pir_score_date';
+export const PIR_SCORE_SUBFILTER = 'score';
+export const LAST_PIR_SCORE_DATE_SUBFILTER = 'date';
+export const PIR_IDS_SUBFILTER = 'pir_ids';
 
 // for users
 export const USER_SERVICE_ACCOUNT_FILTER = 'user_service_account';

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
@@ -46,6 +46,8 @@ import {
   WORKFLOW_FILTER,
   PATTERN_TYPE_FILTER,
   PIR_SCORE_FILTER,
+  PIR_SCORE_SUBFILTER,
+  PIR_IDS_SUBFILTER,
 } from '../filtering-constants';
 import type { Filter } from '../../../generated/graphql';
 import { STIX_RESOLUTION_MAP_PATHS } from '../filtering-resolution';
@@ -460,8 +462,8 @@ export const testCvssSeverity = (stix: any, filter: Filter) => {
 
 export const testPirScore = (stix: any, filter: Filter) => {
   // Retrieve data from the filter.
-  const pirIds = filter.values.find((v) => v.key === 'pir_ids')?.values ?? [];
-  const pirScoreFilter = filter.values.find((v) => v.key === 'score');
+  const pirIds = filter.values.find((v) => v.key === PIR_IDS_SUBFILTER)?.values ?? [];
+  const pirScoreFilter = filter.values.find((v) => v.key === PIR_SCORE_SUBFILTER);
   // Determine which PIR of the stix entity is of interest.
   // If no PIR IDs set in the filter, then we want to check on all PIR of the stix entity.
   const pirInformation: PirInformation[] | undefined = pirIds.length === 0

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -14,7 +14,6 @@ import {
   INSTANCE_DYNAMIC_REGARDING_OF,
   INSTANCE_REGARDING_OF,
   LABEL_FILTER,
-  LAST_PIR_SCORE_DATE_FILTER_PREFIX,
   ME_FILTER_VALUE,
   MEMBERS_GROUP_FILTER,
   MEMBERS_ORGANIZATION_FILTER,
@@ -23,7 +22,6 @@ import {
   OPINIONS_METRICS_MEAN_FILTER,
   OPINIONS_METRICS_MIN_FILTER,
   OPINIONS_METRICS_TOTAL_FILTER,
-  PIR_SCORE_FILTER_PREFIX,
   RELATION_DYNAMIC_FROM_FILTER,
   RELATION_DYNAMIC_TO_FILTER,
   SIGHTED_BY_FILTER,
@@ -463,8 +461,6 @@ const checkFilterKeys = (filterGroup: FilterGroup) => {
     .map((k) => k.split('.')[0]) // keep only the first part of the key to handle composed keys
     .filter((k) => !(getAvailableKeys().has(k)
       || k.startsWith(RULE_PREFIX)
-      || k.startsWith(PIR_SCORE_FILTER_PREFIX)
-      || k.startsWith(LAST_PIR_SCORE_DATE_FILTER_PREFIX)
       || getMetricsAttributesNames().includes(k)
     ));
 


### PR DESCRIPTION
### Proposed changes
Modify the format of the dynamic pir filters (ie 'pir_score' and 'last_pir_score_date')
- to be able to later generalize those filters to several Pirs
- to be consistant with other filters having a given filter key instead of a key depending on an id

### Old vs new format

Former format:
<img width="379" height="110" alt="image" src="https://github.com/user-attachments/assets/eefaf1a4-5699-48b6-9cdf-1cb0e3837701" />


New format:
<img width="570" height="141" alt="image" src="https://github.com/user-attachments/assets/db150b0c-a977-46ba-8672-2301b428d4b5" />


### Related issues
#13344