### PR TITLE
[frontend] fix capa in draft issues (#10981)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "Sie haben keinen Zugriff auf die Support-Pakete dieser OpenCTI-Instanz.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "Sie haben keinen Zugriff auf das Wissen dieser OpenCTI-Instanz.",
   "You do not have permission to view form intakes.": "Sie haben keine Erlaubnis, Formulare einzusehen.",
+  "You do not have the access rights to approve a draft": "Sie haben nicht die Zugriffsrechte, um einen Entwurf zu genehmigen",
   "You exceeded the characters limit. Please input less than 256 characters.": "Sie haben das Zeichenlimit überschritten. Bitte geben Sie weniger als 256 Zeichen ein.",
   "You have canceled the registration process": "Sie haben den Registrierungsprozess abgebrochen",
   "You have canceled the unregistration process": "Sie haben den Vorgang der Abmeldung abgebrochen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "You do not have any access to support packages of this OpenCTI instance.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "You do not have any access to the knowledge of this OpenCTI instance.",
   "You do not have permission to view form intakes.": "You do not have permission to view form intakes.",
+  "You do not have the access rights to approve a draft": "You do not have the access rights to approve a draft",
   "You exceeded the characters limit. Please input less than 256 characters.": "You exceeded the characters limit. Please input less than 256 characters.",
   "You have canceled the registration process": "You have canceled the registration process",
   "You have canceled the unregistration process": "You have canceled the unregistration process",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "No tiene acceso a los paquetes de soporte de esta instancia de OpenCTI.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "No tienes acceso al conocimiento de esta instancia de OpenCTI.",
   "You do not have permission to view form intakes.": "No tiene permiso para ver los formularios.",
+  "You do not have the access rights to approve a draft": "No tiene derechos de acceso para aprobar un borrador",
   "You exceeded the characters limit. Please input less than 256 characters.": "Ha excedido el límite de caracteres. Por favor, introduzca menos de 256 caracteres.",
   "You have canceled the registration process": "Ha cancelado el proceso de registro",
   "You have canceled the unregistration process": "Ha cancelado el proceso de baja",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "Vous n'avez pas accès au support de cette instance OpenCTI.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "Vous n'avez aucun accès à la connaissance de cette instance OpenCTI.",
   "You do not have permission to view form intakes.": "Vous n'êtes pas autorisé à consulter les formulaires d'admission.",
+  "You do not have the access rights to approve a draft": "Vous n'avez pas les droits d'accès pour approuver un projet",
   "You exceeded the characters limit. Please input less than 256 characters.": "Vous avez dépassé la limite de caractères. Veuillez saisir moins de 256 caractères.",
   "You have canceled the registration process": "Vous avez annulé la procédure d'inscription",
   "You have canceled the unregistration process": "Vous avez annulé le processus de désinscription",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "Non avete accesso ai pacchetti di supporto di questa istanza OpenCTI.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "Non hai alcun accesso alla conoscenza di questa istanza OpenCTI.",
   "You do not have permission to view form intakes.": "Non si ha l'autorizzazione a visualizzare i moduli di assunzione.",
+  "You do not have the access rights to approve a draft": "Non si dispone dei diritti di accesso per approvare una bozza",
   "You exceeded the characters limit. Please input less than 256 characters.": "È stato superato il limite di caratteri. Si prega di inserire meno di 256 caratteri.",
   "You have canceled the registration process": "Avete annullato il processo di registrazione",
   "You have canceled the unregistration process": "Avete annullato il processo di disregistrazione",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "この OpenCTI インスタンスのサポートパッケージにはアクセスできません。",
   "You do not have any access to the knowledge of this OpenCTI instance.": "このOpenCTIインスタンスのナレッジデータにアクセスする権限がありません。",
   "You do not have permission to view form intakes.": "あなたには、フォームを閲覧する権限がありません。",
+  "You do not have the access rights to approve a draft": "下書きを承認するアクセス権限がありません。",
   "You exceeded the characters limit. Please input less than 256 characters.": "文字数制限を超えました。256文字以内で入力してください。",
   "You have canceled the registration process": "登録プロセスをキャンセルしました。",
   "You have canceled the unregistration process": "登録解除処理をキャンセルしました。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "이 OpenCTI 인스턴스의 지원 패키지에 대한 액세스 권한이 없습니다.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "이 OpenCTI 인스턴스의 지식에 액세스할 수 없습니다.",
   "You do not have permission to view form intakes.": "양식 접수를 볼 수 있는 권한이 없습니다.",
+  "You do not have the access rights to approve a draft": "초안을 승인할 수 있는 액세스 권한이 없습니다",
   "You exceeded the characters limit. Please input less than 256 characters.": "글자 수 제한을 초과했습니다. 256자 미만으로 입력하세요.",
   "You have canceled the registration process": "등록 절차를 취소했습니다",
   "You have canceled the unregistration process": "등록 취소 프로세스를 취소했습니다",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "У вас нет доступа к пакетам поддержки этого экземпляра OpenCTI.",
   "You do not have any access to the knowledge of this OpenCTI instance.": "Вы не имеете никакого доступа к знаниям этого экземпляра OpenCTI.",
   "You do not have permission to view form intakes.": "У вас нет разрешения на просмотр форм приема.",
+  "You do not have the access rights to approve a draft": "У вас нет прав доступа для утверждения черновика",
   "You exceeded the characters limit. Please input less than 256 characters.": "Вы превысили лимит символов. Пожалуйста, введите менее 256 символов.",
   "You have canceled the registration process": "Вы отменили процесс регистрации",
   "You have canceled the unregistration process": "Вы отменили процесс снятия с регистрации",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -4480,6 +4480,7 @@
   "You do not have any access to support packages of this OpenCTI instance.": "您没有访问此 OpenCTI 实例支持包的权限。",
   "You do not have any access to the knowledge of this OpenCTI instance.": "您无权访问此OpenCTI实例的知识数据。",
   "You do not have permission to view form intakes.": "您无权查看表格接收。",
+  "You do not have the access rights to approve a draft": "您没有批准草稿的访问权限",
   "You exceeded the characters limit. Please input less than 256 characters.": "您超出了字符数限制。请输入少于 256 个字符。",
   "You have canceled the registration process": "您已取消注册过程",
   "You have canceled the unregistration process": "您已取消取消注册程序",

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
@@ -25,7 +25,7 @@ import useDraftContext from '../../../utils/hooks/useDraftContext';
 import { truncate } from '../../../utils/String';
 import { TEN_SECONDS } from '../../../utils/Time';
 import { useGetCurrentUserAccessRight, authorizedMembersToOptions } from '../../../utils/authorizedMembers';
-import useGranted, { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../utils/hooks/useGranted';
+import useUserCanApproveDraft from '../../../utils/hooks/useUserCanApproveDraft';
 
 const interval$ = interval(TEN_SECONDS * 3);
 
@@ -116,7 +116,7 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
   const [displayAuthorizeMembersDialog, setDisplayAuthorizeMembersDialog] = useState(false);
   const navigate = useNavigate();
   const draftContext = useDraftContext();
-  const canDeleteKnowledge = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]);
+  const canDeleteKnowledge = useUserCanApproveDraft();
   const currentAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
 
   const { draftWorkspace } = usePreloadedQuery<DraftContextBannerQuery>(draftContextBannerQuery, queryRef);
