### PR TITLE
[frontend] resend code input disabled (#13380)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "Das öffentliche Dashboard ist deaktiviert",
   "The relations attached to selected entities will be copied to the merged entity.": "Die Beziehungen, die mit den ausgewählten Entitäten verbunden sind, werden in die zusammengeführte Entität kopiert.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "Der von Ihnen eingegebene Rücksetzungscode ist ungültig oder abgelaufen. Sie können nach einer Verzögerung von 30 Sekunden einen neuen Code anfordern.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "Der von Ihnen eingegebene Rückstellcode ist ungültig oder abgelaufen. Sie können einen neuen Code anfordern.",
   "The retention policy will be applied on global files (files contained in": "Die Aufbewahrungsrichtlinie wird auf globale Dateien angewendet (Dateien, die in",
   "The retention policy will be applied on global workbenches (workbenches contained in": "Die Aufbewahrungsrichtlinie wird auf globale Werkbänke angewandt (Werkbänke, die in",
   "The rule has been disabled, clean-up launched...": "Die Regel wurde deaktiviert, Bereinigung eingeleitet...",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "The public dashboard is disabled",
   "The relations attached to selected entities will be copied to the merged entity.": "The relations attached to selected entities will be copied to the merged entity.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "The reset code you entered is invalid or has expired. You can request a new code.",
   "The retention policy will be applied on global files (files contained in": "The retention policy will be applied on global files (files contained in",
   "The retention policy will be applied on global workbenches (workbenches contained in": "The retention policy will be applied on global workbenches (workbenches contained in",
   "The rule has been disabled, clean-up launched...": "The rule has been disabled, clean-up launched...",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "El panel público está desactivado",
   "The relations attached to selected entities will be copied to the merged entity.": "Las relaciones adjuntadas a las entidades seleccionadas serán copiadas a la entidad fusionada.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "El código de restablecimiento que ha introducido no es válido o ha caducado. Puede solicitar un nuevo código tras un retraso de 30 segundos.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "El código de restablecimiento introducido no es válido o ha caducado. Puedes solicitar un nuevo código.",
   "The retention policy will be applied on global files (files contained in": "La política de retención se aplicará a los ficheros globales (ficheros contenidos en",
   "The retention policy will be applied on global workbenches (workbenches contained in": "La política de retención se aplicará a los bancos de trabajo globales (bancos de trabajo contenidos en",
   "The rule has been disabled, clean-up launched...": "La regla ha sido desactivada, limpieza lanzada...",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "Le tableau de bord public est désactivé",
   "The relations attached to selected entities will be copied to the merged entity.": "Les relations attachées aux entités sélectionnées seront copiées sur l'entité fusionnée.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "Le code de réinitialisation que vous avez saisi n'est pas valide ou a expiré. Vous pouvez demander un nouveau code après un délai de 30 secondes.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "Le code de réinitialisation que vous avez saisi n'est pas valide ou a expiré. Vous pouvez demander un nouveau code.",
   "The retention policy will be applied on global files (files contained in": "La politique de conservation sera appliquée aux fichiers globaux (fichiers contenus dans",
   "The retention policy will be applied on global workbenches (workbenches contained in": "La politique de conservation sera appliquée sur les postes de travail globaux (postes de travail contenus dans",
   "The rule has been disabled, clean-up launched...": "La règle a été déséactivée, purge lancée...",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "La dashboard pubblica è disabilitata",
   "The relations attached to selected entities will be copied to the merged entity.": "La relazione allegata alle entità selezionate verrà copiata nell'entità unita.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "Il codice di ripristino inserito non è valido o è scaduto. È possibile richiedere un nuovo codice dopo un ritardo di 30 secondi.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "Il codice di ripristino inserito non è valido o è scaduto. È possibile richiedere un nuovo codice.",
   "The retention policy will be applied on global files (files contained in": "Le polizza di ritenzione verranno applicate a file globali (file contenuti in",
   "The retention policy will be applied on global workbenches (workbenches contained in": "Le polizza di ritenzione verranno applicate a workbench globali (workbench contenuti in",
   "The rule has been disabled, clean-up launched...": "La regola è stata disabilitata, pulizia avviata...",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "公開ダッシュボードは無効",
   "The relations attached to selected entities will be copied to the merged entity.": "選択されたエンティティに付属するリレーションは、マージされたエンティティにコピーされます。",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "入力されたリセットコードが無効であるか、有効期限が切れています。30秒後に新しいコードをリクエストできます。",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "入力されたリセットコードが無効であるか、有効期限が切れています。新しいコードをリクエストしてください。",
   "The retention policy will be applied on global files (files contained in": "に含まれるファイル）に適用されます。",
   "The retention policy will be applied on global workbenches (workbenches contained in": "に含まれるワークベンチ）に適用されます。",
   "The rule has been disabled, clean-up launched...": "ルールは無効化され、クリーンアップが開始されました...",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "공용 대시보드가 비활성화되었습니다",
   "The relations attached to selected entities will be copied to the merged entity.": "선택된 엔터티에 연결된 관계가 병합된 엔터티로 복사됩니다.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "입력한 재설정 코드가 유효하지 않거나 만료되었습니다. 30초 후에 새 코드를 요청할 수 있습니다.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "입력한 재설정 코드가 유효하지 않거나 만료되었습니다. 새 코드를 요청할 수 있습니다.",
   "The retention policy will be applied on global files (files contained in": "보존 정책은 글로벌 파일(",
   "The retention policy will be applied on global workbenches (workbenches contained in": "에 포함된 파일)에 적용됩니다",
   "The rule has been disabled, clean-up launched...": "규칙이 비활성화되었습니다, 정리 시작...",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "Публичнаый дашборд отключена",
   "The relations attached to selected entities will be copied to the merged entity.": "Отношения, привязанные к выбранным сущностям, будут скопированы в объединенную сущность.",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "Введенный вами код сброса недействителен или срок его действия истек. Вы можете запросить новый код после задержки в 30 секунд.",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "Введенный вами код сброса недействителен или срок его действия истек. Вы можете запросить новый код.",
   "The retention policy will be applied on global files (files contained in": "Политика хранения будет применяться к глобальным файлам (файлам, содержащимся в",
   "The retention policy will be applied on global workbenches (workbenches contained in": "Политика хранения будет применяться к глобальным рабочим столам (рабочие столы, содержащиеся в",
   "The rule has been disabled, clean-up launched...": "Правило было отключено, началась очистка...",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3789,6 +3789,7 @@
   "The public dashboard is disabled": "公共仪表板已禁用",
   "The relations attached to selected entities will be copied to the merged entity.": "附加到选定实体的关系将复制到归并的实体中。",
   "The reset code you entered is invalid or has expired. You can request a new code after a delay of 30 seconds.": "您输入的重置密码无效或已过期。您可以在延迟 30 秒后申请新代码。",
+  "The reset code you entered is invalid or has expired. You can request a new code.": "您输入的重置密码无效或已过期。您可以申请新的代码。",
   "The retention policy will be applied on global files (files contained in": "保留策略将应用于全局文件（包含在",
   "The retention policy will be applied on global workbenches (workbenches contained in": "保留策略将应用于全局工作台（工作台包含在",
   "The rule has been disabled, clean-up launched...": "该规则已禁用，清理已启动",

--- a/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
+++ b/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
@@ -110,7 +110,6 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
   const [transactionId, setTransactionId] = useState('');
   const [otp, setOtp] = useState('');
 
-  const [askOtpError, setAskOtpError] = useState(false);
   const [validateOtpError, setValidateOtpError] = useState(false);
   const [changePasswordError, setChangePasswordError] = useState(false);
   const [resendCodeDisabled, setResendCodeDisabled] = useState(false);
@@ -189,10 +188,9 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
         startResendCooldown();
       },
       onError: (error) => {
-        setAskOtpError(true);
         handleErrorInForm(error, setErrors);
         setSubmitting(false);
-        startResendCooldown(() => setAskOtpError(false));
+        startResendCooldown();
       }
     });
   };

