### PR TITLE
[frontend/backend] @me value should not be authorized in playbooks components with stix filtering (#13275)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -61,6 +61,7 @@ const FilterIconButtonWithRepresentativesQuery: FunctionComponent<FilterIconButt
     filterValuesContentQuery,
     {
       filters: removeIdFromFilterGroupObject(filters) as unknown as GqlFilterGroup,
+      isMeValueForbidden: searchContext?.elementType === 'Playbook-Stix-Component',
     },
   );
   return (

--- a/opencti-platform/opencti-front/src/components/FilterValuesContent.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterValuesContent.tsx
@@ -10,8 +10,8 @@ import { FilterDefinition } from '../utils/hooks/useAuth';
 import useAttributes from '../utils/hooks/useAttributes';
 
 export const filterValuesContentQuery = graphql`
-    query FilterValuesContentQuery($filters: FilterGroup!) {
-        filtersRepresentatives(filters: $filters) {
+    query FilterValuesContentQuery($filters: FilterGroup!, $isMeValueForbidden: Boolean) {
+        filtersRepresentatives(filters: $filters, isMeValueForbidden: $isMeValueForbidden) {
             id
             value
             entity_type
@@ -31,7 +31,15 @@ interface FilterValuesContentProps {
 
 const FilterValuesContent: FunctionComponent<
 FilterValuesContentProps
-> = ({ redirection, isFilterTooltip, filterKey, id, value, filterDefinition, filterOperator }) => {
+> = ({
+  redirection,
+  isFilterTooltip,
+  filterKey,
+  id,
+  value,
+  filterDefinition,
+  filterOperator,
+}) => {
   const { t_i18n } = useFormatter();
   const { stixCoreObjectTypes } = useAttributes();
   const completedStixCoreObjectTypes = stixCoreObjectTypes.concat(['Stix-Core-Object', 'Stix-Cyber-Observable']);

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -16,47 +16,7 @@ import { FilterRepresentative } from './FiltersModel';
 import { Filter } from '../../utils/filters/filtersHelpers-types';
 import useSchema from '../../utils/hooks/useSchema';
 import FilterValuesForDynamicSubKey from './FilterValuesForDynamicSubKey';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  inlineOperator: {
-    display: 'inline-block',
-    height: '100%',
-    borderRadius: 0,
-    margin: '0 5px 0 5px',
-    padding: '0 5px 0 5px',
-    cursor: 'pointer',
-    backgroundColor: theme.palette.action?.disabled,
-    fontFamily: 'Consolas, monaco, monospace',
-    '&:hover': {
-      textDecorationLine: 'underline',
-      backgroundColor: theme.palette.text?.disabled,
-    },
-  },
-  inlineOperatorReadOnly: {
-    display: 'inline-block',
-    height: '100%',
-    borderRadius: 0,
-    margin: '0 5px 0 5px',
-    padding: '0 5px 0 5px',
-    backgroundColor: theme.palette.action?.disabled,
-    fontFamily: 'Consolas, monaco, monospace',
-  },
-  regardingOfOperatorReadOnly: {
-    display: 'inline-block',
-    height: '100%',
-    borderRadius: 0,
-    margin: '0 2px 0 0',
-    fontFamily: 'Consolas, monaco, monospace',
-  },
-  label: {
-    cursor: 'pointer',
-    '&:hover': {
-      textDecorationLine: 'underline',
-    },
-  },
-}));
+import { useTheme } from '@mui/material/styles';
 
 interface FilterValuesProps {
   label: string | React.JSX.Element;
@@ -90,7 +50,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   filtersRestrictions,
 }) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
+  const theme = useTheme();
   const { schema: { scos } } = useSchema();
 
   const filterKey = currentFilter.key;
@@ -99,14 +59,21 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   const isOperatorNil = ['nil', 'not_nil'].includes(filterOperator ?? 'eq');
   const deactivatePopoverMenu = !isFilterEditable(filtersRestrictions, filterKey, filterValues) || !isReadWriteFilter;
   const onCLick = deactivatePopoverMenu ? () => {} : onClickLabel;
-  const menuClassName = deactivatePopoverMenu ? '' : classes.label;
+  const labelStyle = deactivatePopoverMenu
+    ? undefined
+    : {
+      cursor: 'pointer',
+      '&:hover': {
+        textDecorationLine: 'underline',
+      },
+    };
 
   // special case for nil/not_nil
   if (isOperatorNil) {
     return (
       <>
         <strong
-          className={menuClassName}
+          style={labelStyle}
           onClick={onCLick}
         >
           {label}
@@ -126,7 +93,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
     return (
       <>
         <strong
-          className={menuClassName}
+          style={labelStyle}
           onClick={onCLick}
         >
           {label}
@@ -145,7 +112,30 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
       && handleSwitchLocalMode
       && !filtersRestrictions?.preventLocalModeSwitchingFor?.includes(filterKey)
       && isFilterEditable(filtersRestrictions, filterKey, filterValues);
-    const operatorClassName = isLocalModeSwitchable ? classes.inlineOperator : classes.inlineOperatorReadOnly;
+    const localModeStyle = isLocalModeSwitchable
+      ? {
+        display: 'inline-block',
+        height: '100%',
+        borderRadius: 0,
+        margin: '0 5px 0 5px',
+        padding: '0 5px 0 5px',
+        cursor: 'pointer',
+        backgroundColor: theme.palette.action?.disabled,
+        fontFamily: 'Consolas, monaco, monospace',
+        '&:hover': {
+          textDecorationLine: 'underline',
+          backgroundColor: theme.palette.text?.disabled,
+        },
+      }
+      : {
+        display: 'inline-block',
+        height: '100%',
+        borderRadius: 0,
+        margin: '0 5px 0 5px',
+        padding: '0 5px 0 5px',
+        backgroundColor: theme.palette.action?.disabled,
+        fontFamily: 'Consolas, monaco, monospace',
+      };
     const operatorOnClick = isLocalModeSwitchable ? () => handleSwitchLocalMode(currentFilter) : undefined;
     const value = filtersRepresentativesMap.get(id) ? filtersRepresentativesMap.get(id)?.value : id;
     const isRegardingOfFilter = parentFilter?.key === 'regardingOf' || parentFilter?.key === 'dynamicRegardingOf';
@@ -177,10 +167,18 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
               filterOperator={filterOperator}
             />
             {last(filterValues) !== id && isRegardingOfFilter && (
-              <div className={classes.regardingOfOperatorReadOnly} onClick={operatorOnClick}>,</div>
+              <div
+                style={{
+                  display: 'inline-block',
+                  height: '100%',
+                  borderRadius: 0,
+                  margin: '0 2px 0 0',
+                  fontFamily: 'Consolas, monaco, monospace',
+                }}
+                onClick={operatorOnClick}>,</div>
             )}
             {last(filterValues) !== id && !isRegardingOfFilter && (
-              <div className={operatorClassName} onClick={operatorOnClick}>
+              <div style={localModeStyle} onClick={operatorOnClick}>
                 {t_i18n((currentFilter.mode ?? 'or').toUpperCase())}
               </div>
             )}
@@ -217,7 +215,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
           </Tooltip>
         )}
         <strong
-          className={menuClassName}
+          style={labelStyle}
           onClick={onCLick}
         >
           {label}
@@ -297,7 +295,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
     return (
       <>
         <strong
-          className={menuClassName}
+          style={labelStyle}
           onClick={onCLick}
         >
           {label}
@@ -312,7 +310,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   return (
     <>
       <strong
-        className={menuClassName}
+        style={labelStyle}
         onClick={onCLick}
       >
         {label}

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment, FunctionComponent } from 'react';
 import { last } from 'ramda';
-import makeStyles from '@mui/styles/makeStyles';
 import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -8,7 +7,6 @@ import { ChipOwnProps } from '@mui/material/Chip/Chip';
 import { WarningOutlined } from '@mui/icons-material';
 import { Link } from 'react-router-dom';
 import { useFormatter } from '../i18n';
-import type { Theme } from '../Theme';
 import { FiltersRestrictions, isFilterEditable, isFilterGroupNotEmpty, isRegardingOfFilterWarning, useFilterDefinition } from '../../utils/filters/filtersUtils';
 import { isDateIntervalTranslatable, translateDateInterval, truncate } from '../../utils/String';
 import FilterValuesContent from '../FilterValuesContent';
@@ -166,7 +164,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
               filterDefinition={filterDefinition}
               filterOperator={filterOperator}
             />
-            {last(filterValues) !== id && isRegardingOfFilter && (
+            {last(filterValues) !== id && isRegardingOfFilter &&
               <div
                 style={{
                   display: 'inline-block',
@@ -175,13 +173,16 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                   margin: '0 2px 0 0',
                   fontFamily: 'Consolas, monaco, monospace',
                 }}
-                onClick={operatorOnClick}>,</div>
-            )}
-            {last(filterValues) !== id && !isRegardingOfFilter && (
+                onClick={operatorOnClick}
+              >
+                ,
+              </div>
+            }
+            {last(filterValues) !== id && !isRegardingOfFilter &&
               <div style={localModeStyle} onClick={operatorOnClick}>
                 {t_i18n((currentFilter.mode ?? 'or').toUpperCase())}
               </div>
-            )}
+            }
           </>
         }
       </Fragment>

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldFilters.tsx
@@ -49,20 +49,25 @@ const PlaybookFlowFieldFilters = ({
     ? ['Stix-Core-Object', 'stix-core-relationship']
     : ['Stix-Core-Object', 'stix-core-relationship', 'Stix-Filtering'];
 
+  const searchContext = {
+    entityTypes,
+    elementType: componentId === 'PLAYBOOK_INTERNAL_DATA_CRON' ? undefined : 'Playbook-Stix-Component',
+  };
+
   return (
     <div>
       <Box sx={{ display: 'flex', gap: 1, marginTop: 4 }}>
         <Filters
           helpers={helpers}
           availableFilterKeys={availableFilterKeys}
-          searchContext={{ entityTypes }}
+          searchContext={searchContext}
         />
       </Box>
       <FilterIconButton
         filters={filters}
         helpers={helpers}
         entityTypes={entityTypes}
-        searchContext={{ entityTypes }}
+        searchContext={searchContext}
         styleNumber={2}
         redirection
       />

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/edges/PlaceholderEdge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/edges/PlaceholderEdge.tsx
@@ -1,19 +1,8 @@
 import React from 'react';
-import { getBezierPath, EdgeProps, EdgeLabelRenderer } from 'reactflow';
-import { makeStyles } from '@mui/styles';
+import { EdgeLabelRenderer, EdgeProps, getBezierPath } from 'reactflow';
 import { useFormatter } from 'src/components/i18n';
+import { useTheme } from '@mui/styles';
 import type { Theme } from '../../../../../../components/Theme';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  placeholderPath: {
-    strokeWidth: 0.5,
-    strokeDasharray: '3 3',
-    stroke: theme.palette.chip.main,
-    fill: 'none',
-  },
-}));
 
 function EdgeLabel({ transform, label }: { transform: string; label: string }) {
   const { t_i18n } = useFormatter();
@@ -46,7 +35,7 @@ export default function PlaceholderEdge({
   markerEnd,
   sourceHandleId,
 }: EdgeProps) {
-  const classes = useStyles();
+  const theme = useTheme<Theme>();
   const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
@@ -59,8 +48,13 @@ export default function PlaceholderEdge({
     <>
       <path
         id={id}
-        style={style}
-        className={classes.placeholderPath}
+        style={{
+          ...style,
+          strokeWidth: 0.5,
+          strokeDasharray: '3 3',
+          stroke: theme.palette.chip.main,
+          fill: 'none',
+        }}
         d={edgePath}
         markerEnd={markerEnd}
       />

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8701,7 +8701,7 @@ type Query {
   stixCoreObjectsMultiNumber(dateAttribute: String, startDate: DateTime, endDate: DateTime, onlyInferred: Boolean, numberParameters: [StixCoreObjectsNumberParameters]): [Number]
   stixCoreObjectsDistribution(objectId: [String], relationship_type: [String], toTypes: [String], elementWithTargetTypes: [String], field: String!, startDate: DateTime, endDate: DateTime, dateAttribute: String, operation: StatsOperation!, limit: Int, order: String, types: [String], filters: FilterGroup, search: String): [Distribution]
   stixCoreObjectsMultiDistribution(field: String!, startDate: DateTime, endDate: DateTime, dateAttribute: String, operation: StatsOperation!, limit: Int, order: String, distributionParameters: StixCoreObjectsDistributionParameters): [MultiDistribution]
-  filtersRepresentatives(filters: FilterGroup!): [RepresentativeWithId!]!
+  filtersRepresentatives(filters: FilterGroup!, isMeValueForbidden: Boolean): [RepresentativeWithId!]!
   stixDomainObject(id: String!): StixDomainObject
   stixDomainObjects(first: Int, after: ID, types: [String], orderBy: StixDomainObjectsOrdering, pirId: ID, orderMode: OrderingMode, filters: FilterGroup, search: String): StixDomainObjectConnection
   bookmarks(first: Int, after: ID, types: [String], filters: FilterGroup): StixDomainObjectConnection

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -380,7 +380,12 @@ export const useBuildFiltersForTemplateWidgets = () => {
 };
 
 // return the i18n label corresponding to a filter value
-export const filterValue = (filterKey: string, value?: string | null, filterType?: string, filterOperator?: string) => {
+export const filterValue = (
+  filterKey: string,
+  value?: string | null,
+  filterType?: string,
+  filterOperator?: string,
+  ) => {
   const { t_i18n, nsd, smhd } = useFormatter();
   if (filterKey === 'regardingOf' || filterKey === 'dynamicRegardingOf' || filterKey === 'dynamic' || filterKey === 'dynamicFrom' || filterKey === 'dynamicTo') {
     return JSON.stringify(value);

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -556,7 +556,8 @@ const useSearchEntities = ({
             group: n?.node.entity_type,
           }));
           unionSetEntities(key, membersEntities);
-          if (entityTypes.includes('User')) { // add @me filter value
+          // add @me value for filters with user id as values, except in stix playbook components
+          if (entityTypes.includes('User') && searchContext.elementType !== 'Playbook-Stix-Component') {
             unionSetEntities(key, [meEntity]);
           }
           const membersSystems = (
@@ -592,8 +593,8 @@ const useSearchEntities = ({
           type,
         });
       }
-      // add @me value for filters with user id as values
-      if (type === 'User') {
+      // add @me value for filters with user id as values, except in stix playbook components
+      if (type === 'User' && searchContext.elementType !== 'Playbook-Stix-Component') {
         newOptions.push(meEntity);
       }
 

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -13814,7 +13814,10 @@ type Query {
     order: String
     distributionParameters: StixCoreObjectsDistributionParameters
   ): [MultiDistribution] @auth(for: [KNOWLEDGE, EXPLORE])
-  filtersRepresentatives(filters: FilterGroup!): [RepresentativeWithId!]! @auth(for: [KNOWLEDGE, SETTINGS_SECURITYACTIVITY, INGESTION_SETINGESTIONS, SETTINGS_SETACCESSES, SETTINGS_SETCUSTOMIZATION])
+  filtersRepresentatives(
+    filters: FilterGroup!
+    isMeValueForbidden: Boolean
+  ): [RepresentativeWithId!]! @auth(for: [KNOWLEDGE, SETTINGS_SECURITYACTIVITY, INGESTION_SETINGESTIONS, SETTINGS_SETACCESSES, SETTINGS_SETCUSTOMIZATION])
 
   ######## STIX DOMAIN OBJECT ENTITIES
 

--- a/opencti-platform/opencti-graphql/src/domain/basicObject.ts
+++ b/opencti-platform/opencti-graphql/src/domain/basicObject.ts
@@ -23,7 +23,12 @@ interface FilterRepresentative {
 // region filters representatives
 // return an array of the value of the ids existing in inputFilters:
 // the entity representative for entities, null for deleted or restricted entities, the id for ids not corresponding to an entity
-export const findFiltersRepresentatives = async (context: AuthContext, user: AuthUser, inputFilters: FilterGroup) => {
+export const findFiltersRepresentatives = async (
+  context: AuthContext,
+  user: AuthUser,
+  inputFilters: FilterGroup,
+  opts?: { isMeValueForbidden?: boolean | null },
+  ) => {
   const filtersRepresentatives: FilterRepresentative[] = [];
   // extract the ids to resolve from inputFilters
   const keysToResolve = schemaRelationsRefDefinition.getAllInputNames()
@@ -77,7 +82,7 @@ export const findFiltersRepresentatives = async (context: AuthContext, user: Aut
     });
   }
   // resolve ME_FILTER_VALUE differently
-  if (idsToResolve.includes(ME_FILTER_VALUE)) {
+  if (!opts?.isMeValueForbidden && idsToResolve.includes(ME_FILTER_VALUE)) {
     filtersRepresentatives.push({
       id: ME_FILTER_VALUE,
       value: ME_FILTER_VALUE,

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -22687,6 +22687,7 @@ export type QueryFileArgs = {
 
 export type QueryFiltersRepresentativesArgs = {
   filters: FilterGroup;
+  isMeValueForbidden?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -54,8 +54,6 @@ import { registerConnectorQueues, unregisterConnector } from '../../database/rab
 import { getEntitiesListFromCache } from '../../database/cache';
 import { SYSTEM_USER } from '../../utils/access';
 import { findFiltersFromKey } from '../../utils/filtering/filtering-utils';
-import { findFiltersFromKey, checkAndConvertFilters, type FiltersIdsFinder } from '../../utils/filtering/filtering-utils';
-import { elFindByIds } from '../../database/engine';
 import { checkEnterpriseEdition, isEnterpriseEdition } from '../../enterprise-edition/ee';
 import pjson from '../../../package.json';
 import { extractContentFrom } from '../../utils/fileToContent';
@@ -146,30 +144,6 @@ export const getPlaybookDefinition = async (context: AuthContext, playbook: Basi
     }
   }
   return playbook.playbook_definition;
-};
-
-const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = async (
-  context: AuthContext,
-  user: AuthUser,
-  input: PlaybookAddNodeInput,
-  userId: string
-) => {
-  if (!input.configuration) {
-    return '{}';
-  }
-  let stringifiedFilters;
-  const config = JSON.parse(input.configuration);
-  if (config.filters) {
-    const filterGroup = JSON.parse(config.filters) as FilterGroup;
-    if (input.component_id === PLAYBOOK_INTERNAL_DATA_CRON.id) {
-      const convertedFilters = await checkAndConvertFilters(context, user, filterGroup, userId, elFindByIds as FiltersIdsFinder, { noFiltersConvert: true });
-      stringifiedFilters = JSON.stringify(convertedFilters);
-    } else { // our stix matching is currently limited, we need to validate the input filters
-      validateFilterGroupForStixMatch(filterGroup);
-      stringifiedFilters = config.filters;
-    }
-  }
-  return JSON.stringify({ ...config, filters: stringifiedFilters });
 };
 
 export const playbookAddNode = async (context: AuthContext, user: AuthUser, id: string, input: PlaybookAddNodeInput) => {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -16,39 +16,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import { v4 as uuidv4 } from 'uuid';
 import type { FileHandle } from 'fs/promises';
 import { BUS_TOPICS } from '../../config/conf';
-import {
-  createEntity,
-  deleteElementById,
-  patchAttribute,
-  stixLoadById,
-  updateAttribute
-} from '../../database/middleware';
-import {
-  type EntityOptions,
-  internalFindByIds,
-  pageEntitiesConnection,
-  storeLoadById
-} from '../../database/middleware-loader';
+import { createEntity, deleteElementById, patchAttribute, stixLoadById, updateAttribute } from '../../database/middleware';
+import { type EntityOptions, internalFindByIds, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import { notify } from '../../database/redis';
 import type { DomainFindById } from '../../domain/domainTypes';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
 import type { AuthContext, AuthUser } from '../../types/user';
-import {
-  type EditInput,
-  FilterMode,
-  type PlaybookAddInput,
-  type PlaybookAddLinkInput,
-  type PlaybookAddNodeInput,
-  type PositionInput
-} from '../../generated/graphql';
+import { type EditInput, FilterMode, type PlaybookAddInput, type PlaybookAddLinkInput, type PlaybookAddNodeInput, type PositionInput } from '../../generated/graphql';
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from './playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from './playbook-types';
 import { PLAYBOOK_COMPONENTS, type SharingConfiguration, type StreamConfiguration } from './playbook-components';
 import { FunctionalError, UnsupportedError } from '../../config/errors';
-import {
-  type BasicStoreEntityOrganization,
-  ENTITY_TYPE_IDENTITY_ORGANIZATION
-} from '../organization/organization-types';
+import { type BasicStoreEntityOrganization, ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
 import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/stix-filtering';
 import { registerConnectorQueues, unregisterConnector } from '../../database/rabbitmq';
 import { getEntitiesListFromCache } from '../../database/cache';
@@ -221,7 +200,7 @@ export const playbookReplaceNode = async (
   }
   const oldComponent = PLAYBOOK_COMPONENTS[oldComponentId];
   if (oldComponent.ports.length > relatedComponent.ports.length) {
-    // eslint-disable-next-line no-plusplus
+     
     for (let i = oldComponent.ports.length - 1; i >= relatedComponent.ports.length; i--) {
       // Find all links to the port
       const linksToDelete = definition.links.filter((n) => n.from.id === nodeId && n.from.port === oldComponent.ports[i].id);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -76,21 +76,6 @@ export const convertMembersToUsers = async (
   return R.uniqBy(R.prop('id'), users);
 };
 
-const removeMeFilterValuesFromFilterGroup = (filterGroup: FilterGroup): FilterGroup => {
-  const newFilters = filterGroup.filters.filter((f) =>
-    (f.key.some((k) => FILTER_KEYS_WITH_ME_VALUE.includes(k) && !f.values.includes(ME_FILTER_VALUE))
-      || !f.key.some((k) => FILTER_KEYS_WITH_ME_VALUE.includes(k)))
-  );
-  const newFilterGroups = filterGroup.filterGroups.length > 0
-    ? filterGroup.filterGroups.map((fg) => removeMeFilterValuesFromFilterGroup(fg))
-    : [];
-  return {
-    ...filterGroup,
-    filters: newFilters,
-    filterGroups: newFilterGroups,
-  };
-};
-
 export const deleteLinksAndAllChildren = (definition: ComponentDefinition, links: LinkDefinition[]) => {
   // Resolve all nodes to delete
   const linksToDelete = links;
@@ -118,6 +103,21 @@ export const deleteLinksAndAllChildren = (definition: ComponentDefinition, links
   return {
     nodes: definition.nodes.filter((n) => !nodesToDelete.map((o) => o.id).includes(n.id)),
     links: definition.links.filter((n) => !linksToDelete.map((o) => o.id).includes(n.id))
+  };
+};
+
+const removeMeFilterValuesFromFilterGroup = (filterGroup: FilterGroup): FilterGroup => {
+  const newFilters = filterGroup.filters.filter((f) =>
+    (f.key.some((k) => FILTER_KEYS_WITH_ME_VALUE.includes(k) && !f.values.includes(ME_FILTER_VALUE))
+      || !f.key.some((k) => FILTER_KEYS_WITH_ME_VALUE.includes(k)))
+  );
+  const newFilterGroups = filterGroup.filterGroups.length > 0
+    ? filterGroup.filterGroups.map((fg) => removeMeFilterValuesFromFilterGroup(fg))
+    : [];
+  return {
+    ...filterGroup,
+    filters: newFilters,
+    filterGroups: newFilterGroups,
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -12,8 +12,7 @@ import type { FilterGroup, PlaybookAddNodeInput } from '../../generated/graphql'
 import { FILTER_KEYS_WITH_ME_VALUE, ME_FILTER_VALUE } from '../../utils/filtering/filtering-constants';
 import { PLAYBOOK_INTERNAL_DATA_CRON } from './playbook-components';
 import { elFindByIds } from '../../database/engine';
-import type { BasicStoreObject } from '../../types/store';
-import { checkAndConvertFilters } from '../../utils/filtering/filtering-utils';
+import { checkAndConvertFilters, type FiltersIdsFinder } from '../../utils/filtering/filtering-utils';
 import { validateFilterGroupForStixMatch } from '../../utils/filtering/filtering-stix/stix-filtering';
 import type { ComponentDefinition, LinkDefinition, NodeDefinition } from './playbook-types';
 import { logApp } from '../../config/conf';
@@ -135,8 +134,7 @@ export const checkPlaybookFiltersAndBuildConfigWithCorrectFilters = async (
   if (config.filters) {
     const filterGroup = JSON.parse(config.filters) as FilterGroup;
     if (input.component_id === PLAYBOOK_INTERNAL_DATA_CRON.id) {
-      const findIds = elFindByIds as (context: AuthContext, user: AuthUser, ids: string[], opts: any) => Promise<Record<string, BasicStoreObject>>;
-      const convertedFilters = await checkAndConvertFilters(context, user, filterGroup, userId, findIds, { noFiltersConvert: true });
+      const convertedFilters = await checkAndConvertFilters(context, user, filterGroup, userId, elFindByIds as FiltersIdsFinder, { noFiltersConvert: true });
       stringifiedFilters = JSON.stringify(convertedFilters);
     } else {
       // our stix matching is currently limited, we need to validate the input filters

--- a/opencti-platform/opencti-graphql/src/resolvers/basicObject.ts
+++ b/opencti-platform/opencti-graphql/src/resolvers/basicObject.ts
@@ -3,7 +3,7 @@ import type { Resolvers } from '../generated/graphql';
 
 const basicObjectResolvers: Resolvers = {
   Query: {
-    filtersRepresentatives: (_, { filters }, context) => findFiltersRepresentatives(context, context.user, filters),
+    filtersRepresentatives: (_, { filters, isMeValueForbidden }, context) => findFiltersRepresentatives(context, context.user, filters, { isMeValueForbidden }),
   },
   BasicObject: {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/playbook-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/playbook-utils-test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { checkPlaybookFiltersAndBuildConfigWithCorrectFilters } from '../../../src/modules/playbook/playbook-utils';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { PLAYBOOK_MATCHING_COMPONENT } from '../../../src/modules/playbook/playbook-components';
+import {
+  CREATOR_FILTER,
+  LABEL_FILTER,
+  ME_FILTER_VALUE,
+  REPRESENTATIVE_FILTER
+} from '../../../src/utils/filtering/filtering-constants';
+
+describe('Playbook utils: checkPlaybookFiltersAndBuildConfigWithCorrectFilters', () => {
+  it('Stix playbook components: should check playbook filters and build config with correct filters', async () => {
+    const userId = 'user1-id';
+    const filters = {
+      mode: 'and',
+      filters: [
+        { key: [CREATOR_FILTER], values: [ME_FILTER_VALUE] },
+        { key: [REPRESENTATIVE_FILTER], values: [ME_FILTER_VALUE], operator: 'includes' },
+      ],
+      filterGroups: [{
+        mode: 'or',
+        filters: [
+          { key: [CREATOR_FILTER], values: [ME_FILTER_VALUE], operator: 'not_eq' },
+          { key: [LABEL_FILTER], values: ['label1'] },
+        ],
+        filterGroups: [],
+      }]
+    };
+    const expectedFilters = {
+      mode: 'and',
+      filters: [
+        { key: [REPRESENTATIVE_FILTER], values: [ME_FILTER_VALUE], operator: 'includes' },
+      ],
+      filterGroups: [{
+        mode: 'or',
+        filters: [
+          { key: [LABEL_FILTER], values: ['label1'] },
+        ],
+        filterGroups: [],
+      }],
+    };
+    const input = {
+      component_id: PLAYBOOK_MATCHING_COMPONENT.id,
+      name: PLAYBOOK_MATCHING_COMPONENT.name,
+      configuration: JSON.stringify({
+        filters: JSON.stringify(filters),
+      }),
+      position: { x: 1, y: 1 },
+    };
+    const result = await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(testContext, ADMIN_USER, input, userId);
+    expect(result).toEqual(JSON.stringify({ filters: JSON.stringify(expectedFilters) }));
+  });
+
+  it('Stix playbook components: should check playbook filters and return an error if filters are incorrect', async () => {
+    const userId = 'user1-id';
+    const filters = {
+      mode: 'or',
+      filters: [
+        { key: ['description'], values: ['test'] }, // key not compatible with stix filtering
+        { key: [REPRESENTATIVE_FILTER], values: ['test'] },
+      ],
+      filterGroups: [],
+    };
+    const input = {
+      component_id: PLAYBOOK_MATCHING_COMPONENT.id,
+      name: PLAYBOOK_MATCHING_COMPONENT.name,
+      configuration: JSON.stringify({
+        filters: JSON.stringify(filters),
+      }),
+      position: { x: 1, y: 1 },
+    };
+    await expect(async () => await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(testContext, ADMIN_USER, input, userId))
+      .rejects.toThrowError('Stix filtering is not compatible with the provided filter key');
+  });
+  });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/playbook-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/playbook-utils-test.ts
@@ -1,44 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { checkPlaybookFiltersAndBuildConfigWithCorrectFilters } from '../../../src/modules/playbook/playbook-utils';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
-import { PLAYBOOK_MATCHING_COMPONENT } from '../../../src/modules/playbook/playbook-components';
-import {
-  CREATOR_FILTER,
-  LABEL_FILTER,
-  ME_FILTER_VALUE,
-  REPRESENTATIVE_FILTER
-} from '../../../src/utils/filtering/filtering-constants';
+import { PLAYBOOK_INTERNAL_DATA_CRON, PLAYBOOK_MATCHING_COMPONENT } from '../../../src/modules/playbook/playbook-components';
+import { CREATOR_FILTER, LABEL_FILTER, REPRESENTATIVE_FILTER } from '../../../src/utils/filtering/filtering-constants';
 
 describe('Playbook utils: checkPlaybookFiltersAndBuildConfigWithCorrectFilters', () => {
-  it('Stix playbook components: should check playbook filters and build config with correct filters', async () => {
+  it('should check playbook filters and build config with correct filters for stix components', async () => {
     const userId = 'user1-id';
     const filters = {
       mode: 'and',
       filters: [
-        { key: [CREATOR_FILTER], values: [ME_FILTER_VALUE] },
-        { key: [REPRESENTATIVE_FILTER], values: [ME_FILTER_VALUE], operator: 'includes' },
+        { key: [REPRESENTATIVE_FILTER], values: ['test'], operator: 'includes' },
       ],
       filterGroups: [{
         mode: 'or',
         filters: [
-          { key: [CREATOR_FILTER], values: [ME_FILTER_VALUE], operator: 'not_eq' },
-          { key: [LABEL_FILTER], values: ['label1'] },
+          { key: [CREATOR_FILTER], values: ['user1_id'], operator: 'not_eq' },
+          { key: [LABEL_FILTER], values: ['label1', 'label2'] },
         ],
         filterGroups: [],
       }]
-    };
-    const expectedFilters = {
-      mode: 'and',
-      filters: [
-        { key: [REPRESENTATIVE_FILTER], values: [ME_FILTER_VALUE], operator: 'includes' },
-      ],
-      filterGroups: [{
-        mode: 'or',
-        filters: [
-          { key: [LABEL_FILTER], values: ['label1'] },
-        ],
-        filterGroups: [],
-      }],
     };
     const input = {
       component_id: PLAYBOOK_MATCHING_COMPONENT.id,
@@ -49,16 +30,15 @@ describe('Playbook utils: checkPlaybookFiltersAndBuildConfigWithCorrectFilters',
       position: { x: 1, y: 1 },
     };
     const result = await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(testContext, ADMIN_USER, input, userId);
-    expect(result).toEqual(JSON.stringify({ filters: JSON.stringify(expectedFilters) }));
+    expect(result).toEqual(JSON.stringify({ filters: JSON.stringify(filters) }));
   });
 
-  it('Stix playbook components: should check playbook filters and return an error if filters are incorrect', async () => {
+  it('should check playbook filters and return an error if filters are incorrect for stix components', async () => {
     const userId = 'user1-id';
     const filters = {
       mode: 'or',
       filters: [
         { key: ['description'], values: ['test'] }, // key not compatible with stix filtering
-        { key: [REPRESENTATIVE_FILTER], values: ['test'] },
       ],
       filterGroups: [],
     };
@@ -72,5 +52,68 @@ describe('Playbook utils: checkPlaybookFiltersAndBuildConfigWithCorrectFilters',
     };
     await expect(async () => await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(testContext, ADMIN_USER, input, userId))
       .rejects.toThrowError('Stix filtering is not compatible with the provided filter key');
+  });
+
+  it('should check playbook filters and build config with correct filters for data cron component', async () => {
+    const userId = 'user1-id';
+    const filters = {
+      mode: 'and',
+      filters: [
+        { key: ['name'], values: ['test'], operator: 'includes' },
+        { key: [CREATOR_FILTER], values: ['@me'], operator: 'not_eq' }, // @me value to be replaced by user id
+      ],
+      filterGroups: [{
+        mode: 'or',
+        filters: [
+          { key: [LABEL_FILTER], values: ['label1', 'label2'] },
+        ],
+        filterGroups: [],
+      }]
+    };
+    const expectedFilters = {
+      mode: 'and',
+      filters: [
+        { key: ['name'], values: ['test'], operator: 'includes' },
+        { key: [CREATOR_FILTER], values: [userId], operator: 'not_eq' },
+      ],
+      filterGroups: [{
+        mode: 'or',
+        filters: [
+          { key: [LABEL_FILTER], values: ['label1', 'label2'] },
+        ],
+        filterGroups: [],
+      }]
+    };
+    const input = {
+      component_id: PLAYBOOK_INTERNAL_DATA_CRON.id,
+      name: PLAYBOOK_INTERNAL_DATA_CRON.name,
+      configuration: JSON.stringify({
+        filters: JSON.stringify(filters),
+      }),
+      position: { x: 1, y: 1 },
+    };
+    const result = await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(testContext, ADMIN_USER, input, userId);
+    expect(result).toEqual(JSON.stringify({ filters: JSON.stringify(expectedFilters) }));
+  });
+
+  it('should check playbook filters and return an error if filters are incorrect for data cron component', async () => {
+    const userId = 'user1-id';
+    const filters = {
+      mode: 'or',
+      filters: [
+        { key: [REPRESENTATIVE_FILTER], values: ['test'] }, // key not compatible with dynamic filtering
+      ],
+      filterGroups: [],
+    };
+    const input = {
+      component_id: PLAYBOOK_INTERNAL_DATA_CRON.id,
+      name: PLAYBOOK_INTERNAL_DATA_CRON.name,
+      configuration: JSON.stringify({
+        filters: JSON.stringify(filters),
+      }),
+      position: { x: 1, y: 1 },
+    };
+    await expect(async () => await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(testContext, ADMIN_USER, input, userId))
+      .rejects.toThrowError('incorrect filter keys not existing in any schema definition');
   });
   });


### PR DESCRIPTION
### Proposed changes
- UI: In Playbook components with stix filtering
       - the @me filter value should not be listed in the possible values of user-value filters (exemple: creator filter)
       - for former playbooks with a @me value in filters, the @me value is displayed as deleted
- Backend: For playbook components with stix filtering, remove filters with @me value if they are some
- Add backend tests for playbook-utils.ts

### Related issues
#13275