### PR TITLE
[backend] RelationToRule inference from/to types of relationships checking (#11824)

### DIFF
--- a/opencti-platform/opencti-graphql/src/rules/participate-to-parts/ParticipateToPartsRule.ts
+++ b/opencti-platform/opencti-graphql/src/rules/participate-to-parts/ParticipateToPartsRule.ts
@@ -1,12 +1,13 @@
-/* eslint-disable camelcase */
 import { RELATION_PART_OF } from '../../schema/stixCoreRelationship';
 import def from './ParticipateToPartsDefinition';
 import buildRelationToRelationRule from '../relationToRelationBuilder';
 import { RELATION_PARTICIPATE_TO } from '../../schema/internalRelationship';
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../modules/organization/organization-types';
 
 const ParticipateToPartsRule = buildRelationToRelationRule(def, {
   leftType: RELATION_PARTICIPATE_TO,
   rightType: RELATION_PART_OF,
+  rightTypesTo: [ENTITY_TYPE_IDENTITY_ORGANIZATION],
   creationType: RELATION_PARTICIPATE_TO,
 });
 

--- a/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
@@ -51,12 +51,11 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
           await createInferredRelation(context, input, ruleContent);
         }
       };
-      const listFromArgs = {
+      await fullRelationsList(context, RULE_MANAGER_USER, leftType, {
         toId: sourceRef,
         fromTypes: leftTypesFrom,
         callback: listFromCallback,
-      };
-      await fullRelationsList(context, RULE_MANAGER_USER, leftType, listFromArgs);
+      });
     }
     // Need to discover on the from and the to if relation also exists
     // (A) -> leftType -> (B)
@@ -85,12 +84,11 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
           await createInferredRelation(context, input, ruleContent);
         }
       };
-      const listToArgs = {
+      await fullRelationsList(context, RULE_MANAGER_USER, rightType, {
         fromId: targetRef,
         toTypes: rightTypesTo,
         callback: listToCallback,
-      };
-      await fullRelationsList(context, RULE_MANAGER_USER, rightType, listToArgs);
+      });
     }
   };
   // Contract

--- a/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
+++ b/opencti-platform/opencti-graphql/src/rules/relationToRelationBuilder.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { buildPeriodFromDates, computeRangeIntersection } from '../utils/format';
 import { createInferredRelation, deleteInferredRuleElement } from '../database/middleware';
 import { createRuleContent } from './rules-utils';
@@ -13,7 +12,7 @@ import { executionContext, RULE_MANAGER_USER } from '../utils/access';
 
 const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTypes: RelationTypes): RuleRuntime => {
   const { id } = ruleDefinition;
-  const { leftType, rightType, creationType } = relationTypes;
+  const { leftType, rightType, leftTypesFrom, rightTypesTo, creationType } = relationTypes;
   // Execution
   const applyUpsert = async (data: StixRelation): Promise<void> => {
     const context = executionContext(ruleDefinition.name, RULE_MANAGER_USER);
@@ -24,9 +23,9 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
     const { object_marking_refs: markings, relationship_type } = data;
     const { confidence: createdConfidence = 0, start_time: startTime, stop_time: stopTime } = data;
     const creationRange = buildPeriodFromDates(startTime, stopTime);
-    // Need to discover on the from and the to if attributed-to also exists
+    // Need to discover on the from and the to if relation also exists
     // IN CREATION: (A) -> RightType -> (B)
-    // (P) -> FIND_RELS (leftType) -> (A) -> RightType -> (B)
+    // (P whose type is in leftTypesFrom if specified) -> FIND_RELS(leftType) -> (A) -> RightType -> (B)
     // (P) -> creationType -> (B)
     if (relationship_type === rightType) {
       const listFromCallback = async (relationships: Array<BasicStoreRelation>): Promise<void> => {
@@ -52,12 +51,16 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
           await createInferredRelation(context, input, ruleContent);
         }
       };
-      const listFromArgs = { toId: sourceRef, callback: listFromCallback };
+      const listFromArgs = {
+        toId: sourceRef,
+        fromTypes: leftTypesFrom,
+        callback: listFromCallback,
+      };
       await fullRelationsList(context, RULE_MANAGER_USER, leftType, listFromArgs);
     }
-    // Need to discover on the from and the to if attributed-to also exists
+    // Need to discover on the from and the to if relation also exists
     // (A) -> leftType -> (B)
-    // (A) -> leftType -> (B) -> FIND_RELS (RightType) -> (P)
+    // (A) -> leftType -> (B) -> FIND_RELS(RightType) -> (P whose type is contained in rightTypesTo if specified)
     // (A) -> creationType -> (P)
     if (relationship_type === leftType) {
       const listToCallback = async (relationships: Array<BasicStoreRelation>): Promise<void> => {
@@ -82,7 +85,11 @@ const buildRelationToRelationRule = (ruleDefinition: RuleDefinition, relationTyp
           await createInferredRelation(context, input, ruleContent);
         }
       };
-      const listToArgs = { fromId: targetRef, callback: listToCallback };
+      const listToArgs = {
+        fromId: targetRef,
+        toTypes: rightTypesTo,
+        callback: listToCallback,
+      };
       await fullRelationsList(context, RULE_MANAGER_USER, rightType, listToArgs);
     }
   };

