### PR TITLE
[frontend] Add has-label in relationship type filter values for knowledge widgets (#13837)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
@@ -34,7 +34,7 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
   let availableEntityTypes;
   let searchContext;
   if (perspective === 'relationships') {
-    searchContext = { entityTypes: ['stix-core-relationship', 'stix-sighting-relationship', 'contains'] };
+    searchContext = { entityTypes: ['stix-core-relationship', 'stix-sighting-relationship', 'contains', 'object-label'] };
   } else if (perspective === 'audits') {
     availableEntityTypes = ['History', 'Activity'];
     searchContext = { entityTypes: ['History'] };

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -325,6 +325,11 @@ const useSearchEntities = ({
     value: 'object',
     type: 'stix-internal-relationship',
   };
+  const labelRelationshipType = {
+    label: t_i18n('relationship_object-label'),
+    value: 'objectLabel',
+    type: 'stix-meta-relationship',
+  };
 
   const unionSetEntities = (key: string, newEntities: EntityValue[]) => setEntities((c) => ({
     ...c,
@@ -918,6 +923,7 @@ const useSearchEntities = ({
               ...scrTypes,
               abstractTypeFilterValue('stix-sighting-relationship'),
               objectRelationshipType,
+              labelRelationshipType,
             ];
           } else { // display relationship types according to searchContext.entityTypes
             const { entityTypes } = searchContext;
@@ -934,6 +940,12 @@ const useSearchEntities = ({
               relationshipsTypes = [
                 ...relationshipsTypes,
                 objectRelationshipType,
+              ];
+            }
+            if (entityTypes.includes('object-label')) {
+              relationshipsTypes = [
+                ...relationshipsTypes,
+                labelRelationshipType,
               ];
             }
           }


### PR DESCRIPTION
### Proposed changes
Add the 'has label' relationship type in the values of the relationship type filter for knowledge widget : 

<img width="1062" height="635" alt="image" src="https://github.com/user-attachments/assets/46b4d790-1a77-4ca8-814a-6c4abe64f4bf" />


### Related issues
#13837