### PR TITLE
[frontend] add `h1` size for fintel template preview (#13445)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
+++ b/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
@@ -111,6 +111,7 @@ export const htmlToPdfReport = async (
     imagesByReference: true,
     ignoreStyles: ['font-family'], // Ignoring fonts to force Roboto later.
     defaultStyles: {
+      h1: { margin: [0, 20, 0, 10], color: DARK, fontSize: 32 },
       h2: { margin: [0, 20, 0, 10], color: DARK, fontSize: 28 },
       h3: { margin: [0, 20, 0, 10], color: DARK, fontSize: 24 },
       th: { bold: true, fillColor: '', font: selectedFont },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Handle `h1` (heading 1) in fintel template preview
<img width="221" height="340" alt="image" src="https://github.com/user-attachments/assets/3825b3ee-56c3-4ae8-9e99-e6464a6975c4" />
<img width="276" height="336" alt="image" src="https://github.com/user-attachments/assets/30b1dd12-cb67-40fa-b8f5-1b926ee53f85" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13445

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
