### PR TITLE
[backend] Rework enrich connector component for playbooks

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -367,7 +367,7 @@ const extendsBundleElementsWithExtensions = (bundle: StixBundle): StixBundle => 
   });
   return newBundle;
 };
-const PLAYBOOK_CONNECTOR_COMPONENT: PlaybookComponent<ConnectorConfiguration> = {
+export const PLAYBOOK_CONNECTOR_COMPONENT: PlaybookComponent<ConnectorConfiguration> = {
   id: 'PLAYBOOK_CONNECTOR_COMPONENT',
   name: 'Enrich through connector',
   description: 'Use a registered platform connector for enrichment',
@@ -385,7 +385,7 @@ const PLAYBOOK_CONNECTOR_COMPONENT: PlaybookComponent<ConnectorConfiguration> = 
     return R.mergeDeepRight<JSONSchemaType<ConnectorConfiguration>, any>(PLAYBOOK_CONNECTOR_COMPONENT_SCHEMA, schemaElement);
   },
   notify: async ({ executionId, eventId, playbookId, playbookNode,
-    previousPlaybookNodeId, dataInstanceId, bundle }) => {
+                   previousPlaybookNodeId, dataInstanceId, bundle }) => {
     if (playbookNode.configuration.connector) {
       const baseData = extractBundleBaseElement(dataInstanceId, bundle);
       const message = {
@@ -411,17 +411,43 @@ const PLAYBOOK_CONNECTOR_COMPONENT: PlaybookComponent<ConnectorConfiguration> = 
       await pushToConnector(playbookNode.configuration.connector, message);
     }
   },
-  executor: async ({ bundle }) => {
+  executor: async ({ bundle, previousStepBundle }) => {
     // Add extensions if needed
     // This is needed as the rest of playbook expecting STIX2.1 format with extensions
     const stixBundle = extendsBundleElementsWithExtensions(bundle);
-    // TODO Could be reactivated after improvement of enrichment connectors
-    // if (previousStepBundle) {
-    //   const diffOperations = jsonpatch.compare(previousStepBundle.objects, bundle.objects);
-    //   if (diffOperations.length === 0) {
-    //     return { output_port: 'unmodified', bundle };
-    //   }
-    // }
+    if (previousStepBundle) {
+      // TODO Could be reactivated after improvement of enrichment connectors
+      //   const diffOperations = jsonpatch.compare(previousStepBundle.objects, bundle.objects);
+      //   if (diffOperations.length === 0) {
+      //     return { output_port: 'unmodified', bundle };
+      //   }
+
+      // Check if new bundle objects has the same object ids of previous bundle objects
+      const enrichedObjects = stixBundle.objects.map(newObj => {
+        const prevObj = previousStepBundle.objects.find(o => o.id === newObj.id);
+        if (prevObj) {
+          const resolveDuplicate = (a: any, b: any) => {
+            if (Array.isArray(a) && Array.isArray(b)) {
+              return R.uniq([...a, ...b]);
+            }
+            return b;
+          };
+          // Merge both objects if same ids
+          return R.mergeDeepWith<StixObject, StixObject>(resolveDuplicate, prevObj, newObj);
+        }
+        return newObj;
+      });
+
+      // Check if new bundle contains objects of previous bundle and add them if not in it
+      previousStepBundle.objects.forEach(prevObj => {
+        const existsInCurrent = stixBundle.objects.some(o => o.id === prevObj.id);
+        if (!existsInCurrent) {
+          enrichedObjects.push(prevObj);
+        }
+      });
+      stixBundle.objects = enrichedObjects;
+      return { output_port: 'out', bundle: stixBundle };
+    }
     return { output_port: 'out', bundle: stixBundle };
   },
 };

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/enrich-connector-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/enrich-connector-component-test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import type { StixBundle, StixObject, StixOpenctiExtension } from '../../../../src/types/stix-2-1-common';
+import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+import { PLAYBOOK_CONNECTOR_COMPONENT } from '../../../../src/modules/playbook/playbook-components';
+
+describe('PLAYBOOK_ENRICH_CONNECTOR_COMPONENT', () => {
+  const baseBundle: StixBundle = {
+    type: 'bundle',
+    spec_version: '2.1',
+    id: 'bundle--id',
+    objects: [],
+  } as StixBundle;
+
+  const ipv4ObjectId = 'bundle--ipv4-id';
+
+  const baseBundleObject = {
+    type: 'sco',
+    spec_version: '2.1',
+    id: ipv4ObjectId,
+    name: 'Playbook Object 1',
+    extensions: {
+      [STIX_EXT_OCTI]: {
+        id: 'internal-uuid',
+        type: 'IPv4-Addr',
+        extension_type: 'property-extension',
+      },
+    },
+  };
+
+  const baseExecutorParams = {
+    ipv4ObjectId,
+    eventId: '',
+    executionId: '',
+    playbookId: '',
+    previousPlaybookNodeId: undefined,
+  };
+
+  const dummyPlaybookNode = {
+    id: 'playbook-node',
+    name: 'node',
+    component_id: 'test',
+    configuration: {
+      all: false,
+      connector: 'virus-total',
+    },
+  };
+
+  it('should add previousStepBundle objects that are not present in the new bundle', async () => {
+    const idInBoth = 'sco--in-both';
+    const idOnlyInPrevious = 'sco--only-in-previous';
+
+    const previousStepBundle: StixBundle = {
+      ...baseBundle,
+      id: 'bundle--previous',
+      objects: [
+        {
+          id: idInBoth,
+          type: 'sco',
+          spec_version: '2.1',
+          name: 'Object in both bundles',
+          extensions: {
+            [STIX_EXT_OCTI]: {
+              id: 'ext-both',
+              type: 'sco',
+              extension_type: 'property-extension',
+              labels_ids: ['label-in-both'],
+            } as StixOpenctiExtension,
+          },
+        } as StixObject,
+        {
+          id: idOnlyInPrevious,
+          type: 'sco',
+          spec_version: '2.1',
+          name: 'Object only in previous bundle',
+          extensions: {
+            [STIX_EXT_OCTI]: {
+              id: 'ext-prev-only',
+              type: 'sco',
+              extension_type: 'property-extension',
+              labels_ids: ['label-prev-only'],
+            } as StixOpenctiExtension,
+          },
+        } as StixObject,
+      ],
+    };
+
+    const bundle: StixBundle = {
+      ...baseBundle,
+      id: 'bundle--current',
+      objects: [
+        {
+          id: idInBoth,
+          type: 'sco',
+          spec_version: '2.1',
+          name: 'Object in both bundles (current)',
+          extensions: {
+            [STIX_EXT_OCTI]: {
+              id: 'ext-both',
+              type: 'sco',
+              extension_type: 'property-extension',
+              labels_ids: ['label-in-both'],
+            } as StixOpenctiExtension,
+          },
+        } as StixObject,
+      ],
+    };
+
+    const result = await PLAYBOOK_CONNECTOR_COMPONENT.executor({
+      ...baseExecutorParams,
+      dataInstanceId: idInBoth,
+      previousStepBundle,
+      bundle,
+      playbookNode: dummyPlaybookNode,
+    });
+
+    const resultIds = result.bundle.objects.map((o: StixObject) => o.id);
+
+    expect(resultIds).toContain(idInBoth);
+    expect(resultIds).toContain(idOnlyInPrevious);
+    const added = result.bundle.objects.find((o) => o.id === idOnlyInPrevious) as StixObject;
+    const addedExt = added.extensions![STIX_EXT_OCTI] as StixOpenctiExtension;
+    expect(addedExt.labels_ids).toEqual(['label-prev-only']);
+  });
+
+  it('should merge previousStepBundle objects and new bundle objects with same id', async () => {
+    const previousStepBundle = {
+      ...baseBundle,
+      objects: [{
+        ...baseBundleObject,
+        labels: ['label-id-1'],
+        extensions: {
+          [STIX_EXT_OCTI]: {
+            id: 'some--id',
+            type: 'sco',
+            extension_type: 'property-extension',
+            labels_ids: ['label-id-1'],
+          } as StixOpenctiExtension,
+        },
+      } as StixObject],
+    } as StixBundle;
+
+    const bundle = {
+      ...baseBundle,
+      objects: [
+        {
+          ...baseBundleObject,
+          labels: ['label-id-2'],
+          extensions: {
+            [STIX_EXT_OCTI]: {
+              id: 'some--id',
+              type: 'sco',
+              extension_type: 'property-extension',
+              labels_ids: ['label-id-2'],
+            } as StixOpenctiExtension,
+          },
+        } as StixObject,
+        {
+          ...baseBundleObject,
+          id: 'some--id-only-in-current-bundle',
+          labels: ['label-id-3'],
+          extensions: {
+            [STIX_EXT_OCTI]: {
+              id: 'some--id-only-in-current-bundle',
+              type: 'sco',
+              extension_type: 'property-extension',
+              labels_ids: ['label-id-3'],
+            } as StixOpenctiExtension,
+          },
+        } as StixObject,
+      ],
+    } as StixBundle;
+
+    const result = await PLAYBOOK_CONNECTOR_COMPONENT.executor({
+      dataInstanceId: '',
+      ...baseExecutorParams,
+      previousStepBundle,
+      bundle,
+      playbookNode: dummyPlaybookNode,
+    });
+    const extensions = result.bundle.objects.map((object) => object.extensions[STIX_EXT_OCTI]);
+    expect(extensions).toHaveLength(2);
+    expect(extensions[0].labels_ids).toEqual(['label-id-1', 'label-id-2']);
+    expect(extensions[1].labels_ids).toEqual(['label-id-3']);
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Rework the enrich connector component for playbooks to be able to merge bundle objects when same ids but different values
* Add previous objects to new bundle if enrichment returns a new object

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/6669

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
