### PR TITLE
[frontend] fix check bypass include capa with bypassref and bypassfields (#10981)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/hooks/useGranted.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useGranted.ts
@@ -1,4 +1,3 @@
-import { filter, includes } from 'ramda';
 import useAuth from './useAuth';
 
 export const OPENCTI_ADMIN_UUID = '88ec0c6a-13ce-5e39-b486-354fe4a7084f';
@@ -74,9 +73,8 @@ const useGranted = (capabilities: string[], matchAll = false): boolean => {
   let numberOfAvailableCapabilities = 0;
   for (let index = 0; index < capabilities.length; index += 1) {
     const checkCapability = capabilities[index];
-    const matchingCapabilities = filter(
-      (r) => includes(checkCapability, r),
-      userCapabilities,
+    const matchingCapabilities = userCapabilities.filter(
+      (capa) => checkCapability !== BYPASS && capa.includes(checkCapability)
     );
     if (matchingCapabilities.length > 0) {
       numberOfAvailableCapabilities += 1;


### PR DESCRIPTION
### Proposed changes

* don't check if the name of the user capa `includes` the name of the capa checked for the `bypass` capa, because the string 'BYPASS' is includes in 'KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE', and the 'BYPASS' check is already executed before this condition.
* Can be tested by check if a user with 'KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE' can see the entry `Data/restriction` in the left menu

### Related issues

* #10981

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality