### PR TITLE
[Frontend] Corrected naming in multi horizontal bar widget legend (#13062)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars.jsx
@@ -448,13 +448,13 @@ const StixRelationshipsMultiHorizontalBars = ({
                     distributionKey = getMainRepresentative(distribution.entity, t_i18n('Restricted'))
                   } else if(distribution.entity) {
                     distributionKey = 
-                    distribution.entity.name 
-                    ? distribution.entity.name
-                    : distribution.entity.representative
-                      ? getMainRepresentative(distribution.entity, t_i18n('Restricted'))
+                    distribution.entity.representative
+                    ? getMainRepresentative(distribution.entity, t_i18n('Restricted'))
+                    : distribution.entity.name
+                      ? distribution.entity.name
                       : distribution.entity.label
                         ? distribution.entity.label 
-                        : ''
+                        : distribution.label
                   } else {
                     distributionKey = distribution.label
                   }
@@ -508,7 +508,7 @@ const StixRelationshipsMultiHorizontalBars = ({
               data: Object.entries(categoriesValues).map((category) => category[1][index])
               };
             })
-            // To avoid displaying empty categories - especially for 'Others' category
+            // To avoid displaying empty categories - especially for 'Others'
             .filter(entity => entity.data.some(data => data > 0))
 
             let subSectionIdsOrder = [];

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars.jsx
@@ -445,7 +445,7 @@ const StixRelationshipsMultiHorizontalBars = ({
             const getDistributionKey = (distribution) => {
                   let distributionKey;
                   if(finalSubDistributionField === 'internal_id') {
-                    distributionKey = getMainRepresentative(distribution.entity, t_i18n('Restricted'))
+                    distributionKey = getMainRepresentative(distribution.entity, t_i18n('Restricted'));
                   } else if(distribution.entity) {
                     distributionKey = 
                     distribution.entity.representative
@@ -454,12 +454,12 @@ const StixRelationshipsMultiHorizontalBars = ({
                       ? distribution.entity.name
                       : distribution.entity.label
                         ? distribution.entity.label 
-                        : distribution.label
+                        : distribution.label;
                   } else {
-                    distributionKey = distribution.label
+                    distributionKey = distribution.label;
                   }
                   return distributionKey;
-                  }
+                  };
             for (const distrib of props.stixRelationshipsDistribution) {
               for (const subDistrib of distrib.entity[distributionKey]) {
                 const subDistributionKey = getDistributionKey(subDistrib);
@@ -509,7 +509,7 @@ const StixRelationshipsMultiHorizontalBars = ({
               };
             })
             // To avoid displaying empty categories - especially for 'Others'
-            .filter(entity => entity.data.some(data => data > 0))
+            .filter(entity => entity.data.some(data => data > 0));
 
             let subSectionIdsOrder = [];
             if (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.jsx
@@ -374,7 +374,10 @@ const StixRelationshipsMultiHorizontalBars = ({
         }
       }
     }
+    
     const finalField = selection.attribute || field || 'entity_type';
+    const finalSubDistributionField = subSelection.attribute || field || 'entity_type';
+    
     let variables = {
       field: finalField,
       operation: 'count',
@@ -387,7 +390,7 @@ const StixRelationshipsMultiHorizontalBars = ({
       dynamicFrom: selection.dynamicFrom,
       dynamicTo: selection.dynamicTo,
     };
-    const finalSubDistributionField = subSelection.attribute || field || 'entity_type';
+    
     if (subSelection.perspective === 'entities') {
       variables = {
         ...variables,
@@ -421,36 +424,38 @@ const StixRelationshipsMultiHorizontalBars = ({
     }
 
     const queryToCall = subSelection.perspective === 'entities'
-            ? stixRelationshipsMultiHorizontalBarsWithEntitiesDistributionQuery
-            : stixRelationshipsMultiHorizontalBarsWithRelationshipsDistributionQuery;
+      ? stixRelationshipsMultiHorizontalBarsWithEntitiesDistributionQuery
+      : stixRelationshipsMultiHorizontalBarsWithRelationshipsDistributionQuery;
 
     const dataFromQuery = useLazyLoadQuery(queryToCall, variables);
+    
     const {
-                chartData,
-                redirectionUtils,
-                categories
-              } = useStixRelationshipsMultiHorizontalBars(subSelection, dataFromQuery.stixRelationshipsDistribution, finalSubDistributionField, finalField);
+      chartData,
+      redirectionUtils,
+      categories
+    } = useStixRelationshipsMultiHorizontalBars(subSelection, dataFromQuery.stixRelationshipsDistribution, finalSubDistributionField, finalField);
 
-              if(dataFromQuery.stixRelationshipsDistribution && dataFromQuery.stixRelationshipsDistribution.length > 0){
-                return (
-                  <WidgetHorizontalBars
-                    series={chartData}
-                    distributed={parameters.distributed}
-                    withExport={withExportPopover}
-                    readonly={isReadOnly}
-                    redirectionUtils={redirectionUtils}
-                    stacked
-                    total
-                    legend
-                    categories={categories}
-                  />
-            );
-              } 
-              if (dataFromQuery) {
-                return <WidgetNoData />;
-              }
-              return <Loader variant={LoaderVariant.inElement} />;
+    if(dataFromQuery.stixRelationshipsDistribution && dataFromQuery.stixRelationshipsDistribution.length > 0){
+        return (
+          <WidgetHorizontalBars
+            series={chartData}
+            distributed={parameters.distributed}
+            withExport={withExportPopover}
+            readonly={isReadOnly}
+            redirectionUtils={redirectionUtils}
+            stacked
+            total
+            legend
+            categories={categories}
+          />
+      );
+    } 
+    if (dataFromQuery) {
+      return <WidgetNoData />;
+    }
+    return <Loader variant={LoaderVariant.inElement} />;
   };
+
   return (
     <WidgetContainer
       height={height}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.jsx
@@ -366,7 +366,6 @@ const StixRelationshipsMultiHorizontalBars = ({
       selection = dataSelection[0];
       filtersAndOptions = buildFiltersAndOptionsForWidgets(selection.filters, { isKnowledgeRelationshipWidget: true });
       if (dataSelection.length > 1) {
-         
         subSelection = dataSelection[1];
         subDistributionFiltersAndOptions = buildFiltersAndOptionsForWidgets(subSelection.filters, { isKnowledgeRelationshipWidget: true });
         if (subSelection.perspective === 'entities') {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
@@ -1,5 +1,4 @@
 import { getMainRepresentative } from '../../../../../utils/defaultRepresentatives';
-import * as R from 'ramda';
 import { useFormatter } from '../../../../../components/i18n';
 
 export const useStixRelationshipsMultiHorizontalBars = (
@@ -9,6 +8,8 @@ export const useStixRelationshipsMultiHorizontalBars = (
   finalField
 ) => {
   const { t_i18n } = useFormatter();
+  const DEFAULT_SUBSELECTION_NUMBER = 15;
+  const subSelectionNumber = subSelection.number ?? DEFAULT_SUBSELECTION_NUMBER;
   const distributionKey =
     subSelection.perspective === 'entities'
       ? 'stixCoreObjectsDistribution'
@@ -48,20 +49,15 @@ export const useStixRelationshipsMultiHorizontalBars = (
     }
   }
 
-  const sortedEntityMapping = R.take(
-    subSelection.number ?? 15,
-    Object.entries(entitiesMapping).sort(([, a], [, b]) => b - a)
-  );
+  const sortedEntityMapping = Object.entries(entitiesMapping)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0,subSelectionNumber);
 
   const categoriesValues = {};
   for (const distrib of stixRelationshipsDistribution) {
     for (const sortedEntity of sortedEntityMapping) {
-      const entityData = R.head(
-        distrib.entity?.[distributionKey].filter(
-          (entityDistrib) =>
-            getDistributionKey(entityDistrib) === sortedEntity[0]
-        )
-      );
+      const entityData = distrib.entity?.[distributionKey]
+      .filter((entityDistrib) =>getDistributionKey(entityDistrib) === sortedEntity[0])[0];
       let value = 0;
       if (entityData) {
         value = entityData.value;
@@ -111,12 +107,10 @@ export const useStixRelationshipsMultiHorizontalBars = (
           (subSectionIdsOrder[subDistrib.label] || 0) + subDistrib.value;
       }
     }
-    subSectionIdsOrder = R.take(
-      subSelection.number ?? 15,
-      Object.entries(subSectionIdsOrder)
+    subSectionIdsOrder = Object.entries(subSectionIdsOrder)
         .sort(([, a], [, b]) => b - a)
         .map((k) => k[0])
-    );
+        .slice(0, subSelectionNumber);
   }
 
   const redirectionUtils =

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
@@ -1,0 +1,139 @@
+import { getMainRepresentative } from '../../../../../utils/defaultRepresentatives';
+import * as R from 'ramda';
+import { useFormatter } from '../../../../../components/i18n';
+
+export const useStixRelationshipsMultiHorizontalBars = (
+  subSelection,
+  stixRelationshipsDistribution,
+  finalSubDistributionField,
+  finalField
+) => {
+  const { t_i18n } = useFormatter();
+  const distributionKey =
+    subSelection.perspective === 'entities'
+      ? 'stixCoreObjectsDistribution'
+      : 'stixCoreRelationshipsDistribution';
+
+  const categories = stixRelationshipsDistribution.map((n) =>
+    getMainRepresentative(n.entity, t_i18n('Restricted'))
+  );
+  const entitiesMapping = {};
+  const getDistributionKey = (distribution) => {
+    let distributionKey;
+    if (finalSubDistributionField === 'internal_id') {
+      distributionKey = getMainRepresentative(
+        distribution.entity,
+        t_i18n('Restricted')
+      );
+    } else if (distribution.entity) {
+      distributionKey = distribution.entity.representative
+        ? getMainRepresentative(distribution.entity, t_i18n('Restricted'))
+        : distribution.entity.name
+          ? distribution.entity.name
+          : distribution.entity.label
+            ? distribution.entity.label
+            : distribution.label;
+    } else {
+      distributionKey = distribution.label;
+    }
+    return distributionKey;
+  };
+  for (const distrib of stixRelationshipsDistribution) {
+    for (const subDistrib of distrib.entity[distributionKey]) {
+      const subDistributionKey = getDistributionKey(subDistrib);
+      entitiesMapping[subDistributionKey] =
+        (entitiesMapping[subDistributionKey] || 0) + subDistrib.value;
+    }
+  }
+  const sortedEntityMapping = R.take(
+    subSelection.number ?? 15,
+    Object.entries(entitiesMapping).sort(([, a], [, b]) => b - a)
+  );
+  const categoriesValues = {};
+  for (const distrib of stixRelationshipsDistribution) {
+    for (const sortedEntity of sortedEntityMapping) {
+      const entityData = R.head(
+        distrib.entity?.[distributionKey].filter(
+          (entityDistrib) =>
+            getDistributionKey(entityDistrib) === sortedEntity[0]
+        )
+      );
+      let value = 0;
+      if (entityData) {
+        value = entityData.value;
+      }
+      if (categoriesValues[getMainRepresentative(distrib.entity)]) {
+        categoriesValues[getMainRepresentative(distrib.entity)].push(value);
+      } else {
+        categoriesValues[getMainRepresentative(distrib.entity)] = [value];
+      }
+    }
+    const sum = (
+      categoriesValues[getMainRepresentative(distrib.entity)] || []
+    ).reduce((partialSum, a) => partialSum + a, 0);
+    if (categoriesValues[getMainRepresentative(distrib.entity)]) {
+      categoriesValues[getMainRepresentative(distrib.entity)].push(
+        distrib.value - sum
+      );
+    } else {
+      categoriesValues[getMainRepresentative(distrib.entity)] = [
+        distrib.value - sum,
+      ];
+    }
+  }
+  sortedEntityMapping.push(['Others', 0]);
+  const chartData = sortedEntityMapping
+    .map((sortedEntity, index) => {
+      return {
+        name: sortedEntity[0],
+        data: Object.entries(categoriesValues).map(
+          (category) => category[1][index]
+        ),
+      };
+    })
+    // To avoid displaying empty categories - especially for 'Others'
+    .filter((entity) => entity.data.some((data) => data > 0));
+
+  let subSectionIdsOrder = [];
+  if (
+    finalField === 'internal_id' &&
+    finalSubDistributionField === 'internal_id'
+  ) {
+    // find subbars orders for entity subbars redirection
+    for (const distrib of stixRelationshipsDistribution) {
+      for (const subDistrib of distrib.entity[distributionKey]) {
+        subSectionIdsOrder[subDistrib.label] =
+          (subSectionIdsOrder[subDistrib.label] || 0) + subDistrib.value;
+      }
+    }
+    subSectionIdsOrder = R.take(
+      subSelection.number ?? 15,
+      Object.entries(subSectionIdsOrder)
+        .sort(([, a], [, b]) => b - a)
+        .map((k) => k[0])
+    );
+  }
+  const redirectionUtils =
+    finalField === 'internal_id'
+      ? stixRelationshipsDistribution.map((n) => ({
+          id: n.label,
+          entity_type: n.entity?.entity_type,
+          series: subSectionIdsOrder.map((subSectionId) => {
+            const [entity] =
+              n.entity[distributionKey]?.filter(
+                (e) => e.label === subSectionId
+              ) ?? [];
+            return {
+              id: subSectionId,
+              entity_type: entity ? entity.entity?.entity_type : null,
+            };
+          }),
+        }))
+      : null;
+
+  return {
+    chartData,
+    redirectionUtils,
+    categories,
+  };
+};

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
@@ -118,7 +118,7 @@ export const useStixRelationshipsMultiHorizontalBars = (
         .map((k) => k[0])
     );
   }
-  
+
   const redirectionUtils =
     finalField === 'internal_id'
       ? stixRelationshipsDistribution.map((n) => ({
@@ -136,7 +136,7 @@ export const useStixRelationshipsMultiHorizontalBars = (
           }),
         }))
       : null;
-
+      
   return {
     chartData,
     redirectionUtils,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
@@ -20,15 +20,15 @@ export const useStixRelationshipsMultiHorizontalBars = (
   );
 
   const getDistributionKey = (distribution) => {
-    if(finalSubDistributionField === 'internal_id'){
+    if (finalSubDistributionField === 'internal_id'){
       return getMainRepresentative(distribution.entity, t_i18n('Restricted'));
     }
 
-    if(!distribution.entity) {
+    if (!distribution.entity) {
       return distribution.label;
     }
 
-    if(distribution.entity.representative) {
+    if (distribution.entity.representative) {
       return getMainRepresentative(distribution.entity, t_i18n('Restricted'));
     }
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
@@ -20,24 +20,21 @@ export const useStixRelationshipsMultiHorizontalBars = (
   );
 
   const getDistributionKey = (distribution) => {
-    let distributionKey;
-    if (finalSubDistributionField === 'internal_id') {
-      distributionKey = getMainRepresentative(
-        distribution.entity,
-        t_i18n('Restricted')
-      );
-    } else if (distribution.entity) {
-      distributionKey = distribution.entity.representative
-        ? getMainRepresentative(distribution.entity, t_i18n('Restricted'))
-        : distribution.entity.name
-          ? distribution.entity.name
-          : distribution.entity.label
-            ? distribution.entity.label
-            : distribution.label;
-    } else {
-      distributionKey = distribution.label;
+    if(finalSubDistributionField === 'internal_id'){
+      return getMainRepresentative(distribution.entity, t_i18n('Restricted'));
     }
-    return distributionKey;
+
+    if(!distribution.entity) {
+      return distribution.label;
+    }
+
+    if(distribution.entity.representative) {
+      return getMainRepresentative(distribution.entity, t_i18n('Restricted'));
+    }
+
+    return distribution.entity.name
+      || distribution.entity.label
+      || distribution.label;
   };
 
   const entitiesMapping = {};

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.js
@@ -17,7 +17,7 @@ export const useStixRelationshipsMultiHorizontalBars = (
   const categories = stixRelationshipsDistribution.map((n) =>
     getMainRepresentative(n.entity, t_i18n('Restricted'))
   );
-  const entitiesMapping = {};
+
   const getDistributionKey = (distribution) => {
     let distributionKey;
     if (finalSubDistributionField === 'internal_id') {
@@ -38,6 +38,8 @@ export const useStixRelationshipsMultiHorizontalBars = (
     }
     return distributionKey;
   };
+
+  const entitiesMapping = {};
   for (const distrib of stixRelationshipsDistribution) {
     for (const subDistrib of distrib.entity[distributionKey]) {
       const subDistributionKey = getDistributionKey(subDistrib);
@@ -45,10 +47,12 @@ export const useStixRelationshipsMultiHorizontalBars = (
         (entitiesMapping[subDistributionKey] || 0) + subDistrib.value;
     }
   }
+
   const sortedEntityMapping = R.take(
     subSelection.number ?? 15,
     Object.entries(entitiesMapping).sort(([, a], [, b]) => b - a)
   );
+
   const categoriesValues = {};
   for (const distrib of stixRelationshipsDistribution) {
     for (const sortedEntity of sortedEntityMapping) {
@@ -82,6 +86,7 @@ export const useStixRelationshipsMultiHorizontalBars = (
     }
   }
   sortedEntityMapping.push(['Others', 0]);
+
   const chartData = sortedEntityMapping
     .map((sortedEntity, index) => {
       return {
@@ -113,6 +118,7 @@ export const useStixRelationshipsMultiHorizontalBars = (
         .map((k) => k[0])
     );
   }
+  
   const redirectionUtils =
     finalField === 'internal_id'
       ? stixRelationshipsDistribution.map((n) => ({

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/useStixRelationshipsMultiHorizontalBars.test.ts
@@ -1,0 +1,296 @@
+import { testRenderHook } from '../../../../../utils/tests/test-render';
+import { describe, expect, it } from 'vitest';
+import { useStixRelationshipsMultiHorizontalBars } from './useStixRelationshipsMultiHorizontalBars';
+
+describe('useStixRelationshipsMultiHorizontalBars', ()=>{
+  const subSelectionMock = {
+    perspective: 'relationships',
+  };
+
+  const finalFieldMock = 'internal_id';
+
+  it('should return correct chartData when stixRelationshipsDistribution is filled with scos entities such as marking definitions', ()=> {
+    const stixRelationshipsDistributionWithMarkings = [
+      {
+        label: '0810d778-0692-4afb-a967-7e1c574b1e92',
+        value: 3,
+        entity: {
+          id: '0810d778-0692-4afb-a967-7e1c574b1e92',
+          entity_type: 'Vulnerability',
+          representative: { main: 'CVE-2013-0422' },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: '66045fab-f138-4fb3-ae4f-b28ad8a22761',
+              value: 2,
+              entity: {
+                id: '66045fab-f138-4fb3-ae4f-b28ad8a22761',
+                entity_type: 'Marking-Definition',
+                representative: { main: 'TLP:CLEAR' },
+                x_opencti_color: '#ffffff'
+              }
+            },
+            {
+              label: '42644a63-b184-46cd-b492-ec0bc23a1c17',
+              value: 1,
+              entity: {
+                id: '42644a63-b184-46cd-b492-ec0bc23a1c17',
+                entity_type: 'Marking-Definition',
+                representative: { main: 'PAP:GREEN' },
+                x_opencti_color: '#2e7d32'
+              }
+            }
+          ]
+        }
+      },
+      {
+        label: '276322c9-6a6e-46e8-8333-6d9337cdddab',
+        value: 2,
+        entity: {
+          id: '276322c9-6a6e-46e8-8333-6d9337cdddab',
+          entity_type: 'Vulnerability',
+          representative: { main: 'CVE-2012-0158' },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: '195e0fb3-86aa-4e94-909d-bee8b8518070',
+              value: 1,
+              entity: {
+                id: '195e0fb3-86aa-4e94-909d-bee8b8518070',
+                entity_type: 'Marking-Definition',
+                representative: { main: 'PAP:RED' },
+                x_opencti_color: '#c62828'
+              }
+            },
+            {
+              label: '42644a63-b184-46cd-b492-ec0bc23a1c17',
+              value: 1,
+              entity: {
+                id: '42644a63-b184-46cd-b492-ec0bc23a1c17',
+                entity_type: 'Marking-Definition',
+                representative: { main: 'PAP:GREEN' },
+                x_opencti_color: '#2e7d32'
+              }
+            }
+          ]
+        }
+      },
+      {
+        label: '98256a7f-065f-4cf6-b1ee-14c846b8699f',
+        value: 2,
+        entity: {
+          id: '98256a7f-065f-4cf6-b1ee-14c846b8699f',
+          entity_type: 'Vulnerability',
+          representative: { main: 'CVE-2010-3333' },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: '3c8e630f-b543-49ad-9209-33925493c930',
+              value: 1,
+              entity: {
+                id: '3c8e630f-b543-49ad-9209-33925493c930',
+                entity_type: 'Marking-Definition',
+                representative: { main: 'PAP:AMBER' },
+                x_opencti_color: '#d84315'
+              }
+            }
+          ]
+        }
+      }
+    ];
+
+    const expectedchartData = [
+      {
+        name: 'TLP:CLEAR',
+        data: [2, 0, 0]
+      },
+      {
+        name: 'PAP:GREEN',
+        data: [1, 1, 0]
+      },
+      {
+        name: 'PAP:RED',
+        data: [0, 1, 0]
+      },
+      {
+        name: 'PAP:AMBER',
+        data: [0, 0, 1]
+      },
+      {
+        name: 'Others',
+        data: [0, 0, 1]
+      }
+    ];
+
+    const finalSubDistributionFieldMarkings = 'object-marking.internal_id';
+
+    const { hook } = testRenderHook(() => {
+      return useStixRelationshipsMultiHorizontalBars(subSelectionMock, stixRelationshipsDistributionWithMarkings,finalSubDistributionFieldMarkings,finalFieldMock);
+    });
+
+    const hookResult = hook.result.current;
+
+    expect(hookResult.chartData).toEqual(expectedchartData);
+  });
+
+  it('should return correct chartData when stixRelationshipsDistribution is filled with non scos entities such as users', ()=> {
+    const stixRelationshipsDistributionWithUsers = [
+      {
+        label: '0810d778-0692-4afb-a967-7e1c574b1e92',
+        value: 2,
+        entity: {
+          id: '0810d778-0692-4afb-a967-7e1c574b1e92',
+          entity_type: 'Vulnerability',
+          representative: {
+            main: 'CVE-2013-0422'
+          },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: '88ec0c6a-13ce-5e39-B486-354fe4a7084f',
+              value: 2,
+              entity: {
+                id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f',
+                entity_type: 'User',
+                name: 'admin'
+              }
+            }
+          ]
+        }
+      },
+      {
+        label: '276322c9-6a6e-46e8-8333-6d9337cdddab',
+        value: 2,
+        entity: {
+          id: '276322c9-6a6e-46e8-8333-6d9337cdddab',
+          entity_type: 'Vulnerability',
+          representative: {
+            main: 'CVE-2012-0158'
+          },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: '88ec0c6a-13ce-5e39-B486-354fe4a7084f',
+              value: 2,
+              entity: {
+                id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f',
+                entity_type: 'User',
+                name: 'admin'
+              }
+            }
+          ]
+        }
+      },
+      {
+        label: '98256a7f-065f-4cf6-b1ee-14c846b8699f',
+        value: 2,
+        entity: {
+          id: '98256a7f-065f-4cf6-b1ee-14c846b8699f',
+          entity_type: 'Vulnerability',
+          representative: {
+            main: 'CVE-2010-3333'
+          },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: '88ec0c6a-13ce-5e39-B486-354fe4a7084f',
+              value: 2,
+              entity: {
+                id: '88ec0c6a-13ce-5e39-b486-354fe4a7084f',
+                entity_type: 'User',
+                name: 'admin'
+              }
+            }
+          ]
+        }
+      }
+    ];
+
+    const expectedchartData = [
+      {
+        name: 'admin',
+        data: [2, 2, 2]
+      }
+    ];
+
+    const finalSubDistributionFieldUsers = 'creator_id';
+
+    const { hook } = testRenderHook(() => {
+      return useStixRelationshipsMultiHorizontalBars(subSelectionMock, stixRelationshipsDistributionWithUsers,finalSubDistributionFieldUsers,finalFieldMock);
+    });
+
+    const hookResult = hook.result.current;
+
+    expect(hookResult.chartData).toEqual(expectedchartData);
+  });
+
+  it('should return correct chartData when stixRelationshipsDistribution is filled with relationships', ()=> {
+    const stixRelationshipsDistributionWithRelationships = [
+      {
+        label: '0810d778-0692-4afb-a967-7e1c574b1e92',
+        value: 2,
+        entity: {
+          id: '0810d778-0692-4afb-a967-7e1c574b1e92',
+          entity_type: 'Vulnerability',
+          representative: {
+            main: 'CVE-2013-0422'
+          },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: 'Targets',
+              value: 2,
+              entity: null
+            }
+          ]
+        }
+      },
+      {
+        label: '276322c9-6a6e-46e8-8333-6d9337cdddab',
+        value: 2,
+        entity: {
+          id: '276322c9-6a6e-46e8-8333-6d9337cdddab',
+          entity_type: 'Vulnerability',
+          representative: {
+            main: 'CVE-2012-0158'
+          },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: 'Targets',
+              value: 2,
+              entity: null
+            }
+          ]
+        }
+      },
+      {
+        label: '98256a7f-065f-4cf6-b1ee-14c846b8699f',
+        value: 3,
+        entity: {
+          id: '98256a7f-065f-4cf6-b1ee-14c846b8699f',
+          entity_type: 'Vulnerability',
+          representative: {
+            main: 'CVE-2010-3333'
+          },
+          stixCoreRelationshipsDistribution: [
+            {
+              label: 'Targets',
+              value: 3,
+              entity: null
+            }
+          ]
+        }
+      }
+    ];
+
+    const expectedchartData = [
+      {
+        name: 'Targets',
+        data: [2, 2, 3]
+      }
+    ];
+
+    const finalSubDistributionFieldRelationships = 'relationship_type';
+
+     const { hook } = testRenderHook(() => {
+      return useStixRelationshipsMultiHorizontalBars(subSelectionMock, stixRelationshipsDistributionWithRelationships,finalSubDistributionFieldRelationships,finalFieldMock);
+    });
+
+    const hookResult = hook.result.current;
+
+    expect(hookResult.chartData).toEqual(expectedchartData);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/DashboardRelationshipsViz.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/DashboardRelationshipsViz.tsx
@@ -7,7 +7,7 @@ import StixRelationshipsMultiLineChart from '@components/common/stix_relationshi
 import StixRelationshipsMultiAreaChart from '@components/common/stix_relationships/StixRelationshipsMultiAreaChart';
 import StixRelationshipsTimeline from '@components/common/stix_relationships/StixRelationshipsTimeline';
 import StixRelationshipsDonut from '@components/common/stix_relationships/StixRelationshipsDonut';
-import StixRelationshipsMultiHorizontalBars from '@components/common/stix_relationships/StixRelationshipsMultiHorizontalBars';
+import StixRelationshipsMultiHorizontalBars from '@components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars';
 import StixRelationshipsHorizontalBars from '@components/common/stix_relationships/StixRelationshipsHorizontalBars';
 import StixRelationshipsRadar from '@components/common/stix_relationships/StixRelationshipsRadar';
 import StixRelationshipsPolarArea from '@components/common/stix_relationships/StixRelationshipsPolarArea';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added a function to get the correct distribution key : 
        * scos entities such as marking definitions => entity representative
        * non scos entities such as user => entity name or label if no name 
        * all other cases : such as a relationship => label

* Added a filter to remove empty categories (category with every value = 0 such as 'Others' category)

* Replaced QueryRenderer with useLazyLoadQuery to be able to move the logic in a hook and test it easily

NB : the fix was done in the front end to avoid side effects. Touching the backend, to always receive an id or a name as the label, could be risky as  stixRelationshipsDistribution objects labels are not only use in widgets. 
They are also used in InvestigationExpandForm and fetchMetaObjectsCount where labels are compared to objects ids for a counting used in InvestigationGraph. 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13062?reload=1?reload=1
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
