### PR TITLE
[frontend] do not include authorized_authorities filter in SettingsOrganizations if user has SETACCESSES (#13499)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/SettingsOrganizations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/SettingsOrganizations.tsx
@@ -15,6 +15,7 @@ import { SettingsOrganizationLine_node$data as Organization } from './organizati
 import useAuth from '../../../utils/hooks/useAuth';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
+import useGranted, { SETTINGS_SETACCESSES } from '../../../utils/hooks/useGranted';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -40,9 +41,10 @@ const SettingsOrganizations = () => {
   });
 
   const userIsOrganizationAdmin = (me.administrated_organizations ?? []).length > 0;
+  const userHasSetAccess = useGranted([SETTINGS_SETACCESSES]);
   const paginationOptions: SettingsOrganizationsLinesPaginationQuery$variables = {
     ...paginationOptionsFromStorage,
-    filters: userIsOrganizationAdmin
+    filters: userIsOrganizationAdmin && !userHasSetAccess
       ? { mode: 'and', filters: [{ key: ['authorized_authorities'], values: [me.id] }], filterGroups: [] }
       : undefined,
   };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* do not include authorized_authorities filter in SettingsOrganizations if user has SETACCESSES
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13499
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
