### PR TITLE
Fix disappearing nodes in correlation graph (#14479)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarEditObject.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarEditObject.tsx
@@ -30,6 +30,7 @@ const GraphToolbarEditObject = ({
   const { updateNode, addLink } = useGraphInteractions();
 
   const {
+    rawObjects,
     graphState: {
       selectedNodes,
       selectedLinks,
@@ -67,7 +68,8 @@ const GraphToolbarEditObject = ({
       if (category === 'domainObject' || category === 'observable') {
         const data = await fetchQuery(stixCoreObjectRefetchQuery, { id: objectToEdit.id })
           .toPromise() as { stixCoreObject: ObjectToParse };
-        updateNode(data.stixCoreObject);
+        const existingNode = rawObjects.find((rawObject) => rawObject.id === objectToEdit.id);
+        updateNode({ ...data.stixCoreObject, linkedContainers: existingNode?.linkedContainers ?? [] });
       } else {
         const data = await fetchQuery(relationshipRefetchQuery, { id: objectToEdit.id })
           .toPromise() as { stixRelationship: ObjectToParse };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* when we close the edit panel in a correlation graph, we refetch the object to edit, but it seems we don't refetch its linked containers making it disappear if they were the reason why it appeared in the graph. If we just keep the current containers in the graph's raw object and inject them in the updated object, the node becomes stable.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fixes https://github.com/OpenCTI-Platform/opencti/issues/14479

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
