### PR TITLE
[backend] Race condition in cache engine causes undefined data for concurrent requesters

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/cache.ts
+++ b/opencti-platform/opencti-graphql/src/database/cache.ts
@@ -11,10 +11,10 @@ import { ENTITY_TYPE_RESOLVED_FILTERS } from '../schema/stixDomainObject';
 import { ENTITY_TYPE_TRIGGER } from '../modules/notification/notification-types';
 import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
 import { type BasicStoreEntityPublicDashboard, ENTITY_TYPE_PUBLIC_DASHBOARD } from '../modules/publicDashboard/publicDashboard-types';
-import { wait } from './utils';
 import { ENTITY_TYPE_PIR } from '../modules/pir/pir-types';
 import { ENTITY_TYPE_DECAY_EXCLUSION_RULE } from '../modules/decayRule/exclusions/decayExclusionRule-types';
 import { ENTITY_TYPE_LABEL, ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
+import { pushAll } from '../utils/arrayUtil';
 
 const STORE_ENTITIES_LINKS: Record<string, string[]> = {
   // Resolved Filters in cache must be reset depending on connector/stream/triggers/playbooks/Pir/label modifications
@@ -130,30 +130,34 @@ const getEntitiesFromCache = async <T extends BasicStoreIdentifier | StixObject>
     // Loop until values are available.
     // If a concurrent fetch fails, waiters retry instead of returning empty data.
     while (!fromCache.values) {
-      if (fromCache.inProgress) {
-        await wait(100);
-        continue;
+      if (!fromCache.inProgress) {
+        const loadFromFn = async () => {
+          try {
+            let cacheData = await fromCache.fn();
+            if (!cacheData) {
+              // This situation must be adapted with code evolution
+              logApp.warn('[CACHE] Cache function refresh return undefined values', { type });
+              cacheData = type === ENTITY_TYPE_RESOLVED_FILTERS ? new Map() : [];
+            }
+            fromCache.values = cacheData;
+          } finally {
+            fromCache.inProgress = undefined;
+          }
+        };
+        fromCache.inProgress = loadFromFn();
       }
-      fromCache.inProgress = true;
+
       try {
-        let cacheData = await fromCache.fn();
-        if (!cacheData) {
-          // This situation must be adapted with code evolution
-          logApp.warn('[CACHE] Cache function refresh return undefined values', { type });
-          cacheData = type === ENTITY_TYPE_RESOLVED_FILTERS ? new Map() : [];
-        }
-        fromCache.values = cacheData;
+        await fromCache.inProgress;
       } catch (err: any) {
         retries += 1;
         logApp.error('[CACHE] Error loading cache', { type, attempt: retries, maxRetries: MAX_CACHE_RETRIES, cause: err });
         if (retries >= MAX_CACHE_RETRIES) {
           throw DatabaseError(err.message);
         }
-      } finally {
-        fromCache.inProgress = false;
       }
     }
-    return fromCache.values;
+    return fromCache.values as Promise<Array<T> | Map<string, T>>;
   };
   return telemetry(context, user, `CACHE ${type}`, {
     [SEMATTRS_DB_NAME]: 'cache_engine',
@@ -165,27 +169,25 @@ const getEntitiesFromCache = async <T extends BasicStoreIdentifier | StixObject>
 export const getEntitiesListFromCache = async <T extends BasicStoreIdentifier | StixObject>(
   context: AuthContext, user: AuthUser, type: string,
 ): Promise<Array<T>> => {
+  const data = await getEntitiesFromCache(context, user, type);
   if (type === ENTITY_TYPE_RESOLVED_FILTERS) {
-    const map = await getEntitiesFromCache(context, user, type) as Map<string, T>;
     const result: T[] = [];
-    for (const value of map.values()) {
-      result.push(value);
-    }
+    pushAll(result, (data as Map<string, T>).values());
     return result;
   }
-  return await getEntitiesFromCache(context, user, type) as T[];
+  return data as T[];
 };
 
 // get a map <id, instance> of the entities in the cache for a given type
 export const getEntitiesMapFromCache = async <T extends BasicStoreIdentifier | StixObject>(
   context: AuthContext, user: AuthUser, type: string,
 ): Promise<Map<string | StixId, T>> => {
+  const data = await getEntitiesFromCache(context, user, type);
   // Filters is already a map
   if (type === ENTITY_TYPE_RESOLVED_FILTERS) {
-    return await getEntitiesFromCache(context, user, type) as Map<string, T>; // map of <standard_id, instance>
+    return data as Map<string, T>; // map of <standard_id, instance>
   }
-  const data = await getEntitiesFromCache(context, user, type) as BasicStoreIdentifier[];
-  return buildStoreEntityMap(data); // map of <id, instance> for all the instance ids (internal_id, standard_id, stix ids)
+  return buildStoreEntityMap(data as BasicStoreIdentifier[]); // map of <id, instance> for all the instance ids (internal_id, standard_id, stix ids)
 };
 
 export const getEntityFromCache = async <T extends BasicStoreIdentifier>(context: AuthContext, user: AuthUser, type: string): Promise<T> => {


### PR DESCRIPTION
## Fix race condition in cache engine concurrent fetch

### Problem

When a cache fetcher fails while other requests are waiting, the waiters silently 
receive empty data (`[]`) instead of retrying. This causes [getEntityFromCache](cci:1://file:///Users/julienrichard/Documents/filigran/opencti/core-engine/opencti-platform/opencti-graphql/src/database/cache.ts:182:0-185:2) to 
return `undefined`, crashing downstream code — most visibly [isUserInPlatformOrganization](cci:1://file:///Users/julienrichard/Documents/filigran/opencti/core-engine/opencti-platform/opencti-graphql/src/utils/access.ts:964:0-973:2) 
with `TypeError: Cannot read properties of undefined (reading 'platform_organization')`.

### Solution

Replace the linear if/else fetch logic with a retry loop in [getEntitiesFromCache](cci:1://file:///Users/julienrichard/Documents/filigran/opencti/core-engine/opencti-platform/opencti-graphql/src/database/cache.ts:120:0-153:2):

```diff
-    if (!fromCache.values) {
-      if (fromCache.inProgress) {
-        while (fromCache.inProgress) {
-          await wait(100);
-        }
-        return fromCache.values ?? (type === ENTITY_TYPE_RESOLVED_FILTERS ? new Map() : []);
-      }
-      fromCache.inProgress = true;
-      try {
-        fromCache.values = await fromCache.fn();
-      } finally {
-        fromCache.inProgress = false;
-      }
-    }
-    return fromCache.values ?? (type === ENTITY_TYPE_RESOLVED_FILTERS ? new Map() : []);
+    const MAX_CACHE_RETRIES = 10;
+    let retries = 0;
+    while (!fromCache.values) {
+      if (fromCache.inProgress) {
+        await wait(100);
+        continue;
+      }
+      fromCache.inProgress = true;
+      try {
+        let cacheData = await fromCache.fn();
+        if (!cacheData) {
+          logApp.warn('[CACHE] Cache function refresh return undefined values', { type });
+          cacheData = type === ENTITY_TYPE_RESOLVED_FILTERS ? new Map() : [];
+        }
+        fromCache.values = cacheData;
+      } catch (err: any) {
+        retries += 1;
+        logApp.error('[CACHE] Error loading cache', { type, attempt: retries, maxRetries: MAX_CACHE_RETRIES, cause: err });
+        if (retries >= MAX_CACHE_RETRIES) {
+          throw DatabaseError(err.message);
+        }
+      } finally {
+        fromCache.inProgress = false;
+      }
+    }
+    return fromCache.values;
```

### Key improvements

| Before | After |
|---|---|
| Waiters return empty data on fetch failure | Waiters retry the fetch |
| Errors silently swallowed by `finally` | Errors logged with type and attempt count |
| No retry limit — could mask issues | Max 10 retries, then `DatabaseError` |
| `null` fetcher result → empty data downstream | `null` result logged as warning, falls back safely |

### Testing

Existing cache and access tests pass:
```
npx vitest run tests/01-unit/manager/cacheManager-test.ts tests/01-unit/utils/access-test.ts
```