### PR TITLE
[backend/frontend] Fix connector reset dialog showing stale message count (#12908)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2294,6 +2294,7 @@
   "Live streams": "Live-Streams",
   "Live Streams | Data Sharing | Data": "Live-Streams | Gemeinsame Nutzung von Daten | Daten",
   "Live trigger": "Live-Trigger",
+  "Loading current message count...": "Laden der aktuellen Nachrichtenanzahl...",
   "Local password policies": "Lokale Kennwortrichtlinien",
   "Local settings": "Lokale Einstellungen",
   "Localized in this country": "Lokalisiert in diesem Land",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2294,6 +2294,7 @@
   "Live streams": "Live streams",
   "Live Streams | Data Sharing | Data": "Live Streams | Data Sharing | Data",
   "Live trigger": "Live trigger",
+  "Loading current message count...": "Loading current message count...",
   "Local password policies": "Local password policies",
   "Local settings": "Local settings",
   "Localized in this country": "Localized in this country",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2294,6 +2294,7 @@
   "Live streams": "Publicación en vivo",
   "Live Streams | Data Sharing | Data": "Transmisiones en directo | Intercambio de datos | Datos",
   "Live trigger": "Disparador en vivo",
+  "Loading current message count...": "Cargando recuento de mensajes actual...",
   "Local password policies": "Políticas locales de contraseñas",
   "Local settings": "Configuración local",
   "Localized in this country": "Localizado en este país",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2294,6 +2294,7 @@
   "Live streams": "Streams live",
   "Live Streams | Data Sharing | Data": "Flux en direct | Partage de données | Données",
   "Live trigger": "Déclencheur live",
+  "Loading current message count...": "Chargement du nombre de messages en cours...",
   "Local password policies": "Politiques locales en matière de mots de passe",
   "Local settings": "Paramètres locaux",
   "Localized in this country": "Localisé dans ce pays",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2294,6 +2294,7 @@
   "Live streams": "Flussi in diretta",
   "Live Streams | Data Sharing | Data": "Streaming dal vivo | Condivisione dati | Dati",
   "Live trigger": "Trigger live",
+  "Loading current message count...": "Caricamento del numero di messaggi attuali...",
   "Local password policies": "Politiche locali sulla password",
   "Local settings": "Impostazioni locali",
   "Localized in this country": "Localizzato in questo paese",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2294,6 +2294,7 @@
   "Live streams": "ライブストリーム",
   "Live Streams | Data Sharing | Data": "ライブストリーム｜データ共有｜データ",
   "Live trigger": "ライブトリガー",
+  "Loading current message count...": "現在のメッセージ数をロード中...",
   "Local password policies": "ローカルパスワードポリシー",
   "Local settings": "ローカル設定",
   "Localized in this country": "この国にローカライズされたもの",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2294,6 +2294,7 @@
   "Live streams": "실시간 스트림",
   "Live Streams | Data Sharing | Data": "실시간 스트림 | 데이터 공유 | 데이터",
   "Live trigger": "실시간 트리거",
+  "Loading current message count...": "현재 메시지 수 로드 중...",
   "Local password policies": "로컬 비밀번호 정책",
   "Local settings": "로컬 설정",
   "Localized in this country": "이 나라에 위치",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -2294,6 +2294,7 @@
   "Live streams": "Прямые трансляции",
   "Live Streams | Data Sharing | Data": "Прямые трансляции | Обмен данными | Данные",
   "Live trigger": "Живой триггер",
+  "Loading current message count...": "Загрузка текущего количества сообщений...",
   "Local password policies": "Локальные политики паролей",
   "Local settings": "Локальные настройки",
   "Localized in this country": "Локализовано в этой стране",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2294,6 +2294,7 @@
   "Live streams": "实时流",
   "Live Streams | Data Sharing | Data": "实时流 | 数据共享 | 数据",
   "Live trigger": "实时触发器",
+  "Loading current message count...": "正在加载当前信息数...",
   "Local password policies": "本地密码策略",
   "Local settings": "本地设置",
   "Localized in this country": "在此国家/地区本地化",

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-reset-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-reset-test.ts
@@ -1,0 +1,173 @@
+import { expect, it, describe, afterAll, beforeAll } from 'vitest';
+import gql from 'graphql-tag';
+import { v4 as uuid } from 'uuid';
+import { queryAsUserWithSuccess } from '../../utils/testQueryHelper';
+import { USER_CONNECTOR } from '../../utils/testQuery';
+import { waitInSec } from '../../../src/database/utils';
+
+const CREATE_CONNECTOR_QUERY = gql`
+  mutation RegisterConnector($input: RegisterConnectorInput) {
+    registerConnector(input: $input) {
+      id
+      connector_state
+      name
+    }
+  }
+`;
+
+const READ_CONNECTOR_QUERY = gql`
+  query GetConnector($id: String!) {
+    connector(id: $id) {
+      id
+      name
+      connector_state
+      connector_queue_details {
+        messages_number
+        messages_size
+      }
+    }
+  }
+`;
+
+const RESET_CONNECTOR_QUERY = gql`
+  mutation ResetStateConnector($id: ID!) {
+    resetStateConnector(id: $id) {
+      id
+      connector_state
+      connector_queue_details {
+        messages_number
+        messages_size
+      }
+    }
+  }
+`;
+
+const DELETE_CONNECTOR_QUERY = gql`
+  mutation ConnectorDeletionMutation($id: ID!) {
+    deleteConnector(id: $id)
+  }
+`;
+
+const TEST_RESET_CN_ID = uuid();
+const TEST_RESET_CN_NAME = 'TestResetConnector';
+
+describe('Connector reset state functionality', () => {
+  beforeAll(async () => {
+    const CONNECTOR_TO_CREATE = {
+      input: {
+        id: TEST_RESET_CN_ID,
+        name: TEST_RESET_CN_NAME,
+        type: 'EXTERNAL_IMPORT',
+        scope: 'Observable',
+        auto: true,
+        only_contextual: false,
+      },
+    };
+    const connector = await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: CREATE_CONNECTOR_QUERY,
+      variables: CONNECTOR_TO_CREATE,
+    });
+    expect(connector).not.toBeNull();
+    expect(connector.data.registerConnector).not.toBeNull();
+    expect(connector.data.registerConnector.id).toEqual(TEST_RESET_CN_ID);
+    
+    await waitInSec(1);
+  });
+
+  it('should fetch connector with queue details from RabbitMQ API', async () => {
+    const queryResult = await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: READ_CONNECTOR_QUERY,
+      variables: { id: TEST_RESET_CN_ID },
+    });
+
+    expect(queryResult.data.connector).toBeDefined();
+    expect(queryResult.data.connector.id).toEqual(TEST_RESET_CN_ID);
+    expect(queryResult.data.connector.connector_queue_details).toBeDefined();
+    expect(typeof queryResult.data.connector.connector_queue_details.messages_number).toBe('number');
+    expect(typeof queryResult.data.connector.connector_queue_details.messages_size).toBe('number');
+    expect(queryResult.data.connector.connector_queue_details.messages_number).toBeGreaterThanOrEqual(0);
+    expect(queryResult.data.connector.connector_queue_details.messages_size).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should return consistent queue details across multiple API calls', async () => {
+    
+    const firstFetch = await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: READ_CONNECTOR_QUERY,
+      variables: { id: TEST_RESET_CN_ID },
+    });
+
+    await waitInSec(0.5);
+
+    const secondFetch = await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: READ_CONNECTOR_QUERY,
+      variables: { id: TEST_RESET_CN_ID },
+    });
+
+    expect(firstFetch.data.connector.connector_queue_details).toBeDefined();
+    expect(secondFetch.data.connector.connector_queue_details).toBeDefined();
+    
+    expect(firstFetch.data.connector.connector_queue_details.messages_number)
+      .toEqual(secondFetch.data.connector.connector_queue_details.messages_number);
+    expect(firstFetch.data.connector.connector_queue_details.messages_size)
+      .toEqual(secondFetch.data.connector.connector_queue_details.messages_size);
+  });
+
+  it('should reset connector state and clear queue', async () => {
+    const resetResult = await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: RESET_CONNECTOR_QUERY,
+      variables: { id: TEST_RESET_CN_ID },
+    });
+
+    expect(resetResult.data.resetStateConnector).toBeDefined();
+    expect(resetResult.data.resetStateConnector.id).toEqual(TEST_RESET_CN_ID);
+    expect(resetResult.data.resetStateConnector.connector_state).toBeNull();
+    
+    expect(resetResult.data.resetStateConnector.connector_queue_details).toBeDefined();
+
+    await waitInSec(2);
+
+    const verifyResult = await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: READ_CONNECTOR_QUERY,
+      variables: { id: TEST_RESET_CN_ID },
+    });
+
+    expect(verifyResult.data.connector.connector_queue_details.messages_number).toEqual(0);
+    expect(verifyResult.data.connector.connector_queue_details.messages_size).toEqual(0);
+  });
+
+  it('should handle rapid successive API calls without errors', async () => {
+ 
+    const rapidCalls = await Promise.all([
+      queryAsUserWithSuccess(USER_CONNECTOR.client, {
+        query: READ_CONNECTOR_QUERY,
+        variables: { id: TEST_RESET_CN_ID },
+      }),
+      queryAsUserWithSuccess(USER_CONNECTOR.client, {
+        query: READ_CONNECTOR_QUERY,
+        variables: { id: TEST_RESET_CN_ID },
+      }),
+      queryAsUserWithSuccess(USER_CONNECTOR.client, {
+        query: READ_CONNECTOR_QUERY,
+        variables: { id: TEST_RESET_CN_ID },
+      }),
+    ]);
+
+    rapidCalls.forEach((result) => {
+      expect(result.data.connector).toBeDefined();
+      expect(result.data.connector.connector_queue_details).toBeDefined();
+      expect(typeof result.data.connector.connector_queue_details.messages_number).toBe('number');
+    });
+
+    const firstCount = rapidCalls[0].data.connector.connector_queue_details.messages_number;
+    rapidCalls.forEach((result) => {
+      expect(result.data.connector.connector_queue_details.messages_number).toEqual(firstCount);
+    });
+  });
+
+  afterAll(async () => {
+    await queryAsUserWithSuccess(USER_CONNECTOR.client, {
+      query: DELETE_CONNECTOR_QUERY,
+      variables: { id: TEST_RESET_CN_ID },
+    });
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Refresh connector data when opening the reset dialog to display accurate message counts
* Add loading state while fetching fresh queue details
* Disable confirm button until fresh data is loaded
* Add error handling for reset operation failures
* Create integration tests on backend

### Related issues

Fixes #12908

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Root Cause:**
The reset confirmation dialog displayed stale `connector_queue_details.messages_number` from cached connector data that was only refreshed when the menu opened, not when the reset dialog opened. This caused inaccurate message counts (often "0 messages") to be shown when users had large queues (e.g., 650k messages).

**Solution:**
Modified `handleOpenResetState()` in `ConnectorPopover.tsx` to call `onRefreshData()` when the dialog opens, ensuring the API fetches fresh queue details from RabbitMQ. Added a loading state with disabled confirm button to prevent actions during the refresh.
