### PR TITLE
[frontend] Relationships representative not displayed in Indicator Knowledge (#13246)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
@@ -63,6 +63,18 @@ class IndicatorEntityLineComponent extends Component {
     const element = node.to?.id === entityId ? node.from : node.to;
     const restricted = isEmptyField(element);
     const link = `${entityLink}/relations/${node.id}`;
+
+    const isRelationship = element.__typename === 'StixCoreRelationship';
+
+    const displayName = !restricted
+      ? isRelationship
+        ? element.representative?.main
+        ?? `${element.from?.name ?? element.from?.observable_value ?? '-'}
+         ${String.fromCharCode(8594)}
+         ${element.to?.name ?? element.to?.observable_value ?? '-'}`
+        : element.name || element.observable_value
+      : t('Restricted');
+
     return (
       <ListItem
         divider={true}
@@ -117,15 +129,7 @@ class IndicatorEntityLineComponent extends Component {
                   className={classes.bodyItem}
                   style={{ width: dataColumns.name.width }}
                 >
-                  {/* eslint-disable-next-line no-nested-ternary */}
-                  {!restricted
-                    ? element.entity_type === 'stix_relation'
-                    || element.entity_type === 'stix-relation'
-                      ? `${element.from.name} ${String.fromCharCode(8594)} ${
-                        element.to.name || element.to.observable_value
-                      }`
-                      : element.name || element.observable_value
-                    : t('Restricted')}
+                  {displayName}
                 </div>
                 <div
                   className={classes.bodyItem}
@@ -227,9 +231,13 @@ const IndicatorEntityLineFragment = createFragmentContainer(
             created_at
             updated_at
           }
+          __typename
           ... on StixCoreRelationship {
             created_at
             updated_at
+            representative {
+              main
+            }
           }
           ... on AttackPattern {
             name
@@ -462,9 +470,13 @@ const IndicatorEntityLineFragment = createFragmentContainer(
             created_at
             updated_at
           }
+          __typename
           ... on StixCoreRelationship {
             created_at
             updated_at
+            representative {
+              main
+            }
           }
           ... on AttackPattern {
             name

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEntityLine.jsx
@@ -64,7 +64,7 @@ class IndicatorEntityLineComponent extends Component {
     const restricted = isEmptyField(element);
     const link = `${entityLink}/relations/${node.id}`;
 
-    const isRelationship = element.__typename === 'StixCoreRelationship';
+    const isRelationship = t(`relationship_${element.entity_type}`) !== `relationship_${element.entity_type}`;
 
     const displayName = !restricted
       ? isRelationship
@@ -231,7 +231,6 @@ const IndicatorEntityLineFragment = createFragmentContainer(
             created_at
             updated_at
           }
-          __typename
           ... on StixCoreRelationship {
             created_at
             updated_at
@@ -470,7 +469,6 @@ const IndicatorEntityLineFragment = createFragmentContainer(
             created_at
             updated_at
           }
-          __typename
           ... on StixCoreRelationship {
             created_at
             updated_at


### PR DESCRIPTION
### Proposed changes

* Fix the display of relationship names in the indicator relations list by using the relationship representative.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/13246
