### PR TITLE
[frontend] entity type filter possible values should be scr in Data>Relationships (#13461)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
@@ -333,6 +333,7 @@ const Relationships = () => {
           lineFragment={relationshipsStixCoreRelationshipsLineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
           exportContext={{ entity_type: 'stix-core-relationship' }}
+          availableEntityTypes={['stix-core-relationship']}
         />
       )}
     </div>

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -782,6 +782,7 @@ const useSearchEntities = ({
             && !availableEntityTypes.includes('Stix-Cyber-Observable')
             && !availableEntityTypes.includes('Stix-Domain-Object')
             && !availableEntityTypes.includes('Stix-Core-Object')
+            && !availableEntityTypes.includes('stix-core-relationship')
           ) {
             let completedAvailableEntityTypes = availableEntityTypes;
             if (availableEntityTypes.includes('Container')) {


### PR DESCRIPTION
### Proposed changes
In Data > Relationships, the 'entity type' filter possible values should only be stix core relationships.

<img width="1867" height="724" alt="image" src="https://github.com/user-attachments/assets/f1caf87c-aa8f-4e8d-872a-4ccded738cf8" />


### Related issues
https://github.com/OpenCTI-Platform/opencti/issues/13461
https://github.com/OpenCTI-Platform/opencti/issues/11336