### PR TITLE
[backend] Optimize JSON mapper memory usage and performance

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -641,10 +641,16 @@ export const jsonExecutor = async (context: AuthContext) => {
     if (isMustExecuteIteration(ingestion.last_execution_date, ingestion.scheduling_period)) {
       const { messages_number, messages_size } = await queueDetails(connectorIdFromIngestId(ingestion.id));
       if (messages_number === 0) { // If no more ingestion to do
-        const { bundle, variables, nextExecutionState } = await executeJsonQuery(context, ingestion);
-        logApp.info('pushBundleToConnectorQueue', bundle.objects.length);
+        const { objects, variables, nextExecutionState } = await executeJsonQuery(context, ingestion);
+        logApp.info('pushBundleToConnectorQueue', objects.length);
         // Push the bundle to absorption queue if required
-        if (bundle.objects.length > 0) {
+        if (objects.length > 0) {
+          const bundle: StixBundle = {
+            id: `bundle--${uuidv4()}`,
+            spec_version: '2.1',
+            type: 'bundle',
+            objects,
+          };
           await pushBundleToConnectorQueue(context, ingestion, bundle);
         }
         // Save new state for next execution

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -14,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import * as JSONPath from 'jsonpath-plus';
-import { v4 as uuidv4 } from 'uuid';
-import type { StixBundle } from '../../types/stix-2-1-common';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { fullEntitiesList, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import { type BasicStoreEntityIngestionJson, type DataParam, ENTITY_TYPE_INGESTION_JSON } from './ingestion-types';
@@ -145,18 +143,12 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
   };
   const platformUsers = await getEntitiesMapFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
   const ingestionUser = ingestion.user_id ? platformUsers.get(ingestion.user_id) : null;
-  const objects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, requestData, jsonMapperParsed);
-  const bundle: StixBundle = {
-    id: `bundle--${uuidv4()}`,
-    spec_version: '2.1',
-    type: 'bundle',
-    objects,
-  };
+  let objects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, requestData, jsonMapperParsed);
   let nextExecutionState = buildQueryObject(ingestion.query_attributes, { ...requestData, ...responseHeaders }, false);
   // region Try to paginate with next page style
   if (ingestion.pagination_with_sub_page && isNotEmptyField(ingestion.pagination_with_sub_page_attribute_path)) {
     let url = getValueFromPath(ingestion.pagination_with_sub_page_attribute_path, requestData);
-    while (isNotEmptyField(url) && (maxResults === 0 || (bundle.objects ?? []).length < maxResults)) {
+    while (isNotEmptyField(url) && (maxResults === 0 || objects.length < maxResults)) {
       logApp.info(`> Sub query: ${url}`);
       await wait(100); // Wait 100 ms between 2 calls
       const { data: paginationData } = await httpClient.call({
@@ -168,7 +160,7 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
       nextExecutionState = { ...nextExecutionState, ...paginationVariables };
       const paginationObjects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, paginationData, jsonMapperParsed);
       if (paginationObjects.length > 0) {
-        bundle.objects = bundle.objects.concat(paginationObjects);
+        objects = objects.concat(paginationObjects);
       }
       url = getValueFromPath(ingestion.pagination_with_sub_page_attribute_path, paginationData);
     }
@@ -176,9 +168,9 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
   // endregion
   // In case of limitation, ensure to not return too many elements
   if (maxResults > 0) {
-    bundle.objects = bundle.objects.slice(0, maxResults);
+    objects = objects.slice(0, maxResults);
   }
-  return { bundle, variables, nextExecutionState };
+  return { objects, variables, nextExecutionState };
 };
 
 export const findById = async (context: AuthContext, user: AuthUser, ingestionId: string, removeCredentials = false) => {
@@ -349,11 +341,11 @@ export const testJsonIngestionMapping = async (context: AuthContext, _user: Auth
   if (input.authentication_value) {
     verifyIngestionAuthenticationContent(input.authentication_type, input.authentication_value);
   }
-  const { bundle, nextExecutionState } = await executeJsonQuery(context, input as BasicStoreEntityIngestionJson, { maxResults: 50 });
+  const { objects, nextExecutionState } = await executeJsonQuery(context, input as BasicStoreEntityIngestionJson, { maxResults: 50 });
   return {
-    objects: JSON.stringify(bundle.objects, null, 2),
-    nbRelationships: bundle.objects.filter((object: StixObject) => object.type === 'relationship').length,
-    nbEntities: bundle.objects.filter((object: StixObject) => object.type !== 'relationship').length,
+    objects: JSON.stringify(objects, null, 2),
+    nbRelationships: objects.filter((object: StixObject) => object.type === 'relationship').length,
+    nbEntities: objects.filter((object: StixObject) => object.type !== 'relationship').length,
     state: JSON.stringify(nextExecutionState),
   };
 };

--- a/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-domain.ts
@@ -52,8 +52,7 @@ export const jsonMapperTest = async (context: AuthContext, user: AuthUser, confi
   const jsonMapperParsed = parseJsonMapper(parsedConfiguration);
   const { createReadStream } = await fileUpload;
   const data: string = await streamConverter(createReadStream());
-  const stixBundle = await jsonMappingExecution(context, user, data, jsonMapperParsed);
-  const allObjects = stixBundle.objects;
+  const allObjects = await jsonMappingExecution(context, user, data, jsonMapperParsed);
   return {
     objects: JSON.stringify(allObjects.slice(0, 50), null, 2), // Max 50 records to display
     nbRelationships: allObjects.filter((object) => object.type === 'relationship').length,

--- a/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
@@ -476,7 +476,7 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
 
   const bundle: StixBundle = {
     id: `bundle--${uuidv4()}`,
-    spec_version: STIX_SPEC_VERSION ?? '2.1',
+    spec_version: STIX_SPEC_VERSION,
     type: 'bundle',
     objects: finalObjects,
   };

--- a/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
@@ -358,10 +358,10 @@ const processAndStoreInput = (
     delete input.__froms;
     delete input.__tos;
   } else {
-    if (results.has(representation.id)) {
-      const current = results.get(representation.id);
-      if (!current?.has(input.__identifier)) {
-        current?.set(input.__identifier, input);
+    const current = results.get(representation.id);
+    if (current) {
+      if (!current.has(input.__identifier)) {
+        current.set(input.__identifier, input);
       }
     } else {
       results.set(representation.id, new Map([[input.__identifier, input]]));

--- a/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
@@ -6,12 +6,12 @@ import { trino_data, trino_mapper } from './json-mapper-trino';
 import { misp_data, misp_mapper } from './json-mapper-misp';
 import { STIX_EXT_OCTI_SCO } from '../../../src/types/stix-2-1-extensions';
 
-const buildMaps = (stixBundle) => {
+const buildMaps = (objects) => {
   const mapById = new Map();
   const mapByType = new Map();
   const mapByFromAndTo = new Map();
-  for (let index = 0; index < stixBundle.objects.length; index += 1) {
-    const element = stixBundle.objects[index];
+  for (let index = 0; index < objects.length; index += 1) {
+    const element = objects[index];
     mapById.set(element.id, element);
     if (element.type === 'relationship') {
       mapByFromAndTo.set(`${element.source_ref}-${element.target_ref}`, element);
@@ -29,9 +29,9 @@ const buildMaps = (stixBundle) => {
 
 describe('JSON mapper testing', () => {
   it('should cisa correctly parsed', async () => {
-    const stixBundle = await jsonMappingExecution(testContext, ADMIN_USER, cisa_data, cisa_mapper);
-    const { mapById, mapByType, mapByFromAndTo } = buildMaps(stixBundle);
-    expect(stixBundle.objects.length).toBe(3556);
+    const objects = await jsonMappingExecution(testContext, ADMIN_USER, cisa_data, cisa_mapper);
+    const { mapById, mapByType, mapByFromAndTo } = buildMaps(objects);
+    expect(objects.length).toBe(3556);
     expect(mapByType.get('marking-definition').length).toBe(1);
     expect(mapByType.get('identity').length).toBe(1);
     expect(mapByType.get('software').length).toBe(528);
@@ -52,8 +52,8 @@ describe('JSON mapper testing', () => {
     expect(relationship).not.toBeNull();
   });
   it('should trino correctly parsed', async () => {
-    const stixBundle = await jsonMappingExecution(testContext, ADMIN_USER, trino_data, trino_mapper);
-    const { mapById, mapByType } = buildMaps(stixBundle);
+    const objects = await jsonMappingExecution(testContext, ADMIN_USER, trino_data, trino_mapper);
+    const { mapById, mapByType } = buildMaps(objects);
     expect(mapByType.get('identity').length).toBe(40);
     // Test organization binding
     const organization = mapById.get('identity--c8b81eb7-706a-5ec5-a0a0-804064556134');
@@ -61,8 +61,8 @@ describe('JSON mapper testing', () => {
     expect(organization.identity_class).toBe('organization');
   });
   it('should misp correctly parsed', async () => {
-    const stixBundle = await jsonMappingExecution(testContext, ADMIN_USER, misp_data, misp_mapper, { externalUri: 'http://localhost' });
-    const { mapById, mapByType } = buildMaps(stixBundle);
+    const objects = await jsonMappingExecution(testContext, ADMIN_USER, misp_data, misp_mapper, { externalUri: 'http://localhost' });
+    const { mapById, mapByType } = buildMaps(objects);
     expect(mapByType.get('marking-definition').length).toBe(1);
     expect(mapByType.get('location').length).toBe(1);
     expect(mapByType.get('identity').length).toBe(1);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Refactor `jsonMappingExecution` for better readability
- Implement early STIX conversion to reduce memory pressure during large dataset processing
- Optimize relationship resolution with O(1) map lookups instead of array filtering

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/14041#issue-3818455091

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
