### PR TITLE
[backend] add ability to configure playbook connectors as Realtime priority instead of default (#14512)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -277,7 +277,8 @@
     "lock_cron_key": "playbook_cron_manager_lock",
     "interval": 60000,
     "cron_max_size": 500,
-    "log_max_size": 10000
+    "log_max_size": 10000,
+    "realtime_priority": false
   },
   "hub_registration_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/src/database/repository.js
+++ b/opencti-platform/opencti-graphql/src/database/repository.js
@@ -13,7 +13,7 @@ import { getSupportedContractsByImage } from '../modules/catalog/catalog-domain'
 import { ENTITY_TYPE_PIR } from '../modules/pir/pir-types';
 import { getEntitiesMapFromCache } from './cache';
 import { SYSTEM_USER } from '../utils/access';
-import { logApp } from '../config/conf';
+import { booleanConf, logApp } from '../config/conf';
 import { ConnectorPriorityGroup } from '../generated/graphql';
 import { injectProxyConfiguration } from '../config/proxy-config';
 
@@ -163,6 +163,7 @@ export const connectorsForWorker = async (context, user) => {
     });
   }
   // Expose playbooks
+  const playbookRealtimePriority = booleanConf('playbook_manager:realtime_priority', false);
   const playbooks = await fullEntitiesList(context, user, [ENTITY_TYPE_PLAYBOOK]);
   for (let i = 0; i < playbooks.length; i += 1) {
     const playbook = playbooks[i];
@@ -171,6 +172,7 @@ export const connectorsForWorker = async (context, user) => {
       name: `Playbook ${playbook.internal_id} queue`,
       connector_scope: [],
       config: connectorConfig(playbook.internal_id),
+      connector_priority_group: playbookRealtimePriority ? ConnectorPriorityGroup.Realtime : ConnectorPriorityGroup.Default,
       active: true,
     });
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add ability to configure playbook connectors as Realtime priority instead of default
* defaults to false (i.e. Default priority), but can be set to true in config (i.e. Realtime priority)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14512
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
