### PR TITLE
[backend] Cache decoded EE license (#13823)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -25,7 +25,7 @@ export const getChatbotProxy = async (req: Express.Request, res: Express.Respons
     const isChatbotCGUAccepted: boolean = settings.filigran_chatbot_ai_cgu_status === CguStatus.Enabled;
     const license_pem = getEnterpriseEditionActivePem(settings.enterprise_license);
     const licenseInfo = getEnterpriseEditionInfo(settings);
-    const isLicenseValidated = licenseInfo.license_validated;
+    const isLicenseValidated = license_pem !== undefined && licenseInfo.license_validated;
 
     if (!isChatbotCGUAccepted || !isLicenseValidated) {
       logApp.error('Error in chatbot proxy', { cguStatus: settings.filigran_chatbot_ai_cgu_status, isLicenseValidated, chatbotUrl: XTM_ONE_CHATBOT_URL });


### PR DESCRIPTION
### Proposed changes

* Cache the decoded EE license to avoid to check it at every request
* Ensure the raw PEM has not been changed since the cached value has been created

### Related issues
* Fix #13823 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
