### PR TITLE
[frontend] Org color is consistent in connector view

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -53,13 +53,6 @@ import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 're
 import { ListItemButton, Stack, Typography } from '@mui/material';
 import { createRefetchContainer, RelayRefetchProp } from 'react-relay';
 
-// Type extension for organization node with authorized_authorities
-interface OrganizationNodeWithAuthorities {
-  id: string;
-  name: string;
-  authorized_authorities?: ReadonlyArray<string>;
-}
-
 const interval$ = interval(FIVE_SECONDS);
 
 export const connectorUpdateTriggerMutation = graphql`
@@ -482,11 +475,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                               <ListItemIcon>
                                 <ItemIcon
                                   type="Organization"
-                                  color={
-                                    ((organizationEdge.node as OrganizationNodeWithAuthorities).authorized_authorities ?? []).includes(connector.connector_user?.id ?? '')
-                                      ? theme.palette.dangerZone.main
-                                      : theme.palette.primary.main
-                                  }
+                                  color={theme.palette.primary.main}
                                 />
                               </ListItemIcon>
                               <ListItemText primary={organizationEdge.node.name} />


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use a fixed color for the org in the connector details view

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes https://github.com/OpenCTI-Platform/opencti/issues/14547

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
