### PR TITLE
[backend] Check available playbooks for an entity according to filters (#13856)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrollPlaybookLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrollPlaybookLines.jsx
@@ -34,6 +34,8 @@ const styles = (theme) => ({
   noResult: {
     color: theme.palette.text.primary,
     fontSize: 15,
+    textAlign: 'center',
+    marginTop: 20,
   },
   itemIcon: {
     color: theme.palette.primary.main,

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -140,7 +140,7 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   if (filteredPlaybooks.length > 0) {
     playbook = filteredPlaybooks.at(0);
   } else {
-    throw FunctionalError('Playbook does not exist', { id });
+    throw FunctionalError('Playbook does not exist for this entity', { id });
   }
   // Execute only if definition is available
   if (playbook && playbook.playbook_definition) {

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -26,7 +26,7 @@ import { AUTOMATION_MANAGER_USER, executionContext, RETENTION_MANAGER_USER, SYST
 import type { SseEvent, StreamDataEvent } from '../../types/event';
 import type { StixBundle, StixObject } from '../../types/stix-2-1-common';
 import { streamEventId, utcDate } from '../../utils/format';
-import { findById } from '../../modules/playbook/playbook-domain';
+import { findById, findPlaybooksForEntity } from '../../modules/playbook/playbook-domain';
 import { type CronConfiguration, PLAYBOOK_INTERNAL_DATA_CRON, type StreamConfiguration } from '../../modules/playbook/playbook-components';
 import { PLAYBOOK_COMPONENTS } from '../../modules/playbook/playbook-components';
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from '../../modules/playbook/playbook-types';
@@ -132,15 +132,17 @@ const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEven
 };
 
 export const executePlaybookOnEntity = async (context: AuthContext, id: string, entityId: string) => {
-  const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
+  // fetch playbooks allowed for this entity
+  const playbooks = await findPlaybooksForEntity(context, RETENTION_MANAGER_USER, entityId);
   let playbook = null;
+  // keep the playbook corresponding to the id
   const filteredPlaybooks = playbooks.filter((n) => n.id === id);
   if (filteredPlaybooks.length > 0) {
     playbook = filteredPlaybooks.at(0);
   } else {
     throw FunctionalError('Playbook does not exist', { id });
   }
-  // Execute only of definition is available
+  // Execute only if definition is available
   if (playbook && playbook.playbook_definition) {
     const def = JSON.parse(playbook.playbook_definition) as ComponentDefinition;
     const instance = def.nodes.find((n) => n.id === playbook.playbook_start);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -22,7 +22,7 @@ import { notify } from '../../database/redis';
 import type { DomainFindById } from '../../domain/domainTypes';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
 import type { AuthContext, AuthUser } from '../../types/user';
-import { type EditInput, FilterMode, type PlaybookAddInput, type PlaybookAddLinkInput, type PlaybookAddNodeInput, type PositionInput } from '../../generated/graphql';
+import { type EditInput, type PlaybookAddInput, type PlaybookAddLinkInput, type PlaybookAddNodeInput, type PositionInput } from '../../generated/graphql';
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from './playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from './playbook-types';
 import { PLAYBOOK_COMPONENTS, type SharingConfiguration, type StreamConfiguration } from './playbook-components';
@@ -32,7 +32,6 @@ import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/sti
 import { registerConnectorQueues, unregisterConnector } from '../../database/rabbitmq';
 import { getEntitiesListFromCache } from '../../database/cache';
 import { SYSTEM_USER } from '../../utils/access';
-import { findFiltersFromKey } from '../../utils/filtering/filtering-utils';
 import { checkEnterpriseEdition, isEnterpriseEdition } from '../../enterprise-edition/ee';
 import pjson from '../../../package.json';
 import { extractContentFrom } from '../../utils/fileToContent';
@@ -72,12 +71,7 @@ export const findPlaybooksForEntity = async (context: AuthContext, user: AuthUse
       if (instance && (instance.component_id === 'PLAYBOOK_INTERNAL_DATA_STREAM' || instance.component_id === 'PLAYBOOK_INTERNAL_MANUAL_TRIGGER')) {
         const { filters } = JSON.parse(instance.configuration ?? '{}') as StreamConfiguration;
         const jsonFilters = filters ? JSON.parse(filters) : null;
-        const newFilters = {
-          mode: FilterMode.And,
-          filters: findFiltersFromKey(jsonFilters?.filters ?? [], 'entity_type'),
-          filterGroups: [],
-        };
-        const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, stixEntity, newFilters);
+        const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, stixEntity, jsonFilters);
         if (isMatch) {
           filteredPlaybooks.push(playbook);
         }


### PR DESCRIPTION
### Proposed changes
- When listing the available playbooks for an entity, check the whole filters of the playbook match the entity (instead of only checking for the entity type filter)
- When running a playbook manually for an entity, check the playbook filters are compatible with the entity

The goal is to avoid running a playbook that was not designed for the entity

### Related issues
#13856