### PR TITLE
[backend/frontend] remove sort by description on vocabularies (#14478)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Vocabularies.tsx
@@ -145,6 +145,7 @@ const Vocabularies = () => {
     description: {
       id: 'description',
       percentWidth: 25,
+      isSortable: false,
     },
     usages: {
       id: 'usages',

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -11565,7 +11565,6 @@ type Vocabulary implements BasicObject & StixObject & StixMetaObject {
 enum VocabularyOrdering {
   name
   category
-  description
   order
   _score
 }

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -34445,7 +34445,6 @@ export type VocabularyFieldDefinition = {
 export enum VocabularyOrdering {
   Score = '_score',
   Category = 'category',
-  Description = 'description',
   Name = 'name',
   Order = 'order'
 }

--- a/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/vocabulary/vocabulary.graphql
@@ -99,7 +99,6 @@ type Vocabulary implements BasicObject & StixObject & StixMetaObject {
 enum VocabularyOrdering {
   name
   category
-  description
   order
   _score
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* it's not possible to sort by description on engine layer since description is not a short mapping but a textMapping. So we remove the ability to sort by description on vocabularies in the API
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14478 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
