### PR TITLE
[backend] Refactor OTP to use a directive to allow specific API

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2,6 +2,8 @@ directive @auth(for: [Capabilities] = [], and: Boolean = false) on OBJECT | FIEL
 
 directive @public on OBJECT | FIELD_DEFINITION
 
+directive @allowUnprotectedOTP on OBJECT | FIELD_DEFINITION
+
 directive @allowUnlicensedLTS on OBJECT | FIELD_DEFINITION
 
 directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, notContains: String, pattern: String, format: String, min: Int, max: Int, exclusiveMin: Int, exclusiveMax: Int, multipleOf: Int) on INPUT_FIELD_DEFINITION

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2,6 +2,7 @@
 
 directive @auth(for: [Capabilities] = [], and: Boolean = false) on OBJECT | FIELD_DEFINITION
 directive @public on OBJECT | FIELD_DEFINITION
+directive @allowUnprotectedOTP on OBJECT | FIELD_DEFINITION
 directive @allowUnlicensedLTS on OBJECT | FIELD_DEFINITION
 directive @constraint(
   # String constraints
@@ -13662,7 +13663,7 @@ type Query {
   roles(first: Int, after: ID, orderBy: RolesOrdering, orderMode: OrderingMode, search: String): RoleConnection
   @auth(for: [SETTINGS_SETACCESSES])
   me: MeUser! @auth
-  otpGeneration: OtpElement @auth
+  otpGeneration: OtpElement @auth @allowUnprotectedOTP
   user(id: String!): User @auth(for: [SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN])
   creators(entityTypes: [String!]): CreatorConnection @auth(for: [KNOWLEDGE])
   assignees(entityTypes: [String!]): AssigneeConnection @auth(for: [KNOWLEDGE])
@@ -15329,10 +15330,10 @@ type Mutation {
   ######## INTERNAL OBJECT ENTITIES
   frontendErrorLog(message: String!, codeStack: String, componentStack: String): Boolean @auth
   token(input: UserLoginInput): String @public # Use for login
-  otpActivation(input: UserOTPActivationInput): MeUser @auth
+  otpActivation(input: UserOTPActivationInput): MeUser @auth @allowUnprotectedOTP
   otpDeactivation: MeUser @auth
   otpUserDeactivation(id: ID!): MeUser @auth(for: [SETTINGS_SETACCESSES])
-  otpLogin(input: UserOTPLoginInput): Boolean @auth @rateLimit(limit: 1, duration: 1)
+  otpLogin(input: UserOTPLoginInput): Boolean @auth @rateLimit(limit: 1, duration: 1) @allowUnprotectedOTP
   settingsEdit(id: ID!): SettingsEditMutations @auth
   setupEnterpriseLicense(input: LicenseActivationInput!): Settings @auth(for: [SETTINGS_SETPARAMETERS, SETTINGS_SETMANAGEXTMHUB]) @allowUnlicensedLTS
   subTypeEdit(id: ID!): SubTypeEditMutations @auth(for: [SETTINGS_SETCUSTOMIZATION])
@@ -15350,7 +15351,7 @@ type Mutation {
   bookmarkAdd(id: ID!, type: String!): StixDomainObject @auth(for: [KNOWLEDGE])
   bookmarkDelete(id: ID!): ID @auth(for: [KNOWLEDGE])
   sendUserMail(input: SendUserMailInput!): Boolean @auth(for: [SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN])
-  logout: ID @auth
+  logout: ID @auth @allowUnprotectedOTP
   roleAdd(input: RoleAddInput!): Role @auth(for: [SETTINGS_SETACCESSES])
   sessionKill(id: ID!): ID @auth(for: [SETTINGS_SETACCESSES])
   userSessionsKill(id: ID!): [ID] @auth(for: [SETTINGS_SETACCESSES])

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -37825,6 +37825,10 @@ export type AllowUnlicensedLtsDirectiveArgs = { };
 
 export type AllowUnlicensedLtsDirectiveResolver<Result, Parent, ContextType = any, Args = AllowUnlicensedLtsDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
+export type AllowUnprotectedOtpDirectiveArgs = { };
+
+export type AllowUnprotectedOtpDirectiveResolver<Result, Parent, ContextType = any, Args = AllowUnprotectedOtpDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
 export type AuthDirectiveArgs = {
   and?: Maybe<Scalars['Boolean']['input']>;
   for?: Maybe<Array<Maybe<Capabilities>>>;
@@ -49014,6 +49018,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
 
 export type DirectiveResolvers<ContextType = any> = ResolversObject<{
   allowUnlicensedLTS?: AllowUnlicensedLtsDirectiveResolver<any, any, ContextType>;
+  allowUnprotectedOTP?: AllowUnprotectedOtpDirectiveResolver<any, any, ContextType>;
   auth?: AuthDirectiveResolver<any, any, ContextType>;
   constraint?: ConstraintDirectiveResolver<any, any, ContextType>;
   public?: PublicDirectiveResolver<any, any, ContextType>;

--- a/opencti-platform/opencti-graphql/src/graphql/authDirective.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/authDirective.ts
@@ -1,6 +1,5 @@
 import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
-// noinspection JSFileReferences
-import { defaultFieldResolver } from 'graphql/index.js';
+import { defaultFieldResolver } from 'graphql';
 import type { GraphQLFieldConfig, GraphQLSchema } from 'graphql';
 import { AuthRequired, ForbiddenAccess, LtsRequiredActivation, OtpRequired, OtpRequiredActivation, UnsupportedError } from '../config/errors';
 import { Capabilities } from '../generated/graphql';

--- a/opencti-platform/opencti-graphql/src/types/graphql.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/graphql.d.ts
@@ -1,6 +1,5 @@
 declare module '*.graphql' {
-  // eslint-disable-next-line import/extensions
-  import { DocumentNode } from 'graphql/index.js';
+  import { DocumentNode } from 'graphql';
 
   const Schema: DocumentNode;
 


### PR DESCRIPTION
Simple refactor to use a directive instead of direct naming in the authDirective.js