### PR TITLE
[worker/client] add ability to specify a provider in API client user agent

### DIFF
--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import tempfile
 import threading
+import re
 from typing import Dict, Tuple, Union
 
 import magic
@@ -92,10 +93,14 @@ _PROXY_SIGNAL_HANDLERS_REGISTERED = False
 
 
 def build_request_headers(token: str, custom_headers: str, app_logger, provider: str):
-    pycti_user_agent = "pycti/"
+    pycti_user_agent = "pycti/" + __version__
     if provider is not None:
-        pycti_user_agent += provider + "/"
-    pycti_user_agent += __version__
+        provider_pattern_checker = re.compile(r"^[A-Za-z]+\/\d+(?:\.\d+){0,2}$")
+        if not provider_pattern_checker.match(provider):
+            raise ValueError(
+                "Provider format is incorrect: format has to be {provider}/{provider_version}, e.g. client/4.5, company_name/1.4.6..."
+            )
+        pycti_user_agent += " " + provider
     headers_dict = {
         "User-Agent": pycti_user_agent,
         "Authorization": "Bearer " + token,

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -5,11 +5,11 @@ import datetime
 import io
 import json
 import os
+import re
 import shutil
 import signal
 import tempfile
 import threading
-import re
 from typing import Dict, Tuple, Union
 
 import magic

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -95,11 +95,6 @@ _PROXY_SIGNAL_HANDLERS_REGISTERED = False
 def build_request_headers(token: str, custom_headers: str, app_logger, provider: str):
     pycti_user_agent = "pycti/" + __version__
     if provider is not None:
-        provider_pattern_checker = re.compile(r"^[A-Za-z]+\/\d+(?:\.\d+){0,2}$")
-        if not provider_pattern_checker.match(provider):
-            raise ValueError(
-                "Provider format is incorrect: format has to be {provider}/{provider_version}, e.g. client/4.5, company_name/1.4.6..."
-            )
         pycti_user_agent += " " + provider
     headers_dict = {
         "User-Agent": pycti_user_agent,
@@ -199,6 +194,12 @@ class OpenCTIApiClient:
         # Define API
         self.api_token = token
         self.api_url = url + "/graphql"
+        if provider is not None:
+            provider_pattern_checker = re.compile(r"^[A-Za-z]+\/\d+(?:\.\d+){0,2}$")
+            if not provider_pattern_checker.match(provider):
+                raise ValueError(
+                    "Provider format is incorrect: format has to be {provider}/{provider_version}, e.g. client/4.5, company_name/1.4.6..."
+                )
         self.provider = provider
         self.request_headers = build_request_headers(
             token, custom_headers, self.app_logger, provider

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -91,9 +91,13 @@ _PROXY_CERT_LOCK = threading.Lock()
 _PROXY_SIGNAL_HANDLERS_REGISTERED = False
 
 
-def build_request_headers(token: str, custom_headers: str, app_logger):
+def build_request_headers(token: str, custom_headers: str, app_logger, provider: str):
+    pycti_user_agent = "pycti/"
+    if provider is not None:
+        pycti_user_agent += provider + "/"
+    pycti_user_agent += __version__
     headers_dict = {
-        "User-Agent": "pycti/" + __version__,
+        "User-Agent": pycti_user_agent,
         "Authorization": "Bearer " + token,
     }
     # Build and add custom headers
@@ -148,6 +152,8 @@ class OpenCTIApiClient:
     :type perform_health_check: bool, optional
     :param requests_timeout: define the timeout for API requests in seconds
     :type requests_timeout: int, optional
+    :param provider: define client provider, and is used to specify it in requests user agent header
+    :type provider: string, optional
     """
 
     def __init__(
@@ -163,6 +169,7 @@ class OpenCTIApiClient:
         custom_headers: str = None,
         perform_health_check: bool = True,
         requests_timeout: int = 300,
+        provider: str = None
     ):
         """Constructor method"""
 
@@ -187,8 +194,9 @@ class OpenCTIApiClient:
         # Define API
         self.api_token = token
         self.api_url = url + "/graphql"
+        self.provider = provider
         self.request_headers = build_request_headers(
-            token, custom_headers, self.app_logger
+            token, custom_headers, self.app_logger, provider
         )
         self.session = requests.session()
         self.session_requests_timeout = requests_timeout

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -174,7 +174,7 @@ class OpenCTIApiClient:
         custom_headers: str = None,
         perform_health_check: bool = True,
         requests_timeout: int = 300,
-        provider: str = None
+        provider: str = None,
     ):
         """Constructor method"""
 

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -186,6 +186,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             perform_health_check=False,  # No need to prevent worker start if API is not available yet
             custom_headers=self.opencti_api_custom_headers,
             requests_timeout=self.opencti_api_requests_timeout,
+            provider='worker'
         )
         self.worker_logger = self.api.logger_class("worker")
 

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -186,7 +186,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             perform_health_check=False,  # No need to prevent worker start if API is not available yet
             custom_headers=self.opencti_api_custom_headers,
             requests_timeout=self.opencti_api_requests_timeout,
-            provider="worker/1.0"
+            provider="worker/1.0",
         )
         self.worker_logger = self.api.logger_class("worker")
 

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -186,7 +186,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             perform_health_check=False,  # No need to prevent worker start if API is not available yet
             custom_headers=self.opencti_api_custom_headers,
             requests_timeout=self.opencti_api_requests_timeout,
-            provider='worker'
+            provider="worker"
         )
         self.worker_logger = self.api.logger_class("worker")
 

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -13,14 +13,14 @@ from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from prometheus_client import start_http_server
-from pycti import OpenCTIApiClient
+from pycti import OpenCTIApiClient, __version__
 from pycti.connector.opencti_connector_helper import (
     create_mq_ssl_context,
     get_config_variable,
 )
 
-from message_queue_consumer import MessageQueueConsumer
 from listen_handler import ListenHandler
+from message_queue_consumer import MessageQueueConsumer
 from push_handler import PushHandler
 from thread_pool_selector import ThreadPoolSelector
 
@@ -186,7 +186,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             perform_health_check=False,  # No need to prevent worker start if API is not available yet
             custom_headers=self.opencti_api_custom_headers,
             requests_timeout=self.opencti_api_requests_timeout,
-            provider="worker/1.0",
+            provider="worker/" + __version__,
         )
         self.worker_logger = self.api.logger_class("worker")
 

--- a/opencti-worker/src/worker.py
+++ b/opencti-worker/src/worker.py
@@ -186,7 +186,7 @@ class Worker:  # pylint: disable=too-few-public-methods, too-many-instance-attri
             perform_health_check=False,  # No need to prevent worker start if API is not available yet
             custom_headers=self.opencti_api_custom_headers,
             requests_timeout=self.opencti_api_requests_timeout,
-            provider="worker"
+            provider="worker/1.0"
         )
         self.worker_logger = self.api.logger_class("worker")
 


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  add ability to specify a provider in API client user agent
* worker now registers in API client as "worker" provider. It's user agent will now be "pycti/worker/${pycti_version}"

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
