### PR TITLE
[frontend/backend] Add metadata in draft creation form (#14058)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -26,7 +26,7 @@ import ObjectParticipantField from '@components/common/form/ObjectParticipantFie
 import CreatedByField from '@components/common/form/CreatedByField';
 import useHelper from '../../../../utils/hooks/useHelper';
 import { useIsMandatoryAttribute } from '../../../../utils/hooks/useEntitySettings';
-import { DraftAddInput, DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
+import { DraftAddInput, DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 
 interface LaunchImportDialogProps {
@@ -51,7 +51,7 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKSPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const { connectorsForImport: connectors } = usePreloadedQuery<ImportWorksDrawerQuery>(fileWorksQuery, queryRef);
   const [selectedConnector, setSelectedConnector] = React.useState<ConnectorType | null>(null);
@@ -154,7 +154,7 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
   const invalidCsvMapper = selectedConnector?.name === 'ImportCsv'
     && selectedConnector?.configurations?.length === 0;
 
-  const draftInitialValues = useDefaultValues<DraftAddInput>(DRAFTWORKPACE_TYPE, {
+  const draftInitialValues = useDefaultValues<DraftAddInput>(DRAFTWORKSPACE_TYPE, {
     name: '',
     description: '',
     objectAssignee: [],
@@ -171,7 +171,7 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
         validation_mode: isDraftContext ? 'draft' : 'workbench',
         configuration: '',
         objectMarking: [],
-        ...draftInitialValues
+        ...draftInitialValues,
       }}
       validationSchema={importValidation(!!selectedConnector?.configurations)}
       onSubmit={onSubmitImport}

--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -225,48 +225,48 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
             )}
             {values.validation_mode === 'draft' && (
               <>
-                  {isFeatureEnable('DRAFT_METADATA') && (
-                    <>
-                      <Field
-                        component={MarkdownField}
-                        name="description"
-                        label={t_i18n('Description')}
-                        required={mandatoryAttributes.includes('description')}
-                        fullWidth={true}
-                        multiline={true}
-                        rows="4"
-                        style={fieldSpacingContainerStyle}
-                        askAi={true}
-                      />
-                      <ObjectAssigneeField
-                        name="objectAssignee"
-                        style={fieldSpacingContainerStyle}
-                        required={mandatoryAttributes.includes('objectAssignee')}
-                      />
-                      <ObjectParticipantField
-                        name="objectParticipant"
-                        style={fieldSpacingContainerStyle}
-                        required={mandatoryAttributes.includes('objectParticipant')}
-                      />
-                      <CreatedByField
-                        name="createdBy"
-                        required={mandatoryAttributes.includes('createdBy')}
-                        style={fieldSpacingContainerStyle}
-                        setFieldValue={setFieldValue}
-                      />
-                    </>
-                  )}
-                  <Field
-                    name="authorizedMembers"
-                    component={AuthorizedMembersField}
-                    owner={owner}
-                    showAllMembersLine={showAllMembersLine}
-                    canDeactivate
-                    addMeUserWithAdminRights
-                    enableAccesses
-                    applyAccesses
-                    style={fieldSpacingContainerStyle}
-                  />
+                {isFeatureEnable('DRAFT_METADATA') && (
+                  <>
+                    <Field
+                      component={MarkdownField}
+                      name="description"
+                      label={t_i18n('Description')}
+                      required={mandatoryAttributes.includes('description')}
+                      fullWidth={true}
+                      multiline={true}
+                      rows="4"
+                      style={fieldSpacingContainerStyle}
+                      askAi={true}
+                    />
+                    <ObjectAssigneeField
+                      name="objectAssignee"
+                      style={fieldSpacingContainerStyle}
+                      required={mandatoryAttributes.includes('objectAssignee')}
+                    />
+                    <ObjectParticipantField
+                      name="objectParticipant"
+                      style={fieldSpacingContainerStyle}
+                      required={mandatoryAttributes.includes('objectParticipant')}
+                    />
+                    <CreatedByField
+                      name="createdBy"
+                      required={mandatoryAttributes.includes('createdBy')}
+                      style={fieldSpacingContainerStyle}
+                      setFieldValue={setFieldValue}
+                    />
+                  </>
+                )}
+                <Field
+                  name="authorizedMembers"
+                  component={AuthorizedMembersField}
+                  owner={owner}
+                  showAllMembersLine={showAllMembersLine}
+                  canDeactivate
+                  addMeUserWithAdminRights
+                  enableAccesses
+                  applyAccesses
+                  style={fieldSpacingContainerStyle}
+                />
               </>
             )}
             {selectedConnector?.configurations && selectedConnector?.configurations?.length > 0 ? (

--- a/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
@@ -1,13 +1,13 @@
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
-import AuthorizedMembersField, { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
-import { DraftsLinesPaginationQuery$variables } from '@components/drafts/__generated__/DraftsLinesPaginationQuery.graphql';
 import DialogActions from '@mui/material/DialogActions';
 import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
+import { DraftsLinesPaginationQuery$variables } from '@components/drafts/__generated__/DraftsLinesPaginationQuery.graphql';
+import AuthorizedMembersField from '@components/common/form/AuthorizedMembersField';
 import * as Yup from 'yup';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';
@@ -17,6 +17,14 @@ import useApiMutation from '../../../../../utils/hooks/useApiMutation';
 import useAuth from '../../../../../utils/hooks/useAuth';
 import { insertNode } from '../../../../../utils/store';
 import { DraftWorkspaceDialogCreationMutation, DraftWorkspaceDialogCreationMutation$variables } from './__generated__/DraftWorkspaceDialogCreationMutation.graphql';
+import MarkdownField from '../../../../../components/fields/MarkdownField';
+import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
+import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
+import CreatedByField from '@components/common/form/CreatedByField';
+import useHelper from '../../../../../utils/hooks/useHelper';
+import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../../utils/hooks/useEntitySettings';
+import { DraftAddInput, DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
+import useDefaultValues from '../../../../../utils/hooks/useDefaultValues';
 
 const draftWorkspaceDialogCreationMutation = graphql`
   mutation DraftWorkspaceDialogCreationMutation($input: DraftWorkspaceAddInput!) {
@@ -35,19 +43,16 @@ interface DraftWorkspaceCreationProps {
   paginationOptions: DraftsLinesPaginationQuery$variables;
 }
 
-interface DraftAddInput {
-  name: string;
-  authorizedMembers?: AuthorizedMembersFieldValue;
-}
-
 const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProps> = ({
   openCreate,
   handleCloseCreate,
   entityId,
   paginationOptions,
 }) => {
+  const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const [commit] = useApiMutation<DraftWorkspaceDialogCreationMutation>(
     draftWorkspaceDialogCreationMutation,
@@ -61,17 +66,30 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
     'draftWorkspaceAdd',
   );
 
-  const draftValidation = Yup.object().shape({
-    name: Yup.string().trim().required(t_i18n('This field is required')),
-  });
+  const basicShape = yupShapeConditionalRequired({
+    name: Yup.string().trim().min(2, t_i18n('Name must be at least 2 characters')),
+    description: Yup.string().nullable(),
+    objectAssignee: Yup.array().nullable(),
+    objectParticipant: Yup.array().nullable(),
+    createdBy: Yup.object().nullable(),
+    authorized_members: Yup.array().nullable(),
+  }, mandatoryAttributes);
+  const draftWorkspaceValidator = useDynamicSchemaCreationValidation(
+    mandatoryAttributes,
+    basicShape,
+  );
 
   const onSubmit: FormikConfig<DraftAddInput>['onSubmit'] = (values, { setSubmitting, setErrors, resetForm }) => {
     const input: DraftWorkspaceDialogCreationMutation$variables['input'] = {
       name: values.name,
       entity_id: entityId,
-      authorized_members: !values.authorizedMembers
+      description: values.description,
+      objectAssignee: values.objectAssignee.map(({ value }) => value),
+      objectParticipant: values.objectParticipant.map(({ value }) => value),
+      createdBy: values.createdBy?.value,
+      authorized_members: !values.authorized_members
         ? null
-        : values.authorizedMembers
+        : values.authorized_members
             .filter((v) => v.accessRight !== 'none')
             .map((member) => ({
               id: member.value,
@@ -99,15 +117,24 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
     });
   };
 
+  const initialValues = useDefaultValues<DraftAddInput>(DRAFTWORKPACE_TYPE, {
+    name: '',
+    description: '',
+    objectAssignee: [],
+    objectParticipant: [],
+    createdBy: undefined,
+    authorized_members: undefined,
+  });
+
   return (
     <Formik<DraftAddInput>
       enableReinitialize={true}
-      initialValues={{ name: '' }}
-      validationSchema={draftValidation}
+      initialValues={initialValues}
+      validationSchema={draftWorkspaceValidator}
       onSubmit={onSubmit}
       onReset={handleCloseCreate}
     >
-      {({ submitForm, handleReset, isSubmitting }) => (
+      {({ submitForm, handleReset, isSubmitting, setFieldValue }) => (
         <Form>
           <Dialog
             open={!!openCreate}
@@ -121,8 +148,39 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
               label={t_i18n('Name')}
               fullWidth
             />
-            <Field
-              name="authorizedMembers"
+            {isFeatureEnable('DRAFT_METADATA') && (
+                <>
+                  <Field
+                    component={MarkdownField}
+                    name="description"
+                    label={t_i18n('Description')}
+                    required={mandatoryAttributes.includes('description')}
+                    fullWidth={true}
+                    multiline={true}
+                    rows="4"
+                    style={fieldSpacingContainerStyle}
+                    askAi={true}
+                  />
+                  <ObjectAssigneeField
+                    name="objectAssignee"
+                    style={fieldSpacingContainerStyle}
+                    required={mandatoryAttributes.includes('objectAssignee')}
+                  />
+                  <ObjectParticipantField
+                    name="objectParticipant"
+                    style={fieldSpacingContainerStyle}
+                    required={mandatoryAttributes.includes('objectParticipant')}
+                  />
+                  <CreatedByField
+                    name="createdBy"
+                    required={mandatoryAttributes.includes('createdBy')}
+                    style={fieldSpacingContainerStyle}
+                    setFieldValue={setFieldValue}
+                  />
+                </>
+              )}
+              <Field
+                name="authorized_members"
               component={AuthorizedMembersField}
               owner={owner}
               showAllMembersLine={showAllMembersLine}
@@ -132,7 +190,6 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
               applyAccesses
               style={fieldSpacingContainerStyle}
             />
-
             <DialogActions>
               <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
                 {t_i18n('Cancel')}

--- a/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
@@ -23,7 +23,7 @@ import ObjectParticipantField from '@components/common/form/ObjectParticipantFie
 import CreatedByField from '@components/common/form/CreatedByField';
 import useHelper from '../../../../../utils/hooks/useHelper';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../../utils/hooks/useEntitySettings';
-import { DraftAddInput, DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
+import { DraftAddInput, DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 import useDefaultValues from '../../../../../utils/hooks/useDefaultValues';
 
 const draftWorkspaceDialogCreationMutation = graphql`
@@ -52,7 +52,7 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKSPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const [commit] = useApiMutation<DraftWorkspaceDialogCreationMutation>(
     draftWorkspaceDialogCreationMutation,
@@ -117,7 +117,7 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
     });
   };
 
-  const initialValues = useDefaultValues<DraftAddInput>(DRAFTWORKPACE_TYPE, {
+  const initialValues = useDefaultValues<DraftAddInput>(DRAFTWORKSPACE_TYPE, {
     name: '',
     description: '',
     objectAssignee: [],

--- a/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
@@ -149,38 +149,38 @@ const DraftWorkspaceDialogCreation: FunctionComponent<DraftWorkspaceCreationProp
               fullWidth
             />
             {isFeatureEnable('DRAFT_METADATA') && (
-                <>
-                  <Field
-                    component={MarkdownField}
-                    name="description"
-                    label={t_i18n('Description')}
-                    required={mandatoryAttributes.includes('description')}
-                    fullWidth={true}
-                    multiline={true}
-                    rows="4"
-                    style={fieldSpacingContainerStyle}
-                    askAi={true}
-                  />
-                  <ObjectAssigneeField
-                    name="objectAssignee"
-                    style={fieldSpacingContainerStyle}
-                    required={mandatoryAttributes.includes('objectAssignee')}
-                  />
-                  <ObjectParticipantField
-                    name="objectParticipant"
-                    style={fieldSpacingContainerStyle}
-                    required={mandatoryAttributes.includes('objectParticipant')}
-                  />
-                  <CreatedByField
-                    name="createdBy"
-                    required={mandatoryAttributes.includes('createdBy')}
-                    style={fieldSpacingContainerStyle}
-                    setFieldValue={setFieldValue}
-                  />
-                </>
-              )}
-              <Field
-                name="authorized_members"
+              <>
+                <Field
+                  component={MarkdownField}
+                  name="description"
+                  label={t_i18n('Description')}
+                  required={mandatoryAttributes.includes('description')}
+                  fullWidth={true}
+                  multiline={true}
+                  rows="4"
+                  style={fieldSpacingContainerStyle}
+                  askAi={true}
+                />
+                <ObjectAssigneeField
+                  name="objectAssignee"
+                  style={fieldSpacingContainerStyle}
+                  required={mandatoryAttributes.includes('objectAssignee')}
+                />
+                <ObjectParticipantField
+                  name="objectParticipant"
+                  style={fieldSpacingContainerStyle}
+                  required={mandatoryAttributes.includes('objectParticipant')}
+                />
+                <CreatedByField
+                  name="createdBy"
+                  required={mandatoryAttributes.includes('createdBy')}
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
+                />
+              </>
+            )}
+            <Field
+              name="authorized_members"
               component={AuthorizedMembersField}
               owner={owner}
               showAllMembersLine={showAllMembersLine}

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -1,16 +1,12 @@
 import { ImportFilesProvider, importFilesQuery, InitialValues, useImportFilesContext } from '@components/common/files/import_files/ImportFilesContext';
-import ImportFilesFormSelector from '@components/common/files/import_files/ImportFilesFormSelector';
-import ImportFilesFormView from '@components/common/files/import_files/ImportFilesFormView';
 import ImportFilesOptions from '@components/common/files/import_files/ImportFilesOptions';
 import ImportFilesStepper from '@components/common/files/import_files/ImportFilesStepper';
-import ImportFilesToggleMode from '@components/common/files/import_files/ImportFilesToggleMode';
 import ImportFilesUploadProgress from '@components/common/files/import_files/ImportFilesUploadProgress';
 import ImportFilesToggleMode from '@components/common/files/import_files/ImportFilesToggleMode';
 import ImportFilesFormSelector from '@components/common/files/import_files/ImportFilesFormSelector';
 import ImportFilesFormView from '@components/common/files/import_files/ImportFilesFormView';
-import { DraftAddInput, draftCreationMutation, DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
+import { DraftAddInput, draftCreationMutation, DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 import { DraftCreationMutation, DraftCreationMutation$data } from '@components/drafts/__generated__/DraftCreationMutation.graphql';
-import { ImportFilesProvider, importFilesQuery, InitialValues, useImportFilesContext } from '@components/common/files/import_files/ImportFilesContext';
 import ImportFilesUploader from '@components/common/files/import_files/ImportFilesUploader';
 import { ImportFilesContextQuery } from '@components/common/files/import_files/__generated__/ImportFilesContextQuery.graphql';
 import {
@@ -23,8 +19,6 @@ import {
 } from '@components/common/files/import_files/__generated__/ImportFilesDialogGlobalMutation.graphql';
 import { AssociatedEntityOption } from '@components/common/form/AssociatedEntityField';
 import { AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
-import { draftCreationMutation } from '@components/drafts/DraftCreation';
-import { DraftCreationMutation, DraftCreationMutation$data } from '@components/drafts/__generated__/DraftCreationMutation.graphql';
 import { Box, DialogActions } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import { FormikConfig, FormikErrors, useFormik } from 'formik';
@@ -47,9 +41,8 @@ import useBulkCommit from '../../../../../utils/hooks/useBulkCommit';
 import useDraftContext from '../../../../../utils/hooks/useDraftContext';
 import { KNOWLEDGE_KNASKIMPORT } from '../../../../../utils/hooks/useGranted';
 import { hasCustomColor } from '../../../../../utils/theme';
-import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../../utils/hooks/useEntitySettings';
+import { useIsMandatoryAttribute } from '../../../../../utils/hooks/useEntitySettings';
 import useDefaultValues from '../../../../../utils/hooks/useDefaultValues';
-import * as Yup from 'yup';
 import useSwitchDraft from '../../../drafts/useSwitchDraft';
 
 export const CSV_MAPPER_NAME = '[FILE] CSV Mapper import';
@@ -134,7 +127,7 @@ export type OptionsFormValues = {
 
 const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
   const { t_i18n } = useFormatter();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKSPACE_TYPE);
 
   const theme = useTheme<Theme>();
 
@@ -351,7 +344,7 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
     }
   };
 
-  const draftDefaultValues = useDefaultValues<DraftAddInput>(DRAFTWORKPACE_TYPE, {
+  const draftDefaultValues = useDefaultValues<DraftAddInput>(DRAFTWORKSPACE_TYPE, {
     name: '',
     description: '',
     objectAssignee: [],

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -359,20 +359,6 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
     createdBy: undefined,
   });
 
-  const basicShape = yupShapeConditionalRequired({
-    name: Yup.string().trim().min(2, t_i18n('Name must be at least 2 characters')),
-    description: Yup.string().nullable(),
-    objectAssignee: Yup.array().nullable(),
-    objectParticipant: Yup.array().nullable(),
-    createdBy: Yup.object().nullable(),
-    authorized_members: Yup.array().nullable(),
-  }, mandatoryAttributes);
-
-  const draftWorkspaceValidator = useDynamicSchemaCreationValidation(
-    mandatoryAttributes,
-    basicShape,
-  );
-
   const optionsContext = useFormik<OptionsFormValues>({
     enableReinitialize: true,
     initialValues: {
@@ -381,7 +367,6 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
       validationMode: importMode === 'manual' ? 'draft' : undefined,
       ...draftDefaultValues,
     },
-    validationSchema: draftWorkspaceValidator,
     onSubmit,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
@@ -20,7 +20,7 @@ import ObjectParticipantField from '@components/common/form/ObjectParticipantFie
 import CreatedByField from '@components/common/form/CreatedByField';
 import useHelper from '../../../../../utils/hooks/useHelper';
 import { useIsMandatoryAttribute } from '../../../../../utils/hooks/useEntitySettings';
-import { DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
+import { DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 
 interface ImportFilesOptionsProps {
   optionsFormikContext: FormikContextType<OptionsFormValues>;
@@ -34,7 +34,7 @@ const ImportFilesOptions = ({
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKSPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const {
     importMode,

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
@@ -14,6 +14,13 @@ import TextField from '../../../../../components/TextField';
 import SelectField from '../../../../../components/fields/SelectField';
 import { DraftContext } from '../../../../../utils/hooks/useDraftContext';
 import useAuth from '../../../../../utils/hooks/useAuth';
+import MarkdownField from '../../../../../components/fields/MarkdownField';
+import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
+import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
+import CreatedByField from '@components/common/form/CreatedByField';
+import useHelper from '../../../../../utils/hooks/useHelper';
+import { useIsMandatoryAttribute } from '../../../../../utils/hooks/useEntitySettings';
+import { DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
 
 interface ImportFilesOptionsProps {
   optionsFormikContext: FormikContextType<OptionsFormValues>;
@@ -24,8 +31,10 @@ const ImportFilesOptions = ({
   optionsFormikContext,
   draftContext,
 }: ImportFilesOptionsProps) => {
+  const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const {
     importMode,
@@ -105,9 +114,41 @@ const ImportFilesOptions = ({
                 <Field
                   name="name"
                   label={t_i18n('Draft name')}
+                  required={mandatoryAttributes.includes('name')}
                   component={TextField}
                   variant="standard"
                 />
+                {isFeatureEnable('DRAFT_METADATA') && (
+                  <>
+                    <Field
+                      component={MarkdownField}
+                      name="description"
+                      label={t_i18n('Description')}
+                      required={mandatoryAttributes.includes('description')}
+                      fullWidth={true}
+                      multiline={true}
+                      rows="4"
+                      style={fieldSpacingContainerStyle}
+                      askAi={true}
+                    />
+                    <ObjectAssigneeField
+                      name="objectAssignee"
+                      style={fieldSpacingContainerStyle}
+                      required={mandatoryAttributes.includes('objectAssignee')}
+                    />
+                    <ObjectParticipantField
+                      name="objectParticipant"
+                      style={fieldSpacingContainerStyle}
+                      required={mandatoryAttributes.includes('objectParticipant')}
+                    />
+                    <CreatedByField
+                      name="createdBy"
+                      required={mandatoryAttributes.includes('createdBy')}
+                      style={fieldSpacingContainerStyle}
+                      setFieldValue={optionsFormikContext.setFieldValue}
+                    />
+                  </>
+                )}
                 <Field
                   name="authorizedMembers"
                   component={AuthorizedMembersField}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
@@ -394,48 +394,48 @@ const StixCoreObjectFilesAndHistory = ({
               )}
               {values.validation_mode === 'draft' && (
                 <>
-                    {isFeatureEnable('DRAFT_METADATA') && (
-                      <>
-                        <Field
-                          component={MarkdownField}
-                          name="description"
-                          label={t_i18n('Description')}
-                          required={mandatoryAttributes.includes('description')}
-                          fullWidth={true}
-                          multiline={true}
-                          rows="4"
-                          style={fieldSpacingContainerStyle}
-                          askAi={true}
-                        />
-                        <ObjectAssigneeField
-                          name="objectAssignee"
-                          style={fieldSpacingContainerStyle}
-                          required={mandatoryAttributes.includes('objectAssignee')}
-                        />
-                        <ObjectParticipantField
-                          name="objectParticipant"
-                          style={fieldSpacingContainerStyle}
-                          required={mandatoryAttributes.includes('objectParticipant')}
-                        />
-                        <CreatedByField
-                          name="createdBy"
-                          required={mandatoryAttributes.includes('createdBy')}
-                          style={fieldSpacingContainerStyle}
-                          setFieldValue={setFieldValue}
-                        />
-                      </>
-                    )}
-                    <Field
-                      name="authorizedMembers"
-                      component={AuthorizedMembersField}
-                      owner={owner}
-                      showAllMembersLine={showAllMembersLine}
-                      canDeactivate
-                      addMeUserWithAdminRights
-                      enableAccesses
-                      applyAccesses
-                      style={fieldSpacingContainerStyle}
-                    />
+                  {isFeatureEnable('DRAFT_METADATA') && (
+                    <>
+                      <Field
+                        component={MarkdownField}
+                        name="description"
+                        label={t_i18n('Description')}
+                        required={mandatoryAttributes.includes('description')}
+                        fullWidth={true}
+                        multiline={true}
+                        rows="4"
+                        style={fieldSpacingContainerStyle}
+                        askAi={true}
+                      />
+                      <ObjectAssigneeField
+                        name="objectAssignee"
+                        style={fieldSpacingContainerStyle}
+                        required={mandatoryAttributes.includes('objectAssignee')}
+                      />
+                      <ObjectParticipantField
+                        name="objectParticipant"
+                        style={fieldSpacingContainerStyle}
+                        required={mandatoryAttributes.includes('objectParticipant')}
+                      />
+                      <CreatedByField
+                        name="createdBy"
+                        required={mandatoryAttributes.includes('createdBy')}
+                        style={fieldSpacingContainerStyle}
+                        setFieldValue={setFieldValue}
+                      />
+                    </>
+                  )}
+                  <Field
+                    name="authorizedMembers"
+                    component={AuthorizedMembersField}
+                    owner={owner}
+                    showAllMembersLine={showAllMembersLine}
+                    canDeactivate
+                    addMeUserWithAdminRights
+                    enableAccesses
+                    applyAccesses
+                    style={fieldSpacingContainerStyle}
+                  />
                 </>
               )}
               {selectedConnector?.configurations?.length > 0

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
@@ -34,7 +34,7 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import AuthorizedMembersField from '../form/AuthorizedMembersField';
 import useHelper from '../../../../utils/hooks/useHelper';
 import { useIsMandatoryAttribute } from '../../../../utils/hooks/useEntitySettings';
-import { DRAFTWORKPACE_TYPE } from '@components/drafts/DraftCreation';
+import { DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import MarkdownField from '../../../../components/fields/MarkdownField';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
@@ -149,7 +149,7 @@ const StixCoreObjectFilesAndHistory = ({
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKSPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const draftContext = useDraftContext();
   const [fileToImport, setFileToImport] = useState(null);
@@ -284,7 +284,7 @@ const StixCoreObjectFilesAndHistory = ({
     setHasUserChoiceCsvMapper(hasUserChoiceCsvMapperRepresentations);
   };
 
-  const draftInitialValues = useDefaultValues(DRAFTWORKPACE_TYPE, {
+  const draftInitialValues = useDefaultValues(DRAFTWORKSPACE_TYPE, {
     name: '',
     description: '',
     objectAssignee: [],

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
@@ -49,7 +49,7 @@ export const draftCreationMutation = graphql`
     }
 `;
 
-const DRAFTWORKPACE_TYPE = 'DraftWorkspace';
+export const DRAFTWORKPACE_TYPE = 'DraftWorkspace';
 
 interface DraftFormProps {
   updater: (
@@ -60,7 +60,7 @@ interface DraftFormProps {
   onCompleted?: () => void;
 }
 
-interface DraftAddInput {
+export interface DraftAddInput {
   name: string;
   description: string;
   objectAssignee: FieldOption[];

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
@@ -20,6 +20,12 @@ import FormButtonContainer from '@common/form/FormButtonContainer';
 import useDefaultValues from '../../../utils/hooks/useDefaultValues';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../utils/hooks/useGranted';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../utils/hooks/useEntitySettings';
+import MarkdownField from '../../../components/fields/MarkdownField';
+import { FieldOption, fieldSpacingContainerStyle } from '../../../utils/field';
+import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
+import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
+import CreatedByField from '@components/common/form/CreatedByField';
+import useHelper from '../../../utils/hooks/useHelper';
 
 export const draftCreationMutation = graphql`
     mutation DraftCreationMutation($input: DraftWorkspaceAddInput!) {
@@ -56,10 +62,15 @@ interface DraftFormProps {
 
 interface DraftAddInput {
   name: string;
+  description: string;
+  objectAssignee: FieldOption[];
+  objectParticipant: FieldOption[];
+  createdBy: FieldOption | undefined;
   authorized_members?: AuthorizedMembersFieldValue;
 }
 
 const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onReset }) => {
+  const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
   const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
@@ -68,6 +79,10 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
 
   const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2, t_i18n('Name must be at least 2 characters')),
+    description: Yup.string().nullable(),
+    objectAssignee: Yup.array().nullable(),
+    objectParticipant: Yup.array().nullable(),
+    createdBy: Yup.object().nullable(),
     authorized_members: Yup.array().nullable(),
   }, mandatoryAttributes);
   const draftWorkspaceValidator = useDynamicSchemaCreationValidation(
@@ -80,6 +95,10 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
   const onSubmit: FormikConfig<DraftAddInput>['onSubmit'] = (values, { setSubmitting, setErrors, resetForm }) => {
     const input: DraftCreationMutation$variables['input'] = {
       name: values.name,
+      description: values.description,
+      objectAssignee: values.objectAssignee.map(({ value }) => value),
+      objectParticipant: values.objectParticipant.map(({ value }) => value),
+      createdBy: values.createdBy?.value,
       authorized_members: !values.authorized_members ? null : (
         values.authorized_members
           .filter((v) => v.accessRight !== 'none')
@@ -117,6 +136,10 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
 
   const initialValues = useDefaultValues<DraftAddInput>(DRAFTWORKPACE_TYPE, {
     name: '',
+    description: '',
+    objectAssignee: [],
+    objectParticipant: [],
+    createdBy: undefined,
     authorized_members: undefined,
   });
   if (!canEditAuthorizedMembers) {
@@ -130,7 +153,7 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
       onSubmit={onSubmit}
       onReset={onReset}
     >
-      {({ submitForm, handleReset, isSubmitting }) => (
+      {({ submitForm, handleReset, isSubmitting, setFieldValue }) => (
         <Form>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }} data-testid="draft-creation-form">
             <Field
@@ -141,6 +164,37 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
               fullWidth
               data-testid="draft-creation-form-name-input"
             />
+            {isFeatureEnable('DRAFT_METADATA') && (
+              <>
+                <Field
+                  component={MarkdownField}
+                  name="description"
+                  label={t_i18n('Description')}
+                  required={mandatoryAttributes.includes('description')}
+                  fullWidth={true}
+                  multiline={true}
+                  rows="4"
+                  style={fieldSpacingContainerStyle}
+                  askAi={true}
+                />
+                <ObjectAssigneeField
+                  name="objectAssignee"
+                  style={fieldSpacingContainerStyle}
+                  required={mandatoryAttributes.includes('objectAssignee')}
+                />
+                <ObjectParticipantField
+                  name="objectParticipant"
+                  style={fieldSpacingContainerStyle}
+                  required={mandatoryAttributes.includes('objectParticipant')}
+                />
+                <CreatedByField
+                  name="createdBy"
+                  required={mandatoryAttributes.includes('createdBy')}
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
+                />
+              </>
+            )}
             <Field
               name="authorized_members"
               component={AuthorizedMembersField}

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
@@ -49,7 +49,7 @@ export const draftCreationMutation = graphql`
     }
 `;
 
-export const DRAFTWORKPACE_TYPE = 'DraftWorkspace';
+export const DRAFTWORKSPACE_TYPE = 'DraftWorkspace';
 
 interface DraftFormProps {
   updater: (
@@ -73,7 +73,7 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
   const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const { me: owner, settings } = useAuth();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKPACE_TYPE);
+  const { mandatoryAttributes } = useIsMandatoryAttribute(DRAFTWORKSPACE_TYPE);
   const showAllMembersLine = !settings.platform_organization?.id;
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
 
@@ -134,7 +134,7 @@ const DraftCreationForm: React.FC<DraftFormProps> = ({ updater, onCompleted, onR
     });
   };
 
-  const initialValues = useDefaultValues<DraftAddInput>(DRAFTWORKPACE_TYPE, {
+  const initialValues = useDefaultValues<DraftAddInput>(DRAFTWORKSPACE_TYPE, {
     name: '',
     description: '',
     objectAssignee: [],

--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -173,15 +173,27 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
 
   const dataColumns: DataTableProps['dataColumns'] = {
     name: {
-      percentWidth: 50,
+      percentWidth: 28,
       isSortable: true,
     },
     creator: {
-      percentWidth: 15,
+      percentWidth: 10,
       isSortable: true,
     },
     created_at: {
-      percentWidth: 15,
+      percentWidth: 12,
+      isSortable: true,
+    },
+    createdBy: {
+      percentWidth: 10,
+      isSortable: true,
+    },
+    objectParticipant: {
+      percentWidth: 10,
+      isSortable: true,
+    },
+    objectAssignee: {
+      percentWidth: 10,
       isSortable: true,
     },
     draft_status: {

--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -191,7 +191,7 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
     setNumberOfElements: storageHelpers.handleSetNumberOfElements,
   } as UsePreloadedPaginationFragment<DraftsLinesPaginationQuery>;
 
-  const previousDataColumns: DataTableProps['dataColumns'] = {
+  const dataColumnsWithoutMetadata: DataTableProps['dataColumns'] = {
     name: {
       percentWidth: 50,
       isSortable: true,
@@ -308,7 +308,7 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
       {queryRef && (
         <>
           <DataTable
-            dataColumns={isFeatureEnable('DRAFT_METADATA') ? dataColumns : previousDataColumns}
+            dataColumns={isFeatureEnable('DRAFT_METADATA') ? dataColumns : dataColumnsWithoutMetadata}
             resolvePath={(data: DraftsLines_data$data) => (data.draftWorkspaces?.edges ?? []).map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}

--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -24,17 +24,36 @@ import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { DraftsLines_data$data } from './__generated__/DraftsLines_data.graphql';
 import { DraftsLinesPaginationQuery, DraftsLinesPaginationQuery$variables } from './__generated__/DraftsLinesPaginationQuery.graphql';
 import DraftPopover from './DraftPopover';
+import useHelper from '../../../utils/hooks/useHelper';
 
 const DraftLineFragment = graphql`
     fragment Drafts_node on DraftWorkspace {
         id
         entity_type
         name
+      description
+      createdBy {
+        ... on Identity {
+          id
+          name
+          entity_type
+        }
+      }
         creators {
           id
           name
         }
         created_at
+      objectAssignee {
+        id
+        name
+        entity_type
+      }
+      objectParticipant {
+        id
+        name
+        entity_type
+      }
         draft_status
         validationWork {
             received_time
@@ -124,6 +143,7 @@ interface DraftsProps {
 }
 
 const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenCreate, emptyStateMessage }) => {
+  const { isFeatureEnable } = useHelper();
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const draftColor = getDraftModeColor(theme);
@@ -170,6 +190,52 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
     nodePath: ['draftWorkspaces', 'pageInfo', 'globalCount'],
     setNumberOfElements: storageHelpers.handleSetNumberOfElements,
   } as UsePreloadedPaginationFragment<DraftsLinesPaginationQuery>;
+
+  const previousDataColumns: DataTableProps['dataColumns'] = {
+    name: {
+      percentWidth: 50,
+      isSortable: true,
+    },
+    creator: {
+      percentWidth: 15,
+      isSortable: true,
+    },
+    created_at: {
+      percentWidth: 15,
+      isSortable: true,
+    },
+    draft_status: {
+      id: 'draft_status',
+      label: 'Status',
+      percentWidth: 10,
+      isSortable: true,
+      render: ({ draft_status }) => (
+        <Chip
+          variant="outlined"
+          label={draft_status}
+          style={{
+            fontSize: 12,
+            lineHeight: '12px',
+            height: 20,
+            float: 'left',
+            textTransform: 'uppercase',
+            borderRadius: 4,
+            width: 90,
+            color: draft_status === 'open' ? draftColor : validatedDraftColor,
+            borderColor: draft_status === 'open' ? draftColor : validatedDraftColor,
+            backgroundColor: hexToRGB(draft_status === 'open' ? draftColor : validatedDraftColor),
+          }}
+        />
+      ),
+    },
+    draft_validation_progress: {
+      id: 'draft_validation_progress',
+      label: 'Validation progress',
+      percentWidth: 10,
+      isSortable: false,
+      render: ({ validationWork }) => defaultRender(computeValidationProgress(validationWork)),
+    },
+  };
 
   const dataColumns: DataTableProps['dataColumns'] = {
     name: {
@@ -242,7 +308,7 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
       {queryRef && (
         <>
           <DataTable
-            dataColumns={dataColumns}
+            dataColumns={isFeatureEnable('DRAFT_METADATA') ? dataColumns : previousDataColumns}
             resolvePath={(data: DraftsLines_data$data) => (data.draftWorkspaces?.edges ?? []).map((n) => n?.node)}
             storageKey={LOCAL_STORAGE_KEY}
             initialValues={initialValues}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -14747,9 +14747,13 @@ type DraftWorkspace implements InternalObject & BasicObject {
   parent_types: [String!]!
   metrics: [Metric]
   name: String!
+  createdBy: Identity
+  description: String
   created_at: DateTime!
   creators: [Creator!]
   entity_id: String
+  objectAssignee: [Assignee!]
+  objectParticipant: [Participant!]
   objectsCount: DraftObjectsCount!
   draft_status: DraftStatus!
   processingCount: Int!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -14792,7 +14792,11 @@ type DraftWorkspaceEdge {
 
 input DraftWorkspaceAddInput {
   name: String!
+  createdBy: String
+  description: String
   entity_id: String
+  objectAssignee: [String]
+  objectParticipant: [String]
   authorized_members: [MemberAccessInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7323,8 +7323,12 @@ export type DraftWorkspaceWorksArgs = {
 
 export type DraftWorkspaceAddInput = {
   authorized_members?: InputMaybe<Array<MemberAccessInput>>;
+  createdBy?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
   entity_id?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
+  objectAssignee?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  objectParticipant?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type DraftWorkspaceConnection = {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7295,15 +7295,19 @@ export type DraftVersion = {
 export type DraftWorkspace = BasicObject & InternalObject & {
   __typename?: 'DraftWorkspace';
   authorizedMembers: Array<MemberAccess>;
+  createdBy?: Maybe<Identity>;
   created_at: Scalars['DateTime']['output'];
   creators?: Maybe<Array<Creator>>;
   currentUserAccessRight?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
   draft_status: DraftStatus;
   entity_id?: Maybe<Scalars['String']['output']>;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   metrics?: Maybe<Array<Maybe<Metric>>>;
   name: Scalars['String']['output'];
+  objectAssignee?: Maybe<Array<Assignee>>;
+  objectParticipant?: Maybe<Array<Participant>>;
   objectsCount: DraftObjectsCount;
   parent_types: Array<Scalars['String']['output']>;
   processingCount: Scalars['Int']['output'];
@@ -41294,15 +41298,19 @@ export type DraftVersionResolvers<ContextType = any, ParentType extends Resolver
 
 export type DraftWorkspaceResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftWorkspace'] = ResolversParentTypes['DraftWorkspace']> = ResolversObject<{
   authorizedMembers?: Resolver<Array<ResolversTypes['MemberAccess']>, ParentType, ContextType>;
+  createdBy?: Resolver<Maybe<ResolversTypes['Identity']>, ParentType, ContextType>;
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   creators?: Resolver<Maybe<Array<ResolversTypes['Creator']>>, ParentType, ContextType>;
   currentUserAccessRight?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   draft_status?: Resolver<ResolversTypes['DraftStatus'], ParentType, ContextType>;
   entity_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  objectAssignee?: Resolver<Maybe<Array<ResolversTypes['Assignee']>>, ParentType, ContextType>;
+  objectParticipant?: Resolver<Maybe<Array<ResolversTypes['Participant']>>, ParentType, ContextType>;
   objectsCount?: Resolver<ResolversTypes['DraftObjectsCount'], ParentType, ContextType>;
   parent_types?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   processingCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-converter.ts
@@ -1,5 +1,6 @@
 import { buildStixObject } from '../../database/stix-2-1-converter';
 import type { StixDraftWorkspace, StoreEntityDraftWorkspace } from './draftWorkspace-types';
+import { INPUT_OBJECTS } from '../../schema/general';
 
 const convertDraftWorkspaceToStix = (instance: StoreEntityDraftWorkspace): StixDraftWorkspace => {
   const stixObject = buildStixObject(instance);
@@ -7,6 +8,8 @@ const convertDraftWorkspaceToStix = (instance: StoreEntityDraftWorkspace): StixD
     ...stixObject,
     name: instance.name,
     draft_status: instance.draft_status,
+    description: instance.description,
+    object_refs: (instance[INPUT_OBJECTS] ?? []).map((m) => m.standard_id),
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-resolvers.ts
@@ -16,7 +16,9 @@ import {
 } from './draftWorkspace-domain';
 import { findById as findWorkById, worksForDraft } from '../../domain/work';
 import { getAuthorizedMembers } from '../../utils/authorizedMembers';
-import { loadCreators } from '../../database/members';
+import { loadAssignees, loadCreators, loadParticipants } from '../../database/members';
+import { loadThroughDenormalized } from '../../resolvers/stix';
+import { INPUT_CREATED_BY } from '../../schema/general';
 
 const draftWorkspaceResolvers: Resolvers = {
   Query: {
@@ -43,6 +45,9 @@ const draftWorkspaceResolvers: Resolvers = {
     validationWork: (draft, _, context) => (draft.validation_work_id ? findWorkById(context, context.user, draft.validation_work_id) as any : null),
     authorizedMembers: (workspace, _, context) => getAuthorizedMembers(context, context.user, workspace),
     currentUserAccessRight: (workspace, _, context) => getCurrentUserAccessRight(context, context.user, workspace),
+    objectParticipant: async (workspace, _, context) => loadParticipants(context, context.user, workspace),
+    objectAssignee: async (workspace, _, context) => loadAssignees(context, context.user, workspace),
+    createdBy: (rel, _, context) => loadThroughDenormalized(context, context.user, rel, INPUT_CREATED_BY),
   },
   Mutation: {
     draftWorkspaceAdd: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-types.ts
@@ -8,14 +8,20 @@ export interface BasicStoreEntityDraftWorkspace extends BasicStoreEntity {
   name: string;
   draft_status: string;
   validation_work_id: string;
+  description: string;
   restricted_members: Array<AuthorizedMember>;
+  object_refs: Array<string>;
 }
 
 export interface StoreEntityDraftWorkspace extends Omit<BasicStoreEntityDraftWorkspace, 'restricted_members'>, StoreEntity {
   restricted_members: Array<AuthorizedMember>;
+  description: string;
+  object_refs: Array<string>;
 }
 
 export interface StixDraftWorkspace extends StixObject {
   name: string;
   draft_status: string;
+  description: string;
+  object_refs: Array<string>;
 }

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -12,9 +12,13 @@ type DraftWorkspace implements InternalObject & BasicObject {
     metrics:[Metric]
     # DraftWorkspace
     name: String!
+    createdBy: Identity
+    description: String
     created_at: DateTime!
     creators: [Creator!]
     entity_id: String
+    objectAssignee: [Assignee!]
+    objectParticipant: [Participant!]
     objectsCount: DraftObjectsCount!
     draft_status: DraftStatus!
     processingCount: Int!

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -110,7 +110,11 @@ type Query {
 
 input DraftWorkspaceAddInput {
     name: String!
+    createdBy: String
+    description: String
     entity_id: String
+    objectAssignee: [String]
+    objectParticipant: [String]
     authorized_members: [MemberAccessInput!]
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
@@ -22,8 +22,8 @@ const DRAFT_WORKSPACE_DEFINITION: ModuleDefinition<StoreEntityDraftWorkspace, St
   },
   attributes: [
     createdAt,
-    { name: 'name', label: 'Draft name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'description', label: 'Description', type: 'string', format: 'text', editDefault: true, mandatoryType: 'customizable', multiple: true, upsert: true, isFilterable: true },
+    { name: 'name', label: 'Draft name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
+    { name: 'description', label: 'Description', type: 'string', format: 'text', editDefault: true, mandatoryType: 'customizable', multiple: false, upsert: true, isFilterable: true },
     { name: 'entity_id', label: 'Related entity', type: 'string', format: 'id', entityTypes: [ABSTRACT_STIX_CORE_OBJECT], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'draft_status', label: 'Draft status', type: 'string', format: 'enum', values: getDraftStatuses(), mandatoryType: 'internal', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'validation_work_id', label: 'Validation work', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_WORK], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: true, isFilterable: false },

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.ts
@@ -6,6 +6,7 @@ import { ENTITY_TYPE_DRAFT_WORKSPACE, type StixDraftWorkspace, type StoreEntityD
 import convertDraftWorkspaceToStix from './draftWorkspace-converter';
 import { getDraftStatuses } from './draftStatuses';
 import { ENTITY_TYPE_WORK } from '../../schema/internalObject';
+import { createdBy, objectAssignee, objectParticipant } from '../../schema/stixRefRelationship';
 
 const DRAFT_WORKSPACE_DEFINITION: ModuleDefinition<StoreEntityDraftWorkspace, StixDraftWorkspace> = {
   type: {
@@ -22,6 +23,7 @@ const DRAFT_WORKSPACE_DEFINITION: ModuleDefinition<StoreEntityDraftWorkspace, St
   attributes: [
     createdAt,
     { name: 'name', label: 'Draft name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'description', label: 'Description', type: 'string', format: 'text', editDefault: true, mandatoryType: 'customizable', multiple: true, upsert: true, isFilterable: true },
     { name: 'entity_id', label: 'Related entity', type: 'string', format: 'id', entityTypes: [ABSTRACT_STIX_CORE_OBJECT], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'draft_status', label: 'Draft status', type: 'string', format: 'enum', values: getDraftStatuses(), mandatoryType: 'internal', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'validation_work_id', label: 'Validation work', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_WORK], mandatoryType: 'internal', editDefault: false, multiple: false, upsert: true, isFilterable: false },
@@ -31,7 +33,7 @@ const DRAFT_WORKSPACE_DEFINITION: ModuleDefinition<StoreEntityDraftWorkspace, St
     { ...authorizedMembersActivationDate },
   ],
   relations: [],
-  relationsRefs: [],
+  relationsRefs: [createdBy, objectAssignee, objectParticipant],
   representative: (stix: StixDraftWorkspace) => {
     return stix.name;
   },


### PR DESCRIPTION
### Proposed changes

* Under Feature Flag : `DRAFT_METADATA`
* Add attributes in draft : 
  * author
  * description
  * assignee
  * participant
* Add columns in the draft datatable
* Add related fields in 5 creation form :
  * Data / import / Drafts / Creation
  * Data / import / Global Files / file line / Show the imports / launch an import
  * Top bar / Import data / 3rd step
  * In an entity / Data / Draft / `+` button
  * In an entity / Data / Uploaded files / file line / Lauch an import of this file

### Related issues

* #14058 
* sub issue : #15070 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality