### PR TITLE
[frontend] change upload icon theme importer (#12190)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/themes/ThemeImporter.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/themes/ThemeImporter.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent, FunctionComponent } from 'react';
 import { Disposable, graphql, RecordSourceSelectorProxy } from 'relay-runtime';
 import { IconButton, Tooltip } from '@mui/material';
-import { FileUpload } from '@mui/icons-material';
+import { FileUploadOutlined } from '@mui/icons-material';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import VisuallyHiddenInput from '../../common/VisuallyHiddenInput';
@@ -72,7 +72,7 @@ const ThemeImporter: FunctionComponent<ThemeImporterProps> = ({
         onChange={handleImport}
         data-testid='import-theme-btn'
       >
-        <FileUpload fontSize="small" />
+        <FileUploadOutlined fontSize="small" />
         <VisuallyHiddenInput type="file" accept={'application/json'} onClick={handleClick} />
       </IconButton>
     </Tooltip>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change icon theme importer to match the import button on the app
old icon 
<img width="646" height="216" alt="image" src="https://github.com/user-attachments/assets/c540acb0-b786-4ff3-8232-c8d0a7eaa39a" />


new icon
<img width="650" height="208" alt="image" src="https://github.com/user-attachments/assets/2b65cf2f-46d9-4925-a237-32035af9a12d" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #12190 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
