### PR TITLE
[frontend] prevent duplicated option security coverage on add (#13118)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CoverageInformationField.tsx
@@ -69,6 +69,10 @@ export const CoverageInformationFieldAdd: FunctionComponent<CoverageInformationF
 }): ReactElement => {
   const { t_i18n } = useFormatter();
 
+  const disabledOptions = values
+    ?.map((v) => v.coverage_name)
+    .filter((coverageName) => coverageName !== '');
+
   return (
     <div style={{ ...fieldSpacingContainerStyle, ...containerStyle }}>
       <Typography variant="h4" gutterBottom>
@@ -102,6 +106,7 @@ export const CoverageInformationFieldAdd: FunctionComponent<CoverageInformationF
                     onChange={(__, value) => {
                       arrayHelpers.replace(index, { ...values[index], coverage_name: value.toString() });
                     }}
+                    disabledOptions={disabledOptions}
                     containerStyle={{ marginTop: 3, width: '100%' }}
                     multiple={false}
                   />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
The previous fix prevented only on update forms, this one also address when we add

### Proposed changes

* Disable options when adding security coverage in create (in reports, in security coverage > add security platforms or add vulnerabilities

https://github.com/user-attachments/assets/43f3d5ed-2bd1-43da-9b32-05bf25934440



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13118

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
