### PR TITLE
[frontend] Preserve case for markings in tooltips and autocomplete chips (#13452)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -143,7 +143,7 @@ const AutocompleteField = <
                 {...getTagProps({ index })}
                 applyLabelTextTransform={applyLabelTextTransform}
                 key={value}
-                label={truncate(label, 50)}
+                label={label}
               />
             );
           })

--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -1,13 +1,15 @@
+import React, { ReactNode, useCallback } from 'react';
 import IconButton from '@common/button/IconButton';
 import { Add } from '@mui/icons-material';
 import { Autocomplete, AutocompleteProps, AutocompleteValue, TextField, TextFieldProps } from '@mui/material';
 import { FieldProps, useField } from 'formik';
-import { fieldToAutocomplete } from 'formik-mui';
-import { ReactNode, useCallback } from 'react';
 import { FieldOption } from '../utils/field';
 import { truncate } from '../utils/String';
-import { isNilField } from '../utils/utils';
 import { useFormatter } from './i18n';
+import { isNilField } from '../utils/utils';
+import { FieldOption } from '../utils/field';
+import { fieldToAutocomplete } from 'formik-mui';
+import Tag from '@common/tag/Tag';
 
 type Bool = boolean | undefined;
 type PossibleValue = FieldOption | string;
@@ -24,6 +26,7 @@ export type AutocompleteFieldProps<
     required?: boolean;
     endAdornment?: ReactNode;
     textfieldprops?: TextFieldProps;
+    applyLabelTextTransform?: boolean;
     onFocus?: (name: string) => void;
     onChange?: (name: string, value: AutocompleteValue<Value, M, DC, FSolo>) => void;
     onInternalChange?: (name: string, value: AutocompleteValue<Value, M, DC, FSolo>) => void;
@@ -53,6 +56,7 @@ const AutocompleteField = <
     renderOption,
     isOptionEqualToValue,
     textfieldprops,
+    applyLabelTextTransform,
     getOptionLabel,
     endAdornment,
     disabled,
@@ -125,6 +129,15 @@ const AutocompleteField = <
         noOptionsText={noOptionsText}
         {...fieldProps}
         renderOption={renderOption}
+        renderTags={(values) => (
+          values.map((option) => (
+            <Tag
+              applyLabelTextTransform={applyLabelTextTransform}
+              key={(option as FieldOption).value}
+              label={truncate((option as FieldOption).label, 50)}
+            />
+          ))
+        )}
         onChange={internalOnChange}
         onFocus={internalOnFocus}
         onBlur={internalOnBlur}

--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -94,6 +94,12 @@ const AutocompleteField = <
       : truncate(option, optionLength);
   };
 
+  const getOptionData = (option: Value) => {
+    return typeof option === 'object' && option !== null
+      ? { label: option.label, value: option.value }
+      : { label: String(option), value: String(option) };
+  };
+
   const helperText = textfieldprops?.helperText;
   const showError = !isNilField(meta.error) && (meta.touched || submitCount > 0);
   const fieldProps = fieldToAutocomplete({
@@ -130,14 +136,17 @@ const AutocompleteField = <
         {...fieldProps}
         renderOption={renderOption}
         renderTags={(values, getTagProps) => (
-          values.map((option, index) => (
-            <Tag
-              {...getTagProps({ index })}
-              applyLabelTextTransform={applyLabelTextTransform}
-              key={(option as FieldOption).value}
-              label={truncate((option as FieldOption).label, 50)}
-            />
-          ))
+          values.map((option, index) => {
+            const { label, value } = getOptionData(option);
+            return (
+              <Tag
+                {...getTagProps({ index })}
+                applyLabelTextTransform={applyLabelTextTransform}
+                key={value}
+                label={truncate(label, 50)}
+              />
+            );
+          })
         )}
         onChange={internalOnChange}
         onFocus={internalOnFocus}

--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -7,7 +7,6 @@ import { FieldOption } from '../utils/field';
 import { truncate } from '../utils/String';
 import { useFormatter } from './i18n';
 import { isNilField } from '../utils/utils';
-import { FieldOption } from '../utils/field';
 import { fieldToAutocomplete } from 'formik-mui';
 import Tag from '@common/tag/Tag';
 

--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -129,9 +129,10 @@ const AutocompleteField = <
         noOptionsText={noOptionsText}
         {...fieldProps}
         renderOption={renderOption}
-        renderTags={(values) => (
-          values.map((option) => (
+        renderTags={(values, getTagProps) => (
+          values.map((option, index) => (
             <Tag
+              {...getTagProps({ index })}
               applyLabelTextTransform={applyLabelTextTransform}
               key={(option as FieldOption).value}
               label={truncate((option as FieldOption).label, 50)}

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -6,7 +6,7 @@ interface TagProps extends Omit<ChipProps, 'color'> {
   label: string;
   color?: string;
   onClick?: (e: React.MouseEvent) => void;
-  onDelete?: () => void;
+  onDelete?: (event?: any) => void;
   maxWidth?: number | string;
   icon?: React.ReactElement;
   tooltipTitle?: string;

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -105,7 +105,17 @@ const Tag = ({
   }
 
   return (
-    <Tooltip title={tooltipTitle ?? label} placement="bottom-start">
+    <Tooltip
+      title={tooltipTitle ?? label}
+      placement="bottom-start"
+      slotProps={{
+        tooltip: {
+          sx: {
+            textTransform: applyLabelTextTransform ? 'inherit' : 'none',
+          },
+        },
+      }}
+    >
       {chip}
     </Tooltip>
   );

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -6,7 +6,7 @@ interface TagProps extends Omit<ChipProps, 'color'> {
   label: string;
   color?: string;
   onClick?: (e: React.MouseEvent) => void;
-  onDelete?: (event?: any) => void;
+  onDelete?: (e: React.MouseEvent) => void;
   maxWidth?: number | string;
   icon?: React.ReactElement;
   tooltipTitle?: string;

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMarkingField.tsx
@@ -259,6 +259,7 @@ const ObjectMarkingField: FunctionComponent<ObjectMarkingFieldProps> = ({
     <>
       <Field
         component={AutocompleteField}
+        applyLabelTextTransform={false}
         style={style}
         name={name}
         required={required}


### PR DESCRIPTION
### Proposed changes

* Prevents text-transform from altering marking values in Tag tooltips.
* Renders ObjectMarking autocomplete chips with Tag to preserve original casing.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/13452