### PR TITLE
[frontend] Fix playbook page loading to not rely on cache (#12362)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/Root.tsx
@@ -13,9 +13,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { Route, Routes, useParams } from 'react-router-dom';
-import { graphql, usePreloadedQuery } from 'react-relay';
+import { graphql, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { PreloadedQuery } from 'react-relay/relay-hooks/EntryPointTypes';
 import { RootPlaybookQuery } from './__generated__/RootPlaybookQuery.graphql';
 import { PlaybookComponentsQuery } from './__generated__/PlaybookComponentsQuery.graphql';
@@ -67,10 +67,11 @@ const RootPlaybook = () => {
   const playbookComponentsQueryRef = useQueryLoading<PlaybookComponentsQuery>(
     playbookComponentsQuery,
   );
-  const playbookQueryRef = useQueryLoading<RootPlaybookQuery>(
-    playbookQuery,
-    { id: playbookId },
-  );
+
+  const [playbookQueryRef, loadPlaybookQuery] = useQueryLoader<RootPlaybookQuery>(playbookQuery);
+  useEffect(() => {
+    loadPlaybookQuery({ id: playbookId }, { fetchPolicy: 'network-only' });
+  }, [playbookId]);
 
   return (
     <Suspense fallback={<Loader />}>


### PR DESCRIPTION
### Proposed changes

* Fix an issue introduced when refactoring Playbooks
* Force refetch playbook when landing on Playbook details page instead of using Relay cache.

Why using this approach? With current API we cannot refresh cache easily when modifying the playbook definition (add/remove/update components). So if you make some modification, change page and go back to the page details you have lost your last updates, you need to refresh the page to retrieve them. By calling the backend to fetch the playbook we solve this issue quickly.

### Related issues

* #12362

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality