### PR TITLE
[backend/client] Support noTriggerImport at file upload in entities (#14297)

### DIFF
--- a/client-python/.gitignore
+++ b/client-python/.gitignore
@@ -3,6 +3,7 @@ config.yml
 exports
 logs
 test.py
+test.json
 examples/*.json
 examples/*.pdf
 Pipfile*

--- a/client-python/pycti/entities/opencti_attack_pattern.py
+++ b/client-python/pycti/entities/opencti_attack_pattern.py
@@ -525,6 +525,7 @@ class AttackPattern:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -565,6 +566,7 @@ class AttackPattern:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -741,6 +743,7 @@ class AttackPattern:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_campaign.py
+++ b/client-python/pycti/entities/opencti_campaign.py
@@ -490,6 +490,7 @@ class Campaign:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -531,6 +532,7 @@ class Campaign:
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -643,6 +645,7 @@ class Campaign:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_case_incident.py
+++ b/client-python/pycti/entities/opencti_case_incident.py
@@ -780,6 +780,7 @@ class CaseIncident:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -821,6 +822,7 @@ class CaseIncident:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1060,6 +1062,7 @@ class CaseIncident:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_case_rfi.py
+++ b/client-python/pycti/entities/opencti_case_rfi.py
@@ -814,6 +814,7 @@ class CaseRfi:
         information_types = kwargs.get("information_types", None)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -855,6 +856,7 @@ class CaseRfi:
                 "information_types": information_types,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1096,6 +1098,7 @@ class CaseRfi:
                 ),
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
             )
         else:
             self.opencti.app_logger.error(

--- a/client-python/pycti/entities/opencti_case_rft.py
+++ b/client-python/pycti/entities/opencti_case_rft.py
@@ -815,6 +815,7 @@ class CaseRft:
         takedown_types = kwargs.get("takedown_types", None)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -856,6 +857,7 @@ class CaseRft:
                 "takedown_types": takedown_types,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1091,6 +1093,7 @@ class CaseRft:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_channel.py
+++ b/client-python/pycti/entities/opencti_channel.py
@@ -461,6 +461,7 @@ class Channel:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -496,6 +497,7 @@ class Channel:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -594,6 +596,7 @@ class Channel:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_course_of_action.py
+++ b/client-python/pycti/entities/opencti_course_of_action.py
@@ -488,6 +488,7 @@ class CourseOfAction:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -527,6 +528,7 @@ class CourseOfAction:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -660,6 +662,7 @@ class CourseOfAction:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_data_component.py
+++ b/client-python/pycti/entities/opencti_data_component.py
@@ -516,6 +516,7 @@ class DataComponent:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -552,6 +553,7 @@ class DataComponent:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -675,6 +677,7 @@ class DataComponent:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_data_source.py
+++ b/client-python/pycti/entities/opencti_data_source.py
@@ -485,6 +485,7 @@ class DataSource:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -522,6 +523,7 @@ class DataSource:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -649,6 +651,7 @@ class DataSource:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_event.py
+++ b/client-python/pycti/entities/opencti_event.py
@@ -484,6 +484,7 @@ class Event:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -520,6 +521,7 @@ class Event:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -617,6 +619,7 @@ class Event:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_external_reference.py
+++ b/client-python/pycti/entities/opencti_external_reference.py
@@ -286,6 +286,7 @@ class ExternalReference:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
 
         if source_name is not None or url is not None:
             self.opencti.app_logger.info(
@@ -314,6 +315,7 @@ class ExternalReference:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
             }
             result = self.opencti.query(query, {"input": input_variables})
             return self.opencti.process_multiple_fields(

--- a/client-python/pycti/entities/opencti_feedback.py
+++ b/client-python/pycti/entities/opencti_feedback.py
@@ -741,6 +741,7 @@ class Feedback:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -777,6 +778,7 @@ class Feedback:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1012,6 +1014,7 @@ class Feedback:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_grouping.py
+++ b/client-python/pycti/entities/opencti_grouping.py
@@ -760,6 +760,7 @@ class Grouping:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None and context is not None:
@@ -798,6 +799,7 @@ class Grouping:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1004,6 +1006,7 @@ class Grouping:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_identity.py
+++ b/client-python/pycti/entities/opencti_identity.py
@@ -520,6 +520,7 @@ class Identity:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if type is not None and name is not None:
@@ -546,6 +547,7 @@ class Identity:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             if type == IdentityTypes.ORGANIZATION.value:
@@ -819,6 +821,7 @@ class Identity:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_incident.py
+++ b/client-python/pycti/entities/opencti_incident.py
@@ -510,6 +510,7 @@ class Incident:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -554,6 +555,7 @@ class Incident:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -673,6 +675,7 @@ class Incident:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_indicator.py
+++ b/client-python/pycti/entities/opencti_indicator.py
@@ -324,6 +324,7 @@ class Indicator:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if (
@@ -389,6 +390,7 @@ class Indicator:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -677,6 +679,7 @@ class Indicator:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_infrastructure.py
+++ b/client-python/pycti/entities/opencti_infrastructure.py
@@ -522,6 +522,7 @@ class Infrastructure:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -564,6 +565,7 @@ class Infrastructure:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -688,6 +690,7 @@ class Infrastructure:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_intrusion_set.py
+++ b/client-python/pycti/entities/opencti_intrusion_set.py
@@ -505,6 +505,7 @@ class IntrusionSet:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -549,6 +550,7 @@ class IntrusionSet:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -678,6 +680,7 @@ class IntrusionSet:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_language.py
+++ b/client-python/pycti/entities/opencti_language.py
@@ -478,6 +478,7 @@ class Language:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
 
         if name is not None:
             self.opencti.app_logger.info("Creating Language", {"name": name})
@@ -512,6 +513,7 @@ class Language:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                     }
                 },
             )
@@ -590,6 +592,7 @@ class Language:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
             )
         else:
             self.opencti.app_logger.error(

--- a/client-python/pycti/entities/opencti_location.py
+++ b/client-python/pycti/entities/opencti_location.py
@@ -518,6 +518,7 @@ class Location:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -559,6 +560,7 @@ class Location:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -690,6 +692,7 @@ class Location:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_malware.py
+++ b/client-python/pycti/entities/opencti_malware.py
@@ -543,6 +543,7 @@ class Malware:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -590,6 +591,7 @@ class Malware:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -728,6 +730,7 @@ class Malware:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_malware_analysis.py
+++ b/client-python/pycti/entities/opencti_malware_analysis.py
@@ -527,6 +527,7 @@ class MalwareAnalysis:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if product is not None and result_name is not None:
@@ -580,6 +581,7 @@ class MalwareAnalysis:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -737,6 +739,7 @@ class MalwareAnalysis:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_narrative.py
+++ b/client-python/pycti/entities/opencti_narrative.py
@@ -468,6 +468,7 @@ class Narrative:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -504,6 +505,7 @@ class Narrative:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -613,6 +615,7 @@ class Narrative:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_note.py
+++ b/client-python/pycti/entities/opencti_note.py
@@ -771,6 +771,7 @@ class Note:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if content is not None:
@@ -809,6 +810,7 @@ class Note:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1022,6 +1024,7 @@ class Note:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_observed_data.py
+++ b/client-python/pycti/entities/opencti_observed_data.py
@@ -709,6 +709,7 @@ class ObservedData:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if (
@@ -750,6 +751,7 @@ class ObservedData:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1000,6 +1002,7 @@ class ObservedData:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_opinion.py
+++ b/client-python/pycti/entities/opencti_opinion.py
@@ -524,6 +524,7 @@ class Opinion:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
 
         if opinion is not None:
             self.opencti.app_logger.info("Creating Opinion", {"opinion": opinion})
@@ -559,6 +560,7 @@ class Opinion:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
             }
             result = self.opencti.query(query, {"input": input_variables})
             return self.opencti.process_multiple_fields(result["data"]["opinionAdd"])
@@ -757,6 +759,7 @@ class Opinion:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
             )
         else:
             self.opencti.app_logger.error(

--- a/client-python/pycti/entities/opencti_report.py
+++ b/client-python/pycti/entities/opencti_report.py
@@ -815,6 +815,7 @@ class Report:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None and published is not None:
@@ -856,6 +857,7 @@ class Report:
                 "update": update,
                 "files": files,
                 "filesMarkings": files_markings,
+                "noTriggerImport": no_trigger_import,
                 "upsertOperations": upsert_operations,
             }
             result = self.opencti.query(query, {"input": input_variables})
@@ -1102,6 +1104,7 @@ class Report:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_security_coverage.py
+++ b/client-python/pycti/entities/opencti_security_coverage.py
@@ -277,6 +277,7 @@ class SecurityCoverage:
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
 
         if name is not None and object_covered is not None:
             self.opencti.app_logger.info("Creating Security Coverage", {"name": name})
@@ -315,6 +316,7 @@ class SecurityCoverage:
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                     }
                 },
             )
@@ -434,6 +436,7 @@ class SecurityCoverage:
                 ),
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
             )
         else:
             self.opencti.app_logger.error(

--- a/client-python/pycti/entities/opencti_stix_cyber_observable.py
+++ b/client-python/pycti/entities/opencti_stix_cyber_observable.py
@@ -327,6 +327,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
         resolve_result_indicators = kwargs.get("resolve_result_indicators", True)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         create_indicator = (
@@ -577,6 +578,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     "rir": observable_data["rir"] if "rir" in observable_data else None,
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Directory":
                 input_variables["Directory"] = {
@@ -597,12 +599,14 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Domain-Name":
                 input_variables["DomainName"] = {
                     "value": observable_data["value"],
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
                 if attribute is not None:
                     input_variables["DomainName"][attribute] = simple_observable_value
@@ -616,6 +620,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Email-Message":
                 input_variables["EmailMessage"] = {
@@ -647,6 +652,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Email-Mime-Part-Type":
                 input_variables["EmailMimePartType"] = {
@@ -665,6 +671,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Artifact":
                 if (
@@ -704,6 +711,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "StixFile":
                 if (
@@ -757,6 +765,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "X509-Certificate":
                 input_variables["X509Certificate"] = {
@@ -898,6 +907,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "SSH-Key" or type.lower() == "ssh-key":
                 input_variables["SSHKey"] = {
@@ -943,6 +953,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "IPv4-Addr":
                 input_variables["IPv4Addr"] = {
@@ -951,6 +962,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "IPv6-Addr":
                 input_variables["IPv6Addr"] = {
@@ -959,6 +971,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Mac-Addr":
                 input_variables["MacAddr"] = {
@@ -967,6 +980,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Mutex":
                 input_variables["Mutex"] = {
@@ -975,6 +989,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Network-Traffic":
                 input_variables["NetworkTraffic"] = {
@@ -1034,6 +1049,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Process":
                 input_variables["Process"] = {
@@ -1061,6 +1077,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Software":
                 if (
@@ -1105,6 +1122,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Url":
                 input_variables["Url"] = {
@@ -1113,6 +1131,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "User-Account":
                 input_variables["UserAccount"] = {
@@ -1188,6 +1207,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Windows-Registry-Key":
                 input_variables["WindowsRegistryKey"] = {
@@ -1206,6 +1226,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Windows-Registry-Value-Type":
                 input_variables["WindowsRegistryValueType"] = {
@@ -1222,6 +1243,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "User-Agent":
                 input_variables["UserAgent"] = {
@@ -1230,6 +1252,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Cryptographic-Key":
                 input_variables["CryptographicKey"] = {
@@ -1238,6 +1261,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Hostname":
                 input_variables["Hostname"] = {
@@ -1246,6 +1270,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Text":
                 input_variables["Text"] = {
@@ -1254,6 +1279,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Bank-Account":
                 input_variables["BankAccount"] = {
@@ -1268,6 +1294,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Phone-Number":
                 input_variables["PhoneNumber"] = {
@@ -1276,6 +1303,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Payment-Card":
                 input_variables["PaymentCard"] = {
@@ -1297,6 +1325,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Media-Content":
                 input_variables["MediaContent"] = {
@@ -1321,6 +1350,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Persona":
                 input_variables["Persona"] = {
@@ -1336,6 +1366,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Payment-Card" or type.lower() == "x-opencti-payment-card":
                 input_variables["PaymentCard"] = {
@@ -1357,6 +1388,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif (
                 type == "Cryptocurrency-Wallet"
@@ -1368,6 +1400,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif type == "Credential" or type.lower() == "x-opencti-credential":
                 input_variables["Credential"] = {
@@ -1376,6 +1409,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             elif (
                 type == "Tracking-Number" or type.lower() == "x-opencti-tracking-number"
@@ -1386,6 +1420,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                     "files": files,
                     "filesMarkings": files_markings,
+                    "noTriggerImport": no_trigger_import,
                 }
             result = self.opencti.query(query, input_variables)
             if "payload_bin" in observable_data and "mime_type" in observable_data:

--- a/client-python/pycti/entities/opencti_task.py
+++ b/client-python/pycti/entities/opencti_task.py
@@ -515,6 +515,7 @@ class Task:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -549,6 +550,7 @@ class Task:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -780,6 +782,7 @@ class Task:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_threat_actor_group.py
+++ b/client-python/pycti/entities/opencti_threat_actor_group.py
@@ -422,6 +422,7 @@ class ThreatActorGroup:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -470,6 +471,7 @@ class ThreatActorGroup:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -613,6 +615,7 @@ class ThreatActorGroup:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_threat_actor_individual.py
+++ b/client-python/pycti/entities/opencti_threat_actor_individual.py
@@ -429,6 +429,7 @@ class ThreatActorIndividual:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -479,6 +480,7 @@ class ThreatActorIndividual:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -621,6 +623,7 @@ class ThreatActorIndividual:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_tool.py
+++ b/client-python/pycti/entities/opencti_tool.py
@@ -395,6 +395,7 @@ class Tool:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -436,6 +437,7 @@ class Tool:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -553,6 +555,7 @@ class Tool:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/entities/opencti_vulnerability.py
+++ b/client-python/pycti/entities/opencti_vulnerability.py
@@ -565,6 +565,7 @@ class Vulnerability:
         update = kwargs.get("update", False)
         files = kwargs.get("files", None)
         files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", False)
         upsert_operations = kwargs.get("upsert_operations", None)
 
         if name is not None:
@@ -655,6 +656,7 @@ class Vulnerability:
                         "update": update,
                         "files": files,
                         "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
                         "upsertOperations": upsert_operations,
                     }
                 },
@@ -1326,6 +1328,7 @@ class Vulnerability:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=(
                     stix_object["opencti_upsert_operations"]
                     if "opencti_upsert_operations" in stix_object

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -646,6 +646,7 @@ class OpenCTIStix2:
                         # Prepare all files for upload during creation
                         files_to_upload = []
                         files_markings = []
+                        no_trigger_import = False
                         for file_obj in ext_ref_files:
                             data = None
                             if "data" in file_obj:
@@ -670,6 +671,9 @@ class OpenCTIStix2:
                                 files_markings.append(
                                     file_obj.get("object_marking_refs", None)
                                 )
+                                # Check if any file requires no trigger import
+                                if file_obj.get("no_trigger_import", False):
+                                    no_trigger_import = True
 
                         # Create external reference with all files attached
                         external_reference_id = self.opencti.external_reference.create(
@@ -683,6 +687,7 @@ class OpenCTIStix2:
                             ),
                             files=files_to_upload if files_to_upload else None,
                             filesMarkings=files_markings if files_markings else None,
+                            noTriggerImport=no_trigger_import,
                         )["id"]
 
                     external_references_ids.append(external_reference_id)
@@ -821,6 +826,7 @@ class OpenCTIStix2:
                     # Prepare all files for direct upload during creation
                     files_to_upload = []
                     files_markings = []
+                    no_trigger_import = False
                     all_files = []
                     if "x_opencti_files" in external_reference:
                         all_files = external_reference["x_opencti_files"]
@@ -858,6 +864,9 @@ class OpenCTIStix2:
                             files_markings.append(
                                 file_obj.get("object_marking_refs", None)
                             )
+                            # Check if any file requires no trigger import
+                            if file_obj.get("no_trigger_import", False):
+                                no_trigger_import = True
 
                     external_reference_id = self.opencti.external_reference.create(
                         source_name=source_name,
@@ -870,6 +879,7 @@ class OpenCTIStix2:
                         ),
                         files=files_to_upload if files_to_upload else None,
                         filesMarkings=files_markings if files_markings else None,
+                        noTriggerImport=no_trigger_import,
                     )["id"]
 
                 external_references_ids.append(external_reference_id)
@@ -1122,6 +1132,7 @@ class OpenCTIStix2:
         # Prepare all files for direct upload during creation
         files_to_upload = []
         files_markings = []
+        no_trigger_import = False
         for file_obj in x_opencti_files:
             data = None
             if "data" in file_obj:
@@ -1140,6 +1151,9 @@ class OpenCTIStix2:
                     )
                 )
                 files_markings.append(file_obj.get("object_marking_refs", None))
+                # Check if any file requires no trigger import
+                if file_obj.get("no_trigger_import", False):
+                    no_trigger_import = True
 
         # Extra
         extras = {
@@ -1154,6 +1168,7 @@ class OpenCTIStix2:
             "sample_ids": sample_refs_ids,
             "files": files_to_upload if files_to_upload else None,
             "filesMarkings": files_markings if files_markings else None,
+            "noTriggerImport": no_trigger_import,
         }
 
         stix_helper = self.get_stix_helper().get(stix_object["type"])
@@ -1244,6 +1259,7 @@ class OpenCTIStix2:
         # Prepare all files for direct upload during creation
         files_to_upload = []
         files_markings = []
+        no_trigger_import = False
         for file_obj in x_opencti_files:
             data = None
             if "data" in file_obj:
@@ -1262,6 +1278,9 @@ class OpenCTIStix2:
                     )
                 )
                 files_markings.append(file_obj.get("object_marking_refs", None))
+                # Check if any file requires no trigger import
+                if file_obj.get("no_trigger_import", False):
+                    no_trigger_import = True
 
         # Extra
         extras = {
@@ -1277,6 +1296,7 @@ class OpenCTIStix2:
             "sample_ids": sample_refs_ids,
             "files": files_to_upload if files_to_upload else None,
             "filesMarkings": files_markings if files_markings else None,
+            "noTriggerImport": no_trigger_import,
         }
         upsert_operations = self.opencti.get_attribute_in_extension(
             "opencti_upsert_operations", stix_object
@@ -1325,6 +1345,7 @@ class OpenCTIStix2:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=upsert_operations,
             )
         else:
@@ -1352,6 +1373,7 @@ class OpenCTIStix2:
                 update=update,
                 files=extras.get("files"),
                 filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", False),
                 upsert_operations=upsert_operations,
             )
         if stix_observable_result is not None:

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -823,23 +823,26 @@ class OpenCTIStix2:
                 if generated_ref_id is None:
                     continue
                 else:
-                    # Prepare all files for direct upload during creation
-                    files_to_upload = []
-                    files_markings = []
-                    no_trigger_import = False
+                    # Collect files from both x_opencti_files and extension
                     all_files = []
                     if "x_opencti_files" in external_reference:
-                        all_files = external_reference["x_opencti_files"]
-                    elif (
+                        all_files.extend(external_reference["x_opencti_files"])
+                    if (
                         self.opencti.get_attribute_in_extension(
                             "files", external_reference
                         )
                         is not None
                     ):
-                        all_files = self.opencti.get_attribute_in_extension(
-                            "files", external_reference
+                        all_files.extend(
+                            self.opencti.get_attribute_in_extension(
+                                "files", external_reference
+                            )
                         )
 
+                    # Prepare all files for direct upload during creation
+                    files_to_upload = []
+                    files_markings = []
+                    no_trigger_import = False
                     for file_obj in all_files:
                         data = None
                         if "data" in file_obj:

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2715,6 +2715,7 @@ input ExternalReferenceAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   external_id: String
   created: DateTime
   modified: DateTime
@@ -3139,6 +3140,7 @@ input AttackPatternAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -3288,6 +3290,7 @@ input CampaignAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -3490,6 +3493,7 @@ input NoteAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -3633,6 +3637,7 @@ input ObservedDataAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -3753,6 +3758,7 @@ input OpinionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
 }
 
 input OpinionUserAddInput {
@@ -3906,6 +3912,7 @@ input ReportAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   authorized_members: [MemberAccessInput!]
   upsertOperations: [EditInput!]
 }
@@ -4022,6 +4029,7 @@ input CourseOfActionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4139,6 +4147,7 @@ input IdentityAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   update: Boolean
   upsertOperations: [EditInput!]
 }
@@ -4262,6 +4271,7 @@ input IndividualAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4381,6 +4391,7 @@ input SectorAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4502,6 +4513,7 @@ input SystemAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4625,6 +4637,7 @@ input InfrastructureAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4752,6 +4765,7 @@ input IntrusionSetAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4866,6 +4880,7 @@ input LocationAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4986,6 +5001,7 @@ input PositionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5105,6 +5121,7 @@ input CityAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5219,6 +5236,7 @@ input CountryAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5335,6 +5353,7 @@ input RegionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5474,6 +5493,7 @@ input MalwareAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5691,6 +5711,7 @@ input ThreatActorGroupAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5806,6 +5827,7 @@ input ToolAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6016,6 +6038,7 @@ input VulnerabilityAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6148,6 +6171,7 @@ input IncidentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6278,6 +6302,7 @@ input AutonomousSystemAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6344,6 +6369,7 @@ input DirectoryAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6402,6 +6428,7 @@ input DomainNameAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6462,6 +6489,7 @@ input EmailAddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6532,6 +6560,7 @@ input EmailMessageAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6594,6 +6623,7 @@ input EmailMimePartTypeAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6736,6 +6766,7 @@ input ArtifactAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6815,6 +6846,7 @@ input StixFileAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6927,6 +6959,7 @@ input X509CertificateAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6988,6 +7021,7 @@ input IPv4AddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7047,6 +7081,7 @@ input IPv6AddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7105,6 +7140,7 @@ input MacAddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7163,6 +7199,7 @@ input MutexAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7244,6 +7281,7 @@ input NetworkTrafficAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7344,6 +7382,7 @@ input ProcessAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7425,6 +7464,7 @@ input SoftwareAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7483,6 +7523,7 @@ input UrlAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7568,6 +7609,7 @@ input UserAccountAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7629,6 +7671,7 @@ input WindowsRegistryKeyAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   number_of_subkeys: Int
   upsertOperations: [EditInput!]
 }
@@ -7692,6 +7735,7 @@ input WindowsRegistryValueTypeAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7750,6 +7794,7 @@ input CryptographicKeyAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7808,6 +7853,7 @@ input CryptocurrencyWalletAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7866,6 +7912,7 @@ input HostnameAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7924,6 +7971,7 @@ input TextAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7982,6 +8030,7 @@ input UserAgentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8044,6 +8093,7 @@ input BankAccountAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8102,6 +8152,7 @@ input TrackingNumberAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8160,6 +8211,7 @@ input CredentialAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8218,6 +8270,7 @@ input PhoneNumberAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8282,6 +8335,7 @@ input PaymentCardAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8349,6 +8403,7 @@ input MediaContentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8410,6 +8465,7 @@ input PersonaAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8486,6 +8542,7 @@ input SSHKeyAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8972,6 +9029,7 @@ input StixRefRelationshipAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
 }
 
 input StixRefRelationshipsAddInput {
@@ -10420,6 +10478,7 @@ input ChannelAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -10560,6 +10619,7 @@ input LanguageAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
 }
 
 type Event implements BasicObject & StixCoreObject & StixDomainObject & StixObject {
@@ -10677,6 +10737,7 @@ input EventAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -10806,6 +10867,7 @@ input GroupingAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   authorized_members: [MemberAccessInput!]
   upsertOperations: [EditInput!]
 }
@@ -10921,6 +10983,7 @@ input NarrativeAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   x_opencti_modified_at: DateTime
   x_opencti_workflow_id: String
   upsertOperations: [EditInput!]
@@ -11202,6 +11265,7 @@ input DataComponentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   x_opencti_workflow_id: String
   x_opencti_modified_at: DateTime
   upsertOperations: [EditInput!]
@@ -11317,6 +11381,7 @@ input DataSourceAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   x_opencti_workflow_id: String
   x_opencti_modified_at: DateTime
   upsertOperations: [EditInput!]
@@ -11561,6 +11626,7 @@ input AdministrativeAreaAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -11678,6 +11744,7 @@ input TaskAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -11984,6 +12051,7 @@ input CaseIncidentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   update: Boolean
   authorized_members: [MemberAccessInput!]
@@ -12126,6 +12194,7 @@ input CaseRfiAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   update: Boolean
   information_types: [String!]
@@ -12262,6 +12331,7 @@ input CaseRftAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   x_opencti_modified_at: DateTime
   x_opencti_workflow_id: String
@@ -12394,6 +12464,7 @@ input FeedbackAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   update: Boolean
   rating: Int
@@ -12685,6 +12756,7 @@ input MalwareAnalysisAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -12928,6 +13000,7 @@ input ThreatActorIndividualAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -13600,6 +13673,7 @@ input IndicatorAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   basedOn: [String!]
   upsertOperations: [EditInput!]
 }
@@ -13829,6 +13903,7 @@ input OrganizationAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -14959,6 +15034,7 @@ input SecurityPlatformAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -15088,6 +15164,7 @@ input SecurityCoverageAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   update: Boolean
   auto_enrichment_disable: Boolean!
   periodicity: String

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2650,6 +2650,7 @@ input ExternalReferenceAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   external_id: String
   created: DateTime
   modified: DateTime
@@ -3305,6 +3306,7 @@ input AttackPatternAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type AttackPatternForMatrix {
@@ -3519,6 +3521,7 @@ input CampaignAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -3901,6 +3904,7 @@ input NoteAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 input NoteUserAddInput {
@@ -4140,6 +4144,7 @@ input ObservedDataAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4357,6 +4362,7 @@ input OpinionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
 }
 input OpinionUserAddInput {
   stix_id: String
@@ -4606,6 +4612,7 @@ input ReportAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   authorized_members: [MemberAccessInput!]
   upsertOperations: [EditInput!]
 }
@@ -4792,6 +4799,7 @@ input CourseOfActionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -4977,6 +4985,7 @@ input IdentityAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   update: Boolean
   upsertOperations: [EditInput!]
 }
@@ -5171,6 +5180,7 @@ input IndividualAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5361,6 +5371,7 @@ input SectorAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5553,6 +5564,7 @@ input SystemAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5746,6 +5758,7 @@ input InfrastructureAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -5943,6 +5956,7 @@ input IntrusionSetAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6126,6 +6140,7 @@ input LocationAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6317,6 +6332,7 @@ input PositionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6507,6 +6523,7 @@ input CityAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6691,6 +6708,7 @@ input CountryAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -6878,6 +6896,7 @@ input RegionAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7086,6 +7105,7 @@ input MalwareAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7451,6 +7471,7 @@ input ThreatActorGroupAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7636,6 +7657,7 @@ input ToolAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -7924,6 +7946,7 @@ input VulnerabilityAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8126,6 +8149,7 @@ input IncidentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -8401,6 +8425,7 @@ input AutonomousSystemAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Directory implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -8540,6 +8565,7 @@ input DirectoryAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type DomainName implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -8671,6 +8697,7 @@ input DomainNameAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type EmailAddr implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -8804,6 +8831,7 @@ input EmailAddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type EmailMessage implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -8947,6 +8975,7 @@ input EmailMessageAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type EmailMimePartType implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -9082,6 +9111,7 @@ input EmailMimePartTypeAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 ############## HashedObservable
@@ -9366,6 +9396,7 @@ input ArtifactAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type StixFile implements BasicObject & StixObject & StixCoreObject & StixCyberObservable & HashedObservable {
@@ -9519,6 +9550,7 @@ input StixFileAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type X509Certificate implements BasicObject & StixObject & StixCoreObject & StixCyberObservable & HashedObservable {
@@ -9707,6 +9739,7 @@ input X509CertificateAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type IPv4Addr implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -9841,6 +9874,7 @@ input IPv4AddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type IPv6Addr implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -9973,6 +10007,7 @@ input IPv6AddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type MacAddr implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -10104,6 +10139,7 @@ input MacAddrAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Mutex implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -10235,6 +10271,7 @@ input MutexAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type NetworkTraffic implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -10389,6 +10426,7 @@ input NetworkTrafficAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Process implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -10566,6 +10604,7 @@ input ProcessAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Software implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -10718,6 +10757,7 @@ input SoftwareAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Url implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -10849,6 +10889,7 @@ input UrlAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type UserAccount implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11007,6 +11048,7 @@ input UserAccountAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type WindowsRegistryKey implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11141,6 +11183,7 @@ input WindowsRegistryKeyAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   number_of_subkeys: Int
   upsertOperations: [EditInput!]
 }
@@ -11277,6 +11320,7 @@ input WindowsRegistryValueTypeAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type CryptographicKey implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11408,6 +11452,7 @@ input CryptographicKeyAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type CryptocurrencyWallet implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11539,6 +11584,7 @@ input CryptocurrencyWalletAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Hostname implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11670,6 +11716,7 @@ input HostnameAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Text implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11801,6 +11848,7 @@ input TextAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type UserAgent implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -11932,6 +11980,7 @@ input UserAgentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type BankAccount implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12068,6 +12117,7 @@ input BankAccountAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type TrackingNumber implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12202,6 +12252,7 @@ input TrackingNumberAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Credential implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12336,6 +12387,7 @@ input CredentialAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type PhoneNumber implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12467,6 +12519,7 @@ input PhoneNumberAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type PaymentCard implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12604,6 +12657,7 @@ input PaymentCardAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type MediaContent implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12744,6 +12798,7 @@ input MediaContentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 type Persona implements BasicObject & StixObject & StixCoreObject & StixCyberObservable {
@@ -12877,6 +12932,7 @@ input PersonaAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 
@@ -13023,6 +13079,7 @@ input SSHKeyAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 ###### RELATIONSHIPS
@@ -13797,6 +13854,7 @@ input StixRefRelationshipAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
 }
 input StixRefRelationshipsAddInput {
   relationship_type: String!

--- a/opencti-platform/opencti-graphql/src/database/data-builder.js
+++ b/opencti-platform/opencti-graphql/src/database/data-builder.js
@@ -47,6 +47,7 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
     R.dissoc('fileMarkings'),
     R.dissoc('files'),
     R.dissoc('filesMarkings'),
+    R.dissoc('noTriggerImport'),
     R.omit(schemaRelationsRefDefinition.getInputNames(input.entity_type)),
   )(input);
   if (inferred) {

--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -3387,6 +3387,7 @@ const internalCreateEntityRaw = async (context, user, rawInput, type, opts = {})
     // Process all files to upload
     if (filesToUpload.length > 0) {
       const isAutoExternal = entitySetting?.platform_entity_files_ref;
+      const noTriggerImport = resolvedInput.noTriggerImport ?? false;
       const path = `import/${type}/${dataEntity.element[ID_INTERNAL]}`;
       const uploadedFiles = [];
       for (let i = 0; i < filesToUpload.length; i += 1) {
@@ -3394,7 +3395,7 @@ const internalCreateEntityRaw = async (context, user, rawInput, type, opts = {})
         const { filename } = await fileInput;
         const key = `${path}/${filename}`;
         const meta = isAutoExternal ? { external_reference_id: generateStandardId(ENTITY_TYPE_EXTERNAL_REFERENCE, { url: `/storage/get/${key}` }) } : {};
-        const { upload: uploadedFile } = await uploadToStorage(context, user, path, fileInput, { entity: dataEntity.element, file_markings, meta });
+        const { upload: uploadedFile } = await uploadToStorage(context, user, path, fileInput, { entity: dataEntity.element, file_markings, meta, noTriggerImport });
         uploadedFiles.push(storeFileConverter(user, uploadedFile));
         // Add external references from files if necessary
         if (isAutoExternal) {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -324,6 +324,7 @@ export type AdministrativeAreaAddInput = {
   longitude?: InputMaybe<Scalars['Float']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -662,6 +663,7 @@ export type ArtifactAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   hashes?: InputMaybe<Array<InputMaybe<HashInput>>>;
   mime_type?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   payload_bin?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   url?: InputMaybe<Scalars['String']['input']>;
@@ -957,6 +959,7 @@ export type AttackPatternAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -1369,6 +1372,7 @@ export type AutonomousSystemAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   name?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   number: Scalars['Int']['input'];
   rir?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
@@ -1706,6 +1710,7 @@ export type BankAccountAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   iban?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
 
@@ -1981,6 +1986,7 @@ export type CampaignAddInput = {
   last_seen?: InputMaybe<Scalars['DateTime']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -2677,6 +2683,7 @@ export type CaseIncidentAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -3004,6 +3011,7 @@ export type CaseRfiAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -3326,6 +3334,7 @@ export type CaseRftAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -3700,6 +3709,7 @@ export type ChannelAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -3987,6 +3997,7 @@ export type CityAddInput = {
   longitude?: InputMaybe<Scalars['Float']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -4793,6 +4804,7 @@ export type CountryAddInput = {
   longitude?: InputMaybe<Scalars['Float']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   precision?: InputMaybe<Scalars['Float']['input']>;
@@ -5079,6 +5091,7 @@ export type CourseOfActionAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -5385,6 +5398,7 @@ export type CredentialAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -5594,6 +5608,7 @@ export type CryptocurrencyWalletAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -5803,6 +5818,7 @@ export type CryptographicKeyAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -6185,6 +6201,7 @@ export type DataComponentAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -6450,6 +6467,7 @@ export type DataSourceAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -6913,6 +6931,7 @@ export type DirectoryAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   mtime?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   path: Scalars['String']['input'];
   path_enc?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
@@ -7200,6 +7219,7 @@ export type DomainNameAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value: Scalars['String']['input'];
 };
@@ -7557,6 +7577,7 @@ export type EmailAddrAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -7777,6 +7798,7 @@ export type EmailMessageAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   is_multipart?: InputMaybe<Scalars['Boolean']['input']>;
   message_id?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   received_lines?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   subject?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
@@ -7992,6 +8014,7 @@ export type EmailMimePartTypeAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
 
@@ -8314,6 +8337,7 @@ export type EventAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   revoked?: InputMaybe<Scalars['Boolean']['input']>;
@@ -8510,6 +8534,7 @@ export type ExternalReferenceAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   hash?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   source_name: Scalars['String']['input'];
   stix_id?: InputMaybe<Scalars['StixId']['input']>;
   update?: InputMaybe<Scalars['Boolean']['input']>;
@@ -8939,6 +8964,7 @@ export type FeedbackAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -9655,6 +9681,7 @@ export type GroupingAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -10155,6 +10182,7 @@ export type HostnameAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -10366,6 +10394,7 @@ export type IPv4AddrAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   resolvesTo?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
@@ -10577,6 +10606,7 @@ export type IPv6AddrAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -10811,6 +10841,7 @@ export type IdentityAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   revoked?: InputMaybe<Scalars['Boolean']['input']>;
@@ -11123,6 +11154,7 @@ export type IncidentAddInput = {
   last_seen?: InputMaybe<Scalars['DateTime']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -11484,6 +11516,7 @@ export type IndicatorAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<Scalars['String']['input']>>;
   objectMarking?: InputMaybe<Array<Scalars['String']['input']>>;
   objectOrganization?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -11795,6 +11828,7 @@ export type IndividualAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -12114,6 +12148,7 @@ export type InfrastructureAddInput = {
   last_seen?: InputMaybe<Scalars['DateTime']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -12804,6 +12839,7 @@ export type IntrusionSetAddInput = {
   last_seen?: InputMaybe<Scalars['DateTime']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -13392,6 +13428,7 @@ export type LanguageAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -13679,6 +13716,7 @@ export type LocationAddInput = {
   longitude?: InputMaybe<Scalars['Float']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   precision?: InputMaybe<Scalars['Float']['input']>;
@@ -14009,6 +14047,7 @@ export type MacAddrAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -14255,6 +14294,7 @@ export type MalwareAddInput = {
   malware_types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -14528,6 +14568,7 @@ export type MalwareAnalysisAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   modules?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -15089,6 +15130,7 @@ export type MediaContentAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   media_category?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   publication_date?: InputMaybe<Scalars['DateTime']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
@@ -18359,6 +18401,7 @@ export type MutexAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   name?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
 
@@ -18598,6 +18641,7 @@ export type NarrativeAddInput = {
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
   narrative_types?: InputMaybe<Array<Scalars['String']['input']>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -18859,6 +18903,7 @@ export type NetworkTrafficAddInput = {
   is_active?: InputMaybe<Scalars['Boolean']['input']>;
   networkDst?: InputMaybe<Scalars['String']['input']>;
   networkSrc?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   protocols?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   src_byte_count?: InputMaybe<Scalars['Int']['input']>;
   src_packets?: InputMaybe<Scalars['Int']['input']>;
@@ -19137,6 +19182,7 @@ export type NoteAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   likelihood?: InputMaybe<Scalars['Int']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   note_types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -19639,6 +19685,7 @@ export type ObservedDataAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   last_observed: Scalars['DateTime']['input'];
   modified?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   number_observed: Scalars['Int']['input'];
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -19989,6 +20036,7 @@ export type OpinionAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -20348,6 +20396,7 @@ export type OrganizationAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   revoked?: InputMaybe<Scalars['Boolean']['input']>;
@@ -20680,6 +20729,7 @@ export type PaymentCardAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   holder_name?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
 
@@ -20889,6 +20939,7 @@ export type PersonaAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   persona_name: Scalars['String']['input'];
   persona_type: Scalars['String']['input'];
   upsertOperations?: InputMaybe<Array<EditInput>>;
@@ -21099,6 +21150,7 @@ export type PhoneNumberAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -21673,6 +21725,7 @@ export type PositionAddInput = {
   longitude?: InputMaybe<Scalars['Float']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   postal_code?: InputMaybe<Scalars['String']['input']>;
@@ -21987,6 +22040,7 @@ export type ProcessAddInput = {
   group_name?: InputMaybe<Scalars['String']['input']>;
   integrity_level?: InputMaybe<Scalars['String']['input']>;
   is_hidden?: InputMaybe<Scalars['Boolean']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   owner_sid?: InputMaybe<Scalars['String']['input']>;
   pid?: InputMaybe<Scalars['Int']['input']>;
   priority?: InputMaybe<Scalars['String']['input']>;
@@ -25805,6 +25859,7 @@ export type RegionAddInput = {
   longitude?: InputMaybe<Scalars['Float']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   precision?: InputMaybe<Scalars['Float']['input']>;
@@ -26175,6 +26230,7 @@ export type ReportAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -26752,6 +26808,7 @@ export type SshKeyAddInput = {
   fingerprint_sha256: Scalars['String']['input'];
   key_length?: InputMaybe<Scalars['String']['input']>;
   key_type?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   public_key?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
@@ -27036,6 +27093,7 @@ export type SectorAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   revoked?: InputMaybe<Scalars['Boolean']['input']>;
@@ -27352,6 +27410,7 @@ export type SecurityCoverageAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectCovered: Scalars['String']['input'];
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -27623,6 +27682,7 @@ export type SecurityPlatformAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   revoked?: InputMaybe<Scalars['Boolean']['input']>;
@@ -28082,6 +28142,7 @@ export type SoftwareAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   languages?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   name?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   swid?: InputMaybe<Scalars['String']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   vendor?: InputMaybe<Scalars['String']['input']>;
@@ -29781,6 +29842,7 @@ export type StixFileAddInput = {
   mtime?: InputMaybe<Scalars['DateTime']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
   name_enc?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   obsContent?: InputMaybe<Scalars['ID']['input']>;
   size?: InputMaybe<Scalars['Int']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
@@ -29991,6 +30053,7 @@ export type StixRefRelationshipAddInput = {
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   fromId?: InputMaybe<Scalars['StixRef']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   relationship_type: Scalars['String']['input'];
@@ -31004,6 +31067,7 @@ export type SystemAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -31340,6 +31404,7 @@ export type TaskAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -31696,6 +31761,7 @@ export type TextAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -32234,6 +32300,7 @@ export type ThreatActorGroupAddInput = {
   last_seen?: InputMaybe<Scalars['DateTime']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -32559,6 +32626,7 @@ export type ThreatActorIndividualAddInput = {
   marital_status?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -32863,6 +32931,7 @@ export type ToolAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -33142,6 +33211,7 @@ export type TrackingNumberAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -33486,6 +33556,7 @@ export type UrlAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -33797,6 +33868,7 @@ export type UserAccountAddInput = {
   is_disabled?: InputMaybe<Scalars['Boolean']['input']>;
   is_privileged?: InputMaybe<Scalars['Boolean']['input']>;
   is_service_account?: InputMaybe<Scalars['Boolean']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   user_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -34029,6 +34101,7 @@ export type UserAgentAddInput = {
   fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   value?: InputMaybe<Scalars['String']['input']>;
 };
@@ -34578,6 +34651,7 @@ export type VulnerabilityAddInput = {
   lang?: InputMaybe<Scalars['String']['input']>;
   modified?: InputMaybe<Scalars['DateTime']['input']>;
   name: Scalars['String']['input'];
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   objectOrganization?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -34958,6 +35032,7 @@ export type WindowsRegistryKeyAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   modified_time?: InputMaybe<Scalars['DateTime']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   number_of_subkeys?: InputMaybe<Scalars['Int']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
@@ -35172,6 +35247,7 @@ export type WindowsRegistryValueTypeAddInput = {
   files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
   filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
   name?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
 };
 
@@ -35596,6 +35672,7 @@ export type X509CertificateAddInput = {
   issuer_alternative_name?: InputMaybe<Scalars['String']['input']>;
   key_usage?: InputMaybe<Scalars['String']['input']>;
   name_constraints?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Scalars['Boolean']['input']>;
   policy_constraints?: InputMaybe<Scalars['String']['input']>;
   policy_mappings?: InputMaybe<Scalars['String']['input']>;
   private_key_usage_period_not_after?: InputMaybe<Scalars['DateTime']['input']>;

--- a/opencti-platform/opencti-graphql/src/modules/administrativeArea/administrativeArea.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/administrativeArea/administrativeArea.graphql
@@ -201,6 +201,7 @@ input AdministrativeAreaAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
@@ -249,6 +249,7 @@ input CaseIncidentAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   update: Boolean
   authorized_members: [MemberAccessInput!]

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rfi/case-rfi.graphql
@@ -253,6 +253,7 @@ input CaseRfiAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   update: Boolean
   information_types: [String!]

--- a/opencti-platform/opencti-graphql/src/modules/case/case-rft/case-rft.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-rft/case-rft.graphql
@@ -244,6 +244,7 @@ input CaseRftAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   x_opencti_modified_at: DateTime
   x_opencti_workflow_id: String

--- a/opencti-platform/opencti-graphql/src/modules/case/feedback/feedback.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/feedback/feedback.graphql
@@ -239,6 +239,7 @@ input FeedbackAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   clientMutationId: String
   update: Boolean
   rating: Int

--- a/opencti-platform/opencti-graphql/src/modules/channel/channel.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/channel/channel.graphql
@@ -197,6 +197,7 @@ input ChannelAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.graphql
@@ -195,6 +195,7 @@ input DataComponentAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     x_opencti_workflow_id: String
     x_opencti_modified_at: DateTime
     upsertOperations: [EditInput!]

--- a/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.graphql
@@ -197,6 +197,7 @@ input DataSourceAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     x_opencti_workflow_id: String
     x_opencti_modified_at: DateTime
     upsertOperations: [EditInput!]

--- a/opencti-platform/opencti-graphql/src/modules/event/event.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/event/event.graphql
@@ -201,6 +201,7 @@ input EventAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/grouping/grouping.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/grouping/grouping.graphql
@@ -273,6 +273,7 @@ input GroupingAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     authorized_members: [MemberAccessInput!]
     upsertOperations: [EditInput!]
 }

--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator.graphql
@@ -254,6 +254,7 @@ input IndicatorAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   basedOn: [String!]
   upsertOperations: [EditInput!]
 }

--- a/opencti-platform/opencti-graphql/src/modules/language/language.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/language/language.graphql
@@ -191,6 +191,7 @@ input LanguageAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/malwareAnalysis/malwareAnalysis.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/malwareAnalysis/malwareAnalysis.graphql
@@ -223,6 +223,7 @@ input MalwareAnalysisAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/narrative/narrative.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/narrative/narrative.graphql
@@ -197,6 +197,7 @@ input NarrativeAddInput {
     fileMarkings: [String]
     files: [Upload]
     filesMarkings: [[String]]
+    noTriggerImport: Boolean
     x_opencti_modified_at: DateTime
     x_opencti_workflow_id: String
     upsertOperations: [EditInput!]

--- a/opencti-platform/opencti-graphql/src/modules/organization/organization.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/organization/organization.graphql
@@ -234,6 +234,7 @@ input OrganizationAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.graphql
@@ -219,6 +219,7 @@ input SecurityCoverageAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   update: Boolean
   # coverage specific
   auto_enrichment_disable: Boolean!

--- a/opencti-platform/opencti-graphql/src/modules/securityPlatform/securityPlatform.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityPlatform/securityPlatform.graphql
@@ -197,6 +197,7 @@ input SecurityPlatformAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/task/task.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/task/task.graphql
@@ -229,6 +229,7 @@ input TaskAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual.graphql
@@ -233,6 +233,7 @@ input ThreatActorIndividualAddInput {
   fileMarkings: [String]
   files: [Upload]
   filesMarkings: [[String]]
+  noTriggerImport: Boolean
   upsertOperations: [EditInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
+++ b/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
@@ -246,9 +246,11 @@ const generateFileInputsForUpsert = async (context, user, resolvedElement, updat
       continue;
     }
 
+    const noTriggerImport = updatePatch.noTriggerImport ?? false;
     const { upload: uploadedFile, untouched } = await uploadToStorage(context, user, filePath, fileInput, {
       entity: resolvedElement,
       file_markings,
+      noTriggerImport,
     });
 
     if (untouched && fileAlreadyExistsOnEntity) {


### PR DESCRIPTION
## Summary

This PR fixes the `noTriggerImport` flag not being respected when files are uploaded during entity creation via STIX import (worker ingestion + STIX import).

Closes #14297

### Problem

When files associated with entities via `x_opencti_files` in STIX bundles include `no_trigger_import: True`, the flag was being ignored. This happened because recent modifications changed the file upload logic from using `add_file` (which supported `noTriggerImport` via `importPush`) to uploading files directly at entity creation time using the new `files: [Upload]` and `filesMarkings: [[String]]` fields - but the `noTriggerImport` parameter was not carried through.

### Solution

1. **GraphQL Schema** - Added `noTriggerImport: Boolean` to all 77 `AddInput` types that support file uploads:
   - 58 types in `opencti.graphql` (including all observable types)
   - 19 types in module-specific `.graphql` files

2. **Backend Processing** - Updated file upload handling to pass `noTriggerImport`:
   - `middleware.js`: Extract and pass `noTriggerImport` from input to `uploadToStorage`
   - `upsert-utils.js`: Extract and pass `noTriggerImport` from update patch to `uploadToStorage`
   - `file-storage.ts`: Already correctly checks `!noTriggerImport` before calling `triggerJobImport`

3. **Python Client** - Updated all entity helpers and STIX import logic:
   - 34 entity files: Added `noTriggerImport` parameter to `create()` methods
   - 32 entity files: Pass `noTriggerImport` from extras in `import_from_stix2()` methods
   - `opencti_stix_cyber_observable.py`: Added `noTriggerImport` to all 34 observable type input dictionaries
   - `opencti_stix2.py`: 
     - Extract `no_trigger_import` from files in both `import_object()` and `import_observable()`
     - Pass `noTriggerImport` in extras dictionary
     - Pass `noTriggerImport` to `stix_cyber_observable.create()` calls
     - Pass `noTriggerImport` to `external_reference.create()` calls for embedded references
     - Fixed file collection to use `extend` for both `x_opencti_files` and extension sources
