### PR TITLE
[frontend] tag fixes (#13458)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -1,13 +1,13 @@
-import { ReactNode, useCallback } from 'react';
-import { Add } from '@mui/icons-material';
-import { TextField, Autocomplete, AutocompleteProps, TextFieldProps, AutocompleteValue } from '@mui/material';
 import IconButton from '@common/button/IconButton';
+import { Add } from '@mui/icons-material';
+import { Autocomplete, AutocompleteProps, AutocompleteValue, TextField, TextFieldProps } from '@mui/material';
 import { FieldProps, useField } from 'formik';
-import { truncate } from '../utils/String';
-import { useFormatter } from './i18n';
-import { isNilField } from '../utils/utils';
-import { FieldOption } from '../utils/field';
 import { fieldToAutocomplete } from 'formik-mui';
+import { ReactNode, useCallback } from 'react';
+import { FieldOption } from '../utils/field';
+import { truncate } from '../utils/String';
+import { isNilField } from '../utils/utils';
+import { useFormatter } from './i18n';
 
 type Bool = boolean | undefined;
 type PossibleValue = FieldOption | string;
@@ -140,10 +140,14 @@ const AutocompleteField = <
         <IconButton
           disabled={disabled}
           onClick={() => openCreate()}
-          style={{ position: 'absolute', top: 5, right: 35 }}
+          sx={{
+            position: 'absolute',
+            bottom: 4,
+            right: 25,
+          }}
           title={t_i18n('Add')}
         >
-          <Add />
+          <Add fontSize="small" />
         </IconButton>
       )}
     </div>

--- a/opencti-platform/opencti-front/src/components/ItemMarkings.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemMarkings.tsx
@@ -1,9 +1,8 @@
 import { useTheme } from '@mui/material/styles';
-import { Badge, Stack } from '@mui/material';
+import { Badge, Stack, Tooltip } from '@mui/material';
 import Tag from '@common/tag/Tag';
 import type { Theme } from './Theme';
 import stopEvent from '../utils/domEvent';
