### PR TITLE
[backend/client] Support S3 Diode In addition to folder (#14160)

### DIFF
--- a/client-python/pycti/api/opencti_api_connector.py
+++ b/client-python/pycti/api/opencti_api_connector.py
@@ -165,6 +165,15 @@ class OpenCTIApiConnector:
                             user
                             pass
                         }
+                        s3 {
+                            endpoint
+                            port
+                            use_ssl
+                            bucket_name
+                            bucket_region
+                            access_key
+                            secret_key
+                        }
                         listen
                         listen_routing
                         listen_exchange

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1743,9 +1743,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         self.s3_secret_key = get_config_variable(
             "S3_SECRET_KEY", ["s3", "secret_key"], config
         )
-        self.s3_use_ssl = get_config_variable(
-            "S3_USE_SSL", ["s3", "use_ssl"], config
-        )
+        self.s3_use_ssl = get_config_variable("S3_USE_SSL", ["s3", "use_ssl"], config)
         self.s3_bucket_region = get_config_variable(
             "S3_BUCKET_REGION", ["s3", "bucket_region"], config
         )

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -37,8 +37,10 @@ from enum import Enum
 from queue import Queue
 from typing import Callable, Dict, List, Optional, Union
 
+import boto3
 import pika
 import uvicorn
+from botocore.config import Config as BotoConfig
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from filigran_sseclient import SSEClient
@@ -1703,6 +1705,50 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             isNumber=True,
             default=7,
         )
+        # S3 send mode configuration
+        self.bundle_send_to_s3 = get_config_variable(
+            "CONNECTOR_SEND_TO_S3",
+            ["connector", "send_to_s3"],
+            config,
+            default=False,
+        )
+        self.bundle_send_to_s3_bucket = get_config_variable(
+            "CONNECTOR_SEND_TO_S3_BUCKET",
+            ["connector", "send_to_s3_bucket"],
+            config,
+        )
+        self.bundle_send_to_s3_folder = get_config_variable(
+            "CONNECTOR_SEND_TO_S3_FOLDER",
+            ["connector", "send_to_s3_folder"],
+            config,
+            default="connectors",
+        )
+        self.bundle_send_to_s3_retention = get_config_variable(
+            "CONNECTOR_SEND_TO_S3_RETENTION",
+            ["connector", "send_to_s3_retention"],
+            config,
+            isNumber=True,
+            default=7,
+        )
+        # Override S3 connection (optional - defaults to OpenCTI's S3)
+        self.s3_endpoint = get_config_variable(
+            "S3_ENDPOINT", ["s3", "endpoint"], config
+        )
+        self.s3_port = get_config_variable(
+            "S3_PORT", ["s3", "port"], config, isNumber=True
+        )
+        self.s3_access_key = get_config_variable(
+            "S3_ACCESS_KEY", ["s3", "access_key"], config
+        )
+        self.s3_secret_key = get_config_variable(
+            "S3_SECRET_KEY", ["s3", "secret_key"], config
+        )
+        self.s3_use_ssl = get_config_variable(
+            "S3_USE_SSL", ["s3", "use_ssl"], config
+        )
+        self.s3_bucket_region = get_config_variable(
+            "S3_BUCKET_REGION", ["s3", "bucket_region"], config
+        )
         self.connect_only_contextual = get_config_variable(
             "CONNECTOR_ONLY_CONTEXTUAL",
             ["connector", "only_contextual"],
@@ -1930,6 +1976,10 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             default=self.connector_config["connection"]["pass"],
         )
 
+        # Initialize S3 config from backend, allow local overrides
+        if "s3" in self.connector_config:
+            self._init_s3_config(self.connector_config["s3"])
+
         # Start ping thread
         if not self.connect_run_and_terminate:
             is_run_and_terminate = False
@@ -1962,6 +2012,109 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
 
         # self.listen_stream = None
         self.listen_queue = None
