### PR TITLE
[backend] fix getConnectorQueueSize when only one targetQueues exists (#14269)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -497,6 +497,9 @@ export const getConnectorQueueSize = async (context, user, connectorId) => {
     metricsCache.set('cached_metrics', stats);
   }
   const targetQueues = stats.queues.filter((queue) => queue.name.includes(connectorId));
+  if (targetQueues.length === 1) {
+    return targetQueues[0].messages ?? 0;
+  }
   return targetQueues.length > 0 ? targetQueues.reduce((a, b) => (a.messages ?? 0) + (b.messages ?? 0)) : 0;
 };
 export const getBestBackgroundConnectorId = async (context, user) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockHttpClient = {
+  get: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../../../src/utils/http-client', () => ({
+  getHttpClient: vi.fn(() => mockHttpClient),
+}));
+
+vi.mock('../../../src/config/conf', () => ({
+  default: { get: vi.fn(() => undefined) },
+  booleanConf: vi.fn(() => false),
+  configureCA: vi.fn(() => ({})),
+  loadCert: vi.fn(),
+  logApp: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/config/tracing', () => ({
+  telemetry: vi.fn((_ctx: unknown, _user: unknown, _name: unknown, _attrs: unknown, fn: () => unknown) => fn()),
+}));
+
+vi.mock('../../../src/database/utils', () => ({
+  isEmptyField: vi.fn((v: unknown) => !v),
+  RABBIT_QUEUE_PREFIX: 'opencti_',
+  wait: vi.fn(),
+}));
+
+vi.mock('../../../src/database/middleware-loader', () => ({
+  fullEntitiesList: vi.fn(async () => []),
+}));
+
+vi.mock('../../../src/database/raw-file-storage', () => ({
+  s3ConnectionConfig: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../src/utils/access', () => ({
+  SYSTEM_USER: {},
+}));
+
+vi.mock('../../../src/schema/internalObject', () => ({
+  ENTITY_TYPE_BACKGROUND_TASK: 'Background-Task',
+  ENTITY_TYPE_CONNECTOR: 'Connector',
+  ENTITY_TYPE_SYNC: 'Sync',
+}));
+
+vi.mock('../../../src/modules/playbook/playbook-types', () => ({
+  ENTITY_TYPE_PLAYBOOK: 'Playbook',
+}));
+
+// Mock LRUCache so the cache never returns stale data between tests
+vi.mock('lru-cache', () => {
+  class FakeLRUCache {
+    get() {
+      return undefined;
+    }
+
+    set() { /* no-op */ }
+  }
+  return { LRUCache: FakeLRUCache };
+});
+
+import { getConnectorQueueSize } from '../../../src/database/rabbitmq';
+
+describe('rabbitmq: getConnectorQueueSize', () => {
+  const context = {};
+  const user = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return the message count when exactly one queue matches', async () => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'opencti_push_connector-abc', messages: 42, consumers: 1 },
+            { name: 'opencti_push_connector-xyz', messages: 10, consumers: 1 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await getConnectorQueueSize(context, user, 'connector-abc');
+    expect(result).toBe(42);
+  });
+
+  it('should return 0 when exactly one queue matches but messages is undefined', async () => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'opencti_push_connector-abc', consumers: 1 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await getConnectorQueueSize(context, user, 'connector-abc');
+    expect(result).toBe(0);
+  });
+
+  it('should return 0 when no queues match', async () => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'opencti_push_connector-xyz', messages: 10, consumers: 1 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await getConnectorQueueSize(context, user, 'connector-unknown');
+    expect(result).toBe(0);
+  });
+
+  it('should return the sum of messages when multiple queues match', async () => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'opencti_push_connector-abc', messages: 10, consumers: 1 },
+            { name: 'opencti_listen_connector-abc', messages: 5, consumers: 0 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await getConnectorQueueSize(context, user, 'connector-abc');
+    expect(result).toBe(15);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -54,7 +54,7 @@ vi.mock('../../../src/modules/playbook/playbook-types', () => ({
   ENTITY_TYPE_PLAYBOOK: 'Playbook',
 }));
 
-// Mock LRUCache so the cache never returns stale data between tests
+// Mock LRUCache so the cache never returns stale data between test
 vi.mock('lru-cache', () => {
   class FakeLRUCache {
     get() {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* calling targetQueues.reduce on targetQueues of length 1 was returning the whole queue object instead of the messages

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14269
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
