### PR TITLE
[frontend] fix dialogs 2fa, apitoken, history, and user service tag (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/drawer/TruncatedRawValue.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/TruncatedRawValue.tsx
@@ -1,13 +1,12 @@
-import React, { CSSProperties, FunctionComponent, useEffect, useRef, useState } from 'react';
+import Dialog from '@common/dialog/Dialog';
+import { Box } from '@mui/material';
+import Button from '@common/button/Button';
+import DialogActions from '@mui/material/DialogActions';
+import Tooltip from '@mui/material/Tooltip';
 import { useTheme } from '@mui/styles';
+import { CSSProperties, FunctionComponent, useEffect, useRef, useState } from 'react';
 import type { Theme } from '../../../../components/Theme';
 import { useFormatter } from '../../../../components/i18n';
-import Tooltip from '@mui/material/Tooltip';
-import Dialog from '@mui/material/Dialog';
-import { Box, DialogTitle } from '@mui/material';
-import DialogContent from '@mui/material/DialogContent';
-import DialogActions from '@mui/material/DialogActions';
-import Button from '@mui/material/Button';
 
 const MAX_LENGTH = 30;
 
@@ -38,18 +37,15 @@ const TruncatedRawValue: FunctionComponent<TruncatedRawValueProps> = ({ value, v
     <Dialog
       open={open}
       onClose={() => setOpen(false)}
-      maxWidth="md"
       fullWidth
+      title={t_i18n('Raw value')}
     >
-      <DialogTitle>{t_i18n('Raw value')}</DialogTitle>
-      <DialogContent>
-        {variant === 'code'
-          ? <pre>{value}</pre>
-          : <span style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{value}</span>
-        }
-      </DialogContent>
+      {variant === 'code'
+        ? <pre>{value}</pre>
+        : <span style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{value}</span>
+      }
       <DialogActions>
-        <Button onClick={() => setOpen(false)} color="primary">
+        <Button onClick={() => setOpen(false)}>
           {t_i18n('Close')}
         </Button>
       </DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/profile/ProfileOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/ProfileOverview.jsx
@@ -3,7 +3,7 @@ import Card from '@common/card/Card';
 import { LockOutlined, NoEncryptionOutlined } from '@mui/icons-material';
 import { ListItem, ListItemText, Stack, Switch } from '@mui/material';
 import Alert from '@mui/material/Alert';
-import Dialog from '@mui/material/Dialog';
+import Dialog from '@common/dialog/Dialog';
 import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/styles';
 import withStyles from '@mui/styles/withStyles';
@@ -286,10 +286,9 @@ const ProfileOverviewComponent = (props) => {
       />
       <Dialog
         open={display2FA}
-        slotProps={{ paper: { elevation: 1 } }}
-        keepMounted={false}
         onClose={() => setDisplay2FA(false)}
         title={t('Enable two-factor authentication')}
+        size="small"
       >
         <OtpComponent closeFunction={() => setDisplay2FA(false)} />
       </Dialog>

--- a/opencti-platform/opencti-front/src/private/components/profile/api_tokens/TokenDeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/api_tokens/TokenDeleteDialog.tsx
@@ -1,4 +1,5 @@
-import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import { DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import Dialog from '@common/dialog/Dialog'
 import { useFormatter } from '../../../../components/i18n';
 import Button from '@common/button/Button';
 
@@ -18,13 +19,12 @@ const TokenDeleteDialog = ({ open, token, onDelete, onClose }: TokenDeleteDialog
       onClose={onClose}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
+      title={t_i18n('Revoke API Token')}
+      size='small'
     >
-      <DialogTitle id="alert-dialog-title">{t_i18n('Revoke API Token')}</DialogTitle>
-      <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          {t_i18n('Do you want to revoke the token')} <strong>{token?.name}</strong>?
-        </DialogContentText>
-      </DialogContent>
+      <DialogContentText id="alert-dialog-description">
+        {t_i18n('Do you want to revoke the token')} <strong>{token?.name}</strong>?
+      </DialogContentText>
       <DialogActions>
         <Button
           variant="secondary"

--- a/opencti-platform/opencti-front/src/private/components/profile/api_tokens/TokenDeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/api_tokens/TokenDeleteDialog.tsx
@@ -1,7 +1,7 @@
-import { DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
-import Dialog from '@common/dialog/Dialog'
-import { useFormatter } from '../../../../components/i18n';
 import Button from '@common/button/Button';
+import Dialog from '@common/dialog/Dialog';
+import { DialogActions, DialogContentText } from '@mui/material';
+import { useFormatter } from '../../../../components/i18n';
 
 interface TokenDeleteDialogProps {
   open: boolean;
@@ -20,7 +20,7 @@ const TokenDeleteDialog = ({ open, token, onDelete, onClose }: TokenDeleteDialog
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
       title={t_i18n('Revoke API Token')}
-      size='small'
+      size="small"
     >
       <DialogContentText id="alert-dialog-description">
         {t_i18n('Do you want to revoke the token')} <strong>{token?.name}</strong>?

--- a/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/User.tsx
@@ -357,7 +357,7 @@ const User: FunctionComponent<UserProps> = ({ data, refetch }) => {
                     <Label>
                       {t_i18n('Account type')}
                     </Label>
-                    {!user.user_service_account
+                    {user.user_service_account
                       ? <Tag label={t_i18n('Service account')} />
                       : EMPTY_VALUE
                     }

--- a/opencti-platform/opencti-front/src/utils/Security.tsx
+++ b/opencti-platform/opencti-front/src/utils/Security.tsx
@@ -1,8 +1,8 @@
-import React, { FunctionComponent, ReactElement } from 'react';
 import { filter, includes } from 'ramda';
+import { FunctionComponent, ReactElement } from 'react';
+import { RootMe_data$data } from '../private/__generated__/RootMe_data.graphql';
 import useAuth from './hooks/useAuth';
 import useGranted, { BYPASS, KNOWLEDGE_KNPARTICIPATE, KNOWLEDGE_KNUPDATE_KNORGARESTRICT } from './hooks/useGranted';
-import { RootMe_data$data } from '../private/__generated__/RootMe_data.graphql';
 
 export const CAPABILITY_INFORMATION = {
   [KNOWLEDGE_KNUPDATE_KNORGARESTRICT]:
@@ -55,7 +55,7 @@ const Security: FunctionComponent<SecurityProps> = ({
   capabilitiesInDraft,
   hasAccess = true,
   children,
-  placeholder = <span />,
+  placeholder = null,
 }) => {
   const isGranted = useGranted(needs, matchAll, { capabilitiesInDraft });
   return isGranted && hasAccess ? children : placeholder;
@@ -66,7 +66,7 @@ export const CollaborativeSecurity: FunctionComponent<DataSecurityProps> = ({
   needs,
   matchAll,
   children,
-  placeholder = <span />,
+  placeholder = null,
 }) => {
   const { me } = useAuth();
   const haveCapability = useGranted(needs, matchAll);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix truncated raw value dialog
<img width="1497" height="747" alt="image" src="https://github.com/user-attachments/assets/1ff0cee3-96bd-4c5c-8bf0-2337ee37a9b4" />

Fix 2fa dialog 
<img width="1479" height="753" alt="image" src="https://github.com/user-attachments/assets/a01cb2e9-8ccf-43c4-9387-f21166fb01cb" />

Fix delete token dialog
<img width="1482" height="737" alt="image" src="https://github.com/user-attachments/assets/cad796dc-3e08-415f-9c0a-4d6fbdc82bf4" />

Fix spaces between buttons when no capa

Fix account type value in user screen
<img width="1090" height="502" alt="image" src="https://github.com/user-attachments/assets/b88f875e-36ae-4448-a081-81f5207a1130" />



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13303 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
