### PR TITLE
[frontend] fix StixDomainObjectEdition drawer and header (#14495)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEdition.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEdition.jsx
@@ -20,6 +20,7 @@ const styles = (theme) => ({
       duration: theme.transitions.duration.enteringScreen,
     }),
     padding: 0,
+    backgroundColor: theme.palette.background.drawer,
   },
 });
 
@@ -47,7 +48,7 @@ class StixDomainObjectEdition extends Component {
       <Drawer
         open={open}
         anchor="right"
-        elevation={1}
+        elevation={0}
         sx={{ zIndex: 1202 }}
         classes={{ paper: classes.drawerPaperInGraph }}
         onClose={handleClose.bind(this)}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEditionOverview.jsx
@@ -2,11 +2,7 @@ import React, { useEffect } from 'react';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import * as R from 'ramda';
-import Typography from '@mui/material/Typography';
-import IconButton from '@common/button/IconButton';
-import { Close } from '@mui/icons-material';
 import * as Yup from 'yup';
-import makeStyles from '@mui/styles/makeStyles';
 import { commitMutation, requestSubscription } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
 import MarkdownField from '../../../../components/fields/MarkdownField';
@@ -21,27 +17,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../form/ConfidenceField';
 import { convertMarkings } from '../../../../utils/edition';
 import useAttributes from '../../../../utils/hooks/useAttributes';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles((theme) => ({
-  header: {
-    backgroundColor: theme.palette.background.nav,
-    padding: '20px 20px 20px 60px',
-  },
-  closeButton: {
-    position: 'absolute',
-    top: 12,
-    left: 5,
-    color: 'inherit',
-  },
-  container: {
-    padding: '10px 20px 20px 20px',
-  },
-  title: {
-    float: 'left',
-  },
-}));
+import DrawerHeader from '@common/drawer/DrawerHeader';
 
 const subscription = graphql`
   subscription StixDomainObjectEditionOverviewSubscription($id: ID!) {
@@ -124,7 +100,6 @@ const stixDomainObjectValidation = (t) => Yup.object().shape({
 const StixDomainObjectEditionContainer = (props) => {
   const { t_i18n } = useFormatter();
   const { typesWithoutName } = useAttributes();
-  const classes = useStyles();
 
   const { handleClose, stixDomainObject, noStoreUpdate } = props;
 
@@ -303,22 +278,12 @@ const StixDomainObjectEditionContainer = (props) => {
   }
   return (
     <div>
-      <div className={classes.header}>
-        <IconButton
-          aria-label="Close"
-          className={classes.closeButton}
-          onClick={handleClose}
-          color="primary"
-        >
-          <Close fontSize="small" color="primary" />
-        </IconButton>
-        <Typography variant="h6" classes={{ root: classes.title }}>
-          {t_i18n('Update an entity')}
-        </Typography>
-        <SubscriptionAvatars context={editContext} />
-        <div className="clearfix" />
-      </div>
-      <div className={classes.container}>
+      <DrawerHeader
+        onClose={handleClose}
+        title={t_i18n('Update an entity')}
+        endContent={<SubscriptionAvatars context={editContext} />}
+      />
+      <div style={{ padding: '10px 20px 20px 20px' }}>
         <Formik
           enableReinitialize={true}
           initialValues={initialValues}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

In graph correlation click on entity, then open edition drawer

* Before:
<img width="572" height="222" alt="image" src="https://github.com/user-attachments/assets/084a1a99-7978-47cf-aec8-b6005c9cd120" />

* After:
<img width="575" height="351" alt="image" src="https://github.com/user-attachments/assets/2bf61402-99a6-4255-a6de-55bdb87df153" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #14495

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
