### PR TITLE
[frontend] Keep context filters when exporting entities lists (#13428)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -17,7 +17,7 @@ import { useDataTableContext } from './components/DataTableContext';
 import { FilterSearchContext, useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
 
 type DataTableInternalFiltersProps = Pick<DataTableProps,
-| 'toolbarFilters'
+| 'contextFilters'
 | 'entityTypes'> & {
   hideSearch?: boolean
   hideFilters?: boolean
@@ -31,7 +31,7 @@ type DataTableInternalFiltersProps = Pick<DataTableProps,
 };
 
 const DataTableInternalFilters = ({
-  toolbarFilters,
+  contextFilters,
   entityTypes,
   hideSearch,
   hideFilters,
@@ -78,7 +78,7 @@ const DataTableInternalFilters = ({
 
           {!hideFilters && (
             <DataTableFilters
-              toolbarFilters={toolbarFilters}
+              contextFilters={contextFilters}
               availableFilterKeys={availableFilterKeys}
               searchContextFinal={searchContextFinal}
               availableEntityTypes={availableEntityTypes}
@@ -106,7 +106,7 @@ const DataTableInternalFilters = ({
 };
 
 type DataTableInternalToolbarProps = Pick<DataTableProps,
-| 'toolbarFilters'
+| 'contextFilters'
 | 'handleCopy'
 | 'removeAuthMembersEnabled'
 | 'removeFromDraftEnabled'
@@ -120,7 +120,7 @@ type DataTableInternalToolbarProps = Pick<DataTableProps,
 const DataTableInternalToolbar = ({
   taskScope,
   handleCopy,
-  toolbarFilters,
+  contextFilters,
   globalSearch,
   removeAuthMembersEnabled,
   removeFromDraftEnabled,
@@ -156,7 +156,7 @@ const DataTableInternalToolbar = ({
         numberOfSelectedElements={numberOfSelectedElements}
         selectAll={selectAll}
         search={searchTerm ?? globalSearch}
-        filters={toolbarFilters}
+        filters={contextFilters}
         types={entityTypes}
         handleClearSelectedElements={handleClearSelectedElements}
         taskScope={taskScope}
@@ -177,7 +177,7 @@ type OCTIDataTableProps = Pick<DataTableProps,
 | 'availableFilterKeys'
 | 'redirectionModeEnabled'
 | 'additionalFilterKeys'
-| 'toolbarFilters'
+| 'contextFilters'
 | 'variant'
 | 'actions'
 | 'hideHeaders'
@@ -213,7 +213,7 @@ const DataTable = (props: OCTIDataTableProps) => {
     lineFragment,
     exportContext,
     entityTypes,
-    toolbarFilters,
+    contextFilters,
     handleCopy,
     additionalHeaderButtons,
     currentView,
@@ -250,7 +250,7 @@ const DataTable = (props: OCTIDataTableProps) => {
         filtersComponent={(
           <DataTableInternalFilters
             entityTypes={entityTypes}
-            toolbarFilters={toolbarFilters}
+            contextFilters={contextFilters}
             additionalHeaderButtons={additionalHeaderButtons}
             availableEntityTypes={availableEntityTypes}
             availableRelationFilterTypes={availableRelationFilterTypes}
@@ -267,7 +267,7 @@ const DataTable = (props: OCTIDataTableProps) => {
             entityTypes={entityTypes}
             handleCopy={handleCopy}
             taskScope={taskScope}
-            toolbarFilters={toolbarFilters}
+            contextFilters={contextFilters}
             globalSearch={globalSearch}
             removeAuthMembersEnabled={removeAuthMembersEnabled}
             removeFromDraftEnabled={removeFromDraftEnabled}

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -17,7 +17,7 @@ import { useDataTableContext } from './components/DataTableContext';
 import { FilterSearchContext, useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
 
 type DataTableInternalFiltersProps = Pick<DataTableProps,
-| 'additionalFilters'
+| 'toolbarFilters'
 | 'entityTypes'> & {
   hideSearch?: boolean
   hideFilters?: boolean
@@ -31,7 +31,7 @@ type DataTableInternalFiltersProps = Pick<DataTableProps,
 };
 
 const DataTableInternalFilters = ({
-  additionalFilters,
+  toolbarFilters,
   entityTypes,
   hideSearch,
   hideFilters,
@@ -78,7 +78,7 @@ const DataTableInternalFilters = ({
 
           {!hideFilters && (
             <DataTableFilters
-              additionalFilters={additionalFilters}
+              toolbarFilters={toolbarFilters}
               availableFilterKeys={availableFilterKeys}
               searchContextFinal={searchContextFinal}
               availableEntityTypes={availableEntityTypes}
@@ -177,7 +177,7 @@ type OCTIDataTableProps = Pick<DataTableProps,
 | 'availableFilterKeys'
 | 'redirectionModeEnabled'
 | 'additionalFilterKeys'
-| 'additionalFilters'
+| 'toolbarFilters'
 | 'variant'
 | 'actions'
 | 'hideHeaders'
@@ -210,7 +210,6 @@ const DataTable = (props: OCTIDataTableProps) => {
     availableRelationFilterTypes,
     preloadedPaginationProps: dataQueryArgs,
     additionalFilterKeys,
-    additionalFilters,
     lineFragment,
     exportContext,
     entityTypes,
@@ -251,7 +250,7 @@ const DataTable = (props: OCTIDataTableProps) => {
         filtersComponent={(
           <DataTableInternalFilters
             entityTypes={entityTypes}
-            additionalFilters={additionalFilters}
+            toolbarFilters={toolbarFilters}
             additionalHeaderButtons={additionalHeaderButtons}
             availableEntityTypes={availableEntityTypes}
             availableRelationFilterTypes={availableRelationFilterTypes}

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -57,7 +57,7 @@ export const DataTableDisplayFilters = ({
 };
 
 const DataTableFilters = ({
-  additionalFilters,
+  toolbarFilters,
   availableFilterKeys,
   searchContextFinal,
   availableEntityTypes,
@@ -96,8 +96,8 @@ const DataTableFilters = ({
   const hasToggleGroup = additionalHeaderButtons || redirectionModeEnabled || !exportDisabled;
 
   const exportFilterGroups = [];
-  if (isFilterGroupNotEmpty(additionalFilters)) {
-    exportFilterGroups.push(additionalFilters);
+  if (isFilterGroupNotEmpty(toolbarFilters)) {
+    exportFilterGroups.push(toolbarFilters);
   }
   if (isFilterGroupNotEmpty(paginationOptions.filters)) {
     exportFilterGroups.push(paginationOptions.filters);

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -57,7 +57,7 @@ export const DataTableDisplayFilters = ({
 };
 
 const DataTableFilters = ({
-  toolbarFilters,
+  contextFilters,
   availableFilterKeys,
   searchContextFinal,
   availableEntityTypes,
@@ -96,8 +96,8 @@ const DataTableFilters = ({
   const hasToggleGroup = additionalHeaderButtons || redirectionModeEnabled || !exportDisabled;
 
   const exportFilterGroups = [];
-  if (isFilterGroupNotEmpty(toolbarFilters)) {
-    exportFilterGroups.push(toolbarFilters);
+  if (isFilterGroupNotEmpty(contextFilters)) {
+    exportFilterGroups.push(contextFilters);
   }
   if (isFilterGroupNotEmpty(paginationOptions.filters)) {
     exportFilterGroups.push(paginationOptions.filters);

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -93,7 +93,6 @@ export interface DataTableProps {
   data?: unknown
   availableFilterKeys?: string[] | undefined;
   redirectionModeEnabled?: boolean
-  additionalFilters?: FilterGroup
   additionalFilterKeys?: string[]
   entityTypes?: string[]
   settingsMessagesBannerHeight?: number
@@ -172,7 +171,7 @@ export interface DataTableDisplayFiltersProps {
 }
 
 export interface DataTableFiltersProps {
-  additionalFilters?: DataTableProps['additionalFilters'];
+  toolbarFilters?: DataTableProps['toolbarFilters'];
   availableFilterKeys?: string[] | undefined;
   availableRelationFilterTypes?: Record<string, string[]> | undefined
   availableEntityTypes?: string[]

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -86,7 +86,7 @@ export interface DataTableProps {
   resolvePath: (data: any) => any
   storageKey: string
   initialValues: LocalStorage
-  toolbarFilters?: FilterGroup
+  contextFilters?: FilterGroup
   handleCopy?: () => void
   lineFragment?: GraphQLTaggedNode
   dataQueryArgs: any
@@ -171,7 +171,7 @@ export interface DataTableDisplayFiltersProps {
 }
 
 export interface DataTableFiltersProps {
-  toolbarFilters?: DataTableProps['toolbarFilters'];
+  contextFilters?: DataTableProps['contextFilters'];
   availableFilterKeys?: string[] | undefined;
   availableRelationFilterTypes?: Record<string, string[]> | undefined
   availableEntityTypes?: string[]

--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -239,7 +239,7 @@ const Search = () => {
           resolvePath={(data: SearchStixCoreObjectsLines_data$data) => data.globalSearch?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           globalSearch={searchTerm}
           lineFragment={searchLineFragment}
           preloadedPaginationProps={preloadedPaginationOptions}

--- a/opencti-platform/opencti-front/src/private/components/analyses/ExternalReferences.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/ExternalReferences.tsx
@@ -158,7 +158,7 @@ const ExternalReferences: FunctionComponent<ExternalReferencesProps> = () => {
           resolvePath={(data: ExternalReferencesLines_data$data) => data.externalReferences?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={externalReferencesLineFragment}
           entityTypes={['External-Reference']}

--- a/opencti-platform/opencti-front/src/private/components/analyses/Groupings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Groupings.tsx
@@ -209,7 +209,7 @@ const Groupings: FunctionComponent<GroupingsProps> = () => {
           resolvePath={(data: GroupingsLines_data$data) => data.groupings?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={groupingLineFragment}
           exportContext={{ entity_type: 'Grouping' }}

--- a/opencti-platform/opencti-front/src/private/components/analyses/MalwareAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/MalwareAnalyses.tsx
@@ -174,7 +174,7 @@ const MalwareAnalyses: FunctionComponent = () => {
           resolvePath={(data: MalwareAnalysesLines_data$data) => data.malwareAnalyses?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={malwareAnalysisFragment}
           exportContext={{ entity_type: 'Malware-Analysis' }}

--- a/opencti-platform/opencti-front/src/private/components/analyses/Notes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Notes.tsx
@@ -209,7 +209,7 @@ const Notes: FunctionComponent = () => {
           resolvePath={(data: NotesLines_data$data) => data.notes?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={notesLineFragment}
           exportContext={{ entity_type: 'Note' }}

--- a/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/Reports.tsx
@@ -212,7 +212,7 @@ const Reports: FunctionComponent = () => {
           resolvePath={(data: ReportsLines_data$data) => data.reports?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={reportLineFragment}
           exportContext={{ entity_type: 'Report' }}

--- a/opencti-platform/opencti-front/src/private/components/analyses/SecurityCoverages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/SecurityCoverages.tsx
@@ -198,7 +198,7 @@ const SecurityCoverages: FunctionComponent = () => {
           resolvePath={(data: SecurityCoveragesLines_data$data) => data.securityCoverages?.edges?.map((n) => n.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={securityCoverageFragment}
           exportContext={{ entity_type: 'Security-Coverage' }}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Channels.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Channels.tsx
@@ -163,7 +163,7 @@ const Channels = () => {
           resolvePath={(data: ChannelsLines_data$data) => data.channels?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={channelLineFragment}
           exportContext={{ entity_type: 'Channel' }}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Malwares.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Malwares.tsx
@@ -162,7 +162,7 @@ const Malwares = () => {
             resolvePath={(data: MalwaresCards_data$data) => data.malwares?.edges?.map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={MalwareCardFragment}
             exportContext={{ entity_type: 'Malware' }}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Tools.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Tools.tsx
@@ -155,7 +155,7 @@ const Tools = () => {
           resolvePath={(data: ToolsLines_data$data) => data.tools?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationOptions}
           lineFragment={toolLineFragment}
           exportContext={{ entity_type: 'Tool' }}

--- a/opencti-platform/opencti-front/src/private/components/arsenal/Vulnerabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/Vulnerabilities.tsx
@@ -168,7 +168,7 @@ const Vulnerabilities = () => {
           resolvePath={(data: VulnerabilitiesLines_data$data) => (data?.vulnerabilities?.edges || []).map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationOptions}
           lineFragment={vulnerabilityLineFragment}
           exportContext={{ entity_type: 'Vulnerability' }}

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseIncidents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseIncidents.tsx
@@ -200,7 +200,7 @@ const CaseIncidents: FunctionComponent<CaseIncidentsProps> = () => {
           resolvePath={(data: CaseIncidentsLinesCases_data$data) => data.caseIncidents?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY_CASE_INCIDENT}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={caseIncidentFragment}
           exportContext={{ entity_type: 'Case-Incident' }}

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseRfis.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseRfis.tsx
@@ -196,7 +196,7 @@ const CaseRfis: FunctionComponent<CaseRfisProps> = () => {
           resolvePath={(data: CaseRfisLinesCases_data$data) => data.caseRfis?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={caseFragment}
           exportContext={{ entity_type: 'Case-Rfi' }}

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseRfts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseRfts.tsx
@@ -203,7 +203,7 @@ const CaseRfts: FunctionComponent<CaseRftsProps> = () => {
           resolvePath={(data: CaseRftsLinesCases_data$data) => data.caseRfts?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={caseFragment}
           exportContext={{ entity_type: 'Case-Rft' }}

--- a/opencti-platform/opencti-front/src/private/components/cases/Feedbacks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/Feedbacks.tsx
@@ -192,7 +192,7 @@ const Feedbacks: FunctionComponent<FeedbacksProps> = () => {
           resolvePath={(data: FeedbacksLines_data$data) => data.feedbacks?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY_FEEDBACK}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={feedbackFragment}
           exportContext={{ entity_type: 'Feedback' }}

--- a/opencti-platform/opencti-front/src/private/components/cases/Tasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/Tasks.tsx
@@ -135,7 +135,7 @@ const Tasks = () => {
           resolvePath={(data: TasksLines_data$data) => data.tasks?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY_TASKS}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={TaskFragment}
           exportContext={{ entity_type: 'Task' }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntity.tsx
@@ -807,7 +807,7 @@ const StixCoreRelationshipCreationFromEntity: FunctionComponent<StixCoreRelation
                       storageKey={LOCAL_STORAGE_KEY}
                       lineFragment={stixCoreRelationshipCreationFromEntityStixCoreObjectsLineFragment}
                       initialValues={{}}
-                      toolbarFilters={contextFilters}
+                      contextFilters={contextFilters}
                       preloadedPaginationProps={preloadedPaginationProps}
                       entityTypes={virtualEntityTypes}
                       availableEntityTypes={virtualEntityTypes}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationships.tsx
@@ -364,7 +364,7 @@ const StixCoreRelationships: FunctionComponent<StixCoreRelationshipsProps> = (
             resolvePath={(data: StixCoreRelationshipsLines_data$data) => data.stixCoreRelationships?.edges?.map((n) => n.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             lineFragment={stixCoreRelationshipsFragment}
             preloadedPaginationProps={preloadedPaginationProps}
             exportContext={{ entity_type: 'stix-core-relationship' }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
@@ -241,7 +241,7 @@ const EntityStixCoreRelationshipsIndicatorsEntitiesView: FunctionComponent<Entit
         resolvePath={(data: EntityStixCoreRelationshipsIndicatorsEntitiesView_data$data) => (data.indicators?.edges ?? []).map((n) => n?.node)}
         storageKey={localStorageKey}
         initialValues={initialValues}
-        toolbarFilters={contextFilters}
+        contextFilters={contextFilters}
         preloadedPaginationProps={preloadedPaginationProps}
         lineFragment={entityStixCoreRelationshipsIndicatorsEntitiesViewLineFragment}
         exportContext={{ entity_id: entityId, entity_type: 'Indicator' }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/views/indicators/EntityStixCoreRelationshipsIndicatorsEntitiesView.tsx
@@ -242,7 +242,6 @@ const EntityStixCoreRelationshipsIndicatorsEntitiesView: FunctionComponent<Entit
         storageKey={localStorageKey}
         initialValues={initialValues}
         toolbarFilters={contextFilters}
-        additionalFilters={contextFilters}
         preloadedPaginationProps={preloadedPaginationProps}
         lineFragment={entityStixCoreRelationshipsIndicatorsEntitiesViewLineFragment}
         exportContext={{ entity_id: entityId, entity_type: 'Indicator' }}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainMatrixInLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainMatrixInLine.tsx
@@ -120,7 +120,7 @@ const StixDomainObjectAttackPatternsKillChainMatrixInline: FunctionComponent<Sti
             resolvePath={(data: StixDomainObjectAttackPatternsKillChainContainer_data$data) => (data.attackPatterns?.edges ?? []).map((n) => n.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={stixDomainObjectAttackPatternsKillChainContainerLineFragment}
             exportContext={{ entity_type: 'Attack-Pattern' }}

--- a/opencti-platform/opencti-front/src/private/components/data/Entities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Entities.tsx
@@ -83,7 +83,7 @@ const Entities = () => {
           resolvePath={(data: EntitiesStixDomainObjectsLines_data$data) => data.stixDomainObjects?.edges?.map((n) => n?.node)}
           dataColumns={dataColumns}
           lineFragment={entitiesFragment}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           exportContext={{ entity_type: 'Stix-Domain-Object' }}
           availableEntityTypes={['Stix-Domain-Object']}
         />

--- a/opencti-platform/opencti-front/src/private/components/data/Management.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Management.tsx
@@ -163,8 +163,8 @@ const Management = () => {
     helpers,
   } = usePaginationLocalStorage<ManagementDefinitionsLinesPaginationQuery$variables>(LOCAL_STORAGE_KEY, initialValues);
 
-  const contextFilters = useBuildEntityTypeBasedFilterContext('Stix-Domain-Object', filters);
-  const toolbarFilters = addFilter(contextFilters, 'authorized_members.id', [], 'not_nil');
+  const filtersWithEntityType = useBuildEntityTypeBasedFilterContext('Stix-Domain-Object', filters);
+  const contextFilters = addFilter(filtersWithEntityType, 'authorized_members.id', [], 'not_nil');
 
   const queryPaginationOptions = {
     ...paginationOptions,
@@ -246,7 +246,7 @@ const Management = () => {
               initialValues={initialValues}
               lineFragment={managementDefinitionLineFragment}
               preloadedPaginationProps={preloadedPaginationProps}
-              toolbarFilters={toolbarFilters}
+              contextFilters={contextFilters}
               entityTypes={['Stix-Core-Object']}
               searchContextFinal={{ entityTypes: ['Stix-Core-Object'] }}
               removeAuthMembersEnabled={true}

--- a/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
@@ -200,7 +200,7 @@ const Playbooks: FunctionComponent = () => {
               resolvePath={(data: PlaybooksLines_data$data) => data.playbooks?.edges?.map((m) => m?.node)}
               storageKey={LOCAL_STORAGE_KEY_PLAYBOOKS}
               initialValues={initialValues}
-              toolbarFilters={contextFilters}
+              contextFilters={contextFilters}
               preloadedPaginationProps={preloadedPaginationProps}
               lineFragment={playbookFragment}
               entityTypes={['Playbook']}

--- a/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
@@ -329,7 +329,7 @@ const Relationships = () => {
           resolvePath={(data: RelationshipsStixCoreRelationshipsLines_data$data) => data.stixCoreRelationships?.edges?.map((n) => n.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={relationshipsStixCoreRelationshipsLineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
           exportContext={{ entity_type: 'stix-core-relationship' }}

--- a/opencti-platform/opencti-front/src/private/components/data/import/ImportFilesContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ImportFilesContent.tsx
@@ -150,7 +150,7 @@ const ImportFilesContent = ({ inDraftOverview }: ImportFilesContentProps) => {
     setNumberOfElements: helpers.handleSetNumberOfElements,
   } as UsePreloadedPaginationFragment<ImportFilesContentQuery>;
 
-  const toolbarFilters = {
+  const contextFilters = {
     mode: 'and',
     filters: [
       {
@@ -210,7 +210,7 @@ const ImportFilesContent = ({ inDraftOverview }: ImportFilesContentProps) => {
           resolvePath={(data: ImportFilesContentLines_data$data) => data.importFiles?.edges?.map(({ node }) => node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={toolbarFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={workbenchLineFragment}
           entityTypes={['InternalFile']}

--- a/opencti-platform/opencti-front/src/private/components/data/import/ImportWorkbenchesContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/import/ImportWorkbenchesContent.tsx
@@ -143,7 +143,7 @@ const ImportWorkbenchesContent = () => {
 
   const queryRef = useQueryLoading<ImportWorkbenchesContentQuery>(importWorkbenchesContentQuery, queryPaginationOptions);
 
-  const toolbarFilters = {
+  const contextFilters = {
     mode: 'and',
     filters: [
       {
@@ -219,7 +219,7 @@ const ImportWorkbenchesContent = () => {
           resolvePath={(data: ImportWorkbenchesContentLines_data$data) => data.pendingFiles?.edges?.map(({ node }) => node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={toolbarFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={workbenchLineFragment}
           entityTypes={['InternalFile']}

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
@@ -9,7 +9,7 @@ import { DraftEntities_node$data } from '@components/drafts/__generated__/DraftE
 import useAuth from '../../../utils/hooks/useAuth';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
+import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup, addFilter } from '../../../utils/filters/filtersUtils';
 import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloadedPaginationFragment';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
@@ -164,9 +164,9 @@ const DraftEntities : FunctionComponent<DraftEntitiesProps> = ({
     filters,
     searchTerm,
   } = viewStorage;
-  const contextFilters = useBuildEntityTypeBasedFilterContext(entitiesType, filters, excludedEntitiesType);
-  const relevantDraftOperationFilter = { key: 'draft_change.draft_operation', values: ['create', 'update', 'delete'], operator: 'eq', mode: 'or' };
-  const toolbarFilters = { ...contextFilters, filters: [...contextFilters.filters, relevantDraftOperationFilter] };
+  const filtersWithType = useBuildEntityTypeBasedFilterContext(entitiesType, filters, excludedEntitiesType);
+  // add filter to keep only relevant draft operations
+  const contextFilters = addFilter(filtersWithType, 'draft_change.draft_operation', ['create', 'update', 'delete']);
   const queryPaginationOptions = {
     ...paginationOptions,
     draftId,
@@ -279,7 +279,7 @@ const DraftEntities : FunctionComponent<DraftEntitiesProps> = ({
           resolvePath={(data: DraftEntitiesLines_data$data) => data.draftWorkspaceEntities?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={toolbarFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           getComputeLink={getRedirectionLink}
           lineFragment={draftEntitiesLineFragment}

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
@@ -9,7 +9,7 @@ import {
 import useAuth from '../../../utils/hooks/useAuth';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
+import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup, addFilter } from '../../../utils/filters/filtersUtils';
 import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloadedPaginationFragment';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
@@ -221,9 +221,9 @@ const DraftRelationships : FunctionComponent<DraftRelationshipsProps> = ({ isRea
     filters,
   } = viewStorage;
 
-  const contextFilters = useBuildEntityTypeBasedFilterContext('stix-core-relationship', filters);
-  const relevantDraftOperationFilter = { key: 'draft_change.draft_operation', values: ['create', 'update', 'delete'], operator: 'eq', mode: 'or' };
-  const toolbarFilters = { ...contextFilters, filters: [...contextFilters.filters, relevantDraftOperationFilter] };
+  const filtersWithType = useBuildEntityTypeBasedFilterContext('stix-core-relationship', filters);
+  // add filter to keep only relevant draft operations
+  const contextFilters = addFilter(filtersWithType, 'draft_change.draft_operation', ['create', 'update', 'delete']);
   const queryPaginationOptions = {
     ...paginationOptions,
     draftId,
@@ -294,7 +294,7 @@ const DraftRelationships : FunctionComponent<DraftRelationshipsProps> = ({ isRea
         storageKey={LOCAL_STORAGE_KEY}
         initialValues={initialValues}
         getComputeLink={getRedirectionLink}
-        toolbarFilters={toolbarFilters}
+        contextFilters={contextFilters}
         preloadedPaginationProps={preloadedPaginationProps}
         lineFragment={draftRelationshipsLineFragment}
         entityTypes={['stix-core-relationship']}

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
@@ -5,7 +5,7 @@ import { DraftSightingsLinesPaginationQuery, DraftSightingsLinesPaginationQuery$
 import { DraftSightingsLines_data$data } from '@components/drafts/__generated__/DraftSightingsLines_data.graphql';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
+import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup, addFilter } from '../../../utils/filters/filtersUtils';
 import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloadedPaginationFragment';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
@@ -309,9 +309,9 @@ const DraftSightings : FunctionComponent<DraftSightingsProps> = ({ isReadOnly })
     filters,
   } = viewStorage;
 
-  const contextFilters = useBuildEntityTypeBasedFilterContext('stix-sighting-relationship', filters);
-  const relevantDraftOperationFilter = { key: 'draft_change.draft_operation', values: ['create', 'update', 'delete'], operator: 'eq', mode: 'or' };
-  const toolbarFilters = { ...contextFilters, filters: [...contextFilters.filters, relevantDraftOperationFilter] };
+  const filtersWithType = useBuildEntityTypeBasedFilterContext('stix-sighting-relationship', filters);
+  // add filter to keep only relevant draft operations
+  const contextFilters = addFilter(filtersWithType, 'draft_change.draft_operation', ['create', 'update', 'delete']);
   const queryPaginationOptions = {
     ...paginationOptions,
     draftId,
@@ -393,7 +393,7 @@ const DraftSightings : FunctionComponent<DraftSightingsProps> = ({ isReadOnly })
         resolvePath={(data: DraftSightingsLines_data$data) => data.draftWorkspaceSightingRelationships?.edges?.map((n) => n?.node)}
         storageKey={LOCAL_STORAGE_KEY}
         initialValues={initialValues}
-        toolbarFilters={toolbarFilters}
+        contextFilters={contextFilters}
         getComputeLink={getRedirectionLink}
         preloadedPaginationProps={preloadedPaginationProps}
         lineFragment={draftSightingsLineFragment}

--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -231,7 +231,7 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
             resolvePath={(data: DraftsLines_data$data) => (data.draftWorkspaces?.edges ?? []).map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={DraftLineFragment}
             hideSearch={!!entityId}

--- a/opencti-platform/opencti-front/src/private/components/entities/SecurityPlatforms.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/SecurityPlatforms.tsx
@@ -135,7 +135,7 @@ const SecurityPlatforms = () => {
         resolvePath={(data: SecurityPlatformsLines_data$data) => data.securityPlatforms?.edges?.map((n) => n?.node)}
         storageKey={LOCAL_STORAGE_KEY}
         initialValues={initialValues}
-        toolbarFilters={contextFilters}
+        contextFilters={contextFilters}
         preloadedPaginationProps={preloadedPaginationProps}
         lineFragment={securityPlatformFragment}
         exportContext={{ entity_type: 'SecurityPlatform' }}

--- a/opencti-platform/opencti-front/src/private/components/events/Incidents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/Incidents.tsx
@@ -85,7 +85,7 @@ const Incidents: FunctionComponent = () => {
           resolvePath={(data: IncidentsLines_data$data) => data.incidents?.edges?.map((n) => n?.node)}
           dataColumns={dataColumns}
           lineFragment={incidentLineFragment}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           exportContext={{ entity_type: 'Incident' }}
           availableEntityTypes={['Incident']}
           createButton={(

--- a/opencti-platform/opencti-front/src/private/components/events/ObservedDatas.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/ObservedDatas.tsx
@@ -190,7 +190,7 @@ const ObservedDatas: FunctionComponent = () => {
           resolvePath={(data: ObservedDatasLines_data$data) => data.observedDatas?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={observedDataFragment}
           exportContext={{ entity_type: 'Observed-Data' }}

--- a/opencti-platform/opencti-front/src/private/components/events/StixSightingRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/StixSightingRelationships.tsx
@@ -369,7 +369,7 @@ const StixSightingRelationships = () => {
           resolvePath={(data: StixSightingRelationshipsLines_data$data) => data.stixSightingRelationships?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationProps}
           lineFragment={stixSightingsLineFragment}
           exportContext={{ entity_type: 'stix-sighting-relationship' }}

--- a/opencti-platform/opencti-front/src/private/components/observations/Artifacts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Artifacts.tsx
@@ -191,7 +191,7 @@ const Artifacts: FunctionComponent = () => {
             resolvePath={(data: ArtifactsLines_data$data) => data.stixCyberObservables?.edges?.map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             lineFragment={artifactLineFragment}
             preloadedPaginationProps={preloadedPaginationOptions}
             exportContext={{ entity_type: 'Artifact' }}

--- a/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
@@ -202,7 +202,7 @@ const Indicators = () => {
           resolvePath={(data: IndicatorsLines_data$data) => data.indicators?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={indicatorLineFragment}
           preloadedPaginationProps={preloadedPaginationOptions}
           exportContext={{ entity_type: 'Indicator' }}

--- a/opencti-platform/opencti-front/src/private/components/observations/Infrastructures.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Infrastructures.tsx
@@ -174,7 +174,7 @@ const Infrastructures = () => {
           resolvePath={(data: InfrastructuresLines_data$data) => data.infrastructures?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY_INFRASTRUCTURES}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={infrastructureFragment}
           preloadedPaginationProps={preloadedPaginationOptions}
           exportContext={{ entity_type: 'Infrastructure' }}

--- a/opencti-platform/opencti-front/src/private/components/observations/StixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/StixCyberObservables.tsx
@@ -141,7 +141,7 @@ const StixCyberObservables: FunctionComponent = () => {
             resolvePath={(data: StixCyberObservablesLines_data$data) => data.stixCyberObservables?.edges?.map?.((n) => n?.node)}
             dataColumns={dataColumns}
             lineFragment={stixCyberObservableLineFragment}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             handleCopy={handleCopy}
             exportContext={{ entity_type: 'Stix-Cyber-Observable' }}
             availableEntityTypes={['Stix-Cyber-Observable']}

--- a/opencti-platform/opencti-front/src/private/components/pir/Pirs.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/Pirs.tsx
@@ -201,7 +201,7 @@ const Pirs = () => {
           resolvePath={(data: Pirs_PirsFragment$data) => data.pirs?.edges?.map((e) => e?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={{
             linesQuery: pirsListQuery,
             linesFragment: pirsFragment,

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_analyses/PirAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_analyses/PirAnalyses.tsx
@@ -312,7 +312,7 @@ const PirAnalyses = ({ data }: PirAnalysesProps) => {
             dataColumns={dataColumns}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={filters}
+            contextFilters={filters}
             lineFragment={pirAnalysesContainerFragment}
             entityTypes={['Container']}
             searchContextFinal={{ entityTypes: ['Container'] }}

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_history/PirHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_history/PirHistory.tsx
@@ -208,7 +208,7 @@ const PirHistory = ({ data }: PirHistoryProps) => {
         dataColumns={dataColumns}
         storageKey={LOCAL_STORAGE_KEY}
         initialValues={initialValues}
-        toolbarFilters={contextFilters}
+        contextFilters={contextFilters}
         lineFragment={pirHistoryLogFragment}
         entityTypes={['History']}
         getComputeLink={({ context_data }: PirHistoryLogFragment$data) => {

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_knowledge/PirKnowledgeEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_knowledge/PirKnowledgeEntities.tsx
@@ -245,7 +245,7 @@ const PirKnowledgeEntities = ({ pirId, localStorage, initialValues, additionalHe
           }}
           storageKey={localStorageKey}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={{
             linesQuery: sourcesFlaggedListQuery,
             linesFragment: sourcesFlaggedFragment,

--- a/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/Notifications.tsx
@@ -426,7 +426,7 @@ const Notifications: FunctionComponent = () => {
         }}
         taskScope={'USER_NOTIFICATION'}
         lineFragment={notificationsLineFragment}
-        toolbarFilters={contextFilters}
+        contextFilters={contextFilters}
         exportContext={{ entity_type: 'Notification' }}
         availableEntityTypes={['Notification']}
         actions={renderActions}

--- a/opencti-platform/opencti-front/src/private/components/settings/KillChainPhases.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/KillChainPhases.jsx
@@ -155,7 +155,7 @@ const KillChainPhases = () => {
           resolvePath={(data) => data.killChainPhases?.edges?.map(({ node }) => node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={lineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
           actions={(killChainPhase) => <KillChainPhasePopover killChainPhase={killChainPhase} paginationOptions={queryPaginationOptions} />}

--- a/opencti-platform/opencti-front/src/private/components/settings/Labels.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Labels.jsx
@@ -165,7 +165,7 @@ const Labels = () => {
           resolvePath={(data) => data.labels?.edges?.map((e) => e?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={lineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
           actions={(label) => <LabelPopover label={label} paginationOptions={queryPaginationOptions} />}

--- a/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/MarkingDefinitions.tsx
@@ -180,7 +180,7 @@ const MarkingDefinitions = () => {
           resolvePath={(data: MarkingDefinitionsLines_data$data) => data.markingDefinitions?.edges?.map((e) => e?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={markingDefinitionLineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
           icon={(data) => {

--- a/opencti-platform/opencti-front/src/private/components/settings/Users.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Users.tsx
@@ -232,7 +232,7 @@ const Users = () => {
             resolvePath={(data) => data.users?.edges?.map(({ node }: { node: UsersLine_node$data }) => node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             lineFragment={usersLineFragment}
             preloadedPaginationProps={preloadedPaginationProps}
             createButton={userCreateButton}

--- a/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
@@ -166,7 +166,7 @@ const Vocabularies = () => {
           resolvePath={(data) => data.vocabularies?.edges?.map(({ node }: { node: useVocabularyCategory_Vocabularynode$data }) => node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={vocabFragment}
           disableNavigation
           taskScope={'SETTINGS'}

--- a/opencti-platform/opencti-front/src/private/components/settings/dissemination_lists/DisseminationLists.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/dissemination_lists/DisseminationLists.tsx
@@ -172,7 +172,7 @@ const DisseminationLists = () => {
                 resolvePath={(data) => data.disseminationLists?.edges?.map(({ node }: { node: DisseminationListsLine_node$data }) => node)}
                 storageKey={LOCAL_STORAGE_KEY}
                 initialValues={initialValues}
-                toolbarFilters={contextFilters}
+                contextFilters={contextFilters}
                 lineFragment={disseminationListsLineFragment}
                 disableLineSelection
                 disableNavigation

--- a/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplates.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplates.tsx
@@ -167,7 +167,7 @@ const EmailTemplates = () => {
               resolvePath={(data) => data.emailTemplates?.edges?.map(({ node }: { node: EmailTemplatesLine_node$data }) => node)}
               storageKey={LOCAL_STORAGE_KEY}
               initialValues={initialValues}
-              toolbarFilters={contextFilters}
+              contextFilters={contextFilters}
               lineFragment={emailTemplatesLineFragment}
               disableLineSelection
               preloadedPaginationProps={preloadedPaginationProps}

--- a/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionLists.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionLists.tsx
@@ -235,7 +235,7 @@ const ExclusionLists = () => {
             resolvePath={(data) => data.exclusionLists?.edges?.map(({ node }: { node: ExclusionListsLine_node$data }) => node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             lineFragment={exclusionListsLineFragment}
             disableLineSelection
             disableNavigation

--- a/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesigns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesigns.tsx
@@ -178,7 +178,7 @@ const FintelDesigns = () => {
               resolvePath={(data: FintelDesignsLines_data$data) => data.fintelDesigns?.edges?.map((n) => n?.node)}
               storageKey={LOCAL_STORAGE_KEY}
               initialValues={initialValues}
-              toolbarFilters={contextFilters}
+              contextFilters={contextFilters}
               getComputeLink={getRedirectionLink}
               lineFragment={fintelDesignsLineFragment}
               disableLineSelection

--- a/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplates.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/status_templates/StatusTemplates.tsx
@@ -144,7 +144,7 @@ const StatusTemplates = () => {
           resolvePath={(data) => data.statusTemplates?.edges?.map(({ node }: { node: StatusTemplatesLine_node$data }) => node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           lineFragment={StatusTemplatesLineFragment}
           disableNavigation
           disableLineSelection

--- a/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUsers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUsers.tsx
@@ -226,7 +226,7 @@ const SettingsOrganizationUsers: FunctionComponent<MembersListContainerProps> = 
           resolvePath={(data) => data.organization?.members?.edges?.map(({ node }: { node: SettingsOrganizationUsersLine_node$data }) => node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           disableLineSelection={isOnlyAdminOrganization}
           lineFragment={settingsOrganizationUsersLineFragment}
           preloadedPaginationProps={preloadedPaginationProps}

--- a/opencti-platform/opencti-front/src/private/components/techniques/AttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/AttackPatterns.tsx
@@ -159,7 +159,7 @@ const AttackPatterns = () => {
           resolvePath={(data: AttackPatternsLines_data$data) => data.attackPatterns?.edges?.map((n) => n?.node)}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationOptions}
           lineFragment={attackPatternLineFragment}
           exportContext={{ entity_type: 'Attack-Pattern' }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/CoursesOfAction.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/CoursesOfAction.tsx
@@ -158,7 +158,7 @@ const CoursesOfAction = () => {
           dataColumns={dataColumns}
           preloadedPaginationProps={preloadedPaginationOptions}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           exportContext={{ entity_type: 'Course-Of-Action' }}
           lineFragment={CourseOfActionLineFragment}
           resolvePath={(data: CoursesOfActionLines_data$data) => data.coursesOfAction?.edges?.map((e) => e?.node)}

--- a/opencti-platform/opencti-front/src/private/components/techniques/DataComponents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/DataComponents.tsx
@@ -155,7 +155,7 @@ const DataComponents: FunctionComponent = () => {
           preloadedPaginationProps={preloadedPaginationOptions}
           initialValues={initialValues}
           storageKey={LOCAL_STORAGE_KEY_DATA_COMPONENTS}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           resolvePath={(data: DataComponentsLines_data$data) => data.dataComponents?.edges?.map((n) => n?.node)}
           lineFragment={dataComponentFragment}
           exportContext={{ entity_type: 'Data-Component' }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/DataSources.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/DataSources.tsx
@@ -159,7 +159,7 @@ const DataSources: FunctionComponent = () => {
           resolvePath={(data: DataSourcesLines_data$data) => data.dataSources?.edges?.map((e) => e?.node)}
           storageKey={LOCAL_STORAGE_KEY_DATA_SOURCES}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={preloadedPaginationOptions}
           lineFragment={dataSourceLineFragment}
           exportContext={{ entity_type: 'Data-Source' }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/Narratives.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/Narratives.tsx
@@ -177,7 +177,7 @@ const Narratives: FunctionComponent = () => {
             lineFragment={narrativeLineFragment}
             resolvePath={(data: NarrativesLines_data$data) => data.narratives?.edges?.map(({ node }) => node)}
             preloadedPaginationProps={preloadedPaginationProps}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             additionalHeaderButtons={[
               (
                 <Tooltip key={'lines'} title={t_i18n('Lines view')}>

--- a/opencti-platform/opencti-front/src/private/components/threats/Campaigns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/Campaigns.tsx
@@ -165,7 +165,7 @@ const Campaigns = () => {
             resolvePath={(data: CampaignsCards_data$data) => data.campaigns?.edges?.map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={CampaignCardFragment}
             exportContext={{ entity_type: 'Campaign' }}

--- a/opencti-platform/opencti-front/src/private/components/threats/IntrusionSets.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/IntrusionSets.tsx
@@ -161,7 +161,7 @@ const IntrusionSets = () => {
             resolvePath={(data: IntrusionSetsCards_data$data) => data.intrusionSets?.edges?.map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={IntrusionSetCardFragment}
             exportContext={{ entity_type: 'Intrusion-Set' }}

--- a/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsGroup.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsGroup.tsx
@@ -166,7 +166,7 @@ const ThreatActorsGroup = () => {
             resolvePath={(data: ThreatActorsGroupCards_data$data) => data.threatActorsGroup?.edges?.map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={ThreatActorGroupCardFragment}
             exportContext={{ entity_type: 'Threat-Actor-Group' }}

--- a/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsIndividual.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/ThreatActorsIndividual.tsx
@@ -169,7 +169,7 @@ const ThreatActorsIndividual = () => {
             resolvePath={(data: ThreatActorsIndividualCards_data$data) => data.threatActorsIndividuals?.edges?.map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY_THREAT_ACTORS_INDIVIDUAL}
             initialValues={initialValues}
-            toolbarFilters={contextFilters}
+            contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={ThreatActorIndividualCardFragment}
             exportContext={{ entity_type: 'Threat-Actor-Individual' }}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/Workspaces.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/Workspaces.tsx
@@ -189,7 +189,7 @@ const Workspaces: FunctionComponent<WorkspacesProps> = ({
           }}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialStorageValues}
-          toolbarFilters={filters}
+          contextFilters={filters}
           preloadedPaginationProps={{
             linesQuery: workspacesLinesQuery,
             linesFragment: workspacesLineFragment,

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboards.tsx
@@ -194,7 +194,7 @@ const PublicDashboards = () => {
           }}
           storageKey={LOCAL_STORAGE_KEY}
           initialValues={initialValues}
-          toolbarFilters={contextFilters}
+          contextFilters={contextFilters}
           preloadedPaginationProps={{
             linesQuery: publicDashboardsListQuery,
             linesFragment: publicDashboardsFragment,


### PR DESCRIPTION
### Proposed changes
- Keep context filters when exporting entities
- Rename 'toolbarFilters' in 'contextFilters' since this filters are not only used in the toolbar anymore (also used in export, there are filters of context the page and should be additionned to the filters in local storage)

### Related issues
#13428