### PR TITLE
[frontend] Filters components refacto to tsx (#13845)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.tsx
@@ -4,22 +4,18 @@ import { FilterListOutlined } from '@mui/icons-material';
 import Popover from '@mui/material/Popover';
 import Tooltip from '@mui/material/Tooltip';
 import { RayEndArrow, RayStartArrow } from 'mdi-material-ui';
-import React from 'react';
-import makeStyles from '@mui/styles/makeStyles';
+import React, { ReactElement } from 'react';
 import { useFormatter } from '../../../../components/i18n';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles(() => ({
-  filters: {
-    float: 'left',
-    margin: '-3px 0 0 -5px',
-  },
-  container: {
-    width: 600,
-    padding: 20,
-  },
-}));
+interface ListFiltersWithoutLocalStorageProps {
+  handleOpenFilters: (event: React.SyntheticEvent) => void;
+  handleCloseFilters: () => void;
+  open: boolean;
+  anchorEl: Element | null;
+  filterElement: ReactElement;
+  variant?: string;
+  type?: string;
+}
 
 const ListFiltersWithoutLocalStorage = ({
   handleOpenFilters,
@@ -29,12 +25,11 @@ const ListFiltersWithoutLocalStorage = ({
   filterElement,
   variant,
   type,
-}) => {
+}: ListFiltersWithoutLocalStorageProps) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
   let icon = <FilterListOutlined fontSize="medium" />;
   let tooltip = t_i18n('Filters');
-  // let color = 'primary';
+  // let color: 'primary' | 'warning' | 'success' = 'primary';
   if (type === 'from') {
     icon = <RayStartArrow fontSize="medium" />;
     tooltip = t_i18n('Dynamic source filters');
@@ -45,7 +40,12 @@ const ListFiltersWithoutLocalStorage = ({
     // color = 'success';
   }
   return (
-    <div className={classes.filters}>
+    <div
+      style={{
+        float: 'left',
+        margin: '-3px 0 0 -5px',
+      }}
+    >
       {variant === 'text' ? (
         <Tooltip title={tooltip}>
           <Button
@@ -68,7 +68,12 @@ const ListFiltersWithoutLocalStorage = ({
         </Tooltip>
       )}
       <Popover
-        classes={{ paper: classes.container }}
+        sx={{
+          '& .MuiPaper-root': {
+            width: 600,
+            padding: 20,
+          },
+        }}
         open={open}
         anchorEl={anchorEl}
         onClose={handleCloseFilters}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFiltersWithoutLocalStorage.tsx
@@ -29,15 +29,12 @@ const ListFiltersWithoutLocalStorage = ({
   const { t_i18n } = useFormatter();
   let icon = <FilterListOutlined fontSize="medium" />;
   let tooltip = t_i18n('Filters');
-  // let color: 'primary' | 'warning' | 'success' = 'primary';
   if (type === 'from') {
     icon = <RayStartArrow fontSize="medium" />;
     tooltip = t_i18n('Dynamic source filters');
-    // color = 'warning';
   } else if (type === 'to') {
     icon = <RayEndArrow fontSize="medium" />;
     tooltip = t_i18n('Dynamic target filters');
-    // color = 'success';
   }
   return (
     <div

--- a/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
@@ -26,7 +26,6 @@ const SearchScopeElement = ({
   setSearchScope,
   availableRelationFilterTypes,
 }: SearchScopeElementProps) => {
-  console.log('test');
   const { t_i18n } = useFormatter();
   const [anchorElSearchScope, setAnchorElSearchScope] = useState<PopoverProps['anchorEl']>();
   const { stixCoreObjectTypes: entityTypes } = useAttributes();

--- a/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
@@ -12,11 +12,11 @@ import useAttributes from '../../../../utils/hooks/useAttributes';
 import { displayEntityTypeForTranslation } from '../../../../utils/String';
 
 interface SearchScopeElementProps {
-  name: string,
-  disabled?: boolean,
-  searchScope: Record<string, string[]>,
-  setSearchScope:  React.Dispatch<React.SetStateAction<Record<string, string[]>>>,
-  availableRelationFilterTypes?: Record<string, string[]>,
+  name: string;
+  disabled?: boolean;
+  searchScope: Record<string, string[]>;
+  setSearchScope: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
+  availableRelationFilterTypes?: Record<string, string[]>;
 }
 
 const SearchScopeElement = ({
@@ -56,7 +56,7 @@ const SearchScopeElement = ({
     }));
   };
 
-  let color: 'secondary' | 'primary' = searchScope[name] && searchScope[name].length > 0
+  const color: 'secondary' | 'primary' = searchScope[name] && searchScope[name].length > 0
     ? 'secondary'
     : 'primary';
 

--- a/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
@@ -62,7 +62,7 @@ const SearchScopeElement = ({
 
   return (
     <InputAdornment position="end" style={{ position: 'absolute', right: 5 }}>
-      <IconButton disabled={disabled} onClick={handleOpenSearchScope} size="small" edge="end">
+      <IconButton disabled={disabled} onClick={handleOpenSearchScope} size="small">
         <PaletteOutlined fontSize="small" color={disabled ? undefined : color} />
       </IconButton>
       <Popover

--- a/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
@@ -1,25 +1,23 @@
 import InputAdornment from '@mui/material/InputAdornment';
 import IconButton from '@common/button/IconButton';
 import { PaletteOutlined } from '@mui/icons-material';
-import Popover from '@mui/material/Popover';
+import Popover, { PopoverProps } from '@mui/material/Popover';
 import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
 import Checkbox from '@mui/material/Checkbox';
 import ListItemText from '@mui/material/ListItemText';
 import React, { useState } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../../components/i18n';
 import useAttributes from '../../../../utils/hooks/useAttributes';
 import { displayEntityTypeForTranslation } from '../../../../utils/String';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles({
-  container2: {
-    width: 300,
-    padding: 0,
-  },
-});
+interface SearchScopeElementProps {
+  name: string,
+  disabled?: boolean,
+  searchScope: Record<string, string[]>,
+  setSearchScope:  React.Dispatch<React.SetStateAction<Record<string, string[]>>>,
+  availableRelationFilterTypes?: Record<string, string[]>,
+}
 
 const SearchScopeElement = ({
   name,
@@ -27,10 +25,10 @@ const SearchScopeElement = ({
   searchScope,
   setSearchScope,
   availableRelationFilterTypes,
-}) => {
+}: SearchScopeElementProps) => {
+  console.log('test');
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
-  const [anchorElSearchScope, setAnchorElSearchScope] = useState();
+  const [anchorElSearchScope, setAnchorElSearchScope] = useState<PopoverProps['anchorEl']>();
   const { stixCoreObjectTypes: entityTypes } = useAttributes();
   if (name === 'contextEntityId') {
     entityTypes.push('User');
@@ -48,9 +46,9 @@ const SearchScopeElement = ({
       };
     })
     .sort((a, b) => a.label.localeCompare(b.label));
-  const handleOpenSearchScope = (event) => setAnchorElSearchScope(event.currentTarget);
+  const handleOpenSearchScope = (event: React.SyntheticEvent) => setAnchorElSearchScope(event.currentTarget);
   const handleCloseSearchScope = () => setAnchorElSearchScope(undefined);
-  const handleToggleSearchScope = (key, value) => {
+  const handleToggleSearchScope = (key: string, value: string) => {
     setSearchScope((c) => ({
       ...c,
       [key]: (searchScope[key] || []).includes(value)
@@ -59,18 +57,22 @@ const SearchScopeElement = ({
     }));
   };
 
-  let color = searchScope[name] && searchScope[name].length > 0
+  let color: 'secondary' | 'primary' = searchScope[name] && searchScope[name].length > 0
     ? 'secondary'
     : 'primary';
-  if (disabled) color = undefined;
 
   return (
     <InputAdornment position="end" style={{ position: 'absolute', right: 5 }}>
       <IconButton disabled={disabled} onClick={handleOpenSearchScope} size="small" edge="end">
-        <PaletteOutlined fontSize="small" color={color} />
+        <PaletteOutlined fontSize="small" color={disabled ? undefined : color} />
       </IconButton>
       <Popover
-        classes={{ paper: classes.container2 }}
+        sx={{
+          '& .MuiPaper-root': {
+            width: 300,
+            padding: 0,
+          },
+        }}
         open={Boolean(anchorElSearchScope)}
         anchorEl={anchorElSearchScope}
         onClose={() => handleCloseSearchScope()}

--- a/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/SearchScopeElement.tsx
@@ -56,7 +56,7 @@ const SearchScopeElement = ({
     }));
   };
 
-  const color: 'secondary' | 'primary' = searchScope[name] && searchScope[name].length > 0
+  const color = searchScope[name] && searchScope[name].length > 0
     ? 'secondary'
     : 'primary';
 


### PR DESCRIPTION
### Proposed changes
Refacto to tsx of the files:
- ListFiltersWithoutLocalStorage.jsx
- SearchScopeElement.jsx

Note that SearchScopeElement correspond to the filters box to pre-filter on entity types: 
<img width="512" height="154" alt="image" src="https://github.com/user-attachments/assets/4e2341ec-6cba-46e2-b55f-df9484fce3b1" />


### Related issues
#13845