### PR TITLE
[frontend] UI: Global kill chain knowledge list (#13303)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2676,8 +2676,6 @@
   "No default": "Keine Voreinstellung",
   "No default value set in Settings...": "In den Entitätseinstellungen ist kein Standardwert für dieses Attribut festgelegt. Sie können einen Wert mit der obigen Eingabe angeben. Dieser Wert wird verwendet, wenn die Daten in der CSV-Datei fehlen.",
   "No description": "Keine Beschreibung",
-  "No description of this targeting": "Keine Beschreibung dieses Ziels",
-  "No description of this usage": "Keine Beschreibung für diese Verwendung",
   "No detail available for this event": "Keine Details für dieses Ereignis verfügbar",
   "No direct instance trigger": "Kein direkter Instanz-Trigger",
   "No draft for the moment": "Vorläufig kein Entwurf",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2676,8 +2676,6 @@
   "No default": "No default",
   "No default value set in Settings...": "No default value set for this attribute in the entity settings. You can provide one with the input above. This value will be used if the data is missing in the CSV file.",
   "No description": "No description",
-  "No description of this targeting": "No description of this targeting",
-  "No description of this usage": "No description of this usage",
   "No detail available for this event": "No detail available for this event",
   "No direct instance trigger": "No direct instance trigger",
   "No draft for the moment": "No draft for the moment",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2676,8 +2676,6 @@
   "No default": "No por defecto",
   "No default value set in Settings...": "No hay valor por defecto para este atributo en la configuración de la entidad. Puede proporcionar uno con la entrada de arriba. Este valor se utilizará si faltan datos en el archivo CSV.",
   "No description": "Sin descripción",
-  "No description of this targeting": "No hay descripción de este objetivo",
-  "No description of this usage": "No hay descripción de este uso",
   "No detail available for this event": "No hay detalles disponibles para este evento",
   "No direct instance trigger": "Sin desencadenador directo de instancias",
   "No draft for the moment": "No hay proyecto por el momento",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2676,8 +2676,6 @@
   "No default": "Pas de défaut",
   "No default value set in Settings...": "Aucune valeur par défaut n'a été définie pour cet attribut dans les paramètres de l'entité. Vous pouvez en fournir une en remplissant le champ ci-dessus. Cette valeur sera utilisée si les données sont manquantes dans le fichier CSV.",
   "No description": "Pas de description",
-  "No description of this targeting": "Aucune description de ce ciblage",
-  "No description of this usage": "Aucune description de cet usage",
   "No detail available for this event": "Aucun détail n'est disponible pour cet événement",
   "No direct instance trigger": "Aucun déclencheur d'instance direct",
   "No draft for the moment": "Pas de brouillon pour le moment",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2676,8 +2676,6 @@
   "No default": "Nessun valore predefinito",
   "No default value set in Settings...": "Nessun valore predefinito impostato per questo attributo nelle impostazioni dell'entità. Puoi fornirne uno con l'input sopra. Questo valore verrà utilizzato se i dati sono mancanti nel file CSV.",
   "No description": "Nessuna descrizione",
-  "No description of this targeting": "Nessuna descrizione di questo targeting",
-  "No description of this usage": "Nessuna descrizione di questo utilizzo",
   "No detail available for this event": "Nessun dettaglio disponibile per questo evento",
   "No direct instance trigger": "Nessun trigger diretto dell'istanza",
   "No draft for the moment": "Nessuna bozza per il momento",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2676,8 +2676,6 @@
   "No default": "デフォルトなし",
   "No default value set in Settings...": "エンティティ設定でこの属性にデフォルト値が設定されていません。上記の入力で指定できます。CSVファイルにデータがない場合、この値が使用されます。",
   "No description": "説明なし",
-  "No description of this targeting": "この標的についての説明はありません",
-  "No description of this usage": "この使用方法についての説明はありません",
   "No detail available for this event": "このイベントの詳細は不明",
   "No direct instance trigger": "直接インスタンストリガーなし",
   "No draft for the moment": "今のところドラフトなし",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2676,8 +2676,6 @@
   "No default": "기본값 없음",
   "No default value set in Settings...": "엔터티 설정에서 이 속성에 대한 기본값이 설정되지 않았습니다. 위의 입력란에 하나를 제공할 수 있습니다. 이 값은 CSV 파일에 데이터가 없을 경우 사용됩니다.",
   "No description": "설명 없음",
-  "No description of this targeting": "이 표적에 대한 설명 없음",
-  "No description of this usage": "이 사용에 대한 설명 없음",
   "No detail available for this event": "이 이벤트에 대한 세부 정보가 없습니다",
   "No direct instance trigger": "직접 인스턴스 트리거 없음",
   "No draft for the moment": "현재 초안 없음",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -2676,8 +2676,6 @@
   "No default": "Нет по умолчанию",
   "No default value set in Settings...": "В Настройках не установлено значение по умолчанию...",
   "No description": "Нет описания",
-  "No description of this targeting": "Нет описания этого таргетинга",
-  "No description of this usage": "Нет описания этого использования",
   "No detail available for this event": "Никаких подробностей для этого события нет",
   "No direct instance trigger": "Прямой триггер инстанции отсутствует",
   "No draft for the moment": "Нет призыва на данный момент",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2676,8 +2676,6 @@
   "No default": "无默认值",
   "No default value set in Settings...": "实体设置中未为此属性设置默认值。您可以通过上面的输入提供一个。如果 CSV 文件中缺少数据，将使用此值。",
   "No description": "无说明",
-  "No description of this targeting": "没有关于此针对的描述",
-  "No description of this usage": "没有关于此用法的描述",
   "No detail available for this event": "此活动无详细信息",
   "No direct instance trigger": "",
   "No draft for the moment": "暂无草案",

--- a/opencti-platform/opencti-front/src/components/ItemYears.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemYears.tsx
@@ -13,7 +13,7 @@ const ItemYears = ({ years, style }: ItemYearsProps) => {
     fontSize: 12,
     lineHeight: '12px',
     height: 20,
-    marginRight: 15,
+    marginRight: 8,
     ...style,
   };
   return (

--- a/opencti-platform/opencti-front/src/components/ItemYears.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemYears.tsx
@@ -5,16 +5,14 @@ import Tag from '@common/tag/Tag';
 
 interface ItemYearsProps {
   years: string;
-  style?: CSSProperties;
 }
 
-const ItemYears = ({ years, style }: ItemYearsProps) => {
+const ItemYears = ({ years }: ItemYearsProps) => {
   const chipStyle: CSSProperties = {
     fontSize: 12,
     lineHeight: '12px',
     height: 20,
     marginRight: 8,
-    ...style,
   };
   return (
     <Tag

--- a/opencti-platform/opencti-front/src/components/ItemYears.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemYears.tsx
@@ -1,32 +1,24 @@
 import React from 'react';
 import { CSSProperties } from '@mui/styles/withStyles';
-import Chip from '@mui/material/Chip';
 import { EMPTY_VALUE } from '../utils/String';
+import Tag from '@common/tag/Tag';
 
 interface ItemYearsProps {
   years: string;
-  variant?: string;
-  disabled?: boolean;
+  style?: CSSProperties;
 }
 
-const ItemYears = ({ years, variant, disabled }: ItemYearsProps) => {
-  const chipStyle: CSSProperties = variant === 'inList'
-    ? {
-        fontSize: 12,
-        lineHeight: '12px',
-        height: 20,
-        marginRight: 15,
-      }
-    : {
-        fontSize: 12,
-        lineHeight: '12px',
-        height: 25,
-        marginRight: 7,
-      };
+const ItemYears = ({ years, style }: ItemYearsProps) => {
+  const chipStyle: CSSProperties = {
+    fontSize: 12,
+    lineHeight: '12px',
+    height: 20,
+    marginRight: 15,
+    ...style,
+  };
   return (
-    <Chip
+    <Tag
       sx={chipStyle}
-      color={disabled ? 'default' : 'secondary'}
       label={years === '1970 - 5138' ? EMPTY_VALUE : years}
     />
   );

--- a/opencti-platform/opencti-front/src/components/MarkdownDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/MarkdownDisplay.tsx
@@ -46,7 +46,7 @@ export const MarkDownComponents = (
 });
 
 interface MarkdownWithRedirectionWarningProps {
-  content: string | null;
+  content?: string | null;
   expand?: boolean;
   limit?: number;
   remarkGfmPlugin?: boolean;

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetText.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetText.tsx
@@ -25,7 +25,7 @@ const WidgetText = ({
     return (
       <div style={{ marginTop: theme.spacing(-1) }}>
         <MarkdownDisplay
-          content={parameters?.content ?? ''}
+          content={parameters?.content}
           remarkGfmPlugin={true}
           commonmark={true}
         />

--- a/opencti-platform/opencti-front/src/private/components/Search.tsx
+++ b/opencti-platform/opencti-front/src/private/components/Search.tsx
@@ -212,9 +212,7 @@ const Search = () => {
       isSortable: true,
     },
     analyses: {
-      label: 'Analyses',
       percentWidth: 8,
-      isSortable: false,
     },
     objectMarking: {
       label: 'Marking',

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNoteCard.tsx
@@ -132,7 +132,7 @@ const StixCoreObjectOrStixCoreRelationshipNoteCard: FunctionComponent<
             <Label>{t_i18n('Abstract')}</Label>
             <FieldOrEmpty source={note.attribute_abstract}>
               <MarkdownDisplay
-                content={note.attribute_abstract ?? null}
+                content={note.attribute_abstract}
                 remarkGfmPlugin
               />
             </FieldOrEmpty>

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/HistoryDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/HistoryDrawer.tsx
@@ -44,7 +44,7 @@ const HistoryDrawer: FunctionComponent<HistoryDrawerProps> = ({ open, onClose, t
             {t_i18n('Message')}
           </Label>
           <MarkdownDisplay
-            content={data?.context_data?.message ?? ''}
+            content={data?.context_data?.message}
             remarkGfmPlugin={true}
             commonmark={true}
           />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
@@ -409,20 +409,15 @@ class StixCoreRelationshipContainer extends Component {
                       {t('Description')}
                     </Label>
                     <MarkdownDisplay
-                      content={
-                        stixCoreRelationship.x_opencti_inferences !== null ? (
-                          t('Inferred knowledge')
-                        ) : (
-                          stixCoreRelationship.description
-                        )
+                      content={stixCoreRelationship.x_opencti_inferences !== null
+                        ? t('Inferred knowledge')
+                        : stixCoreRelationship.description
                       }
                       remarkGfmPlugin={true}
                       commonmark={true}
                     />
                     <StixCoreObjectKillChainPhasesView
-                      killChainPhases={
-                        stixCoreRelationship.killChainPhases
-                      }
+                      killChainPhases={stixCoreRelationship.killChainPhases}
                     />
                   </Grid>
                 </Grid>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainLines.tsx
@@ -20,6 +20,7 @@ import { useInitCreateRelationshipContext } from '@components/common/stix_core_r
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { useFormatter } from '../../../../components/i18n';
+import { EMPTY_VALUE } from '../../../../utils/String';
 
 interface StixDomainObjectAttackPatternsKillChainLinesProps {
   data: StixDomainObjectAttackPatternsKillChainContainer_data$data;
@@ -222,9 +223,7 @@ const StixDomainObjectAttackPatternsKillChainLines: FunctionComponent<StixDomain
                                           remarkGfmPlugin={true}
                                           commonmark={true}
                                         />
-                                      ) : (
-                                        t_i18n('No description of this usage')
-                                      )
+                                      ) : EMPTY_VALUE
                                 }
                               />
                               <ItemMarkings
@@ -264,9 +263,8 @@ const StixDomainObjectAttackPatternsKillChainLines: FunctionComponent<StixDomain
                                           <ListItemText
                                             primary={courseOfAction.name}
                                             secondary={
-                                              courseOfAction.description
-                                              && courseOfAction.description
-                                                .length > 0 ? (
+                                              courseOfAction.description && courseOfAction.description.length > 0
+                                                ? (
                                                     <MarkdownDisplay
                                                       content={
                                                         courseOfAction.description
@@ -275,11 +273,8 @@ const StixDomainObjectAttackPatternsKillChainLines: FunctionComponent<StixDomain
                                                       commonmark={true}
                                                     >
                                                     </MarkdownDisplay>
-                                                  ) : (
-                                                    t_i18n(
-                                                      'No description of this course of action',
-                                                    )
                                                   )
+                                                : EMPTY_VALUE
                                             }
                                           />
                                         </ListItemButton>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainLines.tsx
@@ -20,7 +20,6 @@ import { useInitCreateRelationshipContext } from '@components/common/stix_core_r
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { useFormatter } from '../../../../components/i18n';
-import { EMPTY_VALUE } from '../../../../utils/String';
 
 interface StixDomainObjectAttackPatternsKillChainLinesProps {
   data: StixDomainObjectAttackPatternsKillChainContainer_data$data;
@@ -215,16 +214,13 @@ const StixDomainObjectAttackPatternsKillChainLines: FunctionComponent<StixDomain
                                     - {attackPattern.name}
                                   </span>
                                 )}
-                                secondary={
-                                  attackPattern.description
-                                  && attackPattern.description.length > 0 ? (
-                                        <MarkdownDisplay
-                                          content={attackPattern.description}
-                                          remarkGfmPlugin={true}
-                                          commonmark={true}
-                                        />
-                                      ) : EMPTY_VALUE
-                                }
+                                secondary={(
+                                  <MarkdownDisplay
+                                    content={attackPattern.description}
+                                    remarkGfmPlugin={true}
+                                    commonmark={true}
+                                  />
+                                )}
                               />
                               <ItemMarkings
                                 markingDefinitions={attackPattern.objectMarking ?? []}
@@ -262,20 +258,13 @@ const StixDomainObjectAttackPatternsKillChainLines: FunctionComponent<StixDomain
                                           </ListItemIcon>
                                           <ListItemText
                                             primary={courseOfAction.name}
-                                            secondary={
-                                              courseOfAction.description && courseOfAction.description.length > 0
-                                                ? (
-                                                    <MarkdownDisplay
-                                                      content={
-                                                        courseOfAction.description
-                                                      }
-                                                      remarkGfmPlugin={true}
-                                                      commonmark={true}
-                                                    >
-                                                    </MarkdownDisplay>
-                                                  )
-                                                : EMPTY_VALUE
-                                            }
+                                            secondary={(
+                                              <MarkdownDisplay
+                                                content={courseOfAction.description}
+                                                remarkGfmPlugin={true}
+                                                commonmark={true}
+                                              />
+                                            )}
                                           />
                                         </ListItemButton>
                                       );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import * as PropTypes from 'prop-types';
 import * as R from 'ramda';
 import { Link } from 'react-router-dom';
+import { Box, ListItemButton } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import IconButton from '@common/button/IconButton';
 import List from '@mui/material/List';
@@ -11,7 +12,6 @@ import Collapse from '@mui/material/Collapse';
 import { Launch } from 'mdi-material-ui';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import { createRefetchContainer, graphql } from 'react-relay';
-import { ListItemButton } from '@mui/material';
 import ListItem from '@mui/material/ListItem';
 import { yearFormat } from '../../../../utils/Time';
 import inject18n from '../../../../components/i18n';
@@ -158,6 +158,31 @@ class StixDomainObjectGlobalKillChainComponent extends Component {
                         const entityToDisplay = (stixDomainObject.to?.id === stixDomainObjectId) ? stixDomainObject.from : stixDomainObject.to;
                         const restricted = entityToDisplay === null;
                         const link = `${entityLink}/relations/${stixDomainObject.id}`;
+                        const buildDomainObjectPrimaryText = () => {
+                          if (!restricted) {
+                            if (entityToDisplay.entity_type === 'Attack-Pattern') {
+                              if (entityToDisplay.x_mitre_id) {
+                                return defaultRender(
+                                  <span>
+                                    <strong>
+                                      {entityToDisplay.x_mitre_id}
+                                    </strong>{'  '}
+                                    - {entityToDisplay.name}
+                                  </span>,
+                                );
+                              }
+                              return defaultRender(
+                                <span>
+                                  {entityToDisplay.name}
+                                </span>,
+                              );
+                            }
+                            return defaultRender(entityToDisplay.name);
+                          }
+                          return t('Restricted');
+                        };
+                        const domainObjectPrimaryText = buildDomainObjectPrimaryText();
+
                         return (
                           <ListItem
                             key={stixDomainObject.id}
@@ -176,6 +201,11 @@ class StixDomainObjectGlobalKillChainComponent extends Component {
                               classes={{ root: classes.nested }}
                               component={Link}
                               to={link}
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 3,
+                              }}
                             >
                               <ListItemIcon className={classes.itemIcon}>
                                 <ItemIcon
@@ -188,21 +218,7 @@ class StixDomainObjectGlobalKillChainComponent extends Component {
                               </ListItemIcon>
                               <ListItemText
                                 sx={{ marginRight: 8 }}
-                                primary={
-                                  !restricted
-                                    ? (entityToDisplay.entity_type === 'Attack-Pattern'
-                                        ? defaultRender(
-                                            <span>
-                                              <strong>
-                                                {entityToDisplay.x_mitre_id}
-                                              </strong>{'  '}
-                                              - {entityToDisplay.name}
-                                            </span>,
-                                          )
-                                        : defaultRender(entityToDisplay.name)
-                                      )
-                                    : t('Restricted')
-                                }
+                                primary={domainObjectPrimaryText}
                                 secondary={
                                   stixDomainObject.description && stixDomainObject.description.length > 0
                                     ? (
@@ -215,13 +231,18 @@ class StixDomainObjectGlobalKillChainComponent extends Component {
                                     : EMPTY_VALUE
                                 }
                               />
-                              <ItemMarkings
-                                markingDefinitions={stixDomainObject.objectMarking ?? []}
-                                limit={1}
-                              />
+                              <Box
+                                sx={{
+                                  width: 150,
+                                }}
+                              >
+                                <ItemMarkings
+                                  markingDefinitions={stixDomainObject.objectMarking ?? []}
+                                  limit={1}
+                                />
+                              </Box>
                               <ItemYears
                                 years={stixDomainObject.years}
-                                style={{ marginLeft: 8 }}
                               />
                             </ListItemButton>
                           </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
@@ -21,7 +21,6 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { stixDomainObjectThreatKnowledgeStixRelationshipsQuery } from './StixDomainObjectThreatKnowledgeQuery';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
-import { EMPTY_VALUE } from '../../../../utils/String';
 import { defaultRender } from '../../../../components/dataGrid/dataTableUtils';
 
 const styles = (theme) => ({
@@ -219,17 +218,13 @@ class StixDomainObjectGlobalKillChainComponent extends Component {
                               <ListItemText
                                 sx={{ marginRight: 8 }}
                                 primary={domainObjectPrimaryText}
-                                secondary={
-                                  stixDomainObject.description && stixDomainObject.description.length > 0
-                                    ? (
-                                        <MarkdownDisplay
-                                          content={stixDomainObject.description}
-                                          remarkGfmPlugin={true}
-                                          commonmark={true}
-                                        />
-                                      )
-                                    : EMPTY_VALUE
-                                }
+                                secondary={(
+                                  <MarkdownDisplay
+                                    content={stixDomainObject.description}
+                                    remarkGfmPlugin={true}
+                                    commonmark={true}
+                                  />
+                                )}
                               />
                               <Box
                                 sx={{

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectGlobalKillChain.jsx
@@ -21,6 +21,8 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { stixDomainObjectThreatKnowledgeStixRelationshipsQuery } from './StixDomainObjectThreatKnowledgeQuery';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
+import { EMPTY_VALUE } from '../../../../utils/String';
+import { defaultRender } from '../../../../components/dataGrid/dataTableUtils';
 
 const styles = (theme) => ({
   itemIcon: {
@@ -185,45 +187,41 @@ class StixDomainObjectGlobalKillChainComponent extends Component {
                                 />
                               </ListItemIcon>
                               <ListItemText
+                                sx={{ marginRight: 8 }}
                                 primary={
-
-                                  !restricted ? (
-                                    entityToDisplay.entity_type
-                                    === 'Attack-Pattern' ? (
-                                          <span>
-                                            <strong>
-                                              {entityToDisplay.x_mitre_id}
-                                            </strong>{' '}
-                                            - {entityToDisplay.name}
-                                          </span>
-                                        ) : (
-                                          <span>{entityToDisplay.name}</span>
-                                        )
-                                  ) : (
-                                    t('Restricted')
-                                  )
+                                  !restricted
+                                    ? (entityToDisplay.entity_type === 'Attack-Pattern'
+                                        ? defaultRender(
+                                            <span>
+                                              <strong>
+                                                {entityToDisplay.x_mitre_id}
+                                              </strong>{'  '}
+                                              - {entityToDisplay.name}
+                                            </span>,
+                                          )
+                                        : defaultRender(entityToDisplay.name)
+                                      )
+                                    : t('Restricted')
                                 }
                                 secondary={
-                                  stixDomainObject.description
-                                  && stixDomainObject.description.length > 0 ? (
+                                  stixDomainObject.description && stixDomainObject.description.length > 0
+                                    ? (
                                         <MarkdownDisplay
                                           content={stixDomainObject.description}
                                           remarkGfmPlugin={true}
                                           commonmark={true}
                                         />
-                                      ) : (
-                                        t('No description of this usage')
                                       )
+                                    : EMPTY_VALUE
                                 }
                               />
                               <ItemMarkings
-                                variant="inList"
                                 markingDefinitions={stixDomainObject.objectMarking ?? []}
                                 limit={1}
                               />
                               <ItemYears
-                                variant="inList"
                                 years={stixDomainObject.years}
+                                style={{ marginLeft: 8 }}
                               />
                             </ListItemButton>
                           </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologyRegionsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologyRegionsList.jsx
@@ -20,6 +20,7 @@ import ItemYears from '../../../../components/ItemYears';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
+import { EMPTY_VALUE } from '../../../../utils/String';
 
 const styles = (theme) => ({
   container: {
@@ -351,7 +352,6 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                               )
                             }
                             secondary={
-
                               stixCoreRelationship.description
                               && stixCoreRelationship.description.length > 0 ? (
                                     <MarkdownDisplay
@@ -359,18 +359,14 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                       remarkGfmPlugin={true}
                                       commonmark={true}
                                     />
-                                  ) : (
-                                    t('No description of this targeting')
-                                  )
+                                  ) : EMPTY_VALUE
                             }
                           />
                           <ItemMarkings
-                            variant="inList"
                             markingDefinitions={stixCoreRelationship.objectMarking ?? []}
                             limit={1}
                           />
                           <ItemYears
-                            variant="inList"
                             years={stixCoreRelationship.years}
                             country
                           />
@@ -434,9 +430,7 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                   secondaryAction={stixCoreRelationship.is_inferred ? (
                                     <Tooltip
                                       title={
-                                        t(
-                                          'Inferred knowledge based on the rule ',
-                                        )
+                                        t('Inferred knowledge based on the rule ')
                                         + R.head(
                                           stixCoreRelationship.x_opencti_inferences,
                                         ).rule.name
@@ -470,44 +464,33 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                       />
                                     </ListItemIcon>
                                     <ListItemText
-                                      primary={
-                                        stixCoreRelationship.to.id
-                                        === country.id ? (
-                                              <em>
-                                                {t(
-                                                  'Direct targeting of this country',
-                                                )}
-                                              </em>
-                                            ) : (
-                                              stixCoreRelationship.to.name
-                                            )
+                                      primary={stixCoreRelationship.to.id === country.id
+                                        ? (
+                                            <em>
+                                              {t('Direct targeting of this country')}
+                                            </em>
+                                          )
+                                        : stixCoreRelationship.to.name
                                       }
                                       secondary={
-
-                                        stixCoreRelationship.description
-                                        && stixCoreRelationship.description.length
-                                        > 0 ? (
+                                        stixCoreRelationship.description && stixCoreRelationship.description.length > 0
+                                          ? (
                                               <MarkdownDisplay
-                                                content={
-                                                  stixCoreRelationship.description
-                                                }
+                                                content={stixCoreRelationship.description}
                                                 remarkGfmPlugin={true}
                                                 commonmark={true}
                                               />
-                                            ) : stixCoreRelationship.inferred ? (
-                                              <i>{t('This relation is inferred')}</i>
-                                            ) : (
-                                              t('No description of this targeting')
                                             )
+                                          : stixCoreRelationship.inferred
+                                            ? (<i>{t('This relation is inferred')}</i>)
+                                            : EMPTY_VALUE
                                       }
                                     />
                                     <ItemMarkings
-                                      variant="inList"
                                       markingDefinitions={stixCoreRelationship.objectMarking ?? []}
                                       limit={1}
                                     />
                                     <ItemYears
-                                      variant="inList"
                                       years={stixCoreRelationship.years}
                                     />
                                   </ListItemButton>
@@ -533,12 +516,8 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                           secondaryAction={stixCoreRelationship.is_inferred ? (
                                             <Tooltip
                                               title={
-                                                t(
-                                                  'Inferred knowledge based on the rule ',
-                                                )
-                                                + R.head(
-                                                  stixCoreRelationship.x_opencti_inferences,
-                                                ).rule.name
+                                                t('Inferred knowledge based on the rule ')
+                                                + R.head(stixCoreRelationship.x_opencti_inferences).rule.name
                                               }
                                             >
                                               <AutoFix
@@ -548,22 +527,14 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                             </Tooltip>
                                           ) : (
                                             <StixCoreRelationshipPopover
-                                              stixCoreRelationshipId={
-                                                stixCoreRelationship.id
-                                              }
-                                              paginationOptions={
-                                                paginationOptions
-                                              }
-                                              onDelete={this.props.handleDelete.bind(
-                                                this,
-                                              )}
+                                              stixCoreRelationshipId={stixCoreRelationship.id}
+                                              paginationOptions={paginationOptions}
+                                              onDelete={this.props.handleDelete.bind(this)}
                                             />
                                           )}
                                         >
                                           <ListItemButton
-                                            classes={{
-                                              root: classes.subnested,
-                                            }}
+                                            classes={{ root: classes.subnested }}
                                             component={Link}
                                             to={link}
                                           >
@@ -571,57 +542,39 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                               className={classes.itemIcon}
                                             >
                                               <ItemIcon
-                                                type={
-                                                  stixCoreRelationship.to
-                                                    .entity_type
-                                                }
+                                                type={stixCoreRelationship.to.entity_type}
                                               />
                                             </ListItemIcon>
                                             <ListItemText
-                                              primary={
-                                                stixCoreRelationship.to.id
-                                                === country.id ? (
-                                                      <em>
-                                                        {t(
-                                                          'Direct targeting of this country',
-                                                        )}
-                                                      </em>
-                                                    ) : (
-                                                      stixCoreRelationship.to.name
-                                                    )
+                                              primary={stixCoreRelationship.to.id === country.id
+                                                ? (
+                                                    <em>
+                                                      {t(
+                                                        'Direct targeting of this country',
+                                                      )}
+                                                    </em>
+                                                  )
+                                                : (stixCoreRelationship.to.name)
                                               }
                                               secondary={
-
-                                                stixCoreRelationship.description
-                                                && stixCoreRelationship.description
-                                                  .length > 0 ? (
+                                                stixCoreRelationship.description && stixCoreRelationship.description.length > 0
+                                                  ? (
                                                       <MarkdownDisplay
-                                                        content={
-                                                          stixCoreRelationship.description
-                                                        }
+                                                        content={stixCoreRelationship.description}
                                                         remarkGfmPlugin={true}
                                                         commonmark={true}
                                                       />
-                                                    ) : stixCoreRelationship.inferred ? (
-                                                      <i>
-                                                        {t(
-                                                          'This relation is inferred',
-                                                        )}
-                                                      </i>
-                                                    ) : (
-                                                      t(
-                                                        'No description of this targeting',
-                                                      )
                                                     )
+                                                  : stixCoreRelationship.inferred
+                                                    ? (<i>{t('This relation is inferred')}</i>)
+                                                    : EMPTY_VALUE
                                               }
                                             />
                                             <ItemMarkings
-                                              variant="inList"
                                               markingDefinitions={stixCoreRelationship.objectMarking ?? []}
                                               limit={1}
                                             />
                                             <ItemYears
-                                              variant="inList"
                                               years={stixCoreRelationship.years}
                                             />
                                           </ListItemButton>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologyRegionsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologyRegionsList.jsx
@@ -263,6 +263,22 @@ class StixDomainObjectVictimologyRegionsList extends Component {
       R.sortWith([R.ascend(R.prop('name'))]),
       R.filter(filterByKeyword),
     )(finalRegions);
+
+    const renderRelationshipDescription = (description, inferred) => {
+      if (isNotEmptyField(description)) {
+        return (
+          <MarkdownDisplay
+            content={stixCoreRelationship.description}
+            remarkGfmPlugin={true}
+            commonmark={true}
+          />
+        );
+      }
+      return inferred
+        ? (<i>{t('This relation is inferred')}</i>)
+        : EMPTY_VALUE;
+    };
+
     return (
       <List>
         {orderedFinalRegions.map((region) => {
@@ -351,16 +367,7 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                 stixCoreRelationship.to.name
                               )
                             }
-                            secondary={
-                              stixCoreRelationship.description
-                              && stixCoreRelationship.description.length > 0 ? (
-                                    <MarkdownDisplay
-                                      content={stixCoreRelationship.description}
-                                      remarkGfmPlugin={true}
-                                      commonmark={true}
-                                    />
-                                  ) : EMPTY_VALUE
-                            }
+                            secondary={renderRelationshipDescription(stixCoreRelationship.description, stixCoreRelationship.inferred)}
                           />
                           <ItemMarkings
                             markingDefinitions={stixCoreRelationship.objectMarking ?? []}
@@ -472,19 +479,7 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                           )
                                         : stixCoreRelationship.to.name
                                       }
-                                      secondary={
-                                        stixCoreRelationship.description && stixCoreRelationship.description.length > 0
-                                          ? (
-                                              <MarkdownDisplay
-                                                content={stixCoreRelationship.description}
-                                                remarkGfmPlugin={true}
-                                                commonmark={true}
-                                              />
-                                            )
-                                          : stixCoreRelationship.inferred
-                                            ? (<i>{t('This relation is inferred')}</i>)
-                                            : EMPTY_VALUE
-                                      }
+                                      secondary={renderRelationshipDescription(stixCoreRelationship.description, stixCoreRelationship.inferred)}
                                     />
                                     <ItemMarkings
                                       markingDefinitions={stixCoreRelationship.objectMarking ?? []}
@@ -556,19 +551,7 @@ class StixDomainObjectVictimologyRegionsList extends Component {
                                                   )
                                                 : (stixCoreRelationship.to.name)
                                               }
-                                              secondary={
-                                                stixCoreRelationship.description && stixCoreRelationship.description.length > 0
-                                                  ? (
-                                                      <MarkdownDisplay
-                                                        content={stixCoreRelationship.description}
-                                                        remarkGfmPlugin={true}
-                                                        commonmark={true}
-                                                      />
-                                                    )
-                                                  : stixCoreRelationship.inferred
-                                                    ? (<i>{t('This relation is inferred')}</i>)
-                                                    : EMPTY_VALUE
-                                              }
+                                              secondary={renderRelationshipDescription(stixCoreRelationship.description, stixCoreRelationship.inferred)}
                                             />
                                             <ItemMarkings
                                               markingDefinitions={stixCoreRelationship.objectMarking ?? []}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologyRegionsList.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologyRegionsList.jsx
@@ -15,6 +15,7 @@ import { ListItemButton } from '@mui/material';
 import ListItem from '@mui/material/ListItem';
 import { yearFormat } from '../../../../utils/Time';
 import inject18n from '../../../../components/i18n';
+import { isNotEmptyField } from '../../../../utils/utils';
 import StixCoreRelationshipPopover from '../stix_core_relationships/StixCoreRelationshipPopover';
 import ItemYears from '../../../../components/ItemYears';
 import ItemIcon from '../../../../components/ItemIcon';
@@ -268,7 +269,7 @@ class StixDomainObjectVictimologyRegionsList extends Component {
       if (isNotEmptyField(description)) {
         return (
           <MarkdownDisplay
-            content={stixCoreRelationship.description}
+            content={description}
             remarkGfmPlugin={true}
             commonmark={true}
           />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
@@ -28,7 +28,7 @@ import ItemIcon from '../../../../components/ItemIcon';
 import { buildViewParamsFromUrlAndStorage, saveViewParameters } from '../../../../utils/ListParameters';
 import StixCoreRelationshipsExports from '../stix_core_relationships/StixCoreRelationshipsExports';
 import ItemMarkings from '../../../../components/ItemMarkings';
-import { export_max_size } from '../../../../utils/utils';
+import { export_max_size, isNotEmptyField } from '../../../../utils/utils';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import withRouter from '../../../../utils/compat_router/withRouter';
 import { EMPTY_VALUE } from '../../../../utils/String';
@@ -305,7 +305,7 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
       if (isNotEmptyField(description)) {
         return (
           <MarkdownDisplay
-            content={stixCoreRelationship.description}
+            content={description}
             remarkGfmPlugin={true}
             commonmark={true}
           />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
@@ -31,6 +31,7 @@ import ItemMarkings from '../../../../components/ItemMarkings';
 import { export_max_size } from '../../../../utils/utils';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import withRouter from '../../../../utils/compat_router/withRouter';
+import { EMPTY_VALUE } from '../../../../utils/String';
 
 const styles = (theme) => ({
   container: {
@@ -464,17 +465,15 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
                                 )
                               }
                               secondary={
-
-                                stixCoreRelationship.description
-                                && stixCoreRelationship.description.length > 0 ? (
+                                stixCoreRelationship.description && stixCoreRelationship.description.length > 0
+                                  ? (
                                       <MarkdownDisplay
                                         content={stixCoreRelationship.description}
                                         remarkGfmPlugin={true}
                                         commonmark={true}
                                       />
-                                    ) : (
-                                      t('No description of this targeting')
                                     )
+                                  : EMPTY_VALUE
                               }
                             />
                             <ItemMarkings
@@ -483,7 +482,6 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
                               limit={1}
                             />
                             <ItemYears
-                              variant="inList"
                               years={stixCoreRelationship.years}
                             />
                           </ListItemButton>
@@ -617,11 +615,7 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
                                                   <i>
                                                     {t('This relation is inferred')}
                                                   </i>
-                                                ) : (
-                                                  t(
-                                                    'No description of this targeting',
-                                                  )
-                                                )
+                                                ) : EMPTY_VALUE
                                           }
                                         />
                                         <ItemMarkings
@@ -630,7 +624,6 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
                                           limit={1}
                                         />
                                         <ItemYears
-                                          variant="inList"
                                           years={stixCoreRelationship.years}
                                         />
                                       </ListItemButton>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
@@ -300,6 +300,22 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
       R.filter(filterByKeyword),
     )(finalSectors);
     const exportDisabled = orderedFinalSectors.length > export_max_size;
+
+    const renderRelationshipDescription = (description, inferred) => {
+      if (isNotEmptyField(description)) {
+        return (
+          <MarkdownDisplay
+            content={stixCoreRelationship.description}
+            remarkGfmPlugin={true}
+            commonmark={true}
+          />
+        );
+      }
+      return inferred
+        ? (<i>{t('This relation is inferred')}</i>)
+        : EMPTY_VALUE;
+    };
+
     return (
       <div>
         <div className={classes.parameters}>
@@ -464,17 +480,7 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
                                   stixCoreRelationship.to.name
                                 )
                               }
-                              secondary={
-                                stixCoreRelationship.description && stixCoreRelationship.description.length > 0
-                                  ? (
-                                      <MarkdownDisplay
-                                        content={stixCoreRelationship.description}
-                                        remarkGfmPlugin={true}
-                                        commonmark={true}
-                                      />
-                                    )
-                                  : EMPTY_VALUE
-                              }
+                              secondary={renderRelationshipDescription(stixCoreRelationship.description, stixCoreRelationship.inferred)}
                             />
                             <ItemMarkings
                               variant="inList"
@@ -598,25 +604,7 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
                                                   stixCoreRelationship.to.name
                                                 )
                                           }
-                                          secondary={
-
-                                            stixCoreRelationship.description
-                                            && stixCoreRelationship.description
-                                              .length > 0 ? (
-                                                  <MarkdownDisplay
-                                                    content={
-                                                      stixCoreRelationship.description
-                                                    }
-                                                    remarkGfmPlugin={true}
-                                                    commonmark={true}
-                                                  >
-                                                  </MarkdownDisplay>
-                                                ) : stixCoreRelationship.inferred ? (
-                                                  <i>
-                                                    {t('This relation is inferred')}
-                                                  </i>
-                                                ) : EMPTY_VALUE
-                                          }
+                                          secondary={renderRelationshipDescription(stixCoreRelationship.description, stixCoreRelationship.inferred)}
                                         />
                                         <ItemMarkings
                                           variant="inList"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -62,7 +62,7 @@ const OrganizationDetails: FunctionComponent<OrganizationDetailsComponentProps> 
               {t_i18n('Contact information')}
             </Label>
             <MarkdownDisplay
-              content={organization.contact_information ?? ''}
+              content={organization.contact_information}
               remarkGfmPlugin={true}
               commonmark={true}
             />

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationDetails.tsx
@@ -42,7 +42,7 @@ const SettingsOrganizationDetails: FunctionComponent<
             {t_i18n('Contact information')}
           </Label>
           <MarkdownDisplay
-            content={organization.contact_information ?? ''}
+            content={organization.contact_information}
             remarkGfmPlugin={true}
             commonmark={true}
           />

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
@@ -371,7 +371,7 @@ const UserHistoryLine: FunctionComponent<UserHistoryLineProps> = ({ node }) => {
         <DialogTitle>{t_i18n('Commit message')}</DialogTitle>
         <DialogContent>
           <MarkdownDisplay
-            content={log.context_data?.message ?? EMPTY_VALUE}
+            content={log.context_data?.message}
             remarkGfmPlugin={true}
             commonmark={true}
           />

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserHistoryLine.tsx
@@ -18,7 +18,6 @@ import { useFormatter } from '../../../../components/i18n';
 import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import type { Theme } from '../../../../components/Theme';
 import ItemIcon from '../../../../components/ItemIcon';
-import { EMPTY_VALUE } from '../../../../utils/String';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.


### PR DESCRIPTION
### Proposed changes

- improve empty description rendering

- Rework UI in : 
a malware > knowledge tab > bottom of the page > 'global kill chain' tab

## before
<img width="2048" height="999" alt="image" src="https://github.com/user-attachments/assets/fe187008-6926-4de1-9f1d-6568b3435c7f" />



## after

<img width="1493" height="519" alt="image" src="https://github.com/user-attachments/assets/e6b6616f-82b5-4bb4-aca5-6d468223a715" />



### Related issues
#13303