### PR TITLE
[frontend] Change card design for content mapping (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerMappingContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerMappingContent.tsx
@@ -1,8 +1,7 @@
-import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery, useQueryLoader, UseQueryLoaderLoadQueryOptions } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import StixCoreObjectMappableContent from '@components/common/stix_core_objects/StixCoreObjectMappableContent';
-import Paper from '@mui/material/Paper';
 import { Link } from 'react-router-dom';
 import ContainerStixCoreObjectsSuggestedMapping, { containerStixCoreObjectsSuggestedMappingQuery } from '@components/common/containers/ContainerStixCoreObjectsSuggestedMapping';
 import {
@@ -37,6 +36,7 @@ import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 import { deserializeObjectB64, serializeObjectB64 } from '../../../../utils/object';
+import Card from '../../../../components/common/card/Card';
 
 const OPEN$ = new Subject().pipe(debounce(() => timer(500)));
 
@@ -440,6 +440,7 @@ const ContainerMappingContentComponent: FunctionComponent<
         container
         alignItems="stretch"
         columnSpacing={2}
+        mb={2}
       >
         <Grid item xs={6} sx={{ display: 'flex', flexDirection: 'column' }}>
           <StixCoreObjectMappableContent
@@ -454,16 +455,7 @@ const ContainerMappingContentComponent: FunctionComponent<
         </Grid>
 
         <Grid item xs={6} sx={{ display: 'flex', flexDirection: 'column' }}>
-          <Paper
-            variant="outlined"
-            style={{
-              padding: '15px',
-              borderRadius: 4,
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
+          <Card>
             <ContainerStixCoreObjectsMappingHeader
               suggestedMappingData={suggestedMappingData}
               validateDisabled={askingSuggestion || filteredSuggestedMappedEntities.length === 0}
@@ -501,7 +493,7 @@ const ContainerMappingContentComponent: FunctionComponent<
                 />
               )}
             </div>
-          </Paper>
+          </Card>
         </Grid>
       </Grid>
       <ContainerAddStixCoreObjects

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
@@ -1,5 +1,4 @@
-import React, { FunctionComponent, useEffect, useState } from 'react';
-import Paper from '@mui/material/Paper';
+import { FunctionComponent, useEffect, useState } from 'react';
 import { Field, Form, Formik } from 'formik';
 import CommitMessage from '@components/common/form/CommitMessage';
 import * as Yup from 'yup';
@@ -24,6 +23,7 @@ import { isNotEmptyField } from '../../../../utils/utils';
 import HtmlDisplay from '../../../../components/HtmlDisplay';
 import type { Theme } from '../../../../components/Theme';
 import { MESSAGING$ } from '../../../../relay/environment';
+import Card from '../../../../components/common/card/Card';
 
 const useStyles = makeStyles<Theme>(() => createStyles({
   documentContainer: {
@@ -249,14 +249,7 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
     );
   }
   return (
-    <Paper
-      sx={{
-        height: '100%',
-        minHeight: '100%',
-        padding: '15px',
-      }}
-      variant="outlined"
-    >
+    <Card>
       <Formik<StixCoreObjectMappableContentValues>
         enableReinitialize
         initialValues={initialValues}
@@ -327,7 +320,7 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
           </Form>
         )}
       </Formik>
-    </Paper>
+    </Card>
   );
 };
 


### PR DESCRIPTION
### Proposed changes

* Change card design for content mapping

Go to a Report, tab Content, use Content Mapping view button on the right.

### Related issues

* #13303

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality