### PR TITLE
[backend] move sharing and Auth members changes to activity logs (#8237)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -113,13 +113,14 @@ import {
 } from '../schema/general';
 import { isAnId, isValidDate } from '../schema/schemaUtils';
 import {
-  isStixRefRelationship,
-  RELATION_CREATED_BY,
-  RELATION_EXTERNAL_REFERENCE,
-  RELATION_GRANTED_TO,
-  RELATION_OBJECT,
-  RELATION_OBJECT_MARKING,
-  STIX_REF_RELATIONSHIP_TYPES,
+isStixRefRelationship,
+objectOrganization,
+RELATION_CREATED_BY,
+RELATION_EXTERNAL_REFERENCE,
+RELATION_GRANTED_TO,
+RELATION_OBJECT,
+RELATION_OBJECT_MARKING,
+STIX_REF_RELATIONSHIP_TYPES,
 } from '../schema/stixRefRelationship';
 import { ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS, ENTITY_TYPE_USER } from '../schema/internalObject';
 import { isStixCoreObject } from '../schema/stixCoreObject';
@@ -2506,6 +2507,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
       } : undefined;
       const relatedRestrictions = extractObjectsRestrictionsFromInputs(updatedInputs, initial.entity_type);
       const { pir_ids } = extractObjectsPirsFromInputs(updatedInputs, initial.entity_type);
