### PR TITLE
[docs] Clarify 'capabilities' for draft mode and main context (#14704)

### DIFF
--- a/docs/docs/administration/users.md
+++ b/docs/docs/administration/users.md
@@ -12,7 +12,7 @@ In OpenCTI, the RBAC system not only related to what users can do or cannot do i
 
 Roles are used in the platform to grant the given groups with some **capabilities** to define what users in those groups can do or cannot do.
 
-### List of capabilities in main context
+### List of Capabilities 
 The below capabilities are applicable to the whole application. 
 
 | Capability                                              | Description                                                                                   |
@@ -28,8 +28,8 @@ The below capabilities are applicable to the whole application.
 | &nbsp;&nbsp;&nbsp;&nbsp;`Manage authorized members`     | Restrict the access to an entity to a user, group or organization.                            |
 | &nbsp;&nbsp;&nbsp;&nbsp;`Bypass enforced reference`     | If external references enforced in a type of entity, be able to bypass the enforcement.       |
 | &nbsp;&nbsp;&nbsp;&nbsp;`Bypass mandatory fields`       | Bypass any custom fields marked as mandatory in entity customization.                         |
-| &nbsp;&nbsp;`Upload knowledge files`                    | Upload files in the `Data` and `Content` section of entities.                                 |
-| &nbsp;&nbsp;`Import knowledge`                          | Trigger the ingestion of an uploaded file.                                                    |
+| &nbsp;&nbsp;`Upload knowledge files`                    | Upload files in the `Data` and `Content` section of entities. Required to use Draft mode.     |
+| &nbsp;&nbsp;`Import knowledge`                          | Trigger the ingestion of an uploaded file. Required to use Draft mode.                        |
 | &nbsp;&nbsp;`Download knowledge export`                 | Download the exports generated in the entities (in the `Data` section).                       |
 | &nbsp;&nbsp;&nbsp;&nbsp;`Generate knowledge export`     | Trigger the export of the knowledge of an entity.                                             |
 | &nbsp;&nbsp;`Ask for knowledge enrichment`              | Trigger an enrichment for a given entity.                                                     |
@@ -68,20 +68,19 @@ The below capabilities are applicable to the whole application.
 | &nbsp;&nbsp;`Access to support`                         | Generate and download support packages.                                                       |
 
 
-### Override of capabilities in draft
+### Control of Capabilities in Draft mode
 
 !!! tip "Enterprise edition"
 
-    Override of capabilities in draft is under the "OpenCTI Enterprise Edition" license. 
+    To control which capabilities apply in draft requires an "OpenCTI Enterprise Edition" license. 
     
     [Please read the dedicated page to have all information](enterprise.md)
 
-The override of capabilities in drafts allows you to differentiate capabilities that your users have in a draft from the ones they have in the main context. This is useful when you want your analysts to work only in a draft environment, without impacting your main database. 
-It is not possible to have fewer capabilities in draft than you have in the main context.
+In draft mode users can have access to additional capabilties compared to when accessing the rest of the platform. This is useful when you want your analysts to work only in a draft environment, without impacting your main knowledge database. It is not possible to have fewer capabilities in draft than you have in the main context.
 
 The below capabilities are applicable to the draft mode only: 
 
-| Capability                                              | Description                                                                                                                                                                                    |
+| Capability in Draft                                     | Description                                                                                                                                                                                    |
 |:--------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Access knowledge`                                      | Access in read-only to all the knowledge in the platform.                                                                                                                                      |
 | &nbsp;&nbsp;`Access to collaborative creation`          | Create notes and opinions (and modify their own) on entities and relations.                                                                                                                    |
@@ -98,14 +97,14 @@ The below capabilities are applicable to the draft mode only:
 
 #### Examples 
 
-To clarify these two layers of capabilities, the table below provides an example of a set of actions that you can perform based on your capabilities.
+To clarify these two layers of capabilities, the table below provides an example of a set of actions that you can perform based on the capabilities set.
 
 
-| Action                             | Context                                                       | Capability in Main                                      | Capability in Draft                                           | Result                                                                |
+| Action                             | Context                                                       | Capability (across platform)                            | Capability in Draft                                           | Result                                                                |
 |:-----------------------------------|:--------------------------------------------------------------|:--------------------------------------------------------|:--------------------------------------------------------------|:----------------------------------------------------------------------|
 | Create a draft manually            | From main context                                             | Access knowledge                                        | Access knowledge ; create/update knowledge                    | User is able to create a draft manually & create/edit data in it.     |
 | Create a draft via file upload     | From main context                                             | Access knowledge                                        | Access knowledge ; create/update knowledge                    | Cannot create a draft with file upload.                               |
-| Create a draft via file upload     | From main context                                             | Access knowledge                                        | Access knowledge ; create/update knowledge ; import knowledge | Allowed, but only step-by-step or form intake are allowed, and forced to draft. |
+| Create a draft via file upload     | From main context                                             | Access knowledge                                        | Access knowledge ; create/update knowledge ; import knowledge | Allowed, only step-by-step or form intake are allowed, user is forced to draft. |
 | Validate a draft                   | In draft mode                                                 | Access knowledge                                        | Access knowledge ; create/update knowledge ; delete knowledge | User is not able to validate the draft.                               |
 | Validate a draft                   | In draft mode                                                 | Access knowledge, Delete knowledge                      | Access knowledge ; create/update knowledge                    | User is able to validate the draft.                                   |
 | Manage authorized members on draft | In draft mode                                                 | Access knowledge, Delete knowledge, Manage authorized members | Access knowledge ; create/update knowledge ; Manage authorized members | User is able to manage authorized members.                             |


### PR DESCRIPTION
Updated capabilities section to clarify requirements for draft mode and adjusted descriptions for better understanding of administration options.

