### PR TITLE
build(backend): remove esbuild-plugin-import-glob (#13769)

### DIFF
--- a/opencti-platform/opencti-graphql/builder/dev/dev.js
+++ b/opencti-platform/opencti-graphql/builder/dev/dev.js
@@ -1,5 +1,4 @@
 const esbuild = require('esbuild');
-const {default: importGlobPlugin} = require('esbuild-plugin-import-glob');
 const {default: graphqlLoaderPlugin} = require('@luckycatfactory/esbuild-graphql-loader');
 const nativeNodePlugin = require('../plugin/native.node.plugin');
 const {copy} = require('esbuild-plugin-copy');
@@ -8,7 +7,6 @@ esbuild.build({
     logLevel: 'info',
     define: {'process.env.NODE_ENV': '\"development\"'},
     plugins: [
-        importGlobPlugin(),
         graphqlLoaderPlugin(),
         nativeNodePlugin(),
         copy({

--- a/opencti-platform/opencti-graphql/builder/prod/prod.js
+++ b/opencti-platform/opencti-graphql/builder/prod/prod.js
@@ -1,5 +1,4 @@
 const esbuild = require('esbuild');
-const {default: importGlobPlugin} = require('esbuild-plugin-import-glob');
 const {default: graphqlLoaderPlugin} = require('@luckycatfactory/esbuild-graphql-loader');
 const nativeNodePlugin = require('../plugin/native.node.plugin');
 const {copy} = require('esbuild-plugin-copy');
@@ -8,7 +7,6 @@ esbuild.build({
     logLevel: 'info',
     define: {'process.env.NODE_ENV': '\"production\"'},
     plugins: [
-        importGlobPlugin(),
         graphqlLoaderPlugin(),
         nativeNodePlugin(),
         copy({

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -195,7 +195,6 @@
     "@vitest/coverage-v8": "3.2.4",
     "esbuild": "0.27.1",
     "esbuild-plugin-copy": "2.1.1",
-    "esbuild-plugin-import-glob": "0.1.1",
     "eslint": "9.39.1",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import": "2.32.0",

--- a/opencti-platform/opencti-graphql/src/database/migration.js
+++ b/opencti-platform/opencti-graphql/src/database/migration.js
@@ -28,7 +28,7 @@ const retrieveMigrations = async () => {
     migrationsFilenames.map((file) => import(`../migrations/${file}`)));
 
   const knexMigrations = migrations.map((migration, i) => ({
-    name: migrationsFilenames[i].substring('../migrations/'.length),
+    name: migrationsFilenames[i],
     migration,
   }));
   return knexMigrations.map(({ name, migration }) => {

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -66,7 +66,7 @@ const refreshMappingsAndIndices = async () => {
 
 const initializeMigration = async (context) => {
   logApp.info('[INIT] Creating migration structure');
-  const time = lastAvailableMigrationTime();
+  const time = await lastAvailableMigrationTime();
   const lastRun = `${time}-init`;
   const migrationStatus = { internal_id: uuidv4(), lastRun };
   await createEntity(context, SYSTEM_USER, migrationStatus, ENTITY_TYPE_MIGRATION_STATUS);

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -7363,15 +7363,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-plugin-import-glob@npm:0.1.1":
-  version: 0.1.1
-  resolution: "esbuild-plugin-import-glob@npm:0.1.1"
-  dependencies:
-    fast-glob: "npm:^3.2.5"
-  checksum: 10c0/ae7e47630a78890309c273a055578644870b938f20bf276de39e5fe39be4f5b4b9d7b3edf27025bd8f5cfdaa5277c9a7735b2ed164c717f0dec211f64d591620
-  languageName: node
-  linkType: hard
-
 "esbuild@npm:0.27.1":
   version: 0.27.1
   resolution: "esbuild@npm:0.27.1"
@@ -10939,7 +10930,6 @@ __metadata:
     ejs: "npm:3.1.10"
     esbuild: "npm:0.27.1"
     esbuild-plugin-copy: "npm:2.1.1"
-    esbuild-plugin-import-glob: "npm:0.1.1"
     eslint: "npm:9.39.1"
     eslint-import-resolver-typescript: "npm:4.4.4"
     eslint-plugin-import: "npm:2.32.0"

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -7983,7 +7983,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.5, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.9":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:


### PR DESCRIPTION
### Proposed changes
Remove esbuild-plugin-import-glob and global import from migration.js

Necessary for vite v4

### Related issues
#13769