### PR TITLE
refactor(frontend): rename route integration_feeds (XTMHub)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -35,7 +35,7 @@ const IngestionCsv = () => {
   const classes = useStyles();
   const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/octi_integration_feeds?platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}`
     : '';
 
   const { t_i18n } = useFormatter();


### PR DESCRIPTION
### Proposed changes

* Due to the renaming on the hub from `integration_feeds `to `integrations`, we should update OpenCTI links as well. 
* In the IngestionCsv component, I renamed the link from `octi_integration_feeds `to `opencti_integrations`. 

### Related issues
* Issue on XTM Hub : 1317 and 1412. 

### Checklist


- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
