### PR TITLE
[backend] prevent fullRelationsList from being called without any fromId filter in containerWithRefsBuilder (#13332)

### DIFF
--- a/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/containerWithRefsBuilder.ts
@@ -141,9 +141,12 @@ const buildContainerRefsRule = (ruleDefinition: RuleDefinition, containerType: s
           await createObjectRefsInferences(context, report, addedTargets, []);
         }
       };
-      const listArgs = isSource ? { fromId: originIds, toTypes: [relationTypes.rightType] } : { toId: originIds, fromTypes: [relationTypes.leftType] };
-      const fullListArgs = { ...listArgs, callback: listAddedRefsCallback };
-      await fullRelationsList<BasicStoreRelation>(context, RULE_MANAGER_USER, relationTypes.creationType, fullListArgs);
+      // If originIds could no longer be found, we don't try to list relations since the fromId filter will not be applied
+      if (originIds.length > 0) {
+        const listArgs = isSource ? { fromId: originIds, toTypes: [relationTypes.rightType] } : { toId: originIds, fromTypes: [relationTypes.leftType] };
+        const fullListArgs = { ...listArgs, callback: listAddedRefsCallback };
+        await fullRelationsList<BasicStoreRelation>(context, RULE_MANAGER_USER, relationTypes.creationType, fullListArgs);
+      }
     }
 
     // Find all current inferences that need to be deleted


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* check originIds length before trying to list relations
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13332 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
