### PR TITLE
[frontend] Relation screen reload for each new relation clicked (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEdition.tsx
@@ -1,5 +1,5 @@
 import { StixCoreRelationshipEditionOverviewQuery } from '@components/common/stix_core_relationships/__generated__/StixCoreRelationshipEditionOverviewQuery.graphql';
-import React from 'react';
+import React, { Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -49,10 +49,12 @@ const StixCoreRelationshipEditionContainer = (props: StixCoreRelationshipEdition
   if (!contextQueryRef) return null;
 
   return (
-    <StixCoreRelationshipEditionContainerContent
-      {...props}
-      contextQueryRef={contextQueryRef}
-    />
+    <Suspense>
+      <StixCoreRelationshipEditionContainerContent
+        {...props}
+        contextQueryRef={contextQueryRef}
+      />
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
### Proposed changes

* Add Suspence around StixCoreRelationshipEditionContainerContent to prevent triggering header Suspence

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13303 
* [Notion issues](https://www.notion.so/filigran/Relation-screen-reload-from-data-relationship-for-each-new-relation-clicked-3028fce17f2a80e88ba0ea435518c5a4?v=3028fce17f2a817889da000cad0ada62&source=copy_link)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
