### PR TITLE
[backend] Fix targeting propagation rules descriptions (#13304)

### DIFF
--- a/opencti-platform/opencti-graphql/src/rules/localization-of-targets/LocalizationOfTargetsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/localization-of-targets/LocalizationOfTargetsDefinition.ts
@@ -32,14 +32,6 @@ const display = {
       target: 'Location D',
       target_color: '#00bcd4',
     },
-    {
-      action: 'CREATE',
-      relation: 'relationship_object',
-      source: 'Report A',
-      source_color: '#ff9800',
-      target: 'Relation D',
-      target_color: '#7e57c2',
-    },
   ],
 };
 

--- a/opencti-platform/opencti-graphql/src/rules/location-targets/LocationTargetsDefinition.ts
+++ b/opencti-platform/opencti-graphql/src/rules/location-targets/LocationTargetsDefinition.ts
@@ -11,11 +11,11 @@ const display = {
       source: 'Entity A',
       source_color: '#ff9800',
       relation: 'relationship_targets',
-      target: 'Location B',
+      target: 'Entity B',
       target_color: '#4caf50',
     },
     {
-      source: 'Location B',
+      source: 'Entity B',
       source_color: '#4caf50',
       relation: 'relationship_located-at',
       target: 'Location C',


### PR DESCRIPTION
### Proposed changes
Fix descriptions of the targeting propagation rules (in Customization > Rules engine) :

- changing "Location B" to "Entity B" in the rule "Targeting Propagation via Location"
Entity A → targets → entity B
entity B → located at → Location C

- removing any mention to report creation in the rule "Targeting Propagation When Located" since report is not linked to this rule

### Related issues
#13304