### PR TITLE
[backend] standalone connector migration composer (#13202)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2299,7 +2299,7 @@ input MigrateConnectorToManagedInput {
   connectorId: ID!
   contractSlug: String!
   configuration: [ContractConfigInput!]
-  preserveState: Boolean
+  resetConnectorState: Boolean
   convertUserToServiceAccount: Boolean
 }
 
@@ -2339,24 +2339,14 @@ type MigrationAssessment {
   connector_id: ID!
   connector_name: String!
   contract_slug: String!
-  contract_title: String!
   summary: MigrationAssessmentSummary!
   mapped: [MappedConfigKey!]!
   ignored: [IgnoredConfigKey!]!
   missing: [MissingConfigKey!]!
 }
 
-type MigrationWarning {
-  field: String
-  message: String!
-}
-
 type MigrateConnectorToManagedResult {
   connector: Connector!
-  warnings: [MigrationWarning!]!
-  state_preserved: Boolean!
-  dryRun: Boolean!
-  skipped: Boolean
 }
 
 type Connector implements BasicObject & InternalObject {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9725,7 +9725,7 @@ type Mutation {
   updateConnectorLogs(input: LogsConnectorStatusInput!): ID!
   updateConnectorHealth(input: HealthConnectorStatusInput!): ID!
   updateConnectorTrigger(id: ID!, input: [EditInput]!): Connector
-  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): ManagedConnector!
+  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!): ManagedConnector!
   feedAdd(input: FeedAddInput!): Feed
   feedDelete(id: ID!): ID!
   feedEdit(id: ID!, input: FeedAddInput!): Feed!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2289,6 +2289,74 @@ enum ConnectorPriorityGroup {
   DEFAULT
 }
 
