### PR TITLE
[backend] Allow "Reduce Knowledge" component to filter on any entities in the bundle, not just the triggering entities (#13264)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -289,20 +289,19 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const bundleElement = bundle.objects[index];
       const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
-      if (isMatch) {
-        matchedElements.push(bundleElement);
-      } else {
+      if (!isMatch && bundleElement.id !== baseData.id) {
         unmatchedElements.push(bundleElement);
+      } else if (isMatch) {
+        matchedElements.push(bundleElement);
       }
     }
     if (matchedElements.length === 0) {
-      // Add the unmatched objects to another bundle to be able to work with them as well if needed.
-      const unmatchedObjects = uniqBy(prop('id'), [baseData, ...unmatchedElements]);
-      return { output_port: 'unmatch', bundle: mergeDeepRight(bundle, { objects: unmatchedObjects }) };
+      // Only unmatched elements, base element is not included to avoid side effects on other branches
+      const unmatchedObjects = R.uniqBy(R.prop('id'), [...unmatchedElements]);
+      return { output_port: 'unmatch', bundle: { ...bundle, objects: unmatchedObjects } };
     }
-    const mergedObjects = uniqBy(prop('id'), [baseData, ...matchedElements]);
-    const newBundle = mergeDeepRight(bundle, { objects: mergedObjects });
-    return { output_port: 'out', bundle: newBundle };
+    const mergedObjects = R.uniqBy(R.prop('id'), [baseData, ...matchedElements]);
+    return { output_port: 'out', bundle: { ...bundle, objects: mergedObjects } };
   },
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -295,10 +295,11 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     if (matchedElements.length === 0) {
       return { output_port: 'unmatch', bundle };
     }
-    const mergedObjects = [...new Map(
-      [baseData, ...matchedElements].map((item) => [item.id, item]),
-    ).values()];
-    return { output_port: 'out', bundle: { ...bundle, objects: mergedObjects } };
+    // always add main entity to the final bundle if not already in it
+    if (matchedElements.length > 0 && !matchedElements.some((e) => e.id === baseData.id)) {
+      matchedElements.push(baseData);
+    }
+    return { output_port: 'out', bundle: { ...bundle, objects: matchedElements } };
   },
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -284,14 +284,15 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
-    const matchedElements = [baseData];
+    const matchedElements = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const bundleElement = bundle.objects[index];
       const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
-      if (isMatch && baseData.id !== bundleElement.id) matchedElements.push(bundleElement);
+      if (isMatch) matchedElements.push(bundleElement);
     }
-    const newBundle = { ...bundle, objects: matchedElements };
-    if (matchedElements.length === 1) {
+    const mergedObjects = uniqBy(prop('id'), [baseData, ...matchedElements]);
+    const newBundle = mergeDeepRight(bundle, { objects: mergedObjects });
+    if (matchedElements.length === 0) {
       return { output_port: 'unmatch', bundle: newBundle };
     }
     return { output_port: 'out', bundle: newBundle };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -269,7 +269,7 @@ const PLAYBOOK_REDUCING_COMPONENT_SCHEMA: JSONSchemaType<ReduceConfiguration> = 
   },
   required: ['filters'],
 };
