### PR TITLE
[frontend] fix datatable rendering in drawer (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/Drawer.tsx
@@ -35,6 +35,9 @@ const useStyles = makeStyles<Theme, { bannerHeightNumber: number }>((theme) => c
     padding: theme.spacing(3),
     height: '100%',
     overflowY: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
   },
   mainButton: ({ bannerHeightNumber }) => ({
     position: 'fixed',
@@ -242,10 +245,8 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
             backgroundColor: theme.palette.background.drawer,
           }}
         >
-          <Stack gap={2}>
-            {renderSubHeader()}
-            {component}
-          </Stack>
+          {renderSubHeader()}
+          {component}
         </div>
       </DrawerMUI>
     </>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* DatatableBody miscalculate height with a div flex, remove that level of wrapping and handle gap in superior level

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13303 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
