### PR TITLE
[ci] Reduce integration tests duration (#13540)

### DIFF
--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/connector-composer-test.ts
@@ -380,12 +380,12 @@ describe('Connector Composer and Managed Connectors', () => {
         await xtmComposer.runOrchestrationCycle();
       } else {
         await awaitUntilCondition(async () => {
-            const connectorResult = await queryAsAdminWithSuccess({
-              query: GET_CONNECTOR_QUERY_CURRENT_STATUS,
-              variables: { id: deploymentConnectorId }
-            });
-            return connectorResult.data?.connector.manager_current_status === 'started'; // Wait connector to be started
-          }, 400, 5);
+          const connectorResult = await queryAsAdminWithSuccess({
+            query: GET_CONNECTOR_QUERY_CURRENT_STATUS,
+            variables: { id: deploymentConnectorId }
+          });
+          return connectorResult.data?.connector.manager_current_status === 'started'; // Wait connector to be started
+        }, 300, 5);
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -439,7 +439,13 @@ describe('Connector Composer and Managed Connectors', () => {
       if (FORCE_POLLING) {
         await xtmComposer.runOrchestrationCycle();
       } else {
-        await wait(1500);
+        await awaitUntilCondition(async () => {
+          const connectorResult = await queryAsAdminWithSuccess({
+            query: GET_CONNECTOR_QUERY_CURRENT_STATUS,
+            variables: { id: deploymentConnectorId }
+          });
+          return connectorResult.data?.connector.manager_current_status === 'started';
+        }, 300, 5);        
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -469,7 +475,13 @@ describe('Connector Composer and Managed Connectors', () => {
       if (FORCE_POLLING) {
         await xtmComposer.runOrchestrationCycle();
       } else {
-        await wait(1500);
+        await awaitUntilCondition(async () => {
+          const connectorResult = await queryAsAdminWithSuccess({
+            query: GET_CONNECTOR_QUERY_CURRENT_STATUS,
+            variables: { id: deploymentConnectorId }
+          });
+          return connectorResult.data?.connector.manager_current_status === 'stopped';
+        }, 300, 5);   
       }
 
       const connectorResult = await queryAsAdminWithSuccess({
@@ -496,7 +508,13 @@ describe('Connector Composer and Managed Connectors', () => {
       if (FORCE_POLLING) {
         await xtmComposer.runOrchestrationCycle();
       } else {
-        await wait(1500);
+        await awaitUntilCondition(async () => {
+          const connectorResult = await queryAsAdminWithSuccess({
+            query: GET_CONNECTOR_QUERY_CURRENT_STATUS,
+            variables: { id: deploymentConnectorId }
+          });
+          return connectorResult.data?.connector.manager_current_status === 'stopped';
+        }, 300, 5);
       }
 
       let connectorResult = await queryAsAdminWithSuccess({
@@ -521,7 +539,13 @@ describe('Connector Composer and Managed Connectors', () => {
       if (FORCE_POLLING) {
         await xtmComposer.runOrchestrationCycle();
       } else {
-        await wait(1500);
+        await awaitUntilCondition(async () => {
+          const connectorResult = await queryAsAdminWithSuccess({
+            query: GET_CONNECTOR_QUERY_CURRENT_STATUS,
+            variables: { id: deploymentConnectorId }
+          });
+          return connectorResult.data?.connector.manager_current_status === 'started';
+        }, 300, 5); 
       }
 
       // Verify status
@@ -582,14 +606,7 @@ describe('Connector Composer and Managed Connectors', () => {
         variables: { input: { id: logLevelConnectorId, status: 'starting' } }
       });
 
-      // Wait for XTM Composer to deploy
-      if (FORCE_POLLING) {
-        await xtmComposer.runOrchestrationCycle();
-      } else {
-        await wait(1500);
-      }
-
-      // Get current configuration to preserve other settings
+            // Get current configuration to preserve other settings
       const GET_CONNECTOR_QUERY = gql`
         query GetConnector($id: String!) {
           connector(id: $id) {
@@ -602,6 +619,19 @@ describe('Connector Composer and Managed Connectors', () => {
           }
         }
       `;
+
+      // Wait for XTM Composer to deploy
+      if (FORCE_POLLING) {
+        await xtmComposer.runOrchestrationCycle();
+      } else {
+        await awaitUntilCondition(async () => {
+            const connectorResult = await queryAsAdminWithSuccess({
+              query: GET_CONNECTOR_QUERY,
+              variables: { id: logLevelConnectorId }
+            });
+            return connectorResult.data?.connector.manager_current_status === 'started';
+          }, 300, 5);
+      }
 
       const connectorResult = await queryAsAdminWithSuccess({
         query: GET_CONNECTOR_QUERY,
@@ -770,7 +800,7 @@ describe('Connector Composer and Managed Connectors', () => {
       // Count occurrences of redeploys - should only have the two from configuration changes
       const allLogStrings = logs3.join('\n');
       const redeployCount = (allLogStrings.match(/Connector redeployed successfully/g) || []).length;
-      const deployCount = (logStrings.match(/Connector deployed successfully/g) || []).length;
+      const deployCount = (allLogStrings.match(/Connector deployed successfully/g) || []).length;
       expect(redeployCount).toBe(2); // Only the two previous configuration changes
       expect(deployCount).toBe(2); // Only the first and last configuration changes
     });
@@ -791,7 +821,13 @@ describe('Connector Composer and Managed Connectors', () => {
       if (FORCE_POLLING) {
         await xtmComposer.runOrchestrationCycle();
       } else {
-        await wait(1500);
+        await awaitUntilCondition(async () => {
+          const deleteResult = await queryAsAdminWithSuccess({
+            query: DELETE_CONNECTOR_MUTATION,
+            variables: { id: deploymentConnectorId }
+          });
+          return deleteResult.data?.deleteConnector === deploymentConnectorId;
+        }, 300, 5);
       }
 
       // Now delete the connector

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
@@ -1,10 +1,11 @@
 import { expect, it, describe } from 'vitest';
 import gql from 'graphql-tag';
 import { ADMIN_API_TOKEN, ADMIN_USER, API_URI, editorQuery, PYTHON_PATH, queryAsAdmin, TEST_ORGANIZATION, testContext, USER_PARTICIPATE } from '../../utils/testQuery';
-import { awaitUntilCondition, queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
+import { queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
 import { MARKING_TLP_AMBER_STRICT, MARKING_TLP_RED } from '../../../src/schema/identifier';
 import { execChildPython } from '../../../src/python/pythonBridge';
+import { wait } from '../../../src/database/utils';
 
 const CREATE_REPORT_QUERY = gql`
     mutation ReportAdd($input: ReportAddInput!) {
@@ -249,13 +250,7 @@ describe('Delete operation resolver testing', () => {
     deleteOperationId = getAllDeletedOperations.data?.deleteOperations.edges[0].node.id;
 
     // Restore the report (wait for report deletion lock to expire before restoring)
-    await awaitUntilCondition(async () => {
-        const deleteOperationResult = await queryAsAdminWithSuccess({ 
-          query: READ_DELETE_OPERATION_QUERY, 
-          variables: { id: deleteOperationId }
-        });
-        return deleteOperationResult.data?.deleteOperation !== null;
-    }, 500, 11);
+    await wait(5010);
 
     await queryAsAdmin({ query: DELETE_RESTORE_MUTATION, variables: { id: deleteOperationId }, });
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
@@ -4,8 +4,8 @@ import { ADMIN_API_TOKEN, ADMIN_USER, API_URI, editorQuery, PYTHON_PATH, queryAs
 import { queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
 import { MARKING_TLP_AMBER_STRICT, MARKING_TLP_RED } from '../../../src/schema/identifier';
-import { execChildPython } from '../../../src/python/pythonBridge';
 import { wait } from '../../../src/database/utils';
+import { execChildPython } from '../../../src/python/pythonBridge';
 
 const CREATE_REPORT_QUERY = gql`
     mutation ReportAdd($input: ReportAddInput!) {
@@ -249,9 +249,8 @@ describe('Delete operation resolver testing', () => {
     expect(getAllDeletedOperations.data?.deleteOperations.edges.length).toEqual(1);
     deleteOperationId = getAllDeletedOperations.data?.deleteOperations.edges[0].node.id;
 
-    // Restore the report (wait for report deletion lock to expire before restoring)
+    // Restore the report (wait 5s for report deletion lock to expire before restoring)
     await wait(5010);
-
     await queryAsAdmin({ query: DELETE_RESTORE_MUTATION, variables: { id: deleteOperationId }, });
 
     const deleteOperationQueryResult = await queryAsAdminWithSuccess({ query: READ_DELETE_OPERATION_QUERY, variables: { id: deleteOperationId } });

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
@@ -250,7 +250,10 @@ describe('Delete operation resolver testing', () => {
 
     // Restore the report (wait for report deletion lock to expire before restoring)
     await awaitUntilCondition(async () => {
-        const deleteOperationResult = await queryAsAdmin({ query: DELETE_RESTORE_MUTATION, variables: { id: deleteOperationId }, });
+        const deleteOperationResult = await queryAsAdminWithSuccess({ 
+          query: READ_DELETE_OPERATION_QUERY, 
+          variables: { id: deleteOperationId }
+        });
         return deleteOperationResult.data?.deleteOperation !== null;
     }, 500, 11);
 

--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/deleteOperation-test.ts
@@ -1,10 +1,9 @@
 import { expect, it, describe } from 'vitest';
 import gql from 'graphql-tag';
 import { ADMIN_API_TOKEN, ADMIN_USER, API_URI, editorQuery, PYTHON_PATH, queryAsAdmin, TEST_ORGANIZATION, testContext, USER_PARTICIPATE } from '../../utils/testQuery';
-import { queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
+import { awaitUntilCondition, queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
 import { MARKING_TLP_AMBER_STRICT, MARKING_TLP_RED } from '../../../src/schema/identifier';
-import { wait } from '../../../src/database/utils';
 import { execChildPython } from '../../../src/python/pythonBridge';
 
 const CREATE_REPORT_QUERY = gql`
@@ -249,8 +248,12 @@ describe('Delete operation resolver testing', () => {
     expect(getAllDeletedOperations.data?.deleteOperations.edges.length).toEqual(1);
     deleteOperationId = getAllDeletedOperations.data?.deleteOperations.edges[0].node.id;
 
-    // Restore the report (wait 5s for report deletion lock to expire before restoring)
-    await wait(5010);
+    // Restore the report (wait for report deletion lock to expire before restoring)
+    await awaitUntilCondition(async () => {
+        const deleteOperationResult = await queryAsAdmin({ query: DELETE_RESTORE_MUTATION, variables: { id: deleteOperationId }, });
+        return deleteOperationResult.data?.deleteOperation !== null;
+    }, 500, 11);
+
     await queryAsAdmin({ query: DELETE_RESTORE_MUTATION, variables: { id: deleteOperationId }, });
 
     const deleteOperationQueryResult = await queryAsAdminWithSuccess({ query: READ_DELETE_OPERATION_QUERY, variables: { id: deleteOperationId } });

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -162,7 +162,7 @@ export const readCsvFromFileStream = async (filePath: string, fileName: string) 
 
   const csvLines: string[] = [];
   // Need an async interator to prevent blocking
-  // eslint-disable-next-line no-restricted-syntax
+   
   for await (const line of rl) {
     csvLines.push(line);
   }
@@ -263,7 +263,6 @@ export const awaitUntilCondition = async (
 ) => {
   let isConditionOk = await conditionPromise();
   let loopCurrent = 0;
-
   while (!isConditionOk === expectToBeTrue && loopCurrent < loopCount) {
     await new Promise(resolve => setTimeout(resolve, sleepTimeBetweenLoop));
     isConditionOk = await conditionPromise();

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -262,7 +262,6 @@ export const awaitUntilCondition = async (
   expectToBeTrue = true,
 ) => {
   let isConditionOk = await conditionPromise();
-  console.log(isConditionOk);
   let loopCurrent = 0;
   while (!isConditionOk === expectToBeTrue && loopCurrent < loopCount) {
     await new Promise(resolve => setTimeout(resolve, sleepTimeBetweenLoop));

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -262,6 +262,7 @@ export const awaitUntilCondition = async (
   expectToBeTrue = true,
 ) => {
   let isConditionOk = await conditionPromise();
+  console.log(isConditionOk);
   let loopCurrent = 0;
   while (!isConditionOk === expectToBeTrue && loopCurrent < loopCount) {
     await new Promise(resolve => setTimeout(resolve, sleepTimeBetweenLoop));

--- a/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQueryHelper.ts
@@ -263,6 +263,7 @@ export const awaitUntilCondition = async (
 ) => {
   let isConditionOk = await conditionPromise();
   let loopCurrent = 0;
+  
   while (!isConditionOk === expectToBeTrue && loopCurrent < loopCount) {
     await new Promise(resolve => setTimeout(resolve, sleepTimeBetweenLoop));
     isConditionOk = await conditionPromise();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Using awaitUntilCondition helper :
* added a check to see if queue is ready in ingestionManager integration test : 
   Before : 62430ms Now : 1849ms

* Removed all waits of 1500 ms and above and replaced them with individual checks in connector-composer-test
   Before : 8145ms Now : 7318ms (most improvment is when FORCE_PULLING is false : 24060ms to 11460ms)
          
* Removed wait(TEN_SECONDS * 2) in organization-sharing-test.ts‎
   Before : 22804ms Now : 3192ms 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
* https://github.com/OpenCTI-Platform/opencti/issues/13540

NB : I moved :

7136ms tests/02-integration/02-resolvers/deleteOperation-test.ts
6395ms tests/02-integration/02-resolvers/user-test.ts

in another subtask (part 5), no simple alternative found at the moment.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
