### PR TITLE
[backend] fix @me value conversion for stix filtering (#13040)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-resolution.ts
@@ -103,8 +103,7 @@ const resolveFilter = async (
   // 3. handle the special case of dynamic @me value
   if (key.some((k) => FILTER_KEYS_WITH_ME_VALUE.includes(k))) {
     if (filter.values.includes(ME_FILTER_VALUE)) {
-      // eslint-disable-next-line no-param-reassign
-      filter.values = filter.values.map((v) => (v === ME_FILTER_VALUE ? user.id : v));
+      newFilterValues = filter.values.map((v) => (v === ME_FILTER_VALUE ? user.id : v));
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-filtering.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-filtering.ts
@@ -5,39 +5,41 @@ import type { AuthContext, AuthUser } from '../../../types/user';
 import { getEntitiesMapFromCache } from '../../../database/cache';
 import type { StixObject } from '../../../types/stix-2-1-common';
 import { ENTITY_TYPE_RESOLVED_FILTERS } from '../../../schema/stixDomainObject';
-import { type Filter, type FilterGroup } from '../../../generated/graphql';
+import { type FilterGroup } from '../../../generated/graphql';
 import type { FilterResolutionMap } from '../filtering-resolution';
 import { buildResolutionMapForFilterGroup, resolveFilterGroup } from '../filtering-resolution';
 import { UnsupportedError } from '../../../config/errors';
+import { checkFiltersFormat } from '../filtering-utils';
 
 //----------------------------------------------------------------------------------------------------------------------
 
 /**
- * Pass through all individual filters and throws an error if it cannot be handled properly.
- * This is very aggressive but will allow us to detect rapidly any corner-case.
+ * check a FilterGroup's keys validity in stix filtering
  */
-export const validateFilterForStixMatch = (filter: Filter) => {
-  if (!Array.isArray(filter.key)) {
-    throw UnsupportedError('The provided filter key is not an array', { key: JSON.stringify(filter.key) });
-  }
-  if (filter.key.length !== 1) {
-    throw UnsupportedError('Stix filtering can only be executed on a unique filter key', { key: JSON.stringify(filter.key) });
-  }
-  if (FILTER_KEY_TESTERS_MAP[filter.key[0]] === undefined) {
-    const availableFilters = JSON.stringify(Object.keys(FILTER_KEY_TESTERS_MAP));
-    throw UnsupportedError('Stix filtering is not compatible with the provided filter key', { key: JSON.stringify(filter.key), availableFilters });
-  }
+const checkFiltersKeysForStixMatch = (filterGroup: FilterGroup) => {
+  filterGroup.filters.forEach((filter) => {
+    if (!Array.isArray(filter.key)) {
+      throw UnsupportedError('The provided filter key is not an array', { key: JSON.stringify(filter.key) });
+    }
+    if (filter.key.length !== 1) {
+      throw UnsupportedError('Stix filtering can only be executed on a unique filter key', { key: JSON.stringify(filter.key) });
+    }
+    if (FILTER_KEY_TESTERS_MAP[filter.key[0]] === undefined) {
+      const availableFilters = JSON.stringify(Object.keys(FILTER_KEY_TESTERS_MAP));
+      throw UnsupportedError('Stix filtering is not compatible with the provided filter key', { key: JSON.stringify(filter.key), availableFilters });
+    }
+  });
+  filterGroup.filterGroups.forEach((fg) => checkFiltersKeysForStixMatch(fg));
 };
 
 /**
- * Recursively call validateFilter inside a FilterGroup
+ * validate a FilterGroup in stix filtering: check the filters format and the filter keys validity
  */
 export const validateFilterGroupForStixMatch = (filterGroup: FilterGroup) => {
-  if (!filterGroup?.filterGroups || !filterGroup?.filters) {
-    throw UnsupportedError('Unrecognized filter format; expecting FilterGroup');
-  }
-  filterGroup.filters.forEach((f) => validateFilterForStixMatch(f));
-  filterGroup.filterGroups.forEach((fg) => validateFilterGroupForStixMatch(fg));
+  // check filters format
+  checkFiltersFormat(filterGroup);
+  // check filters keys validity
+  checkFiltersKeysForStixMatch(filterGroup);
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -417,7 +417,7 @@ export const replaceEnrichValuesInFilters = (filterGroup: FilterGroup, userId: s
     return {
       ...filter,
       values: newFilterValues,
-    }
+    };
   });
   // recursivity on the filter groups
   let newFilterGroups: FilterGroup[] = [];

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -367,6 +367,9 @@ const getConvertedRelationsNames = (relationNames: string[]) => {
   return convertedRelationsNames;
 };
 
+/**
+ * Extract the filter keys values of a FilterGroup
+ */
 export const extractFilterKeyValues = (filterKey: string, filterGroup: FilterGroup) => {
   const values: string[] = [];
   const filtersResult = { ...filterGroup };
@@ -455,21 +458,26 @@ const checkFilterKeys = (filterGroup: FilterGroup) => {
     ));
 
   if (incorrectKeys.length > 0) {
-    throw UnsupportedError('incorrect filter keys not existing in any schema definition', { keys: incorrectKeys });
+    throw UnsupportedError('Incorrect filter keys not existing in any schema definition', { keys: incorrectKeys });
   }
 };
 
-export const checkFiltersValidity = (filterGroup: FilterGroup, noFiltersChecking = false) => {
+export const checkFiltersFormat = (filterGroup: FilterGroup) => {
   // detect filters in the old format or in a bad format
   if (!isFilterGroupFormatCorrect(filterGroup)) {
     throw UnsupportedError('Incorrect filters format', { filter: JSON.stringify(filterGroup) });
   }
+  // check values are in a correct syntax
+  checkFilterGroupValuesSyntax(filterGroup);
+};
+
+export const checkFiltersValidity = (filterGroup: FilterGroup, noFiltersChecking = false) => {
+  // check filters syntax
+  checkFiltersFormat(filterGroup);
   // check filters keys exist in schema
   if (!noFiltersChecking && isFilterGroupNotEmpty(filterGroup)) {
     checkFilterKeys(filterGroup);
   }
-  // check values are in a correct syntax
-  checkFilterGroupValuesSyntax(filterGroup);
 };
 
 const BASE_FORCE_LABEL = '{{byName}}=';

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/filtering-utils-test.ts
@@ -358,7 +358,7 @@ describe('Filtering utils', () => {
     } as FilterGroup;
     expect(extractFilterGroupValues(dynamicToFilter, 'objectLabel', false, true)).toStrictEqual(['label1', 'label2', 'label3', 'dynamic', 'label4']);
   });
-  it('should replace ME_FILTER_VALUE values in filters compatible with @me', async () => {
+  it('should replace special values in filters: @me value by the user id for filter keys compatible with @me, and labels values by their ids', async () => {
     const user_id = 'user-id';
     const filterGroup = {
       mode: 'and',
@@ -371,9 +371,10 @@ describe('Filtering utils', () => {
         {
           mode: 'or',
           filters: [
-            { key: ['objectLabel'], values: ['label1-id', 'label2-id'], mode: 'and' },
+            { key: ['objectLabel'], values: ['label1-id', 'label2-id', 'label3'], mode: 'and' },
             { key: ['objectParticipant'], values: [ME_FILTER_VALUE] },
             { key: ['description'], values: [ME_FILTER_VALUE], operator: 'starts_with' },
+            { key: ['creator_id'], values: [ME_FILTER_VALUE] },
           ],
           filterGroups: [],
         },
@@ -390,15 +391,16 @@ describe('Filtering utils', () => {
         {
           mode: 'or',
           filters: [
-            { key: ['objectLabel'], values: ['label1-id', 'label2-id'], mode: 'and' },
+            { key: ['objectLabel'], values: ['label1-id', 'label2-id', 'label3-id'], mode: 'and' },
             { key: ['objectParticipant'], values: [user_id] },
             { key: ['description'], values: [ME_FILTER_VALUE], operator: 'starts_with' },
+            { key: ['creator_id'], values: [user_id] },
           ],
           filterGroups: [],
         },
       ],
     } as FilterGroup;
-    const finalFilter = replaceEnrichValuesInFilters(filterGroup, user_id, {});
+    const finalFilter = replaceEnrichValuesInFilters(filterGroup, user_id, { label1: 'label1-id', label3: 'label3-id' });
     expect(finalFilter).toEqual(expectedFilter);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
@@ -140,7 +140,7 @@ describe('Stix Filtering', () => {
     expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, ADMIN_USER, stixIndicator, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(true);
   });
 
-  it('matches stix object with filters with @me value in filters', async () => {
+  it('matches stix object with filters containing a @me value (@me value representing the current user)', async () => {
     const filterGroup = {
       mode: 'and',
       filters: [{

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/playbook-test.ts
@@ -248,7 +248,7 @@ describe('Playbook resolver standard behavior', () => {
           input: addNodeInput,
         }
       },
-      'incorrect filter keys not existing in any schema definition',
+      'Incorrect filter keys not existing in any schema definition',
       UNSUPPORTED_ERROR
     );
   });


### PR DESCRIPTION
### Proposed changes
- Backend filters checking little code improvements
- Fix @me filter value conversion for stix filtering (avoid filters values reassignement: create a new value that is returned)
- add backend tests for @me filter value in stix filtering
- improve replaceEnrichValuesInFilters by removing the params reassignement
- add tests for replaceEnrichValuesInFilters with labels values replacement

### Related issues
#13040