+      const security = updatedInputs.find((input) => input.key === (objectOrganization.name || authorizedMembers.name));
       const event = await storeUpdateEvent(
         context,
         user,
@@ -2515,6 +2517,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
         changes,
         {
           ...opts,
+          noHistory: security ?? false,
           commit,
           related_restrictions: relatedRestrictions,
           pir_ids,

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2068,6 +2068,9 @@ const buildAttribute = async (context, user, key, array) => {
     if (!item) {
       return item;
     }
+    if (key === authorizedMembers.name || key === objectOrganization.name) {
+      return ;
+    }
     if (typeof item === 'object') {
       if (item?.entity_type !== undefined) {
         return extractEntityRepresentativeName(item, 250);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3186,7 +3186,7 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   const input = { ...rawInput };
   const { confidenceLevelToApply } = controlCreateInputWithUserConfidence(user, input, type);
   input.confidence = confidenceLevelToApply; // confidence of new entity will be capped to user's confidence
-  // authori  zed_members renaming
+  // authorized_members renaming
   if (input.authorized_members?.length > 0) {
     input.restricted_members = input.authorized_members;
   }

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2515,6 +2515,9 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
       const isSecurityUpdate = () => {
         return updatedInputs.some((input) => input.key === objectOrganization.name || input.key === authorizedMembers.name);
       };
+      const isNotOnlySecurityUpdate = () => {
+        return updatedInputs.some((input) => input.key !== objectOrganization.name && input.key !== authorizedMembers.name);
+      };
       const securityUpdate = isSecurityUpdate();
       if (securityUpdate) {
         await publishUserAction({
@@ -2535,7 +2538,7 @@ export const updateAttributeMetaResolved = async (context, user, initial, inputs
         changes,
         {
           ...opts,
-          noHistory: securityUpdate,
+          noHistory: securityUpdate && !isNotOnlySecurityUpdate(),
           commit,
           related_restrictions: relatedRestrictions,
           pir_ids,

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -9,7 +9,7 @@ import { TYPE_LOCK_ERROR } from '../config/errors';
 import { executionContext, REDACTED_USER, SYSTEM_USER } from '../utils/access';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import type { Change, SseEvent, StreamDataEvent, StreamDataEventType, UpdateEvent } from '../types/event';
-import { utcDate } from '../utils/format';
+import { truncate, utcDate } from '../utils/format';
 import { elIndexElements } from '../database/engine';
 import type { StixRelation, StixSighting } from '../types/stix-2-1-sro';
 import { internalFindByIds, topEntitiesList } from '../database/middleware-loader';
@@ -138,16 +138,16 @@ export const generatePirContextData = (event: SseEvent<StreamDataEvent>): Partia
 };
 
 export const historyMessage = (eventType: StreamDataEventType, changes: Change[]): string => {
-  const message: string[] = [];
+  const messages: string[] = [];
   if (!changes) {
     return '';
   }
   if (changes.length > 0) {
     changes.forEach((change) => {
-      message.push(`${eventType} ${change.new} in ${change.field}`);
+      messages.push(`${truncate(change.new, 250)} in ${change.field}`);
     });
   }
-  return message.join(' - ');
+  return `${eventType}s ${messages.join(' - ')}${messages.length > 3 ? ` and ${messages.length - 3} more operations` : ''}`;
 };
 export const buildHistoryElementsFromEvents = async (context: AuthContext, events: Array<SseEvent<StreamDataEvent>>) => {
   // load all markings to resolve object_marking_refs

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -144,9 +144,7 @@ export const historyMessage = (eventType: StreamDataEventType, changes: Change[]
   }
   if (changes.length > 0) {
     changes.forEach((change) => {
-      if (change.field !== 'Authorized members' && change.field !== 'ObjectOrganization') {
-        message.push(`${eventType} ${change.new} in ${change.field}`);
-      }
+      message.push(`${eventType} ${change.new} in ${change.field}`);
     });
   }
   return message.join(' - ');
@@ -175,7 +173,7 @@ export const buildHistoryElementsFromEvents = async (context: AuthContext, event
     const eventType = event.data.type;
     let contextData: HistoryContext = {
       id: stix.extensions[STIX_EXT_OCTI].id,
-      message: historyMessage(eventType, updateEvent.context.changes),
+      message: historyMessage(eventType, updateEvent.context?.changes),
       entity_type: stix.extensions[STIX_EXT_OCTI].type,
       entity_name: extractStixRepresentative(stix),
       creator_ids: stix.extensions[STIX_EXT_OCTI].creator_ids,

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -139,14 +139,16 @@ export const generatePirContextData = (event: SseEvent<StreamDataEvent>): Partia
 
 export const historyMessage = (eventType: StreamDataEventType, changes: Change[]): string => {
   const message: string[] = [];
-  if (!changes || changes.length === 0) {
+  if (!changes) {
     return '';
   }
-  changes.forEach((change) => {
-    if (change.field !== 'Authorized members' && change.field !== 'ObjectOrganization') {
-      message.push(`${eventType} ${change.new} in ${change.field}`);
-    }
-  });
+  if (changes.length > 0) {
+    changes.forEach((change) => {
+      if (change.field !== 'Authorized members' && change.field !== 'ObjectOrganization') {
+        message.push(`${eventType} ${change.new} in ${change.field}`);
+      }
+    });
+  }
   return message.join(' - ');
 };
 export const buildHistoryElementsFromEvents = async (context: AuthContext, events: Array<SseEvent<StreamDataEvent>>) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
@@ -9,8 +9,8 @@ describe('historyMessage tests', () => {
       previous: [],
       new: ['description'],
     }];
-    const message = historyMessage('update', changes);
-    expect(message).toEqual('updates description in Description');
+    const message = historyMessage('replace', changes);
+    expect(message).toEqual('replaces `description` in `Description`');
   });
   it('should generate history message for multiple update', () => {
     const changes = [{
@@ -25,8 +25,8 @@ describe('historyMessage tests', () => {
       added: [],
       removed: ['bootkit'],
     }];
-    const message = historyMessage('update', changes);
-    expect(message).toEqual('updates description in Description - backdoor in Malware types');
+    const message = historyMessage('replace', changes);
+    expect(message).toEqual('replaces `description` in `Description` - `backdoor` in `Malware types`');
   });
   it('should generate history message for multiple update', () => {
     const changes = [{
@@ -50,7 +50,7 @@ describe('historyMessage tests', () => {
       field: 'Workflow status',
       previous: ['status1'],
       new: ['status2'] }];
-    const message = historyMessage('update', changes as Change[]);
-    expect(message).toEqual('updates description in Description - backdoor in Malware types - 52 in Confidence - status2 in Workflow status and 1 more operations');
+    const message = historyMessage('replace', changes as Change[]);
+    expect(message).toEqual('replaces `description` in `Description` - `backdoor` in `Malware types` - `52` in `Confidence` - `status2` in `Workflow status` and 1 more operations');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
@@ -3,43 +3,55 @@ import { historyMessage } from '../../../src/manager/historyManager';
 import type { Change } from '../../../src/types/event';
 
 describe('historyMessage tests', () => {
-  it('should generate history message for Description update', () => {
+  it('should generate history message for single replace', () => {
     const changes = [{
       field: 'Description',
       previous: [],
       new: ['description'],
     }];
-    const message = historyMessage('replace', changes);
+    const message = historyMessage(changes);
     expect(message).toEqual('replaces `description` in `Description`');
   });
-  it('should generate history message for multiple update', () => {
+  it('should generate history message for single add', () => {
     const changes = [{
-      field: 'Description',
+      added: ['attack-pattern'],
+      field: 'Label',
+      new: ['attack-pattern'],
       previous: [],
-      new: ['description'],
-    },
-    {
-      field: 'Malware types',
-      previous: ['backdoor', 'bootkit'],
-      new: ['backdoor'],
-      added: [],
-      removed: ['bootkit'],
+      removed: [],
     }];
-    const message = historyMessage('replace', changes);
-    expect(message).toEqual('replaces `description` in `Description` - `backdoor` in `Malware types`');
+    const message = historyMessage(changes);
+    expect(message).toEqual('adds `attack-pattern` in `Label`');
   });
-  it('should generate history message for multiple update', () => {
+  it('should generate history message for single remove', () => {
+    const changes = [{
+      added: [],
+      field: 'Markings',
+      new: [],
+      previous: ['TLP:GREEN'],
+      removed: ['TLP:GREEN'],
+    }];
+    const message = historyMessage(changes);
+    expect(message).toEqual('removes `TLP:GREEN` in `Markings`');
+  });
+  it('should generate history message for multiple replace', () => {
     const changes = [{
       field: 'Description',
       previous: [],
       new: ['description'],
     },
     {
-      field: 'Malware types',
-      previous: ['backdoor', 'bootkit'],
-      new: ['backdoor'],
-      added: [],
-      removed: ['bootkit'],
+      field: 'Workflow status',
+      previous: ['status1'],
+      new: ['status2'] }];
+    const message = historyMessage(changes);
+    expect(message).toEqual('replaces `description` in `Description` - `status2` in `Workflow status`');
+  });
+  it('should generate history message for more than 3 replaces', () => {
+    const changes = [{
+      field: 'Description',
+      previous: [],
+      new: ['description'],
     },
     {
       field: 'Confidence',
@@ -49,8 +61,36 @@ describe('historyMessage tests', () => {
     {
       field: 'Workflow status',
       previous: ['status1'],
-      new: ['status2'] }];
-    const message = historyMessage('replace', changes as Change[]);
-    expect(message).toEqual('replaces `description` in `Description` - `backdoor` in `Malware types` - `52` in `Confidence` - `status2` in `Workflow status` and 1 more operations');
+      new: ['status2'] },
+    {
+      field: 'Reliability',
+      previous: ['A - Completely reliable'],
+      new: ['B - Usually reliable'],
+      added: [],
+      removed: [],
+    },
+    ];
+    const message = historyMessage(changes as Change[]);
+    expect(message).toEqual('replaces `description` in `Description` - `52` in `Confidence` - `status2` in `Workflow status` - `B - Usually reliable` in `Reliability` and 1 more operations');
+  });
+  it('should generate history message for add and remove update', () => {
+    const changes = [
+      {
+        added: ['attack-pattern'],
+        field: 'Label',
+        new: ['attack-pattern'],
+        previous: [],
+        removed: [],
+      },
+      {
+        added: [],
+        field: 'Markings',
+        new: [],
+        previous: ['TLP:GREEN'],
+        removed: ['TLP:GREEN'],
+      },
+    ];
+    const message = historyMessage(changes as Change[]);
+    expect(message).toEqual('adds `attack-pattern` in `Label` | removes `TLP:GREEN` in `Markings`');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { historyMessage } from '../../../src/manager/historyManager';
+import type { Change } from '../../../src/types/event';
 
 describe('historyMessage tests', () => {
   it('should generate history message for Description update', () => {
@@ -26,5 +27,30 @@ describe('historyMessage tests', () => {
     }];
     const message = historyMessage('update', changes);
     expect(message).toEqual('updates description in Description - backdoor in Malware types');
+  });
+  it('should generate history message for multiple update', () => {
+    const changes = [{
+      field: 'Description',
+      previous: [],
+      new: ['description'],
+    },
+    {
+      field: 'Malware types',
+      previous: ['backdoor', 'bootkit'],
+      new: ['backdoor'],
+      added: [],
+      removed: ['bootkit'],
+    },
+    {
+      field: 'Confidence',
+      previous: [58],
+      new: [52],
+    },
+    {
+      field: 'Workflow status',
+      previous: ['status1'],
+      new: ['status2'] }];
+    const message = historyMessage('update', changes as Change[]);
+    expect(message).toEqual('updates description in Description - backdoor in Malware types - 52 in Confidence - status2 in Workflow status and 1 more operations');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/historyManager-test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { historyMessage } from '../../../src/manager/historyManager';
+
+describe('historyMessage tests', () => {
+  it('should generate history message for Description update', () => {
+    const changes = [{
+      field: 'Description',
+      previous: [],
+      new: ['description'],
+    }];
+    const message = historyMessage('update', changes);
+    expect(message).toEqual('updates description in Description');
+  });
+  it('should generate history message for multiple update', () => {
+    const changes = [{
+      field: 'Description',
+      previous: [],
+      new: ['description'],
+    },
+    {
+      field: 'Malware types',
+      previous: ['backdoor', 'bootkit'],
+      new: ['backdoor'],
+      added: [],
+      removed: ['bootkit'],
+    }];
+    const message = historyMessage('update', changes);
+    expect(message).toEqual('updates description in Description - backdoor in Malware types');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/build-changes-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/build-changes-test.ts
@@ -552,18 +552,17 @@ describe('buildChanges standard behavior', async () => {
       value: [{
         access_right: 'admin',
         id: ADMIN_USER.id,
-      },
-      {
-        key: 'description',
-        previous: ['description'],
-        value: ['new description'],
-      }],
+      }] },
+    {
+      key: 'description',
+      previous: ['description'],
+      value: ['new description'],
     }];
     const changes = await buildChanges(testContext, ADMIN_USER, ENTITY_TYPE_CONTAINER_REPORT, inputs);
-    expect(changes).toEqual([[{
+    expect(changes).toEqual([{
       field: 'Description',
       previous: ['description'],
       new: ['new description'],
-    }]]);
+    }]);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/build-changes-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/build-changes-test.ts
@@ -535,35 +535,35 @@ describe('buildChanges standard behavior', async () => {
   });
   it('should build empty changes for Auth members change', async () => {
     const inputs = [{
-      key:'restricted_members',
-      previous:[],
-      value:[{
+      key: 'restricted_members',
+      previous: [],
+      value: [{
         access_right: 'admin',
         id: ADMIN_USER.id,
-      }]
+      }],
     }];
     const changes = await buildChanges(testContext, ADMIN_USER, ENTITY_TYPE_CONTAINER_REPORT, inputs);
     expect(changes).toEqual([]);
   });
   it('should not have auth member in changes for description and auth members add', async () => {
     const inputs = [{
-      key:'restricted_members',
-      previous:[],
-      value:[{
+      key: 'restricted_members',
+      previous: [],
+      value: [{
         access_right: 'admin',
         id: ADMIN_USER.id,
       },
-        {
-          key: 'description',
-          previous: ['description'],
-          value: ['new description']
-        }]
+      {
+        key: 'description',
+        previous: ['description'],
+        value: ['new description'],
+      }],
     }];
     const changes = await buildChanges(testContext, ADMIN_USER, ENTITY_TYPE_CONTAINER_REPORT, inputs);
     expect(changes).toEqual([[{
       field: 'Description',
       previous: ['description'],
-      new: ['new description']
+      new: ['new description'],
     }]]);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/build-changes-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/build-changes-test.ts
@@ -533,4 +533,37 @@ describe('buildChanges standard behavior', async () => {
     const changes = await buildChanges(testContext, ADMIN_USER, ENTITY_TYPE_CONTAINER_REPORT, inputs);
     expect(changes).toEqual([{ field: 'Creators', previous: ['security@opencti.io'], new: ['security@opencti.io', 'editor@opencti.io'], added: ['editor@opencti.io'], removed: [] }]);
   });
+  it('should build empty changes for Auth members change', async () => {
+    const inputs = [{
+      key:'restricted_members',
+      previous:[],
+      value:[{
+        access_right: 'admin',
+        id: ADMIN_USER.id,
+      }]
+    }];
+    const changes = await buildChanges(testContext, ADMIN_USER, ENTITY_TYPE_CONTAINER_REPORT, inputs);
+    expect(changes).toEqual([]);
+  });
+  it('should not have auth member in changes for description and auth members add', async () => {
+    const inputs = [{
+      key:'restricted_members',
+      previous:[],
+      value:[{
+        access_right: 'admin',
+        id: ADMIN_USER.id,
+      },
+        {
+          key: 'description',
+          previous: ['description'],
+          value: ['new description']
+        }]
+    }];
+    const changes = await buildChanges(testContext, ADMIN_USER, ENTITY_TYPE_CONTAINER_REPORT, inputs);
+    expect(changes).toEqual([[{
+      field: 'Description',
+      previous: ['description'],
+      new: ['new description']
+    }]]);
+  });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* we don't stor any more Auth members or OrgSharing changes 
* history message is rebuild from changes
* use `publiUserAction` to push in activity logs if Auth members or OrgSharing changes 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/8237


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
