### PR TITLE
[frontend] UI: color fixes (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Sync.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.tsx
@@ -110,7 +110,7 @@ const Sync = () => {
               <a
                 href="https://filigran.notion.site/63392969969c4941905520d37dc7ad4a?v=0a5716cac77b4406825ba3db0acfaeb2"
                 target="_blank"
-                style={{ color: theme.palette.secondary.main }}
+                style={{ color: theme.palette.primary.main }}
                 rel="noreferrer"
               >
                 {t_i18n('OpenCTI ecosystem space')}

--- a/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
@@ -143,6 +143,13 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
     handlePause();
     resetManager();
   };
+
+  const iconStyle = {
+    fontSize: 40,
+    color: theme.palette.text.primary,
+    opacity: 0.35,
+  };
+
   return (
     <Grid container={true} spacing={3}>
       <Grid item xs={6}>
@@ -167,9 +174,13 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
             variant="determinate"
           />
           {isStarted ? (
-            <SyncOutlined color="primary" sx={{ fontSize: 40 }} />
+            <SyncOutlined
+              sx={iconStyle}
+            />
           ) : (
-            <SyncDisabledOutlined color="primary" sx={{ fontSize: 40 }} />
+            <SyncDisabledOutlined
+              sx={iconStyle}
+            />
           )}
         </Card>
       </Grid>
@@ -186,11 +197,7 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
             {indexedFiles} / {totalFiles}
           </Typography>
           <FolderOutlined
-            sx={{
-              fontSize: 40,
-              color: theme.palette.text.primary,
-              opacity: 0.35,
-            }}
+            sx={iconStyle}
           />
         </Card>
       </Grid>
@@ -207,11 +214,7 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
             {indexedFiles ? n(volumeIndexed) : 0}
           </Typography>
           <StorageOutlined
-            sx={{
-              fontSize: 40,
-              color: theme.palette.text.primary,
-              opacity: 0.35,
-            }}
+            sx={iconStyle}
           />
         </Card>
       </Grid>

--- a/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
@@ -25,7 +25,7 @@ import { FileIndexingMonitoringQuery } from '@components/settings/file_indexing/
 import { interval } from 'rxjs';
 import LinearProgress, { linearProgressClasses } from '@mui/material/LinearProgress';
 import { FileIndexingConfigurationAndMonitoringQuery$data } from '@components/settings/file_indexing/__generated__/FileIndexingConfigurationAndMonitoringQuery.graphql';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import FileIndexingConfiguration from '@components/settings/file_indexing/FileIndexingConfiguration';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -98,6 +98,7 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
 }) => {
   const { n, t_i18n, fldt, b } = useFormatter();
   const classes = useStyles();
+  const theme = useTheme();
   const { indexedFilesMetrics } = usePreloadedQuery<FileIndexingMonitoringQuery>(
     fileIndexingMonitoringQuery,
     queryRef,
@@ -198,7 +199,13 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
           <Typography variant="h2" style={{ margin: 0 }}>
             {indexedFiles} / {totalFiles}
           </Typography>
-          <FolderOutlined color="primary" sx={{ fontSize: 40 }} />
+          <FolderOutlined
+            sx={{
+              fontSize: 40,
+              color: theme.palette.text.primary,
+              opacity: 0.35,
+            }}
+          />
         </Card>
       </Grid>
       <Grid item xs={3}>
@@ -213,7 +220,13 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
           <Typography variant="h2" style={{ margin: 0 }}>
             {indexedFiles ? n(volumeIndexed) : 0}
           </Typography>
-          <StorageOutlined color="primary" sx={{ fontSize: 40 }} />
+          <StorageOutlined
+            sx={{
+              fontSize: 40,
+              color: theme.palette.text.primary,
+              opacity: 0.35,
+            }}
+          />
         </Card>
       </Grid>
       <Grid item xs={4}>

--- a/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/file_indexing/FileIndexingMonitoring.tsx
@@ -14,7 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import React, { FunctionComponent, useEffect } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import Button from '@common/button/Button';
@@ -33,7 +32,6 @@ import ListItemText from '@mui/material/ListItemText';
 import { FileIndexingConfigurationQuery$data } from '@components/settings/file_indexing/__generated__/FileIndexingConfigurationQuery.graphql';
 import DangerZoneBlock from '@components/common/danger_zone/DangerZoneBlock';
 import { useFormatter } from '../../../../components/i18n';
-import type { Theme } from '../../../../components/Theme';
 import { handleError, MESSAGING$ } from '../../../../relay/environment';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { TEN_SECONDS } from '../../../../utils/Time';
@@ -43,17 +41,6 @@ import Card from '../../../../components/common/card/Card';
 import Label from '../../../../components/common/label/Label';
 
 const interval$ = interval(TEN_SECONDS);
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  header: {
-    textTransform: 'uppercase',
-  },
-  mimeTypeCount: {
-    color: theme.palette.primary.main,
-  },
-}));
 
 const fileIndexingMonitoringQuery = graphql`
   query FileIndexingMonitoringQuery {
@@ -97,7 +84,6 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
   refetch,
 }) => {
   const { n, t_i18n, fldt, b } = useFormatter();
-  const classes = useStyles();
   const theme = useTheme();
   const { indexedFilesMetrics } = usePreloadedQuery<FileIndexingMonitoringQuery>(
     fileIndexingMonitoringQuery,
@@ -324,18 +310,24 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
                 >
                   <ListItemText
                     primary={t_i18n('Type')}
-                    className={classes.header}
-                    style={{ width: '30%' }}
+                    style={{
+                      width: '30%',
+                      textTransform: 'uppercase',
+                    }}
                   />
                   <ListItemText
                     primary={t_i18n('Files count')}
-                    className={classes.header}
-                    style={{ width: '30%' }}
+                    style={{
+                      width: '30%',
+                      textTransform: 'uppercase',
+                    }}
                   />
                   <ListItemText
                     primary={t_i18n('Files size')}
-                    className={classes.header}
-                    style={{ width: '30%' }}
+                    style={{
+                      width: '30%',
+                      textTransform: 'uppercase',
+                    }}
                   />
                 </ListItem>
                 {metricsByMimeType.map((metrics) => (
@@ -347,18 +339,21 @@ const FileIndexingMonitoringComponent: FunctionComponent<FileIndexingMonitoringC
                   >
                     <ListItemText
                       primary={t_i18n(metrics.mimeType)}
-                      className={classes.mimeType}
                       style={{ width: '30%' }}
                     />
                     <ListItemText
                       primary={`${metrics.count}`}
-                      className={classes.mimeTypeCount}
-                      style={{ width: '30%' }}
+                      style={{
+                        width: '30%',
+                        color: theme.palette.primary.main,
+                      }}
                     />
                     <ListItemText
                       primary={`${b(metrics.size)}`}
-                      className={classes.mimeTypeCount}
-                      style={{ width: '30%' }}
+                      style={{
+                        width: '30%',
+                        color: theme.palette.primary.main,
+                      }}
                     />
                   </ListItem>
                 ))}


### PR DESCRIPTION
### Proposed changes
- Fix color of text in Ingestion > OCTI stream: should be blue

<img width="490" height="86" alt="image" src="https://github.com/user-attachments/assets/769fcc02-fbbb-4d28-9097-6b25ed1c1400" />
 
- In Settings > Files indexing, change color of these icons

before
<img width="734" height="160" alt="image" src="https://github.com/user-attachments/assets/b5b7f5d2-0b60-4e00-8e21-fa2584d13bc2" />

after
<img width="874" height="174" alt="image" src="https://github.com/user-attachments/assets/b803f13d-955f-4e46-8534-a83ca92be0cd" />



### Related issues
#13303