### PR TITLE
[backend] Import Form does not prevent submitting badly formatted values (#13320)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/forms/Form.d.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/Form.d.ts
@@ -8,7 +8,7 @@ export interface FormFieldAttribute {
   name: string;
   label: string; // Display label for the field
   description?: string;
-  type: string; // Field type: text, select, openvocab, etc.
+  type: string; // Field type: text, select, open vocabulary, etc.
   required: boolean;
   isMandatory?: boolean; // Whether this field is for a mandatory attribute
   width?: 'full' | 'half' | 'third'; // Field width in grid: full (12), half (6), third (4)

--- a/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
@@ -415,12 +415,12 @@ export const formSubmit = async (
   const observableInputs = [];
   observableInputs.push({
     type: form.main_entity_type,
-    value: values.value,
+    ...values,
   });
   for (const additionalEntity of additionalEntities) {
     observableInputs.push({
       type: additionalEntity.entityType,
-      value: values[`additional_${additionalEntity.id}`].value, // stock this way in DB
+      ...values[`additional_${additionalEntity.id}`], // stock this way in DB
     });
   }
 


### PR DESCRIPTION
### Proposed changes

* Add a backend check before creation for observables entities as they are the one with syntax complexity

To test this feature we need to : 
- create a form using form intake (data -> ingestion -> form intakes)
- create an ipv4 form (a simple one with only value is good enough)
- now import data with header icon
- select "import using a form"
- select the one previously created for ipv4
- try to enter a false value such as "plop" -> you should have an error in display and the creation of the entity is stoped 

** please tell me if you think of any other special field to check for this case **

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13320