### PR TITLE
[ci] Start only required service for integration test

### DIFF
--- a/.github/workflows/ci-license-check.yml
+++ b/.github/workflows/ci-license-check.yml
@@ -30,6 +30,7 @@ jobs:
           -v ${{ github.workspace }}:/home/workspace \
           nikolaik/python-nodejs:python3.11-nodejs22-alpine \
           sh -c 'set -ex;
+             exit 1
              echo "$(ls /root/.yarn/berry/cache/ 2> /dev/null | wc -l || echo 0) packages in Yarn global cache"
              apk add build-base git libffi-dev cargo
              pip3 install --upgrade setuptools
@@ -56,7 +57,6 @@ jobs:
              cp /home/workspace/opencti-platform/.yarnrc.yml .
              yarn install
              yarn verify-licenses
-             exit 1
             '
 
     - name: Generate license

--- a/.github/workflows/ci-license-check.yml
+++ b/.github/workflows/ci-license-check.yml
@@ -30,7 +30,6 @@ jobs:
           -v ${{ github.workspace }}:/home/workspace \
           nikolaik/python-nodejs:python3.11-nodejs22-alpine \
           sh -c 'set -ex;
-             exit 1
              echo "$(ls /root/.yarn/berry/cache/ 2> /dev/null | wc -l || echo 0) packages in Yarn global cache"
              apk add build-base git libffi-dev cargo
              pip3 install --upgrade setuptools

--- a/.github/workflows/ci-license-check.yml
+++ b/.github/workflows/ci-license-check.yml
@@ -56,6 +56,7 @@ jobs:
              cp /home/workspace/opencti-platform/.yarnrc.yml .
              yarn install
              yarn verify-licenses
+             exit 1
             '
 
     - name: Generate license

--- a/.github/workflows/ci-test-api.yml
+++ b/.github/workflows/ci-test-api.yml
@@ -38,7 +38,7 @@ jobs:
          cd scripts/ci
          export TAG=${{ github.sha }}
          docker network create runner-docker-network
-         docker compose --profile "*" up -d
+         docker compose  --profile "backend" --profile ci-test-api up -d
 
     - name: Wait for OpenCTI sync instances to start
       run: |

--- a/.github/workflows/ci-test-api.yml
+++ b/.github/workflows/ci-test-api.yml
@@ -38,7 +38,7 @@ jobs:
          cd scripts/ci
          export TAG=${{ github.sha }}
          docker network create runner-docker-network
-         docker compose  --profile "backend" --profile ci-test-api up -d
+         docker compose  --profile "backend" --profile "ci-test-api-sync" up -d
 
     - name: Wait for OpenCTI sync instances to start
       run: |
@@ -148,7 +148,7 @@ jobs:
          cd scripts/ci
          export TAG=${{ github.sha }}
          docker network create runner-docker-network
-         docker compose --profile "backend" --profile ci-test-api up -d
+         docker compose --profile "backend" --profile "ci-test-rules" up -d
 
     - name: Start rules test
       run: |

--- a/scripts/ci/docker-compose.yml
+++ b/scripts/ci/docker-compose.yml
@@ -146,7 +146,7 @@ services:
 
   opencti-test-worker:
     container_name: opencti-test-worker
-    profiles: ["ci-test-api-sync","ci-test-api"]
+    profiles: ["ci-test-api-sync","ci-test-rules"]
     image: filigran/worker:${TAG}
     restart: unless-stopped
     environment:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

API integration test start all services from docker compose. But opencti-pycti-start is not used for integration test
Related to: https://github.com/OpenCTI-Platform/opencti/issues/13368

### Proposed changes

Use profiles to only start needed services for integration test
