### PR TITLE
[frontend] Context filters for draft entities background tasks (#14345)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftEntities.tsx
@@ -9,7 +9,7 @@ import { DraftEntities_node$data } from '@components/drafts/__generated__/DraftE
 import useAuth from '../../../utils/hooks/useAuth';
 import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
-import { useBuildEntityTypeBasedFilterContext, emptyFilterGroup } from '../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, useBuildEntityTypeBasedFilterContext } from '../../../utils/filters/filtersUtils';
 import { UsePreloadedPaginationFragment } from '../../../utils/hooks/usePreloadedPaginationFragment';
 import DataTable from '../../../components/dataGrid/DataTable';
 import { DataTableProps } from '../../../components/dataGrid/dataTableTypes';
@@ -120,13 +120,13 @@ const LOCAL_STORAGE_KEY = 'draft_entities';
 
 interface DraftEntitiesProps {
   entitiesType?: string;
-  excludedEntitiesType?: string;
+  excludedEntityTypes?: string;
   isReadOnly: boolean;
 }
 
 const DraftEntities: FunctionComponent<DraftEntitiesProps> = ({
   entitiesType = 'Stix-Core-Object',
-  excludedEntitiesType,
+  excludedEntityTypes,
   isReadOnly,
 }) => {
   const computeLink = useComputeLink();
@@ -166,7 +166,7 @@ const DraftEntities: FunctionComponent<DraftEntitiesProps> = ({
     filters,
     searchTerm,
   } = viewStorage;
-  const contextFilters = useBuildEntityTypeBasedFilterContext(entitiesType, filters, excludedEntitiesType);
+  const contextFilters = useBuildEntityTypeBasedFilterContext(entitiesType, filters, { excludedEntityTypesParam: excludedEntityTypes, draftId });
 
   const queryPaginationOptions = {
     ...paginationOptions,

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRelationships.tsx
@@ -221,7 +221,7 @@ const DraftRelationships: FunctionComponent<DraftRelationshipsProps> = ({ isRead
     filters,
   } = viewStorage;
 
-  const contextFilters = useBuildEntityTypeBasedFilterContext('stix-core-relationship', filters);
+  const contextFilters = useBuildEntityTypeBasedFilterContext('stix-core-relationship', filters, { draftId });
 
   const queryPaginationOptions = {
     ...paginationOptions,

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
@@ -235,7 +235,7 @@ const RootDraftComponent = ({ draftId, queryRef, refetch }) => {
         />
         <Route
           path="/entities"
-          element={<DraftEntities entitiesType="Stix-Domain-Object" excludedEntitiesType="Container" isReadOnly={isDraftReadOnly} />}
+          element={<DraftEntities entitiesType="Stix-Domain-Object" excludedEntityTypes="Container" isReadOnly={isDraftReadOnly} />}
         />
         <Route
           path="/observables"

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftSightings.tsx
@@ -309,7 +309,7 @@ const DraftSightings: FunctionComponent<DraftSightingsProps> = ({ isReadOnly }) 
     filters,
   } = viewStorage;
 
-  const contextFilters = useBuildEntityTypeBasedFilterContext('stix-sighting-relationship', filters);
+  const contextFilters = useBuildEntityTypeBasedFilterContext('stix-sighting-relationship', filters, { draftId });
 
   const queryPaginationOptions = {
     ...paginationOptions,

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -484,15 +484,15 @@ describe('Filters utils', () => {
       const contextFilters = {
         mode: 'and',
         filters: [
-          { key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+          { key: 'entity_type', values: ['Stix-Core-Object'], operator: 'eq', mode: 'or' },
         ],
         filterGroups: [filters],
       };
       const { hook } = testRenderHook(
-        () => useBuildEntityTypeBasedFilterContext('Malware', filters),
+        () => useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters),
         { userContext },
       );
-      expect(hook.result.current).toStrictEqual(contextFilters);
+      expect(hook.result.current).toEqual(contextFilters);
     });
 
     it('should return filters with added entity type and draft context', () => {
@@ -539,7 +539,7 @@ describe('Filters utils', () => {
         () => useBuildEntityTypeBasedFilterContext(['Stix-Core-Object'], filters, { excludedEntityTypesParam: ['Report'], draftId }),
         { userContext },
       );
-      expect(hook.result.current).toStrictEqual(contextFilters);
+      expect(hook.result.current).toEqual(contextFilters);
     });
   });
 });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -464,6 +464,23 @@ describe('Filters utils', () => {
   });
 
   describe('useBuildEntityTypeBasedFilterContext', () => {
+    it('should return filters with added entity type context', () => {
+      const filters: FilterGroup = {
+        mode: 'and',
+        filters: [{ key: 'objectLabel', operator: 'not_eq', values: ['label1'] }],
+        filterGroups: [],
+      };
+      const contextFilters = {
+        mode: 'and',
+        filters: [
+          { key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+        ],
+        filterGroups: [filters],
+      };
+      const result = useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters);
+      expect(result).toEqual(contextFilters);
+    });
+
     it('should return filters with added entity type and draft context', () => {
       const draftId = 'draft1-id';
       const filters: FilterGroup = {

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -516,7 +516,7 @@ describe('Filters utils', () => {
         mode: 'and',
         filters: [
           { key: 'entity_type', values: ['Stix-Core-Object'], operator: 'eq', mode: 'or' },
-          { key: 'entity_type', values: ['Report'], operator: 'not_eq', mode: 'or' },
+          { key: 'entity_type', values: ['Report'], operator: 'not_eq', mode: 'and' },
           { key: 'draft_ids', values: [draftId] },
           { key: 'draft_change', operator: 'not_nil', values: [] },
         ],

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -464,6 +464,17 @@ describe('Filters utils', () => {
   });
 
   describe('useBuildEntityTypeBasedFilterContext', () => {
+    const userContext = createMockUserContext({
+      schema: {
+        scos: [{ id: '', label: '' }],
+        sdos: [{ id: '', label: '' }],
+        smos: [{ id: '', label: '' }],
+        scrs: [{ id: '', label: '' }],
+        schemaRelationsTypesMapping: new Map<string, readonly string[]>(),
+        schemaRelationsRefTypesMapping: new Map<string, readonly { name: string; toTypes: string[] }[]>(),
+        filterKeysSchema,
+      },
+    });
     it('should return filters with added entity type context', () => {
       const filters: FilterGroup = {
         mode: 'and',
@@ -477,8 +488,11 @@ describe('Filters utils', () => {
         ],
         filterGroups: [filters],
       };
-      const result = useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters);
-      expect(result).toEqual(contextFilters);
+      const { hook } = testRenderHook(
+        () => useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters),
+        { userContext },
+      );
+      expect(hook.result.current).toStrictEqual(contextFilters);
     });
 
     it('should return filters with added entity type and draft context', () => {
@@ -521,8 +535,11 @@ describe('Filters utils', () => {
           ],
         }],
       };
-      const result = useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters, { excludedEntityTypesParam: ['Report'], draftId });
-      expect(result).toEqual(contextFilters);
+      const { hook } = testRenderHook(
+        () => useBuildEntityTypeBasedFilterContext(['Stix-Core-Object'], filters, { excludedEntityTypesParam: ['Report'], draftId }),
+        { userContext },
+      );
+      expect(hook.result.current).toStrictEqual(contextFilters);
     });
   });
 });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -9,6 +9,7 @@ import {
   removeIdAndIncorrectKeysFromFilterGroupObject,
   removeIdFromFilterGroupObject,
   serializeFilterGroupForBackend,
+  useBuildEntityTypeBasedFilterContext,
   useBuildFilterKeysMapFromEntityType,
 } from './filtersUtils';
 import { createMockUserContext, testRenderHook } from '../tests/test-render';
@@ -459,6 +460,52 @@ describe('Filters utils', () => {
       };
       const result3 = getEntityTypeTwoFirstLevelsFilterValues(filters3, ['File', 'Domain-Name'], []);
       expect(result3).toEqual(['Stix-Cyber-Observable', 'File']);
+    });
+  });
+
+  describe('useBuildEntityTypeBasedFilterContext', () => {
+    it('should return filters with added entity type and draft context', () => {
+      const draftId = 'draft1-id';
+      const filters: FilterGroup = {
+        mode: 'and',
+        filters: [{ key: 'objectLabel', operator: 'not_eq', values: ['label1'] }],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: 'objectMarking', values: ['marking1', 'marking2'] },
+              { key: 'created_at', values: ['now-1d'], operator: 'gt' },
+              { key: 'fake_filter_key', values: ['test'] }, // to be removed in the result
+            ],
+            filterGroups: [],
+          },
+        ],
+      };
+      const contextFilters = {
+        mode: 'and',
+        filters: [
+          { key: 'entity_type', values: ['Stix-Core-Object'], operator: 'eq', mode: 'or' },
+          { key: 'entity_type', values: ['Report'], operator: 'not_eq', mode: 'or' },
+          { key: 'draft_ids', values: [draftId] },
+          { key: 'draft_change', operator: 'not_nil', values: [] },
+        ],
+        filterGroups: [{
+          mode: 'and',
+          filters: [{ key: 'objectLabel', operator: 'not_eq', values: ['label1'] }],
+          filterGroups: [
+            {
+              mode: 'and',
+              filters: [
+                { key: 'objectMarking', values: ['marking1', 'marking2'] },
+                { key: 'created_at', values: ['now-1d'], operator: 'gt' },
+              ],
+              filterGroups: [],
+            },
+          ],
+        }],
+      };
+      const result = useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters, { excludedEntityTypesParam: ['Report'], draftId });
+      expect(result).toEqual(contextFilters);
     });
   });
 });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -489,7 +489,7 @@ describe('Filters utils', () => {
         filterGroups: [filters],
       };
       const { hook } = testRenderHook(
-        () => useBuildEntityTypeBasedFilterContext('Stix-Core-Object', filters),
+        () => useBuildEntityTypeBasedFilterContext('Malware', filters),
         { userContext },
       );
       expect(hook.result.current).toStrictEqual(contextFilters);

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -61,6 +61,8 @@ const NOT_CLEANABLE_FILTER_KEYS = [
   'entity_id',
   'ids',
   'bulkSearchKeywords',
+  'draft_ids',
+  'draft_change',
   PIR_SCORE_FILTER,
   LAST_PIR_SCORE_DATE_FILTER,
 ];
@@ -857,8 +859,6 @@ export const removeIdFromFilterGroupObject = (filters?: FilterGroup | null): Fil
   };
 };
 
