### PR TITLE
[backend] move logout_remote out of Passeport options (#3923)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -413,15 +413,14 @@ const createApp = async (app, schema) => {
         await delUserContext(user);
         res.clearCookie(OPENCTI_SESSION);
 
-        let providerCache = PROVIDERS.findIndex((conf) => conf.provider === provider);
-
+        let providerCache = PROVIDERS.find((conf) => conf.provider === provider);
+        logApp.info(`[LOGOUT] checking remote logout for ${provider}`, { providerCache });
         req.session.destroy(() => {
           const strategy = passport._strategy(provider);
           if (strategy) {
             if (providerCache.logout_remote === true) {
-              logApp.debug('[LOGOUT] Looking for logout_remote parameters: ', providerCache.logout_remote);
               if (strategy.logout) {
-                logApp.debug('[LOGOUT] requesting remote logout using authentication strategy parameters.');
+                logApp.info('[LOGOUT] requesting remote logout using authentication strategy parameters.');
                 req.user = user; // Needed for passport
                 strategy.logout(req, (error, request) => {
                   // When logout is implemented for strategy

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -414,7 +414,7 @@ const createApp = async (app, schema) => {
         res.clearCookie(OPENCTI_SESSION);
 
         let providerCache = PROVIDERS.find((conf) => conf.provider === provider);
-        logApp.info(`[LOGOUT] checking remote logout for ${provider}`, { providerCache });
+        logApp.debug(`[LOGOUT] checking remote logout for ${provider}`, { providerCache });
         req.session.destroy(() => {
           const strategy = passport._strategy(provider);
           if (strategy) {

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -420,7 +420,7 @@ const createApp = async (app, schema) => {
           if (strategy) {
             if (providerCache.logout_remote === true) {
               if (strategy.logout) {
-                logApp.info('[LOGOUT] requesting remote logout using authentication strategy parameters.');
+                logApp.debug('[LOGOUT] requesting remote logout using authentication strategy parameters.');
                 req.user = user; // Needed for passport
                 strategy.logout(req, (error, request) => {
                   // When logout is implemented for strategy

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -33,7 +33,7 @@ import initHttpRollingFeeds from './httpRollingFeed';
 import { createAuthenticatedContext } from './httpAuthenticatedContext';
 import { setCookieError } from './httpUtils';
 import { getChatbotProxy } from './httpChatbotProxy';
-import { EnvStrategyType, isStrategyActivated } from '../modules/singleSignOn/providers-configuration';
+import { EnvStrategyType, isStrategyActivated, PROVIDERS } from '../modules/singleSignOn/providers-configuration';
 
 export const sanitizeReferer = (refererToSanitize) => {
   // NOTE: basePath will be configured, if the site is hosted behind a reverseProxy otherwise '/' should be accurate
@@ -412,11 +412,14 @@ const createApp = async (app, schema) => {
         });
         await delUserContext(user);
         res.clearCookie(OPENCTI_SESSION);
+
+        let providerCache = PROVIDERS.findIndex((conf) => conf.provider === provider);
+
         req.session.destroy(() => {
           const strategy = passport._strategy(provider);
           if (strategy) {
-            if (strategy.logout_remote === true) {
-              logApp.debug('[LOGOUT] Looking for logout_remote parameters: ', strategy.logout_remote);
+            if (providerCache.logout_remote === true) {
+              logApp.debug('[LOGOUT] Looking for logout_remote parameters: ', providerCache.logout_remote);
               if (strategy.logout) {
                 logApp.debug('[LOGOUT] requesting remote logout using authentication strategy parameters.');
                 req.user = user; // Needed for passport

--- a/opencti-platform/opencti-graphql/src/modules/singleSignOn/providers-configuration.ts
+++ b/opencti-platform/opencti-graphql/src/modules/singleSignOn/providers-configuration.ts
@@ -55,6 +55,7 @@ export interface ProviderConfiguration {
   provider: string;
   reqLoginHandler?: () => void;
   logout_uri?: string;
+  logout_remote?: boolean;
 }
 export const PROVIDERS: ProviderConfiguration[] = [];
 

--- a/opencti-platform/opencti-graphql/src/modules/singleSignOn/providers-initialization.js
+++ b/opencti-platform/opencti-graphql/src/modules/singleSignOn/providers-initialization.js
@@ -337,9 +337,8 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
               // SAML Logout function
               logApp.info(`[ENV-PROVIDER][SAML] Logout done for ${profile}`);
             });
-            samlStrategy.logout_remote = samlOptions.logout_remote;
             passport.use(providerRef, samlStrategy);
-            PROVIDERS.push({ name: providerName, type: AuthType.AUTH_SSO, strategy, provider: providerRef });
+            PROVIDERS.push({ name: providerName, type: AuthType.AUTH_SSO, strategy, provider: providerRef, logout_remote: mappedConfig.logout_remote });
             // end region backward compatibility
           } else {
             if (isAuthenticationProviderMigrated(existingIdentifiers, providerRef)) {
@@ -376,7 +375,7 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
                 }
                 // endregion
                 const openIdScope = R.uniq(openIdScopes).join(' ');
-                const options = { logout_remote: mappedConfig.logout_remote, client, passReqToCallback: true,
+                const options = { client, passReqToCallback: true,
                   params: { scope: openIdScope, ...(mappedConfig.audience && { audience: mappedConfig.audience }),
                   } };
                 const debugCallback = (message, meta) => logApp.info(message, meta);
@@ -448,7 +447,6 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
                     done({ message: 'Restricted access, ask your administrator' });
                   }
                 });
-                openIDStrategy.logout_remote = options.logout_remote;
                 logApp.debug('[ENV-PROVIDER][OPENID] logout remote options', options);
                 openIDStrategy.logout = (_, callback) => {
                   const isSpecificUri = isNotEmptyField(config.logout_callback_url);
@@ -462,7 +460,7 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
                   }
                 };
                 passport.use(providerRef, openIDStrategy);
-                PROVIDERS.push({ name: providerName, type: AuthType.AUTH_SSO, strategy, provider: providerRef });
+                PROVIDERS.push({ name: providerName, type: AuthType.AUTH_SSO, strategy, provider: providerRef, logout_remote: mappedConfig.logout_remote });
               }).catch((err) => {
                 logApp.error('[ENV-PROVIDER][OPENID] Error initializing authentication provider', { cause: err, provider: providerRef });
               });

--- a/opencti-platform/opencti-graphql/src/modules/singleSignOn/providers-initialization.js
+++ b/opencti-platform/opencti-graphql/src/modules/singleSignOn/providers-initialization.js
@@ -582,7 +582,6 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
             const openIdScope = mappedConfig.scope ?? 'openid email profile';
             const options = {
               ...auth0OpenIDConfiguration,
-              logout_remote: mappedConfig.logout_remote,
               client,
               passReqToCallback: true,
               params: { scope: openIdScope },
@@ -594,7 +593,6 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
               const { email, name } = userinfo;
               providerLoginHandler({ email, name }, done);
             });
-            auth0Strategy.logout_remote = options.logout_remote;
 
             auth0Strategy.logout = (_, callback) => {
               const params = {
@@ -610,7 +608,7 @@ export const initializeEnvAuthenticationProviders = async (context, user) => {
               callback(null, endpointUri);
             };
             passport.use(providerRef, auth0Strategy);
-            PROVIDERS.push({ name: providerName, type: AuthType.AUTH_SSO, strategy, provider: providerRef });
+            PROVIDERS.push({ name: providerName, type: AuthType.AUTH_SSO, strategy, provider: providerRef, logout_remote: mappedConfig.logout_remote });
           }).catch((reason) => logApp.error('[ENV-PROVIDER][AUTH0] Error when enrich with remote credentials', { cause: reason }));
         }
         // CERT Strategies

--- a/opencti-platform/opencti-graphql/src/modules/singleSignOn/singleSignOn-provider-openid.js
+++ b/opencti-platform/opencti-graphql/src/modules/singleSignOn/singleSignOn-provider-openid.js
@@ -108,7 +108,8 @@ export const registerOpenIdStrategy = async (ssoEntity) => {
         // endregion
         const openIdScope = R.uniq(openIdScopes).join(' ');
         const options = {
-          logout_remote: ssoConfig.logout_remote, client, passReqToCallback: true,
+          client,
+          passReqToCallback: true,
           params: {
             scope: openIdScope, ...(ssoConfig.audience && { audience: ssoConfig.audience }),
           },
@@ -147,7 +148,6 @@ export const registerOpenIdStrategy = async (ssoEntity) => {
             done({ message: 'Restricted access, ask your administrator' });
           }
         });
-        openIDStrategy.logout_remote = options.logout_remote;
         logAuthInfo('logout remote options', EnvStrategyType.STRATEGY_OPENID, options);
         openIDStrategy.logout = (_, callback) => {
           const isSpecificUri = isNotEmptyField(ssoConfig.logout_callback_url);
@@ -160,7 +160,13 @@ export const registerOpenIdStrategy = async (ssoEntity) => {
             callback(null, endpointUri);
           }
         };
-        const providerConfig = { name: providerName, type: AuthType.AUTH_SSO, strategy: EnvStrategyType.STRATEGY_OPENID, provider: providerRef };
+        const providerConfig = {
+          name: providerName,
+          type: AuthType.AUTH_SSO,
+          strategy: EnvStrategyType.STRATEGY_OPENID,
+          provider: providerRef,
+          logout_remote: ssoConfig.logout_remote,
+        };
         registerAuthenticationProvider(providerRef, openIDStrategy, providerConfig);
       }).catch((err) => {
         logApp.error('[SSO OPENID] Error initializing authentication provider', {

--- a/opencti-platform/opencti-graphql/src/modules/singleSignOn/singleSignOn-provider-openid.js
+++ b/opencti-platform/opencti-graphql/src/modules/singleSignOn/singleSignOn-provider-openid.js
@@ -117,7 +117,7 @@ export const registerOpenIdStrategy = async (ssoEntity) => {
         const debugCallback = (message, meta) => logApp.info(message, meta);
         const openIDStrategy = new OpenIDStrategy(options, debugCallback, (_, tokenset, userinfo, done) => {
           logAuthInfo('Successfully logged', EnvStrategyType.STRATEGY_OPENID, { userinfo });
-          addUserLoginCount();
+
           const isGroupMapping = (isNotEmptyField(ssoEntity?.groups_management) && isNotEmptyField(ssoEntity?.groups_management.groups_mapping));
           logAuthInfo('Groups management configuration', EnvStrategyType.STRATEGY_OPENID, { groupsManagement: ssoEntity?.groups_management });
           const groupManagement = ssoEntity?.groups_management;
@@ -143,6 +143,7 @@ export const registerOpenIdStrategy = async (ssoEntity) => {
               providerOrganizations: organizationsToAssociate,
               autoCreateGroup: ssoConfig.auto_create_group ?? false,
             };
+            addUserLoginCount();
             providerLoginHandler(userInfo, done, opts);
           } else {
             done({ message: 'Restricted access, ask your administrator' });

--- a/opencti-platform/opencti-graphql/src/modules/singleSignOn/singleSignOn-provider-saml.ts
+++ b/opencti-platform/opencti-graphql/src/modules/singleSignOn/singleSignOn-provider-saml.ts
@@ -106,9 +106,9 @@ export const registerSAMLStrategy = async (ssoEntity: BasicStoreEntitySingleSign
   logAuthInfo('Configuring SAML', EnvStrategyType.STRATEGY_SAML, { id: ssoEntity.id, identifier: ssoEntity.identifier, providerRef });
   const providerName = ssoEntity?.label || ssoEntity?.identifier || ssoEntity.id;
   const samlOptions: PassportSamlConfig = await buildSAMLOptions(ssoEntity);
+  const ssoConfiguration: any = convertKeyValueToJsConfiguration(ssoEntity);
 
   const samlLoginCallback: VerifyWithoutRequest = (profile, done) => {
-    const ssoConfiguration: any = convertKeyValueToJsConfiguration(ssoEntity);
     const groupsManagement = ssoEntity.groups_management;
     const orgsManagement = ssoEntity.organizations_management;
 
@@ -139,8 +139,13 @@ export const registerSAMLStrategy = async (ssoEntity: BasicStoreEntitySingleSign
   };
   samlOptions.name = ssoEntity.identifier || 'saml';
   const samlStrategy = new SamlStrategy(samlOptions, samlLoginCallback, samlLogoutCallback);
-  // TODO samlStrategy.logout_remote = samlOptions.logout_remote;
-  const providerConfig: ProviderConfiguration = { name: providerName, type: AuthType.AUTH_SSO, strategy: EnvStrategyType.STRATEGY_SAML, provider: providerRef };
+  const providerConfig: ProviderConfiguration = {
+    name: providerName,
+    type: AuthType.AUTH_SSO,
+    strategy: EnvStrategyType.STRATEGY_SAML,
+    provider: providerRef,
+    logout_remote: ssoConfiguration.logout_remote,
+  };
   registerAuthenticationProvider(providerRef, samlStrategy, providerConfig);
   logAuthInfo('Passport SAML configured', EnvStrategyType.STRATEGY_SAML, { id: ssoEntity.id, identifier: ssoEntity.identifier, providerRef });
 };

--- a/opencti-platform/opencti-graphql/tests/03-integration/10 - Modules/singleSignOn/singleSignOn-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10 - Modules/singleSignOn/singleSignOn-domain-test.ts
@@ -42,7 +42,34 @@ describe('Single sign on Domain coverage tests', () => {
 
       // Here there is a pub/sub on redis, let's just call the same method than listener
       await onAuthenticationMessageAdd({ instance: samlEntity });
+      const cacheConfig = PROVIDERS.find((strategyProv) => strategyProv.provider === 'samlTestDomain');
+      expect(cacheConfig?.logout_remote).toBeFalsy();
       expect(PROVIDERS.some((strategyProv) => strategyProv.provider === 'samlTestDomain')).toBeTruthy();
+    });
+
+    it('should logout_remote be in SAML provider', async () => {
+      const input: SingleSignOnAddInput = {
+        name: 'Saml for test domain',
+        strategy: StrategyType.SamlStrategy,
+        identifier: 'samlTestDomainLogout',
+        enabled: true,
+        label: 'Nice SAML button',
+        configuration: [
+          { key: 'callbackUrl', value: 'http://myopencti/auth/samlTestDomainLogout/callback', type: 'string' },
+          { key: 'idpCert', value: '21341234', type: 'string' },
+          { key: 'issuer', value: 'issuer', type: 'string' },
+          { key: 'logout_remote', value: 'true', type: 'boolean' },
+        ],
+      };
+      const samlEntity = await addSingleSignOn(testContext, ADMIN_USER, input);
+      expect(samlEntity.identifier).toBe('samlTestDomainLogout');
+      expect(samlEntity.enabled).toBe(true);
+      expect(samlEntity.label).toBe('Nice SAML button');
+
+      // Here there is a pub/sub on redis, let's just call the same method than listener
+      await onAuthenticationMessageAdd({ instance: samlEntity });
+      const cacheConfig = PROVIDERS.find((strategyProv) => strategyProv.provider === 'samlTestDomainLogout');
+      expect(cacheConfig?.logout_remote).toBeTruthy();
     });
 
     it('should convert to stix', async () => {

--- a/opencti-platform/opencti-graphql/tests/10-streams/00-Raw/raw-test.js
+++ b/opencti-platform/opencti-graphql/tests/10-streams/00-Raw/raw-test.js
@@ -23,7 +23,7 @@ describe('Raw streams tests', () => {
     async () => {
       const startTime = new Date().getTime();
 
-      await waitInSec(60);
+      await waitInSec(10);
 
       // Read all events from the beginning.
       const events = await fetchStreamEvents(`http://localhost:${PORT}/stream`, { from: '0' });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

During moving to typescript, the mistake on remote_logout option has been quite obvious: it's not part of passport it's for OpenCTI behavior only. => Using the local cache (PROVIDERS) instead.

* Moved logout_remote from Passport strategy object to ProviderConfiguration interface
* Updated SAML, OpenID, and Auth0 provider registration to include logout_remote in provider config
* Modified logout handler to retrieve logout_remote from PROVIDERS cache instead of strategy object

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* relates to #3923

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
