### PR TITLE
[frontend] fix spacing and add DataTable in Vocabulary Categories (#10713)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableWithoutFragment.tsx
@@ -21,6 +21,7 @@ type OCTIDataTableProps = Pick<DataTableProps, 'dataColumns'
   | 'pageSize'
   | 'hideHeaders'
   | 'onLineClick'
+  | 'onSort'
   | 'isLocalStorageEnabled'
   | 'variant'> & {
     data: unknown;

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -43,6 +43,7 @@ type DataTableComponentProps = Pick<DataTableProps,
   | 'getComputeLink'
   | 'selectOnLineClick'
   | 'onLineClick'
+  | 'onSort'
   | 'data'
   | 'emptyStateMessage'
   | 'disableLineSelection'
@@ -75,6 +76,7 @@ const DataTableComponent = ({
   removeSelectAll,
   selectOnLineClick,
   onLineClick,
+  onSort,
   emptyStateMessage,
   pageSize,
 }: DataTableComponentProps) => {
@@ -256,7 +258,7 @@ const DataTableComponent = ({
         useDataTableColumnsLocalStorage: columnsLocalStorage,
         useDataTablePaginationLocalStorage: paginationLocalStorage,
         onAddFilter: (id) => helpers.handleAddFilterWithEmptyValue(getDefaultFilterObject(id)),
-        onSort: helpers.handleSort,
+        onSort: onSort ?? helpers.handleSort,
         formatter: useDataTableFormatter(),
         variant,
         rootRef,

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -385,7 +385,8 @@ const defaultColumns: DataTableProps['dataColumns'] = {
               float: 'left',
               marginRight: 7,
               overflow: 'hidden',
-              whiteSpace: 'nowrap' }}
+              whiteSpace: 'nowrap',
+            }}
             >
               <Chip
                 key={type}

--- a/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
@@ -1,103 +1,96 @@
-import React from 'react';
-import makeStyles from '@mui/styles/makeStyles';
-import Chip from '@mui/material/Chip';
-import ListLines from '../../../components/list_lines/ListLines';
+import React, { useEffect } from 'react';
+import { useTheme } from '@mui/material';
 import { useFormatter } from '../../../components/i18n';
 import LabelsVocabulariesMenu from './LabelsVocabulariesMenu';
 import { useVocabularyCategoryAsQuery, VocabularyDefinition } from '../../../utils/hooks/useVocabularyCategory';
-import ListLinesContent from '../../../components/list_lines/ListLinesContent';
-import { VocabularyCategoryLine, VocabularyCategoryLineDummy } from './attributes/VocabularyCategoryLine';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
+import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
+import DataTableWithoutFragment from '../../../components/dataGrid/DataTableWithoutFragment';
+import { ShortTextOutlined } from '@mui/icons-material';
+import SearchInput from '../../../components/SearchInput';
+import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles(() => ({
-  container: {
-    margin: 0,
-    padding: '0 200px 50px 0',
-  },
-  label: {
-    fontSize: 12,
-    height: 20,
-    float: 'left',
-    marginRight: 7,
-  },
-}));
+const LOCAL_STORAGE_KEY = 'vocabulary_categories';
 
 const VocabularyCategories = () => {
-  const classes = useStyles();
   const { t_i18n } = useFormatter();
   const { setTitle } = useConnectedDocumentModifier();
+  const theme = useTheme();
+
   setTitle(t_i18n('Vocabularies | Taxonomies | Settings'));
-  const { categories, sortBy, orderAsc, searchTerm, handleSort, handleSearch } = useVocabularyCategoryAsQuery();
-  const renderLines = () => {
-    const dataColumns = {
-      name: {
-        label: 'Name',
-        width: '20%',
-        isSortable: true,
-        render: (node: VocabularyDefinition) => node.key,
-      },
-      entity_types: {
-        label: 'Used in',
-        width: '20%',
-        isSortable: false,
-        render: (node: VocabularyDefinition) => (
-          <>
-            {node.entity_types.map((type) => (
-              <Chip
-                key={type}
-                classes={{ root: classes.label }}
-                variant="outlined"
-                label={t_i18n(`entity_${type}`)}
-                color="primary"
-              />
-            ))}
-          </>
-        ),
-      },
-      description: {
-        label: t_i18n('Description'),
-        width: '45%',
-        isSortable: false,
-        render: (node: VocabularyDefinition) => {
-          if (node.description) {
-            return t_i18n(node.description);
-          }
-          return null;
-        },
-      },
-    };
-    return (
-      <ListLines
-        sortBy={sortBy}
-        orderAsc={orderAsc}
-        dataColumns={dataColumns}
-        handleSort={handleSort}
-        handleSearch={handleSearch}
-        displayImport={false}
-        keyword={searchTerm}
-      >
-        <ListLinesContent
-          initialLoading={false}
-          loadMore={() => {}}
-          hasMore={() => {}}
-          isLoading={() => false}
-          dataList={categories}
-          globalCount={categories.length}
-          LineComponent={VocabularyCategoryLine}
-          DummyLineComponent={VocabularyCategoryLineDummy}
-          dataColumns={dataColumns}
-        />
-      </ListLines>
-    );
+
+  const { categories, sortBy: sortByVocabularyCategory, orderAsc: orderAscVocabularyCategory, searchTerm, handleSearch, handleSort } = useVocabularyCategoryAsQuery();
+
+  const { viewStorage, helpers } = usePaginationLocalStorage(
+    LOCAL_STORAGE_KEY,
+    {
+      sortBy: 'name',
+      orderAsc: true,
+    },
+  );
+  const { sortBy = 'name', orderAsc = true } = viewStorage;
+
+  // Sync local storage sorting with hook sorting
+  useEffect(() => {
+    if (sortBy !== sortByVocabularyCategory || orderAsc !== orderAscVocabularyCategory) {
+      handleSort(sortBy, orderAsc);
+    }
+  }, [sortBy, orderAsc, sortByVocabularyCategory, orderAscVocabularyCategory, handleSort]);
+
+  const onSort = (field: string, order: boolean) => {
+    handleSort(field, order);
+    helpers.handleSort(field, order);
   };
+
+  const dataColumns: DataTableProps['dataColumns'] = {
+    name: {
+      id: 'name',
+      percentWidth: 20,
+      isSortable: true,
+      render: (data: { category: VocabularyDefinition }) => data.category.key,
+    },
+    entity_types: {
+      id: 'entity_types',
+      percentWidth: 20,
+      isSortable: true,
+    },
+    description: {
+      id: 'description',
+      percentWidth: 60,
+      isSortable: false,
+      render: (data: { category: VocabularyDefinition }) => (data.category.description ? t_i18n(data.category.description) : ''),
+    },
+  };
+
   return (
-    <div className={classes.container} data-testid="vocabularies-page">
+    <div style={{ paddingRight: 200 }} data-testid="vocabularies-page">
       <LabelsVocabulariesMenu />
-      <Breadcrumbs elements={[{ label: t_i18n('Settings') }, { label: t_i18n('Taxonomies') }, { label: t_i18n('Vocabularies'), current: true }]} />
-      {renderLines()}
+      <Breadcrumbs
+        elements={[
+          { label: t_i18n('Settings') },
+          { label: t_i18n('Taxonomies') },
+          { label: t_i18n('Vocabularies'), current: true },
+        ]}
+      />
+      <div>
+        <SearchInput
+          variant="small"
+          onSubmit={handleSearch}
+          keyword={searchTerm}
+          style={{ marginBottom: theme.spacing(2) }}
+        />
+        <DataTableWithoutFragment
+          storageKey={LOCAL_STORAGE_KEY}
+          isLocalStorageEnabled={false}
+          data={categories.map(({ node }) => ({ category: node }))}
+          dataColumns={dataColumns}
+          getComputeLink={({ category }: { category: VocabularyDefinition }) => (category.key)}
+          globalCount={categories.length}
+          icon={() => (<ShortTextOutlined color="primary" />)}
+          onSort={onSort}
+        />
+      </div>
     </div>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
@@ -7,6 +7,7 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
 import DataTableWithoutFragment from '../../../components/dataGrid/DataTableWithoutFragment';
+import { defaultRender } from '../../../components/dataGrid/dataTableUtils';
 import { ShortTextOutlined } from '@mui/icons-material';
 import SearchInput from '../../../components/SearchInput';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
@@ -36,7 +37,7 @@ const VocabularyCategories = () => {
     if (sortBy !== sortByVocabularyCategory || orderAsc !== orderAscVocabularyCategory) {
       handleSort(sortBy, orderAsc);
     }
-  }, [sortBy, orderAsc, sortByVocabularyCategory, orderAscVocabularyCategory, handleSort]);
+  }, [sortBy, orderAsc, sortByVocabularyCategory, orderAscVocabularyCategory]);
 
   const onSort = (field: string, order: boolean) => {
     handleSort(field, order);
@@ -59,7 +60,7 @@ const VocabularyCategories = () => {
       id: 'description',
       percentWidth: 60,
       isSortable: false,
-      render: (data: { category: VocabularyDefinition }) => (data.category.description ? t_i18n(data.category.description) : ''),
+      render: (data: { category: VocabularyDefinition }) => defaultRender(data.category.description),
     },
   };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Migrate VocabularyCategories to DataTable to use dataTableUtils formatting 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #10713 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