-const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration> = {
+export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration> = {
   id: 'PLAYBOOK_REDUCING_COMPONENT',
   name: 'Reduce knowledge',
   description: 'Reduce STIX data according to the filter (keep only matching)',

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -285,20 +285,15 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
     const matchedElements = [];
-    const unmatchedElements = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const bundleElement = bundle.objects[index];
       const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
-      if (!isMatch && bundleElement.id !== baseData.id) {
-        unmatchedElements.push(bundleElement);
-      } else if (isMatch) {
+      if (isMatch) {
         matchedElements.push(bundleElement);
       }
     }
     if (matchedElements.length === 0) {
-      // Only unmatched elements, base element is not included to avoid side effects on other branches
-      const unmatchedObjects = R.uniqBy(R.prop('id'), [...unmatchedElements]);
-      return { output_port: 'unmatch', bundle: { ...bundle, objects: unmatchedObjects } };
+      return { output_port: 'unmatch', bundle };
     }
     const mergedObjects = R.uniqBy(R.prop('id'), [baseData, ...matchedElements]);
     return { output_port: 'out', bundle: { ...bundle, objects: mergedObjects } };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -284,10 +284,6 @@ const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration> = {
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
-    const baseMatches = await isStixMatchFilterGroup(context, SYSTEM_USER, baseData, jsonFilters);
-    if (!baseMatches) {
-      return { output_port: 'unmatch', bundle };
-    }
     const matchedElements = [baseData];
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const bundleElement = bundle.objects[index];

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -295,7 +295,9 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     if (matchedElements.length === 0) {
       return { output_port: 'unmatch', bundle };
     }
-    const mergedObjects = R.uniqBy(R.prop('id'), [baseData, ...matchedElements]);
+    const mergedObjects = [...new Map(
+      [baseData, ...matchedElements].map((item) => [item.id, item]),
+    ).values()];
     return { output_port: 'out', bundle: { ...bundle, objects: mergedObjects } };
   },
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -27,7 +27,7 @@ import { ENTITY_TYPE_CONTAINER_REPORT, isStixDomainObjectContainer } from '../..
 import type { CyberObjectExtension, StixBundle, StixCyberObject, StixObject, StixOpenctiExtension } from '../../types/stix-2-1-common';
 import { STIX_EXT_OCTI, STIX_EXT_OCTI_SCO } from '../../types/stix-2-1-extensions';
 import { connectorsForPlaybook } from '../../database/repository';
-import { fullEntitiesList, fullRelationsList, internalFindByIds, storeLoadById } from '../../database/middleware-loader';
+import { fullEntitiesList, fullRelationsList, storeLoadById } from '../../database/middleware-loader';
 import { getEntityFromCache } from '../../database/cache';
 import { logApp } from '../../config/conf';
 import { isEmptyField, isNotEmptyField, READ_RELATIONSHIPS_INDICES, READ_RELATIONSHIPS_INDICES_WITHOUT_INFERRED } from '../../database/utils';

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -27,11 +27,11 @@ import { ENTITY_TYPE_CONTAINER_REPORT, isStixDomainObjectContainer } from '../..
 import type { CyberObjectExtension, StixBundle, StixCyberObject, StixObject, StixOpenctiExtension } from '../../types/stix-2-1-common';
 import { STIX_EXT_OCTI, STIX_EXT_OCTI_SCO } from '../../types/stix-2-1-extensions';
 import { connectorsForPlaybook } from '../../database/repository';
-import { fullEntitiesList, fullRelationsList, storeLoadById } from '../../database/middleware-loader';
+import { fullEntitiesList, fullRelationsList, internalFindByIds, storeLoadById } from '../../database/middleware-loader';
 import { getEntityFromCache } from '../../database/cache';
 import { logApp } from '../../config/conf';
 import { isEmptyField, isNotEmptyField, READ_RELATIONSHIPS_INDICES, READ_RELATIONSHIPS_INDICES_WITHOUT_INFERRED } from '../../database/utils';
-import { stixLoadByIds } from '../../database/middleware';
+import { stixLoadById, stixLoadByIds } from '../../database/middleware';
 import { usableNotifiers } from '../notifier/notifier-domain';
 import { convertToNotificationUser, type DigestEvent, EVENT_NOTIFICATION_VERSION } from '../../manager/notificationManager';
 import { storeNotificationEvent } from '../../database/stream/stream-handler';
@@ -284,13 +284,25 @@ const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration> = {
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
-    const matchedElements = [baseData];
-    for (let index = 0; index < bundle.objects.length; index += 1) {
-      const bundleElement = bundle.objects[index];
-      const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
-      if (isMatch && baseData.id !== bundleElement.id) matchedElements.push(bundleElement);
+    const matchedElements: StixObject[] = [baseData];
+    const matchedRefIds: typeof baseData.object_refs = [];
+    const objectRefs = baseData.object_refs ?? [];
+    for (const ref of objectRefs) {
+      const stixObject = await stixLoadById(context, SYSTEM_USER, ref);
+      const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, stixObject, jsonFilters);
+      if (isMatch) {
+        matchedElements.push(stixObject as StixObject);
+        matchedRefIds.push(ref);
+      }
     }
+    baseData.object_refs = matchedRefIds;
+
     const newBundle = { ...bundle, objects: matchedElements };
+
+    if (matchedRefIds.length === 0) {
+      return { output_port: 'unmatch', bundle };
+    }
+
     return { output_port: 'out', bundle: newBundle };
   },
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -31,7 +31,7 @@ import { fullEntitiesList, fullRelationsList, internalFindByIds, storeLoadById }
 import { getEntityFromCache } from '../../database/cache';
 import { logApp } from '../../config/conf';
 import { isEmptyField, isNotEmptyField, READ_RELATIONSHIPS_INDICES, READ_RELATIONSHIPS_INDICES_WITHOUT_INFERRED } from '../../database/utils';
-import { stixLoadById, stixLoadByIds } from '../../database/middleware';
+import { stixLoadByIds } from '../../database/middleware';
 import { usableNotifiers } from '../notifier/notifier-domain';
 import { convertToNotificationUser, type DigestEvent, EVENT_NOTIFICATION_VERSION } from '../../manager/notificationManager';
 import { storeNotificationEvent } from '../../database/stream/stream-handler';
@@ -284,25 +284,13 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
-    const matchedElements: StixObject[] = [baseData];
-    const matchedRefIds: typeof baseData.object_refs = [];
-    const objectRefs = baseData.object_refs ?? [];
-    for (const ref of objectRefs) {
-      const stixObject = await stixLoadById(context, SYSTEM_USER, ref);
-      const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, stixObject, jsonFilters);
-      if (isMatch) {
-        matchedElements.push(stixObject as StixObject);
-        matchedRefIds.push(ref);
-      }
+    const matchedElements = [baseData];
+    for (let index = 0; index < bundle.objects.length; index += 1) {
+      const bundleElement = bundle.objects[index];
+      const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
+      if (isMatch && baseData.id !== bundleElement.id) matchedElements.push(bundleElement);
     }
-    baseData.object_refs = matchedRefIds;
-
     const newBundle = { ...bundle, objects: matchedElements };
-
-    if (matchedRefIds.length === 0) {
-      return { output_port: 'unmatch', bundle };
-    }
-
     return { output_port: 'out', bundle: newBundle };
   },
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -285,16 +285,23 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
     const matchedElements = [];
+    const unmatchedElements = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const bundleElement = bundle.objects[index];
       const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
-      if (isMatch) matchedElements.push(bundleElement);
+      if (isMatch) {
+        matchedElements.push(bundleElement);
+      } else {
+        unmatchedElements.push(bundleElement);
+      }
+    }
+    if (matchedElements.length === 0) {
+      // Add the unmatched objects to another bundle to be able to work with them as well if needed.
+      const unmatchedObjects = uniqBy(prop('id'), [baseData, ...unmatchedElements]);
+      return { output_port: 'unmatch', bundle: mergeDeepRight(bundle, { objects: unmatchedObjects }) };
     }
     const mergedObjects = uniqBy(prop('id'), [baseData, ...matchedElements]);
     const newBundle = mergeDeepRight(bundle, { objects: mergedObjects });
-    if (matchedElements.length === 0) {
-      return { output_port: 'unmatch', bundle: newBundle };
-    }
     return { output_port: 'out', bundle: newBundle };
   },
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -291,6 +291,9 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
       if (isMatch && baseData.id !== bundleElement.id) matchedElements.push(bundleElement);
     }
     const newBundle = { ...bundle, objects: matchedElements };
+    if (matchedElements.length === 1) {
+      return { output_port: 'unmatch', bundle: newBundle };
+    }
     return { output_port: 'out', bundle: newBundle };
   },
 };

--- a/opencti-platform/opencti-graphql/src/types/stix-2-1-common.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/stix-2-1-common.d.ts
@@ -87,6 +87,7 @@ interface StixObject {
   type: string;
   spec_version: string;
   object_marking_refs?: Array<StixId>; // optional
+  object_refs?: Array<StixId>; // optional
   // TODO Implement granular_markings
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtension;

--- a/opencti-platform/opencti-graphql/src/types/stix-2-1-common.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/stix-2-1-common.d.ts
@@ -87,7 +87,7 @@ interface StixObject {
   type: string;
   spec_version: string;
   object_marking_refs?: Array<StixId>; // optional
-  object_refs?: Array<StixId>; // optional
+  object_refs?: string[]; // optional
   // TODO Implement granular_markings
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtension;

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import type { StixBundle, StixObject, StixOpenctiExtension } from '../../../../src/types/stix-2-1-common';
+import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+import { PLAYBOOK_REDUCING_COMPONENT } from '../../../../src/modules/playbook/playbook-components';
+import * as access from '../../../../src/utils/access';
+import * as filterUtils from '../../../../src/utils/filtering/filtering-stix/stix-filtering';
+import * as stixLoader from '../../../../src/database/middleware';
+
+const REPORT_ID = 'report--5f78a68b-2c4d-5e6f-beaa-7b987b0e7165';
+const CAMPAIGN_ID = 'campaign--fdcacc8e-de4d-5a13-8886-401d363664fd';
+const MALWARE_ID = 'malware--aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const createBasicObject = (id: string, type: string, extra: object = {}): StixObject =>
+  ({
+    id,
+    spec_version: '2.1',
+    type,
+    extensions: {
+      [STIX_EXT_OCTI]: {
+        extension_type: 'property-extension',
+        id: `ext-${id}`,
+        type,
+      } as StixOpenctiExtension,
+    },
+    ...extra,
+  } as StixObject);
+
+const createReport = (objectRefs: string[]): StixObject =>
+  createBasicObject(REPORT_ID, 'report', {
+    name: 'Test Report',
+    published: '2026-01-01T00:00:00.000Z',
+    object_refs: objectRefs,
+  });
+
+const createBundle = (report: StixObject, ...extras: StixObject[]): StixBundle => ({
+  id: 'bundle--00000000-0000-0000-0000-000000000001',
+  spec_version: '2.1',
+  type: 'bundle',
+  objects: [report, ...extras],
+} as StixBundle);
+
+const makePlaybookNode = (filters: object) => ({
+  id: 'playbook-node-reduce',
+  name: 'reduce-node',
+  component_id: 'PLAYBOOK_REDUCING_COMPONENT',
+  configuration: {
+    filters: JSON.stringify(filters),
+  },
+});
+
+const EMPTY_FILTER = {};
+
+const callExecutor = (bundle: StixBundle, filters: object = EMPTY_FILTER) =>
+  PLAYBOOK_REDUCING_COMPONENT.executor({
+    dataInstanceId: REPORT_ID,
+    eventId: '',
+    executionId: '',
+    playbookId: '',
+    previousPlaybookNodeId: undefined,
+    previousStepBundle: null as StixBundle | null,
+    bundle,
+    playbookNode: makePlaybookNode(filters),
+  });
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PLAYBOOK_REDUCING_COMPONENT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(access, 'executionContext').mockReturnValue({} as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('when base object has no object_refs', () => {
+    it('should return unmatch port when object_refs is empty', async () => {
+      const bundle = createBundle(createReport([]));
+
+      const result = await callExecutor(bundle);
+
+      expect(result.output_port).toBe('unmatch');
+      expect(result.bundle).toBe(bundle);
+    });
+  });
+
+  describe('when all object_refs match the filter', () => {
+    it('should return out port and keep all refs', async () => {
+      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
+      const finalBundle = createBundle(createReport([CAMPAIGN_ID]), campaign);
+
+      vi.spyOn(stixLoader, 'stixLoadById').mockResolvedValue(campaign as any);
+      vi.spyOn(filterUtils, 'isStixMatchFilterGroup').mockResolvedValue(true);
+
+      const result = await callExecutor(finalBundle, { mode: 'and', filters: [], filterGroups: [] });
+
+      expect(result.output_port).toBe('out');
+
+      const report = result.bundle.objects.find((o) => o.id === REPORT_ID) as StixObject & { object_refs: string[] };
+      expect(report.object_refs).toContain(CAMPAIGN_ID);
+      expect(report.object_refs).toHaveLength(1);
+      expect(result.bundle.objects).toHaveLength(2);
+    });
+
+    it('should keep all refs when multiple objects all match', async () => {
+      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
+      const malware = createBasicObject(MALWARE_ID, 'malware');
+      const bundle = createBundle(createReport([CAMPAIGN_ID, MALWARE_ID]), campaign, malware);
+
+      vi.spyOn(stixLoader, 'stixLoadById')
+        .mockResolvedValueOnce(campaign as any)
+        .mockResolvedValueOnce(malware as any);
+      vi.spyOn(filterUtils, 'isStixMatchFilterGroup').mockResolvedValue(true);
+
+      const result = await callExecutor(bundle);
+
+      expect(result.output_port).toBe('out');
+
+      const report = result.bundle.objects.find((o) => o.id === REPORT_ID) as StixObject & { object_refs: string[] };
+      expect(report.object_refs).toContain(CAMPAIGN_ID);
+      expect(report.object_refs).toContain(MALWARE_ID);
+      expect(report.object_refs).toHaveLength(2);
+      expect(result.bundle.objects).toHaveLength(3);
+    });
+  });
+
+  describe('when no object_refs match the filter', () => {
+    it('should return unmatch port and original bundle', async () => {
+      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
+      const bundle = createBundle(createReport([CAMPAIGN_ID]), campaign);
+
+      vi.spyOn(stixLoader, 'stixLoadById').mockResolvedValue(campaign as any);
+      vi.spyOn(filterUtils, 'isStixMatchFilterGroup').mockResolvedValue(false);
+
+      const result = await callExecutor(bundle);
+
+      expect(result.output_port).toBe('unmatch');
+      expect(result.bundle).toBe(bundle);
+    });
+  });
+
+  describe('when only some object_refs match the filter', () => {
+    it('should keep only matching refs and objects', async () => {
+      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
+      const malware = createBasicObject(MALWARE_ID, 'malware');
+      const bundle = createBundle(createReport([CAMPAIGN_ID, MALWARE_ID]), campaign, malware);
+
+      vi.spyOn(stixLoader, 'stixLoadById')
+        .mockResolvedValueOnce(campaign as any)
+        .mockResolvedValueOnce(malware as any);
+      vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      const result = await callExecutor(bundle);
+
+      expect(result.output_port).toBe('out');
+
+      const report = result.bundle.objects.find((o) => o.id === REPORT_ID) as StixObject & { object_refs: string[] };
+      expect(report.object_refs).toContain(CAMPAIGN_ID);
+      expect(report.object_refs).not.toContain(MALWARE_ID);
+      expect(report.object_refs).toHaveLength(1);
+      expect(result.bundle.objects).toHaveLength(2);
+      expect(result.bundle.objects.map((o) => o.id)).not.toContain(MALWARE_ID);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -4,53 +4,27 @@ import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
 import { PLAYBOOK_REDUCING_COMPONENT } from '../../../../src/modules/playbook/playbook-components';
 import * as access from '../../../../src/utils/access';
 import * as filterUtils from '../../../../src/utils/filtering/filtering-stix/stix-filtering';
-import * as stixLoader from '../../../../src/database/middleware';
 
 const REPORT_ID = 'report--5f78a68b-2c4d-5e6f-beaa-7b987b0e7165';
 const CAMPAIGN_ID = 'campaign--fdcacc8e-de4d-5a13-8886-401d363664fd';
-const MALWARE_ID = 'malware--aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
-const createBasicObject = (id: string, type: string, extra: object = {}): StixObject =>
-  ({
-    id,
-    spec_version: '2.1',
-    type,
-    extensions: {
-      [STIX_EXT_OCTI]: {
-        extension_type: 'property-extension',
-        id: `ext-${id}`,
-        type,
-      } as StixOpenctiExtension,
-    },
-    ...extra,
-  } as StixObject);
-
-const createReport = (objectRefs: string[]): StixObject =>
-  createBasicObject(REPORT_ID, 'report', {
-    name: 'Test Report',
-    published: '2026-01-01T00:00:00.000Z',
-    object_refs: objectRefs,
-  });
-
-const createBundle = (report: StixObject, ...extras: StixObject[]): StixBundle => ({
+const createBundle = (...objects: StixObject[]): StixBundle => ({
   id: 'bundle--00000000-0000-0000-0000-000000000001',
   spec_version: '2.1',
   type: 'bundle',
-  objects: [report, ...extras],
+  objects,
 } as StixBundle);
 
-const makePlaybookNode = (filters: object) => ({
-  id: 'playbook-node-reduce',
-  name: 'reduce-node',
-  component_id: 'PLAYBOOK_REDUCING_COMPONENT',
-  configuration: {
-    filters: JSON.stringify(filters),
+const createObject = (id: string, type: string): StixObject => ({
+  id,
+  spec_version: '2.1',
+  type,
+  extensions: {
+    [STIX_EXT_OCTI]: { extension_type: 'property-extension', id: `ext-${id}`, type } as StixOpenctiExtension,
   },
-});
+} as StixObject);
 
-const EMPTY_FILTER = {};
-
-const callExecutor = (bundle: StixBundle, filters: object = EMPTY_FILTER) =>
+const callExecutor = (bundle: StixBundle, filters: object = {}) =>
   PLAYBOOK_REDUCING_COMPONENT.executor({
     dataInstanceId: REPORT_ID,
     eventId: '',
@@ -59,10 +33,13 @@ const callExecutor = (bundle: StixBundle, filters: object = EMPTY_FILTER) =>
     previousPlaybookNodeId: undefined,
     previousStepBundle: null as StixBundle | null,
     bundle,
-    playbookNode: makePlaybookNode(filters),
+    playbookNode: {
+      id: 'playbook-node-reduce',
+      name: 'reduce-node',
+      component_id: 'PLAYBOOK_REDUCING_COMPONENT',
+      configuration: { filters: JSON.stringify(filters) },
+    },
   });
-
-// ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('PLAYBOOK_REDUCING_COMPONENT', () => {
   beforeEach(() => {
@@ -74,95 +51,37 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     vi.restoreAllMocks();
   });
 
-  describe('when base object has no object_refs', () => {
-    it('should return unmatch port when object_refs is empty', async () => {
-      const bundle = createBundle(createReport([]));
+  it('should keep objects that match the filter alongside the base element', async () => {
+    const report = createObject(REPORT_ID, 'report');
+    const campaign = createObject(CAMPAIGN_ID, 'campaign');
+    const bundle = createBundle(report, campaign);
 
-      const result = await callExecutor(bundle);
+    vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
+      .mockResolvedValueOnce(false) // report (base element, always kept regardless)
+      .mockResolvedValueOnce(true); // campaign matches
 
-      expect(result.output_port).toBe('unmatch');
-      expect(result.bundle).toBe(bundle);
-    });
+    const result = await callExecutor(bundle);
+
+    expect(result.output_port).toBe('out');
+    expect(result.bundle.objects).toHaveLength(2);
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined();
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined();
   });
 
-  describe('when all object_refs match the filter', () => {
-    it('should return out port and keep all refs', async () => {
-      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
-      const finalBundle = createBundle(createReport([CAMPAIGN_ID]), campaign);
+  it('should remove objects that do not match the filter', async () => {
+    const report = createObject(REPORT_ID, 'report');
+    const campaign = createObject(CAMPAIGN_ID, 'campaign');
+    const bundle = createBundle(report, campaign);
 
-      vi.spyOn(stixLoader, 'stixLoadById').mockResolvedValue(campaign as any);
-      vi.spyOn(filterUtils, 'isStixMatchFilterGroup').mockResolvedValue(true);
+    vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
+      .mockResolvedValueOnce(false) // report (base element, always kept regardless)
+      .mockResolvedValueOnce(false); // campaign does not match
 
-      const result = await callExecutor(finalBundle, { mode: 'and', filters: [], filterGroups: [] });
+    const result = await callExecutor(bundle);
 
-      expect(result.output_port).toBe('out');
-
-      const report = result.bundle.objects.find((o) => o.id === REPORT_ID) as StixObject & { object_refs: string[] };
-      expect(report.object_refs).toContain(CAMPAIGN_ID);
-      expect(report.object_refs).toHaveLength(1);
-      expect(result.bundle.objects).toHaveLength(2);
-    });
-
-    it('should keep all refs when multiple objects all match', async () => {
-      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
-      const malware = createBasicObject(MALWARE_ID, 'malware');
-      const bundle = createBundle(createReport([CAMPAIGN_ID, MALWARE_ID]), campaign, malware);
-
-      vi.spyOn(stixLoader, 'stixLoadById')
-        .mockResolvedValueOnce(campaign as any)
-        .mockResolvedValueOnce(malware as any);
-      vi.spyOn(filterUtils, 'isStixMatchFilterGroup').mockResolvedValue(true);
-
-      const result = await callExecutor(bundle);
-
-      expect(result.output_port).toBe('out');
-
-      const report = result.bundle.objects.find((o) => o.id === REPORT_ID) as StixObject & { object_refs: string[] };
-      expect(report.object_refs).toContain(CAMPAIGN_ID);
-      expect(report.object_refs).toContain(MALWARE_ID);
-      expect(report.object_refs).toHaveLength(2);
-      expect(result.bundle.objects).toHaveLength(3);
-    });
-  });
-
-  describe('when no object_refs match the filter', () => {
-    it('should return unmatch port and original bundle', async () => {
-      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
-      const bundle = createBundle(createReport([CAMPAIGN_ID]), campaign);
-
-      vi.spyOn(stixLoader, 'stixLoadById').mockResolvedValue(campaign as any);
-      vi.spyOn(filterUtils, 'isStixMatchFilterGroup').mockResolvedValue(false);
-
-      const result = await callExecutor(bundle);
-
-      expect(result.output_port).toBe('unmatch');
-      expect(result.bundle).toBe(bundle);
-    });
-  });
-
-  describe('when only some object_refs match the filter', () => {
-    it('should keep only matching refs and objects', async () => {
-      const campaign = createBasicObject(CAMPAIGN_ID, 'campaign');
-      const malware = createBasicObject(MALWARE_ID, 'malware');
-      const bundle = createBundle(createReport([CAMPAIGN_ID, MALWARE_ID]), campaign, malware);
-
-      vi.spyOn(stixLoader, 'stixLoadById')
-        .mockResolvedValueOnce(campaign as any)
-        .mockResolvedValueOnce(malware as any);
-      vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false);
-
-      const result = await callExecutor(bundle);
-
-      expect(result.output_port).toBe('out');
-
-      const report = result.bundle.objects.find((o) => o.id === REPORT_ID) as StixObject & { object_refs: string[] };
-      expect(report.object_refs).toContain(CAMPAIGN_ID);
-      expect(report.object_refs).not.toContain(MALWARE_ID);
-      expect(report.object_refs).toHaveLength(1);
-      expect(result.bundle.objects).toHaveLength(2);
-      expect(result.bundle.objects.map((o) => o.id)).not.toContain(MALWARE_ID);
-    });
+    expect(result.output_port).toBe('out');
+    expect(result.bundle.objects).toHaveLength(1);
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined();
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -79,7 +79,7 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
 
     const result = await callExecutor(bundle);
 
-    expect(result.output_port).toBe('out');
+    expect(result.output_port).toBe('unmatch');
     expect(result.bundle.objects).toHaveLength(1);
     expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined();
     expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined();

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -7,6 +7,7 @@ import * as filterUtils from '../../../../src/utils/filtering/filtering-stix/sti
 
 const REPORT_ID = 'report--5f78a68b-2c4d-5e6f-beaa-7b987b0e7165';
 const CAMPAIGN_ID = 'campaign--fdcacc8e-de4d-5a13-8886-401d363664fd';
+const MALWARE_ID = 'malware--a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 
 const createBundle = (...objects: StixObject[]): StixBundle => ({
   id: 'bundle--00000000-0000-0000-0000-000000000001',
@@ -51,37 +52,77 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     vi.restoreAllMocks();
   });
 
-  it('should keep objects that match the filter alongside the base element', async () => {
+  it('should return base element (Report) + matched element (Campaign) when filter matches Campaign', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const bundle = createBundle(report, campaign);
 
     vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
-      .mockResolvedValueOnce(false) // report (base element, always kept regardless)
-      .mockResolvedValueOnce(true); // campaign matches
+      .mockResolvedValueOnce(false) // report does not match filter
+      .mockResolvedValueOnce(true); // campaign matches filter
 
     const result = await callExecutor(bundle);
 
     expect(result.output_port).toBe('out');
     expect(result.bundle.objects).toHaveLength(2);
-    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined();
-    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined();
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // matched element included
   });
 
-  it('should remove objects that do not match the filter', async () => {
+  it('should return base element (Report) + matched element (Malware) only when filter matches Malware', async () => {
+    const report = createObject(REPORT_ID, 'report');
+    const campaign = createObject(CAMPAIGN_ID, 'campaign');
+    const malware = createObject(MALWARE_ID, 'malware');
+    const bundle = createBundle(report, campaign, malware);
+
+    vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
+      .mockResolvedValueOnce(false) // report does not match filter
+      .mockResolvedValueOnce(false) // campaign does not match filter
+      .mockResolvedValueOnce(true); // malware matches filter
+
+    const result = await callExecutor(bundle);
+
+    expect(result.output_port).toBe('out');
+    expect(result.bundle.objects).toHaveLength(2);
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined(); // not matched, excluded
+    expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeDefined(); // matched element included
+  });
+
+  it('should return only base element (Report) deduplicated when filter matches Report itself', async () => {
+    const report = createObject(REPORT_ID, 'report');
+    const campaign = createObject(CAMPAIGN_ID, 'campaign');
+    const malware = createObject(MALWARE_ID, 'malware');
+    const bundle = createBundle(report, campaign, malware);
+
+    vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
+      .mockResolvedValueOnce(true) // report matches filter
+      .mockResolvedValueOnce(false) // campaign does not match filter
+      .mockResolvedValueOnce(false); // malware does not match filter
+
+    const result = await callExecutor(bundle);
+
+    expect(result.output_port).toBe('out');
+    expect(result.bundle.objects).toHaveLength(1); // Report deduplicated (baseData + matchedElement = same)
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined();
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined();
+    expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeUndefined();
+  });
+
+  it('should return unmatch port with only base element (Report) when nothing matches filter', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const bundle = createBundle(report, campaign);
 
     vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
-      .mockResolvedValueOnce(false) // report (base element, always kept regardless)
-      .mockResolvedValueOnce(false); // campaign does not match
+      .mockResolvedValueOnce(false) // report does not match filter
+      .mockResolvedValueOnce(false); // campaign does not match filter
 
     const result = await callExecutor(bundle);
 
     expect(result.output_port).toBe('unmatch');
-    expect(result.bundle.objects).toHaveLength(1);
-    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined();
-    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined();
+    expect(result.bundle.objects).toHaveLength(1); // only base element (Report) kept
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined(); // not matched, excluded
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -127,7 +127,6 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
   });
 
-  // Cas unmatch (2 objets): rien ne matche → unmatch: [Campaign, Malware] uniquement
   it('should return unmatch port with only unmatched elements (Campaign + Malware) without base element when nothing matches filter', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -109,7 +109,7 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeUndefined();
   });
 
-  it('should return unmatch port with base element (Report) + all unmatched elements (Campaign) when nothing matches filter', async () => {
+  it('should return unmatch port with only unmatched elements (Campaign) without base element when nothing matches filter', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const bundle = createBundle(report, campaign);
@@ -121,12 +121,14 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     const result = await callExecutor(bundle);
 
     expect(result.output_port).toBe('unmatch');
-    expect(result.bundle.objects).toHaveLength(2); // Report (baseData) + Campaign (unmatched)
-    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
+    console.log('result', result.bundle.objects);
+    expect(result.bundle.objects).toHaveLength(1); // only Campaign (unmatched), Report excluded
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeUndefined(); // base element NOT included on unmatch
     expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
   });
 
-  it('should return unmatch port with base element (Report) + all unmatched elements (Campaign + Malware) when nothing matches filter', async () => {
+  // Cas unmatch (2 objets): rien ne matche → unmatch: [Campaign, Malware] uniquement
+  it('should return unmatch port with only unmatched elements (Campaign + Malware) without base element when nothing matches filter', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const malware = createObject(MALWARE_ID, 'malware');
@@ -140,8 +142,8 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     const result = await callExecutor(bundle);
 
     expect(result.output_port).toBe('unmatch');
-    expect(result.bundle.objects).toHaveLength(3); // Report (baseData) + Campaign + Malware (all unmatched)
-    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
+    expect(result.bundle.objects).toHaveLength(2); // Campaign + Malware (unmatched), Report excluded
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeUndefined(); // base element NOT included on unmatch
     expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
     expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeDefined(); // unmatched element included
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -69,7 +69,7 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // matched element included
   });
 
-  it('should return base element (Report) + matched element (Malware) only when filter matches Malware', async () => {
+  it('should return base element (Report) + matched element (Malware) when filter matches Malware', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const malware = createObject(MALWARE_ID, 'malware');
@@ -109,7 +109,7 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeUndefined();
   });
 
-  it('should return unmatch port with only base element (Report) when nothing matches filter', async () => {
+  it('should return unmatch port with base element (Report) + all unmatched elements (Campaign) when nothing matches filter', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const bundle = createBundle(report, campaign);
@@ -121,8 +121,28 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     const result = await callExecutor(bundle);
 
     expect(result.output_port).toBe('unmatch');
-    expect(result.bundle.objects).toHaveLength(1); // only base element (Report) kept
+    expect(result.bundle.objects).toHaveLength(2); // Report (baseData) + Campaign (unmatched)
     expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
-    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeUndefined(); // not matched, excluded
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
+  });
+
+  it('should return unmatch port with base element (Report) + all unmatched elements (Campaign + Malware) when nothing matches filter', async () => {
+    const report = createObject(REPORT_ID, 'report');
+    const campaign = createObject(CAMPAIGN_ID, 'campaign');
+    const malware = createObject(MALWARE_ID, 'malware');
+    const bundle = createBundle(report, campaign, malware);
+
+    vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
+      .mockResolvedValueOnce(false) // report does not match filter
+      .mockResolvedValueOnce(false) // campaign does not match filter
+      .mockResolvedValueOnce(false); // malware does not match filter
+
+    const result = await callExecutor(bundle);
+
+    expect(result.output_port).toBe('unmatch');
+    expect(result.bundle.objects).toHaveLength(3); // Report (baseData) + Campaign + Malware (all unmatched)
+    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeDefined(); // base element always included
+    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
+    expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeDefined(); // unmatched element included
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/reduce-knowledge-component-test.ts
@@ -109,41 +109,18 @@ describe('PLAYBOOK_REDUCING_COMPONENT', () => {
     expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeUndefined();
   });
 
-  it('should return unmatch port with only unmatched elements (Campaign) without base element when nothing matches filter', async () => {
+  it('should return unmatch port with bundle untouched when nothing matches filter', async () => {
     const report = createObject(REPORT_ID, 'report');
     const campaign = createObject(CAMPAIGN_ID, 'campaign');
     const bundle = createBundle(report, campaign);
 
     vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
-      .mockResolvedValueOnce(false) // report does not match filter
-      .mockResolvedValueOnce(false); // campaign does not match filter
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
 
     const result = await callExecutor(bundle);
 
     expect(result.output_port).toBe('unmatch');
-    console.log('result', result.bundle.objects);
-    expect(result.bundle.objects).toHaveLength(1); // only Campaign (unmatched), Report excluded
-    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeUndefined(); // base element NOT included on unmatch
-    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
-  });
-
-  it('should return unmatch port with only unmatched elements (Campaign + Malware) without base element when nothing matches filter', async () => {
-    const report = createObject(REPORT_ID, 'report');
-    const campaign = createObject(CAMPAIGN_ID, 'campaign');
-    const malware = createObject(MALWARE_ID, 'malware');
-    const bundle = createBundle(report, campaign, malware);
-
-    vi.spyOn(filterUtils, 'isStixMatchFilterGroup')
-      .mockResolvedValueOnce(false) // report does not match filter
-      .mockResolvedValueOnce(false) // campaign does not match filter
-      .mockResolvedValueOnce(false); // malware does not match filter
-
-    const result = await callExecutor(bundle);
-
-    expect(result.output_port).toBe('unmatch');
-    expect(result.bundle.objects).toHaveLength(2); // Campaign + Malware (unmatched), Report excluded
-    expect(result.bundle.objects.find((o) => o.id === REPORT_ID)).toBeUndefined(); // base element NOT included on unmatch
-    expect(result.bundle.objects.find((o) => o.id === CAMPAIGN_ID)).toBeDefined(); // unmatched element included
-    expect(result.bundle.objects.find((o) => o.id === MALWARE_ID)).toBeDefined(); // unmatched element included
+    expect(result.bundle).toBe(bundle);
   });
 });


### PR DESCRIPTION
### Proposed changes

* Rollback changes
* Fix the old code as it was not working and filtering properly
* Add tests for reduce knowledge playbook

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13264