--- a/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
+++ b/opencti-platform/opencti-front/src/public/components/ResetPassword.tsx
@@ -262,14 +262,6 @@ const ResetPassword: FunctionComponent<ResetProps> = ({ onCancel, email, setEmai
           {({ isSubmitting, isValid }) => {
             return (
               <Form>
-                {
-                  askOtpError && (
-                    <AlertMessage 
-                      severity="error" 
-                      text={t_i18n('You have already requested a new code to reset your password. You can request a new code after a delay of 30 seconds.')}
-                    />
-                  )
-                }
                 <Field
                   component={TextField}
                   name="email"

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -2,7 +2,7 @@ import { authenticator } from 'otplib';
 import bcrypt from 'bcryptjs';
 import { v4 as uuid } from 'uuid';
 import { findById, getUserByEmail, userEditField } from '../../domain/user';
-import { AuthenticationFailure, FunctionalError, UnsupportedError } from '../../config/errors';
+import { AuthenticationFailure, UnsupportedError } from '../../config/errors';
 import { sendMail, smtpComputeFrom } from '../../database/smtp';
 import type { AuthContext } from '../../types/user';
 import type { AskSendOtpInput, ChangePasswordInput, VerifyMfaInput, VerifyOtpInput } from '../../generated/graphql';
@@ -56,9 +56,7 @@ export const askSendOtp = async (context: AuthContext, input: AskSendOtpInput) =
   // Don't generate new redis key under 30-second delay
   const previousKey = await redisGetForgotPasswordOtpPointer(input.email);
   const isTooRecent = previousKey.ttl > (OTP_TTL - 30);
-  if (isTooRecent) {
-    return transactionId;
-  } 
+  if (isTooRecent) return transactionId;
 
   // Delete the previous OTP if it exists based on the pointer
   if (previousKey.id) await redisDelForgotPassword(previousKey.id, email);

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -56,10 +56,8 @@ export const askSendOtp = async (context: AuthContext, input: AskSendOtpInput) =
   // Don't generate new redis key under 30-second delay
   const previousKey = await redisGetForgotPasswordOtpPointer(input.email);
   const isTooRecent = previousKey.ttl > (OTP_TTL - 30);
-  console.log('isTooRecent ?? ', isTooRecent, '--- previousKey.ttl',  previousKey.ttl, ' OTP_TTL - 30', OTP_TTL - 30);
   if (isTooRecent) {
-    // return transactionId;
-    throw FunctionalError('remaining time too recent', { ttl: previousKey.ttl });
+    return transactionId;
   } 
 
   // Delete the previous OTP if it exists based on the pointer

--- a/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/auth/auth-domain.ts
@@ -2,7 +2,7 @@ import { authenticator } from 'otplib';
 import bcrypt from 'bcryptjs';
 import { v4 as uuid } from 'uuid';
 import { findById, getUserByEmail, userEditField } from '../../domain/user';
-import { AuthenticationFailure, UnsupportedError } from '../../config/errors';
+import { AuthenticationFailure, FunctionalError, UnsupportedError } from '../../config/errors';
 import { sendMail, smtpComputeFrom } from '../../database/smtp';
 import type { AuthContext } from '../../types/user';
 import type { AskSendOtpInput, ChangePasswordInput, VerifyMfaInput, VerifyOtpInput } from '../../generated/graphql';
@@ -56,7 +56,11 @@ export const askSendOtp = async (context: AuthContext, input: AskSendOtpInput) =
   // Don't generate new redis key under 30-second delay
   const previousKey = await redisGetForgotPasswordOtpPointer(input.email);
   const isTooRecent = previousKey.ttl > (OTP_TTL - 30);
-  if (isTooRecent) return transactionId;
+  console.log('isTooRecent ?? ', isTooRecent, '--- previousKey.ttl',  previousKey.ttl, ' OTP_TTL - 30', OTP_TTL - 30);
+  if (isTooRecent) {
+    // return transactionId;
+    throw FunctionalError('remaining time too recent', { ttl: previousKey.ttl });
+  } 
 
   // Delete the previous OTP if it exists based on the pointer
   if (previousKey.id) await redisDelForgotPassword(previousKey.id, email);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

https://github.com/user-attachments/assets/6300c463-36ac-4ab6-89db-b2f1d793ccc3


* The input field remain editable in all cases
* Resend code link is disabled for 30 secs
* The code has been a little refactored to handle the reset cooldown, factorize Alert message as a component, 
* remove Ramda function and rename some states to be more meaningful

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13380 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
