### PR TITLE
[backend] fix filterMembersWithUsersOrgs (#13338)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -929,7 +929,9 @@ export const filterMembersWithUsersOrgs = async (
       } else {
         const memberOrgIds = member[RELATION_PARTICIPATE_TO] ?? [];
         const sameOrg = memberOrgIds.some((id) => userOrgIds.includes(id));
-        if (!sameOrg) {
+        if (sameOrg) {
+          resultMembers.push(member);
+        } else {
           if (filterMode === FilterMembersMode.RESTRICT) {
             const restrictedMember = {
               ...member,
@@ -942,8 +944,6 @@ export const filterMembersWithUsersOrgs = async (
             };
             resultMembers.push(restrictedMember);
           }
-        } else {
-          resultMembers.push(member);
         }
       }
     }

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -926,21 +926,24 @@ export const filterMembersWithUsersOrgs = async (
       const member = members[i];
       if (member.id === user.id || INTERNAL_USERS[member.id] || member.user_service_account) {
         resultMembers.push(member);
-      }
-      const memberOrgIds = member[RELATION_PARTICIPATE_TO] ?? [];
-      const sameOrg = memberOrgIds.some((id) => userOrgIds.includes(id));
-      if (!sameOrg) {
-        if (filterMode === FilterMembersMode.RESTRICT) {
-          const restrictedMember = {
-            ...member,
-            name: RESTRICTED_USER.name,
-            user_email: RESTRICTED_USER.user_email,
-            representative: {
-              main: RESTRICTED_USER.name,
-              secondary: RESTRICTED_USER.name
-            }
-          };
-          resultMembers.push(restrictedMember);
+      } else {
+        const memberOrgIds = member[RELATION_PARTICIPATE_TO] ?? [];
+        const sameOrg = memberOrgIds.some((id) => userOrgIds.includes(id));
+        if (!sameOrg) {
+          if (filterMode === FilterMembersMode.RESTRICT) {
+            const restrictedMember = {
+              ...member,
+              name: RESTRICTED_USER.name,
+              user_email: RESTRICTED_USER.user_email,
+              representative: {
+                main: RESTRICTED_USER.name,
+                secondary: RESTRICTED_USER.name
+              }
+            };
+            resultMembers.push(restrictedMember);
+          }
+        } else {
+          resultMembers.push(member);
         }
       }
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fix filterMembersWithUsersOrgs logic introduced in https://github.com/OpenCTI-Platform/opencti/pull/12894
* before changes, we were correctly returning the member if it was a member in the same orgs as the user. After the change, this default return was removed, causing all members in the same orgs to be filtered out
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13338 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
