### PR TITLE
fix(backend): fix Mistral AI init when ai:endpoint is empty

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -41,7 +41,7 @@ if (AI_ENABLED && AI_TOKEN) {
         } */
       });
 
-      if (AI_ENDPOINT.includes('https://api.mistral.ai')) {
+      if (isEmptyField(AI_ENDPOINT) || AI_ENDPOINT.includes('https://api.mistral.ai')) {
         // Official MistralAI API
         nlqChat = new ChatMistralAI({
           model: AI_MODEL,

--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -24,14 +24,16 @@ const AI_MAX_TOKENS = conf.get('ai:max_tokens');
 const AI_VERSION = conf.get('ai:version');
 const AI_AZURE_INSTANCE = conf.get('ai:ai_azure_instance');
 const AI_AZURE_DEPLOYMENT = conf.get('ai:ai_azure_deployment');
+const MISTRAL_OFFICIAL_ENDPOINT = 'https://api.mistral.ai';
 
 let client: Mistral | OpenAI | AzureOpenAI | null = null;
 let nlqChat: ChatOpenAI | ChatMistralAI | AzureChatOpenAI | null = null;
 if (AI_ENABLED && AI_TOKEN) {
   switch (AI_TYPE) {
-    case 'mistralai':
+    case 'mistralai': {
+      const mistralEndpoint = isEmptyField(AI_ENDPOINT) ? MISTRAL_OFFICIAL_ENDPOINT : AI_ENDPOINT;
       client = new Mistral({
-        serverURL: isEmptyField(AI_ENDPOINT) ? undefined : AI_ENDPOINT,
+        serverURL: mistralEndpoint,
         apiKey: AI_TOKEN,
         /* uncomment if you need low level debug on AI
         debugLogger: {
@@ -41,7 +43,7 @@ if (AI_ENABLED && AI_TOKEN) {
         } */
       });
 
-      if (isEmptyField(AI_ENDPOINT) || AI_ENDPOINT.includes('https://api.mistral.ai')) {
+      if (mistralEndpoint.includes(MISTRAL_OFFICIAL_ENDPOINT)) {
         // Official MistralAI API
         nlqChat = new ChatMistralAI({
           model: AI_MODEL,
@@ -55,12 +57,13 @@ if (AI_ENABLED && AI_TOKEN) {
           apiKey: AI_TOKEN,
           temperature: 0,
           configuration: {
-            baseURL: `${AI_ENDPOINT}/v1`,
+            baseURL: `${mistralEndpoint}/v1`,
           },
         });
       }
 
       break;
+    }
 
     case 'openai':
       client = new OpenAI({

--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -43,7 +43,19 @@ if (AI_ENABLED && AI_TOKEN) {
         } */
       });
 
-      if (mistralEndpoint.includes(MISTRAL_OFFICIAL_ENDPOINT)) {
+      const isOfficialMistralEndpoint = (() => {
+        try {
+          const official = new URL(MISTRAL_OFFICIAL_ENDPOINT);
+          const endpointUrl = new URL(mistralEndpoint);
+          return endpointUrl.protocol === official.protocol
+            && endpointUrl.hostname === official.hostname
+            && endpointUrl.port === official.port;
+        } catch {
+          return false;
+        }
+      })();
+
+      if (isOfficialMistralEndpoint) {
         // Official MistralAI API
         nlqChat = new ChatMistralAI({
           model: AI_MODEL,

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/ai-llm-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/ai-llm-test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const chatMistralAiCtor = vi.fn();
+const chatOpenAiCtor = vi.fn();
+const mistralCtor = vi.fn();
+
+vi.mock('@langchain/mistralai', () => {
+  return {
+    ChatMistralAI: chatMistralAiCtor,
+  };
+});
+
+vi.mock('@langchain/openai', () => {
+  return {
+    ChatOpenAI: chatOpenAiCtor,
+    AzureChatOpenAI: vi.fn(),
+  };
+});
+
+vi.mock('@mistralai/mistralai', () => {
+  return {
+    Mistral: mistralCtor,
+  };
+});
+
+vi.mock('openai', () => {
+  class AuthenticationError extends Error {}
+  return {
+    AuthenticationError,
+    OpenAI: vi.fn(),
+    AzureOpenAI: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    default: {
+      get: (key: string) => {
+        switch (key) {
+          case 'ai:enabled':
+            return true;
+          case 'ai:type':
+            return 'mistralai';
+          case 'ai:endpoint':
+            return undefined;
+          case 'ai:token':
+            return 'test-token';
+          case 'ai:model':
+            return 'mistral-large-latest';
+          case 'ai:max_tokens':
+            return 256;
+          case 'ai:version':
+            return undefined;
+          case 'ai:ai_azure_instance':
+            return undefined;
+          case 'ai:ai_azure_deployment':
+            return undefined;
+          default:
+            return undefined;
+        }
+      },
+    },
+    BUS_TOPICS: {},
+    logApp: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+describe('ai-llm initialization', () => {
+  it('should not throw and should use ChatMistralAI when endpoint is empty', async () => {
+    vi.resetModules();
+
+    await expect(import('../../../src/database/ai-llm')).resolves.toBeDefined();
+
+    expect(chatMistralAiCtor).toHaveBeenCalledTimes(1);
+    expect(chatOpenAiCtor).not.toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/ai-llm-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/ai-llm-test.ts
@@ -39,6 +39,8 @@ vi.mock('../../../src/config/conf', async (importOriginal) => {
     default: {
       get: (key: string) => {
         switch (key) {
+          case 'redis:ca':
+            return [];
           case 'ai:enabled':
             return true;
           case 'ai:type':


### PR DESCRIPTION
### Context
When configuring AI with `ai:type=mistralai`, [opencti-graphql/src/database/ai-llm.ts](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/opencti/opencti-platform/opencti-graphql/src/database/ai-llm.ts:0:0-0:0) called `AI_ENDPOINT.includes(...)` during module initialization. If `ai:endpoint` is unset/empty, this can throw and prevent the platform from starting.

### Changes
- Guard against empty `ai:endpoint` in the `mistralai` initialization path.
- When endpoint is empty, default to the official Mistral API behavior (`ChatMistralAI` path).

### Tests
- Added unit test [tests/01-unit/database/ai-llm-test.ts](cci:7://file:///c:/Users/brass/OneDrive/Desktop/Work/opencti/opencti-platform/opencti-graphql/tests/01-unit/database/ai-llm-test.ts:0:0-0:0) to ensure:
  - importing `ai-llm` does not throw when `ai:endpoint` is undefined
  - `ChatMistralAI` is used (and `ChatOpenAI` is not)

### Notes
This is a backwards-compatible change and only affects the `mistralai` initialization branch.