### PR TITLE
[CI] change integration test to run test:ci-integration-sync instead of test:ci-integration

### DIFF
--- a/.github/workflows/ci-test-api.yml
+++ b/.github/workflows/ci-test-api.yml
@@ -68,7 +68,7 @@ jobs:
             wget -O ../../opencti-connectors/stream/backup-files/src/backup-files.py https://raw.githubusercontent.com/OpenCTI-Platform/connectors/master/stream/backup-files/src/backup-files.py
             mkdir -p ../../opencti-connectors/external-import/restore-files/src
             wget -O ../../opencti-connectors/external-import/restore-files/src/restore-files.py https://raw.githubusercontent.com/OpenCTI-Platform/connectors/master/external-import/restore-files/src/restore-files.py
-            NODE_OPTIONS=--max_old_space_size=8192 yarn test:ci-integration --coverage
+            NODE_OPTIONS=--max_old_space_size=8192 yarn test:ci-integration-sync --coverage
         '
 
     - name: Upload backend test result


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* it looks like the Intregration test on our GH actions is running test:ci-integration instead of test:ci-integration-sync: we're missing the streams & sync tests
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
