### PR TITLE
[backend] redirect after sso login (#13386)

### DIFF
--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -165,8 +165,8 @@ services:
       container_name: opencti-dev-keycloak
       command: start-dev
       environment:
-        KEYCLOAK_ADMIN: "admin"
-        KEYCLOAK_ADMIN_PASSWORD: "admin"
+        KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+        KC_BOOTSTRAP_ADMIN_PASSWORD: "admin"
       ports:
         - "9999:8080"
 

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -1,5 +1,4 @@
-/* eslint-disable camelcase */
-import { URL } from 'node:url';
+ import { URL } from 'node:url';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import express from 'express';
@@ -53,17 +52,18 @@ export const sanitizeReferer = (refererToSanitize) => {
 };
 
 const extractRefererPathFromReq = (req) => {
-  if (isNotEmptyField(req.headers.referer)) {
-    try {
-      const refererUrl = new URL(req.headers.referer);
-      // Keep only the pathname to prevent OPEN REDIRECT CWE-601
-      return refererUrl.pathname;
-    } catch {
-      // prevent any invalid referer
-      logApp.warn('Invalid referer for redirect extraction', { referer: req.headers.referer });
-    }
+  if (isEmptyField(req.headers.referer)) {
+    return undefined;
   }
-  return undefined;
+  
+  try {
+    const refererUrl = new URL(req.headers.referer);
+    // Keep only the pathname and search to prevent OPEN REDIRECT CWE-601
+    return refererUrl.pathname + refererUrl.search;
+  } catch {
+    // prevent any invalid referer
+    logApp.warn('Invalid referer for redirect extraction', { referer: req.headers.referer });
+  }
 };
 
 const publishFileDownload = async (executeContext, auth, file) => {
@@ -454,17 +454,31 @@ const createApp = async (app, schema) => {
       const { provider } = req.params;
       const strategy = passport._strategy(provider);
       const referer = extractRefererPathFromReq(req);
+
       if (strategy._saml) {
         // For SAML, no session is required, referer will be send back through RelayState
-        req.query.RelayState = referer;
-      } else {
-        // For openid / oauth, session is required so we can use it
-        req.session.referer = referer;
-      }
-      passport.authenticate(provider, {}, (err) => {
-        setCookieError(res, err?.message);
-        next(err);
-      })(req, res, next);
+        return passport.authenticate(
+          provider, 
+          { additionalParams: { RelayState: referer }}, 
+          {},
+          (err) => {
+            setCookieError(res, err?.message);
+            next(err);
+          }
+        )(req, res, next);
+      } 
+
+      // For openid / oauth, session is required so we can use it
+      req.session.referer = referer;
+      return passport.authenticate(
+        provider, 
+        {}, 
+        (err) => {
+          setCookieError(res, err?.message);
+          next(err);
+        }
+      )(req, res, next);
+
     } catch (e) {
       setCookieError(res, e.message);
       logApp.error('Error auth provider', { cause: e });
@@ -477,6 +491,7 @@ const createApp = async (app, schema) => {
   const urlencodedParser = AUTH_PAYLOAD_BODY_SIZE ? bodyParser.urlencoded({ extended: true, limit: AUTH_PAYLOAD_BODY_SIZE }) : bodyParser.urlencoded({ extended: true });
   app.all(`${basePath}/auth/:provider/callback`, urlencodedParser, async (req, res, next) => {
     const { provider } = req.params;
+
     const callbackLogin = () => new Promise((accept, reject) => {
       passport.authenticate(provider, {}, (err, user) => {
         if (err || !user) {
@@ -486,6 +501,7 @@ const createApp = async (app, schema) => {
         }
       })(req, res, next);
     });
+
     try {
       const context = executionContext(`${provider}_strategy`);
       const logged = await callbackLogin();

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -460,7 +460,6 @@ const createApp = async (app, schema) => {
         return passport.authenticate(
           provider, 
           { additionalParams: { RelayState: referer }}, 
-          {},
           (err) => {
             setCookieError(res, err?.message);
             next(err);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

The issue is when authenticating with Saml provider, the user is redirected to base url thus the dashboard in the app.

### Proposed changes

* Fix SAML authentication redirect by passing RelayState via additionalParams in passport.authenticate(). This preserves the original URL through the SAML flow, allowing post-login redirection. 
* Should fix redirection with search params for SAML and OpenId/Oauth providers

Auth with SAML provider and redirect on auth to the url with search params

https://github.com/user-attachments/assets/7b54ff59-839f-4c30-893d-006dfab4e73f


Auth with OpenId provider and redirect on auth to the url with search params

https://github.com/user-attachments/assets/a03ce3a2-2a7f-466b-b5ba-851362b0ca90



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13386 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [X] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
