### PR TITLE
[frontend/backend] Replaced Stix-Core-Relationship with stix-core-relationship

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -696,7 +696,7 @@ describe('buildFiltersAndOptionsForWidgets', () => {
     };
     const expectedFilters = {
       mode: 'and',
-      filters: [{ key: 'entity_type', values: ['Stix-Core-Relationship', 'stix-sighting-relationship', 'object', 'object-label'], operator: 'eq', mode: 'or' }],
+      filters: [{ key: 'entity_type', values: ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'], operator: 'eq', mode: 'or' }],
       filterGroups: [inputFilters],
     };
     const { filters } = buildFiltersAndOptionsForWidgets(inputFilters, { isKnowledgeRelationshipWidget: true });

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -857,7 +857,7 @@ const useSearchEntities = ({
               if (!availableEntityTypes
                 || (availableEntityTypes && availableEntityTypes.length > 1)) {
                 result = [
-                  abstractTypeFilterValue('Stix-Core-Relationship'),
+                  abstractTypeFilterValue('stix-core-relationship'),
                   ...result,
                 ];
               }
@@ -900,7 +900,7 @@ const useSearchEntities = ({
               ...sdoTypes,
               abstractTypeFilterValue('Stix-Domain-Object'),
               ...scrTypes,
-              abstractTypeFilterValue('Stix-Core-Relationship'),
+              abstractTypeFilterValue('stix-core-relationship'),
             ].sort((a, b) => a.label.localeCompare(b.label)),
           );
           break;

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
@@ -17,7 +17,7 @@ import {
   ViewListOutline,
 } from 'mdi-material-ui';
 import React from 'react';
-// eslint-disable-next-line import/extensions
+
 import type { WidgetDataSelection } from './widget';
 
 const widgetVisualizationTypes = [
@@ -206,7 +206,7 @@ const widgetVisualizationTypes = [
 export type WidgetVisualizationTypes
   = (typeof widgetVisualizationTypes)[number]['key'];
 
-export const RELATIONSHIP_WIDGETS_TYPES = ['Stix-Core-Relationship', 'stix-sighting-relationship', 'object', 'object-label'];
+export const RELATIONSHIP_WIDGETS_TYPES = ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'];
 
 export const workspacesWidgetVisualizationTypes = widgetVisualizationTypes.filter((w) => w.key !== 'attribute');
 

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -154,7 +154,7 @@ export const stixCoreRelationshipEditContext = async (context, user, stixCoreRel
 export const stixCoreRelationshipRemoveFromDraft = async (context, user, stixCoreObjectId) => {
   const stixCoreRelationship = await storeLoadById(context, user, stixCoreObjectId, ABSTRACT_STIX_CORE_RELATIONSHIP, { includeDeletedInDraft: true });
   if (!stixCoreRelationship) {
-    throw FunctionalError('Cannot remove the object from draft, Stix-Core-Relationship cannot be found.', { id: stixCoreObjectId });
+    throw FunctionalError('Cannot remove the object from draft, stix-core-relationship cannot be found.', { id: stixCoreObjectId });
   }
   // TODO currently not locked, but might need to be
   await elRemoveElementFromDraft(context, user, stixCoreRelationship);

--- a/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/01-database/stix-filtering-test.ts
@@ -102,7 +102,7 @@ describe('Stix Filtering', () => {
         key: ['entity_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Report']
+        values: ['Report'],
       }],
       filterGroups: [],
     } as FilterGroup;
@@ -118,7 +118,7 @@ describe('Stix Filtering', () => {
         key: ['entity_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Report']
+        values: ['Report'],
       }],
       filterGroups: [],
     } as FilterGroup;
@@ -131,7 +131,7 @@ describe('Stix Filtering', () => {
         key: ['entity_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Report', 'Indicator']
+        values: ['Report', 'Indicator'],
       }],
       filterGroups: [],
     } as FilterGroup;
@@ -147,12 +147,12 @@ describe('Stix Filtering', () => {
         key: ['entity_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Report']
+        values: ['Report'],
       }, {
         key: ['creator_id'],
         mode: 'or',
         operator: 'eq',
-        values: [ME_FILTER_VALUE]
+        values: [ME_FILTER_VALUE],
       }],
       filterGroups: [],
     } as FilterGroup;
@@ -164,7 +164,7 @@ describe('Stix Filtering', () => {
     expect(await isStixMatchFilterGroup_MockableForUnitTests(testContext, WHITE_USER, stixReport, filterGroup, MOCK_RESOLUTION_MAP)).toEqual(false);
   });
 
-  //--------------------------------------------------------------------------------------------------------------------
+  // --------------------------------------------------------------------------------------------------------------------
   // Now testing complex filters with edge cases
   describe('Complex filtering cases', () => {
     it('using all types of filter keys (string, numeric, boolean)', async () => {
@@ -179,7 +179,7 @@ describe('Stix Filtering', () => {
             mode: 'and',
             filters: [
               { key: ['entity_type'], mode: 'or', operator: 'eq', values: ['Report', 'Indicator'] },
-              { key: ['confidence'], mode: 'and', operator: 'gt', values: ['25'] }
+              { key: ['confidence'], mode: 'and', operator: 'gt', values: ['25'] },
             ],
             filterGroups: [],
           },
@@ -188,7 +188,7 @@ describe('Stix Filtering', () => {
             filters: [
               { key: ['revoked'], mode: 'or', operator: 'eq', values: ['true'] },
               { key: ['objectLabel'], mode: 'or', operator: 'eq', values: ['id-for-label-indicator'] },
-              { key: ['objectMarking'], mode: 'or', operator: 'eq', values: ['id-for-marking-tlp:green'] }
+              { key: ['objectMarking'], mode: 'or', operator: 'eq', values: ['id-for-marking-tlp:green'] },
             ],
             filterGroups: [],
           },
@@ -214,7 +214,7 @@ describe('Stix Filtering', () => {
             mode: 'or',
             filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software'], mode: 'or' }],
             filterGroups: [],
-          }
+          },
         ],
       } as FilterGroup;
       expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([3, 61]); // 2 malware + 1 software
@@ -234,7 +234,7 @@ describe('Stix Filtering', () => {
             mode: 'or',
             filters: [{ key: ['entity_type'], operator: 'eq', values: ['Software'], mode: 'or' }],
             filterGroups: [],
-          }
+          },
         ],
       } as FilterGroup;
       expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([0, 64]); // nothing is both malware and software
@@ -346,7 +346,7 @@ describe('Stix Filtering', () => {
 
       filterGroup = {
         mode: 'or',
-        filters: [{ key: ['entity_type'], operator: 'eq', values: ['Stix-Core-Relationship'], mode: 'or' }],
+        filters: [{ key: ['entity_type'], operator: 'eq', values: ['stix-core-relationship'], mode: 'or' }],
         filterGroups: [],
       } as FilterGroup;
       expect(await testManyStix(stixBundle.objects, makeCallback(filterGroup))).toEqual([24, 40]); // 24/26 rels are Stix-core-rel


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Replaced Stix-Core-Relationship with stix-core-relationship because the case could cause a problem of mapping : 

The bug is occurring on a client's platform because of a difference in their elasticsearch mapping compared to the expected mapping: some of their elasticsearch fields are not normalized. This causes some queries to be case sensitive when they shouldn't be, and in the case of their dashboard, it can't find any data because it's looking for Stix-Core-Relationship entities when the stored type on elasticsearch is stix-core-relationship.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* [Some filters can be broken on old ES mappings](https://github.com/OpenCTI-Platform/opencti/issues/13696)
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
