### PR TITLE
[frontend] nested header tags displayed (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/components/common/header/HeaderMainEntityLayout.tsx
+++ b/opencti-platform/opencti-front/src/components/common/header/HeaderMainEntityLayout.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from '@mui/material';
 
 interface HeaderMainEntityLayoutProps {
   title: string;
-  hideTitle?: boolean;
+  isNestedHeader?: boolean;
   titleRight?: ReactNode;
   rightActions?: ReactNode;
   leftTags?: ReactNode;
@@ -18,7 +18,7 @@ const TAGS_HEIGHT = 25;
 
 const HeaderMainEntityLayout = ({
   title,
-  hideTitle = false,
+  isNestedHeader = false,
   titleRight,
   rightActions,
   leftTags,
@@ -46,7 +46,7 @@ const HeaderMainEntityLayout = ({
           gap={1}
         >
           {/* Title */}
-          {!hideTitle && (
+          {!isNestedHeader && (
             <Stack
               sx={{
                 minWidth: 0,
@@ -85,38 +85,41 @@ const HeaderMainEntityLayout = ({
       </Stack>
 
       {/* Second row */}
-      <Stack
-        direction="row"
-        alignContent="center"
-        justifyContent="space-between"
-        gap={3}
-        sx={{ height: hasPlaceholderTags ? TAGS_HEIGHT : 0 }}
-      >
-        <Stack
-          direction="row"
-          gap={1}
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            maxWidth: hasBothTags ? '50%' : '100%',
-            overflow: 'hidden',
-          }}
-        >
-          {leftTags}
-        </Stack>
+      {!isNestedHeader
+        && (
+          <Stack
+            direction="row"
+            alignContent="center"
+            justifyContent="space-between"
+            gap={3}
+            sx={{ height: hasPlaceholderTags ? TAGS_HEIGHT : 0 }}
+          >
+            <Stack
+              direction="row"
+              gap={1}
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                maxWidth: hasBothTags ? '50%' : '100%',
+                overflow: 'hidden',
+              }}
+            >
+              {leftTags}
+            </Stack>
 
-        <Stack
-          direction="row"
-          alignItems="center"
-          sx={{
-            flex: 1,
-            minWidth: 0,
-            maxWidth: hasBothTags ? '50%' : '100%',
-          }}
-        >
-          {rightTags}
-        </Stack>
-      </Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                maxWidth: hasBothTags ? '50%' : '100%',
+              }}
+            >
+              {rightTags}
+            </Stack>
+          </Stack>
+        )}
     </Stack>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -571,7 +571,7 @@ const ContainerHeader = (props) => {
         <React.Suspense fallback={<span />}>
           <HeaderMainEntityLayout
             title={title}
-            hideTitle={knowledge}
+            isNestedHeader={knowledge}
             rightActions={(
               <>
                 {!knowledge && (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectVictimologySectors.jsx
@@ -314,7 +314,7 @@ class StixDomainObjectVictimologySectorsComponent extends Component {
             <div style={{ float: 'right', marginTop: -10 }}>
               <ToggleButtonGroup
                 size="small"
-                color="secondary"
+                color="primary"
                 value="nested"
                 exclusive={true}
                 onChange={(_, value) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix draft tag displayed in knowledge 
* Fix nested view toggle button in victimology color

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13303 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
