### PR TITLE
[frontend] fix external ref drawer header wrapping

### DIFF
--- a/opencti-platform/opencti-front/src/components/SearchInput.jsx
+++ b/opencti-platform/opencti-front/src/components/SearchInput.jsx
@@ -39,6 +39,8 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: 4,
     padding: '0 10px 0 10px',
     height: 30,
+    width: '100%',
+    minWidth: 100,
   },
   searchRootThin: {
     borderRadius: 4,
@@ -52,6 +54,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.default,
   },
   searchInputTopBar: {
+    width: '100%',
+  },
+  searchInputInDrawer: {
     width: '100%',
   },
   searchInput: {
@@ -117,6 +122,8 @@ const SearchInput = (props) => {
     classInput = classes.searchInputTopBar;
   } else if (variant === 'noAnimation') {
     classInput = classes.searchInputNoAnimation;
+  } else if (variant === 'inDrawer') {
+    classInput = classes.searchInputInDrawer;
   }
 
   const handleChangeAskAI = () => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
@@ -64,9 +64,9 @@ const AddExternalReferences = ({
             marginLeft: 'auto',
             marginRight: '20px',
             display: 'flex',
-            flexWrap: 'wrap',
-            alignItems: 'flex-end',
+            alignItems: 'center',
             justifyContent: 'flex-end',
+            gap: '12px',
           }}
           >
             <SearchInput
@@ -74,7 +74,6 @@ const AddExternalReferences = ({
               onSubmit={handleSearch}
             />
             <Button
-              sx={{ margin: '5px 0 0 5px' }}
               onClick={() => setDialogOpen(true)}
               color="primary"
               size="small"

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
@@ -178,7 +178,7 @@ const Drawer = forwardRef(({
           >
             <Close fontSize="small" color="primary" />
           </IconButton>
-          <Typography variant="subtitle2" style={{ textWrap: 'nowrap' }}>{title}</Typography>
+          <Typography variant="subtitle2" style={{ textWrap: 'nowrap', marginRight: 12 }}>{title}</Typography>
           {context && <SubscriptionAvatars context={context} />}
           {header}
         </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* make the search bar able to shrink and the create button text able to wrap
* add 12px gap between elements to stay consistent with icon spacing and improve readability

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13892


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
