### PR TITLE
[frontend] remove header gap when no alias or tags (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/components/common/header/HeaderMainEntityLayout.tsx
+++ b/opencti-platform/opencti-front/src/components/common/header/HeaderMainEntityLayout.tsx
@@ -10,11 +10,7 @@ interface HeaderMainEntityLayoutProps {
   rightActions?: ReactNode;
   leftTags?: ReactNode;
   rightTags?: ReactNode;
-  // should be removed when knowledge buttons is fixed
-  hasPlaceholderTags?: boolean;
 }
-
-const TAGS_HEIGHT = 25;
 
 const HeaderMainEntityLayout = ({
   title,
@@ -23,7 +19,6 @@ const HeaderMainEntityLayout = ({
   rightActions,
   leftTags,
   rightTags,
-  hasPlaceholderTags = true,
 }: HeaderMainEntityLayoutProps) => {
   const hasLeftTags = Boolean(leftTags);
   const hasRightTags = Boolean(rightTags);
@@ -92,7 +87,6 @@ const HeaderMainEntityLayout = ({
             alignContent="center"
             justifyContent="space-between"
             gap={3}
-            sx={{ height: hasPlaceholderTags ? TAGS_HEIGHT : 0 }}
           >
             <Stack
               direction="row"

--- a/opencti-platform/opencti-front/src/components/graph/GraphContainerCorrelation.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphContainerCorrelation.tsx
@@ -1,20 +1,18 @@
-import { graphql, PreloadedQuery, useFragment } from 'react-relay';
-import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
-import { useTheme } from '@mui/material/styles';
-import { useSettingsMessagesBannerHeight } from '@components/settings/settings_messages/SettingsMessagesBanner';
 import { knowledgeCorrelationStixCoreObjectQuery, knowledgeCorrelationStixCoreRelationshipQuery } from '@components/common/containers/KnowledgeCorrelationQuery';
-import type { Theme } from '../Theme';
-import Graph from './Graph';
-import GraphToolbar from './GraphToolbar';
-import { GraphProvider } from './GraphContext';
+import { useSettingsMessagesBannerHeight } from '@components/settings/settings_messages/SettingsMessagesBanner';
+import { CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
+import { graphql, PreloadedQuery, useFragment } from 'react-relay';
+import useDebounceCallback from '../../utils/hooks/useDebounceCallback';
 import usePreloadedPaginationFragment from '../../utils/hooks/usePreloadedPaginationFragment';
+import { deserializeObjectB64 } from '../../utils/object';
+import Graph from './Graph';
+import { GraphProvider } from './GraphContext';
+import GraphToolbar from './GraphToolbar';
 import { GraphContainerCorrelationObjectsQuery } from './__generated__/GraphContainerCorrelationObjectsQuery.graphql';
 import { GraphContainerCorrelationObjects_fragment$key } from './__generated__/GraphContainerCorrelationObjects_fragment.graphql';
-import useDebounceCallback from '../../utils/hooks/useDebounceCallback';
 import { GraphContainerCorrelationPositions_fragment$key } from './__generated__/GraphContainerCorrelationPositions_fragment.graphql';
-import { getObjectsToParse } from './utils/graphUtils';
-import { deserializeObjectB64 } from '../../utils/object';
 import { OctiGraphPositions } from './graph.types';
+import { getObjectsToParse } from './utils/graphUtils';
 import useGraphInteractions from './utils/useGraphInteractions';
 
 // region Relay queries and fragments
@@ -341,7 +339,6 @@ const GraphContainerCorrelationComponent = ({
   onPositionsChanged,
 }: GraphContainerCorrelationComponentProps) => {
   const ref = useRef(null);
-  const theme = useTheme<Theme>();
   const bannerHeight = useSettingsMessagesBannerHeight();
 
   const {
@@ -362,7 +359,6 @@ const GraphContainerCorrelationComponent = ({
   const toolbarHeight = 54;
   const totalHeight = bannerHeight + headerHeight + paddingHeight + breadcrumbHeight + titleHeight + tabsHeight + toolbarHeight;
   const graphContainerStyle: CSSProperties = {
-    margin: `-${theme.spacing(3)}`,
     height: `calc(100vh - ${totalHeight}px)`,
   };
 

--- a/opencti-platform/opencti-front/src/components/graph/GraphContainerKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphContainerKnowledge.tsx
@@ -1,26 +1,24 @@
-import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
-import { graphql, PreloadedQuery, useFragment } from 'react-relay';
-import { useTheme } from '@mui/material/styles';
-import { useSettingsMessagesBannerHeight } from '@components/settings/settings_messages/SettingsMessagesBanner';
 import ContainerHeader from '@components/common/containers/ContainerHeader';
 import { knowledgeGraphStixCoreObjectQuery, knowledgeGraphStixRelationshipQuery } from '@components/common/containers/KnowledgeGraphQuery';
 import { ContainerHeader_container$key } from '@components/common/containers/__generated__/ContainerHeader_container.graphql';
-import { deserializeObjectB64 } from '../../utils/object';
-import { getObjectsToParse } from './utils/graphUtils';
+import { useSettingsMessagesBannerHeight } from '@components/settings/settings_messages/SettingsMessagesBanner';
+import { CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
+import { graphql, PreloadedQuery, useFragment } from 'react-relay';
+import investigationAddFromContainer from '../../utils/InvestigationUtils';
 import useDebounceCallback from '../../utils/hooks/useDebounceCallback';
 import usePreloadedPaginationFragment from '../../utils/hooks/usePreloadedPaginationFragment';
+import { deserializeObjectB64 } from '../../utils/object';
+import Graph from './Graph';
+import { GraphProvider } from './GraphContext';
+import GraphToolbar, { GraphToolbarProps } from './GraphToolbar';
+import { GraphContainerKnowledgeData_fragment$key } from './__generated__/GraphContainerKnowledgeData_fragment.graphql';
 import { GraphContainerKnowledgeObjectsQuery } from './__generated__/GraphContainerKnowledgeObjectsQuery.graphql';
 import { GraphContainerKnowledgeObjects_fragment$key } from './__generated__/GraphContainerKnowledgeObjects_fragment.graphql';
 import { GraphContainerKnowledgePositions_fragment$key } from './__generated__/GraphContainerKnowledgePositions_fragment.graphql';
-import { GraphContainerKnowledgeData_fragment$key } from './__generated__/GraphContainerKnowledgeData_fragment.graphql';
-import { GraphProvider } from './GraphContext';
-import type { Theme } from '../Theme';
-import GraphToolbar, { GraphToolbarProps } from './GraphToolbar';
-import { ObjectToParse } from './utils/useGraphParser';
-import investigationAddFromContainer from '../../utils/InvestigationUtils';
-import useGraphInteractions from './utils/useGraphInteractions';
-import Graph from './Graph';
 import { OctiGraphPositions } from './graph.types';
+import { getObjectsToParse } from './utils/graphUtils';
+import useGraphInteractions from './utils/useGraphInteractions';
+import { ObjectToParse } from './utils/useGraphParser';
 
 // region Relay queries and fragments
 
@@ -476,7 +474,6 @@ const GraphContainerKnowledgeComponent = ({
   },
 }: GraphContainerKnowledgeComponentProps) => {
   const ref = useRef(null);
-  const theme = useTheme<Theme>();
   const bannerHeight = useSettingsMessagesBannerHeight();
 
   const {
@@ -500,8 +497,8 @@ const GraphContainerKnowledgeComponent = ({
   const toolbarHeight = 54;
   const totalHeight = bannerHeight + headerHeight + paddingHeight + breadcrumbHeight + titleHeight + tabsHeight + toolbarHeight;
   const graphContainerStyle: CSSProperties = {
-    margin: `-${theme.spacing(3)}`,
     height: `calc(100vh - ${totalHeight}px)`,
+    position: 'relative',
   };
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -52,6 +52,7 @@ class GroupingKnowledgeComponent extends Component {
         style={{
           width: '100%',
           height: '100%',
+          position: 'relative',
         }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
         data-testid="groupings-knowledge"
@@ -111,10 +112,11 @@ class GroupingKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={true}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.jsx
@@ -153,6 +153,7 @@ class ReportKnowledgeComponent extends Component {
         style={{
           width: '100%',
           height: '100%',
+          position: 'relative',
         }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
         data-testid="report-knowledge"
@@ -187,7 +188,11 @@ class ReportKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />
@@ -232,10 +237,11 @@ class ReportKnowledgeComponent extends Component {
                       );
                     }
                     return (
-                      <Loader
-                        variant={LoaderVariant.inElement}
-                        withTopMargin={false}
-                      />
+                      <div style={{ height: '50vh' }}>
+                        <Loader
+                          variant={LoaderVariant.inElement}
+                        />
+                      </div>
                     );
                   }}
                 />
@@ -258,10 +264,11 @@ class ReportKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={false}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -155,6 +155,7 @@ class IncidentKnowledgeComponent extends Component {
           height: '100%',
           margin: 0,
           padding: 0,
+          position: 'relative',
         }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
         data-testid="incident-response-knowledge"
@@ -189,10 +190,11 @@ class IncidentKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={true}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />
@@ -237,10 +239,11 @@ class IncidentKnowledgeComponent extends Component {
                       );
                     }
                     return (
-                      <Loader
-                        variant={LoaderVariant.inElement}
-                        withTopMargin={true}
-                      />
+                      <div style={{ height: '50vh' }}>
+                        <Loader
+                          variant={LoaderVariant.inElement}
+                        />
+                      </div>
                     );
                   }}
                 />
@@ -263,10 +266,11 @@ class IncidentKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={true}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -155,6 +155,7 @@ class CaseRfiKnowledgeComponent extends Component {
           height: '100%',
           margin: 0,
           padding: 0,
+          position: 'relative',
         }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
         data-testid="case-rfi-knowledge"
@@ -237,10 +238,11 @@ class CaseRfiKnowledgeComponent extends Component {
                       );
                     }
                     return (
-                      <Loader
-                        variant={LoaderVariant.inElement}
-                        withTopMargin={true}
-                      />
+                      <div style={{ height: '50vh' }}>
+                        <Loader
+                          variant={LoaderVariant.inElement}
+                        />
+                      </div>
                     );
                   }}
                 />
@@ -263,10 +265,11 @@ class CaseRfiKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={true}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -155,6 +155,7 @@ class CaseRftKnowledgeComponent extends Component {
           height: '100%',
           margin: 0,
           padding: 0,
+          position: 'relative',
         }}
         id={location.pathname.includes('matrix') ? 'parent' : 'container'}
         data-testid="case-rft-knowledge"
@@ -189,10 +190,11 @@ class CaseRftKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={true}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />
@@ -237,10 +239,11 @@ class CaseRftKnowledgeComponent extends Component {
                       );
                     }
                     return (
-                      <Loader
-                        variant={LoaderVariant.inElement}
-                        withTopMargin={true}
-                      />
+                      <div style={{ height: '50vh' }}>
+                        <Loader
+                          variant={LoaderVariant.inElement}
+                        />
+                      </div>
                     );
                   }}
                 />
@@ -263,10 +266,11 @@ class CaseRftKnowledgeComponent extends Component {
                     );
                   }
                   return (
-                    <Loader
-                      variant={LoaderVariant.inElement}
-                      withTopMargin={true}
-                    />
+                    <div style={{ height: '50vh' }}>
+                      <Loader
+                        variant={LoaderVariant.inElement}
+                      />
+                    </div>
                   );
                 }}
               />

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerHeader.jsx
@@ -16,7 +16,6 @@ import PopoverMenu from '../../../../components/PopoverMenu';
 import { authorizedMembersToOptions, useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import { resolveLink } from '../../../../utils/Entity';
-import useAuth from '../../../../utils/hooks/useAuth';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';
 import useGranted, {
   AUTOMATION,
@@ -27,7 +26,6 @@ import useGranted, {
   KNOWLEDGE_KNUPDATE_KNORGARESTRICT,
 } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
-import { useSettingsMessagesBannerHeight } from '../../settings/settings_messages/SettingsMessagesBanner';
 import { DraftChip } from '../draft/DraftChip';
 import FormAuthorizedMembersDialog from '../form/FormAuthorizedMembersDialog';
 import StixCoreObjectBackgroundTasks from '../stix_core_objects/StixCoreObjectActiveBackgroundTasks';
@@ -494,8 +492,6 @@ const ContainerHeader = (props) => {
     navigate(`${entityLink}/${targetTab}?${urlParams}`);
   };
 
-  const { bannerSettings: { bannerHeightNumber } } = useAuth();
-  const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
   // containerDefault style
   let containerStyle = {
     display: 'flex',
@@ -503,16 +499,18 @@ const ContainerHeader = (props) => {
     alignItems: 'center',
     marginBottom: theme.spacing(1),
   };
+
   const overrideContainerStyle = knowledge || currentMode === 'graph' || currentMode === 'correlation';
+
   if (overrideContainerStyle) {
     // container knowledge / graph style
     containerStyle = {
       position: 'absolute',
-      display: 'flex',
-      top: 196 + bannerHeightNumber + settingsMessagesBannerHeight,
-      right: 24,
+      top: '-75px',
+      right: 0,
     };
   }
+
   const triggersPaginationOptions = {
     includeAuthorities: true,
     filters: {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChain.tsx
@@ -304,7 +304,6 @@ const StixDomainObjectAttackPatternsKillChain: FunctionComponent<StixDomainObjec
           sx={{
             marginBottom: 2,
             padding: 0,
-            marginTop: -1,
             gap: 1,
           }}
         >

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftApprove.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftApprove.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { graphql } from 'relay-runtime';
-import { Alert, AlertTitle, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Tooltip } from '@mui/material';
+import { Alert, AlertTitle, DialogActions, DialogContentText, Tooltip } from '@mui/material';
+import Dialog from '@common/dialog/Dialog';
 import { useFragment } from 'react-relay';
 import { useFormatter } from '../../../components/i18n';
 import Button from '../../../components/common/button/Button';
@@ -108,22 +109,19 @@ export const DraftApprove = ({ data }: DraftApproveProps) => {
         keepMounted={true}
         slots={{ transition: Transition }}
         onClose={() => setDisplayApprove(false)}
+        title={t_i18n('Are you sure?')}
+        size="small"
       >
-        <DialogTitle>
-          {t_i18n('Are you sure?')}
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            {t_i18n('Do you want to approve this draft and send it to ingestion?')}
-            {processingCount > 0 && (
-              <Alert sx={{ marginTop: 1 }} severity="warning">
-                <AlertTitle>{t_i18n('Ongoing processes')}</AlertTitle>
-                {t_i18n('There are processes still running that could impact the data of the draft. '
-                  + 'By approving the draft now, the remaining changes that would have been applied by those processes will be ignored.')}
-              </Alert>
-            )}
-          </DialogContentText>
-        </DialogContent>
+        <DialogContentText>
+          {t_i18n('Do you want to approve this draft and send it to ingestion?')}
+          {processingCount > 0 && (
+            <Alert sx={{ marginTop: 1 }} severity="warning">
+              <AlertTitle>{t_i18n('Ongoing processes')}</AlertTitle>
+              {t_i18n('There are processes still running that could impact the data of the draft. '
+                + 'By approving the draft now, the remaining changes that would have been applied by those processes will be ignored.')}
+            </Alert>
+          )}
+        </DialogContentText>
         <DialogActions>
           <Button
             variant="secondary"

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasks.tsx
@@ -111,7 +111,6 @@ const CaseHeaderMenu: FunctionComponent<CaseHeaderMenuProps> = ({
       <Breadcrumbs elements={breadcrumb} />
 
       <HeaderMainEntityLayout
-        hasPlaceholderTags={false}
         title={caseTemplate.name}
         rightActions={(
           <>

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetUpsert.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetUpsert.tsx
@@ -33,6 +33,7 @@ const WidgetUpsert: FunctionComponent<WidgetUpsertProps> = ({
       open={open}
       onClose={onCancel}
       className="noDrag"
+      size="large"
     >
       <WidgetConfigStepper />
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* before, there was a fixed placeholder for handling the nested container, but it creates an empty space when no alias or no organisations
<img width="1393" height="597" alt="image" src="https://github.com/user-attachments/assets/6223d543-b920-4079-9593-f791bd320f5b" />

* now: 
<img width="1394" height="594" alt="image" src="https://github.com/user-attachments/assets/8c85065b-d294-4f9d-9dcf-e24f76cae5a8" />

* enlarge widget config dialog : 
<img width="1437" height="691" alt="image" src="https://github.com/user-attachments/assets/5f639820-a0be-4209-a888-931570312f04" />



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13303 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
