### PR TITLE
[worker/client] add ability to customize API requests timeout in OpenCTIApiClient init and in worker config

### DIFF
--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -610,7 +610,7 @@ class OpenCTIApiClient:
             verify=self.ssl_verify,
             cert=self.cert,
             proxies=self.proxies,
-            timeout=300,
+            timeout=self.session_requests_timeout,
         )
         if binary:
             if serialize:

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -146,6 +146,8 @@ class OpenCTIApiClient:
     :type custom_headers: str, optional must in the format header01:value;header02:value
     :param perform_health_check: if client init must check the api access
     :type perform_health_check: bool, optional
+    :param requests_timeout: define the timeout for API requests in seconds
+    :type requests_timeout: int, optional
     """
 
     def __init__(
@@ -160,6 +162,7 @@ class OpenCTIApiClient:
         cert: Union[str, Tuple[str, str], None] = None,
         custom_headers: str = None,
         perform_health_check: bool = True,
+        requests_timeout: int = 300,
     ):
         """Constructor method"""
 
@@ -188,6 +191,7 @@ class OpenCTIApiClient:
             token, custom_headers, self.app_logger
         )
         self.session = requests.session()
+        self.session_requests_timeout = requests_timeout
         # Define the dependencies
         self.work = OpenCTIApiWork(self)
         self.notification = OpenCTIApiNotification(self)
@@ -551,7 +555,7 @@ class OpenCTIApiClient:
                 verify=self.ssl_verify,
                 cert=self.cert,
                 proxies=self.proxies,
-                timeout=300,
+                timeout=self.session_requests_timeout,
             )
         # If no
         else:
@@ -562,7 +566,7 @@ class OpenCTIApiClient:
                 verify=self.ssl_verify,
                 cert=self.cert,
                 proxies=self.proxies,
-                timeout=300,
+                timeout=self.session_requests_timeout,
             )
         # Build response
         if r.status_code == 200:


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Some heavy requests can sometime take longer to process than the default 5minutes timeout in the request timeout (rule apply operations for example). There is currently no way to configure and change this default 5 minutes timeout. The goal of the change here is to make this timeout configurable in the worker
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
