### PR TITLE
[frontend] fix display delete button (#10599)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -465,8 +465,9 @@ const ContainerHeader = (props) => {
 
   const draftContext = useDraftContext();
   const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
+  const currentAccessRight = useGetCurrentUserAccessRight(container.currentUserAccessRight);
 
-  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]) && (!draftContext || currentDraftAccessRight.canEdit);
+  const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]) && currentAccessRight.canEdit && (!draftContext || currentDraftAccessRight.canEdit);
 
   const handleCloseEnrollPlaybook = () => {
     setOpenEnrollPlaybook(false);
@@ -535,7 +536,6 @@ const ContainerHeader = (props) => {
   };
 
   const isAuthorizedMembersEnabled = !disableAuthorizedMembers;
-  const currentAccessRight = useGetCurrentUserAccessRight(container.currentUserAccessRight);
   const enableManageAuthorizedMembers = currentAccessRight.canManage && isAuthorizedMembersEnabled;
 
   // sharing buttons should be disabled for containers according to some autorized members conditions

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -303,7 +303,7 @@ const StixDomainObjectHeader = (props) => {
   // Remove CRUD button in Draft context without the minimal right access "canEdit"
   const draftContext = useDraftContext();
   const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
-  const canEdit = !draftContext || currentDraftAccessRight.canEdit;
+  const canEdit = currentAccessRight.canEdit && (!draftContext || currentDraftAccessRight.canEdit);
 
   const openAliasesCreate = false;
   const [openAlias, setOpenAlias] = useState(false);

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -31,7 +31,8 @@ const StixCyberObservableHeaderComponent = ({ stixCyberObservable, DeleteCompone
   const { t_i18n } = useFormatter();
   const draftContext = useDraftContext();
   const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
-  const canEdit = !draftContext || currentDraftAccessRight.canEdit;
+  const currentAccessRight = useGetCurrentUserAccessRight(stixCyberObservable.currentUserAccessRight);
+  const canEdit = currentAccessRight.canEdit && (!draftContext || currentDraftAccessRight.canEdit);
 
   const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]) && canEdit;
   const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]) && canEdit;

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableHeader.jsx
@@ -31,8 +31,7 @@ const StixCyberObservableHeaderComponent = ({ stixCyberObservable, DeleteCompone
   const { t_i18n } = useFormatter();
   const draftContext = useDraftContext();
   const currentDraftAccessRight = useGetCurrentUserAccessRight(draftContext?.currentUserAccessRight);
-  const currentAccessRight = useGetCurrentUserAccessRight(stixCyberObservable.currentUserAccessRight);
-  const canEdit = currentAccessRight.canEdit && (!draftContext || currentDraftAccessRight.canEdit);
+  const canEdit = !draftContext || currentDraftAccessRight.canEdit;
 
   const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]) && canEdit;
   const isKnowledgeEnricher = useGranted([KNOWLEDGE_KNENRICHMENT]) && canEdit;


### PR DESCRIPTION
### Proposed changes

* fix display delete button
* Check the Authorized members of the entity

### Related issues

* #10599 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Reproduce the use case
- Have a user with capa : `Access knowledge` in main, and `Delete knowledge` in draft
- Have an entity with Authorized members : The user `can view` this entity (not can edit)
- Have a draft without authorized members (or a draft with authorized members : the user `can edit` the draft)
- Login with the user
- Access to the draft
- Try to delete this entity
- Expected output : the delete button isn't displayed