### PR TITLE
[frontend] Toolbar disapeared from container's entity/observable tabs (#13688)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
@@ -279,7 +279,6 @@ const ContainerStixCyberObservablesComponent: FunctionComponent<
               search={searchTerm}
               filters={contextFilters}
               handleClearSelectedElements={handleClearSelectedElements}
-              variant="large"
               container={container}
               handleCopy={handleCopy}
               warning={true}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjects.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjects.tsx
@@ -239,7 +239,6 @@ const ContainerStixDomainObjects = ({ container, enableReferences }: {
             filters={contextFilters}
             search={searchTerm}
             handleClearSelectedElements={handleClearSelectedElements}
-            variant="large"
             container={containerData}
             warning={true}
             warningMessage={t_i18n('Be careful, you are about to delete the selected entities (not the relationships)')}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -2145,10 +2145,15 @@ class DataTableToolBar extends Component {
       warning,
       warningMessage,
       taskScope,
-      displayEditButtons,
     } = this.props;
-    const { actions, keptEntityId, mergingElement, actionsInputs, promoteToContainer } = this.state;
-
+    const {
+      actions,
+      keptEntityId,
+      mergingElement,
+      actionsInputs,
+      promoteToContainer,
+      displayEditButtons,
+    } = this.state;
     const isUserDatatable = taskScope === 'USER';
 
     let deleteCapability = KNOWLEDGE_KNUPDATE_KNDELETE;


### PR DESCRIPTION
### Proposed changes

* Move the displayEditButton in a state not in props

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13688

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
