### PR TITLE
BUG: [backend/frontend] Fix trailing / on .gitignore for .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # MacOS Finder files
-.DS_Store/
+.DS_Store
 
 # IntelliJ Platform) | JetBrains
 .idea/


### PR DESCRIPTION
Since the recent commit (https://github.com/OpenCTI-Platform/opencti/pull/13166/commits/e91c79e205a223a3b063ef35986e01c940376bba) on Nov 14th, the `.DS_Store` files have not been properly ignored by `.gitignore` The removal or the trailing `/ `resolves this issue, that commit added a trailing `/`.

With Trailing `/`:

<img width="535" height="155" alt="image" src="https://github.com/user-attachments/assets/5be7cb64-4e6a-4a1a-b506-28a9ed5a63fa" />


Without:

<img width="594" height="92" alt="image" src="https://github.com/user-attachments/assets/a1de87c7-20e1-40e7-93b2-6914c396c342" />


### Proposed changes

* Remove trailing `/` on the base `.gitignore` file for the `.DS_Store` entry


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

None
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
