### PR TITLE
[frontend] In ExportList, change the FAB button into a primary button (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
@@ -5,14 +5,13 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
-import { Add, InfoOutlined } from '@mui/icons-material';
+import { InfoOutlined } from '@mui/icons-material';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import MenuItem from '@mui/material/MenuItem';
 import * as Yup from 'yup';
 import Tooltip from '@mui/material/Tooltip';
 import makeStyles from '@mui/styles/makeStyles';
-import Fab from '@mui/material/Fab';
 import { CONTENT_MAX_MARKINGS_HELPERTEXT, CONTENT_MAX_MARKINGS_TITLE } from '../files/FileManager';
 import ObjectMarkingField from '../form/ObjectMarkingField';
 import { useFormatter } from '../../../../components/i18n';
@@ -128,16 +127,14 @@ const StixCoreObjectsExportCreationComponent = ({
               }
               aria-label="generate-export"
             >
-              <Fab
+              <Button
                 onClick={() => setOpen(true)}
                 color="secondary"
-                aria-label="Add"
                 className={classes.createButton}
                 disabled={!isExportPossible}
-                data-testid="StixCoreObjectsExportCreationAddButton"
               >
-                <Add />
-              </Fab>
+                {t_i18n('Generate an export')}
+              </Button>
             </Tooltip>
             <Formik
               enableReinitialize={true}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
@@ -6,12 +6,11 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import { InfoOutlined } from '@mui/icons-material';
-import { createFragmentContainer, graphql } from 'react-relay';
+import { graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import MenuItem from '@mui/material/MenuItem';
 import * as Yup from 'yup';
 import Tooltip from '@mui/material/Tooltip';
-import makeStyles from '@mui/styles/makeStyles';
 import { CONTENT_MAX_MARKINGS_HELPERTEXT, CONTENT_MAX_MARKINGS_TITLE } from '../files/FileManager';
 import ObjectMarkingField from '../form/ObjectMarkingField';
 import { useFormatter } from '../../../../components/i18n';
@@ -21,17 +20,6 @@ import SelectField from '../../../../components/fields/SelectField';
 import Loader from '../../../../components/Loader';
 import { ExportContext } from '../../../../utils/ExportContextProvider';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles(() => ({
-  createButton: {
-    position: 'fixed',
-    bottom: 30,
-    right: 30,
-    zIndex: 2000,
-  },
-}));
 
 export const StixCoreObjectsExportCreationMutation = graphql`
   mutation StixCoreObjectsExportCreationMutation(
@@ -65,16 +53,18 @@ export const scopesConn = (exportConnectors) => {
   return R.fromPairs(zipped);
 };
 
-const StixCoreObjectsExportCreationComponent = ({
+const StixCoreObjectsExportCreation = ({
   paginationOptions,
   exportContext,
   onExportAsk,
   exportType,
-  data,
+  exportScopes,
+  isExportActive,
+  open,
+  setOpen,
 }) => {
   const { t_i18n } = useFormatter();
-  const classes = useStyles();
-  const [open, setOpen] = useState(false);
+
   const [selectedContentMaxMarkingsIds, setSelectedContentMaxMarkingsIds] = useState([]);
   const handleSelectedContentMaxMarkingsChange = (values) => setSelectedContentMaxMarkingsIds(values.map(({ value }) => value));
   const onSubmit = (selectedIds, values, { setSubmitting, resetForm }) => {
@@ -106,36 +96,12 @@ const StixCoreObjectsExportCreationComponent = ({
       },
     });
   };
-  const connectorsExport = R.propOr([], 'connectorsForExport', data);
-  const exportScopes = R.uniq(
-    R.flatten(R.map((c) => c.connector_scope, connectorsExport)),
-  );
-  const exportConnsPerFormat = scopesConn(connectorsExport);
 
-  const isExportActive = (format) => R.filter((x) => x.data.active, exportConnsPerFormat[format]).length > 0;
-  const isExportPossible = R.filter((x) => isExportActive(x), exportScopes).length > 0;
   return (
     <ExportContext.Consumer>
       {({ selectedIds }) => {
         return (
           <>
-            <Tooltip
-              title={
-                isExportPossible
-                  ? t_i18n('Generate an export')
-                  : t_i18n('No export connector available to generate an export')
-              }
-              aria-label="generate-export"
-            >
-              <Button
-                onClick={() => setOpen(true)}
-                color="secondary"
-                className={classes.createButton}
-                disabled={!isExportPossible}
-              >
-                {t_i18n('Generate an export')}
-              </Button>
-            </Tooltip>
             <Formik
               enableReinitialize={true}
               initialValues={{
@@ -236,16 +202,4 @@ const StixCoreObjectsExportCreationComponent = ({
   );
 };
 
-export default createFragmentContainer(StixCoreObjectsExportCreationComponent, {
-  data: graphql`
-    fragment StixCoreObjectsExportCreation_data on Query {
-      connectorsForExport {
-        id
-        name
-        active
-        connector_scope
-        updated_at
-      }
-    }
-  `,
-});
+export default StixCoreObjectsExportCreation;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportCreation.jsx
@@ -101,101 +101,99 @@ const StixCoreObjectsExportCreation = ({
     <ExportContext.Consumer>
       {({ selectedIds }) => {
         return (
-          <>
-            <Formik
-              enableReinitialize={true}
-              initialValues={{
-                format: '',
-                contentMaxMarkings: [],
-                fileMarkings: [],
-              }}
-              validationSchema={exportValidation(t_i18n)}
-              onSubmit={(values, { setSubmitting, resetForm }) => onSubmit(selectedIds, values, { setSubmitting, resetForm })
-              }
-              onReset={() => setOpen(false)}
-            >
-              {({ submitForm, handleReset, isSubmitting, resetForm, setFieldValue }) => (
-                <Form>
-                  <Dialog
-                    slotProps={{ paper: { elevation: 1 } }}
-                    open={open}
-                    onClose={() => {
-                      resetForm();
-                      setOpen(false);
+          <Formik
+            enableReinitialize={true}
+            initialValues={{
+              format: '',
+              contentMaxMarkings: [],
+              fileMarkings: [],
+            }}
+            validationSchema={exportValidation(t_i18n)}
+            onSubmit={(values, { setSubmitting, resetForm }) => onSubmit(selectedIds, values, { setSubmitting, resetForm })
+            }
+            onReset={() => setOpen(false)}
+          >
+            {({ submitForm, handleReset, isSubmitting, resetForm, setFieldValue }) => (
+              <Form>
+                <Dialog
+                  slotProps={{ paper: { elevation: 1 } }}
+                  open={open}
+                  onClose={() => {
+                    resetForm();
+                    setOpen(false);
+                  }}
+                  fullWidth={true}
+                  data-testid="StixCoreObjectsExportCreationDialog"
+                >
+                  <DialogTitle>
+                    {t_i18n('Generate an export')}
+                    <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
+                      <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
+                    </Tooltip>
+                  </DialogTitle>
+                  <QueryRenderer
+                    query={markingDefinitionsLinesSearchQuery}
+                    variables={{ first: 200 }}
+                    render={({ props }) => {
+                      if (props && props.markingDefinitions) {
+                        return (
+                          <DialogContent>
+                            <Field
+                              component={SelectField}
+                              variant="standard"
+                              name="format"
+                              label={t_i18n('Export format')}
+                              fullWidth={true}
+                              containerstyle={{ width: '100%' }}
+                            >
+                              {exportScopes.map((value, i) => (
+                                <MenuItem
+                                  key={i}
+                                  value={value}
+                                  disabled={!isExportActive(value)}
+                                >
+                                  {value}
+                                </MenuItem>
+                              ))}
+                            </Field>
+                            <ObjectMarkingField
+                              name="contentMaxMarkings"
+                              label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
+                              onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values)}
+                              style={fieldSpacingContainerStyle}
+                              setFieldValue={setFieldValue}
+                              limitToMaxSharing
+                              helpertext={t_i18n(CONTENT_MAX_MARKINGS_HELPERTEXT)}
+                            />
+                            <ObjectMarkingField
+                              name="fileMarkings"
+                              label={t_i18n('File marking definition levels')}
+                              filterTargetIds={selectedContentMaxMarkingsIds}
+                              style={fieldSpacingContainerStyle}
+                              setFieldValue={setFieldValue}
+                            />
+                          </DialogContent>
+                        );
+                      }
+                      return <Loader variant="inElement" />;
                     }}
-                    fullWidth={true}
-                    data-testid="StixCoreObjectsExportCreationDialog"
-                  >
-                    <DialogTitle>
-                      {t_i18n('Generate an export')}
-                      <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
-                        <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
-                      </Tooltip>
-                    </DialogTitle>
-                    <QueryRenderer
-                      query={markingDefinitionsLinesSearchQuery}
-                      variables={{ first: 200 }}
-                      render={({ props }) => {
-                        if (props && props.markingDefinitions) {
-                          return (
-                            <DialogContent>
-                              <Field
-                                component={SelectField}
-                                variant="standard"
-                                name="format"
-                                label={t_i18n('Export format')}
-                                fullWidth={true}
-                                containerstyle={{ width: '100%' }}
-                              >
-                                {exportScopes.map((value, i) => (
-                                  <MenuItem
-                                    key={i}
-                                    value={value}
-                                    disabled={!isExportActive(value)}
-                                  >
-                                    {value}
-                                  </MenuItem>
-                                ))}
-                              </Field>
-                              <ObjectMarkingField
-                                name="contentMaxMarkings"
-                                label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
-                                onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values)}
-                                style={fieldSpacingContainerStyle}
-                                setFieldValue={setFieldValue}
-                                limitToMaxSharing
-                                helpertext={t_i18n(CONTENT_MAX_MARKINGS_HELPERTEXT)}
-                              />
-                              <ObjectMarkingField
-                                name="fileMarkings"
-                                label={t_i18n('File marking definition levels')}
-                                filterTargetIds={selectedContentMaxMarkingsIds}
-                                style={fieldSpacingContainerStyle}
-                                setFieldValue={setFieldValue}
-                              />
-                            </DialogContent>
-                          );
-                        }
-                        return <Loader variant="inElement" />;
-                      }}
-                    />
-                    <DialogActions>
-                      <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
-                        {t_i18n('Cancel')}
-                      </Button>
-                      <Button
-                        // color="secondary"
-                        onClick={submitForm}
-                        disabled={isSubmitting}
-                      >
-                        {t_i18n('Create')}
-                      </Button>
-                    </DialogActions>
-                  </Dialog>
-                </Form>
-              )}
-            </Formik>
-          </>
+                  />
+                  <DialogActions>
+                    <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
+                      {t_i18n('Cancel')}
+                    </Button>
+                    <Button
+                      // color="secondary"
+                      onClick={submitForm}
+                      disabled={isSubmitting}
+                    >
+                      {t_i18n('Create')}
+                    </Button>
+                  </DialogActions>
+                </Dialog>
+              </Form>
+            )}
+          </Formik>
         );
       }}
     </ExportContext.Consumer>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsExportsContent.jsx
@@ -11,6 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Button from '@common/button/Button';
 import Tooltip from '@mui/material/Tooltip';
 import * as R from 'ramda';
+import { Stack } from '@mui/material';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -51,7 +52,11 @@ const StixCoreObjectsExportsContentComponent = ({
 
   return (
     <>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', paddingBottom: 8 }}>
+      <Stack
+        direction="row"
+        justifyContent="flex-end"
+        gap={1}
+      >
         <Tooltip
           title={
             isExportPossible
@@ -68,7 +73,7 @@ const StixCoreObjectsExportsContentComponent = ({
             {t_i18n('Generate an export')}
           </Button>
         </Tooltip>
-      </div>
+      </Stack>
       <List>
         {stixCoreObjectsExportFiles.length > 0 ? (
           stixCoreObjectsExportFiles.map((file) => file?.node && (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportCreation.jsx
@@ -142,111 +142,109 @@ class StixDomainObjectsExportCreation extends Component {
       <ExportContext.Consumer>
         {({ selectedIds }) => {
           return (
-            <>
-              <Formik
-                enableReinitialize={true}
-                initialValues={{
-                  format: '',
-                  type: 'simple',
-                  maxMarkingDefinition: 'none',
-                  contentMaxMarkings: [],
-                  fileMarkings: [],
-                }}
-                validationSchema={exportValidation(t)}
-                onSubmit={this.onSubmit.bind(this, selectedIds)}
-                onReset={() => this.props.onClose()}
-              >
-                {({ submitForm, resetForm, isSubmitting, setFieldValue }) => (
-                  <Form>
-                    <Dialog
-                      slotProps={{ paper: { elevation: 1 } }}
-                      open={this.props.open}
-                      onClose={this.props.onClose}
-                      fullWidth={true}
-                      data-testid="StixDomainObjectsExportCreationDialog"
-                    >
-                      <DialogTitle>
-                        {t('Generate an export')}
-                        <Tooltip title={t('Your max shareable markings will be applied to the content max markings')}>
-                          <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
-                        </Tooltip>
-                      </DialogTitle>
-                      <DialogContent>
-                        <Field
-                          component={SelectField}
-                          variant="standard"
-                          name="format"
-                          label={t('Export format')}
-                          fullWidth={true}
-                          containerstyle={{ width: '100%' }}
-                        >
-                          {availableFormat.map((value, i) => (
-                            <MenuItem
-                              key={i}
-                              value={value}
-                              disabled={!isExportActive(value)}
-                            >
-                              {value}
-                            </MenuItem>
-                          ))}
-                        </Field>
-                        <Field
-                          component={SelectField}
-                          variant="standard"
-                          name="type"
-                          label={t('Export type')}
-                          fullWidth={true}
-                          containerstyle={fieldSpacingContainerStyle}
-                        >
-                          <MenuItem value="simple">
-                            {t('Simple export (just the entity)')}
+            <Formik
+              enableReinitialize={true}
+              initialValues={{
+                format: '',
+                type: 'simple',
+                maxMarkingDefinition: 'none',
+                contentMaxMarkings: [],
+                fileMarkings: [],
+              }}
+              validationSchema={exportValidation(t)}
+              onSubmit={this.onSubmit.bind(this, selectedIds)}
+              onReset={() => this.props.onClose()}
+            >
+              {({ submitForm, resetForm, isSubmitting, setFieldValue }) => (
+                <Form>
+                  <Dialog
+                    slotProps={{ paper: { elevation: 1 } }}
+                    open={this.props.open}
+                    onClose={this.props.onClose}
+                    fullWidth={true}
+                    data-testid="StixDomainObjectsExportCreationDialog"
+                  >
+                    <DialogTitle>
+                      {t('Generate an export')}
+                      <Tooltip title={t('Your max shareable markings will be applied to the content max markings')}>
+                        <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
+                      </Tooltip>
+                    </DialogTitle>
+                    <DialogContent>
+                      <Field
+                        component={SelectField}
+                        variant="standard"
+                        name="format"
+                        label={t('Export format')}
+                        fullWidth={true}
+                        containerstyle={{ width: '100%' }}
+                      >
+                        {availableFormat.map((value, i) => (
+                          <MenuItem
+                            key={i}
+                            value={value}
+                            disabled={!isExportActive(value)}
+                          >
+                            {value}
                           </MenuItem>
-                          <MenuItem value="full">
-                            {t(
-                              'Full export (entity and first neighbours)',
-                            )}
-                          </MenuItem>
-                        </Field>
-                        <ObjectMarkingField
-                          name="contentMaxMarkings"
-                          label={t(CONTENT_MAX_MARKINGS_TITLE)}
-                          onChange={(_, values) => this.handleSelectedContentMaxMarkingsChange(values)}
-                          style={fieldSpacingContainerStyle}
-                          setFieldValue={setFieldValue}
-                          limitToMaxSharing
-                          helpertext={t(CONTENT_MAX_MARKINGS_HELPERTEXT)}
-                        />
-                        <ObjectMarkingField
-                          name="fileMarkings"
-                          label={t('File marking definition levels')}
-                          filterTargetIds={this.state.selectedContentMaxMarkingsIds}
-                          style={fieldSpacingContainerStyle}
-                          setFieldValue={setFieldValue}
-                        />
-                      </DialogContent>
-                      <DialogActions>
-                        <Button
-                          variant="secondary"
-                          onClick={() => {
-                            this.props.onClose();
-                            resetForm();
-                          }}
-                          disabled={isSubmitting}
-                        >
-                          {t('Cancel')}
-                        </Button>
-                        <Button
-                          onClick={submitForm}
-                          disabled={isSubmitting}
-                        >
-                          {t('Create')}
-                        </Button>
-                      </DialogActions>
-                    </Dialog>
-                  </Form>
-                )}
-              </Formik>
-            </>
+                        ))}
+                      </Field>
+                      <Field
+                        component={SelectField}
+                        variant="standard"
+                        name="type"
+                        label={t('Export type')}
+                        fullWidth={true}
+                        containerstyle={fieldSpacingContainerStyle}
+                      >
+                        <MenuItem value="simple">
+                          {t('Simple export (just the entity)')}
+                        </MenuItem>
+                        <MenuItem value="full">
+                          {t(
+                            'Full export (entity and first neighbours)',
+                          )}
+                        </MenuItem>
+                      </Field>
+                      <ObjectMarkingField
+                        name="contentMaxMarkings"
+                        label={t(CONTENT_MAX_MARKINGS_TITLE)}
+                        onChange={(_, values) => this.handleSelectedContentMaxMarkingsChange(values)}
+                        style={fieldSpacingContainerStyle}
+                        setFieldValue={setFieldValue}
+                        limitToMaxSharing
+                        helpertext={t(CONTENT_MAX_MARKINGS_HELPERTEXT)}
+                      />
+                      <ObjectMarkingField
+                        name="fileMarkings"
+                        label={t('File marking definition levels')}
+                        filterTargetIds={this.state.selectedContentMaxMarkingsIds}
+                        style={fieldSpacingContainerStyle}
+                        setFieldValue={setFieldValue}
+                      />
+                    </DialogContent>
+                    <DialogActions>
+                      <Button
+                        variant="secondary"
+                        onClick={() => {
+                          this.props.onClose();
+                          resetForm();
+                        }}
+                        disabled={isSubmitting}
+                      >
+                        {t('Cancel')}
+                      </Button>
+                      <Button
+                        onClick={submitForm}
+                        disabled={isSubmitting}
+                      >
+                        {t('Create')}
+                      </Button>
+                    </DialogActions>
+                  </Dialog>
+                </Form>
+              )}
+            </Formik>
           );
         }}
       </ExportContext.Consumer>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportCreation.jsx
@@ -8,13 +8,12 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import Slide from '@mui/material/Slide';
-import { Add, InfoOutlined } from '@mui/icons-material';
+import { InfoOutlined } from '@mui/icons-material';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import MenuItem from '@mui/material/MenuItem';
 import * as Yup from 'yup';
 import Tooltip from '@mui/material/Tooltip';
-import Fab from '@mui/material/Fab';
 import ObjectMarkingField from '../form/ObjectMarkingField';
 import inject18n from '../../../../components/i18n';
 import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
@@ -167,16 +166,14 @@ class StixDomainObjectsExportCreationComponent extends Component {
                 }
                 aria-label="generate-export"
               >
-                <Fab
+                <Button
                   onClick={this.handleOpen.bind(this)}
                   color="secondary"
-                  aria-label="Add"
                   className={classes.createButton}
                   disabled={!isExportPossible}
-                  data-testid="StixDomainObjectsExportCreationAddButton"
                 >
-                  <Add />
-                </Fab>
+                  {t('Generate an export')}
+                </Button>
               </Tooltip>
               <Formik
                 enableReinitialize={true}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.jsx
@@ -13,6 +13,7 @@ import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNGETEXPORT_KNASKEXPORT } from '../../../../utils/hooks/useGranted';
 import Button from '@common/button/Button';
 import Tooltip from '@mui/material/Tooltip';
+import { Stack } from '@mui/material';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -61,7 +62,11 @@ class StixDomainObjectsExportsContentComponent extends Component {
 
     return (
       <>
-        <div style={{ display: 'flex', justifyContent: 'flex-end', paddingBottom: 8 }}>
+        <Stack
+          direction="row"
+          justifyContent="flex-end"
+          gap={1}
+        >
           <Tooltip
             title={
               isExportPossible
@@ -78,7 +83,7 @@ class StixDomainObjectsExportsContentComponent extends Component {
               {t('Generate an export')}
             </Button>
           </Tooltip>
-        </div>
+        </Stack>
         <List>
           {stixDomainObjectsExportFiles.length > 0 ? (
             stixDomainObjectsExportFiles.map(

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectsExportsContent.jsx
@@ -1,16 +1,18 @@
 import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { compose } from 'ramda';
+import { compose, filter, flatten, map, uniq } from 'ramda';
 import Slide from '@mui/material/Slide';
 import { createRefetchContainer, graphql } from 'react-relay';
 import List from '@mui/material/List';
 import { interval } from 'rxjs';
-import StixDomainObjectsExportCreation from './StixDomainObjectsExportCreation';
+import StixDomainObjectsExportCreation, { scopesConn } from './StixDomainObjectsExportCreation';
 import { FIVE_SECONDS } from '../../../../utils/Time';
 import FileLine from '../files/FileLine';
 import inject18n from '../../../../components/i18n';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNGETEXPORT_KNASKEXPORT } from '../../../../utils/hooks/useGranted';
+import Button from '@common/button/Button';
+import Tooltip from '@mui/material/Tooltip';
 
 const interval$ = interval(FIVE_SECONDS);
 
@@ -20,6 +22,11 @@ const Transition = React.forwardRef((props, ref) => (
 Transition.displayName = 'TransitionSlide';
 
 class StixDomainObjectsExportsContentComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+  }
+
   componentDidMount() {
     this.subscription = interval$.subscribe(() => {
       if (this.props.isOpen) {
@@ -32,11 +39,46 @@ class StixDomainObjectsExportsContentComponent extends Component {
     this.subscription.unsubscribe();
   }
 
+  handleOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
   render() {
     const { t, data, exportContext, paginationOptions } = this.props;
     const stixDomainObjectsExportFiles = data?.stixDomainObjectsExportFiles?.edges ?? [];
+
+    const connectorsExport = data?.connectorsForExport ?? [];
+    const exportScopes = uniq(
+      flatten(map((c) => c.connector_scope, connectorsExport)),
+    );
+    const exportConnsPerFormat = scopesConn(connectorsExport);
+    const isExportActive = (format) => filter((x) => x.data.active, exportConnsPerFormat[format]).length > 0;
+    const isExportPossible = filter((x) => isExportActive(x), exportScopes).length > 0;
+
     return (
       <>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', paddingBottom: 8 }}>
+          <Tooltip
+            title={
+              isExportPossible
+                ? t('Generate an export')
+                : t('No export connector available to generate an export')
+            }
+            aria-label="generate-export"
+          >
+            <Button
+              onClick={this.handleOpen.bind(this)}
+              color="secondary"
+              disabled={!isExportPossible}
+            >
+              {t('Generate an export')}
+            </Button>
+          </Tooltip>
+        </div>
         <List>
           {stixDomainObjectsExportFiles.length > 0 ? (
             stixDomainObjectsExportFiles.map(
@@ -69,7 +111,11 @@ class StixDomainObjectsExportsContentComponent extends Component {
             data={data}
             exportContext={exportContext}
             paginationOptions={paginationOptions}
+            open={this.state.open}
+            onClose={this.handleClose}
             onExportAsk={() => this.props.relay.refetch({ count: 25, exportContext: this.props.exportContext })}
+            exportScopes={exportScopes}
+            isExportActive={isExportActive}
           />
         </Security>
       </>
@@ -105,7 +151,13 @@ const StixDomainObjectsExportsContent = createRefetchContainer(
             }
           }
         }
-        ...StixDomainObjectsExportCreation_data
+        connectorsForExport {
+          id
+          name
+          active
+          connector_scope
+          updated_at
+        }
       }
     `,
   },


### PR DESCRIPTION
### Proposed changes

* Change the FAB buttons into primary buttons.
* Move export creation button to StixDomainObjectsExportsContent.
* Move export creation button to StixCoreObjectsExportsContent.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/13303?reload=1
