### PR TITLE
[frontend] fix inconsistent icon sizes (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/AddExternalReferences.jsx
@@ -49,7 +49,7 @@ const AddExternalReferences = ({
         aria-label="Add"
         onClick={handleOpen}
       >
-        <Add fontSize="small" />
+        <Add />
       </IconButton>
       <Drawer
         title={t_i18n('Add external references')}


### PR DESCRIPTION
### Proposed changes

* Adjusts the size of the "Add External Reference" icon button to match the others
This component is used in three places:
- Threats > Intrusion Set
- Threats > Intrusion Set > Relationship
- Events > Sightings > Sighting

### UI changes

Before

<img width="1044" height="1180" alt="image" src="https://github.com/user-attachments/assets/bc26ccd3-1e8d-490a-84e8-a7ccb842dd6b" />

After

<img width="1066" height="1360" alt="image" src="https://github.com/user-attachments/assets/9cd49ebf-4eb5-4314-9f65-76e905a21c46" />


### Related issues

* #13303 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)

### Further comments

N/A