### PR TITLE
fix(backend): gate AI exclusively by settings.platform_ai_enabled (#13568)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -5,7 +5,7 @@ import { Mistral } from '@mistralai/mistralai';
 import type { ChatCompletionStreamRequest } from '@mistralai/mistralai/models/components';
 import { AuthenticationError, AzureOpenAI, OpenAI } from 'openai';
 import conf, { BUS_TOPICS, logApp } from '../config/conf';
-import { UnknownError, UnsupportedError } from '../config/errors';
+import { FunctionalError, UnknownError, UnsupportedError } from '../config/errors';
 import { OutputSchema } from '../modules/ai/ai-nlq-schema';
 import type { Output } from '../modules/ai/ai-nlq-schema';
 import { AI_BUS } from '../modules/ai/ai-types';
@@ -14,8 +14,8 @@ import { truncate } from '../utils/format';
 import { notify } from './redis';
 import { isEmptyField } from './utils';
 import { addNlqQueryCount } from '../manager/telemetryManager';
+import { AI_DISABLED_ERROR_MESSAGE } from '../utils/ai/aiConstants';
 
-const AI_ENABLED = conf.get('ai:enabled');
 const AI_TYPE = conf.get('ai:type');
 const AI_ENDPOINT = conf.get('ai:endpoint');
 const AI_TOKEN = conf.get('ai:token');
@@ -25,9 +25,44 @@ const AI_VERSION = conf.get('ai:version');
 const AI_AZURE_INSTANCE = conf.get('ai:ai_azure_instance');
 const AI_AZURE_DEPLOYMENT = conf.get('ai:ai_azure_deployment');
 
+const AI_CONFIG_ENABLED = conf.get('ai:enabled') !== false;
+let AI_ENABLED = AI_CONFIG_ENABLED;
 let client: Mistral | OpenAI | AzureOpenAI | null = null;
 let nlqChat: ChatOpenAI | ChatMistralAI | AzureChatOpenAI | null = null;
-if (AI_ENABLED && AI_TOKEN) {
+// Promise chain used to serialize all client initialization and state-change operations.
+// NOTE: `clientsUpdate` is the canonical promise chain used throughout this module.
+let clientsUpdate: Promise<void> = Promise.resolve();
+
+export const getAiConfigEnabled = () => AI_CONFIG_ENABLED;
+
+const resetClients = () => {
+  client = null;
+  nlqChat = null;
+};
+
+const initClients = () => {
+  if (client && nlqChat) {
+    return;
+  }
+  // Defensive check: a partially initialized state (only one of `client` or `nlqChat` is set)
+  // is unexpected and can lead to inconsistent behavior. We log a concise warning and reset both
+  // so that the initialization below always starts from a clean state.
+  // Possible causes include concurrent initialization, a failure during a previous initialization
+  // attempt, or partial AI configuration changes.
+  if ((client && !nlqChat) || (!client && nlqChat)) {
+    logApp.warn(
+      '[AI] Partially initialized AI clients detected; resetting client and nlqChat before re-initialization.',
+      {
+        hasClient: !!client,
+        hasNlqChat: !!nlqChat,
+        aiType: AI_TYPE,
+      },
+    );
+    resetClients();
+  }
+  if (!AI_ENABLED || !AI_TOKEN) {
+    return;
+  }
   switch (AI_TYPE) {
     case 'mistralai':
       client = new Mistral({
@@ -99,12 +134,132 @@ if (AI_ENABLED && AI_TOKEN) {
     default:
       throw UnsupportedError('Not supported AI type (currently support: mistralai, openai, azureopenai)', { type: AI_TYPE });
   }
-}
+};
+
+const ensureClientsInitialized = async () => {
+  // Chain the initialization operation onto the current clientsUpdate promise,
+  // but keep a separate operation promise for the caller so that we can both:
+  // - propagate errors to the caller, and
+  // - prevent `clientsUpdate` from remaining in a permanently rejected state.
+  const operation = clientsUpdate
+    .then(() => {
+      if (!AI_ENABLED) {
+        return;
+      }
+      initClients();
+    })
+    .catch((err) => {
+      logApp.error('[AI] Failed to initialize AI clients', { cause: err });
+      // On failure, reset the local clients so that a future successful call can
+      // re-establish a consistent state.
+      resetClients();
+      // Preserve already-classified GraphQL/OpenCTI errors (with extensions.code)
+      // so callers can rely on stable error codes for configuration issues.
+      if (
+        err
+        && typeof err === 'object'
+        && 'extensions' in err
+        && (err as { extensions?: unknown }).extensions
+        && typeof (err as { extensions?: unknown }).extensions === 'object'
+        && 'code' in ((err as { extensions: Record<string, unknown> }).extensions)
+      ) {
+        throw err;
+      }
+      throw UnknownError('Failed to initialize AI clients', { cause: err });
+    });
+
+  // Ensure that the shared `clientsUpdate` chain never remains rejected: any error
+  // is handled above for the caller and swallowed here so the chain can be reused.
+  clientsUpdate = operation.catch(() => {
+    // Intentionally ignore to keep the chain resolved.
+  });
+
+  await operation;
+};
+
+export const setAiEnabled = (enabled: boolean) => {
+  // Similar pattern to `ensureClientsInitialized`: the `operation` promise reflects
+  // the real outcome for the caller, while `clientsUpdate` is kept reusable.
+  const initializeClients = true;
+  return setAiEnabledWithOptions(enabled, { initializeClients });
+};
+
+export const setAiEnabledWithOptions = (
+  enabled: boolean,
+  { initializeClients = true }: { initializeClients?: boolean } = {},
+) => {
+  // Similar pattern to `ensureClientsInitialized`: the `operation` promise reflects
+  // the real outcome for the caller, while `clientsUpdate` is kept reusable.
+  let previousEnabled: boolean | undefined;
+  const operation = clientsUpdate
+    .then(() => {
+      previousEnabled = AI_ENABLED;
+
+      // If AI is disabled at the configuration level, keep it disabled regardless
+      // of runtime/platform settings.
+      if (!AI_CONFIG_ENABLED && enabled) {
+        logApp.info('[AI] AI is disabled by configuration; ignoring enable request.');
+        AI_ENABLED = false;
+        resetClients();
+        return;
+      }
+
+      // If there is no actual state change requested, do nothing.
+      if (previousEnabled === enabled) {
+        return;
+      }
+
+      logApp.info('[AI] AI enabled state changed', { enabled });
+
+      if (!enabled) {
+        // Disabling AI: reset clients and then update the flag.
+        resetClients();
+        AI_ENABLED = false;
+        return;
+      }
+
+      // Enabling AI: update the flag and then initialize clients.
+      AI_ENABLED = true;
+      if (initializeClients) {
+        initClients();
+      }
+    })
+    .catch((err) => {
+      logApp.error('[AI] Failed to apply AI enabled state change', { enabled, cause: err });
+      if (previousEnabled !== undefined) {
+        AI_ENABLED = previousEnabled;
+      }
+      resetClients();
+      // Preserve already-classified GraphQL/OpenCTI errors (those with `extensions.code`)
+      // and only wrap truly unknown errors in `UnknownError`, matching `ensureClientsInitialized`.
+      if ((err as any)?.extensions?.code) {
+        throw err;
+      }
+      throw UnknownError('Failed to apply AI enabled state change', { cause: err });
+    });
+
+  clientsUpdate = operation.catch(() => {
+    // Intentionally ignore to keep the chain resolved and allow future operations.
+  });
+
+  return operation;
+};
+
+// Client initialization is now fully lazy and driven by `ensureClientsInitialized`
+// and `setAiEnabled`, which already respect `AI_ENABLED` and handle failures.
 
 // Query MistralAI (Streaming)
 export const queryMistralAi = async (busId: string | null, systemMessage: string, userMessage: string, user: AuthUser) => {
+  if (!AI_ENABLED) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
+  await ensureClientsInitialized();
+  // AI may have been disabled while initializing clients; re-check to return a consistent error.
+  if (!AI_ENABLED) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
   if (!client) {
-    throw UnsupportedError('Incorrect AI configuration', { enabled: AI_ENABLED, type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
+    throw UnsupportedError('Incorrect AI configuration', { type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
   }
   try {
     logApp.debug('[AI] Querying MistralAI with prompt', { questionStart: userMessage.substring(0, 100) });
@@ -142,8 +297,16 @@ export const queryMistralAi = async (busId: string | null, systemMessage: string
 
 // Query OpenAI (Streaming)
 export const queryChatGpt = async (busId: string | null, developerMessage: string, userMessage: string, user: AuthUser) => {
+  if (!AI_ENABLED) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
+  await ensureClientsInitialized();
+  // AI may have been disabled while initializing clients; re-check to return a consistent error.
+  if (!AI_ENABLED) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
   if (!client) {
-    throw UnsupportedError('Incorrect AI configuration', { enabled: AI_ENABLED, type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
+    throw UnsupportedError('Incorrect AI configuration', { type: AI_TYPE, endpoint: AI_ENDPOINT, model: AI_MODEL });
   }
   try {
     logApp.info('[AI] Querying OpenAI with prompt', { type: AI_TYPE });
@@ -196,11 +359,18 @@ export const queryAi = async (busId: string | null, developerMessage: string | n
 // NLQ AI Query with LangChain's Chat Models
 export const queryNLQAi = async (promptValue: ChatPromptValueInterface) => {
   const badAiConfigError = UnsupportedError('Incorrect AI configuration for NLQ', {
-    enabled: AI_ENABLED,
     type: AI_TYPE,
     endpoint: AI_ENDPOINT,
     model: AI_MODEL,
   });
+  if (!AI_ENABLED) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
+  await ensureClientsInitialized();
+  // AI may have been disabled while initializing clients; re-check to return a consistent error.
+  if (!AI_ENABLED) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
   if (!nlqChat) {
     throw badAiConfigError;
   }

--- a/opencti-platform/opencti-graphql/src/domain/container.js
+++ b/opencti-platform/opencti-graphql/src/domain/container.js
@@ -33,6 +33,7 @@ import conf, { BUS_TOPICS, logApp } from '../config/conf';
 import { checkEnterpriseEdition } from '../enterprise-edition/ee';
 import { getContainerKnowledge, resolveFiles } from '../utils/ai/dataResolutionHelpers';
 import { queryAi } from '../database/ai-llm';
+import { checkPlatformAiEnabled } from '../utils/ai/platformAiEnabled';
 import { notify } from '../database/redis';
 import { AI_BUS } from '../modules/ai/ai-types';
 import { cleanHtmlTags } from '../utils/ai/cleanHtmlTags';
@@ -281,6 +282,7 @@ export const containerEditAuthorizedMembers = async (context, user, entityId, in
 
 export const aiSummary = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
 
   const { busId = null, language = 'English', forceRefresh = false } = args;
   const hasTypesArgs = args.types && args.types.length > 0;

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -96,6 +96,7 @@ import {
   systemPrompt,
 } from '../utils/ai/dataResolutionHelpers';
 import { queryAi } from '../database/ai-llm';
+import { checkPlatformAiEnabled } from '../utils/ai/platformAiEnabled';
 import { ENTITY_TYPE_THREAT_ACTOR_INDIVIDUAL } from '../modules/threatActorIndividual/threatActorIndividual-types';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 import { ENTITY_TYPE_EVENT } from '../modules/event/event-types';
@@ -1079,6 +1080,7 @@ export const stixCoreObjectEditContext = async (context, user, stixCoreObjectId,
 // region ai
 export const aiActivity = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
 
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
@@ -1119,6 +1121,7 @@ export const aiActivity = async (context, user, args) => {
 
 export const aiForecast = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
 
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
@@ -1150,6 +1153,7 @@ export const aiForecast = async (context, user, args) => {
 
 export const aiHistory = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
   const identifier = `${id}-history`;

--- a/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import nconf from 'nconf';
 import { logApp } from '../../config/conf';
 import { FunctionalError, UnknownError } from '../../config/errors';
-import { queryAi, queryNLQAi } from '../../database/ai-llm';
+import { queryAi, queryNLQAi, setAiEnabled } from '../../database/ai-llm';
 import { elSearchFiles } from '../../database/file-search';
 import { storeLoadById } from '../../database/middleware-loader';
 import { isEmptyField } from '../../database/utils';
@@ -42,6 +42,7 @@ import { RELATION_EXTERNAL_REFERENCE } from '../../schema/stixRefRelationship';
 import type { BasicStoreEntity } from '../../types/store';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { getContainerKnowledge } from '../../utils/ai/dataResolutionHelpers';
+import { syncPlatformAiEnabled } from '../../utils/ai/platformAiEnabled';
 import { INSTANCE_REGARDING_OF } from '../../utils/filtering/filtering-constants';
 import { addFilter, checkFiltersValidity, emptyFilterGroup, extractFilterGroupValues, filtersEntityIdsMappingResult } from '../../utils/filtering/filtering-utils';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-incident-types';
@@ -49,11 +50,33 @@ import { paginatedForPathWithEnrichment } from '../internal/document/document-do
 import type { BasicStoreEntityDocument } from '../internal/document/document-types';
 import { NLQPromptTemplate } from './ai-nlq-utils';
 import { callWithTimeout, TimeoutError } from '../../utils/promiseUtils';
+import { AI_DISABLED_ERROR_MESSAGE } from '../../utils/ai/aiConstants';
 
 const SYSTEM_PROMPT = 'You are an assistant helping cyber threat intelligence analysts to generate text about cyber threat intelligence information or from a cyber threat intelligence knowledge graph based on the STIX 2.1 model.';
 
+let lastPlatformAiEnabled: boolean | null = null;
+let platformAiEnabledUpdate: Promise<boolean | null> = Promise.resolve(null);
+const checkPlatformAiEnabled = async (context: AuthContext) => {
+  platformAiEnabledUpdate = platformAiEnabledUpdate.then(async () => {
+    const aiEnabled = await syncPlatformAiEnabled(context, { initializeClients: false });
+    if (lastPlatformAiEnabled === null) {
+      // First check: sync the lower-level state without eagerly initializing clients.
+    } else if (lastPlatformAiEnabled !== aiEnabled) {
+      // Subsequent checks: propagate actual state changes.
+      await setAiEnabled(aiEnabled);
+    }
+    lastPlatformAiEnabled = aiEnabled;
+    return aiEnabled;
+  });
+  const aiEnabled = await platformAiEnabledUpdate;
+  if (!aiEnabled) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
+};
+
 export const fixSpelling = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -74,6 +97,7 @@ export const fixSpelling = async (context: AuthContext, user: AuthUser, id: stri
 
 export const makeShorter = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -94,6 +118,7 @@ export const makeShorter = async (context: AuthContext, user: AuthUser, id: stri
 
 export const makeLonger = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -116,6 +141,7 @@ export const makeLonger = async (context: AuthContext, user: AuthUser, id: strin
 // eslint-disable-next-line max-len
 export const changeTone = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text, tone: InputMaybe<Tone> = Tone.Tactical) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -136,6 +162,7 @@ export const changeTone = async (context: AuthContext, user: AuthUser, id: strin
 
 export const summarize = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -155,6 +182,7 @@ export const summarize = async (context: AuthContext, user: AuthUser, id: string
 
 export const explain = async (context: AuthContext, user: AuthUser, id: string, content: string) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -174,6 +202,7 @@ export const explain = async (context: AuthContext, user: AuthUser, id: string, 
 
 export const generateContainerReport = async (context: AuthContext, user: AuthUser, args: MutationAiContainerGenerateReportArgs) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   const { id, containerId, paragraphs = 10, tone = 'technical', format = 'HTML', language = 'en-us' } = args;
   const paragraphsNumber = !paragraphs || paragraphs > 20 ? 20 : paragraphs;
   const container = await storeLoadById(context, user, containerId, ENTITY_TYPE_CONTAINER) as BasicStoreEntity;
@@ -215,6 +244,7 @@ export const generateContainerReport = async (context: AuthContext, user: AuthUs
 // TODO This function is deprecated (AI Insights)
 export const summarizeFiles = async (context: AuthContext, user: AuthUser, args: MutationAiSummarizeFilesArgs) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   const { id, elementId, paragraphs = 10, fileIds, tone = 'technical', format = 'HTML', language = 'en-us' } = args;
   const paragraphsNumber = !paragraphs || paragraphs > 20 ? 20 : paragraphs;
   const stixCoreObject = await storeLoadById(context, user, elementId, ABSTRACT_STIX_CORE_OBJECT) as BasicStoreEntity;
@@ -274,6 +304,7 @@ export const summarizeFiles = async (context: AuthContext, user: AuthUser, args:
 // TODO This function is deprecated (NLP)
 export const convertFilesToStix = async (context: AuthContext, user: AuthUser, args: MutationAiSummarizeFilesArgs) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   const { id, elementId, fileIds } = args;
   const stixCoreObject = await storeLoadById(context, user, elementId, ABSTRACT_STIX_CORE_OBJECT) as BasicStoreEntity;
   let finalFilesIds = fileIds;
@@ -410,6 +441,7 @@ export const filtersEntityIdsMapping = async (context: AuthContext, user: AuthUs
 
 export const generateNLQresponse = async (context: AuthContext, user: AuthUser, args: MutationAiNlqArgs) => {
   await checkEnterpriseEdition(context);
+  await checkPlatformAiEnabled(context);
   const { search } = args;
   const promptValue = await NLQPromptTemplate.formatPromptValue({ text: search });
 

--- a/opencti-platform/opencti-graphql/src/utils/ai/aiConstants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/ai/aiConstants.ts
@@ -1,0 +1,1 @@
+export const AI_DISABLED_ERROR_MESSAGE = 'AI is disabled in platform settings';

--- a/opencti-platform/opencti-graphql/src/utils/ai/platformAiEnabled.ts
+++ b/opencti-platform/opencti-graphql/src/utils/ai/platformAiEnabled.ts
@@ -1,0 +1,25 @@
+import { FunctionalError } from '../../config/errors';
+import { getEntityFromCache } from '../../database/cache';
+import { getAiConfigEnabled, setAiEnabledWithOptions } from '../../database/ai-llm';
+import { ENTITY_TYPE_SETTINGS } from '../../schema/internalObject';
+import type { BasicStoreSettings } from '../../types/settings';
+import type { AuthContext } from '../../types/user';
+import { SYSTEM_USER } from '../access';
+import { AI_DISABLED_ERROR_MESSAGE } from './aiConstants';
+
+export const syncPlatformAiEnabled = async (
+  context: AuthContext,
+  { initializeClients = false }: { initializeClients?: boolean } = {},
+) => {
+  const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+  const enabled = getAiConfigEnabled() && settings.platform_ai_enabled !== false;
+  await setAiEnabledWithOptions(enabled, { initializeClients });
+  return enabled;
+};
+
+export const checkPlatformAiEnabled = async (context: AuthContext) => {
+  const enabled = await syncPlatformAiEnabled(context, { initializeClients: false });
+  if (!enabled) {
+    throw FunctionalError(AI_DISABLED_ERROR_MESSAGE);
+  }
+};

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.js
@@ -4,6 +4,97 @@ import { head } from 'ramda';
 import { queryAsAdmin } from '../../utils/testQueryHelper';
 import { resetCacheForEntity } from '../../../src/database/cache';
 import { ENTITY_TYPE_SETTINGS } from '../../../src/schema/internalObject';
+import { AI_DISABLED_ERROR_MESSAGE } from '../../../src/utils/ai/aiConstants';
+
+const PLATFORM_AI_ENABLED_QUERY = gql`
+  query settingsPlatformAiEnabled {
+    settings {
+      platform_ai_enabled
+    }
+  }
+`;
+
+const STIX_CORE_OBJECTS_QUERY = gql`
+  query stixCoreObjects($first: Int!) {
+    stixCoreObjects(first: $first) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const getAnyStixCoreObjectId = async () => {
+  const result = await queryAsAdmin({ query: STIX_CORE_OBJECTS_QUERY, variables: { first: 1 } });
+  return result?.data?.stixCoreObjects?.edges?.at(0)?.node?.id;
+};
+
+const waitForPlatformAiEnabled = async (expectedEnabled) => {
+  const WAIT_FOR_SETTINGS_TIMEOUT_MS = Number(process.env.WAIT_FOR_SETTINGS_TIMEOUT_MS) || 10000;
+  const WAIT_FOR_SETTINGS_INTERVAL_MS = Number(process.env.WAIT_FOR_SETTINGS_INTERVAL_MS) || 250;
+  const deadline = Date.now() + WAIT_FOR_SETTINGS_TIMEOUT_MS;
+  let lastValue;
+
+  // Poll directly so we fully control timeout detection. Genuine query errors
+  // (GraphQL/network) propagate as-is and are never masked as a timeout, while
+  // an actual timeout throws a dedicated message that includes lastValue.
+  do {
+    const settingsResult = await queryAsAdmin({ query: PLATFORM_AI_ENABLED_QUERY, variables: {} });
+    lastValue = settingsResult?.data?.settings?.platform_ai_enabled;
+    if (lastValue === expectedEnabled) {
+      return;
+    }
+    await new Promise((resolve) => { setTimeout(resolve, WAIT_FOR_SETTINGS_INTERVAL_MS); });
+  } while (Date.now() < deadline);
+
+  throw new Error(
+    `Timed out waiting for settings.platform_ai_enabled to become ${expectedEnabled} (last observed: ${lastValue})`,
+  );
+};
+
+const UPDATE_SETTINGS_QUERY = gql`
+  mutation SettingsEdit($id: ID!, $input: [EditInput]!) {
+    settingsEdit(id: $id) {
+      fieldPatch(input: $input) {
+        id
+        platform_ai_enabled
+      }
+    }
+  }
+`;
+
+const AI_FIX_SPELLING_MUTATION = gql`
+  mutation AiFixSpelling($id: ID!, $content: String!) {
+    aiFixSpelling(id: $id, content: $content)
+  }
+`;
+
+const AI_ACTIVITY_QUERY = gql`
+  query StixCoreObjectAskAiActivity($id: ID!) {
+    stixCoreObjectAskAiActivity(id: $id) {
+      result
+      trend
+      updated_at
+    }
+  }
+`;
+
+const ENTERPRISE_EDITION_QUERY = gql`
+  query settingsEnterpriseEdition {
+    settings {
+      platform_enterprise_edition {
+        license_validated
+      }
+    }
+  }
+`;
+
+const isEnterpriseEditionEnabled = async () => {
+  const result = await queryAsAdmin({ query: ENTERPRISE_EDITION_QUERY, variables: {} });
+  return result?.data?.settings?.platform_enterprise_edition?.license_validated === true;
+};
 
 const ABOUT_QUERY = gql`
   query about {
@@ -21,6 +112,7 @@ const READ_QUERY = gql`
   query settings {
     settings {
       id
+      platform_ai_enabled
       platform_title
       platform_email
       platform_language
@@ -154,6 +246,78 @@ describe('Settings resolver standard behavior', () => {
     const readResult = await queryAsAdmin({ query: READ_QUERY, variables: {} });
     const { editContext } = readResult.data.settings;
     expect(editContext.length).toEqual(0);
+  });
+
+  it('should block AI operations when platform AI is disabled', async function () {
+    const settingsInternalId = await settingsId();
+    const initialSettingsResult = await queryAsAdmin({ query: READ_QUERY, variables: {} });
+    const platformAiEnabled = initialSettingsResult.data.settings.platform_ai_enabled;
+    const initialAiEnabled = platformAiEnabled;
+
+    // If Enterprise edition is not enabled, AI mutations are not available.
+    // Detect EE via a stable settings field instead of probing an AI resolver
+    // (which could trigger a real AI call and make the test slow/flaky), and
+    // skip the test cleanly before mutating settings in that case.
+    if (!(await isEnterpriseEditionEnabled())) {
+      this.skip();
+    }
+
+    if (!initialAiEnabled) {
+      await queryAsAdmin({
+        query: UPDATE_SETTINGS_QUERY,
+        variables: { id: settingsInternalId, input: [{ key: 'platform_ai_enabled', value: [true] }] },
+      });
+      resetCacheForEntity(ENTITY_TYPE_SETTINGS);
+      await waitForPlatformAiEnabled(true);
+    }
+
+    try {
+      await queryAsAdmin({
+        query: UPDATE_SETTINGS_QUERY,
+        variables: { id: settingsInternalId, input: [{ key: 'platform_ai_enabled', value: [false] }] },
+      });
+      resetCacheForEntity(ENTITY_TYPE_SETTINGS);
+
+      await waitForPlatformAiEnabled(false);
+
+      const stixCoreObjectId = await getAnyStixCoreObjectId();
+      expect(stixCoreObjectId).toBeDefined();
+
+      const aiResult = await queryAsAdmin({
+        query: AI_FIX_SPELLING_MUTATION,
+        variables: { id: 'ai-test', content: 'Some content to check.' },
+      });
+      expect(aiResult).not.toBeNull();
+      expect(aiResult.errors).toBeDefined();
+      expect(aiResult.errors.length).toEqual(1);
+      const errorMessage = aiResult.errors.at(0).message;
+      expect(errorMessage).toBe(AI_DISABLED_ERROR_MESSAGE);
+
+      const aiActivityResult = await queryAsAdmin({
+        query: AI_ACTIVITY_QUERY,
+        variables: { id: stixCoreObjectId },
+      });
+      expect(aiActivityResult).not.toBeNull();
+      expect(aiActivityResult.errors).toBeDefined();
+      expect(aiActivityResult.errors.length).toEqual(1);
+      const activityErrorMessage = aiActivityResult.errors.at(0).message;
+      expect(activityErrorMessage).toBe(AI_DISABLED_ERROR_MESSAGE);
+    } finally {
+      try {
+        await queryAsAdmin({
+          query: UPDATE_SETTINGS_QUERY,
+          variables: { id: settingsInternalId, input: [{ key: 'platform_ai_enabled', value: [initialAiEnabled] }] },
+        });
+        resetCacheForEntity(ENTITY_TYPE_SETTINGS);
+
+        await waitForPlatformAiEnabled(initialAiEnabled);
+      } catch (cleanupError) {
+        // Best-effort cleanup: do not mask the original test failure
+        // but log the cleanup error to aid debugging.
+        // eslint-disable-next-line no-console
+        console.error('Failed to restore initial platform_ai_enabled setting after test:', cleanupError);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #13568

- Remove legacy ai:enabled gating from AI LLM initialization (ai-llm.ts)
- Add runtime guard in ai-domain.ts to block AI operations when settings.platform_ai_enabled is false
- Add integration coverage ensuring AI mutations are blocked when platform AI is disabled

Note: CI/integration tests were not run locally due to a Windows test bootstrap crash referencing detectors/platform/node/machine-id/execAsync (unrelated to this change).