### PR TITLE
[frontend] fixed data table pagination shrink issue (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTableFilters.tsx
@@ -136,7 +136,7 @@ const DataTableFilters = ({
             />
           )}
         </div>
-        <div style={{ display: 'flex', gap: theme.spacing(1) }}>
+        <div style={{ display: 'flex', gap: theme.spacing(1), flexShrink: 0 }}>
           {(variant === DataTableVariant.default) && (
             <DataTablePagination
               page={page}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added a flexShrink : 0 to DataTablePagination container in DataTableFilters to avoid the componant to shrink like this : 

<img width="1396" height="285" alt="Capture d’écran 2026-02-16 à 12 39 03" src="https://github.com/user-attachments/assets/506eae3c-9117-4c38-950e-376e42c22b1a" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13303
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
