### PR TITLE
[backend] Allow to customize URL and headers for manifest fetch during build (#13069)

### DIFF
--- a/opencti-platform/opencti-graphql/script/get-connectors-manifest.js
+++ b/opencti-platform/opencti-graphql/script/get-connectors-manifest.js
@@ -3,6 +3,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const getSchemaURL = () => {
+  if (process.env.OPENCTI_MANIFEST_URL) {
+    return process.env.OPENCTI_MANIFEST_URL;
+  }
+
   if (process.env.TAG_VERSION) {
     return `https://raw.githubusercontent.com/OpenCTI-Platform/connectors/refs/tags/${process.env.TAG_VERSION}/manifest.json`;
   }
@@ -10,6 +14,11 @@ const getSchemaURL = () => {
   return 'https://raw.githubusercontent.com/OpenCTI-Platform/connectors/refs/heads/master/manifest.json';
 };
 // use tags instead of master if env from circle TAG is set
+
+const getFetchHeaders = () => {
+  const headersEnv = process.env.OPENCTI_MANIFEST_HEADERS;
+  return headersEnv ? JSON.parse(headersEnv) : {};
+};
 
 const OUTPUT_DIR = '../src/__generated__';
 const OUTPUT_FILE = 'opencti-manifest.json';
@@ -23,7 +32,9 @@ async function getConnectorManifest() {
   try {
     // fetch file
     console.info(`➡️ Fetching manifest from: ${schemaUrl}`);
-    const res = await fetch(schemaUrl);
+    const res = await fetch(schemaUrl, {
+      headers: getFetchHeaders(),
+    });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.text();
 


### PR DESCRIPTION
### Proposed changes

*  Allow to customize URL and headers for manifest fetch during build by using env var: `OPENCTI_MANIFEST_URL` & `OPENCTI_MANIFEST_HEADERS`

### Related issues
* Fix #13069

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
