### PR TITLE
[backend] Add upsert fallback when using auto merging option and confidence don't match (#14124)

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/errors.js
+++ b/opencti-platform/opencti-graphql/src/config/errors.js
@@ -142,6 +142,7 @@ export const TECHNICAL_ERRORS = [
 
 // region CATEGORY_FUNCTIONAL
 export const FUNCTIONAL_ERROR = 'FUNCTIONAL_ERROR';
+export const INSUFFICIENT_CONFIDENCE_LEVEL = 'INSUFFICIENT_CONFIDENCE_LEVEL';
 export const FunctionalError = (reason, data) => error('FUNCTIONAL_ERROR', reason || 'Business validation', {
   http_status: 400,
   genre: CATEGORY_BUSINESS,

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3430,7 +3430,7 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
   } catch (e) {
     // In case of insufficient confidence level, don't reject and continue to upsert
     // as upsert have a complex strategy about confidence that doesn't reject everything
-    if (e?.extensions?.data?.doc_code === INSUFFICIENT_CONFIDENCE_LEVEL) {
+    if (rawInput.update !== false && e?.extensions?.data?.doc_code === INSUFFICIENT_CONFIDENCE_LEVEL) {
       logApp.warn('Merging stopped because of user confidence level, applying upsert', { cause: e });
       // Try to execute the method forcing update to false, prevent auto merging.
       return await internalCreateEntityRaw(context, user, { ...rawInput, update: false }, type, opts);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -2953,7 +2953,7 @@ export const createRelationRaw = async (context, user, rawInput, opts = {}) => {
 
   // when creating stix ref, we must check confidence on from side (this count has modifying this element itself)
   // Through UI we use direct relationship creation ref to add label, external ref ...
-  // That's also true for some connectors that directly used the API. It's a bad practice but still a reality
+  // This is also true for some connectors that directly use the API. It's a bad practice but still a reality
   if (isStixRefRelationship(relationshipType) && shouldCheckConfidenceOnRefRelationship(relationshipType)) {
     controlUserConfidenceAgainstElement(user, from);
   }
@@ -3344,7 +3344,7 @@ const internalCreateEntityRaw = async (context, user, rawInput, type, opts = {})
         await mergeEntities(context, user, target.internal_id, sources.map((s) => s.internal_id), { locks: participantIds });
         return upsertElement(context, user, target, type, resolvedInput, { ...opts, locks: participantIds });
       }
-      // We can't merge, so we need a least to upsert one element.
+      // We can't merge, so we need at least to upsert one element.
       // First, looking for an instance that directly has the provided stix id
       // If we found an entity by the official stix_id, no need to cumulate the id, only upsert information.
       const targetByStixId = R.head(filteredEntities.filter((n) => getInstanceIds(n).includes(resolvedInput.stix_id)));
@@ -3428,7 +3428,7 @@ const createEntityRaw = async (context, user, rawInput, type, opts = {}) => {
     // Await is mandatory here to correctly catch the promise exception.
     return await internalCreateEntityRaw(context, user, rawInput, type, opts);
   } catch (e) {
-    // In case of insufficient confidence level, don't reject continue to upsert
+    // In case of insufficient confidence level, don't reject and continue to upsert
     // as upsert have a complex strategy about confidence that doesn't reject everything
     if (e?.extensions?.data?.doc_code === INSUFFICIENT_CONFIDENCE_LEVEL) {
       logApp.warn('Merging stopped because of user confidence level, applying upsert', { cause: e });

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3346,7 +3346,7 @@ const internalCreateEntityRaw = async (context, user, rawInput, type, opts = {})
       // We can't merge, so we need at least to upsert one element.
       // First, looking for an instance that directly has the provided stix id
       // If we found an entity by the official stix_id, no need to cumulate the id, only upsert information.
-      const targetByStixId = R.head(filteredEntities.filter((n) => getInstanceIds(n).includes(resolvedInput.stix_id)));
+      const targetByStixId = filteredEntities.filter((n) => getInstanceIds(n).includes(resolvedInput.stix_id))[0];
       // If not found by stix id, we select the first one, cumulate the stix id for upsert
       const selectedTarget = targetByStixId ?? R.head(filteredEntities.filter((n) => !getInstanceIds(n).includes(resolvedInput.stix_id)));
       const cleanInputPatch = cleanEntityForIdsCollision(resolvedInput, type, selectedTarget, filteredEntities);

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3330,7 +3330,7 @@ const internalCreateEntityRaw = async (context, user, rawInput, type, opts = {})
           }
         }
         // In this mode we can safely consider this entity like the existing one.
-        const otherEntities = R.filter((e) => e.standard_id !== standardId, filteredEntities);
+        const otherEntities = filteredEntities.filter((e) => e.standard_id !== standardId);
         const cleanInputPatch = cleanEntityForIdsCollision(resolvedInput, type, existingByStandard, otherEntities);
         return upsertElement(context, user, existingByStandard, type, cleanInputPatch, { ...opts, locks: participantIds });
       }

--- a/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
+++ b/opencti-platform/opencti-graphql/src/utils/confidence-level.ts
@@ -1,7 +1,7 @@
 import type { AuthUser } from '../types/user';
 import { cropNumber } from './math';
 import { isEmptyField, isNotEmptyField } from '../database/utils';
-import { FunctionalError } from '../config/errors';
+import { FunctionalError, INSUFFICIENT_CONFIDENCE_LEVEL } from '../config/errors';
 import { logApp } from '../config/conf';
 import { schemaAttributesDefinition } from '../schema/schema-attributes';
 import { isBypassUser } from './access';
@@ -172,7 +172,8 @@ export const controlUserConfidenceAgainstElement = <T extends ObjectWithConfiden
     if (noThrow) {
       return false;
     }
-    throw FunctionalError('User effective max confidence level is insufficient to update this element', { user_id: user.id, element_id: existingElement.id, doc_code: 'INSUFFICIENT_CONFIDENCE_LEVEL' });
+    const data = { user_id: user.id, element_id: existingElement.id, doc_code: INSUFFICIENT_CONFIDENCE_LEVEL };
+    throw FunctionalError('User effective max confidence level is insufficient to update this element', data);
   }
 
   return true; // ok

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
@@ -1163,6 +1163,7 @@ describe('Upsert and merge entities', () => {
       stix_id: 'threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f03',
       name: 'THREAT_UPDATE_UPSERT_03',
       description: 'THREAT_UPDATE_UPSERT_03',
+      x_opencti_stix_ids: ['threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f02'],
       aliases: ['upsert_update_alias01', 'upsert_update_alias02'],
       objectLabel: ['malware', 'identity'], // will be added by upsert
       update: true,
@@ -1172,6 +1173,9 @@ describe('Upsert and merge entities', () => {
     expect(threat03.id).toEqual(threat01.id);
     expect(threat03.name).toEqual(threat01.name);
     expect(threat03.description).toEqual(threat01.description);
+    expect(threat03.x_opencti_stix_ids.length).toEqual(2);
+    expect(threat03.x_opencti_stix_ids.sort()).toEqual(['threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f01',
+      'threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f03']);
     expect(threat03.creator_id.length).toEqual(2);
     expect(threat03.creator_id.sort()).toEqual([lowConfidenceUser.id, ADMIN_USER.id]);
     expect(threat03.objectLabel.length).toEqual(2);

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
@@ -94,14 +94,14 @@ describe('Attribute updater', () => {
     const campaignId = campaign.internal_id;
     const input = { id: '92d46985-17a6-4610-8be8-cc70c82ed214' };
     const dataPromise = patchAttribute(testContext, ADMIN_USER, campaignId, ENTITY_TYPE_CAMPAIGN, input);
-    expect(dataPromise).rejects.toThrow();
+    await expect(dataPromise).rejects.toThrow();
   });
   it('should update fail for unknown attributes', async () => {
     const campaign = await elLoadById(testContext, ADMIN_USER, 'campaign--92d46985-17a6-4610-8be8-cc70c82ed214');
     const campaignId = campaign.internal_id;
     const input = { observable_value: 'test' };
     const dataPromise = patchAttribute(testContext, ADMIN_USER, campaignId, ENTITY_TYPE_CAMPAIGN, input);
-    expect(dataPromise).rejects.toThrow();
+    await expect(dataPromise).rejects.toThrow();
   });
   it('should update dont do anything if already the same', async () => {
     const campaign = await elLoadById(testContext, ADMIN_USER, 'campaign--92d46985-17a6-4610-8be8-cc70c82ed214');
@@ -179,7 +179,7 @@ describe('Entities listing', () => {
     expect(R.includes('Basic-Object', malware.parent_types)).toBeTruthy();
     expect(malware.created).toEqual('2019-09-30T16:38:26.000Z');
     expect(malware.name).toEqual('Paradise Ransomware');
-     
+
     expect(malware._index).not.toBeNull();
   });
   it('should list multiple entities', async () => {
@@ -301,7 +301,7 @@ describe('Relations listing', () => {
     expect(stixRelations.edges.length).toEqual(2);
     for (let index = 0; index < stixRelations.edges.length; index += 1) {
       const stixRelation = stixRelations.edges[index].node;
-       
+
       const toThing = await elLoadById(testContext, ADMIN_USER, stixRelation.toId);
       expect(toThing.entity_type).toEqual('Attack-Pattern');
       expect(stixRelation.fromId).toEqual(malware.internal_id);
@@ -315,7 +315,7 @@ describe('Relations listing', () => {
     // Every relations must have natural ordering for from and to
     for (let index = 0; index < stixRelations.edges.length; index += 1) {
       const stixRelation = stixRelations.edges[index].node;
-       
+
       const { fromRole, toRole, relationship_type: relationshipType } = stixRelation;
       expect(fromRole).toEqual(`${relationshipType}_from`);
       expect(toRole).toEqual(`${relationshipType}_to`);
@@ -452,7 +452,7 @@ describe('Element loader', () => {
     const report = await elLoadById(testContext, ADMIN_USER, 'report--a445d22a-db0c-4b5d-9ec8-e9ad0b6dbdd7');
     const internalId = report.internal_id;
     const loadPromise = storeLoadById(testContext, ADMIN_USER, internalId);
-    expect(loadPromise).rejects.toThrow();
+    await expect(loadPromise).rejects.toThrow();
     const element = await storeLoadById(testContext, ADMIN_USER, internalId, ENTITY_TYPE_CONTAINER_REPORT);
     expect(element).not.toBeNull();
     expect(element.id).toEqual(internalId);
@@ -462,7 +462,7 @@ describe('Element loader', () => {
     // No type
     const stixId = 'report--a445d22a-db0c-4b5d-9ec8-e9ad0b6dbdd7';
     const loadPromise = storeLoadById(testContext, ADMIN_USER, stixId);
-    expect(loadPromise).rejects.toThrow();
+    await expect(loadPromise).rejects.toThrow();
     const element = await storeLoadById(testContext, ADMIN_USER, stixId, ENTITY_TYPE_CONTAINER_REPORT);
     expect(element).not.toBeNull();
     expect(element.standard_id).toEqual('report--f3e554eb-60f5-587c-9191-4f25e9ba9f32');
@@ -473,7 +473,7 @@ describe('Element loader', () => {
     const relation = await elLoadById(testContext, ADMIN_USER, 'relationship--e35b3fc1-47f3-4ccb-a8fe-65a0864edd02');
     const relationId = relation.internal_id;
     const loadPromise = storeLoadById(testContext, ADMIN_USER, relationId, null);
-    expect(loadPromise).rejects.toThrow();
+    await expect(loadPromise).rejects.toThrow();
     const element = await storeLoadById(testContext, ADMIN_USER, relationId, 'uses');
     expect(element).not.toBeNull();
     expect(element.id).toEqual(relationId);
@@ -482,7 +482,7 @@ describe('Element loader', () => {
   it('should load relation by stix id', async () => {
     const stixId = 'relationship--e35b3fc1-47f3-4ccb-a8fe-65a0864edd02';
     const loadPromise = storeLoadById(testContext, ADMIN_USER, stixId, null);
-    expect(loadPromise).rejects.toThrow();
+    await expect(loadPromise).rejects.toThrow();
     const element = await storeLoadById(testContext, ADMIN_USER, stixId, 'uses');
     expect(element).not.toBeNull();
     expect(element.x_opencti_stix_ids).toEqual([stixId]);
@@ -591,7 +591,7 @@ describe('Relations time series', () => {
           operator: 'eq',
         }],
         filterGroups: [],
-      }
+      },
     };
     const series = await timeSeriesRelations(testContext, ADMIN_USER, options);
     expect(series.length).toEqual(13); // 13 months groups in the interval
@@ -633,7 +633,7 @@ describe('Entities distribution', () => {
     expect(distribution.length).toEqual(2);
     expect(distribution).toMatchObject([
       { label: '100', value: 2 },
-      { label: '75', value: 1 }
+      { label: '75', value: 1 },
     ]);
   });
   it.skip('should entity distribution filters', async () => {
@@ -773,9 +773,9 @@ describe('Relations distribution', () => {
 });
 
 // Some utils
-const createThreat = async (input) => {
-  const threat = await addThreatActorGroup(testContext, ADMIN_USER, input);
-  return storeLoadById(testContext, ADMIN_USER, threat.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
+const createThreat = async (input, user = ADMIN_USER) => {
+  const threat = await addThreatActorGroup(testContext, user, input);
+  return storeLoadByIdWithRefs(testContext, user, threat.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
 };
 const createOrganization = async (input) => {
   const organization = await addOrganization(testContext, ADMIN_USER, input);
@@ -977,7 +977,7 @@ describe('Upsert and merge entities', () => {
       loadMalware.internal_id,
       clear.internal_id,
       RELATION_OBJECT_MARKING,
-      ABSTRACT_STIX_REF_RELATIONSHIP
+      ABSTRACT_STIX_REF_RELATIONSHIP,
     );
     const checkers = await elFindByIds(testContext, ADMIN_USER, loadMalware.id);
     const test = await internalLoadById(testContext, ADMIN_USER, testMarking);
@@ -1137,6 +1137,51 @@ describe('Upsert and merge entities', () => {
     await deleteElementById(testContext, ADMIN_USER, malware03.id, ENTITY_TYPE_MALWARE);
     await deleteElementById(testContext, ADMIN_USER, loadedThreat.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
   });
+  it('should multiple threat actors that need merge still upserted with using lower confidence', async () => {
+    // 01. Create Threat by admin
+    const updateUpsert01 = {
+      stix_id: 'threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f01',
+      name: 'THREAT_UPDATE_UPSERT_01',
+      description: 'THREAT_UPDATE_UPSERT_01',
+      aliases: ['upsert_update_alias01'],
+      objectLabel: ['identity'],
+    };
+    const threat01 = await createThreat(updateUpsert01);
+    expect(threat01.name).toEqual('THREAT_UPDATE_UPSERT_01');
+    // 02. Create Threat by low confidence user
+    const lowConfidenceUser = buildStandardUser([], [], [], 50);
+    const updateUpsert02 = {
+      stix_id: 'threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f02',
+      name: 'THREAT_UPDATE_UPSERT_02',
+      description: 'THREAT_UPDATE_UPSERT_02',
+      aliases: ['upsert_update_alias02'],
+    };
+    const threat02 = await createThreat(updateUpsert02, lowConfidenceUser);
+    expect(threat02.name).toEqual('THREAT_UPDATE_UPSERT_02');
+    // 03. Create a Threat with update=true and low confidence user.
+    const updateUpsert03 = {
+      stix_id: 'threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f03',
+      name: 'THREAT_UPDATE_UPSERT_03',
+      description: 'THREAT_UPDATE_UPSERT_03',
+      aliases: ['upsert_update_alias01', 'upsert_update_alias02'],
+      objectLabel: ['malware', 'identity'], // will be added by upsert
+      update: true,
+    };
+    const threat03 = await createThreat(updateUpsert03, lowConfidenceUser);
+    // 04. Verify the upsert
+    expect(threat03.id).toEqual(threat01.id);
+    expect(threat03.name).toEqual(threat01.name);
+    expect(threat03.description).toEqual(threat01.description);
+    expect(threat03.creator_id.length).toEqual(2);
+    expect(threat03.creator_id.sort()).toEqual([lowConfidenceUser.id, ADMIN_USER.id]);
+    expect(threat03.objectLabel.length).toEqual(2);
+    expect(threat03.objectLabel.map((l) => l.value).sort()).toEqual(['identity', 'malware']);
+    expect(threat03.aliases.length).toEqual(1);
+    expect(threat03.aliases.sort()).toEqual(['upsert_update_alias01']);
+    // Cleanup
+    await deleteElementById(testContext, ADMIN_USER, threat01.id, ENTITY_TYPE_THREAT_ACTOR_GROUP); // delete 1 and 3
+    await deleteElementById(testContext, ADMIN_USER, threat02.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
+  });
   it('should reports keep their author after organizations merging', async () => {
     // 01. Create organizations
     const organization1 = await createOrganization({ name: 'organization1' });
@@ -1147,7 +1192,7 @@ describe('Upsert and merge entities', () => {
       name: 'REPORT_TEST_02',
       published: '2022-10-06T22:00:00.000Z',
       createdBy: organization2.id,
-      objects: [report1.id]
+      objects: [report1.id],
     });
     // Merge with fully resolved entities
     const merged = await mergeEntities(testContext, ADMIN_USER, organization1.internal_id, [organization2.internal_id]);
@@ -1179,7 +1224,7 @@ describe('Upsert and merge entities', () => {
   it('should multiple createdBy correction merged to empty target', async () => {
     const organization1 = await createOrganization({ name: 'REPORT_CREATED_BY_ORGANIZATION01' });
     const organization2 = await createOrganization({ name: 'REPORT_CREATED_BY_ORGANIZATION02' });
-    const reportTarget = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_TARGET_ORGANIZATION', published: '2022-10-06T22:00:00.000Z', });
+    const reportTarget = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_TARGET_ORGANIZATION', published: '2022-10-06T22:00:00.000Z' });
     const reportSource1 = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_ORGANIZATION_01', published: '2022-10-06T22:00:00.000Z', createdBy: organization1.id });
     const reportSource2 = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_ORGANIZATION_02', published: '2022-10-06T22:00:00.000Z', createdBy: organization2.id });
     const merged = await mergeEntities(testContext, ADMIN_USER, reportTarget.internal_id, [reportSource1.internal_id, reportSource2.internal_id]);
@@ -1196,7 +1241,7 @@ describe('Upsert and merge entities', () => {
   it('should multiple createdBy identity merged to empty target', async () => {
     const individual1 = await createIndividual({ name: 'REPORT_CREATED_BY_INDIVIDUAL_01' });
     const organization2 = await createOrganization({ name: 'REPORT_CREATED_BY_ORGANIZATION_02' });
-    const reportTarget = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_TARGET_INDIVIDUAL', published: '2022-10-06T22:00:00.000Z', });
+    const reportTarget = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_TARGET_INDIVIDUAL', published: '2022-10-06T22:00:00.000Z' });
     const reportSource1 = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_INDIVIDUAL_01', published: '2022-10-06T22:00:00.000Z', createdBy: individual1.id });
     const reportSource2 = await addReport(testContext, ADMIN_USER, { name: 'REPORT_CREATED_BY_INDIVIDUAL_02', published: '2022-10-06T22:00:00.000Z', createdBy: organization2.id });
     const merged = await mergeEntities(testContext, ADMIN_USER, reportTarget.internal_id, [reportSource1.internal_id, reportSource2.internal_id]);
@@ -1229,7 +1274,7 @@ describe('Upsert and merge entities', () => {
     // Merged 3 Stix File into one
     const md5 = await createFile({
       hashes: { MD5 },
-      objectMarking: [clearMarking] /* TLP:1 */
+      objectMarking: [clearMarking], /* TLP:1 */
     });
     const sha1 = await createFile({
       hashes: { 'SHA-1': SHA1 },
@@ -1279,13 +1324,13 @@ describe('Elements impacts deletions', () => {
     const malware = await addMalware(testContext, ADMIN_USER, { name: 'MY MAL', description: 'MY MAL' });
     const indicator = await addIndicator(testContext, ADMIN_USER, { name: 'MY INDIC', pattern: '[domain-name:value = \'www.test.ru\']', pattern_type: 'stix' });
     // Create basic relations
-     
+
     const intrusionSet_uses_Malware = await createRelation(testContext, ADMIN_USER, {
       fromId: intrusionSet.internal_id,
       toId: malware.internal_id,
       relationship_type: 'uses',
     });
-     
+
     const indicator_indicated_uses = await createRelation(testContext, ADMIN_USER, {
       fromId: indicator.internal_id,
       toId: intrusionSet_uses_Malware.internal_id,
@@ -1351,7 +1396,7 @@ describe('Elements upsert behaviors', () => {
       is_family: true,
       revoked: true,
       objectMarking: [clearMarking],
-      description: 'TO DESC'
+      description: 'TO DESC',
     });
     expect(malware.confidence).toEqual(10);
     expect(malware.description).toEqual('TO DESC');
@@ -1428,6 +1473,7 @@ describe('Elements upsert behaviors', () => {
     await deleteElementById(testContext, ADMIN_USER, stixId, ENTITY_TYPE_MALWARE);
   });
 });
+
 describe('Elements deduplication behaviors', () => {
   it('should prevent update resulting in duplicate entities', async () => {
     const WHITE_TLP = { standard_id: 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9', internal_id: null };

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
@@ -1137,7 +1137,7 @@ describe('Upsert and merge entities', () => {
     await deleteElementById(testContext, ADMIN_USER, malware03.id, ENTITY_TYPE_MALWARE);
     await deleteElementById(testContext, ADMIN_USER, loadedThreat.id, ENTITY_TYPE_THREAT_ACTOR_GROUP);
   });
-  it('should multiple threat actors that need merge still upserted with using lower confidence', async () => {
+  it('should upsert multiple threat actors that need merging when using lower confidence', async () => {
     // 01. Create Threat by admin
     const updateUpsert01 = {
       stix_id: 'threat-actor--d1e2ff9a-60e2-43a2-9896-986b6fcd9f01',

--- a/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
@@ -53,7 +53,7 @@ testCreatedCounter.relationship = 133;
 testCreatedCounter.report = 36;
 testCreatedCounter.sighting = 4;
 testCreatedCounter.software = 1;
-testCreatedCounter['threat-actor'] = 19;
+testCreatedCounter['threat-actor'] = 21;
 testCreatedCounter.tool = 5;
 testCreatedCounter['tracking-number'] = 1;
 testCreatedCounter.vocabulary = VOCABULARY_NUMBERS;
@@ -90,7 +90,7 @@ testUpdatedCounter['case-rfi'] = 10;
 testUpdatedCounter['ipv4-addr'] = 4;
 testUpdatedCounter.tool = 10;
 testUpdatedCounter.sighting = 4;
-testUpdatedCounter['threat-actor'] = 17;
+testUpdatedCounter['threat-actor'] = 18;
 testUpdatedCounter.vocabulary = 3;
 testUpdatedCounter.vulnerability = 3;
 
@@ -139,7 +139,7 @@ testDeletedCounter.relationship = 1;
 testDeletedCounter.report = 28;
 testDeletedCounter.sighting = 1;
 testDeletedCounter['ssh-key'] = 1;
-testDeletedCounter['threat-actor'] = 10;
+testDeletedCounter['threat-actor'] = 12;
 testDeletedCounter.tool = 5;
 testDeletedCounter.vulnerability = 2;
 

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -642,7 +642,6 @@ export const getAuthUser = async (id: string) => {
     origin: { referer: 'test', user_id: user.internal_id },
   } as AuthUser;
 };
-
 // endregion
 
 // Search for test organizations
@@ -665,7 +664,6 @@ export const getOrganizationIdByName = async (name: string) => {
   }
   return data.organizations.edges[0].node.id;
 };
-
 // endregion
 
 // Search for test group
@@ -696,6 +694,7 @@ export const buildStandardUser = (
   allowedMarkings: markingType[],
   allMarkings?: markingType[],
   capabilities?: { name: string }[],
+  maxConfidence?: number,
 ): AuthUser => {
   return {
     administrated_organizations: [],
@@ -717,11 +716,11 @@ export const buildStandardUser = (
     account_status: ACCOUNT_STATUS_ACTIVE,
     account_lock_after_date: undefined,
     effective_confidence_level: {
-      max_confidence: 100,
+      max_confidence: maxConfidence ?? 100,
       overrides: [],
     },
     user_confidence_level: {
-      max_confidence: 100,
+      max_confidence: maxConfidence ?? 100,
       overrides: [],
     },
     restrict_delete: false,


### PR DESCRIPTION
### 🎯 Target of the Modification
The primary goal of this update is to **resolve a blocking issue where low-confidence users could not update or enrich existing high-confidence entities** when their action triggered an automatic "merge" operation.

Previously, if a user with low confidence (e.g., `50`) tried to create an entity that already existed (based on STIX ID) and was created by a high-confidence user (e.g., `100`), the system would attempt to **merge** the two. This merge operation would fail with an `INSUFFICIENT_CONFIDENCE_LEVEL` error, completely blocking the user from adding any data.

The fix ensures that instead of failing, the system **falls back to an "Upsert"** (Update/Insert) strategy. This allows the user to contribute data (like new aliases or references) without overwriting high-confidence fields they shouldn't touch.

### 🛠️ Key Fixes & Changes

#### 1. Backend Logic: Auto-Merge Fallback (`middleware.js`)
*   **Problem:** `createEntityRaw` attempts to merge duplicate entities (using specific option update=true). If the user lacks sufficient confidence to modify the existing entity during a merge, the operation throws an error.
*   **Fix:** A `try-catch` block was added around the creation logic.
    *   It listens specifically for the `INSUFFICIENT_CONFIDENCE_LEVEL` error code.
    *   If caught, it logs a warning and **re-executes the operation with `update: false`**.
    *   This forces the system to skip the "merge" attempt and instead treat it as a standard "upsert", allowing non-conflicting additions to proceed.

#### 2. Upsert Logic: Relaxed Confidence for Metadata (`upsert-utils.js`)
*   **Problem:** Strictly enforcing confidence levels prevented users from adding simple non-destructive metadata like **Labels** or **External References** to high-confidence objects.
*   **Fix:** In `generateRefsInputsForUpsert`, the confidence check was bypassed for specific relationship types:
    *   `object-label` (Labels)
    *   `external-reference` (External References)
*   **Result:** A lower-confidence user can now add a label to a high-confidence object, whereas previously this would have been rejected.

#### 3. Testing Infrastructure ([testQuery.ts](cci:7://file:///Users/julienrichard/Documents/filigran/opencti/core-engine/opencti-platform/opencti-graphql/tests/utils/testQuery.ts:0:0-0:0) & [middleware-test.js](cci:7://file:///Users/julienrichard/Documents/filigran/opencti/core-engine/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js:0:0-0:0))
*   **Validation:** A new test case `should multiple threat actors that need merge still upserted with using lower confidence` was added.
    *   It creates a high-confidence Threat Actor.
    *   It attempts to "update" it using a low-confidence user.
    *   It verifies that the operation succeeds (no error) and that the allowed fields are updated while high-confidence fields remain untouched.
*   **Utils:** Updated [buildStandardUser](cci:1://file:///Users/julienrichard/Documents/filigran/opencti/core-engine/opencti-platform/opencti-graphql/tests/utils/testQuery.ts:692:0-728:2) to accept a `maxConfidence` parameter, facilitating easier testing of these confidence-mismatch scenarios.

### 📝 Summary of Impact
| Feature | Before | After |
| :--- | :--- | :--- |
| **Low Confidence Merge** | Failed with `Access Denied` / `Insufficient Confidence`. | **Success**: Falls back to specialized upsert behavior. |
| **Adding Labels** | Blocked if user confidence < entity confidence. | **Allowed**: Labels are treated as additive metadata regardless of confidence. |
| **Adding External Refs** | Blocked if user confidence < entity confidence. | **Allowed**: External refs are treated simply as additive. |