--- a/opencti-platform/opencti-graphql/src/types/rules.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/rules.d.ts
@@ -24,6 +24,8 @@ interface RelationTypes {
   rightType: string;
   creationType: string;
   isSource?: boolean;
+  leftTypesFrom?: string[]; // the types of the source of the left relationship (in case leftType is a relationship and not enough to identify the relations of interest)
+  rightTypesTo?: string[]; // the types of the target of the right relationship (in case rightType is a relationship and not enough to identify the relations of interest)
 }
 
 interface StepDefinition {

--- a/opencti-platform/opencti-graphql/tests/20-rules/relationToRelationBuilder-test.ts
+++ b/opencti-platform/opencti-graphql/tests/20-rules/relationToRelationBuilder-test.ts
@@ -163,7 +163,7 @@ describe('relationToRelationBuilder applyUpsert function', () => {
           {
             internal_id: existingRelationId,
             toId: existingRelationTargetId,
-            start_time: existingRelationStopTime,
+            start_time: existingRelationStartTime,
             stop_time: existingRelationStopTime,
             fromId: 'dummyId',
           } as BasicStoreRelation,

--- a/opencti-platform/opencti-graphql/tests/20-rules/relationToRelationBuilder-test.ts
+++ b/opencti-platform/opencti-graphql/tests/20-rules/relationToRelationBuilder-test.ts
@@ -1,0 +1,204 @@
+import buildRelationToRelationRule from '../../src/rules/relationToRelationBuilder';
+import * as middleware from '../../src/database/middleware';
+import * as middlewareLoader from '../../src/database/middleware-loader';
+import { describe, expect, it, vi } from 'vitest';
+import { STIX_EXT_OCTI } from '../../src/types/stix-2-1-extensions';
+import type { BasicStoreRelation } from '../../src/types/store';
+import { v4 as uuid } from 'uuid';
+import { RELATION_PARTICIPATE_TO } from '../../src/schema/internalRelationship';
+import { RELATION_PART_OF } from '../../src/schema/stixCoreRelationship';
+import { executionContext, RULE_MANAGER_USER } from '../../src/utils/access';
+import { createRuleContent } from '../../src/rules/rules-utils';
+import { RELATION_OBJECT_MARKING } from '../../src/schema/stixRefRelationship';
+
+// Mocks
+vi.mock('../database/middleware');
+vi.mock('../database/middleware-loader');
+
+describe('relationToRelationBuilder applyUpsert function', () => {
+  const ruleDefinition = {
+    id: uuid(),
+    name: 'TestRule',
+    description: 'rule to test relationToRelationBuilder',
+    category: 'cat',
+    display: {
+      if: [
+        { source: 'User', source_color: '#000' },
+      ],
+      then: [
+        { source: 'Organization', source_color: '#fff' },
+      ],
+    },
+    scan: { types: [] },
+    scopes: [],
+  };
+  const relationTypes = {
+    leftType: RELATION_PARTICIPATE_TO,
+    rightType: RELATION_PART_OF,
+    rightTypesTo: ['Organization'],
+    creationType: RELATION_PARTICIPATE_TO,
+  };
+  const builtRule = buildRelationToRelationRule(ruleDefinition, relationTypes);
+  const context = executionContext(ruleDefinition.name, RULE_MANAGER_USER);
+
+  // Prevent createInferredRelation from actually being called and just tack calls to it
+  vi.spyOn(middleware, 'createInferredRelation').mockImplementation((() => {}) as any);
+
+  // Create useful ids and dates for the created and the existing relations
+  const createdRelationId = uuid();
+  const createdRelationSourceId = uuid();
+  const createdRelationTargetId = uuid();
+  const existingRelationId = uuid();
+  const createdRelationStartTime = new Date('2020-01-01').toISOString();
+  const createdRelationStopTime = new Date('2020-12-31').toISOString();
+  const existingRelationStartTime = new Date('2019-01-01');
+  const existingRelationStopTime = new Date('2019-12-31');
+
+  it('should handle creation of a relationship matching the right side of the rule definition and call createInferredRelation', async () => {
+    // The created relationship that matches the right side of the rule definition and should lead to an inferred relation creation
+    const createdRelationship = {
+      extensions: { [STIX_EXT_OCTI]: { id: createdRelationId, source_ref: createdRelationSourceId, target_ref: createdRelationTargetId } },
+      relationship_type: RELATION_PART_OF,
+      confidence: 30,
+      start_time: createdRelationStartTime,
+      stop_time: createdRelationStopTime,
+    };
+    // Mock fullRelationsList to return an existing relation that matches the left side of the rule definition
+    const existingRelationSourceId = uuid();
+    vi.spyOn(middlewareLoader, 'fullRelationsList').mockImplementation(async (_ctx, _user, _type, args) => {
+      if (args && typeof args.callback === 'function') {
+        await args.callback([
+          {
+            internal_id: existingRelationId,
+            confidence: 50,
+            fromId: existingRelationSourceId,
+            start_time: existingRelationStartTime,
+            stop_time: existingRelationStopTime,
+          } as BasicStoreRelation,
+        ]);
+      }
+      return [];
+    });
+    // Call the function under test
+    await builtRule.insert(createdRelationship);
+    // Check createInferredRelation has been called with correct parameters
+    const ruleContent = createRuleContent(
+      ruleDefinition.id,
+      [existingRelationSourceId, existingRelationId, createdRelationSourceId, createdRelationId, createdRelationTargetId],
+      [existingRelationId, createdRelationId],
+      {
+        confidence: 40, // mid value between created relationship (30) and existing relationship (50)
+        start_time: existingRelationStartTime.toISOString(),
+        stop_time: existingRelationStopTime.toISOString(),
+        objectMarking: [], // no markings for both the created and the existing relation
+      });
+    expect(middleware.createInferredRelation).toHaveBeenCalledWith(
+      context,
+      { fromId: existingRelationSourceId, toId: createdRelationTargetId, relationship_type: RELATION_PARTICIPATE_TO },
+      ruleContent,
+    );
+  });
+
+  it('should handle creation of a relationship matching left side of the rule and call createInferredRelation', async () => {
+    // The created relationship that matches the left side of the rule definition and should lead to an inferred relation creation
+    const createdRelationship = {
+      extensions: {
+        [STIX_EXT_OCTI]: { id: createdRelationId, source_ref: createdRelationSourceId, target_ref: createdRelationTargetId },
+      },
+      relationship_type: RELATION_PARTICIPATE_TO,
+      start_time: createdRelationStartTime,
+      stop_time: createdRelationStopTime,
+      object_marking_refs: ['markingA', 'markingB'],
+    };
+    // Mock fullRelationsList to return an existing relation that matches the criteria for the right side of the rule definition
+    const existingRelationTargetId = uuid();
+    vi.spyOn(middlewareLoader, 'fullRelationsList').mockImplementation(async (_ctx, _user, _type, args) => {
+      if (args && typeof args.callback === 'function') {
+        await args.callback([
+          {
+            internal_id: existingRelationId,
+            toId: existingRelationTargetId,
+            start_time: existingRelationStartTime,
+            stop_time: existingRelationStopTime,
+            confidence: 50,
+            [RELATION_OBJECT_MARKING]: ['markingC'],
+          } as BasicStoreRelation,
+        ]);
+      }
+      return [];
+    });
+    // Call the function under test
+    await builtRule.insert(createdRelationship);
+    // Check createInferredRelation has been called with correct parameters
+    const ruleContent = createRuleContent(
+      ruleDefinition.id,
+      [createdRelationSourceId, createdRelationId, existingRelationTargetId, existingRelationId, createdRelationTargetId],
+      [createdRelationId, existingRelationId],
+      {
+        confidence: 25, // mid value between created relationship (0 by default) and existing relationship (50)
+        start_time: existingRelationStartTime.toISOString(),
+        stop_time: existingRelationStopTime.toISOString(),
+        objectMarking: ['markingA', 'markingB', 'markingC'], // combination of markings from created and existing relations
+      });
+    expect(middleware.createInferredRelation).toHaveBeenCalledWith(
+      context,
+      { fromId: createdRelationSourceId, toId: existingRelationTargetId, relationship_type: RELATION_PARTICIPATE_TO },
+      ruleContent,
+    );
+  });
+
+  it('should handle creation of a relationship matching left side of the rule and call createInferredRelation in case rightTypesTo is specified in the rule definition', async () => {
+    // The created relationship that matches the left side of the rule definition and should lead to an inferred relation creation
+    const createdRelationship = {
+      extensions: { [STIX_EXT_OCTI]: { id: createdRelationId, source_ref: createdRelationSourceId, target_ref: createdRelationTargetId } },
+      relationship_type: RELATION_PARTICIPATE_TO,
+      start_time: createdRelationStartTime,
+      stop_time: createdRelationStopTime,
+    };
+    // Mock fullRelationsList to return an existing relation that matches the criteria for the right side of the rule definition
+    const existingRelationTargetId = uuid();
+    const fullRelationsListSpy = vi.spyOn(middlewareLoader, 'fullRelationsList').mockImplementation(async (_ctx, _user, _type, args) => {
+      if (args && typeof args.callback === 'function') {
+        await args.callback([
+          {
+            internal_id: existingRelationId,
+            toId: existingRelationTargetId,
+            start_time: existingRelationStopTime,
+            stop_time: existingRelationStopTime,
+            fromId: 'dummyId',
+          } as BasicStoreRelation,
+        ]);
+      }
+      return [];
+    });
+    // Call the function under test
+    await builtRule.insert(createdRelationship);
+    // Check fullRelationsList has been called with correct parameters to check for existing relations matching the right side of the rule definition
+    expect(fullRelationsListSpy).toHaveBeenCalledWith(
+      context,
+      RULE_MANAGER_USER,
+      RELATION_PART_OF,
+      {
+        fromId: createdRelationTargetId,
+        toTypes: ['Organization'], // call to rightTypesTo from the rule definition
+        callback: expect.any(Function),
+      },
+    );
+    // Check createInferredRelation has been called with correct parameters
+    const ruleContent = createRuleContent(
+      ruleDefinition.id,
+      [createdRelationSourceId, createdRelationId, existingRelationTargetId, existingRelationId, createdRelationTargetId],
+      [createdRelationId, existingRelationId],
+      {
+        confidence: 0, // mid value between created relationship (0 by default) and existing relationship (0 by default)
+        start_time: existingRelationStartTime.toISOString(),
+        stop_time: existingRelationStopTime.toISOString(),
+        objectMarking: [],
+      });
+    expect(middleware.createInferredRelation).toHaveBeenCalledWith(
+      context,
+      { fromId: createdRelationSourceId, toId: existingRelationTargetId, relationship_type: RELATION_PARTICIPATE_TO },
+      ruleContent,
+    );
+  });
+});


### PR DESCRIPTION
### Proposed changes
- RelationParticipateToRule should not create participate-to relationships between a user and a sector if an organization is part of a sector. This rule should only be applied for organizations being part of organizations, and create participate-to relationships between a user and an organization.

- buildRelationToRelationRule function should eventually take into account source/target type of right/left relationships implied in the rule definition to ensure a complete type checking if the right and left relationship types are not enough to fully identify the concerned relations

### Related issues
#11824