### PR TITLE
[frontend] Rework Mitre headers UI (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.tsx
@@ -166,11 +166,11 @@ const ListFilters = ({
             groupBy={isNotUniqEntityTypes ? (option) => option?.groupLabel ?? '' : undefined}
             sx={{ width: 200 }}
             value={null}
-            onChange={(event, selectOptionValue) => {
+            onChange={(_, selectOptionValue) => {
               if (selectOptionValue?.value) handleChange(selectOptionValue.value);
             }}
             inputValue={inputValue}
-            onInputChange={(event, newValue, reason) => {
+            onInputChange={(_, newValue, reason) => {
               if (reason === 'reset') {
                 return;
               }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
@@ -305,6 +305,91 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
             marginTop: -12,
           }}
         >
+          {currentView === 'matrix' && (
+            <>
+              <Box
+                style={{
+                  float: 'left',
+                  display: 'flex',
+                  paddingInline: 10,
+                  paddingBlock: 10,
+                  gap: 1,
+                }}
+              >
+                <InputLabel
+                  style={{ paddingInlineEnd: 10, marginTop: 1 }}
+                >
+                  {t_i18n('Kill chain :')}
+                </InputLabel>
+                <FormControl>
+                  <Select
+                    size="small"
+                    value={selectedKillChain}
+                    onChange={handleKillChainChange}
+                  >
+                    {killChains.map((killChainName) => (
+                      <MenuItem key={killChainName} value={killChainName}>
+                        {killChainName}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
+              <Box
+                style={{
+                  float: 'left',
+                  display: 'flex',
+                  marginBlockStart: -4,
+                  paddingInline: 10,
+                  marginTop: 2,
+                }}
+              >
+                <Tooltip
+                  title={
+                    isModeOnlyActive
+                      ? t_i18n('Display the whole matrix')
+                      : t_i18n('Display only used techniques')
+                  }
+                >
+                  <span>
+                    <IconButton
+                      color={isModeOnlyActive ? 'secondary' : 'primary'}
+                      onClick={() => setIsModeOnlyActive((value) => !value)}
+                    >
+                      <VisibilityOutlined />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Box>
+
+              {!isSecurityPlatform && (
+                <Box
+                  style={{
+                    float: 'right',
+                    display: 'flex',
+                    paddingInline: 10,
+                  }}
+                >
+                  <FormControl style={{ display: 'flex', paddingInlineEnd: 10, minWidth: 300, maxWidth: 500 }}>
+                    <EntitySelect
+                      multiple
+                      variant="outlined"
+                      size="small"
+                      value={selectedSecurityPlatforms}
+                      label={t_i18n('Compare with my security posture')}
+                      types={['SecurityPlatform']}
+                      onChange={(newSelectedSecurityPlatforms) => {
+                        handleSecurityPlatformsChange(newSelectedSecurityPlatforms as EntityOption[]);
+                      }}
+                    />
+                  </FormControl>
+                </Box>
+              )}
+            </>
+          )}
+
+          <div className="clearfix" />
+
           <div
             style={{
               float: 'left',
@@ -333,100 +418,7 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
               searchContext={{ entityTypes: ['Attack-Pattern'] }}
             />
           </Box>
-          <Box
-            style={{
-              float: 'left',
-              display: 'flex',
-              margin: '-6px 4px 0 0',
-            }}
-          >
-            <FilterIconButton
-              filters={filters}
-              helpers={helpers}
-              styleNumber={2}
-              redirection
-              searchContext={{ entityTypes: ['Attack-Pattern'] }}
-            />
-          </Box>
-          {currentView === 'matrix' && (
-            <>
-              <Box
-                style={{
-                  float: 'left',
-                  display: 'flex',
-                  paddingInline: 10,
-                  paddingBlock: 10,
-                  gap: 1,
-                }}
-              >
-                <InputLabel style={{ paddingInlineEnd: 10 }}>
-                  {t_i18n('Kill chain :')}
-                </InputLabel>
-                <FormControl>
-                  <Select
-                    size="small"
-                    value={selectedKillChain}
-                    onChange={handleKillChainChange}
-                  >
-                    {killChains.map((killChainName) => (
-                      <MenuItem key={killChainName} value={killChainName}>
-                        {killChainName}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box
-                style={{
-                  float: 'left',
-                  display: 'flex',
-                  marginBlockStart: -4,
-                  paddingInline: 10,
-                }}
-              >
-                <Tooltip
-                  title={
-                    isModeOnlyActive
-                      ? t_i18n('Display the whole matrix')
-                      : t_i18n('Display only used techniques')
-                  }
-                >
-                  <span>
-                    <IconButton
-                      color={isModeOnlyActive ? 'secondary' : 'primary'}
-                      onClick={() => setIsModeOnlyActive((value) => !value)}
-                    >
-                      <VisibilityOutlined />
-                    </IconButton>
-                  </span>
-                </Tooltip>
-              </Box>
 
-              {!isSecurityPlatform && (
-                <Box
-                  style={{
-                    float: 'left',
-                    display: 'flex',
-                    paddingInline: 10,
-                  }}
-                >
-                  <FormControl style={{ display: 'flex', paddingInlineEnd: 10, minWidth: 300, maxWidth: 500 }}>
-                    <EntitySelect
-                      multiple
-                      variant="outlined"
-                      size="small"
-                      value={selectedSecurityPlatforms}
-                      label={t_i18n('Compare with my security posture')}
-                      types={['SecurityPlatform']}
-                      onChange={(newSelectedSecurityPlatforms) => {
-                        handleSecurityPlatformsChange(newSelectedSecurityPlatforms as EntityOption[]);
-                      }}
-                    />
-                  </FormControl>
-                </Box>
-              )}
-            </>
-          )}
           {displayButtons
             && (
               <div style={{ float: 'right', margin: 0 }} id="container-view-buttons">
@@ -472,6 +464,22 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
                 </div>
               </div>
             )}
+
+          <div className="clearfix" />
+
+          <Box
+            style={{
+              float: 'left',
+            }}
+          >
+            <FilterIconButton
+              filters={filters}
+              helpers={helpers}
+              styleNumber={2}
+              redirection
+              searchContext={{ entityTypes: ['Attack-Pattern'] }}
+            />
+          </Box>
           <div className="clearfix" />
         </div>
       )}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
@@ -367,10 +367,9 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
                   style={{
                     float: 'right',
                     display: 'flex',
-                    paddingInline: 10,
                   }}
                 >
-                  <FormControl style={{ display: 'flex', paddingInlineEnd: 10, minWidth: 300, maxWidth: 500 }}>
+                  <FormControl style={{ display: 'flex', minWidth: 300, maxWidth: 500 }}>
                     <EntitySelect
                       multiple
                       variant="outlined"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
@@ -49,6 +49,7 @@ import usePreloadedFragment from '../../../../utils/hooks/usePreloadedFragment';
 import { fetchQuery } from '../../../../relay/environment';
 import { containerTypes } from '../../../../utils/hooks/useAttributes';
 import { useInitCreateRelationshipContext } from '../stix_core_relationships/CreateRelationshipContextProvider';
+import Stack from '@mui/material/Stack';
 
 export const stixDomainObjectAttackPatternsKillChainQuery = graphql`
   query StixDomainObjectAttackPatternsKillChainQuery(
@@ -298,52 +299,46 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
   return (
     <>
       {currentView !== 'matrix-in-line' && currentView !== 'relationships' && (
-        <div
-          style={{
-            marginBottom: 20,
+        <Stack
+          sx={{
+            marginBottom: 2,
             padding: 0,
-            marginTop: -12,
+            marginTop: -1,
+            gap: 1,
           }}
         >
           {currentView === 'matrix' && (
-            <>
-              <Box
-                style={{
-                  float: 'left',
-                  display: 'flex',
-                  paddingInline: 10,
-                  paddingBlock: 10,
-                  gap: 1,
-                }}
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Stack
+                direction="row"
+                alignItems="center"
+                gap={1}
               >
-                <InputLabel
-                  style={{ paddingInlineEnd: 10, marginTop: 1 }}
-                >
-                  {t_i18n('Kill chain :')}
-                </InputLabel>
-                <FormControl>
-                  <Select
-                    size="small"
-                    value={selectedKillChain}
-                    onChange={handleKillChainChange}
+                <Stack direction="row">
+                  <InputLabel
+                    style={{ paddingInlineEnd: 10, marginTop: 1 }}
                   >
-                    {killChains.map((killChainName) => (
-                      <MenuItem key={killChainName} value={killChainName}>
-                        {killChainName}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box
-                style={{
-                  float: 'left',
-                  display: 'flex',
-                  marginBlockStart: -4,
-                  paddingInline: 10,
-                  marginTop: 2,
-                }}
-              >
+                    {t_i18n('Kill chain :')}
+                  </InputLabel>
+                  <FormControl>
+                    <Select
+                      size="small"
+                      value={selectedKillChain}
+                      onChange={handleKillChainChange}
+                    >
+                      {killChains.map((killChainName) => (
+                        <MenuItem key={killChainName} value={killChainName}>
+                          {killChainName}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Stack>
+
                 <Tooltip
                   title={
                     isModeOnlyActive
@@ -360,7 +355,7 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
                     </IconButton>
                   </span>
                 </Tooltip>
-              </Box>
+              </Stack>
 
               {!isSecurityPlatform && (
                 <Box
@@ -384,103 +379,89 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
                   </FormControl>
                 </Box>
               )}
-            </>
+            </Stack>
           )}
 
-          <div className="clearfix" />
+          <Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Stack
+                direction="row"
+                gap={1}
+                alignItems="center"
+              >
+                <SearchInput
+                  variant="small"
+                  keyword={searchTerm}
+                  onSubmit={handleSearch}
+                />
+                <Filters
+                  availableFilterKeys={availableFilterKeys}
+                  helpers={helpers}
+                  searchContext={{ entityTypes: ['Attack-Pattern'] }}
+                />
+              </Stack>
 
-          <div
-            style={{
-              float: 'left',
-            }}
-          >
-            <SearchInput
-              variant="small"
-              keyword={searchTerm}
-              onSubmit={handleSearch}
-            />
-          </div>
-          <Box
-            style={{
-              display: 'flex',
-              float: 'left',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              marginRight: 20,
-              marginLeft: 8,
-              gap: 10,
-            }}
-          >
-            <Filters
-              availableFilterKeys={availableFilterKeys}
-              helpers={helpers}
-              searchContext={{ entityTypes: ['Attack-Pattern'] }}
-            />
-          </Box>
+              {displayButtons
+                && (
+                  <div id="container-view-buttons">
+                    <ToggleButtonGroup size="small" color="secondary" exclusive={true}>
+                      {[...viewButtons]}
+                      {typeof handleToggleExports === 'function' && (
+                        <Tooltip
+                          key="export"
+                          title={
+                            exportDisabled
+                              ? `${t_i18n('Export is disabled because too many entities are targeted (maximum number of entities is: ') + export_max_size})`
+                              : t_i18n('Open export panel')
+                          }
+                        >
+                          <ToggleButton
+                            size="small"
+                            value="export"
+                            aria-label="export"
+                            onClick={exportDisabled ? undefined : handleToggleExports}
+                            disabled={exportDisabled}
+                          >
+                            <FileDownloadOutlined
+                              fontSize="small"
+                              color={!exportDisabled && openExports ? 'secondary' : 'primary'}
+                            />
+                          </ToggleButton>
+                        </Tooltip>
+                      )}
+                    </ToggleButtonGroup>
 
-          {displayButtons
-            && (
-              <div style={{ float: 'right', margin: 0 }} id="container-view-buttons">
-                <ToggleButtonGroup size="small" color="secondary" exclusive={true}>
-                  {[...viewButtons]}
-                  {typeof handleToggleExports === 'function' && (
-                    <Tooltip
-                      key="export"
-                      title={
-                        exportDisabled
-                          ? `${t_i18n('Export is disabled because too many entities are targeted (maximum number of entities is: ') + export_max_size})`
-                          : t_i18n('Open export panel')
-                      }
+                    <div
+                      style={{
+                        float: 'right',
+                        margin: '0 0 0 20px',
+                      }}
                     >
-                      <ToggleButton
-                        size="small"
-                        value="export"
-                        aria-label="export"
-                        onClick={exportDisabled ? undefined : handleToggleExports}
-                        disabled={exportDisabled}
-                      >
-                        <FileDownloadOutlined
-                          fontSize="small"
-                          color={!exportDisabled && openExports ? 'secondary' : 'primary'}
-                        />
-                      </ToggleButton>
-                    </Tooltip>
-                  )}
-                </ToggleButtonGroup>
+                      <ExportButtons
+                        domElementId="container"
+                        name={t_i18n('Attack patterns kill chain')}
+                        csvData={csvData}
+                        csvFileName={`${t_i18n('Attack pattern courses of action')}.csv`}
+                      />
+                    </div>
+                  </div>
+                )}
 
-                <div
-                  style={{
-                    float: 'right',
-                    margin: '0 0 0 20px',
-                  }}
-                >
-                  <ExportButtons
-                    domElementId="container"
-                    name={t_i18n('Attack patterns kill chain')}
-                    csvData={csvData}
-                    csvFileName={`${t_i18n('Attack pattern courses of action')}.csv`}
-                  />
-                </div>
-              </div>
-            )}
+            </Stack>
 
-          <div className="clearfix" />
-
-          <Box
-            style={{
-              float: 'left',
-            }}
-          >
-            <FilterIconButton
-              filters={filters}
-              helpers={helpers}
-              styleNumber={2}
-              redirection
-              searchContext={{ entityTypes: ['Attack-Pattern'] }}
-            />
-          </Box>
-          <div className="clearfix" />
-        </div>
+          </Stack>
+          <FilterIconButton
+            filters={filters}
+            helpers={helpers}
+            styleNumber={2}
+            redirection
+            searchContext={{ entityTypes: ['Attack-Pattern'] }}
+          />
+        </Stack>
       )}
       <div
         style={{


### PR DESCRIPTION
## Proposed changes
Rework the headers of the mitre page (an entity > Knowledge tab > Attack patterns > mitre attack view) to put filters/icons in 3 lines

### Before

<img width="1684" height="763" alt="image" src="https://github.com/user-attachments/assets/659b4553-80ca-4f31-949a-4abf86fd9a5e" />



### Now

<img width="1677" height="820" alt="image" src="https://github.com/user-attachments/assets/13b9dde4-1f3c-4c2e-9be4-8280528710cf" />




## Related issues
#13303