-const notCleanableFilterKeys = ['ids', 'entity_type', 'authorized_members.id', 'user_id', 'internal_id', 'entity_id'];
-
 // TODO use useRemoveIdAndIncorrectKeysFromFilterGroupObject instead when all the calling files are in pure function
 export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGroup | null | undefined, availableFilterKeys: string[]): FilterGroup | undefined => {
   if (!filters) {
@@ -888,7 +888,7 @@ export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGro
 };
 
 export const useRemoveIdAndIncorrectKeysFromFilterGroupObject = (filters?: FilterGroup | null, entityTypes = ['Stix-Core-Object']): FilterGroup | undefined => {
-  const availableFilterKeys = useAvailableFilterKeysForEntityTypes(entityTypes).concat(notCleanableFilterKeys);
+  const availableFilterKeys = useAvailableFilterKeysForEntityTypes(entityTypes).concat(NOT_CLEANABLE_FILTER_KEYS);
   return removeIdAndIncorrectKeysFromFilterGroupObject(filters, availableFilterKeys);
 };
 
@@ -901,7 +901,7 @@ interface BuildEntityTypeBasedFilterContextArgs {
 export const useBuildEntityTypeBasedFilterContext = (
   entityTypeParam: string | string[],
   filters: FilterGroup | undefined,
-  args?: BuildEntityTypeBasedFilterContextArgs = {},
+  args: BuildEntityTypeBasedFilterContextArgs = {},
 ): FilterGroup => {
   const { excludedEntityTypesParam = null, entityTypesContext = null, draftId = null } = args;
   const entityTypes = Array.isArray(entityTypeParam) ? entityTypeParam : [entityTypeParam];

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -903,7 +903,7 @@ export const useBuildEntityTypeBasedFilterContext = (
   filters: FilterGroup | undefined,
   args: BuildEntityTypeBasedFilterContextArgs = {},
 ): FilterGroup => {
-  const { excludedEntityTypesParam = null, entityTypesContext = null, draftId = null } = args;
+  const { excludedEntityTypesParam = undefined, entityTypesContext = undefined, draftId = undefined } = args;
   const entityTypes = Array.isArray(entityTypeParam) ? entityTypeParam : [entityTypeParam];
   const userFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, entityTypesContext ?? entityTypes);
   const entityTypeFilter = { key: 'entity_type', values: entityTypes, operator: 'eq', mode: 'or' };

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -910,7 +910,7 @@ export const useBuildEntityTypeBasedFilterContext = (
   const entityTypeContextFilters: Filter[] = [entityTypeFilter];
   if (excludedEntityTypesParam && excludedEntityTypesParam.length > 0) {
     const excludedEntityTypes = Array.isArray(excludedEntityTypesParam) ? excludedEntityTypesParam : [excludedEntityTypesParam];
-    const excludedEntityTypeFilter = { key: 'entity_type', values: excludedEntityTypes, operator: 'not_eq', mode: 'or' };
+    const excludedEntityTypeFilter = { key: 'entity_type', values: excludedEntityTypes, operator: 'not_eq', mode: 'and' };
     entityTypeContextFilters.push(excludedEntityTypeFilter);
   }
   if (draftId) {

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -914,11 +914,11 @@ export const useBuildEntityTypeBasedFilterContext = (
     entityTypeContextFilters.push(excludedEntityTypeFilter);
   }
   if (draftId) {
-    entityTypeContextFilters.push({
+    entityTypeContextFilters.push({ // entities that are in the draft 'draftId'
       key: 'draft_ids',
       values: [draftId],
     });
-    entityTypeContextFilters.push({
+    entityTypeContextFilters.push({ // entities that are in the draft index (ie, don't take into account entities existing outside drafts but modified in a draft)
       key: 'draft_change',
       operator: 'not_nil',
       values: [],

--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -1,6 +1,7 @@
 import { ENTITY_TYPE_GROUP, ENTITY_TYPE_USER } from './internalObject';
 import { ABSTRACT_BASIC_OBJECT, ABSTRACT_BASIC_RELATIONSHIP } from './general';
 import { getDraftOperations } from '../modules/draftWorkspace/draftOperations';
+import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 
 export const shortMapping = {
   type: 'text',
@@ -108,7 +109,7 @@ export const draftIds: AttributeDefinition = {
   editDefault: false,
   upsert: false,
   isFilterable: false,
-  entityTypes: [ABSTRACT_BASIC_OBJECT, ABSTRACT_BASIC_RELATIONSHIP],
+  entityTypes: [ENTITY_TYPE_DRAFT_WORKSPACE],
 };
 
 export const draftContext: AttributeDefinition = {


### PR DESCRIPTION
### Proposed changes
- Add context filters in draft (for draft entities, relationships and sightings) for background tasks on the entities in the draft
- unit test for useBuildEntityTypeBasedFilterContext

### Related issues
#14345