### PR TITLE
[frontend] add custom renderer jsonform for integer with format date-time (#13657)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -39,6 +39,7 @@ import TextField from '../../../../components/TextField';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import { resolveLink } from '../../../../utils/Entity';
 import { JsonFormVerticalLayout, jsonFormVerticalLayoutTester } from './utils/JsonFormVerticalLayout';
+import JsonFormTimestampRenderer, { jsonFormTimestampTester } from './utils/JsonTimestampRenderer';
 
 const ingestionCatalogConnectorCreationMutation = graphql`
   mutation IngestionCatalogConnectorCreationMutation($input: AddManagedConnectorInput) {
@@ -82,6 +83,7 @@ const customRenderers = [
   { tester: jsonFormVerticalLayoutTester, renderer: JsonFormVerticalLayout },
   { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
   { tester: jsonFormArrayTester, renderer: JsonFormArrayRenderer },
+  { tester: jsonFormTimestampTester, renderer: JsonFormTimestampRenderer },
   { tester: jsonFormUnsupportedTypeTester, renderer: JsonFormUnsupportedType },
 ];
 

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/JsonTimestampRenderer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/utils/JsonTimestampRenderer.tsx
@@ -1,0 +1,34 @@
+import { ControlProps, rankWith, schemaMatches } from '@jsonforms/core';
+import { withJsonFormsControlProps } from '@jsonforms/react';
+import { DateTimePicker } from '@mui/x-date-pickers';
+
+export const JsonFormTimestampRendererBase = (props: ControlProps) => {
+  const { data, handleChange, path, schema } = props;
+
+  const label =
+    schema?.title || (path ? path.split('/').pop()?.replace(/_/g, ' ') : 'Unknown');
+  const description = schema?.description;
+
+  const numericData = data ? Number(data) : undefined;
+  const date = numericData !== undefined ? new Date(numericData) : null;
+
+  return (
+    <DateTimePicker
+      label={label}
+      value={date}
+      onChange={(date) => handleChange(path, date ? date.getTime() : null)}
+      slotProps={{
+        textField: { helperText: description, fullWidth: true },
+      }}
+    />
+  );
+};
+
+export const jsonFormTimestampTester = rankWith(
+  100,
+  schemaMatches((schema) => {
+    return schema?.type === 'integer' && schema?.format === 'date-time';
+  })
+);
+
+export default withJsonFormsControlProps(JsonFormTimestampRendererBase);

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ManagedConnectorEdition.tsx
@@ -29,6 +29,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import { MESSAGING$ } from '../../../../relay/environment';
 import { JsonFormVerticalLayout, jsonFormVerticalLayoutTester } from '../IngestionCatalog/utils/JsonFormVerticalLayout';
+import JsonFormTimestampRenderer, { jsonFormTimestampTester } from '../IngestionCatalog/utils/JsonTimestampRenderer';
 
 type ManagerContractProperty = [string, IngestionTypedProperty];
 
@@ -57,6 +58,7 @@ const customRenderers = [
   { tester: jsonFormVerticalLayoutTester, renderer: JsonFormVerticalLayout },
   { tester: jsonFormPasswordTester, renderer: JsonFormPasswordRenderer },
   { tester: jsonFormArrayTester, renderer: JsonFormArrayRenderer },
+  { tester: jsonFormTimestampTester, renderer: JsonFormTimestampRenderer },
   { tester: jsonFormUnsupportedTypeTester, renderer: JsonFormUnsupportedType },
 ];
 


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* It requires manifest changes to work with the changes by adding format=date-time for the variables that require timestamp such as Crowdstrike


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13657


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
