### PR TITLE
[worker/client] iterative retry when message is nacked or unroutable (#13905)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -2342,6 +2342,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             message["work_id"] = work_id
 
         # Send the message
+        retry_count = 0
         while True:
             try:
                 channel.basic_publish(
@@ -2358,7 +2359,10 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                 self.connector_info.buffering = False
                 return
             except (UnroutableError, NackError):
-                self.connector_logger.error("Unable to send bundle, retry...")
+                retry_count = retry_count + 1
+                self.connector_logger.info(
+                    "Unable to send bundle, retrying...", {"retry_count": retry_count}
+                )
                 self.connector_info.buffering = True
                 self.metric.inc("error_count")
                 time.sleep(10)

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -2355,9 +2355,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                 )
                 self.connector_logger.debug("Bundle has been sent")
                 self.metric.inc("bundle_send")
+                self.connector_info.buffering = False
                 return
             except (UnroutableError, NackError):
                 self.connector_logger.error("Unable to send bundle, retry...")
+                self.connector_info.buffering = True
                 self.metric.inc("error_count")
                 time.sleep(10)
 

--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -69,7 +69,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
             except (UnroutableError, NackError):
                 retry_count = retry_count + 1
                 self.logger.info(
-                    "Unable to send bundle, retrying...", {"retry_count": ++retry_count}
+                    "Unable to send bundle, retrying...", {"retry_count": retry_count}
                 )
                 time.sleep(10)
 

--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -64,7 +64,6 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                         content_encoding="utf-8",  # make message persistent
                     ),
                 )
-                self.logger.debug("Bundle has been sent")
                 return
             except (UnroutableError, NackError):
                 self.logger.error("Unable to send bundle, retry...")

--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -53,6 +53,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
         ).decode("utf-8")
 
         # Send the message
+        retry_count = 0
         while True:
             try:
                 push_channel.basic_publish(
@@ -66,7 +67,10 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                 )
                 return
             except (UnroutableError, NackError):
-                self.logger.error("Unable to send bundle, retry...")
+                retry_count = retry_count + 1
+                self.logger.info(
+                    "Unable to send bundle, retrying...", {"retry_count": ++retry_count}
+                )
                 time.sleep(10)
 
     def handle_message(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* iterative retry when message is nacked or unourtable 
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fix #13905
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
