### PR TITLE
[frontend] UI: fix Analyses chip redirection for containers in Advanced search (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/hooks/useAttributes.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAttributes.ts
@@ -218,7 +218,19 @@ export const aliasedTypes = [
   'Vocabulary',
 ];
 
-export const typesWithNoAnalysesTab = ['Note', 'Opinion', 'Course-Of-Action', 'Data-Component', 'Data-Source'];
+export const typesWithNoAnalysesTab = [
+  'Report',
+  'Grouping',
+  'Malware-Analysis',
+  'Note',
+  'Opinion',
+  'Case-Incident',
+  'Case-Rfi',
+  'Case-Rft',
+  'Course-Of-Action',
+  'Data-Component',
+  'Data-Source',
+];
 
 const useAttributes = () => {
   const vocabularies = useVocabularyCategory();


### PR DESCRIPTION
### Proposed changes
In Advanced search, in Analyses column: 
chips should not be clickable for entities having no Analyses tab (like containers)

<img width="1735" height="825" alt="image" src="https://github.com/user-attachments/assets/e13c4124-bca6-4dcc-a322-caedace03c42" />


### Related issues
#13303