### PR TITLE
[ci] move resolver test to resolver folder and try to remove flake (#13772)

### DIFF
--- a/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/schema-validator-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/02-resolvers/schema-validator-test.ts
@@ -130,6 +130,21 @@ describe('Create and Update Validation', () => {
 
   it('should check mandatory attributes at update for standard users', async () => {
     await updateEntitySetting([{ name: 'description', mandatory: false }]);
+
+    const entitySettingUpdated = await queryAsAdmin({
+      query: gql`
+        query entitySettingsByTargetType($targetType: String!) {
+          entitySettingByType(targetType: $targetType) {
+            id
+              attributes_configuration
+          }
+        }
+      `,
+      variables: { targetType: ENTITY_TYPE_DATA_COMPONENT }
+    });
+
+    expect(entitySettingUpdated?.data?.entitySettingByType?.attributes_configuration).toBe('[{"name":"description","mandatory":false}]');
+
     await queryAsUserWithSuccess(USER_EDITOR.client, {
       query: CREATE_DATA_COMPONENT_QUERY,
       variables: { input: { name: 'entity name', stix_id: dataComponentStixId } }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Move that test to resolver folder since actually it's made of graphQL queries
* Try to remove a flake by verifying first that the configuration is updated. At least fail message will be more explicit.

<img width="721" height="162" alt="image" src="https://github.com/user-attachments/assets/9fe92784-64d0-40df-bbd9-83e90e76a938" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
