### PR TITLE
[backend] Support upsert on modified (#13296)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2811,6 +2811,12 @@ const upsertElement = async (context, user, element, type, basePatch, opts = {})
   if (!INTERNAL_USERS[user.id] && !user.no_creators) {
     updatePatch.creator_id = [user.id];
   }
+  // Handle "modified" upsert
+  // Only upsert modified if after the existing one
+  if (isNotEmptyField(updatePatch.modified)) {
+    const { date: alignedModified } = computeExtendedDateValues(updatePatch.modified, resolvedElement.modified, ALIGN_NEWEST);
+    updatePatch.modified = alignedModified;
+  }
   // Upsert observed data count and times extensions
   if (type === ENTITY_TYPE_CONTAINER_OBSERVED_DATA) {
     const { date: cFo, updated: isCFoUpdated } = computeExtendedDateValues(updatePatch.first_observed, resolvedElement.first_observed, ALIGN_OLDEST);

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -499,7 +499,7 @@ export const modified: AttributeDefinition = {
   mandatoryType: 'no',
   editDefault: false,
   multiple: false,
-  upsert: false,
+  upsert: true,
   isFilterable: false, // use updated_at filter
 };
 


### PR DESCRIPTION
### Proposed changes

* [backend] Support upsert on modified

### Description

The "modified" field is now upserted when it is after the existing one, a stream event is emmitted. 

### Related issues

* Closes #13296