+input ConnectorMigrationAssessmentInput {
+  connectorId: ID!
+  contractSlug: String!
+  configuration: [ContractConfigInput!]
+}
+
+input MigrateConnectorToManagedInput {
+  connectorId: ID!
+  contractSlug: String!
+  configuration: [ContractConfigInput!]
+  preserveState: Boolean
+}
+
+type MigrationAssessmentSummary {
+  total_source_keys: Int!
+  mapped_keys: Int!
+  ignored_keys: Int!
+  missing_mandatory_keys: Int!
+  can_migrate: Boolean!
+  assessment_date: DateTime!
+}
+
+type MappedConfigKey {
+  key: String!
+  sourceKey: String!
+  value: String!
+  type: String!
+  required: Boolean!
+}
+
+type IgnoredConfigKey {
+  key: String!
+  value: String!
+  reason: String!
+}
+
+type MissingConfigKey {
+  key: String!
+  type: String!
+  description: String!
+  format: String
+  enum: [String!]
+}
+
+type MigrationAssessment {
+  connector_id: ID!
+  connector_name: String!
+  contract_slug: String!
+  contract_title: String!
+  summary: MigrationAssessmentSummary!
+  mapped: [MappedConfigKey!]!
+  ignored: [IgnoredConfigKey!]!
+  missing: [MissingConfigKey!]!
+}
+
+type MigrationWarning {
+  field: String
+  message: String!
+}
+
+type MigrateConnectorToManagedResult {
+  connector: Connector!
+  warnings: [MigrationWarning!]!
+  state_preserved: Boolean!
+  dryRun: Boolean!
+  skipped: Boolean
+}
+
 type Connector implements BasicObject & InternalObject {
   id: ID!
   standard_id: String!
@@ -8777,6 +8845,7 @@ type Query {
   connectorsForImport: [Connector]
   connectorsForAnalysis: [Connector]
   connectorsForNotification: [Connector]
+  connectorMigrationAssessment(connectorId: ID!, contractSlug: String!, configuration: [ContractConfigInput!]): MigrationAssessment!
   work(id: ID!): Work
   isWorkAlive(id: ID!): Boolean
   works(first: Int, after: ID, orderBy: WorksOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): WorkConnection
@@ -9668,6 +9737,7 @@ type Mutation {
   updateConnectorLogs(input: LogsConnectorStatusInput!): ID!
   updateConnectorHealth(input: HealthConnectorStatusInput!): ID!
   updateConnectorTrigger(id: ID!, input: [EditInput]!): Connector
+  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): MigrateConnectorToManagedResult!
   feedAdd(input: FeedAddInput!): Feed
   feedDelete(id: ID!): ID!
   feedEdit(id: ID!, input: FeedAddInput!): Feed!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2291,13 +2291,13 @@ enum ConnectorPriorityGroup {
 
 input ConnectorMigrationAssessmentInput {
   connectorId: ID!
-  contractSlug: String!
+  containerImage: String!
   configuration: [ContractConfigInput!]
 }
 
 input MigrateConnectorToManagedInput {
   connectorId: ID!
-  contractSlug: String!
+  containerImage: String!
   configuration: [ContractConfigInput!]
   resetConnectorState: Boolean
   convertUserToServiceAccount: Boolean
@@ -2338,7 +2338,7 @@ type MissingConfigKey {
 type MigrationAssessment {
   connector_id: ID!
   connector_name: String!
-  contract_slug: String!
+  contract_image: String!
   summary: MigrationAssessmentSummary!
   mapped: [MappedConfigKey!]!
   ignored: [IgnoredConfigKey!]!
@@ -8837,7 +8837,7 @@ type Query {
   connectorsForImport: [Connector]
   connectorsForAnalysis: [Connector]
   connectorsForNotification: [Connector]
-  connectorMigrationAssessment(connectorId: ID!, contractSlug: String!, configuration: [ContractConfigInput!]): MigrationAssessment!
+  connectorMigrationAssessment(connectorId: ID!, containerImage: String!, configuration: [ContractConfigInput!]): MigrationAssessment!
   work(id: ID!): Work
   isWorkAlive(id: ID!): Boolean
   works(first: Int, after: ID, orderBy: WorksOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): WorkConnection

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2345,10 +2345,6 @@ type MigrationAssessment {
   missing: [MissingConfigKey!]!
 }
 
-type MigrateConnectorToManagedResult {
-  connector: Connector!
-}
-
 type Connector implements BasicObject & InternalObject {
   id: ID!
   standard_id: String!
@@ -9729,7 +9725,7 @@ type Mutation {
   updateConnectorLogs(input: LogsConnectorStatusInput!): ID!
   updateConnectorHealth(input: HealthConnectorStatusInput!): ID!
   updateConnectorTrigger(id: ID!, input: [EditInput]!): Connector
-  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): MigrateConnectorToManagedResult!
+  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): ManagedConnector!
   feedAdd(input: FeedAddInput!): Feed
   feedDelete(id: ID!): ID!
   feedEdit(id: ID!, input: FeedAddInput!): Feed!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2333,6 +2333,7 @@ type MissingConfigKey {
   format: String
   enum: [String!]
   default: JSON
+  required: Boolean!
 }
 
 type MigrationAssessment {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2300,6 +2300,7 @@ input MigrateConnectorToManagedInput {
   contractSlug: String!
   configuration: [ContractConfigInput!]
   preserveState: Boolean
+  convertUserToServiceAccount: Boolean
 }
 
 type MigrationAssessmentSummary {
@@ -2331,6 +2332,7 @@ type MissingConfigKey {
   description: String!
   format: String
   enum: [String!]
+  default: JSON
 }
 
 type MigrationAssessment {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2198,6 +2198,77 @@ enum ConnectorPriorityGroup {
   DEFAULT
 }
 
+# CONNECTOR MIGRATION INPUT TYPES
+input ConnectorMigrationAssessmentInput {
+  connectorId: ID!
+  contractSlug: String!
+  configuration: [ContractConfigInput!]
+}
+
+input MigrateConnectorToManagedInput {
+  connectorId: ID!
+  contractSlug: String!
+  configuration: [ContractConfigInput!]
+  preserveState: Boolean
+}
+
+# CONNECTOR MIGRATION ASSESSMENT TYPES
+type MigrationAssessmentSummary {
+  total_source_keys: Int!
+  mapped_keys: Int!
+  ignored_keys: Int!
+  missing_mandatory_keys: Int!
+  can_migrate: Boolean!
+  assessment_date: DateTime!
+}
+
+type MappedConfigKey {
+  key: String!
+  sourceKey: String!
+  value: String!
+  type: String!
+  required: Boolean!
+}
+
+type IgnoredConfigKey {
+  key: String!
+  value: String!
+  reason: String!
+}
+
+type MissingConfigKey {
+  key: String!
+  type: String!
+  description: String!
+  format: String
+  enum: [String!]
+}
+
+type MigrationAssessment {
+  connector_id: ID!
+  connector_name: String!
+  contract_slug: String!
+  contract_title: String!
+  summary: MigrationAssessmentSummary!
+  mapped: [MappedConfigKey!]!
+  ignored: [IgnoredConfigKey!]!
+  missing: [MissingConfigKey!]!
+}
+
+# CONNECTOR MIGRATION RESULT TYPES
+type MigrationWarning {
+  field: String
+  message: String!
+}
+
+type MigrateConnectorToManagedResult {
+  connector: Connector!
+  warnings: [MigrationWarning!]!
+  state_preserved: Boolean!
+  dryRun: Boolean!
+  skipped: Boolean
+}
+
 type Connector implements BasicObject & InternalObject {
   id: ID! # internal_id
   standard_id: String!
@@ -13699,6 +13770,7 @@ type Query {
   connectorsForImport: [Connector] @auth(for: [KNOWLEDGE])
   connectorsForAnalysis: [Connector] @auth(for: [KNOWLEDGE])
   connectorsForNotification: [Connector] @auth(for: [SETTINGS_SETACCESSES, SETTINGS_SETCUSTOMIZATION])
+  connectorMigrationAssessment(connectorId: ID!, contractSlug: String!, configuration: [ContractConfigInput!]): MigrationAssessment! @auth(for: [MODULES])
   work(id: ID!): Work @auth(for: [MODULES])
   isWorkAlive(id: ID!): Boolean @auth(for: [MODULES])
   works(
@@ -15369,6 +15441,7 @@ type Mutation {
   updateConnectorLogs(input: LogsConnectorStatusInput!): ID! @auth(for: [CONNECTORAPI])
   updateConnectorHealth(input: HealthConnectorStatusInput!): ID! @auth(for: [CONNECTORAPI])
   updateConnectorTrigger(id: ID!, input: [EditInput]!): Connector @auth(for: [MODULES_MODMANAGE])
+  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): MigrateConnectorToManagedResult! @auth(for: [CONNECTORAPI])
   feedAdd(input: FeedAddInput!): Feed @auth(for: [TAXIIAPI_SETCOLLECTIONS])
   feedDelete(id: ID!): ID! @auth(for: [TAXIIAPI_SETCOLLECTIONS])
   feedEdit(id: ID!, input: FeedAddInput!): Feed! @auth(for: [TAXIIAPI_SETCOLLECTIONS])

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -13757,7 +13757,7 @@ type Query {
   connectorsForImport: [Connector] @auth(for: [KNOWLEDGE])
   connectorsForAnalysis: [Connector] @auth(for: [KNOWLEDGE])
   connectorsForNotification: [Connector] @auth(for: [SETTINGS_SETACCESSES, SETTINGS_SETCUSTOMIZATION])
-  connectorMigrationAssessment(connectorId: ID!, containerImage: String!, configuration: [ContractConfigInput!]): MigrationAssessment! @auth(for: [MODULES])
+  connectorMigrationAssessment(connectorId: ID!, containerImage: String!, configuration: [ContractConfigInput!]): MigrationAssessment! @auth(for: [MODULES_MODMANAGE])
   work(id: ID!): Work @auth(for: [MODULES])
   isWorkAlive(id: ID!): Boolean @auth(for: [MODULES])
   works(
@@ -15428,7 +15428,7 @@ type Mutation {
   updateConnectorLogs(input: LogsConnectorStatusInput!): ID! @auth(for: [CONNECTORAPI])
   updateConnectorHealth(input: HealthConnectorStatusInput!): ID! @auth(for: [CONNECTORAPI])
   updateConnectorTrigger(id: ID!, input: [EditInput]!): Connector @auth(for: [MODULES_MODMANAGE])
-  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): ManagedConnector! @auth(for: [CONNECTORAPI])
+  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!): ManagedConnector! @auth(for: [MODULES_MODMANAGE])
   feedAdd(input: FeedAddInput!): Feed @auth(for: [TAXIIAPI_SETCOLLECTIONS])
   feedDelete(id: ID!): ID! @auth(for: [TAXIIAPI_SETCOLLECTIONS])
   feedEdit(id: ID!, input: FeedAddInput!): Feed! @auth(for: [TAXIIAPI_SETCOLLECTIONS])

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2255,9 +2255,6 @@ type MigrationAssessment {
   ignored: [IgnoredConfigKey!]!
   missing: [MissingConfigKey!]!
 }
-type MigrateConnectorToManagedResult {
-  connector: Connector!
-}
 
 type Connector implements BasicObject & InternalObject {
   id: ID! # internal_id
@@ -15431,7 +15428,7 @@ type Mutation {
   updateConnectorLogs(input: LogsConnectorStatusInput!): ID! @auth(for: [CONNECTORAPI])
   updateConnectorHealth(input: HealthConnectorStatusInput!): ID! @auth(for: [CONNECTORAPI])
   updateConnectorTrigger(id: ID!, input: [EditInput]!): Connector @auth(for: [MODULES_MODMANAGE])
-  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): MigrateConnectorToManagedResult! @auth(for: [CONNECTORAPI])
+  connectorMigrateToManaged(input: MigrateConnectorToManagedInput!, dryRun: Boolean): ManagedConnector! @auth(for: [CONNECTORAPI])
   feedAdd(input: FeedAddInput!): Feed @auth(for: [TAXIIAPI_SETCOLLECTIONS])
   feedDelete(id: ID!): ID! @auth(for: [TAXIIAPI_SETCOLLECTIONS])
   feedEdit(id: ID!, input: FeedAddInput!): Feed! @auth(for: [TAXIIAPI_SETCOLLECTIONS])

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2244,6 +2244,7 @@ type MissingConfigKey {
   format: String
   enum: [String!]
   default: JSON
+  required: Boolean!
 }
 
 type MigrationAssessment {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2201,13 +2201,13 @@ enum ConnectorPriorityGroup {
 # CONNECTOR MIGRATION INPUT TYPES
 input ConnectorMigrationAssessmentInput {
   connectorId: ID!
-  contractSlug: String!
+  containerImage: String!
   configuration: [ContractConfigInput!]
 }
 
 input MigrateConnectorToManagedInput {
   connectorId: ID!
-  contractSlug: String!
+  containerImage: String!
   configuration: [ContractConfigInput!]
   resetConnectorState: Boolean
   convertUserToServiceAccount: Boolean
@@ -2249,7 +2249,7 @@ type MissingConfigKey {
 type MigrationAssessment {
   connector_id: ID!
   connector_name: String!
-  contract_slug: String!
+  contract_image: String!
   summary: MigrationAssessmentSummary!
   mapped: [MappedConfigKey!]!
   ignored: [IgnoredConfigKey!]!
@@ -13760,7 +13760,7 @@ type Query {
   connectorsForImport: [Connector] @auth(for: [KNOWLEDGE])
   connectorsForAnalysis: [Connector] @auth(for: [KNOWLEDGE])
   connectorsForNotification: [Connector] @auth(for: [SETTINGS_SETACCESSES, SETTINGS_SETCUSTOMIZATION])
-  connectorMigrationAssessment(connectorId: ID!, contractSlug: String!, configuration: [ContractConfigInput!]): MigrationAssessment! @auth(for: [MODULES])
+  connectorMigrationAssessment(connectorId: ID!, containerImage: String!, configuration: [ContractConfigInput!]): MigrationAssessment! @auth(for: [MODULES])
   work(id: ID!): Work @auth(for: [MODULES])
   isWorkAlive(id: ID!): Boolean @auth(for: [MODULES])
   works(

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2209,7 +2209,8 @@ input MigrateConnectorToManagedInput {
   connectorId: ID!
   contractSlug: String!
   configuration: [ContractConfigInput!]
-  preserveState: Boolean
+  resetConnectorState: Boolean
+  convertUserToServiceAccount: Boolean
 }
 
 # CONNECTOR MIGRATION ASSESSMENT TYPES
@@ -2242,31 +2243,20 @@ type MissingConfigKey {
   description: String!
   format: String
   enum: [String!]
+  default: JSON
 }
 
 type MigrationAssessment {
   connector_id: ID!
   connector_name: String!
   contract_slug: String!
-  contract_title: String!
   summary: MigrationAssessmentSummary!
   mapped: [MappedConfigKey!]!
   ignored: [IgnoredConfigKey!]!
   missing: [MissingConfigKey!]!
 }
-
-# CONNECTOR MIGRATION RESULT TYPES
-type MigrationWarning {
-  field: String
-  message: String!
-}
-
 type MigrateConnectorToManagedResult {
   connector: Connector!
-  warnings: [MigrationWarning!]!
-  state_preserved: Boolean!
-  dryRun: Boolean!
-  skipped: Boolean
 }
 
 type Connector implements BasicObject & InternalObject {

--- a/opencti-platform/opencti-graphql/src/database/repository.js
+++ b/opencti-platform/opencti-graphql/src/database/repository.js
@@ -24,7 +24,15 @@ export const completeConnector = (connector) => {
     const completed = { ...connector };
     completed.title = connector.title ? connector.title : connector.name;
     completed.is_managed = isNotEmptyField(connector.catalog_id);
-    completed.connector_scope = connector.connector_scope ? connector.connector_scope.split(',') : [];
+
+    if (Array.isArray(connector.connector_scope)) {
+      completed.connector_scope = connector.connector_scope;
+    } else if (connector.connector_scope) {
+      completed.connector_scope = connector.connector_scope.split(',');
+    } else {
+      completed.connector_scope = [];
+    }
+
     completed.config = connectorConfig(connector.id, connector.listen_callback_uri);
     completed.active = connector.built_in ? (connector.active ?? true) : (sinceNowInMinutes(connector.updated_at) < 5);
     return completed;
@@ -41,6 +49,7 @@ export const connector = async (context, user, id) => {
     const conn = await builtInConnector(context, user, id);
     return completeConnector(conn);
   }
+
   return element;
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -1,0 +1,270 @@
+import { FunctionalError } from '../config/errors';
+import { storeLoadById } from '../database/middleware-loader';
+import { connector, connectorManagers } from '../database/repository';
+import { findContractBySlug, getContractBySlug, getSupportedSlugs } from '../modules/catalog/catalog-domain';
+import { ENTITY_TYPE_CONNECTOR } from '../schema/internalObject';
+import type { BasicStoreEntityConnector } from '../types/connector';
+import type { AuthContext, AuthUser } from '../types/user';
+
+type ConfigInput = {
+  key: string;
+  value: string;
+};
+
+type MappedKey = {
+  key: string;
+  value: string;
+  type: string;
+  required: boolean;
+  autoMapped?: boolean;
+};
+
+type MissingKey = {
+  key: string;
+  type: string;
+  description: string;
+  format?: string;
+  required: boolean;
+  defaultValue: any;
+  enum: string[] | null;
+};
+
+type IgnoredKey = {
+  key: string;
+  value: string;
+  reason: string;
+};
+
+export const getConnector = async (context: AuthContext, user: AuthUser, id: string) => {
+  const connectorFound = connector(context, user, id);
+
+  if (!connectorFound) {
+    throw FunctionalError('No connector found with the specified ID', { id });
+  }
+};
+
+const checkComposerRegistered = async (context:AuthContext, user: AuthUser) => {
+  const managers = await connectorManagers(context, user);
+  return managers.length > 0;
+};
+
+export const migrateConnectorToManagedConnector = async (context:AuthContext, user: AuthUser, id: string) => {
+  if (!checkComposerRegistered(context, user)) {
+    throw FunctionalError('No registered composer found');
+  }
+};
+
+export const assessConnectorMigration = async (context: AuthContext, user: AuthUser, connectorId: string, contractSlug: string, configuration: ConfigInput[]) => {
+  const existingConnector = await connector(context, user, connectorId);
+
+  if (!existingConnector) {
+    throw FunctionalError('Connector not found', { id: connectorId });
+  }
+
+  if (existingConnector.is_managed) {
+    throw FunctionalError('Connector is already managed', { id: connectorId });
+  }
+
+  const contractData = await findContractBySlug(context, user, contractSlug);
+  if (!contractData) {
+    throw FunctionalError('Contract not found', { slug: contractSlug });
+  }
+
+  let contract;
+  try {
+    contract = JSON.parse(contractData.contract);
+  } catch (e) {
+    throw FunctionalError('Cannot parse contract found');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { logo, description, short_description, ...contractDefinition } = contract;
+
+  if (existingConnector.connector_type !== contractDefinition.container_type) {
+    throw FunctionalError('Connector type mismatch', {
+      connector_type: existingConnector.connector_type,
+      contract_type: contractDefinition.container_type
+    });
+  }
+
+  const schemaProperties = contractDefinition.config_schema.properties;
+  const requiredKeys = contractDefinition.config_schema.required || [];
+
+  const sourceConfig = configuration || {};
+
+  const configMap = new Map();
+  if (Array.isArray(sourceConfig)) {
+    sourceConfig.forEach((c) => {
+      configMap.set(c.key.toUpperCase(), c.value);
+    });
+  } else {
+    Object.entries(sourceConfig).forEach(([key, value]) => {
+      configMap.set(key.toUpperCase(), value);
+    });
+  }
+
+  const mapped: any[] = [];
+  const missing: any[] = [];
+
+  Object.keys(schemaProperties).forEach((schemaKey) => {
+    const propSchema = schemaProperties[schemaKey];
+    const value = configMap.get(schemaKey.toUpperCase());
+
+    if (value !== null && value !== undefined) {
+      mapped.push({
+        key: schemaKey,
+        value: String(value),
+        type: propSchema.type,
+        required: requiredKeys.includes(schemaKey)
+      });
+    } else {
+      const isRequired = requiredKeys.includes(schemaKey);
+      const hasDefault = propSchema.default !== undefined;
+
+      missing.push({
+        key: schemaKey,
+        type: propSchema.type,
+        description: propSchema.description || 'No description',
+        format: propSchema.format,
+        required: isRequired,
+        defaultValue: hasDefault ? propSchema.default : null,
+        enum: propSchema.enum ?? null
+      });
+    }
+  });
+
+  const ignored: any[] = [];
+  const schemaKeysUpper = new Set(
+    Object.keys(schemaProperties).map((k) => k.toUpperCase())
+  );
+
+  configMap.forEach((value: string, key: string) => {
+    if (!schemaKeysUpper.has(key)) {
+      ignored.push({
+        key,
+        value: String(value),
+        reason: 'Not in target contract schema'
+      });
+    }
+  });
+
+  const missingMandatory = missing.filter((m) => m.required);
+
+  return {
+    connector_id: connectorId,
+    connector_name: existingConnector.name,
+    connector_type: existingConnector.connector_type,
+    contract_slug: contractSlug,
+    contract_title: contractDefinition.title,
+    contract_image: contractDefinition.container_image,
+    summary: {
+      total_source_keys: configMap.size,
+      mapped_keys: mapped.length,
+      ignored_keys: ignored.length,
+      missing_mandatory_keys: missingMandatory.length,
+      missing_optional_keys: missing.length - missingMandatory.length,
+      can_migrate: missingMandatory.length === 0,
+      configuration_provided: configuration !== null,
+    },
+    mapped,
+    ignored,
+    missing,
+    message: configuration === null
+      ? 'No configuration provided. You must provide configuration manually with exact schema keys.'
+      : null
+  };
+};
+
+interface MigrationWarning {
+  field?: string;
+  message: string;
+}
+
+interface MigrateConnectorToManagedResult {
+  connector: BasicStoreEntityConnector;
+  warnings: MigrationWarning[];
+  state_preserved: boolean;
+  dryRun: boolean;
+  skipped?: boolean;
+}
+
+export const migrateConnectorToManaged = async (
+  context: AuthContext,
+  user: AuthUser,
+  connectorId: string,
+  contractSlug: string,
+  configuration: Array<{ key: string; value: string }> | null = null,
+  preserveState: boolean = true,
+  dryRun: boolean = false
+): Promise<MigrateConnectorToManagedResult> => {
+  // 1. Get connector
+  const existingConnector = await connector(context, user, connectorId);
+  if (!existingConnector) {
+    throw FunctionalError('Connector not found', { id: connectorId });
+  }
+
+  // 2. Check if already managed
+  if (existingConnector.is_managed) {
+    return {
+      connector: existingConnector,
+      warnings: [{ message: 'Connector is already managed' }],
+      state_preserved: false,
+      dryRun,
+      skipped: true
+    };
+  }
+
+  // 3. Get contract by slug
+  // TODO: Implement getContractBySlug
+
+  // 4. Validate type compatibility
+  // TODO: Implement validation
+
+  // 5. Map configuration
+  // TODO: Implement mapStandaloneConfigToContract
+
+  // 6. Validate - check missing required fields
+  // TODO: Implement findMissingRequiredFields
+
+  // 7. Get manager for encryption
+  // TODO: Implement getActiveConnectorManager
+
+  // 8. Process config (with encryption)
+  // TODO: Implement computeConnectorTargetContract
+
+  // 9. Build update payload
+  const updatePayload = {
+    // TODO: Build payload
+  };
+
+  // 10. Generate warnings
+  const warnings: MigrationWarning[] = [];
+  // TODO: Generate warnings
+
+  // 11. DRY RUN: Return without saving
+  if (dryRun) {
+    return {
+      connector: { ...existingConnector, ...updatePayload, is_managed: true },
+      warnings,
+      state_preserved: preserveState,
+      dryRun: true
+    };
+  }
+
+  // 12. ACTUAL MIGRATION: Save to database
+  // await elUpdateElement({
+  //   _index: existingConnector._index,
+  //   internal_id: existingConnector.internal_id,
+  //   ...updatePayload
+  // });
+
+  // 13. Reload connector
+  const migratedConnector = await connector(context, user, connectorId);
+
+  return {
+    connector: migratedConnector,
+    warnings,
+    state_preserved: preserveState && !!existingConnector.connector_state,
+    dryRun: false
+  };
+};

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -168,7 +168,7 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
   let contract;
   try {
     contract = JSON.parse(contractData.contract);
-  } catch (e) {
+  } catch () {
     throw FunctionalError('Cannot parse contract found');
   }
 
@@ -252,7 +252,7 @@ export const migrateConnectorToManaged = async (
   let contract;
   try {
     contract = JSON.parse(contractData.contract);
-  } catch (e) {
+  } catch () {
     throw FunctionalError('Cannot parse contract');
   }
 
@@ -371,7 +371,7 @@ export const migrateConnectorToManaged = async (
 
   // delete queues like in connector.deleteQueues but for that specific connector id
   await unregisterConnector(existingConnector.id);
-  try { await unregisterExchanges(); } catch (e) { /* nothing */ }
+  try { await unregisterExchanges(); } catch () { /* nothing */ }
 
   await patchAttribute(
     context,

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -8,7 +8,7 @@ import { completeConnector, connector } from '../database/repository';
 import type { ConnectorContractConfiguration, ContractConfigInput } from '../generated/graphql';
 import { publishUserAction } from '../listener/UserActionListener';
 import { addConnectorDeployedCount } from '../manager/telemetryManager';
-import { computeConnectorTargetContract, findContractByContainerImage, findContractBySlug } from '../modules/catalog/catalog-domain';
+import { computeConnectorTargetContract, findContractByContainerImage } from '../modules/catalog/catalog-domain';
 import { ABSTRACT_INTERNAL_OBJECT } from '../schema/general';
 import { ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_CONNECTOR_MANAGER, ENTITY_TYPE_USER } from '../schema/internalObject';
 import type { BasicStoreEntityConnectorManager } from '../types/connector';

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -94,7 +94,7 @@ const categorizeKeys = (
   schemaProperties: any,
   requiredKeys: string[],
   configMap: Map<string, string>,
-  autoMappedKeys: Map<string, string>
+  autoMappedKeys: Map<string, string>,
 ): { mapped: MappedKey[]; missing: MissingKey[] } => {
   const mapped: MappedKey[] = [];
   const missing: MissingKey[] = [];
@@ -112,7 +112,7 @@ const categorizeKeys = (
         key: schemaKey,
         value: String(value),
         type: propSchema.type,
-        required: requiredKeys.includes(schemaKey)
+        required: requiredKeys.includes(schemaKey),
       });
     } else {
       missing.push({
@@ -122,7 +122,7 @@ const categorizeKeys = (
         format: propSchema.format,
         required: requiredKeys.includes(schemaKey),
         default: propSchema.default ?? null,
-        enum: propSchema.enum ?? null
+        enum: propSchema.enum ?? null,
       });
     }
   });
@@ -133,7 +133,7 @@ const categorizeKeys = (
 const findIgnoredKeys = (schemaProperties: any, configMap: Map<string, string>): IgnoredKey[] => {
   const ignored: IgnoredKey[] = [];
   const schemaKeysUpper = new Set(
-    Object.keys(schemaProperties).map((k) => k.toUpperCase())
+    Object.keys(schemaProperties).map((k) => k.toUpperCase()),
   );
 
   configMap.forEach((value: string, key: string) => {
@@ -141,7 +141,7 @@ const findIgnoredKeys = (schemaProperties: any, configMap: Map<string, string>):
       ignored.push({
         key,
         value: String(value),
-        reason: 'Not in target contract schema'
+        reason: 'Not in target contract schema',
       });
     }
   });
@@ -179,7 +179,7 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
   if (existingConnector.connector_type !== contractDefinition.container_type) {
     throw FunctionalError('Connector type mismatch', {
       connector_type: existingConnector.connector_type,
-      contract_type: contractDefinition.container_type
+      contract_type: contractDefinition.container_type,
     });
   }
 
@@ -198,7 +198,7 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
     schemaProperties,
     requiredKeys,
     configMap,
-    autoMappedConfig
+    autoMappedConfig,
   );
 
   const ignored = findIgnoredKeys(schemaProperties, configMap);
@@ -227,7 +227,7 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
     missing,
     message: configuration === null
       ? 'No configuration provided. You must provide configuration manually with exact schema keys.'
-      : null
+      : null,
   };
 };
 
@@ -272,14 +272,14 @@ export const migrateConnectorToManaged = async (
   if (existingConnector.connector_type !== contract.container_type) {
     throw FunctionalError('Connector type mismatch', {
       connector_type: existingConnector.connector_type,
-      contract_type: contract.container_type
+      contract_type: contract.container_type,
     });
   }
 
   const connectorManagers = await fullEntitiesList<BasicStoreEntityConnectorManager>(
     context,
     user,
-    [ENTITY_TYPE_CONNECTOR_MANAGER]
+    [ENTITY_TYPE_CONNECTOR_MANAGER],
   );
   if (connectorManagers?.length < 1) {
     throw FunctionalError('No connector manager configured');
@@ -292,7 +292,7 @@ export const migrateConnectorToManaged = async (
 
   const schemaProperties = contract.config_schema.properties;
   const schemaKeysUpper = new Set(
-    Object.keys(schemaProperties).map((k) => k.toUpperCase())
+    Object.keys(schemaProperties).map((k) => k.toUpperCase()),
   );
 
   const invalidKeys: string[] = [];
@@ -305,13 +305,13 @@ export const migrateConnectorToManaged = async (
   if (invalidKeys.length > 0) {
     throw FunctionalError('Invalid configuration keys provided', {
       invalid_keys: invalidKeys,
-      message: `The following keys do not exist in the contract schema: ${invalidKeys.join(', ')}`
+      message: `The following keys do not exist in the contract schema: ${invalidKeys.join(', ')}`,
     });
   }
 
   const configurationArray: ContractConfigInput[] = Array.from(configMap.entries()).map(([key, value]) => ({
     key,
-    value
+    value,
   }));
 
   let configurations: ConnectorContractConfiguration[];
@@ -324,7 +324,7 @@ export const migrateConnectorToManaged = async (
   } catch (err: any) {
     throw FunctionalError('Configuration validation failed', {
       message: err.message,
-      details: err.data
+      details: err.data,
     });
   }
 
@@ -332,14 +332,14 @@ export const migrateConnectorToManaged = async (
   // so remove them
   const RUNTIME_PROVIDED_FIELDS = ['CONNECTOR_NAME', 'CONNECTOR_ID', 'CONNECTOR_TYPE'];
   const filteredConfigurations = configurations.filter(
-    (config) => !RUNTIME_PROVIDED_FIELDS.includes(config.key)
+    (config) => !RUNTIME_PROVIDED_FIELDS.includes(config.key),
   );
 
   const existingUser = await storeLoadById(
     context,
     user,
     existingConnector.connector_user_id,
-    ENTITY_TYPE_USER
+    ENTITY_TYPE_USER,
   );
 
   // If existing user is not a service account, transform it to service account
@@ -352,7 +352,7 @@ export const migrateConnectorToManaged = async (
       context,
       user,
       existingUser.id,
-      [{ key: 'user_service_account', value: [true] }]
+      [{ key: 'user_service_account', value: [true] }],
     );
   }
 
@@ -371,14 +371,16 @@ export const migrateConnectorToManaged = async (
 
   // delete queues like in connector.deleteQueues but for that specific connector id
   await unregisterConnector(existingConnector.id);
-  try { await unregisterExchanges(); } catch { /* nothing */ }
+  try {
+    await unregisterExchanges();
+  } catch { /* nothing */ }
 
   const { element } = await patchAttribute(
     context,
     user,
     existingConnector.id,
     ENTITY_TYPE_CONNECTOR,
-    managedConnectorData
+    managedConnectorData,
   );
 
   const completedConnector = completeConnector(element);
@@ -395,7 +397,7 @@ export const migrateConnectorToManaged = async (
       id: existingConnector.internal_id,
       entity_type: ENTITY_TYPE_CONNECTOR,
       input: managedConnectorData,
-    }
+    },
   });
 
   await notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].ADDED_TOPIC, completedConnector, user);

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -168,7 +168,7 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
   let contract;
   try {
     contract = JSON.parse(contractData.contract);
-  } catch () {
+  } catch {
     throw FunctionalError('Cannot parse contract found');
   }
 
@@ -252,7 +252,7 @@ export const migrateConnectorToManaged = async (
   let contract;
   try {
     contract = JSON.parse(contractData.contract);
-  } catch () {
+  } catch {
     throw FunctionalError('Cannot parse contract');
   }
 
@@ -371,7 +371,7 @@ export const migrateConnectorToManaged = async (
 
   // delete queues like in connector.deleteQueues but for that specific connector id
   await unregisterConnector(existingConnector.id);
-  try { await unregisterExchanges(); } catch () { /* nothing */ }
+  try { await unregisterExchanges(); } catch { /* nothing */ }
 
   await patchAttribute(
     context,

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -241,7 +241,7 @@ export const migrateConnectorToManaged = async (
   connectorId: string,
   contractSlug: string,
   configuration: ConfigInput[] | null,
-  convertUserToServiceAccount: boolean = false,
+  convertUserToServiceAccount: boolean = true,
   resetConnectorState: boolean = false,
 ) => {
   const contractData = await findContractBySlug(context, user, contractSlug);

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -77,21 +77,15 @@ const categorizeKeys = (
   schemaProperties: any,
   requiredKeys: string[],
   configMap: Map<string, string>,
-  autoMappedKeys: Map<string, string>,
 ): { mapped: MappedKey[]; missing: MissingKey[] } => {
   const mapped: MappedKey[] = [];
   const missing: MissingKey[] = [];
-
-  console.log('CONFIG MAP ', configMap);
-  console.log('autoMappedKeys ', autoMappedKeys);
 
   Object.keys(schemaProperties).forEach((schemaKey) => {
     const propSchema = schemaProperties[schemaKey];
 
     const keyUpper = schemaKey.toUpperCase();
-    const value = autoMappedKeys.has(keyUpper)
-      ? autoMappedKeys.get(keyUpper)
-      : configMap.get(keyUpper);
+    const value = configMap.get(keyUpper);
 
     if (value !== null && value !== undefined) {
       mapped.push({
@@ -170,9 +164,6 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
   const autoMappedConfig = autoMapConnectorFields(existingConnector);
   const userConfig = buildConfigMap(configuration || []);
 
-  console.log('autoMappedConfig', autoMappedConfig);
-  console.log('userConfig', userConfig);
-
   // Merge: auto-mapped first, then user config (user overrides auto)
   const configMap = new Map([...autoMappedConfig, ...userConfig]);
 
@@ -184,7 +175,6 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
     schemaProperties,
     requiredKeys,
     configMap,
-    autoMappedConfig,
   );
 
   const ignored = findIgnoredKeys(schemaProperties, configMap);

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15842,7 +15842,6 @@ export type MutationCityEditArgs = {
 
 
 export type MutationConnectorMigrateToManagedArgs = {
-  dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   input: MigrateConnectorToManagedInput;
 };
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -14996,6 +14996,7 @@ export type MigrateConnectorToManagedInput = {
   configuration?: InputMaybe<Array<ContractConfigInput>>;
   connectorId: Scalars['ID']['input'];
   contractSlug: Scalars['String']['input'];
+  convertUserToServiceAccount?: InputMaybe<Scalars['Boolean']['input']>;
   preserveState?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -15038,6 +15039,7 @@ export type MigrationWarning = {
 
 export type MissingConfigKey = {
   __typename?: 'MissingConfigKey';
+  default?: Maybe<Scalars['JSON']['output']>;
   description: Scalars['String']['output'];
   enum?: Maybe<Array<Scalars['String']['output']>>;
   format?: Maybe<Scalars['String']['output']>;
@@ -43160,6 +43162,7 @@ export type MigrationWarningResolvers<ContextType = any, ParentType extends Reso
 }>;
 
 export type MissingConfigKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['MissingConfigKey'] = ResolversParentTypes['MissingConfigKey']> = ResolversObject<{
+  default?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   enum?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   format?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -14997,16 +14997,12 @@ export type MigrateConnectorToManagedInput = {
   connectorId: Scalars['ID']['input'];
   contractSlug: Scalars['String']['input'];
   convertUserToServiceAccount?: InputMaybe<Scalars['Boolean']['input']>;
-  preserveState?: InputMaybe<Scalars['Boolean']['input']>;
+  resetConnectorState?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type MigrateConnectorToManagedResult = {
   __typename?: 'MigrateConnectorToManagedResult';
   connector: Connector;
-  dryRun: Scalars['Boolean']['output'];
-  skipped?: Maybe<Scalars['Boolean']['output']>;
-  state_preserved: Scalars['Boolean']['output'];
-  warnings: Array<MigrationWarning>;
 };
 
 export type MigrationAssessment = {
@@ -15014,7 +15010,6 @@ export type MigrationAssessment = {
   connector_id: Scalars['ID']['output'];
   connector_name: Scalars['String']['output'];
   contract_slug: Scalars['String']['output'];
-  contract_title: Scalars['String']['output'];
   ignored: Array<IgnoredConfigKey>;
   mapped: Array<MappedConfigKey>;
   missing: Array<MissingConfigKey>;
@@ -15029,12 +15024,6 @@ export type MigrationAssessmentSummary = {
   mapped_keys: Scalars['Int']['output'];
   missing_mandatory_keys: Scalars['Int']['output'];
   total_source_keys: Scalars['Int']['output'];
-};
-
-export type MigrationWarning = {
-  __typename?: 'MigrationWarning';
-  field?: Maybe<Scalars['String']['output']>;
-  message: Scalars['String']['output'];
 };
 
 export type MissingConfigKey = {
@@ -36602,7 +36591,6 @@ export type ResolversTypes = ResolversObject<{
   MigrateConnectorToManagedResult: ResolverTypeWrapper<Omit<MigrateConnectorToManagedResult, 'connector'> & { connector: ResolversTypes['Connector'] }>;
   MigrationAssessment: ResolverTypeWrapper<MigrationAssessment>;
   MigrationAssessmentSummary: ResolverTypeWrapper<MigrationAssessmentSummary>;
-  MigrationWarning: ResolverTypeWrapper<MigrationWarning>;
   MissingConfigKey: ResolverTypeWrapper<MissingConfigKey>;
   Module: ResolverTypeWrapper<Module>;
   MultiDistribution: ResolverTypeWrapper<Omit<MultiDistribution, 'data'> & { data?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>> }>;
@@ -37564,7 +37552,6 @@ export type ResolversParentTypes = ResolversObject<{
   MigrateConnectorToManagedResult: Omit<MigrateConnectorToManagedResult, 'connector'> & { connector: ResolversParentTypes['Connector'] };
   MigrationAssessment: MigrationAssessment;
   MigrationAssessmentSummary: MigrationAssessmentSummary;
-  MigrationWarning: MigrationWarning;
   MissingConfigKey: MissingConfigKey;
   Module: Module;
   MultiDistribution: Omit<MultiDistribution, 'data'> & { data?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>> };
@@ -41503,7 +41490,6 @@ export type IgnoredConfigKeyResolvers<ContextType = any, ParentType extends Reso
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   reason?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type IncidentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Incident'] = ResolversParentTypes['Incident']> = ResolversObject<{
@@ -42869,7 +42855,6 @@ export type MappedConfigKeyResolvers<ContextType = any, ParentType extends Resol
   sourceKey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type MappedEntityResolvers<ContextType = any, ParentType extends ResolversParentTypes['MappedEntity'] = ResolversParentTypes['MappedEntity']> = ResolversObject<{
@@ -43126,23 +43111,16 @@ export type MetricsByMimeTypeResolvers<ContextType = any, ParentType extends Res
 
 export type MigrateConnectorToManagedResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrateConnectorToManagedResult'] = ResolversParentTypes['MigrateConnectorToManagedResult']> = ResolversObject<{
   connector?: Resolver<ResolversTypes['Connector'], ParentType, ContextType>;
-  dryRun?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  skipped?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  state_preserved?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  warnings?: Resolver<Array<ResolversTypes['MigrationWarning']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type MigrationAssessmentResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationAssessment'] = ResolversParentTypes['MigrationAssessment']> = ResolversObject<{
   connector_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   connector_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   contract_slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  contract_title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ignored?: Resolver<Array<ResolversTypes['IgnoredConfigKey']>, ParentType, ContextType>;
   mapped?: Resolver<Array<ResolversTypes['MappedConfigKey']>, ParentType, ContextType>;
   missing?: Resolver<Array<ResolversTypes['MissingConfigKey']>, ParentType, ContextType>;
   summary?: Resolver<ResolversTypes['MigrationAssessmentSummary'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type MigrationAssessmentSummaryResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationAssessmentSummary'] = ResolversParentTypes['MigrationAssessmentSummary']> = ResolversObject<{
@@ -43152,13 +43130,6 @@ export type MigrationAssessmentSummaryResolvers<ContextType = any, ParentType ex
   mapped_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   missing_mandatory_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_source_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-}>;
-
-export type MigrationWarningResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationWarning'] = ResolversParentTypes['MigrationWarning']> = ResolversObject<{
-  field?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type MissingConfigKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['MissingConfigKey'] = ResolversParentTypes['MissingConfigKey']> = ResolversObject<{
@@ -43168,7 +43139,6 @@ export type MissingConfigKeyResolvers<ContextType = any, ParentType extends Reso
   format?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type ModuleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Module'] = ResolversParentTypes['Module']> = ResolversObject<{
@@ -48953,7 +48923,6 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   MigrateConnectorToManagedResult?: MigrateConnectorToManagedResultResolvers<ContextType>;
   MigrationAssessment?: MigrationAssessmentResolvers<ContextType>;
   MigrationAssessmentSummary?: MigrationAssessmentSummaryResolvers<ContextType>;
-  MigrationWarning?: MigrationWarningResolvers<ContextType>;
   MissingConfigKey?: MissingConfigKeyResolvers<ContextType>;
   Module?: ModuleResolvers<ContextType>;
   MultiDistribution?: MultiDistributionResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15000,11 +15000,6 @@ export type MigrateConnectorToManagedInput = {
   resetConnectorState?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-export type MigrateConnectorToManagedResult = {
-  __typename?: 'MigrateConnectorToManagedResult';
-  connector: Connector;
-};
-
 export type MigrationAssessment = {
   __typename?: 'MigrationAssessment';
   connector_id: Scalars['ID']['output'];
@@ -15113,8 +15108,8 @@ export type Mutation = {
   checkXTMHubConnectivity: CheckXtmHubConnectivityResponse;
   cityAdd?: Maybe<City>;
   cityEdit?: Maybe<CityEditMutations>;
+  connectorMigrateToManaged: ManagedConnector;
   contactUsXtmHub: Success;
-  connectorMigrateToManaged: MigrateConnectorToManagedResult;
   containerEdit?: Maybe<ContainerEditMutations>;
   countryAdd?: Maybe<Country>;
   countryEdit?: Maybe<CountryEditMutations>;
@@ -36588,7 +36583,6 @@ export type ResolversTypes = ResolversObject<{
   MetricDefinition: ResolverTypeWrapper<MetricDefinition>;
   MetricsByMimeType: ResolverTypeWrapper<MetricsByMimeType>;
   MigrateConnectorToManagedInput: MigrateConnectorToManagedInput;
-  MigrateConnectorToManagedResult: ResolverTypeWrapper<Omit<MigrateConnectorToManagedResult, 'connector'> & { connector: ResolversTypes['Connector'] }>;
   MigrationAssessment: ResolverTypeWrapper<MigrationAssessment>;
   MigrationAssessmentSummary: ResolverTypeWrapper<MigrationAssessmentSummary>;
   MissingConfigKey: ResolverTypeWrapper<MissingConfigKey>;
@@ -37549,7 +37543,6 @@ export type ResolversParentTypes = ResolversObject<{
   MetricDefinition: MetricDefinition;
   MetricsByMimeType: MetricsByMimeType;
   MigrateConnectorToManagedInput: MigrateConnectorToManagedInput;
-  MigrateConnectorToManagedResult: Omit<MigrateConnectorToManagedResult, 'connector'> & { connector: ResolversParentTypes['Connector'] };
   MigrationAssessment: MigrationAssessment;
   MigrationAssessmentSummary: MigrationAssessmentSummary;
   MissingConfigKey: MissingConfigKey;
@@ -43109,10 +43102,6 @@ export type MetricsByMimeTypeResolvers<ContextType = any, ParentType extends Res
   size?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
-export type MigrateConnectorToManagedResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrateConnectorToManagedResult'] = ResolversParentTypes['MigrateConnectorToManagedResult']> = ResolversObject<{
-  connector?: Resolver<ResolversTypes['Connector'], ParentType, ContextType>;
-}>;
-
 export type MigrationAssessmentResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationAssessment'] = ResolversParentTypes['MigrationAssessment']> = ResolversObject<{
   connector_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   connector_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -43214,8 +43203,8 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   checkXTMHubConnectivity?: Resolver<ResolversTypes['CheckXTMHubConnectivityResponse'], ParentType, ContextType>;
   cityAdd?: Resolver<Maybe<ResolversTypes['City']>, ParentType, ContextType, RequireFields<MutationCityAddArgs, 'input'>>;
   cityEdit?: Resolver<Maybe<ResolversTypes['CityEditMutations']>, ParentType, ContextType, RequireFields<MutationCityEditArgs, 'id'>>;
+  connectorMigrateToManaged?: Resolver<ResolversTypes['ManagedConnector'], ParentType, ContextType, RequireFields<MutationConnectorMigrateToManagedArgs, 'input'>>;
   contactUsXtmHub?: Resolver<ResolversTypes['Success'], ParentType, ContextType>;
-  connectorMigrateToManaged?: Resolver<ResolversTypes['MigrateConnectorToManagedResult'], ParentType, ContextType, RequireFields<MutationConnectorMigrateToManagedArgs, 'input'>>;
   containerEdit?: Resolver<Maybe<ResolversTypes['ContainerEditMutations']>, ParentType, ContextType, RequireFields<MutationContainerEditArgs, 'id'>>;
   countryAdd?: Resolver<Maybe<ResolversTypes['Country']>, ParentType, ContextType, RequireFields<MutationCountryAddArgs, 'input'>>;
   countryEdit?: Resolver<Maybe<ResolversTypes['CountryEditMutations']>, ParentType, ContextType, RequireFields<MutationCountryEditArgs, 'id'>>;
@@ -48920,7 +48909,6 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   MetricAttributes?: MetricAttributesResolvers<ContextType>;
   MetricDefinition?: MetricDefinitionResolvers<ContextType>;
   MetricsByMimeType?: MetricsByMimeTypeResolvers<ContextType>;
-  MigrateConnectorToManagedResult?: MigrateConnectorToManagedResultResolvers<ContextType>;
   MigrationAssessment?: MigrationAssessmentResolvers<ContextType>;
   MigrationAssessmentSummary?: MigrationAssessmentSummaryResolvers<ContextType>;
   MissingConfigKey?: MissingConfigKeyResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -4177,7 +4177,7 @@ export type ConnectorMetadata = {
 export type ConnectorMigrationAssessmentInput = {
   configuration?: InputMaybe<Array<ContractConfigInput>>;
   connectorId: Scalars['ID']['input'];
-  contractSlug: Scalars['String']['input'];
+  containerImage: Scalars['String']['input'];
 };
 
 export enum ConnectorPriorityGroup {
@@ -14995,7 +14995,7 @@ export type MetricsByMimeType = {
 export type MigrateConnectorToManagedInput = {
   configuration?: InputMaybe<Array<ContractConfigInput>>;
   connectorId: Scalars['ID']['input'];
-  contractSlug: Scalars['String']['input'];
+  containerImage: Scalars['String']['input'];
   convertUserToServiceAccount?: InputMaybe<Scalars['Boolean']['input']>;
   resetConnectorState?: InputMaybe<Scalars['Boolean']['input']>;
 };
@@ -15009,7 +15009,7 @@ export type MigrationAssessment = {
   __typename?: 'MigrationAssessment';
   connector_id: Scalars['ID']['output'];
   connector_name: Scalars['String']['output'];
-  contract_slug: Scalars['String']['output'];
+  contract_image: Scalars['String']['output'];
   ignored: Array<IgnoredConfigKey>;
   mapped: Array<MappedConfigKey>;
   missing: Array<MissingConfigKey>;
@@ -22585,7 +22585,7 @@ export type QueryConnectorManagerArgs = {
 export type QueryConnectorMigrationAssessmentArgs = {
   configuration?: InputMaybe<Array<ContractConfigInput>>;
   connectorId: Scalars['ID']['input'];
-  contractSlug: Scalars['String']['input'];
+  containerImage: Scalars['String']['input'];
 };
 
 
@@ -43116,7 +43116,7 @@ export type MigrateConnectorToManagedResultResolvers<ContextType = any, ParentTy
 export type MigrationAssessmentResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationAssessment'] = ResolversParentTypes['MigrationAssessment']> = ResolversObject<{
   connector_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   connector_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  contract_slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  contract_image?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ignored?: Resolver<Array<ResolversTypes['IgnoredConfigKey']>, ParentType, ContextType>;
   mapped?: Resolver<Array<ResolversTypes['MappedConfigKey']>, ParentType, ContextType>;
   missing?: Resolver<Array<ResolversTypes['MissingConfigKey']>, ParentType, ContextType>;
@@ -44934,7 +44934,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   connector?: Resolver<Maybe<ResolversTypes['Connector']>, ParentType, ContextType, RequireFields<QueryConnectorArgs, 'id'>>;
   connectorManager?: Resolver<ResolversTypes['ConnectorManager'], ParentType, ContextType, RequireFields<QueryConnectorManagerArgs, 'managerId'>>;
   connectorManagers?: Resolver<Array<ResolversTypes['ConnectorManager']>, ParentType, ContextType>;
-  connectorMigrationAssessment?: Resolver<ResolversTypes['MigrationAssessment'], ParentType, ContextType, RequireFields<QueryConnectorMigrationAssessmentArgs, 'connectorId' | 'contractSlug'>>;
+  connectorMigrationAssessment?: Resolver<ResolversTypes['MigrationAssessment'], ParentType, ContextType, RequireFields<QueryConnectorMigrationAssessmentArgs, 'connectorId' | 'containerImage'>>;
   connectors?: Resolver<Array<ResolversTypes['Connector']>, ParentType, ContextType>;
   connectorsForAnalysis?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType>;
   connectorsForExport?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15028,6 +15028,7 @@ export type MissingConfigKey = {
   enum?: Maybe<Array<Scalars['String']['output']>>;
   format?: Maybe<Scalars['String']['output']>;
   key: Scalars['String']['output'];
+  required: Scalars['Boolean']['output'];
   type: Scalars['String']['output'];
 };
 
@@ -43126,6 +43127,7 @@ export type MissingConfigKeyResolvers<ContextType = any, ParentType extends Reso
   enum?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   format?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  required?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -4174,6 +4174,12 @@ export type ConnectorMetadata = {
   configuration: Scalars['String']['output'];
 };
 
+export type ConnectorMigrationAssessmentInput = {
+  configuration?: InputMaybe<Array<ContractConfigInput>>;
+  connectorId: Scalars['ID']['input'];
+  contractSlug: Scalars['String']['input'];
+};
+
 export enum ConnectorPriorityGroup {
   Default = 'DEFAULT',
   Realtime = 'REALTIME'
@@ -10716,6 +10722,13 @@ export enum IdentityType {
   System = 'System'
 }
 
+export type IgnoredConfigKey = {
+  __typename?: 'IgnoredConfigKey';
+  key: Scalars['String']['output'];
+  reason: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
 export type ImportConfigurationInput = {
   dashboardManifest?: InputMaybe<Scalars['String']['input']>;
   file: Scalars['Upload']['input'];
@@ -14467,6 +14480,15 @@ export type ManagerContractExcerpt = {
   title: Scalars['String']['output'];
 };
 
+export type MappedConfigKey = {
+  __typename?: 'MappedConfigKey';
+  key: Scalars['String']['output'];
+  required: Scalars['Boolean']['output'];
+  sourceKey: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
 export type MappedEntity = {
   __typename?: 'MappedEntity';
   isEntityInContainer: Scalars['Boolean']['output'];
@@ -14970,6 +14992,59 @@ export type MetricsByMimeType = {
   size: Scalars['Float']['output'];
 };
 
+export type MigrateConnectorToManagedInput = {
+  configuration?: InputMaybe<Array<ContractConfigInput>>;
+  connectorId: Scalars['ID']['input'];
+  contractSlug: Scalars['String']['input'];
+  preserveState?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type MigrateConnectorToManagedResult = {
+  __typename?: 'MigrateConnectorToManagedResult';
+  connector: Connector;
+  dryRun: Scalars['Boolean']['output'];
+  skipped?: Maybe<Scalars['Boolean']['output']>;
+  state_preserved: Scalars['Boolean']['output'];
+  warnings: Array<MigrationWarning>;
+};
+
+export type MigrationAssessment = {
+  __typename?: 'MigrationAssessment';
+  connector_id: Scalars['ID']['output'];
+  connector_name: Scalars['String']['output'];
+  contract_slug: Scalars['String']['output'];
+  contract_title: Scalars['String']['output'];
+  ignored: Array<IgnoredConfigKey>;
+  mapped: Array<MappedConfigKey>;
+  missing: Array<MissingConfigKey>;
+  summary: MigrationAssessmentSummary;
+};
+
+export type MigrationAssessmentSummary = {
+  __typename?: 'MigrationAssessmentSummary';
+  assessment_date: Scalars['DateTime']['output'];
+  can_migrate: Scalars['Boolean']['output'];
+  ignored_keys: Scalars['Int']['output'];
+  mapped_keys: Scalars['Int']['output'];
+  missing_mandatory_keys: Scalars['Int']['output'];
+  total_source_keys: Scalars['Int']['output'];
+};
+
+export type MigrationWarning = {
+  __typename?: 'MigrationWarning';
+  field?: Maybe<Scalars['String']['output']>;
+  message: Scalars['String']['output'];
+};
+
+export type MissingConfigKey = {
+  __typename?: 'MissingConfigKey';
+  description: Scalars['String']['output'];
+  enum?: Maybe<Array<Scalars['String']['output']>>;
+  format?: Maybe<Scalars['String']['output']>;
+  key: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
 export type Module = {
   __typename?: 'Module';
   enable: Scalars['Boolean']['output'];
@@ -15048,6 +15123,7 @@ export type Mutation = {
   cityAdd?: Maybe<City>;
   cityEdit?: Maybe<CityEditMutations>;
   contactUsXtmHub: Success;
+  connectorMigrateToManaged: MigrateConnectorToManagedResult;
   containerEdit?: Maybe<ContainerEditMutations>;
   countryAdd?: Maybe<Country>;
   countryEdit?: Maybe<CountryEditMutations>;
@@ -15776,6 +15852,12 @@ export type MutationCityAddArgs = {
 
 export type MutationCityEditArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationConnectorMigrateToManagedArgs = {
+  dryRun?: InputMaybe<Scalars['Boolean']['input']>;
+  input: MigrateConnectorToManagedInput;
 };
 
 
@@ -21860,6 +21942,7 @@ export type Query = {
   connector?: Maybe<Connector>;
   connectorManager: ConnectorManager;
   connectorManagers: Array<ConnectorManager>;
+  connectorMigrationAssessment: MigrationAssessment;
   connectors: Array<Connector>;
   connectorsForAnalysis?: Maybe<Array<Maybe<Connector>>>;
   connectorsForExport?: Maybe<Array<Maybe<Connector>>>;
@@ -22505,6 +22588,13 @@ export type QueryConnectorArgs = {
 
 export type QueryConnectorManagerArgs = {
   managerId: Scalars['ID']['input'];
+};
+
+
+export type QueryConnectorMigrationAssessmentArgs = {
+  configuration?: InputMaybe<Array<ContractConfigInput>>;
+  connectorId: Scalars['ID']['input'];
+  contractSlug: Scalars['String']['input'];
 };
 
 
@@ -36087,6 +36177,7 @@ export type ResolversTypes = ResolversObject<{
   ConnectorInfoInput: ConnectorInfoInput;
   ConnectorManager: ResolverTypeWrapper<ConnectorManager>;
   ConnectorMetadata: ResolverTypeWrapper<ConnectorMetadata>;
+  ConnectorMigrationAssessmentInput: ConnectorMigrationAssessmentInput;
   ConnectorPriorityGroup: ConnectorPriorityGroup;
   ConnectorQueueDetails: ResolverTypeWrapper<ConnectorQueueDetails>;
   ConnectorRequestStatus: ConnectorRequestStatus;
@@ -36330,6 +36421,7 @@ export type ResolversTypes = ResolversObject<{
   IdentityEdge: ResolverTypeWrapper<Omit<IdentityEdge, 'node'> & { node: ResolversTypes['Identity'] }>;
   IdentityEditMutations: ResolverTypeWrapper<Omit<IdentityEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'relationAdd' | 'relationDelete'> & { contextClean?: Maybe<ResolversTypes['Identity']>, contextPatch?: Maybe<ResolversTypes['Identity']>, fieldPatch?: Maybe<ResolversTypes['Identity']>, relationAdd?: Maybe<ResolversTypes['StixRefRelationship']>, relationDelete?: Maybe<ResolversTypes['Identity']> }>;
   IdentityType: IdentityType;
+  IgnoredConfigKey: ResolverTypeWrapper<IgnoredConfigKey>;
   ImportConfigurationInput: ImportConfigurationInput;
   ImportWidgetInput: ImportWidgetInput;
   Incident: ResolverTypeWrapper<Omit<Incident, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'securityCoverage' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversTypes['OpenCtiFile']>, cases?: Maybe<ResolversTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, securityCoverage?: Maybe<ResolversTypes['SecurityCoverage']>, status?: Maybe<ResolversTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
@@ -36472,6 +36564,7 @@ export type ResolversTypes = ResolversObject<{
   ManagerConfiguration: ResolverTypeWrapper<BasicStoreEntityManagerConfiguration>;
   ManagerContractConfiguration: ResolverTypeWrapper<ManagerContractConfiguration>;
   ManagerContractExcerpt: ResolverTypeWrapper<ManagerContractExcerpt>;
+  MappedConfigKey: ResolverTypeWrapper<MappedConfigKey>;
   MappedEntity: ResolverTypeWrapper<Omit<MappedEntity, 'matchedEntity'> & { matchedEntity: ResolversTypes['StixCoreObject'] }>;
   MappedEntityInput: MappedEntityInput;
   MappingAnalysis: ResolverTypeWrapper<Omit<MappingAnalysis, 'mappedEntities'> & { mappedEntities?: Maybe<Array<ResolversTypes['MappedEntity']>> }>;
@@ -36503,6 +36596,12 @@ export type ResolversTypes = ResolversObject<{
   MetricAttributes: ResolverTypeWrapper<MetricAttributes>;
   MetricDefinition: ResolverTypeWrapper<MetricDefinition>;
   MetricsByMimeType: ResolverTypeWrapper<MetricsByMimeType>;
+  MigrateConnectorToManagedInput: MigrateConnectorToManagedInput;
+  MigrateConnectorToManagedResult: ResolverTypeWrapper<Omit<MigrateConnectorToManagedResult, 'connector'> & { connector: ResolversTypes['Connector'] }>;
+  MigrationAssessment: ResolverTypeWrapper<MigrationAssessment>;
+  MigrationAssessmentSummary: ResolverTypeWrapper<MigrationAssessmentSummary>;
+  MigrationWarning: ResolverTypeWrapper<MigrationWarning>;
+  MissingConfigKey: ResolverTypeWrapper<MissingConfigKey>;
   Module: ResolverTypeWrapper<Module>;
   MultiDistribution: ResolverTypeWrapper<Omit<MultiDistribution, 'data'> & { data?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>> }>;
   MultiTimeSeries: ResolverTypeWrapper<MultiTimeSeries>;
@@ -37103,6 +37202,7 @@ export type ResolversParentTypes = ResolversObject<{
   ConnectorInfoInput: ConnectorInfoInput;
   ConnectorManager: ConnectorManager;
   ConnectorMetadata: ConnectorMetadata;
+  ConnectorMigrationAssessmentInput: ConnectorMigrationAssessmentInput;
   ConnectorQueueDetails: ConnectorQueueDetails;
   ConnectorWithConfig: ConnectorWithConfig;
   ConstraintNumber: Scalars['ConstraintNumber']['output'];
@@ -37307,6 +37407,7 @@ export type ResolversParentTypes = ResolversObject<{
   IdentityConnection: Omit<IdentityConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['IdentityEdge']>>> };
   IdentityEdge: Omit<IdentityEdge, 'node'> & { node: ResolversParentTypes['Identity'] };
   IdentityEditMutations: Omit<IdentityEditMutations, 'contextClean' | 'contextPatch' | 'fieldPatch' | 'relationAdd' | 'relationDelete'> & { contextClean?: Maybe<ResolversParentTypes['Identity']>, contextPatch?: Maybe<ResolversParentTypes['Identity']>, fieldPatch?: Maybe<ResolversParentTypes['Identity']>, relationAdd?: Maybe<ResolversParentTypes['StixRefRelationship']>, relationDelete?: Maybe<ResolversParentTypes['Identity']> };
+  IgnoredConfigKey: IgnoredConfigKey;
   ImportConfigurationInput: ImportConfigurationInput;
   ImportWidgetInput: ImportWidgetInput;
   Incident: Omit<Incident, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'securityCoverage' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversParentTypes['OpenCtiFile']>, cases?: Maybe<ResolversParentTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, securityCoverage?: Maybe<ResolversParentTypes['SecurityCoverage']>, status?: Maybe<ResolversParentTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
@@ -37427,6 +37528,7 @@ export type ResolversParentTypes = ResolversObject<{
   ManagerConfiguration: BasicStoreEntityManagerConfiguration;
   ManagerContractConfiguration: ManagerContractConfiguration;
   ManagerContractExcerpt: ManagerContractExcerpt;
+  MappedConfigKey: MappedConfigKey;
   MappedEntity: Omit<MappedEntity, 'matchedEntity'> & { matchedEntity: ResolversParentTypes['StixCoreObject'] };
   MappedEntityInput: MappedEntityInput;
   MappingAnalysis: Omit<MappingAnalysis, 'mappedEntities'> & { mappedEntities?: Maybe<Array<ResolversParentTypes['MappedEntity']>> };
@@ -37456,6 +37558,12 @@ export type ResolversParentTypes = ResolversObject<{
   MetricAttributes: MetricAttributes;
   MetricDefinition: MetricDefinition;
   MetricsByMimeType: MetricsByMimeType;
+  MigrateConnectorToManagedInput: MigrateConnectorToManagedInput;
+  MigrateConnectorToManagedResult: Omit<MigrateConnectorToManagedResult, 'connector'> & { connector: ResolversParentTypes['Connector'] };
+  MigrationAssessment: MigrationAssessment;
+  MigrationAssessmentSummary: MigrationAssessmentSummary;
+  MigrationWarning: MigrationWarning;
+  MissingConfigKey: MissingConfigKey;
   Module: Module;
   MultiDistribution: Omit<MultiDistribution, 'data'> & { data?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>> };
   MultiTimeSeries: MultiTimeSeries;
@@ -41389,6 +41497,13 @@ export type IdentityEditMutationsResolvers<ContextType = any, ParentType extends
   relationDelete?: Resolver<Maybe<ResolversTypes['Identity']>, ParentType, ContextType, RequireFields<IdentityEditMutationsRelationDeleteArgs, 'relationship_type' | 'toId'>>;
 }>;
 
+export type IgnoredConfigKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['IgnoredConfigKey'] = ResolversParentTypes['IgnoredConfigKey']> = ResolversObject<{
+  key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  reason?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type IncidentResolvers<ContextType = any, ParentType extends ResolversParentTypes['Incident'] = ResolversParentTypes['Incident']> = ResolversObject<{
   aliases?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
@@ -42746,6 +42861,15 @@ export type ManagerContractExcerptResolvers<ContextType = any, ParentType extend
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
+export type MappedConfigKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['MappedConfigKey'] = ResolversParentTypes['MappedConfigKey']> = ResolversObject<{
+  key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  required?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  sourceKey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type MappedEntityResolvers<ContextType = any, ParentType extends ResolversParentTypes['MappedEntity'] = ResolversParentTypes['MappedEntity']> = ResolversObject<{
   isEntityInContainer?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   matchedEntity?: Resolver<ResolversTypes['StixCoreObject'], ParentType, ContextType>;
@@ -42998,6 +43122,52 @@ export type MetricsByMimeTypeResolvers<ContextType = any, ParentType extends Res
   size?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
+export type MigrateConnectorToManagedResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrateConnectorToManagedResult'] = ResolversParentTypes['MigrateConnectorToManagedResult']> = ResolversObject<{
+  connector?: Resolver<ResolversTypes['Connector'], ParentType, ContextType>;
+  dryRun?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  skipped?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  state_preserved?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  warnings?: Resolver<Array<ResolversTypes['MigrationWarning']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MigrationAssessmentResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationAssessment'] = ResolversParentTypes['MigrationAssessment']> = ResolversObject<{
+  connector_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  connector_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  contract_slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  contract_title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  ignored?: Resolver<Array<ResolversTypes['IgnoredConfigKey']>, ParentType, ContextType>;
+  mapped?: Resolver<Array<ResolversTypes['MappedConfigKey']>, ParentType, ContextType>;
+  missing?: Resolver<Array<ResolversTypes['MissingConfigKey']>, ParentType, ContextType>;
+  summary?: Resolver<ResolversTypes['MigrationAssessmentSummary'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MigrationAssessmentSummaryResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationAssessmentSummary'] = ResolversParentTypes['MigrationAssessmentSummary']> = ResolversObject<{
+  assessment_date?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  can_migrate?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  ignored_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  mapped_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  missing_mandatory_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  total_source_keys?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MigrationWarningResolvers<ContextType = any, ParentType extends ResolversParentTypes['MigrationWarning'] = ResolversParentTypes['MigrationWarning']> = ResolversObject<{
+  field?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MissingConfigKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['MissingConfigKey'] = ResolversParentTypes['MissingConfigKey']> = ResolversObject<{
+  description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  enum?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  format?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type ModuleResolvers<ContextType = any, ParentType extends ResolversParentTypes['Module'] = ResolversParentTypes['Module']> = ResolversObject<{
   enable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -43072,6 +43242,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   cityAdd?: Resolver<Maybe<ResolversTypes['City']>, ParentType, ContextType, RequireFields<MutationCityAddArgs, 'input'>>;
   cityEdit?: Resolver<Maybe<ResolversTypes['CityEditMutations']>, ParentType, ContextType, RequireFields<MutationCityEditArgs, 'id'>>;
   contactUsXtmHub?: Resolver<ResolversTypes['Success'], ParentType, ContextType>;
+  connectorMigrateToManaged?: Resolver<ResolversTypes['MigrateConnectorToManagedResult'], ParentType, ContextType, RequireFields<MutationConnectorMigrateToManagedArgs, 'input'>>;
   containerEdit?: Resolver<Maybe<ResolversTypes['ContainerEditMutations']>, ParentType, ContextType, RequireFields<MutationContainerEditArgs, 'id'>>;
   countryAdd?: Resolver<Maybe<ResolversTypes['Country']>, ParentType, ContextType, RequireFields<MutationCountryAddArgs, 'input'>>;
   countryEdit?: Resolver<Maybe<ResolversTypes['CountryEditMutations']>, ParentType, ContextType, RequireFields<MutationCountryEditArgs, 'id'>>;
@@ -44790,6 +44961,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   connector?: Resolver<Maybe<ResolversTypes['Connector']>, ParentType, ContextType, RequireFields<QueryConnectorArgs, 'id'>>;
   connectorManager?: Resolver<ResolversTypes['ConnectorManager'], ParentType, ContextType, RequireFields<QueryConnectorManagerArgs, 'managerId'>>;
   connectorManagers?: Resolver<Array<ResolversTypes['ConnectorManager']>, ParentType, ContextType>;
+  connectorMigrationAssessment?: Resolver<ResolversTypes['MigrationAssessment'], ParentType, ContextType, RequireFields<QueryConnectorMigrationAssessmentArgs, 'connectorId' | 'contractSlug'>>;
   connectors?: Resolver<Array<ResolversTypes['Connector']>, ParentType, ContextType>;
   connectorsForAnalysis?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType>;
   connectorsForExport?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType>;
@@ -48657,6 +48829,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   IdentityConnection?: IdentityConnectionResolvers<ContextType>;
   IdentityEdge?: IdentityEdgeResolvers<ContextType>;
   IdentityEditMutations?: IdentityEditMutationsResolvers<ContextType>;
+  IgnoredConfigKey?: IgnoredConfigKeyResolvers<ContextType>;
   Incident?: IncidentResolvers<ContextType>;
   IncidentConnection?: IncidentConnectionResolvers<ContextType>;
   IncidentEdge?: IncidentEdgeResolvers<ContextType>;
@@ -48750,6 +48923,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   ManagerConfiguration?: ManagerConfigurationResolvers<ContextType>;
   ManagerContractConfiguration?: ManagerContractConfigurationResolvers<ContextType>;
   ManagerContractExcerpt?: ManagerContractExcerptResolvers<ContextType>;
+  MappedConfigKey?: MappedConfigKeyResolvers<ContextType>;
   MappedEntity?: MappedEntityResolvers<ContextType>;
   MappingAnalysis?: MappingAnalysisResolvers<ContextType>;
   MarkingDefinition?: MarkingDefinitionResolvers<ContextType>;
@@ -48773,6 +48947,11 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   MetricAttributes?: MetricAttributesResolvers<ContextType>;
   MetricDefinition?: MetricDefinitionResolvers<ContextType>;
   MetricsByMimeType?: MetricsByMimeTypeResolvers<ContextType>;
+  MigrateConnectorToManagedResult?: MigrateConnectorToManagedResultResolvers<ContextType>;
+  MigrationAssessment?: MigrationAssessmentResolvers<ContextType>;
+  MigrationAssessmentSummary?: MigrationAssessmentSummaryResolvers<ContextType>;
+  MigrationWarning?: MigrationWarningResolvers<ContextType>;
+  MissingConfigKey?: MissingConfigKeyResolvers<ContextType>;
   Module?: ModuleResolvers<ContextType>;
   MultiDistribution?: MultiDistributionResolvers<ContextType>;
   MultiTimeSeries?: MultiTimeSeriesResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -428,8 +428,8 @@ export const findCatalog = async (_context: AuthContext, _user: AuthUser) => {
   return Object.values(catalogDefinitions).map((catalog) => catalog.graphql);
 };
 
-const findContract = (_context: AuthContext, _user: AuthUser, predicate: (contract: any) => boolean) => {
-  const catalogDefinitions = getCatalogs();
+const findContract = async (_context: AuthContext, _user: AuthUser, predicate: (contract: any) => boolean) => {
+  const catalogDefinitions = await getCatalogs();
   if (!catalogDefinitions) {
     return null;
   }
@@ -453,9 +453,5 @@ export const findContractBySlug = (context: AuthContext, user: AuthUser, contrac
 };
 
 export const findContractByContainerImage = (context: AuthContext, user: AuthUser, containerImage: string) => {
-  return findContract(context, user, (contract) => {
-    const { container_image } = contract;
-    console.log('---  container_image', container_image);
-    return contract.container_image === containerImage;
-  });
+  return findContract(context, user, (contract) => contract.container_image === containerImage);
 };

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -91,7 +91,7 @@ const connectorResolvers = {
     connectorManagers: (_, __, context) => connectorManagers(context, context.user),
     connectorMigrationAssessment: async (_, { connectorId, containerImage, configuration }, context) => {
       return assessConnectorMigration(context, context.user, connectorId, containerImage, configuration);
-    }
+    },
     // endregion
   },
   Connector: {

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -89,8 +89,8 @@ const connectorResolvers = {
     // region new managed connectors
     connectorManager: (_, { managerId }, context) => connectorManager(context, context.user, managerId),
     connectorManagers: (_, __, context) => connectorManagers(context, context.user),
-    connectorMigrationAssessment: async (_, { connectorId, contractSlug, configuration }, context) => {
-      return assessConnectorMigration(context, context.user, connectorId, contractSlug, configuration);
+    connectorMigrationAssessment: async (_, { connectorId, containerImage, configuration }, context) => {
+      return assessConnectorMigration(context, context.user, connectorId, containerImage, configuration);
     }
     // endregion
   },
@@ -192,12 +192,12 @@ const connectorResolvers = {
     synchronizerTest: (_, { input }, context) => testSync(context, context.user, input),
 
     connectorMigrateToManaged: (_, { input }, context) => {
-      const { connectorId, contractSlug, configuration, resetConnectorState, convertUserToServiceAccount = false } = input;
+      const { connectorId, containerImage, configuration, resetConnectorState, convertUserToServiceAccount = false } = input;
       return migrateConnectorToManaged(
         context,
         context.user,
         connectorId,
-        contractSlug,
+        containerImage,
         configuration,
         convertUserToServiceAccount,
         resetConnectorState,

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -199,8 +199,8 @@ const connectorResolvers = {
         connectorId,
         contractSlug,
         configuration,
-        resetConnectorState,
         convertUserToServiceAccount,
+        resetConnectorState,
       );
     },
   },

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -192,7 +192,7 @@ const connectorResolvers = {
     synchronizerTest: (_, { input }, context) => testSync(context, context.user, input),
 
     connectorMigrateToManaged: (_, { input }, context) => {
-      const { connectorId, containerImage, configuration, resetConnectorState, convertUserToServiceAccount = false } = input;
+      const { connectorId, containerImage, configuration, resetConnectorState, convertUserToServiceAccount } = input;
       return migrateConnectorToManaged(
         context,
         context.user,

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -66,6 +66,7 @@ import { getConnectorQueueSize } from '../database/rabbitmq';
 import { redisGetConnectorLogs } from '../database/redis';
 import pjson from '../../package.json';
 import { ConnectorPriorityGroup } from '../generated/graphql';
+import { assessConnectorMigration } from '../domain/connector-migration';
 
 export const PLATFORM_VERSION = pjson.version;
 
@@ -88,6 +89,11 @@ const connectorResolvers = {
     // region new managed connectors
     connectorManager: (_, { managerId }, context) => connectorManager(context, context.user, managerId),
     connectorManagers: (_, __, context) => connectorManagers(context, context.user),
+    connectorMigrationAssessment: async (_, { connectorId, contractSlug, configuration }, context) => {
+      const a = await assessConnectorMigration(context, context.user, connectorId, contractSlug, configuration);
+      console.log('------res ? ', a);
+      return a;
+    }
     // endregion
   },
   Connector: {
@@ -186,6 +192,19 @@ const connectorResolvers = {
     synchronizerStart: (_, { id }, context) => patchSync(context, context.user, id, { running: true }),
     synchronizerStop: (_, { id }, context) => patchSync(context, context.user, id, { running: false }),
     synchronizerTest: (_, { input }, context) => testSync(context, context.user, input),
+
+    // connectorMigrateToManaged: (_, { input, dryRun }, context) => {
+    //   const { connectorId, contractSlug, configuration, preserveState } = input;
+    //   return migrateConnectorToManaged(
+    //     context,
+    //     context.user,
+    //     connectorId,
+    //     contractSlug,
+    //     configuration,
+    //     preserveState,
+    //     dryRun
+    //   );
+    // },
   },
 };
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -180,7 +180,7 @@ describe('Check connector migration', () => {
             input: {
               connectorId: standaloneConnector.id,
               contractSlug: 'nist-nvd-cve',
-              preserveState: true,
+              resetConnectorState: false,
               convertUserToServiceAccount: true,
               configuration: [
                 { key: 'CVE_API_KEY', value: 'cve_api_key' },

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -32,18 +32,16 @@ const DELETE_USER_MUTATION = gql`
 const MIGRATE_CONNECTOR_TO_MANAGED = gql`
   mutation MigrateConnectorToManaged($input: MigrateConnectorToManagedInput!) {
     connectorMigrateToManaged(input: $input){
-      connector {
-        id
-        name
-        standard_id
-        manager_contract_configuration {
-          key
-          value
-        }
-        connector_user {
-          user_service_account
-        }
-      }   
+      id
+      name
+      standard_id
+      manager_contract_configuration {
+        key
+        value
+      }
+      connector_user {
+        user_service_account
+      } 
     }
 }`;
 
@@ -206,18 +204,15 @@ describe('Check connector migration', () => {
         }
 
         // same values excluded from catalog-domain
-        const RUNTIME_KEYS = ['CONNECTOR_ID', 'CONNECTOR_TYPE', 'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'HTTPS_PROXY_REJECT_UNAUTHORIZED'];
-        const managedConnector = managedConnectorResult.data.connectorMigrateToManaged.connector;
+        const RUNTIME_KEYS = ['OPENCTI_TOKEN', 'CONNECTOR_ID', 'CONNECTOR_TYPE', 'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'HTTPS_PROXY_REJECT_UNAUTHORIZED'];
+        const managedConnector = managedConnectorResult.data.connectorMigrateToManaged;
         const rawConfig = managedConnector.manager_contract_configuration;
         rawConfig.filter((c: any) => !RUNTIME_KEYS.includes(c.key));
 
         const actualConfig = rawConfig.filter((c: { key: string }) => !RUNTIME_KEYS.includes(c.key));
         const schemaProperties = contractParsed.config_schema.properties;
 
-        const expectedKeys = Object.keys(schemaProperties).filter(
-          (key) => !key.endsWith('API_KEY'),
-        );
-
+        const expectedKeys = Object.keys(schemaProperties);
         const actualKeys = actualConfig.map((c: { key: string }) => c.key);
 
         // Assert all expected keys are present and no extra keys

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -1,0 +1,316 @@
+import gql from 'graphql-tag';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { registerConnector } from '../../../src/domain/connector';
+import { ConnectorType } from '../../../src/generated/graphql';
+import * as catalogDomain from '../../../src/modules/catalog/catalog-domain';
+import { ADMIN_USER, queryAsAdmin, testContext } from '../../utils/testQuery';
+import { adminQueryWithSuccess, queryAsAdminWithSuccess } from '../../utils/testQueryHelper';
+
+const CREATE_USER_QUERY = gql`
+  mutation UserAdd($input: UserAddInput!) {
+    userAdd(input: $input) {
+      id
+      standard_id
+      name
+      user_email
+      firstname
+      lastname
+      user_service_account
+    }
+  }
+`;
+
+const DELETE_USER_MUTATION = gql`
+  mutation DeleteUser($id: ID!) {
+    userEdit(id: $id) {
+      delete
+    }
+  }
+`;
+
+const MIGRATE_CONNECTOR_TO_MANAGED = gql`
+  mutation MigrateConnectorToManaged($input: MigrateConnectorToManagedInput!) {
+    connectorMigrateToManaged(input: $input){
+      connector {
+        id
+        name
+        standard_id
+        manager_contract_configuration {
+          key
+          value
+        }
+        connector_user {
+          user_service_account
+        }
+      }   
+    }
+}`;
+
+const DELETE_CONNECTOR_QUERY = gql`
+  mutation ConnectorDeletionMutation($id: ID!) {
+    deleteConnector(id: $id)
+  }
+`;
+
+const READ_CONNECTOR_QUERY = gql`
+  query GetConnectors($id: String!) {
+    connector(id: $id) {
+      id
+      name
+      active
+      auto
+      only_contextual
+      connector_type
+      connector_scope
+      connector_state
+      connector_user_id
+      connector_user {
+        user_service_account
+      }
+      connector_state
+      connector_state_timestamp
+      connector_queue_details {
+        messages_number
+        messages_size
+      }
+      updated_at
+      created_at
+      config {
+        listen
+        listen_exchange
+        push
+        push_exchange
+      }
+      built_in
+    }
+  }
+`;
+
+const TEST_CN_ID = '5ed680de-75e2-4aa0-bec0-4e8e5a0d1695';
+const TEST_CN_NAME = 'TestConnector';
+
+describe('Check connector migration', () => {
+  let userId: string;
+
+  /**
+   * - Create a user account without being a service account
+   * - Register a standalone connector
+   * - Get catalogId
+   */
+  beforeAll(async () => {
+    const user = await adminQueryWithSuccess({
+      query: CREATE_USER_QUERY,
+      variables: { input: {
+        name: 'firstname lastname',
+        password: 'password',
+        user_email: 'user@test.com',
+        user_service_account: false,
+        groups: [],
+        objectOrganization: [],
+      } },
+    });
+
+    userId = user.data.userAdd.id;
+
+    const connectorData = {
+      id: TEST_CN_ID,
+      name: TEST_CN_NAME,
+      type: ConnectorType.ExternalImport,
+      scope: ['Observable'],
+      auto: true,
+      only_contextual: true,
+    };
+
+    const opts = {
+      connector_user_id: userId,
+    };
+
+    // register connector with domain function because the graphql
+    // RegisterConnectorInput doesn't accept options input which is required
+    // to pass the userId to the connector
+    const connector = await registerConnector(
+      testContext,
+      ADMIN_USER,
+      connectorData,
+      opts,
+    );
+
+    expect(connector).not.toBeNull();
+    expect(connector.name).toEqual(TEST_CN_NAME);
+    expect(connector.id).toEqual(TEST_CN_ID);
+  });
+
+  /**
+   * - delete the user created
+   * - delete the connector
+   */
+  afterAll(async () => {
+    // Delete the connector
+    await queryAsAdminWithSuccess({ query: DELETE_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+    // Verify is no longer found
+    const queryResult = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+
+    expect(queryResult).not.toBeNull();
+    expect(queryResult.data?.connector).toBeNull();
+
+    await queryAsAdminWithSuccess({ query: DELETE_USER_MUTATION, variables: { id: userId } });
+    vi.restoreAllMocks();
+  });
+
+  describe('migrate connector to managed', () => {
+    describe('when migration is successful', () => {
+      it('shoud migrate a standalone connector to managed, and user is now service account', async () => {
+        const queryConnectorRegistered = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+        const standaloneConnector = queryConnectorRegistered.data?.connector;
+        expect(standaloneConnector).not.toBeNull();
+
+        if (!standaloneConnector) {
+          throw new Error('Connector should not be null');
+        }
+
+        expect(standaloneConnector.connector_state).toBeNull();
+        expect(standaloneConnector.connector_state_timestamp).not.toBeNull();
+        expect(standaloneConnector.connector_user_id).toMatch(userId);
+        expect(standaloneConnector.connector_user.user_service_account).toBeFalsy();
+
+        const managedConnectorResult = await adminQueryWithSuccess({
+          query: MIGRATE_CONNECTOR_TO_MANAGED,
+          variables: {
+            input: {
+              connectorId: standaloneConnector.id,
+              contractSlug: 'nist-nvd-cve',
+              preserveState: true,
+              convertUserToServiceAccount: true,
+              configuration: [
+                { key: 'CVE_API_KEY', value: 'cve_api_key' },
+                // all other keys are get from catalog contract
+              ],
+            },
+          },
+        });
+
+        const contractFound = catalogDomain.findContractBySlug(testContext, ADMIN_USER, 'nist-nvd-cve');
+        if (!contractFound?.contract) {
+          throw new Error('Connector nist-nvd-cve slug not found in catalog');
+        }
+
+        let contractParsed;
+        try {
+          contractParsed = JSON.parse(contractFound?.contract);
+        } catch (e) {
+          throw new Error('Cannot parse nist-nvd-cve catalog');
+        }
+
+        if (!contractParsed) {
+          throw new Error('Contract nist-nvd-cve catalog is undefined');
+        }
+
+        // same values excluded from catalog-domain
+        const RUNTIME_KEYS = ['CONNECTOR_ID', 'CONNECTOR_TYPE'];
+        const managedConnector = managedConnectorResult.data.connectorMigrateToManaged.connector;
+        const rawConfig = managedConnector.manager_contract_configuration;
+        rawConfig.filter((c: any) => !RUNTIME_KEYS.includes(c.key));
+
+        const actualConfig = rawConfig.filter((c: { key: string }) => !RUNTIME_KEYS.includes(c.key));
+        const schemaProperties = contractParsed.config_schema.properties;
+
+        const expectedKeys = Object.keys(schemaProperties).filter(
+          (key) => !key.endsWith('API_KEY'),
+        );
+
+        const actualKeys = actualConfig.map((c: { key: string }) => c.key);
+
+        // Assert all expected keys are present and no extra keys
+        expect(actualKeys.sort()).toEqual(expectedKeys.sort());
+        // connector state timestamp should be the same
+        expect(managedConnector.connector_state_timestamp).not.toBeNull();
+        // connector managed id is the same as the standalone one
+        expect(managedConnector.id).toMatch(standaloneConnector.id);
+        // user should be a service account
+        expect(managedConnector.connector_user.user_service_account).toBeTruthy();
+      });
+    });
+  });
+
+  // it('should fail because the connector registered is not found', async () => {
+  //   await adminQueryWithError(
+  //     {
+  //       query: MIGRATE_CONNECTOR_TO_MANAGED,
+  //       variables: {
+  //         input: {
+  //           connectorId: 'threatfox-id-1',
+  //           contractSlug: 'threatfox',
+  //           preserveState: true,
+  //           convertUserToServiceAccount: true,
+  //           configuration: [
+  //             { key: 'CONNECTOR_LOG_LEVEL', value: 'debug' },
+  //           ]
+  //         }
+  //       }
+  //     },
+  //     'Connector not found',
+  //     FUNCTIONAL_ERROR,
+  //   );
+  // });
+
+  // it('should fail because the connector registered is not found', async () => {
+  //   await adminQueryWithError(
+  //     {
+  //       query: MIGRATE_CONNECTOR_TO_MANAGED,
+  //       variables: {
+  //         input: {
+  //           connectorId: 'threatfox-id-1',
+  //           contractSlug: 'threatfox',
+  //           preserveState: true,
+  //           convertUserToServiceAccount: true,
+  //           configuration: [
+  //             { key: 'CONNECTOR_LOG_LEVEL', value: 'debug' },
+  //           ]
+  //         }
+  //       }
+  //     },
+  //     'Connector not found',
+  //     FUNCTIONAL_ERROR,
+  //   );
+  // });
+
+  // TODELETE
+  // it('should migrate a connector to a managed connector', async () => {
+  //   const a = false;
+  //   expect(a).toBe(false);
+
+  //   const queryConnectorRegistered = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+  //   const standaloneConnector = queryConnectorRegistered.data?.connector;
+  //   expect(standaloneConnector).not.toBeNull();
+
+  //   if (!standaloneConnector) {
+  //     throw new Error('Connector should not be null');
+  //   }
+
+  //   expect(standaloneConnector.connector_state).toBeNull();
+  //   expect(standaloneConnector.connector_state_timestamp).not.toBeNull();
+  //   expect(standaloneConnector.connector_user_id).toMatch(userId);
+
+  //   // console.log('queryResult', queryResult.data);
+
+  //   // MIGRATE_CONNECTOR_TO_MANAGED;
+
+  //   const managedConnector = await adminQueryWithSuccess({
+  //     query: MIGRATE_CONNECTOR_TO_MANAGED,
+  //     variables: {
+  //       input: {
+  //         connectorId: 'threatfox-id-1',
+  //         contractSlug: 'threatfox',
+  //         preserveState: true,
+  //         convertUserToServiceAccount: true,
+  //         configuration: [
+  //           { key: 'CONNECTOR_LOG_LEVEL', value: 'debug' },
+  //         ]
+  //       }
+  //     }
+  //   });
+
+  //   console.log('managedConnector', managedConnector);
+  // });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -189,7 +189,7 @@ describe('Check connector migration', () => {
           },
         });
 
-        const contractFound = catalogDomain.findContractByContainerImage(testContext, ADMIN_USER, 'opencti/connector-cve');
+        const contractFound = await catalogDomain.findContractByContainerImage(testContext, ADMIN_USER, 'opencti/connector-cve');
         if (!contractFound?.contract) {
           throw new Error('Connector nist-nvd-cve container-image not found in catalog');
         }

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -178,7 +178,7 @@ describe('Check connector migration', () => {
           variables: {
             input: {
               connectorId: standaloneConnector.id,
-              contractSlug: 'nist-nvd-cve',
+              containerImage: 'opencti/connector-cve',
               resetConnectorState: false,
               convertUserToServiceAccount: true,
               configuration: [
@@ -189,15 +189,15 @@ describe('Check connector migration', () => {
           },
         });
 
-        const contractFound = catalogDomain.findContractBySlug(testContext, ADMIN_USER, 'nist-nvd-cve');
+        const contractFound = catalogDomain.findContractByContainerImage(testContext, ADMIN_USER, 'opencti/connector-cve');
         if (!contractFound?.contract) {
-          throw new Error('Connector nist-nvd-cve slug not found in catalog');
+          throw new Error('Connector nist-nvd-cve container-image not found in catalog');
         }
 
         let contractParsed;
         try {
           contractParsed = JSON.parse(contractFound?.contract);
-        } catch (e) {
+        } catch {
           throw new Error('Cannot parse nist-nvd-cve catalog');
         }
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -155,7 +155,6 @@ describe('Check connector migration', () => {
     expect(queryResult.data?.connector).toBeNull();
 
     await queryAsAdminWithSuccess({ query: DELETE_USER_MUTATION, variables: { id: userId } });
-    vi.restoreAllMocks();
   });
 
   describe('migrate connector to managed', () => {
@@ -207,7 +206,7 @@ describe('Check connector migration', () => {
         }
 
         // same values excluded from catalog-domain
-        const RUNTIME_KEYS = ['CONNECTOR_ID', 'CONNECTOR_TYPE'];
+        const RUNTIME_KEYS = ['CONNECTOR_ID', 'CONNECTOR_TYPE', 'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'HTTPS_PROXY_REJECT_UNAUTHORIZED'];
         const managedConnector = managedConnectorResult.data.connectorMigrateToManaged.connector;
         const rawConfig = managedConnector.manager_contract_configuration;
         rawConfig.filter((c: any) => !RUNTIME_KEYS.includes(c.key));


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
addresses #13202 

### Proposed changes

* Add a query to assess the migration, checks if standalone connector is elligible for migration to composer
```
query assessConnectorMigration {
  connectorMigrationAssessment(
    connectorId: "nist-cve-id-4",  
    contractSlug: "nist-nvd-cve", 
    configuration: [
      { key: "CVE_BASE_URL", value: "http://test" },
      { key: "CONNECTOR_LOG_LEVEL", value: "error" }
    ]
  ) {
    connector_id
  	contract_slug
    mapped {
      key
      value
      type
      required
    }
    missing {
      key
      type
      description
      enum
      default
    }
  }
}
```

* Add a mutation to migrate the standalone connector to managed connector

Here's an example of the migration mutation: 
```
mutation migrate {
  connectorMigrateToManaged(input: {
    connectorId: "mitre-standalone-id14",
    contractSlug: "mitre",
    resetConnectorState: false,
    convertUserToServiceAccount: true,
    configuration: [
    	{
      	key: "CONNECTOR_LOG_LEVEL", value: "debug"
      }
    ]
  }){
    connector {
      id
      name
      standard_id
      manager_contract_configuration {key value}
      connector_user {
        user_service_account
      }
    }   
  }
}
```
- Depending on the connector catalog's schema, some keys could be required such as xxx_api_key, if not set in the mutation, the function will fail. 
- Configuration could also be empty, if no required keys are found
- The config keys not override uses the keys defined from the connector's catalog schema properties, it will also use the default set in the manifest


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13202 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
