### PR TITLE
[backend] stabilize email mime part type and windows registry value type standard_id (#13501)

### DIFF
--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -138,8 +138,8 @@ const stixBaseCyberObservableContribution = {
     [C.ENTITY_ICCID]: [{ src: 'value' }],
     [C.ENTITY_IMSI]: [{ src: 'value' }],
     // Types embedded
-    [C.ENTITY_EMAIL_MIME_PART_TYPE]: [], // ALL
-    [C.ENTITY_WINDOWS_REGISTRY_VALUE_TYPE]: [], // ALL
+    [C.ENTITY_EMAIL_MIME_PART_TYPE]: [{ src: 'body' }, { src: 'content_type' }, { src: 'data_content_dispositiontype' }],
+    [C.ENTITY_WINDOWS_REGISTRY_VALUE_TYPE]: [{ src: 'name' }, { src: 'data' }, { src: 'data_type' }],
   },
   resolvers: {
     from(from) {

--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -138,7 +138,7 @@ const stixBaseCyberObservableContribution = {
     [C.ENTITY_ICCID]: [{ src: 'value' }],
     [C.ENTITY_IMSI]: [{ src: 'value' }],
     // Types embedded
-    [C.ENTITY_EMAIL_MIME_PART_TYPE]: [{ src: 'body' }, { src: 'content_type' }, { src: 'data_content_dispositiontype' }],
+    [C.ENTITY_EMAIL_MIME_PART_TYPE]: [{ src: 'body' }, { src: 'content_type' }, { src: 'content_disposition' }],
     [C.ENTITY_WINDOWS_REGISTRY_VALUE_TYPE]: [{ src: 'name' }, { src: 'data' }, { src: 'data_type' }],
   },
   resolvers: {


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* stabilize email mime part type and windows registry value type standard_id by specifying attributes to use for standard_id computation
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13501
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
