### PR TITLE
[frontend] Indicator Lifecycle button color (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -78,7 +78,7 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
                     variant="secondary"
                     onClick={openLifecycleDialog}
                     startIcon={<TroubleshootOutlined />}
-                    color={indicator.decay_exclusion_applied_rule ? 'primary' : undefined}
+                    color={indicator.decay_exclusion_applied_rule ? 'warn' : 'primary'}
                   >
                     {t_i18n('Lifecycle')}
                   </Button>


### PR DESCRIPTION
### Proposed changes
In Indicator details, the 'Lifecycle' icon next to the score is displayed if the indicator is under a decay rule or under a decay exclusion list. This button should be:
- orange if the indicator is under a decay exclusion list,
<img width="209" height="71" alt="image" src="https://github.com/user-attachments/assets/90dfc413-1667-42a9-8cdc-34715d92fbf1" />

- primary if he is under a decay rule.
<img width="207" height="61" alt="image" src="https://github.com/user-attachments/assets/7b5fb912-1ed4-444d-8210-c4ce01904851" />


### Context

<img width="1711" height="750" alt="image" src="https://github.com/user-attachments/assets/4c11923a-caa1-4f38-9120-abe9852baadc" />


### Related issues
#13303