@@ -230,49 +230,53 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
             {t_i18n('Exit draft')}
           </Button>
         </div>
-        {canDeleteKnowledge && currentAccessRight.canEdit && (
-          <div style={{ padding: '0 12px' }}>
-            <Button
-              variant="contained"
-              color="primary"
-              style={{ width: '100%' }}
-              onClick={() => setDisplayApprove(true)}
-              disabled={objectsCount.totalCount < 1}
-            >
-              {t_i18n('Approve draft')}
-            </Button>
-            <Dialog
-              open={displayApprove}
-              slotProps={{ paper: { elevation: 1 } }}
-              keepMounted={true}
-              slots={{ transition: Transition }}
-              onClose={() => setDisplayApprove(false)}
-            >
-              <DialogTitle>
-                {t_i18n('Are you sure?')}
-              </DialogTitle>
-              <DialogContent>
-                <DialogContentText>
-                  {t_i18n('Do you want to approve this draft and send it to ingestion?')}
-                  {currentlyProcessing && (
-                  <Alert style={{ marginTop: 10 }} severity={'warning'}>
-                    <AlertTitle>{t_i18n('Ongoing processes')}</AlertTitle>
-                    {t_i18n('There are processes still running that could impact the data of the draft. '
-                      + 'By approving the draft now, the remaining changes that would have been applied by those processes will be ignored.')}
-                  </Alert>)}
-                </DialogContentText>
-              </DialogContent>
-              <DialogActions>
-                <Button onClick={() => setDisplayApprove(false)} disabled={approving}>
-                  {t_i18n('Cancel')}
-                </Button>
-                <Button color="secondary" onClick={handleValidateDraft} disabled={approving}>
-                  {t_i18n('Approve')}
-                </Button>
-              </DialogActions>
-            </Dialog>
-          </div>
-        )}
+        
+        <div style={{ padding: '0 12px' }}>
+          <Tooltip title={(!canDeleteKnowledge || !currentAccessRight.canEdit) ? t_i18n("You don't have the access rights to approve a draft") : ''}>
+            <span>
+              <Button
+                variant="contained"
+                color="primary"
+                style={{ width: '100%' }}
+                onClick={() => setDisplayApprove(true)}
+                disabled={objectsCount.totalCount < 1 || !canDeleteKnowledge || !currentAccessRight.canEdit}
+              >
+                {t_i18n('Approve draft')}
+              </Button>
+            </span>
+          </Tooltip>
+          <Dialog
+            open={displayApprove}
+            slotProps={{ paper: { elevation: 1 } }}
+            keepMounted={true}
+            slots={{ transition: Transition }}
+            onClose={() => setDisplayApprove(false)}
+          >
+            <DialogTitle>
+              {t_i18n('Are you sure?')}
+            </DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                {t_i18n('Do you want to approve this draft and send it to ingestion?')}
+                {currentlyProcessing && (
+                <Alert style={{ marginTop: 10 }} severity={'warning'}>
+                  <AlertTitle>{t_i18n('Ongoing processes')}</AlertTitle>
+                  {t_i18n('There are processes still running that could impact the data of the draft. '
+                    + 'By approving the draft now, the remaining changes that would have been applied by those processes will be ignored.')}
+                </Alert>)}
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={() => setDisplayApprove(false)} disabled={approving}>
+                {t_i18n('Cancel')}
+              </Button>
+              <Button color="secondary" onClick={handleValidateDraft} disabled={approving}>
+                {t_i18n('Approve')}
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </div>
+      
       </div>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftContextBanner.tsx
@@ -232,7 +232,7 @@ const DraftContextBannerComponent: FunctionComponent<DraftContextBannerComponent
         </div>
         
         <div style={{ padding: '0 12px' }}>
-          <Tooltip title={(!canDeleteKnowledge || !currentAccessRight.canEdit) ? t_i18n("You don't have the access rights to approve a draft") : ''}>
+          <Tooltip title={(!canDeleteKnowledge || !currentAccessRight.canEdit) ? t_i18n('You do not have the access rights to approve a draft') : ''}>
             <span>
               <Button
                 variant="contained"

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -224,8 +224,9 @@ const LeftBar = () => {
     settings: { filigran_chatbot_ai_cgu_status },
   } = useAuth();
   const navigate = useNavigate();
+  const hasOnlyAccessToImportDraftTab = useHasOnlyAccessToImportDraftTab();
   const isGrantedToKnowledge = useGranted([KNOWLEDGE]);
-  const isGrantedToImport = useGranted([KNOWLEDGE_KNASKIMPORT]) || useHasOnlyAccessToImportDraftTab();
+  const isGrantedToImport = useGranted([KNOWLEDGE_KNASKIMPORT]) || hasOnlyAccessToImportDraftTab;
   const isGrantedToProcessing = useGranted([KNOWLEDGE_KNUPDATE, AUTOMATION_AUTMANAGE, CSVMAPPERS]);
   const isGrantedToSharing = useGranted([TAXIIAPI]);
   const isGrantedToManage = useGranted([BYPASS]);

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
@@ -72,7 +72,8 @@ const CapabilitiesList: FunctionComponent<CapabilitiesListProps> = ({
               && r.name.includes(capability.name)
               && capability.name !== 'BYPASS',
           );
-          const isDisabled = matchingCapabilities.length > 0;
+          const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name.includes(capability.name));
+          const isDisabled = isCapabilitiesInDraft ? matchingCapabilities.length > 0 || draftCapaMatchingMainCapa.length > 0 : matchingCapabilities.length > 0;
           const isChecked = isDisabled || roleCapability !== undefined;
           if (isChecked) {
             return (

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from 'react';
 import { createFragmentContainer, graphql, usePreloadedQuery } from 'react-relay';
-import * as R from 'ramda';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Checkbox from '@mui/material/Checkbox';
@@ -190,13 +189,13 @@ const RoleEditionCapabilitiesComponent: FunctionComponent<RoleEditionCapabilitie
             const roleCapability = roleCapabilities.find(
               (r) => r.name === capability.name,
             );
-            const matchingCapabilities = R.filter(
+            const matchingCapabilities = roleCapabilities.filter(
               (r) => capability.name !== r.name
-                && R.includes(capability.name, r.name)
+                && r.name.includes(capability.name)
                 && capability.name !== 'BYPASS',
-              roleCapabilities,
             );
-            const isDisabled = matchingCapabilities.length > 0;
+            const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name.includes(capability.name));
+            const isDisabled = isCapabilitiesInDraft ? matchingCapabilities.length > 0 || draftCapaMatchingMainCapa.length > 0 : matchingCapabilities.length > 0;
             const isChecked = isDisabled || roleCapability !== undefined;
             return (
               <ListItem

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
@@ -156,7 +156,7 @@ const RoleEditionCapabilitiesComponent: FunctionComponent<RoleEditionCapabilitie
   if (capabilitiesBaseList && capabilitiesBaseList.edges) {
     return (
       <List dense={true}>
-        {isSensitive && (
+        {isSensitive && !isCapabilitiesInDraft && (
           <ListItem
             key="sensitive"
             divider={true}

--- a/opencti-platform/opencti-front/src/utils/hooks/useGranted.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useGranted.ts
@@ -63,6 +63,11 @@ export const getCapabilitiesName = (capabilities: readonly { name: string }[]) =
   return (capabilities ?? []).map((capability) => capability?.name);
 };
 
+export const isBypassUser = (me: { id: string; capabilities: readonly { name: string }[] }) => {
+  const userCapabilities = getCapabilitiesName(me.capabilities);
+  return userCapabilities.includes(BYPASS);
+};
+
 const useGranted = (capabilities: string[], matchAll = false): boolean => {
   const { me } = useAuth();
   const { isFeatureEnable } = useHelper();
@@ -76,7 +81,7 @@ const useGranted = (capabilities: string[], matchAll = false): boolean => {
   let userCapabilities: string[] = [];
   const userBaseCapabilities = getCapabilitiesName(me.capabilities);
   
-  if (userBaseCapabilities.includes(BYPASS)) {
+  if (isBypassUser(me)) {
     return true;
   }
 

--- a/opencti-platform/opencti-front/src/utils/hooks/useHasOnlyAccessToImportDraftTab.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useHasOnlyAccessToImportDraftTab.ts
@@ -14,7 +14,7 @@ const useHasOnlyAccessToImportDraftTab = (): boolean => {
   if (isCapabilitiesInDraftEnabled || hasImportCapability) {
     return false;
   } 
-  return userCapabilitiesInDraft.includes(KNOWLEDGE);
+  return userCapabilitiesInDraft.some((capability) => capability.includes(KNOWLEDGE));
 };
 
 export default useHasOnlyAccessToImportDraftTab;

--- a/opencti-platform/opencti-front/src/utils/hooks/useHasOnlyAccessToImportDraftTab.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useHasOnlyAccessToImportDraftTab.ts
@@ -11,9 +11,9 @@ const useHasOnlyAccessToImportDraftTab = (): boolean => {
   
   const { isFeatureEnable } = useHelper();
   const isCapabilitiesInDraftEnabled = isFeatureEnable('CAPABILITIES_IN_DRAFT');
-  if (isCapabilitiesInDraftEnabled || hasImportCapability) {
+  if (!isCapabilitiesInDraftEnabled || hasImportCapability) {
     return false;
-  } 
+  }
   return userCapabilitiesInDraft.some((capability) => capability.includes(KNOWLEDGE));
 };
 

--- a/opencti-platform/opencti-front/src/utils/hooks/useUserCanApproveDraft.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useUserCanApproveDraft.ts
@@ -1,0 +1,14 @@
+import { getCapabilitiesName, isBypassUser, KNOWLEDGE_KNUPDATE_KNDELETE } from './useGranted';
+import useAuth from './useAuth';
+
+// Check if the user has only KNOWLEDGE_KNUPDATE_KNDELETE in base capabilities (or is bypass)
+const useUserCanApproveDraft = (): boolean => {
+  const { me } = useAuth();
+ 
+  const isBypassUserFlag = isBypassUser(me);
+  const canDeleteKnowledge = getCapabilitiesName(me.capabilities).includes(KNOWLEDGE_KNUPDATE_KNDELETE);
+
+  return canDeleteKnowledge || isBypassUserFlag;
+};
+
+export default useUserCanApproveDraft;


### PR DESCRIPTION
### Proposed changes

* remove `Allow modification of sensitive configuration` in "capabilities in draft" tab
* When you check capa in main, this capa will be checked in draft
* Approve draft button is always visible but disable when you don't have right access
* Data/Import menu is accessible with Knowledge capability in draft

### Related issues

* #10981

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality