### PR TITLE
[backend] Delete workbenches as other files when deleting an entity (#14301)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.js
+++ b/opencti-platform/opencti-graphql/src/database/middleware.js
@@ -1468,6 +1468,12 @@ const mergeEntitiesRaw = async (context, user, targetEntity, sourceEntities, tar
     { concurrency: ES_MAX_CONCURRENCY },
   );
 
+  // Delete remaining files for source entities (workbenches linked via metaData.entity_id)
+  // Note: regular files were already moved by moveAllFilesFromEntityToAnother
+  for (let i = 0; i < sourceEntities.length; i += 1) {
+    await deleteAllObjectFiles(context, SYSTEM_USER, sourceEntities[i]);
+  }
+
   // Take care of relations deletions to prevent duplicate marking definitions.
   const elementToRemoves = [...sourceEntities, ...fromDeletions, ...toDeletions];
   // All not move relations will be deleted, so we need to remove impacted rel in entities.

--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
@@ -45,7 +45,8 @@ export const deleteElement = async (context: AuthContext, scope: string, nodeId:
     const deleteOpts = { forceDelete: true, forceRefresh: opts.forceRefresh ?? false };
     await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, knowledgeType, deleteOpts);
   } else if (scope === 'file' || scope === 'workbench') {
-    await deleteFile(context, RETENTION_MANAGER_USER, nodeId);
+    // forceDelete: true to clean up orphan ES entries even if S3 file doesn't exist
+    await deleteFile(context, RETENTION_MANAGER_USER, nodeId, { forceDelete: true });
   } else {
     throw Error(`[Retention manager] Scope ${scope} not existing for Retention Rule.`);
   }


### PR DESCRIPTION
## Summary

This PR fixes orphan workbenches cleanup when entities are deleted or merged. Previously, workbenches stored in `import/pending` with `metaData.entity_id` pointing to an entity were not cleaned up when that entity was deleted, leading to orphan entries in Elasticsearch that caused retention policy execution errors.

Closes #14301

### Changes

**1. Workbench cleanup on entity deletion (`file-storage.ts`)**
- Modified `deleteAllObjectFiles` to also delete workbenches linked to the entity via `metaData.entity_id`
- This ensures that when an entity is deleted through `deleteElementById`, its associated workbenches in `import/pending/` are also removed

**2. Workbench cleanup on entity merge (`middleware.js`)**
- Added explicit `deleteAllObjectFiles` call for each source entity before `elDeleteElements` during merge operations
- Previously, the merge function only moved regular files but bypassed file cleanup by calling `elDeleteElements` directly
- Now workbenches linked to merged (source) entities are properly cleaned up

**3. Resilient retention policy execution (`file-storage.ts` / `retentionManager.ts`)**
- Added `forceDelete` option to `deleteFile` function that allows deletion to proceed even if S3 file is missing
- Retention manager now uses `forceDelete: true` for file/workbench scope to clean up orphan Elasticsearch entries
- This prevents retention policies from getting stuck on files that exist in ES but not in S3