### PR TITLE
[backend] switch express query parser from default simple to extended (#14517)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpTaxii.js
+++ b/opencti-platform/opencti-graphql/src/http/httpTaxii.js
@@ -97,6 +97,7 @@ const JsonTaxiiMiddleware = express.json({
 });
 
 const initTaxiiApi = (app) => {
+  app.set('query parser', 'extended');
   // Discovery api
   app.get(`${basePath}/taxii2/`, async (req, res) => {
     try {

--- a/opencti-platform/opencti-graphql/tests/30-httpTaxii/httpTaxii-test.ts
+++ b/opencti-platform/opencti-graphql/tests/30-httpTaxii/httpTaxii-test.ts
@@ -16,9 +16,9 @@ describe('Taxii push Feed coverage', () => {
       authorized_members: [
         {
           id: connectorsGroup.id,
-          access_right: 'view'
-        }
-      ]
+          access_right: 'view',
+        },
+      ],
     };
     const taxiiPushIngestion = await addIngestion(testContext, ADMIN_USER, ingestionAdd);
     expect(taxiiPushIngestion.id).toBeDefined();
@@ -51,17 +51,17 @@ describe('Taxii push Feed coverage', () => {
             created_at: '2025-10-08T06: 17: 24.882Z',
             updated_at: '2025-10-08T06: 17: 24.882Z',
             creator_ids: [
-              '88ec0c6a-13ce-5e39-b486-354fe4a7084f'
-            ]
+              '88ec0c6a-13ce-5e39-b486-354fe4a7084f',
+            ],
           },
           'extension-definition--f93e2c80-4231-4f9a-af8b-95c9bd566a82': {
             extension_type: 'property-extension',
-            score: 50
-          }
+            score: 50,
+          },
         },
-        value: 'patate@truc.fr'
-      }
-    ]
+        value: 'patate@truc.fr',
+      },
+    ],
   };
 
   it.each([
@@ -74,7 +74,7 @@ describe('Taxii push Feed coverage', () => {
       method: 'POST',
       headers: {
         'Content-Type': contentType,
-        Authorization: `Bearer ${ADMIN_API_TOKEN}`
+        Authorization: `Bearer ${ADMIN_API_TOKEN}`,
       },
       body: JSON.stringify(bundleObject),
     });
@@ -100,7 +100,7 @@ describe('Taxii push Feed coverage', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/taxiiiii+json;version=2.1',
-        Authorization: `Bearer ${ADMIN_API_TOKEN}`
+        Authorization: `Bearer ${ADMIN_API_TOKEN}`,
       },
       body: JSON.stringify(bundleObject),
     });
@@ -123,7 +123,7 @@ describe('Should taxii collection coverage', () => {
       filters: JSON.stringify({
         mode: 'and',
         filters: [{ key: ['entity_type'], operator: 'eq', values: ['Indicator'], mode: 'or' }],
-        filterGroups: [] })
+        filterGroups: [] }),
     };
     const taxiiCollection = await createTaxiiCollection(testContext, ADMIN_USER, dataSharingTaxiiPublic);
 
@@ -141,7 +141,7 @@ describe('Should taxii collection coverage', () => {
       filters: JSON.stringify({
         mode: 'and',
         filters: [{ key: ['entity_type'], operator: 'eq', values: ['Malware'], mode: 'or' }],
-        filterGroups: [] })
+        filterGroups: [] }),
     };
     const taxiiCollectionWithauth = await createTaxiiCollection(testContext, ADMIN_USER, dataSharingTaxiiAuth);
 
@@ -157,7 +157,7 @@ describe('Should taxii collection coverage', () => {
 
   it('should taxii root works', async () => {
     const headers = {
-      Authorization: `Bearer ${ADMIN_API_TOKEN}`
+      Authorization: `Bearer ${ADMIN_API_TOKEN}`,
     };
     const taxiiRootResponse = await fetch(`${getBaseUrl()}/taxii2/root/`, { headers });
     const data: any = await taxiiRootResponse.json();
@@ -172,14 +172,32 @@ describe('Should taxii collection coverage', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/taxii+json;version=2.1',
-          Accept: 'application/taxii+json;version=2.1'
-        }
-      }
+          Accept: 'application/taxii+json;version=2.1',
+        },
+      },
     );
     expect(taxiiCollectionResponse.status).toBe(200);
-    const content = await taxiiCollectionResponse.json() as { more: boolean, next: string };
+    const content = await taxiiCollectionResponse.json() as { more: boolean; next: string; objects: { id: string }[] };
     expect(content.more).toBeFalsy();
     expect(content.next.length).toBeGreaterThan(0);
+    const firstItem = content.objects[0];
+    expect(firstItem).toBeDefined();
+    expect(firstItem.id).toBeDefined();
+
+    const taxiiCollectionResponseWithMatch = await fetch(
+      `${getBaseUrl()}/taxii2/root/collections/${taxiiCollectionPublicId}/objects?match[id]=${firstItem.id}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/taxii+json;version=2.1',
+          Accept: 'application/taxii+json;version=2.1',
+        },
+      },
+    );
+    expect(taxiiCollectionResponseWithMatch.status).toBe(200);
+    const contentWithMatch = await taxiiCollectionResponseWithMatch.json() as { more: boolean; next: string; objects: { id: string }[] };
+    expect(contentWithMatch.more).toBeFalsy();
+    expect(contentWithMatch.objects.length).toBe(1);
   });
 
   it('should restricted taxii collection without user be forbidden', async () => {
@@ -189,9 +207,9 @@ describe('Should taxii collection coverage', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/taxii+json;version=2.1',
-          Accept: 'application/taxii+json;version=2.1'
-        }
-      }
+          Accept: 'application/taxii+json;version=2.1',
+        },
+      },
     );
     expect(taxiiCollectionResponse.status).toBe(401);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* to handle object params in req.query for taxii objects endpoint (match param is not currently handled properly because of this), we switch express query parser from default simple to extended
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14517 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
