### PR TITLE
[backend/frontend] Indicator "Reliability" field is not configurable (#12495)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectOverview.jsx
@@ -129,6 +129,7 @@ const StixDomainObjectOverview = ({
 
   const otherStixIds = stixDomainObject.x_opencti_stix_ids || [];
   const stixIds = otherStixIds.filter((n) => n !== stixDomainObject.standard_id);
+  const isIndicator = stixDomainObject.entity_type === 'Indicator';
   const isReliabilityOfSource = !stixDomainObject.x_opencti_reliability;
   const reliability = isReliabilityOfSource
     ? stixDomainObject.createdBy?.x_opencti_reliability
@@ -184,7 +185,7 @@ const StixDomainObjectOverview = ({
                       style={{ marginTop: 20 }}
                     >
                       {t_i18n('Reliability')}
-                      {isReliabilityOfSource && (
+                      {isReliabilityOfSource && !isIndicator && (
                         <span style={{ fontStyle: 'italic' }}>
                           {' '}
                           ({t_i18n('of author')})

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectOverview.jsx
@@ -129,7 +129,6 @@ const StixDomainObjectOverview = ({
 
   const otherStixIds = stixDomainObject.x_opencti_stix_ids || [];
   const stixIds = otherStixIds.filter((n) => n !== stixDomainObject.standard_id);
-  const isIndicator = stixDomainObject.entity_type === 'Indicator';
   const isReliabilityOfSource = !stixDomainObject.x_opencti_reliability;
   const reliability = isReliabilityOfSource
     ? stixDomainObject.createdBy?.x_opencti_reliability
@@ -185,7 +184,7 @@ const StixDomainObjectOverview = ({
                       style={{ marginTop: 20 }}
                     >
                       {t_i18n('Reliability')}
-                      {isReliabilityOfSource && !isIndicator && (
+                      {isReliabilityOfSource && (
                         <span style={{ fontStyle: 'italic' }}>
                           {' '}
                           ({t_i18n('of author')})

--- a/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/Indicators.tsx
@@ -30,6 +30,7 @@ const indicatorLineFragment = graphql`
     valid_until
     x_opencti_score
     x_opencti_main_observable_type
+    x_opencti_reliability
     created
     confidence
     draftVersion {

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Indicator.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Indicator.tsx
@@ -18,6 +18,7 @@ const indicatorFragment = graphql`
     standard_id
     entity_type
     x_opencti_stix_ids
+    x_opencti_reliability
     spec_version
     revoked
     confidence

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -85,6 +85,7 @@ interface IndicatorAddInput {
   pattern: string;
   pattern_type: string;
   x_opencti_main_observable_type: string;
+  x_opencti_reliability: string | undefined;
   createObservables: boolean;
   x_mitre_platforms: string[];
   valid_from: Date | null;
@@ -129,6 +130,8 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
     pattern: Yup.string(),
     pattern_type: Yup.string(),
     x_opencti_main_observable_type: Yup.string(),
+    x_opencti_reliability: Yup.string()
+      .nullable(),
     valid_from: Yup.date()
       .nullable()
       .typeError(t_i18n('The value must be a datetime (yyyy-MM-dd hh:mm (a|p)m)')),
@@ -168,6 +171,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
       pattern_type: values.pattern_type,
       createObservables: values.createObservables,
       x_opencti_main_observable_type: values.x_opencti_main_observable_type,
+      x_opencti_reliability: values.x_opencti_reliability,
       x_mitre_platforms: values.x_mitre_platforms,
       confidence: parseInt(String(values.confidence), 10),
       x_opencti_score: parseInt(String(values.x_opencti_score), 10),
@@ -213,6 +217,7 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
       pattern: '',
       pattern_type: '',
       x_opencti_main_observable_type: '',
+      x_opencti_reliability: undefined,
       x_mitre_platforms: [],
       valid_from: null,
       valid_until: null,
@@ -287,6 +292,15 @@ export const IndicatorCreationForm: FunctionComponent<IndicatorFormProps> = ({
             label={t_i18n('Main observable type')}
             required={(mandatoryAttributes.includes('x_opencti_main_observable_type'))}
             containerstyle={fieldSpacingContainerStyle}
+          />
+          <OpenVocabField
+            label={t_i18n('Reliability')}
+            type="reliability_ov"
+            name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
+            containerStyle={fieldSpacingContainerStyle}
+            multiple={false}
+            onChange={setFieldValue}
           />
           <Field
             component={DateTimePickerField}

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -249,6 +249,7 @@ const IndicatorDetails = createFragmentContainer(IndicatorDetailsComponent, {
       x_opencti_score
       x_opencti_detection
       x_opencti_main_observable_type
+      x_opencti_reliability
       x_mitre_platforms
       indicator_types
       decay_base_score

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEdition.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { graphql } from 'react-relay';
-import { commitMutation, QueryRenderer } from '../../../../relay/environment';
+import React, { FunctionComponent } from 'react';
+import { commitMutation, graphql } from 'react-relay';
+import { environment, QueryRenderer } from '../../../../relay/environment';
 import IndicatorEditionContainer from './IndicatorEditionContainer';
 import { indicatorEditionOverviewFocus } from './IndicatorEditionOverview';
-import Loader from '../../../../components/Loader';
+import Loader, { LoaderVariant } from '../../../../components/Loader';
 import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
+import { IndicatorEditionContainerQuery$data } from '@components/observations/indicators/__generated__/IndicatorEditionContainerQuery.graphql';
 
 export const indicatorEditionQuery = graphql`
   query IndicatorEditionContainerQuery($id: String!) {
@@ -14,9 +15,15 @@ export const indicatorEditionQuery = graphql`
   }
 `;
 
-const IndicatorEdition = ({ indicatorId }) => {
+interface IndicatorEditionProps {
+  indicatorId: string;
+}
+
+const IndicatorEdition: FunctionComponent<IndicatorEditionProps> = ({
+  indicatorId,
+}) => {
   const handleClose = () => {
-    commitMutation({
+    commitMutation(environment, {
       mutation: indicatorEditionOverviewFocus,
       variables: {
         id: indicatorId,
@@ -29,8 +36,8 @@ const IndicatorEdition = ({ indicatorId }) => {
     <QueryRenderer
       query={indicatorEditionQuery}
       variables={{ id: indicatorId }}
-      render={({ props }) => {
-        if (props) {
+      render={({ props }: { props: IndicatorEditionContainerQuery$data }) => {
+        if (props && props.indicator) {
           return (
             <IndicatorEditionContainer
               indicator={props.indicator}
@@ -39,7 +46,7 @@ const IndicatorEdition = ({ indicatorId }) => {
             />
           );
         }
-        return <Loader variant="inline" />;
+        return <Loader variant={LoaderVariant.inline} />;
       }}
     />
   );

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEdition.tsx
@@ -6,6 +6,7 @@ import { indicatorEditionOverviewFocus } from './IndicatorEditionOverview';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
 import { IndicatorEditionContainerQuery$data } from '@components/observations/indicators/__generated__/IndicatorEditionContainerQuery.graphql';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
 
 export const indicatorEditionQuery = graphql`
   query IndicatorEditionContainerQuery($id: String!) {
@@ -22,9 +23,10 @@ interface IndicatorEditionProps {
 const IndicatorEdition: FunctionComponent<IndicatorEditionProps> = ({
   indicatorId,
 }) => {
+  const [commit] = useApiMutation(indicatorEditionOverviewFocus);
+
   const handleClose = () => {
-    commitMutation(environment, {
-      mutation: indicatorEditionOverviewFocus,
+    commit({
       variables: {
         id: indicatorId,
         input: { focusOn: '' },

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEdition.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
-import { commitMutation, graphql } from 'react-relay';
-import { environment, QueryRenderer } from '../../../../relay/environment';
+import { graphql } from 'react-relay';
+import { QueryRenderer } from '../../../../relay/environment';
 import IndicatorEditionContainer from './IndicatorEditionContainer';
 import { indicatorEditionOverviewFocus } from './IndicatorEditionOverview';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionContainer.tsx
@@ -1,19 +1,28 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import IndicatorEditionOverview from './IndicatorEditionOverview';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import Drawer from '../../common/drawer/Drawer';
+import Drawer, { DrawerControlledDialType } from '../../common/drawer/Drawer';
+import { IndicatorEditionContainer_indicator$data } from '@components/observations/indicators/__generated__/IndicatorEditionContainer_indicator.graphql';
 
-const IndicatorEditionContainer = (props) => {
+interface IndicatorEditionContainerProps {
+  handleClose: () => void;
+  indicator: IndicatorEditionContainer_indicator$data;
+  controlledDial?: DrawerControlledDialType;
+}
+
+const IndicatorEditionContainer: FunctionComponent<IndicatorEditionContainerProps> = ({
+  handleClose,
+  indicator,
+  controlledDial,
+}) => {
   const { t_i18n } = useFormatter();
-  const { handleClose, indicator, open, controlledDial } = props;
   const { editContext } = indicator;
 
   return (
     <Drawer
       title={t_i18n('Update an indicator')}
-      open={open}
       onClose={handleClose}
       context={editContext}
       controlledDial={controlledDial}

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 import * as PropTypes from 'prop-types';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import * as R from 'ramda';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
@@ -19,11 +18,15 @@ import { convertCreatedBy, convertKillChainPhases, convertMarkings, convertStatu
 import StatusField from '../../common/form/StatusField';
 import { buildDate, parse } from '../../../../utils/Time';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import { fieldSpacingContainerStyle } from '../../../../utils/field';
+import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
-import useFormEditor from '../../../../utils/hooks/useFormEditor';
+import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import { GenericContext } from '@components/common/model/GenericContextModel';
+import { IndicatorEditionOverview_indicator$data } from '@components/observations/indicators/__generated__/IndicatorEditionOverview_indicator.graphql';
+import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
+import { FormikConfig } from 'formik/dist/types';
 
 const indicatorMutationFieldPatch = graphql`
   mutation IndicatorEditionOverviewFieldPatchMutation(
@@ -32,7 +35,12 @@ const indicatorMutationFieldPatch = graphql`
     $commitMessage: String
     $references: [String]
   ) {
-    indicatorFieldPatch(id: $id, input: $input, commitMessage: $commitMessage, references: $references) {
+    indicatorFieldPatch(
+      id: $id
+      input: $input
+      commitMessage: $commitMessage
+      references: $references
+    ) {
       ...IndicatorEditionOverview_indicator
       ...Indicator_indicator
     }
@@ -76,8 +84,27 @@ const indicatorMutationRelationDelete = graphql`
 `;
 
 const INDICATOR_TYPE = 'Indicator';
+type IndicatorGenericData = IndicatorEditionOverview_indicator$data & GenericData;
 
-const IndicatorEditionOverviewComponent = ({
+interface IndicatorEditionOverviewComponentProps {
+  indicator: IndicatorGenericData;
+  enableReferences: boolean;
+  context?: readonly (GenericContext | null)[] | null;
+  handleClose: () => void;
+}
+
+interface IndicatorEditionFormData {
+  message?: string;
+  createdBy?: FieldOption;
+  objectMarking?: FieldOption[];
+  x_opencti_workflow_id: FieldOption;
+  killChainPhases?: FieldOption[];
+  valid_from?: Date | string | null;
+  valid_until?: Date | string | null;
+  references: ExternalReferencesValues | undefined;
+}
+
+const IndicatorEditionOverviewComponent: FunctionComponent<IndicatorEditionOverviewComponentProps> = ({
   indicator,
   handleClose,
   context,
@@ -85,9 +112,11 @@ const IndicatorEditionOverviewComponent = ({
 }) => {
   const { t_i18n } = useFormatter();
   const { mandatoryAttributes } = useIsMandatoryAttribute(INDICATOR_TYPE);
+
   const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2),
     indicator_types: Yup.array(),
+    x_opencti_reliability: Yup.string().nullable(),
     confidence: Yup.number(),
     pattern: Yup.string().trim(),
     valid_from: Yup.date()
@@ -112,6 +141,7 @@ const IndicatorEditionOverviewComponent = ({
     killChainPhases: Yup.array().nullable(),
     objectMarking: Yup.array().nullable(),
   }, mandatoryAttributes);
+
   const indicatorValidator = useDynamicSchemaEditionValidation(
     mandatoryAttributes,
     basicShape,
@@ -130,29 +160,25 @@ const IndicatorEditionOverviewComponent = ({
     indicatorValidator,
   );
 
-  const onSubmit = (values, { setSubmitting }) => {
-    const commitMessage = values.message;
-    const references = R.pluck('value', values.references || []);
-    const inputValues = R.pipe(
-      R.dissoc('message'),
-      R.dissoc('references'),
-      R.assoc('x_opencti_workflow_id', values.x_opencti_workflow_id?.value),
-      R.assoc('createdBy', values.createdBy?.value),
-      R.assoc('x_mitre_platforms', values.x_mitre_platforms ?? []),
-      R.assoc('indicator_types', values.indicator_types),
-      R.assoc('objectMarking', R.pluck('value', values.objectMarking)),
-      R.assoc('killChainPhases', R.pluck('value', values.killChainPhases)),
-      R.assoc(
-        'valid_from',
-        values.valid_from ? parse(values.valid_from).format() : null,
-      ),
-      R.assoc(
-        'valid_until',
-        values.valid_until ? parse(values.valid_until).format() : null,
-      ),
-      R.toPairs,
-      R.map((n) => ({ key: n[0], value: adaptFieldValue(n[1]) })),
-    )(values);
+  const onSubmit: FormikConfig<IndicatorEditionFormData>['onSubmit'] = (values, { setSubmitting }) => {
+    const { message, references, ...otherValues } = values;
+    const commitMessage = message ?? '';
+    const commitReferences = (references ?? []).map(({ value }) => value);
+
+    const inputValues = Object.entries({
+      ...otherValues,
+      createdBy: values.createdBy?.value,
+      x_opencti_workflow_id: values.x_opencti_workflow_id?.value,
+      objectMarking: (values.objectMarking ?? []).map(({ value }) => value),
+      killChainPhases: (values.killChainPhases ?? []).map(({ value }) => value),
+      valid_from: values.valid_from
+        ? parse(values.valid_from).format()
+        : null,
+
+      valid_until: values.valid_until
+        ? parse(values.valid_until).format()
+        : null,
+    }).map(([key, value]) => ({ key, value: adaptFieldValue(value) }));
 
     editor.fieldPatch({
       variables: {
@@ -160,9 +186,8 @@ const IndicatorEditionOverviewComponent = ({
         input: inputValues,
         commitMessage:
           commitMessage && commitMessage.length > 0 ? commitMessage : null,
-        references,
+        references: commitReferences,
       },
-      setSubmitting,
       onCompleted: () => {
         setSubmitting(false);
         handleClose();
@@ -170,11 +195,11 @@ const IndicatorEditionOverviewComponent = ({
     });
   };
 
-  const handleSubmitField = (name, value) => {
+  const handleSubmitField = (name: string, value: string | string[] | number | number[] | FieldOption | null) => {
     if (!enableReferences) {
       let finalValue = value;
       if (name === 'x_opencti_workflow_id') {
-        finalValue = value.value;
+        finalValue = (value as FieldOption).value;
       }
       indicatorValidator
         .validateAt(name, { [name]: value })
@@ -193,36 +218,27 @@ const IndicatorEditionOverviewComponent = ({
     }
   };
 
-  const initialValues = R.pipe(
-    R.assoc('killChainPhases', convertKillChainPhases(indicator)),
-    R.assoc('createdBy', convertCreatedBy(indicator)),
-    R.assoc('objectMarking', convertMarkings(indicator)),
-    R.assoc('x_opencti_workflow_id', convertStatus(t_i18n, indicator)),
-    R.assoc('x_mitre_platforms', R.propOr([], 'x_mitre_platforms', indicator)),
-    R.assoc('indicator_types', R.propOr([], 'indicator_types', indicator)),
-    R.assoc('valid_from', buildDate(indicator.valid_from)),
-    R.assoc('valid_until', buildDate(indicator.valid_until)),
-    R.assoc('references', []),
-    R.pick([
-      'name',
-      'references',
-      'confidence',
-      'pattern',
-      'description',
-      'valid_from',
-      'valid_until',
-      'x_opencti_score',
-      'x_opencti_detection',
-      'indicator_types',
-      'x_mitre_platforms',
-      'killChainPhases',
-      'createdBy',
-      'objectMarking',
-      'x_opencti_workflow_id',
-    ]),
-  )(indicator);
+  const initialValues = {
+    name: indicator.name,
+    confidence: indicator.confidence,
+    pattern: indicator.pattern,
+    description: indicator.description,
+    x_opencti_score: indicator.x_opencti_score,
+    x_opencti_detection: indicator.x_opencti_detection,
+    indicator_types: indicator.indicator_types ?? [],
+    x_mitre_platforms: indicator.x_mitre_platforms ?? [],
+    x_opencti_reliability: indicator.x_opencti_reliability,
+    valid_from: buildDate(indicator.valid_from),
+    valid_until: buildDate(indicator.valid_until),
+    killChainPhases: convertKillChainPhases(indicator),
+    createdBy: convertCreatedBy(indicator) as FieldOption,
+    objectMarking: convertMarkings(indicator),
+    x_opencti_workflow_id: convertStatus(t_i18n, indicator) as FieldOption,
+    references: [],
+  };
+
   return (
-    <Formik
+    <Formik<IndicatorEditionFormData>
       enableReinitialize={true}
       initialValues={initialValues}
       validationSchema={indicatorValidator}
@@ -289,6 +305,19 @@ const IndicatorEditionOverviewComponent = ({
             helperText={
               <SubscriptionFocus context={context} fieldName="pattern" />
             }
+          />
+          <OpenVocabField
+            label={t_i18n('Reliability')}
+            type="reliability_ov"
+            name="x_opencti_reliability"
+            required={(mandatoryAttributes.includes('x_opencti_reliability'))}
+            onChange={(name, value) => setFieldValue(name, value)}
+            onFocus={editor.changeFocus}
+            onSubmit={handleSubmitField}
+            multiple={false}
+            editContext={context}
+            variant="edit"
+            containerStyle={fieldSpacingContainerStyle}
           />
           <Field
             component={DateTimePickerField}
@@ -371,7 +400,6 @@ const IndicatorEditionOverviewComponent = ({
             name="killChainPhases"
             required={(mandatoryAttributes.includes('killChainPhases'))}
             style={fieldSpacingContainerStyle}
-            setFieldValue={setFieldValue}
             helpertext={
               <SubscriptionFocus context={context} fieldName="killChainPhases" />
             }
@@ -468,6 +496,7 @@ const IndicatorEditionOverview = createFragmentContainer(
         revoked
         x_opencti_score
         x_opencti_detection
+        x_opencti_reliability
         x_mitre_platforms
         indicator_types
         createdBy {

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
@@ -276,7 +276,7 @@ const IndicatorEditionOverviewComponent: FunctionComponent<IndicatorEditionOverv
             required={(mandatoryAttributes.includes('indicator_types'))}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
-            onChange={(name, value) => setFieldValue(name, value)}
+            onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
             variant="edit"
             multiple={true}
@@ -311,7 +311,7 @@ const IndicatorEditionOverviewComponent: FunctionComponent<IndicatorEditionOverv
             type="reliability_ov"
             name="x_opencti_reliability"
             required={(mandatoryAttributes.includes('x_opencti_reliability'))}
-            onChange={(name, value) => setFieldValue(name, value)}
+            onChange={setFieldValue}
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             multiple={false}
@@ -358,7 +358,7 @@ const IndicatorEditionOverviewComponent: FunctionComponent<IndicatorEditionOverv
             required={(mandatoryAttributes.includes('x_mitre_platforms'))}
             variant="edit"
             onSubmit={handleSubmitField}
-            onChange={(name, value) => setFieldValue(name, value)}
+            onChange={setFieldValue}
             containerStyle={fieldSpacingContainerStyle}
             multiple={true}
             editContext={context}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -13267,6 +13267,7 @@ type Indicator implements BasicObject & StixObject & StixCoreObject & StixDomain
   x_opencti_detection: Boolean
   x_opencti_main_observable_type: String
   x_opencti_observable_values: [ObservablesValues!]
+  x_opencti_reliability: String
   x_mitre_platforms: [String]
   killChainPhases: [KillChainPhase!]
   observables(first: Int): StixCyberObservableConnection
@@ -13311,6 +13312,7 @@ input IndicatorAddInput {
   x_opencti_score: Int
   x_opencti_detection: Boolean
   x_opencti_main_observable_type: String
+  x_opencti_reliability: String
   x_mitre_platforms: [String!]
   killChainPhases: [String!]
   createdBy: String

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -11155,6 +11155,7 @@ export type Indicator = BasicObject & StixCoreObject & StixDomainObject & StixOb
   x_opencti_main_observable_type?: Maybe<Scalars['String']['output']>;
   x_opencti_modified_at?: Maybe<Scalars['DateTime']['output']>;
   x_opencti_observable_values?: Maybe<Array<ObservablesValues>>;
+  x_opencti_reliability?: Maybe<Scalars['String']['output']>;
   x_opencti_score?: Maybe<Scalars['Int']['output']>;
   x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
 };
@@ -11344,6 +11345,7 @@ export type IndicatorAddInput = {
   x_opencti_detection?: InputMaybe<Scalars['Boolean']['input']>;
   x_opencti_main_observable_type?: InputMaybe<Scalars['String']['input']>;
   x_opencti_modified_at?: InputMaybe<Scalars['DateTime']['input']>;
+  x_opencti_reliability?: InputMaybe<Scalars['String']['input']>;
   x_opencti_score?: InputMaybe<Scalars['Int']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<Scalars['StixId']['input']>>;
   x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
@@ -41669,6 +41671,7 @@ export type IndicatorResolvers<ContextType = any, ParentType extends ResolversPa
   x_opencti_main_observable_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   x_opencti_modified_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   x_opencti_observable_values?: Resolver<Maybe<Array<ResolversTypes['ObservablesValues']>>, ParentType, ContextType>;
+  x_opencti_reliability?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   x_opencti_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
@@ -179,6 +179,7 @@ type Indicator implements BasicObject & StixObject & StixCoreObject & StixDomain
   x_opencti_detection: Boolean
   x_opencti_main_observable_type: String
   x_opencti_observable_values: [ObservablesValues!]
+  x_opencti_reliability: String
   x_mitre_platforms: [String]
   killChainPhases: [KillChainPhase!]
   observables(first: Int): StixCyberObservableConnection
@@ -236,6 +237,7 @@ input IndicatorAddInput {
   x_opencti_score: Int @constraint(min: 0, max: 100)
   x_opencti_detection: Boolean
   x_opencti_main_observable_type: String
+  x_opencti_reliability: String
   x_mitre_platforms: [String!]
   killChainPhases: [String!]
   createdBy: String

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.ts
@@ -3,7 +3,7 @@ import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import { ENTITY_TYPE_INDICATOR, type StixIndicator, type StoreEntityIndicator } from './indicator-types';
 import convertIndicatorToStix from './indicator-converter';
 import { killChainPhases, objectOrganization } from '../../schema/stixRefRelationship';
-import { revoked } from '../../schema/attribute-definition';
+import { revoked, xOpenctiReliability } from '../../schema/attribute-definition';
 import { RELATION_DERIVED_FROM } from '../../schema/stixCoreRelationship';
 import { REL_BUILT_IN } from '../../database/stix';
 
@@ -21,6 +21,7 @@ const INDICATOR_DEFINITION: ModuleDefinition<StoreEntityIndicator, StixIndicator
     resolvers: {},
   },
   attributes: [
+    xOpenctiReliability,
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'pattern_type', label: 'Pattern type', type: 'string', format: 'vocabulary', vocabularyCategory: 'pattern_type_ov', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },


### PR DESCRIPTION
### Proposed changes

* Enable editing of x_opencti_reliability 
* If reliability has not been selected or modified, the author's reliability is displayed by default. 
* Refactor TSX components

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/12495