### PR TITLE
[frontend] fix Disable button typo in rule deactivation pop-up (#13485)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/rules/RulesStatusChangeDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/rules/RulesStatusChangeDialog.tsx
@@ -96,7 +96,7 @@ const RulesStatusChangeDialog = ({
           {t_i18n('Cancel')}
         </Button>
         <Button onClick={submit} color="secondary" disabled={processing}>
-          {t_i18n('Enable')}
+          {status === 'enable' ? t_i18n('Enable') : t_i18n('Disable')}
         </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
### Proposed changes
When deactivating a rule, in the pop-up, the button should be labelled 'Disabled', and not 'Enable'

<img width="1834" height="706" alt="image" src="https://github.com/user-attachments/assets/63c76c22-9012-433e-8c16-f33b5e777692" />


### Related issues
#13485