### PR TITLE
[frontend] fix inconsistent external reference item rendering for relationship

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/StixCoreRelationshipExternalReferencesLines.jsx
@@ -214,10 +214,11 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
                   }
                   if (externalReference.url) {
                     return (
-                      <div key={externalReference.id}>
+                      <React.Fragment key={externalReference.id}>
                         <ListItem
                           dense={true}
                           divider={true}
+                          disablePadding
                           secondaryAction={(
                             <Stack direction="row" gap={1}>
                               <Tooltip title={t('Browse the link')}>
@@ -289,14 +290,15 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
                             ))}
                           </List>
                         )}
-                      </div>
+                      </React.Fragment>
                     );
                   }
                   return (
-                    <div key={externalReference.id}>
+                    <React.Fragment key={externalReference.id}>
                       <ListItem
                         dense={true}
                         divider={true}
+                        disablePadding
                         secondaryAction={(
                           <>
                             <Security needs={[KNOWLEDGE_KNUPLOAD]}>
@@ -349,7 +351,7 @@ class StixCoreRelationshipExternalReferencesLinesContainer extends Component {
                           ))}
                         </List>
                       )}
-                    </div>
+                    </React.Fragment>
                   );
                 },
               )}


### PR DESCRIPTION
### Proposed changes

* Fix a small rendering inconsistency of the "External References" items when hovering. Happens on a relationship and shows particularly on mouseover. See the captured screens.
* Bonus: removes an unneeded `div` tag by using a `React.Fragment`

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/13303

### UI changes

#### Before

![capture_13303_inconsistent_external_reference_rendering_before](https://github.com/user-attachments/assets/5e060fc4-2882-4f6d-abfc-d99d43685905)

#### After

![capture_13303_inconsistent_external_reference_rendering_after](https://github.com/user-attachments/assets/01bf41b1-967f-4652-821c-97dbe8c0db9d)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

N/A