-import EnrichedTooltip from './EnrichedTooltip';
 
 interface Marking {
   id: string;
@@ -20,11 +19,13 @@ interface ItemMarkingsProps {
 interface ChipMarkingProps {
   markingDefinition: Marking;
   onClick?: ItemMarkingsProps['onClick'];
+  disableTooltip?: boolean;
 }
 
 const ChipMarking = ({
   markingDefinition,
   onClick,
+  disableTooltip = false,
 }: ChipMarkingProps) => {
   const theme = useTheme<Theme>();
 
@@ -72,6 +73,7 @@ const ChipMarking = ({
     <Tag
       label={markingDefinition.definition || 'no definition'}
       applyLabelTextTransform={false}
+      disableTooltip={disableTooltip}
       {...itemMarkingColor && { color: itemMarkingColor }}
       {...hasClickCallback && {
         onClick: (e) => {
@@ -88,6 +90,7 @@ const ItemMarkings = ({
   limit = 0,
   onClick,
 }: ItemMarkingsProps) => {
+  const theme = useTheme<Theme>();
   const markings = markingDefinitions ?? [];
 
   if (!limit || markings.length <= 1) {
@@ -110,20 +113,41 @@ const ItemMarkings = ({
     );
   }
 
+  // return a multiple marking tags in the tooltip
   return (
-    <EnrichedTooltip
-      placement="bottom"
+    <Tooltip
       title={(
-        <Stack direction="row" gap={1} flexWrap="wrap">
-          {markings.map((markingDefinition) => (
-            <ChipMarking
-              key={markingDefinition.id}
-              markingDefinition={markingDefinition}
-              onClick={onClick}
-            />
-          ))}
+        <Stack
+          gap={1}
+          direction="row"
+          flexWrap="wrap"
+          sx={{
+            alignItems: 'flex-start',
+            p: 1,
+          }}
+        >
+          {
+            markings.map((markingDefinition) => (
+              <ChipMarking
+                key={markingDefinition.id}
+                markingDefinition={markingDefinition}
+                onClick={onClick}
+                disableTooltip
+              />
+            ))
+          }
         </Stack>
       )}
+      slotProps={{
+        tooltip: {
+          sx: {
+            backgroundColor: theme.palette.mode === 'light'
+              ? theme.palette.common.white
+              : theme.palette.common.black,
+            maxWidth: 260,
+          },
+        },
+      }}
     >
       <Stack direction="row" gap={1} flexWrap="wrap">
         {markings.slice(0, limit).map((markingDefinition) => (
@@ -131,6 +155,7 @@ const ItemMarkings = ({
             key={markingDefinition.id}
             markingDefinition={markingDefinition}
             onClick={onClick}
+            disableTooltip
           />
         ))}
         <Badge
@@ -144,7 +169,7 @@ const ItemMarkings = ({
           }}
         />
       </Stack>
-    </EnrichedTooltip>
+    </Tooltip>
   );
 };
 

--- a/opencti-platform/opencti-front/src/components/common/button/Button.styles.factory.ts
+++ b/opencti-platform/opencti-front/src/components/common/button/Button.styles.factory.ts
@@ -28,6 +28,7 @@ export const createBaseStyles = (params: StyleFactoryParams): SxProps<Theme> => 
     borderRadius: `${theme.shape.borderRadius}px`,
     transition: 'all 0.2s ease-in-out',
     fontFamily: theme.typography.fontFamily,
+    flexShrink: 0,
 
     '& .MuiButton-startIcon, & .MuiButton-endIcon': {
       '& > *:nth-of-type(1)': {

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -45,6 +45,7 @@ const Tag = ({
   const bgColor = getBackgroundColor();
 
   const chipStyle: CSSProperties = {
+    backgroundColor: applyAlpha ? alpha(color ?? defaultColor, 0.2) : defaultColor,
     borderRadius: 4,
     height: 25,
     fontSize: 12,

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -45,7 +45,6 @@ const Tag = ({
   const bgColor = getBackgroundColor();
 
   const chipStyle: CSSProperties = {
-    backgroundColor: applyAlpha ? alpha(color ?? defaultColor, 0.2) : defaultColor,
     borderRadius: 4,
     fontSize: 12,
     fontWeight: 400,

--- a/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
+++ b/opencti-platform/opencti-front/src/components/common/tag/Tag.tsx
@@ -47,7 +47,6 @@ const Tag = ({
   const chipStyle: CSSProperties = {
     backgroundColor: applyAlpha ? alpha(color ?? defaultColor, 0.2) : defaultColor,
     borderRadius: 4,
-    height: 25,
     fontSize: 12,
     fontWeight: 400,
     paddingLeft: '8px',
@@ -61,6 +60,7 @@ const Tag = ({
       backgroundColor: onClick ? lighten(bgColor, 0.2) : undefined,
     },
     maxWidth: typeof maxWidth === 'number' ? `${maxWidth}px` : maxWidth,
+    height: 25,
     '& .MuiChip-label': {
       overflow: 'hidden',
       textOverflow: 'ellipsis',
@@ -73,6 +73,7 @@ const Tag = ({
     ...(icon && {
       '& .MuiChip-icon': {
         color: color,
+        mr: 0.1,
       },
     }),
     '& .MuiChip-deleteIcon': {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectSharingList.tsx
@@ -1,15 +1,13 @@
+import { useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import Tooltip from '@mui/material/Tooltip';
-import Chip from '@mui/material/Chip';
-import { AccountBalanceOutlined } from '@mui/icons-material';
-import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { truncate } from '../../../../utils/String';
-import { StixCoreObjectSharingListFragment$key } from './__generated__/StixCoreObjectSharingListFragment.graphql';
-import { StixCoreObjectSharingListDeleteMutation } from './__generated__/StixCoreObjectSharingListDeleteMutation.graphql';
-import useDraftContext from '../../../../utils/hooks/useDraftContext';
-import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { useFormatter } from '../../../../components/i18n';
+import useApiMutation from '../../../../utils/hooks/useApiMutation';
+import useDraftContext from '../../../../utils/hooks/useDraftContext';
+import { StixCoreObjectSharingListDeleteMutation } from './__generated__/StixCoreObjectSharingListDeleteMutation.graphql';
+import { StixCoreObjectSharingListFragment$key } from './__generated__/StixCoreObjectSharingListFragment.graphql';
+import Tag from '@common/tag/Tag';
+import { AccountBalanceOutlined } from '@mui/icons-material';
 
 const objectOrganizationFragment = graphql`
   fragment StixCoreObjectSharingListFragment on StixCoreObject {
@@ -77,25 +75,17 @@ const StixCoreObjectSharingList = ({ data, disabled, inContainer }: StixCoreObje
   return (
     <div>
       {objectOrganization?.map((organization) => (
-        <Tooltip key={organization.id} title={organization.name}>
-          <Chip
-            sx={{
-              '&.MuiChip-root': {
-                margin: '4px 7px 0 0',
-                fontSize: 12,
-                lineHeight: '12px',
-                height: 28,
-                borderRadius: 1,
-              },
-            }}
-            icon={<AccountBalanceOutlined />}
-            color="primary"
-            variant="outlined"
-            label={truncate(organization.name, 15)}
-            onDelete={() => removeOrganization(organization.id)}
-            disabled={fullyDisabled || disabledOrgs.includes(organization.id)}
-          />
-        </Tooltip>
+        <Tag
+          key={organization.id}
+          label={organization.name}
+          onDelete={() => removeOrganization(organization.id)}
+          disabled={fullyDisabled || disabledOrgs.includes(organization.id)}
+          sx={{
+            height: 36,
+            maxWidth: 160,
+          }}
+          icon={<AccountBalanceOutlined fontSize="small" />}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix autocomplete "add"  iconbutton position
<img width="957" height="850" alt="Screenshot 2026-01-20 at 18 14 23" src="https://github.com/user-attachments/assets/6f9f8ea5-f23a-4460-ae11-23a39d4adb99" />

* Fix multiple markings badge position and tooltip
<img width="1568" height="447" alt="Screenshot 2026-01-20 at 18 13 49" src="https://github.com/user-attachments/assets/c0749dec-424c-4d08-bed8-d95b99cab4e1" />

* Fix Organization label tag height
<img width="1582" height="151" alt="Screenshot 2026-01-20 at 18 13 26" src="https://github.com/user-attachments/assets/5a881081-14ee-4e45-94a6-23ad5ef127fc" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13458 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
