### PR TITLE
docs: grammar & terminology improvements (#14506)

### DIFF
--- a/docs/docs/deployment/installation.md
+++ b/docs/docs/deployment/installation.md
@@ -4,9 +4,9 @@ All components of OpenCTI are shipped both as [Docker images](https://hub.docker
 
 !!! note "Production deployment"
 
-    For production deployment, we recommend to deploy all components in containers, including dependencies, using native cloud services or orchestration systems such as [Kubernetes](https://kubernetes.io).
+    For production deployment, we recommend deploying all components in containers, including dependencies, using native cloud services or orchestration systems such as [Kubernetes](https://kubernetes.io).
 
-    To have more details about deploying OpenCTI and its dependencies in cluster mode, please read the [dedicated section](clustering.md).
+    To get more details about deploying OpenCTI and its dependencies in cluster mode, please read the [dedicated section](clustering.md).
 
 <div class="grid cards" markdown>
 
@@ -15,7 +15,7 @@ All components of OpenCTI are shipped both as [Docker images](https://hub.docker
     ---
 
     Deploy OpenCTI using Docker and the default `docker-compose.yml` provided
-    in the [docker](https://github.com/OpenCTI-Platform/docker).
+    in the [docker repository](https://github.com/OpenCTI-Platform/docker).
 
     [:octicons-arrow-right-24:{ .middle } Setup](#using-docker)
 
@@ -41,7 +41,7 @@ OpenCTI can be deployed using the *docker-compose* command.
 
     We provide FIPS 140-2 compliant images. Please read the [dedicated documentation](../reference/fips.md) to understand how to deploy OpenCTI in FIPS-compliant mode.
 
-### Pre-requisites
+### Prerequisites
 
 **:material-linux:{ .middle } Linux**
 
@@ -100,7 +100,7 @@ You can either rename the file `.env.sample` as `.env` and enter the values or j
 
     The complete list of available static parameters is available in the [configuration](configuration.md) section.
 
-Here is an example to quickly generate the `.env` file under Linux, especially all the default UUIDv4:
+Here is an example to quickly generate the `.env` file on Linux, including all default UUIDv4 values:
 
 ```bash
 sudo apt install -y jq
@@ -140,7 +140,7 @@ As OpenCTI has a dependency on ElasticSearch, you have to set `vm.max_map_count`
 sudo sysctl -w vm.max_map_count=1048575
 ```
 
-To make this parameter persistent, add the following to the end of your `/etc/sysctl.conf`:
+To make this parameter persistent, add the following at the end of your `/etc/sysctl.conf`:
 
 ```bash
 vm.max_map_count=1048575
@@ -210,7 +210,7 @@ sudo apt-get install build-essential nodejs npm python3 python3-pip python3-dev
 
 #### Download the application files
 
-First, you have to [download and extract the latest release file](https://github.com/OpenCTI-Platform/opencti/releases). Then select the version to install depending of your operating system:
+First, you have to [download and extract the latest release file](https://github.com/OpenCTI-Platform/opencti/releases). Then select the version to install depending on your operating system:
 
 **For Linux:**
 
@@ -219,7 +219,7 @@ First, you have to [download and extract the latest release file](https://github
 
 **For Windows:**
 
-We don't provide any Windows release for now. However it is still possible to check the code out, manually install the dependencies and build the software.
+We currently don't provide any Windows release. However, it is still possible to check-out the code, manually install the dependencies and build the software.
 
 ```bash
 mkdir /path/to/your/app && cd /path/to/your/app
@@ -227,11 +227,11 @@ wget <https://github.com/OpenCTI-Platform/opencti/releases/download/{RELEASE_VER
 tar xvfz opencti-release-{RELEASE_VERSION}.tar.gz
 ```
 
-### Install the main platform
+### Install the platform core
 
 #### Configure the application
 
-The main application has just one JSON configuration file to change and a few Python modules to install
+The main application has just one JSON configuration file to change and a few Python modules to install.
 
 ```bash
 cd opencti
@@ -250,11 +250,11 @@ cd ../..
 
 #### Start the application
 
-The application is just a NodeJS process, the creation of the database schema and the migration will be done at starting.
+The application is a single NodeJS process. The creation of the database schema and potential data migrations happen during startup.
 
-> Please verify NodeJS version is greater or equals to v20 and corepack is installed.
-> Please note that some Node.js version are outdated in linux package manager, you can download a recent one in https://nodejs.org/en/download or alternatively nvm can help to chose a recent version of Node.js https://github.com/nvm-sh/nvm
-> To install corepack, execute the following command after the installation of nodejs: `npm install -g corepack`
+> Please verify Node.js version is greater than or equal to v20, and that corepack is installed.
+> Please note that some Node.js versions are outdated in linux package managers. You can download a recent one at https://nodejs.org/en/download. Alternatively, consider using nvm (https://github.com/nvm-sh/nvm) to help pick a recent version of Node.js.
+> To install corepack, execute the following command after the installation of Node.js: `npm install -g corepack`
 
 ```bash
 node --version
@@ -263,18 +263,19 @@ corepack --version
 #0.34.0
 ```
 
-Once Node.js is setup, you can build and run with (from inside `opencti` folder):
+Once Node.js is set up, you can build and run the application with (from inside `opencti` folder):
+
 ```bash
 yarn install
 yarn build
 yarn serv
 ```
 
-The default username and password are those you have put in the `config/production.json` file.
+The default username and password are those you have set in the `config/production.json` file.
 
 ### Install the worker
 
-The OpenCTI worker is used to write the data coming from the RabbitMQ messages broker.
+The OpenCTI worker is used to write the data coming from the RabbitMQ message brokers.
 
 #### Configure the worker
 
@@ -366,20 +367,20 @@ OpenCTI platform is based on a NodeJS runtime, with a memory limit of **8GB by d
 
 #### Workers and connectors
 
-OpenCTI workers and connectors are Python processes. If you want to limit the memory of the process, we recommend to directly use Docker to do that. You can find more information in the [official Docker documentation](https://docs.docker.com/compose/compose-file/).
+OpenCTI workers and connectors are Python processes. If you want to limit the memory of the process, we recommend directly using Docker to do that. You can find more information in the [official Docker documentation](https://docs.docker.com/compose/compose-file/).
 
 #### ElasticSearch
 
-ElasticSearch is also a JAVA process. In order to setup the JAVA memory allocation, you can use the environment variable `ES_JAVA_OPTS`. You can find more information in the [official ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
+ElasticSearch is also a JAVA process. In order to set up the JAVA memory allocation, you can use the `ES_JAVA_OPTS` environment variable. You can find more information in the [official ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
 
 #### Redis
 
-Redis has a very small footprint on keys but will consume memory for the stream. By default the size of the stream is limited to 2 millions which represents a memory footprint around `8 GB`. You can find more information in the [Redis docker hub](https://hub.docker.com/_/redis).
+Redis has a very small footprint on keys but will consume memory for the stream. By default, the size of the stream is limited to 2 million which represents a memory footprint of about `8 GB`. You can find more information in the [Redis docker hub](https://hub.docker.com/_/redis).
 
 #### MinIO / S3 Bucket
 
-MinIO is a small process and does not require a high amount of memory. More information are available for Linux here on the [Kernel tuning guide](https://github.com/minio/minio/tree/master/docs/deployment/kernel-tuning).
+MinIO is a small process and does not require a high amount of memory. More information is available for Linux in the [Kernel tuning guide](https://github.com/minio/minio/tree/master/docs/deployment/kernel-tuning).
 
 #### RabbitMQ
 
-The RabbitMQ memory configuration can be find in the [RabbitMQ official documentation](https://www.rabbitmq.com/memory.html). RabbitMQ will consumed memory until a specific threshold, therefore it should be configure along with the Docker memory limitation.
+The RabbitMQ memory configuration can be found in the [official RabbitMQ documentation](https://www.rabbitmq.com/memory.html). RabbitMQ will consume memory until it reaches a specific threshold, so it should be configured in alignment with Docker's memory limitations.

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Before starting the installation, let's discover how OpenCTI is working, which dependencies are needed and what are the minimal requirements to deploy it in production.
+Before starting the installation, let's discover how OpenCTI works, which dependencies are needed and what are the minimal requirements to deploy it in production.
 
 !!! tip "Docker deployment of the full XTM suite (OpenCTI - OpenAEV - OpenGRC)"
 
@@ -12,17 +12,17 @@ The OpenCTI platform relies on several external databases and services in order 
 
 ![Architecture](assets/architecture.png)
 
-### Platform
+### Core
 
-The platform is the central part of the OpenCTI technological stack. It allows users to access to the user interface but also provides the [GraphQL API](https://graphql.org) used by connectors and workers to insert data. In the context of a production deployment, you may need to scale horizontally and launch multiple platforms behind a load balancer connected to the same databases (ElasticSearch, Redis, S3, RabbitMQ).
+The platform core is the central part of the OpenCTI technological stack. It allows users to access to the user interface but also provides the [GraphQL API](https://graphql.org) used by connectors and workers to insert data. In the context of a production deployment, you may need to scale horizontally and launch multiple cores behind a load balancer connected to the same databases (ElasticSearch, Redis, S3, RabbitMQ).
 
 ### Workers
 
-The workers are standalone Python processes consuming messages from the RabbitMQ broker in order to do asynchronous write queries. You can launch as many workers as you need to increase the write performances. At some point, the write performances will be limited by the throughput of the ElasticSearch database cluster.
+The workers are standalone Python processes consuming messages from the RabbitMQ broker in order to execute asynchronous write operations. You can launch as many workers as you need to increase the writes performance. At some point, the writes performance will be limited by the throughput of the ElasticSearch database cluster.
 
 !!! note "Number of workers"
 
-    If you need to increase performances, it is better to launch more platforms to handle worker queries. The recommended setup is to have at least one platform for 3 workers (ie. 9 workers distributed over 3 platforms).
+    If you need to increase performance, it is better to spawn more core instances to handle worker queries. The recommended setup is to have at least one core running for 3 workers (ie. 9 workers distributed over 3 cores).
 
 ### Connectors
 

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-Before starting the installation, let's discover how OpenCTI works, which dependencies are needed and what are the minimal requirements to deploy it in production.
+Before starting the installation, let's discover how OpenCTI works, which dependencies are needed and what are the minimum requirements for deploying it in production.
 
 !!! tip "Docker deployment of the full XTM suite (OpenCTI - OpenAEV - OpenGRC)"
 
@@ -8,17 +8,18 @@ Before starting the installation, let's discover how OpenCTI works, which depend
 
 ## Architecture
 
-The OpenCTI platform relies on several external databases and services in order to work.
+The OpenCTI platform is mainly composed of three distinct parts to handle the flow of data: the core, the connectors and the workers.
+It also relies on several third party storage, databases and messaging systems in order to operate.
 
 ![Architecture](assets/architecture.png)
 
 ### Core
 
-The platform core is the central part of the OpenCTI technological stack. It allows users to access to the user interface but also provides the [GraphQL API](https://graphql.org) used by connectors and workers to insert data. In the context of a production deployment, you may need to scale horizontally and launch multiple cores behind a load balancer connected to the same databases (ElasticSearch, Redis, S3, RabbitMQ).
+The platform core is the central part of the OpenCTI technological stack. It allows users to access the user interface but also provides the [GraphQL API](https://graphql.org) used by connectors and workers to insert data. In the context of a production deployment, you may need to scale horizontally and launch multiple cores behind a load balancer connected to the same databases, storage & messaging components (ElasticSearch, Redis, S3, RabbitMQ).
 
 ### Workers
 
-The workers are standalone Python processes consuming messages from the RabbitMQ broker in order to execute asynchronous write operations. You can launch as many workers as you need to increase the writes performance. At some point, the writes performance will be limited by the throughput of the ElasticSearch database cluster.
+The workers are standalone Python processes consuming messages from the RabbitMQ broker in order to execute asynchronous write operations. You can launch as many workers as needed to increase write performance. At some point, the write performance will be limited by the throughput of the ElasticSearch database cluster.
 
 !!! note "Number of workers"
 
@@ -29,13 +30,13 @@ The workers are standalone Python processes consuming messages from the RabbitMQ
 The connectors are third-party pieces of software (Python processes) that can play five different 
 roles on the platform:
 
-| Type                 | Description                                                                                       | Examples                                              |
-|:---------------------|:---------------------------------------------------------------------------------------------------|:------------------------------------------------------|
-| EXTERNAL_IMPORT      | Pull data from remote sources, convert it to STIX2 and insert it on the OpenCTI platform.          | MITRE Datasets, MISP, CVE, AlienVault, Mandiant, etc. |
-| INTERNAL_ENRICHMENT  | Listen for new OpenCTI entities or users requests, pull data from remote sources to enrich.        | Shodan, DomainTools, IpInfo, etc.                     |
-| INTERNAL_IMPORT_FILE | [Extract data from files](../usage/import-files.md) uploaded on OpenCTI through the UI or the API. | STIX 2.1, PDF, Text, HTML, etc.                       |
-| INTERNAL_EXPORT_FILE | [Generate export](../usage/export.md) from OpenCTI data, based on a single object or a list.       | STIX 2.1, CSV, PDF, etc.                              |
-| STREAM               | Consume a platform [data stream](../usage/feeds.md) and _do_ something with events.                | Splunk, Elastic Security, Q-Radar, etc.               |
+| Type                 | Description                                                                                               | Examples                                              |
+|:---------------------|:----------------------------------------------------------------------------------------------------------|:------------------------------------------------------|
+| EXTERNAL_IMPORT      | Pull data from remote sources, convert it to STIX2, and insert it into the OpenCTI platform.              | MITRE Datasets, MISP, CVE, AlienVault, Mandiant, etc. |
+| INTERNAL_ENRICHMENT  | Listen for new OpenCTI entities or users requests and pull data from remote sources to enrich them.       | Shodan, DomainTools, IpInfo, etc.                     |
+| INTERNAL_IMPORT_FILE | [Extract data from files](../usage/import-files.md) uploaded on OpenCTI through the UI or the API.        | STIX 2.1, PDF, Text, HTML, etc.                       |
+| INTERNAL_EXPORT_FILE | [Generate an export](../usage/export.md) from OpenCTI data based on a single object or a list of objects. | STIX 2.1, CSV, PDF, etc.                              |
+| STREAM               | Consume a [data stream](../usage/feeds.md) produced by the platform and process the events at will.       | Splunk, Elastic Security, Q-Radar, etc.               |
 
 !!! note "List of connectors"
     

--- a/opencti-worker/src/config.yml.sample
+++ b/opencti-worker/src/config.yml.sample
@@ -1,6 +1,6 @@
 ---
 opencti:
-  url: 'http://localhost:8080'
+  url: 'http://localhost:4000'
   token: 'ChangeMe'
   json_logging: true
 


### PR DESCRIPTION
### Proposed changes

Documentation updates:

* Fixes terminology : uses the wording `core` to designate the `frontend` and `backend` (`graphql api`) subsystem instead of `platform`, which already designates the entire system.
* Fixes English grammar issues.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/14506

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I'll remove the `Draft` label after going through the entire documentation.