### PR TITLE
[frontend] Fix Not the same actions on Indicators (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -57,6 +57,7 @@ const malwareAnalysisQuery = graphql`
       product
       result_name
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...MalwareAnalysis_malwareAnalysis
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -56,6 +56,7 @@ const eventQuery = graphql`
       entity_type
       name
       aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Event_event

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -60,6 +60,7 @@ const individualQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Individual_individual

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -59,6 +59,7 @@ const sectorQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Sector_sector

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
@@ -60,6 +60,7 @@ const securityPlatformQuery = graphql`
       name
       x_opencti_aliases
       security_platform_type
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...SecurityPlatform_securityPlatform

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -58,6 +58,7 @@ const systemQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...System_system

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -59,6 +59,7 @@ const administrativeAreaQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...AdministrativeArea_administrativeArea

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -59,6 +59,7 @@ const cityQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...City_city

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -60,6 +60,7 @@ const countryQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Country_country

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -56,6 +56,7 @@ const positionQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Position_position

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -60,6 +60,7 @@ const regionQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Region_region

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
@@ -58,6 +58,7 @@ const indicatorQuery = graphql`
       entity_type
       name
       pattern
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...Indicator_indicator
       ...IndicatorDetails_indicator

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -57,6 +57,7 @@ const attackPatternQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...AttackPattern_attackPattern

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -51,6 +51,7 @@ const courseOfActionQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...CourseOfAction_courseOfAction
       ...FileImportViewer_entity
       ...FileExportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -54,6 +54,7 @@ const dataComponentQuery = graphql`
       entity_type
       name
       x_opencti_graph_data
+      currentUserAccessRight
       ...DataComponent_dataComponent
       ...DataComponentKnowledge_dataComponent
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -53,6 +53,7 @@ const dataSourceQuery = graphql`
       entity_type
       name
       x_opencti_graph_data
+      currentUserAccessRight
       ...DataSource_dataSource
       ...DataSourceKnowledge_dataSource
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -57,6 +57,7 @@ const narrativeQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Narrative_narrative


### PR DESCRIPTION
### Proposed changes

The popover actions wasn't on display because the attribute currentUserAccessRight was missing on some entities, and we need that to be able to check capabilities to display actions.

* Add missing attributes query (currentUserAccessRight) to missing entities

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* v7 bugs