### PR TITLE
[frontend] add currentUserAccessRight to all SDOs fragments

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -57,6 +57,7 @@ const malwareAnalysisQuery = graphql`
       product
       result_name
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...MalwareAnalysis_malwareAnalysis
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -51,6 +51,7 @@ const securityCoverageQuery = graphql`
       objectMarking {
         id
       }
+      currentUserAccessRight
       ...SecurityCoverage_securityCoverage
       ...SecurityCoverageKnowledge_securityCoverage
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -57,6 +57,7 @@ const channelQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Channel_channel

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -60,6 +60,7 @@ const malwareQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Malware_malware

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -57,6 +57,7 @@ const toolQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Tool_tool

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -57,6 +57,7 @@ const vulnerabilityQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Vulnerability_vulnerability

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -56,6 +56,7 @@ const eventQuery = graphql`
       entity_type
       name
       aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Event_event

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -60,6 +60,7 @@ const individualQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Individual_individual

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -59,6 +59,7 @@ const sectorQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Sector_sector

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
@@ -60,6 +60,7 @@ const securityPlatformQuery = graphql`
       name
       x_opencti_aliases
       security_platform_type
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...SecurityPlatform_securityPlatform

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -58,6 +58,7 @@ const systemQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...System_system

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -62,6 +62,7 @@ const incidentQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       securityCoverage {
         id
         coverage_information {

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -59,6 +59,7 @@ const administrativeAreaQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...AdministrativeArea_administrativeArea

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -59,6 +59,7 @@ const cityQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...City_city

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -60,6 +60,7 @@ const countryQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Country_country

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -56,6 +56,7 @@ const positionQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Position_position

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -60,6 +60,7 @@ const regionQuery = graphql`
       name
       x_opencti_aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Region_region

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
@@ -58,6 +58,7 @@ const indicatorQuery = graphql`
       entity_type
       name
       pattern
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...Indicator_indicator
       ...IndicatorDetails_indicator

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -58,6 +58,7 @@ const infrastructureQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...Infrastructure_infrastructure
       ...InfrastructureKnowledge_infrastructure

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -57,6 +57,7 @@ const attackPatternQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...AttackPattern_attackPattern

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -51,6 +51,7 @@ const courseOfActionQuery = graphql`
       entity_type
       name
       x_opencti_aliases
+      currentUserAccessRight
       ...CourseOfAction_courseOfAction
       ...FileImportViewer_entity
       ...FileExportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -54,6 +54,7 @@ const dataComponentQuery = graphql`
       entity_type
       name
       x_opencti_graph_data
+      currentUserAccessRight
       ...DataComponent_dataComponent
       ...DataComponentKnowledge_dataComponent
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -53,6 +53,7 @@ const dataSourceQuery = graphql`
       entity_type
       name
       x_opencti_graph_data
+      currentUserAccessRight
       ...DataSource_dataSource
       ...DataSourceKnowledge_dataSource
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -57,6 +57,7 @@ const narrativeQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject
       ...Narrative_narrative

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -59,6 +59,7 @@ const campaignQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       securityCoverage {
         id
         coverage_information {

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -63,6 +63,7 @@ const intrusionSetQuery = graphql`
         id
       }
       x_opencti_graph_data
+      currentUserAccessRight
       securityCoverage {
         id
         coverage_information {

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -59,6 +59,7 @@ const ThreatActorGroupQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject @arguments(relatedRelationshipTypes: $relatedRelationshipTypes)
       ...ThreatActorGroup_ThreatActorGroup

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -59,6 +59,7 @@ const ThreatActorIndividualQuery = graphql`
       name
       aliases
       x_opencti_graph_data
+      currentUserAccessRight
       ...StixCoreRelationshipCreationFromEntityHeader_stixCoreObject
       ...StixCoreObjectKnowledgeBar_stixCoreObject @arguments(relatedRelationshipTypes: $relatedRelationshipTypes)
       ...ThreatActorIndividual_ThreatActorIndividual


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add currentUserAccessRight to all SDOs fragments

StixDomainObjectHeader needs its stixDomainObject props to have a currentUserAccessRight for it to be able to compute canEdit properly

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
