### PR TITLE
fix(frontend): normalize correlation graph filters from URL

### DIFF
--- a/opencti-platform/opencti-front/src/utils/ListParameters.js
+++ b/opencti-platform/opencti-front/src/utils/ListParameters.js
@@ -211,6 +211,21 @@ export const buildViewParamsFromUrlAndStorage = (
       ? split(',', finalParams.createdBy)
       : [];
   }
+  if (typeof finalParams.disabledEntityTypes === 'string') {
+    finalParams.disabledEntityTypes = finalParams.disabledEntityTypes
+      ? split(',', finalParams.disabledEntityTypes)
+      : [];
+  }
+  if (typeof finalParams.disabledCreators === 'string') {
+    finalParams.disabledCreators = finalParams.disabledCreators
+      ? split(',', finalParams.disabledCreators)
+      : [];
+  }
+  if (typeof finalParams.disabledMarkings === 'string') {
+    finalParams.disabledMarkings = finalParams.disabledMarkings
+      ? split(',', finalParams.disabledMarkings)
+      : [];
+  }
   if (typeof finalParams.selectedTimeRangeInterval === 'string') {
     finalParams.selectedTimeRangeInterval = finalParams.selectedTimeRangeInterval
       .split(',').map((d) => new Date(d));

--- a/opencti-platform/opencti-front/src/utils/ListParameters.test.ts
+++ b/opencti-platform/opencti-front/src/utils/ListParameters.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildViewParamsFromUrlAndStorage } from './ListParameters';
+
+describe('ListParameters utils', () => {
+  let mockNavigate: ReturnType<typeof vi.fn>;
+  let mockLocation: { pathname: string; search: string };
+
+  beforeEach(() => {
+    mockNavigate = vi.fn();
+    mockLocation = {
+      pathname: '/test',
+      search: '',
+    };
+    localStorage.clear();
+  });
+
+  afterAll(() => {
+    localStorage.clear();
+  });
+
+  describe(buildViewParamsFromUrlAndStorage, () => {
+    it('should convert comma-separated string from URL to array', () => {
+      mockLocation.search = '?disabledEntityTypes=Malware,Indicator,Report';
+      
+      const result = buildViewParamsFromUrlAndStorage(
+        mockNavigate,
+        mockLocation,
+        'test-key'
+      );
+
+      expect(result.disabledEntityTypes).toEqual(['Malware', 'Indicator', 'Report']);
+    });
+
+    it('should convert localStorage string values to arrays (backward compatibility)', () => {
+      localStorage.setItem('test-key', JSON.stringify({
+        disabledEntityTypes: 'toto,tutu',
+        disabledCreators: 'creator1',
+        disabledMarkings: 'marking1,marking2,marking3'
+      }));
+      
+      mockLocation.search = '';
+      
+      const result = buildViewParamsFromUrlAndStorage(
+        mockNavigate,
+        mockLocation,
+        'test-key'
+      );
+
+      expect(result.disabledEntityTypes).toEqual(['toto', 'tutu']);
+      expect(result.disabledCreators).toEqual(['creator1']);
+      expect(result.disabledMarkings).toEqual(['marking1', 'marking2', 'marking3']);
+    });
+
+    it('should return empty array when URL parameter value is empty string', () => {
+      mockLocation.search = '?disabledEntityTypes=';
+      
+      const result = buildViewParamsFromUrlAndStorage(
+        mockNavigate,
+        mockLocation,
+        'test-key'
+      );
+
+      expect(result.disabledEntityTypes).toEqual([]);
+    });
+
+    it('should convert single value to single-element array', () => {
+      mockLocation.search = '?disabledEntityTypes=Malware';
+      
+      const result = buildViewParamsFromUrlAndStorage(
+        mockNavigate,
+        mockLocation,
+        'test-key'
+      );
+
+      expect(result.disabledEntityTypes).toEqual(['Malware']);
+    });
+
+    it('should give URL parameters priority over localStorage', () => {
+      localStorage.setItem('test-key', JSON.stringify({
+        disabledEntityTypes: ['toto', 'tutu']
+      }));
+
+      mockLocation.search = '?disabledEntityTypes=Malware,Indicator';
+      
+      const result = buildViewParamsFromUrlAndStorage(
+        mockNavigate,
+        mockLocation,
+        'test-key'
+      );
+
+      expect(result.disabledEntityTypes).toEqual(['Malware', 'Indicator']);
+    });
+
+    it('should handle missing parameters without errors', () => {
+      mockLocation.search = '?otherParam=value';
+      
+      expect(() => {
+        buildViewParamsFromUrlAndStorage(
+          mockNavigate,
+          mockLocation,
+          'test-key'
+        );
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #13280.

### Problem

The correlation view for groupings could crash with a technical error when opened with certain URL parameters, for example:

- `disabledCreators=`
- `disabledEntityTypes=`
- `disabledMarkings=`

In this situation, the filters were not in the expected array format, which could lead to:

```text
TypeError: Cannot read properties of undefined (reading 'includes')
```

in the correlation graph.

### Root cause

`buildViewParamsFromUrlAndStorage` in `src/utils/ListParameters.js` merges URL and local storage state into the view parameters.

For the correlation graph, the following parameters can come from the URL as strings (including empty strings):

- `disabledEntityTypes`
- `disabledCreators`
- `disabledMarkings`

Later, the graph filtering code uses these values as arrays (for example with `.includes`), which is unsafe if they are not normalized.

### Solution

In `buildViewParamsFromUrlAndStorage`:

- When `disabledEntityTypes`, `disabledCreators` and `disabledMarkings` are strings, they are now split on `,` into string arrays.
- When they are empty strings, they are treated as empty arrays.

This is consistent with the existing handling of `markedBy` and `createdBy` in the same function, and ensures the graph filters always receive arrays.

### Testing

Manual test on a grouping correlation view:

1. Open a grouping correlation view in the UI.
2. Use a URL containing:

   ```text
   disabledCreators=&disabledEntityTypes=&disabledMarkings=&mode3D=false&modeTree=null&withForces=true
   ```

3. Verified:

   - The correlation view loads without a technical error.
   - No `TypeError: Cannot read properties of undefined (reading 'includes')` appears in the browser console.

> Note: Automated tests could not be run locally because of a Corepack/Yarn setup issue in my environment. The change is limited to URL parameter normalization in `ListParameters.js` and follows existing patterns used in that file.

---

### Proposed changes

- Normalize correlation graph filter parameters (`disabledEntityTypes`, `disabledCreators`, `disabledMarkings`) loaded from URL and local storage.
- Keep the implementation consistent with the existing normalization for `markedBy` and `createdBy` in `src/utils/ListParameters.js`.

### Related issues

- Fixes #13280

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

> Note: I could not run the frontend test suite locally due to a Corepack/Yarn setup issue, so I focused on a minimal change that reuses existing patterns and manually validated the behavior in the correlation view.

### Further comments

This PR keeps the scope intentionally small and focused on the correlation view crash described in #13280.

The solution reuses the same normalization pattern that already exists in `ListParameters.js` for `markedBy` and `createdBy`, to avoid introducing a new approach for parameter handling. This should prevent `TypeError: Cannot read properties of undefined (reading 'includes')` when correlation filters are present in the URL as empty or comma‑separated strings, without changing the intended behavior of the filters.