+
+    def _init_s3_config(self, backend_s3_config: Dict) -> None:
+        """Initialize S3 config using backend values with local overrides.
+
+        Local environment variables or config file settings take precedence
+        over backend-provided values. If no local override is provided,
+        the backend value is used.
+
+        :param backend_s3_config: S3 configuration from backend registration
+        :type backend_s3_config: Dict
+        """
+        # Use local override if set, otherwise use backend value
+        self.s3_endpoint = self.s3_endpoint or backend_s3_config.get("endpoint")
+        self.s3_port = self.s3_port or backend_s3_config.get("port")
+        self.s3_access_key = self.s3_access_key or backend_s3_config.get("access_key")
+        self.s3_secret_key = self.s3_secret_key or backend_s3_config.get("secret_key")
+        self.s3_use_ssl = (
+            self.s3_use_ssl
+            if self.s3_use_ssl is not None
+            else backend_s3_config.get("use_ssl")
+        )
+        self.s3_bucket_region = self.s3_bucket_region or backend_s3_config.get(
+            "bucket_region"
+        )
+        # Use OpenCTI bucket by default, unless overridden
+        if self.bundle_send_to_s3_bucket is None:
+            self.bundle_send_to_s3_bucket = backend_s3_config.get("bucket_name")
+
+    def _get_s3_client(self):
+        """Create and return an S3 client configured with current settings.
+
+        :return: Configured boto3 S3 client
+        :rtype: boto3.client
+        """
+        endpoint_url = (
+            f"{'https' if self.s3_use_ssl else 'http'}://"
+            f"{self.s3_endpoint}:{self.s3_port}"
+        )
+        return boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id=self.s3_access_key,
+            aws_secret_access_key=self.s3_secret_key,
+            region_name=self.s3_bucket_region,
+            config=BotoConfig(signature_version="s3v4"),
+        )
+
+    def _send_bundle_to_s3(self, bundle_content: str, bundle_file: str) -> None:
+        """Upload bundle to S3 bucket.
+
+        :param bundle_content: JSON string content of the bundle to upload
+        :type bundle_content: str
+        :param bundle_file: Filename for the bundle in S3
+        :type bundle_file: str
+        """
+        s3_client = self._get_s3_client()
+
+        key = f"{self.bundle_send_to_s3_folder}/{bundle_file}"
+        s3_client.put_object(
+            Bucket=self.bundle_send_to_s3_bucket,
+            Key=key,
+            Body=bundle_content.encode("utf-8"),
+            ContentType="application/json",
+        )
+
+        self.connector_logger.info(
+            "Bundle uploaded to S3",
+            {"bucket": self.bundle_send_to_s3_bucket, "key": key},
+        )
+
+        # Handle retention - delete old files
+        if self.bundle_send_to_s3_retention > 0:
+            self._cleanup_old_s3_bundles(s3_client)
+
+    def _cleanup_old_s3_bundles(self, s3_client) -> None:
+        """Remove expired bundles from S3 based on retention policy.
+
+        :param s3_client: Configured boto3 S3 client
+        :type s3_client: boto3.client
+        """
+        prefix = f"{self.bundle_send_to_s3_folder}/"
+        cutoff_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            days=self.bundle_send_to_s3_retention
+        )
+
+        try:
+            paginator = s3_client.get_paginator("list_objects_v2")
+            for page in paginator.paginate(
+                Bucket=self.bundle_send_to_s3_bucket, Prefix=prefix
+            ):
+                for obj in page.get("Contents", []):
+                    if obj["LastModified"] < cutoff_time:
+                        s3_client.delete_object(
+                            Bucket=self.bundle_send_to_s3_bucket, Key=obj["Key"]
+                        )
+                        self.connector_logger.debug(
+                            "Deleted expired S3 bundle",
+                            {"key": obj["Key"], "modified": str(obj["LastModified"])},
+                        )
+        except Exception as e:
+            self.connector_logger.warning(
+                "Failed to cleanup old S3 bundles", {"error": str(e)}
+            )
 
     def stop(self) -> None:
         """Stop the connector and clean up resources.
@@ -2629,6 +2782,8 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :type send_to_directory_path: str, optional
         :param send_to_directory_retention: Days to retain exported files (default: self.bundle_send_to_directory_retention)
         :type send_to_directory_retention: int, optional
+        :param send_to_s3: Whether to upload bundle to S3 (default: self.bundle_send_to_s3)
+        :type send_to_s3: bool, optional
 
         :return: List of processed bundle chunks
         :rtype: list
@@ -2657,6 +2812,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         bundle_send_to_directory_retention = kwargs.get(
             "send_to_directory_retention", self.bundle_send_to_directory_retention
         )
+        bundle_send_to_s3 = kwargs.get("send_to_s3", self.bundle_send_to_s3)
 
         # In case of enrichment ingestion, ensure the sharing if needed
         if self.enrichment_shared_organizations is not None:
@@ -2784,6 +2940,41 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             # Rename the file after full write
             final_write_file = os.path.join(bundle_send_to_directory_path, bundle_file)
             os.rename(write_file, final_write_file)
+
+        # If S3 setup, upload the bundle to the target S3 bucket
+        if bundle_send_to_s3 and self.bundle_send_to_s3_bucket is not None:
+            self.connector_logger.info(
+                "The connector sending bundle to S3",
+                {
+                    "connector": self.connect_name,
+                    "bucket": self.bundle_send_to_s3_bucket,
+                    "folder": self.bundle_send_to_s3_folder,
+                    "also_queuing": bundle_send_to_queue,
+                },
+            )
+            bundle_file = (
+                self.connect_name.lower().replace(" ", "_")
+                + "-"
+                + time.strftime("%Y%m%d-%H%M%S-")
+                + str(time.time())
+                + ".json"
+            )
+            message_bundle = {
+                "bundle_type": "S3_BUNDLE",
+                "applicant_id": self.applicant_id,
+                "connector": {
+                    "id": self.connect_id,
+                    "name": self.connect_name,
+                    "type": self.connect_type,
+                    "scope": self.connect_scope,
+                    "auto": self.connect_auto,
+                    "validate_before_import": self.connect_validate_before_import,
+                },
+                "entities_types": entities_types,
+                "bundle": json.loads(bundle),
+                "update": update,
+            }
+            self._send_bundle_to_s3(json.dumps(message_bundle), bundle_file)
 
         stix2_splitter = OpenCTIStix2Splitter()
         (expectations_number, _, bundles) = (

--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -1,4 +1,5 @@
 # Filigran
+boto3>=1.35.0, <2
 datefinder~=0.7.3
 pika~=1.3.0
 python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'

--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -1,5 +1,5 @@
 # Filigran
-boto3>=1.35.0, <2
+boto3~=1.42.33
 datefinder~=0.7.3
 pika~=1.3.0
 python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'

--- a/client-python/setup.cfg
+++ b/client-python/setup.cfg
@@ -35,6 +35,7 @@ packages =
 include_package_data = True
 install_requires =
     # Filigran
+    boto3~=1.42.33
     datefinder~=0.7.3
     pika~=1.3.0
     pydantic>=2.8.2, <3

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2221,6 +2221,16 @@ type RabbitMQConnection {
   pass: String!
 }
 
+type S3Connection {
+  endpoint: String!
+  port: Int!
+  use_ssl: Boolean!
+  bucket_name: String!
+  bucket_region: String!
+  access_key: String!
+  secret_key: String!
+}
+
 input ConnectorInfoInput {
   run_and_terminate: Boolean!
   buffering: Boolean!
@@ -2241,6 +2251,7 @@ type ConnectorInfo {
 
 type ConnectorConfig {
   connection: RabbitMQConnection!
+  s3: S3Connection!
   listen: String!
   listen_routing: String!
   listen_exchange: String!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2132,6 +2132,16 @@ type RabbitMQConnection {
   pass: String!
 }
 
+type S3Connection {
+  endpoint: String!
+  port: Int!
+  use_ssl: Boolean!
+  bucket_name: String!
+  bucket_region: String!
+  access_key: String!
+  secret_key: String!
+}
+
 input ConnectorInfoInput {
   run_and_terminate: Boolean!
   buffering: Boolean!
@@ -2152,6 +2162,7 @@ type ConnectorInfo {
 
 type ConnectorConfig {
   connection: RabbitMQConnection! @auth(for: [CONNECTORAPI])
+  s3: S3Connection! @auth(for: [CONNECTORAPI])
   listen: String!
   listen_routing: String!
   listen_exchange: String!

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -11,6 +11,7 @@ import { getHttpClient } from '../utils/http-client';
 import { fullEntitiesList } from './middleware-loader';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_SYNC } from '../schema/internalObject';
 import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
+import { s3ConnectionConfig } from './raw-file-storage';
 
 export const CONNECTOR_EXCHANGE = `${RABBIT_QUEUE_PREFIX}amqp.connector.exchange`;
 export const WORKER_EXCHANGE = `${RABBIT_QUEUE_PREFIX}amqp.worker.exchange`;
@@ -47,7 +48,7 @@ const amqpCred = () => {
   return { credentials: amqp.credentials.plain(USERNAME, PASSWORD) };
 };
 
-export const config = () => {
+export const rabbitmqConnectionConfig = () => {
   return {
     host: HOSTNAME,
     vhost: VHOST,
@@ -201,8 +202,21 @@ export const getBestBackgroundConnectorId = async (context, user) => {
   return bestQueue.name.substring(`${RABBIT_QUEUE_PREFIX}push_`.length);
 };
 
+export const listenRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}listen_routing_${connectorId}`;
+export const pushRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}push_routing_${connectorId}`;
+
+// Dead letter queue ID for bundles that are too large
+const CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID = 'too-large-bundle';
+
+/**
+ * Build the complete connector configuration that includes:
+ * - RabbitMQ connection info
+ * - S3 connection info
+ * - Queue routing configuration
+ */
 export const connectorConfig = (id, listen_callback_uri = undefined) => ({
-  connection: config(),
+  connection: rabbitmqConnectionConfig(),
+  s3: s3ConnectionConfig(),
   push: `${RABBIT_QUEUE_PREFIX}push_${id}`,
   push_routing: pushRouting(id),
   push_exchange: WORKER_EXCHANGE,
@@ -210,11 +224,8 @@ export const connectorConfig = (id, listen_callback_uri = undefined) => ({
   listen_routing: listenRouting(id),
   listen_exchange: CONNECTOR_EXCHANGE,
   listen_callback_uri,
-  dead_letter_routing: listenRouting(CONNECTOR_QUEUE_BUNDLES_TOO_LARGE.id),
+  dead_letter_routing: listenRouting(CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID),
 });
-
-export const listenRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}listen_routing_${connectorId}`;
-export const pushRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}push_routing_${connectorId}`;
 
 export const registerConnectorQueues = async (id, name, type, scope) => {
   const listenQueue = `${RABBIT_QUEUE_PREFIX}listen_${id}`;

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -205,7 +205,11 @@ export const getBestBackgroundConnectorId = async (context, user) => {
 export const listenRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}listen_routing_${connectorId}`;
 export const pushRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}push_routing_${connectorId}`;
 
-// Dead letter queue ID for bundles that are too large
+// Dead letter queue routing ID for bundles that are too large.
+// NOTE:
+// - This constant is used here to build the dead_letter_routing value in connectorConfig.
+// - The full CONNECTOR_QUEUE_BUNDLES_TOO_LARGE queue configuration object is defined later
+//   in this file near the rest of the queue declarations.
 const CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID = 'too-large-bundle';
 
 /**

--- a/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
@@ -31,6 +31,20 @@ const useAwsLogs = booleanConf('minio:use_aws_logs', false);
 const disableChecksumValidation = booleanConf('minio:disable_checksum_validation', false);
 export const defaultValidationMode = conf.get('app:validation_mode');
 
+/**
+ * Export S3 connection configuration for connectors.
+ * This allows connectors to upload bundles directly to S3 storage.
+ */
+export const s3ConnectionConfig = () => ({
+  endpoint: clientEndpoint,
+  port: clientPort,
+  use_ssl: useSslConnection,
+  bucket_name: bucketName,
+  bucket_region: bucketRegion,
+  access_key: clientAccessKey,
+  secret_key: clientSecretKey,
+});
+
 let s3Client: S3Client; // Client reference
 
 const buildCredentialProvider = async () => {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -4151,6 +4151,7 @@ export type ConnectorConfig = {
   push: Scalars['String']['output'];
   push_exchange: Scalars['String']['output'];
   push_routing: Scalars['String']['output'];
+  s3: S3Connection;
 };
 
 export type ConnectorConfiguration = {
@@ -26463,6 +26464,17 @@ export type RuleTask = BackgroundTask & {
   work?: Maybe<Work>;
 };
 
+export type S3Connection = {
+  __typename?: 'S3Connection';
+  access_key: Scalars['String']['output'];
+  bucket_name: Scalars['String']['output'];
+  bucket_region: Scalars['String']['output'];
+  endpoint: Scalars['String']['output'];
+  port: Scalars['Int']['output'];
+  secret_key: Scalars['String']['output'];
+  use_ssl: Scalars['Boolean']['output'];
+};
+
 export type SshKey = BasicObject & StixCoreObject & StixCyberObservable & StixObject & {
   __typename?: 'SSHKey';
   cases?: Maybe<CaseConnection>;
@@ -37042,6 +37054,7 @@ export type ResolversTypes = ResolversObject<{
   RuleExecutionError: ResolverTypeWrapper<RuleExecutionError>;
   RuleManager: ResolverTypeWrapper<RuleManager>;
   RuleTask: ResolverTypeWrapper<Omit<RuleTask, 'work'> & { work?: Maybe<ResolversTypes['Work']> }>;
+  S3Connection: ResolverTypeWrapper<S3Connection>;
   SSHKey: ResolverTypeWrapper<Omit<SshKey, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<ResolversTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, indicators?: Maybe<ResolversTypes['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   SSHKeyAddInput: SshKeyAddInput;
   SavedFilter: ResolverTypeWrapper<BasicStoreEntitySavedFilter>;
@@ -37973,6 +37986,7 @@ export type ResolversParentTypes = ResolversObject<{
   RuleExecutionError: RuleExecutionError;
   RuleManager: RuleManager;
   RuleTask: Omit<RuleTask, 'work'> & { work?: Maybe<ResolversParentTypes['Work']> };
+  S3Connection: S3Connection;
   SSHKey: Omit<SshKey, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<ResolversParentTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, indicators?: Maybe<ResolversParentTypes['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
   SSHKeyAddInput: SshKeyAddInput;
   SavedFilter: BasicStoreEntitySavedFilter;
@@ -39558,6 +39572,7 @@ export type ConnectorConfigResolvers<ContextType = any, ParentType extends Resol
   push?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   push_exchange?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   push_routing?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  s3?: Resolver<ResolversTypes['S3Connection'], ParentType, ContextType>;
 }>;
 
 export type ConnectorConfigurationResolvers<ContextType = any, ParentType extends ResolversParentTypes['ConnectorConfiguration'] = ResolversParentTypes['ConnectorConfiguration']> = ResolversObject<{
@@ -45888,6 +45903,16 @@ export type RuleTaskResolvers<ContextType = any, ParentType extends ResolversPar
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type S3ConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['S3Connection'] = ResolversParentTypes['S3Connection']> = ResolversObject<{
+  access_key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bucket_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  bucket_region?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  endpoint?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  port?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  secret_key?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  use_ssl?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+}>;
+
 export type SshKeyResolvers<ContextType = any, ParentType extends ResolversParentTypes['SSHKey'] = ResolversParentTypes['SSHKey']> = ResolversObject<{
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<SshKeyCasesArgs>>;
   comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -49266,6 +49291,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   RuleExecutionError?: RuleExecutionErrorResolvers<ContextType>;
   RuleManager?: RuleManagerResolvers<ContextType>;
   RuleTask?: RuleTaskResolvers<ContextType>;
+  S3Connection?: S3ConnectionResolvers<ContextType>;
   SSHKey?: SshKeyResolvers<ContextType>;
   SavedFilter?: SavedFilterResolvers<ContextType>;
   SavedFilterConnection?: SavedFilterConnectionResolvers<ContextType>;


### PR DESCRIPTION
## Summary

This PR adds a new **S3 send mode** for connectors, allowing them to upload STIX bundles directly to an S3 bucket in addition to (or instead of) the existing directory and queue modes.

### Key Changes

**Backend (opencti-graphql):**
- Added `S3Connection` GraphQL type with endpoint, port, use_ssl, bucket_name, bucket_region, access_key, and secret_key fields
- Added `s3` field to `ConnectorConfig` type (protected by `@auth(for: [CONNECTORAPI])`)
- Added `s3ConnectionConfig()` export in `raw-file-storage.ts` to expose S3 credentials
- Updated `connectorConfig()` in `rabbitmq.js` to include S3 configuration alongside RabbitMQ config

**Python Client (pycti):**
- Added S3 configuration variables to `OpenCTIConnectorHelper`:
  - `CONNECTOR_SEND_TO_S3` - Enable S3 send mode
  - `CONNECTOR_SEND_TO_S3_BUCKET` - Target bucket (defaults to OpenCTI bucket)
  - `CONNECTOR_SEND_TO_S3_FOLDER` - Folder prefix (defaults to "connectors")
  - `CONNECTOR_SEND_TO_S3_RETENTION` - Days to retain bundles (defaults to 7)
- Added S3 override variables (`S3_ENDPOINT`, `S3_PORT`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_USE_SSL`, `S3_BUCKET_REGION`) to connect to a different S3 bucket
- Implemented `_send_bundle_to_s3()` method with automatic retention cleanup
- Updated `send_stix2_bundle()` to support `send_to_s3` parameter
- Updated register query to fetch S3 credentials from backend
- Added `boto3` dependency

### Configuration

| Environment Variable | Default | Description |
|---------------------|---------|-------------|
| `CONNECTOR_SEND_TO_S3` | `false` | Enable S3 send mode |
| `CONNECTOR_SEND_TO_S3_BUCKET` | OpenCTI bucket | Target S3 bucket |
| `CONNECTOR_SEND_TO_S3_FOLDER` | `connectors` | Folder prefix in bucket |
| `CONNECTOR_SEND_TO_S3_RETENTION` | `7` | Days to retain bundles (0 to disable cleanup) |
| `S3_ENDPOINT` | From OpenCTI | Override S3 endpoint |
| `S3_PORT` | From OpenCTI | Override S3 port |
| `S3_ACCESS_KEY` | From OpenCTI | Override access key |
| `S3_SECRET_KEY` | From OpenCTI | Override secret key |
| `S3_USE_SSL` | From OpenCTI | Override SSL setting |
| `S3_BUCKET_REGION` | From OpenCTI | Override region |

### How It Works

1. When a connector registers, it receives S3 credentials from the backend (same credentials OpenCTI uses for its file storage)
2. Connectors can override these credentials to use a different S3 bucket
3. When `send_to_s3` is enabled, bundles are uploaded to `{bucket}/{folder}/{connector_name}-{timestamp}.json`
4. Old bundles are automatically cleaned up based on the retention policy

### Files Modified

- `opencti-platform/opencti-graphql/config/schema/opencti.graphql`
- `opencti-platform/opencti-graphql/src/database/raw-file-storage.ts`
- `opencti-platform/opencti-graphql/src/database/rabbitmq.js`
- `client-python/pycti/api/opencti_api_connector.py`
- `client-python/pycti/connector/opencti_connector_helper.py`
- `client-python/requirements.txt`

## Test Plan

- [ ] Verify connector registration returns S3 config
- [ ] Test S3 upload with OpenCTI credentials
- [ ] Test S3 upload with custom credentials override
- [ ] Test retention cleanup removes old files
- [ ] Verify `send_to_queue` and `send_to_s3` can work together
- [ ] Verify `send_to_directory` and `send_to_s3` can work together