### PR TITLE
[backend] Handle base_path setting in httpPlatform redirection (#13450)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -37,7 +37,14 @@ import { getChatbotProxy } from './httpChatbotProxy';
 import { isStrategyActivated, StrategyType } from '../config/providers-configuration';
 
 export const sanitizeReferer = (refererToSanitize) => {
-  if (!refererToSanitize) return '/';
+  // NOTE: basePath will be configured, if the site is hosted behind a reverseProxy otherwise '/' should be accurate
+  // Ternary Operator (?): Defaults if basePath is undefined, null, "" (empty string), 0, etc (falsy values).
+  // basePath is trimmed in '../config/conf.js' to prevent a user from setting it to something like '       '
+  // NOTE: Do NOT use Nullish Coalescing (??): Would only default if basePath is undefined or null. 
+  // It might be set to an empty string and would fail to set properly in base2return var in next line 
+  const base2return = basePath ? basePath : '/';
+  // In some odd configurations refererToSanitize will be the string('undefined') versus value(undefined)
+  if (!refererToSanitize || refererToSanitize === 'undefined') return base2return;
   const base = getBaseUrl();
   const resolvedUrl = new URL(refererToSanitize, base).toString();
   if (resolvedUrl === base || resolvedUrl.startsWith(`${base}/`)) {
@@ -49,7 +56,7 @@ export const sanitizeReferer = (refererToSanitize) => {
     return resolvedUrl;
   }
   logApp.info('Error auth provider callback : url has been altered', { url: refererToSanitize });
-  return '/';
+  return base2return;
 };
 
 const extractRefererPathFromReq = (req) => {


### PR DESCRIPTION
This should correct the behavior of the redirect that was altered via (https://github.com/OpenCTI-Platform/opencti/commit/a8f648b3a7c6bb632e098bf87f397a35fb8bca88) and did not account for systems that had app:base_path setup for deployment behind a reverse proxy

Also accounts for an oddity where in some reverse proxy situations - - may actually be the `string` '**_undefined_**' versus the javascript `value` of `undefined`.

### Proposed changes

* Modify checking in function to account for app:base_path being setup/configured
* Handle odd edge case of `string` '**_undefined_**' versus the javascript `value` of `undefined`.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13450


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality (via SAML and normal logins with and without base_path defined)
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
None
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
