### PR TITLE
[client] fix: batch_size race conditions (#15187)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1345,16 +1345,26 @@ class BatchCallbackWrapper:
                     if should_process:
                         batch_data = self._extract_batch_data(trigger_reason)
 
-            if batch_data is not None:
+            while batch_data is not None:
                 self._execute_batch_callback(batch_data)
+                batch_data = None
+                if self._stop_event.is_set():
+                    break
+                with self._lock:
+                    if self.batch_size and len(self.batch) >= self.batch_size:
+                        batch_data = self._extract_batch_data("size_limit")
 
         # Process remaining messages after loop exits
         batch_data = None
         with self._lock:
             if len(self.batch) > 0:
                 batch_data = self._extract_batch_data("shutdown")
-        if batch_data is not None:
+        while batch_data is not None:
             self._execute_batch_callback(batch_data)
+            batch_data = None
+            with self._lock:
+                if len(self.batch) > 0:
+                    batch_data = self._extract_batch_data("shutdown")
 
     def __call__(self, msg) -> None:
         """Accumulate a message into the current batch.
@@ -1377,29 +1387,40 @@ class BatchCallbackWrapper:
         :param trigger_reason: What triggered batch processing
         :return: Dictionary containing events and batch metadata
         """
+        if self.batch_size:
+            extracted = self.batch[:self.batch_size]
+            self.batch = self.batch[self.batch_size:]
+        else:
+            extracted = self.batch.copy()
+            self.batch = []
+
         elapsed = time.time() - self.batch_start_time if self.batch_start_time else 0
 
         self.helper.connector_logger.info(
             "Processing batch",
             {
-                "batch_size": len(self.batch),
+                "batch_size": len(extracted),
                 "elapsed_time": elapsed,
                 "trigger": trigger_reason,
             },
         )
 
         batch_data = {
-            "events": self.batch.copy(),
+            "events": extracted,
             "batch_metadata": {
-                "batch_size": len(self.batch),
+                "batch_size": len(extracted),
                 "trigger_reason": trigger_reason,
                 "elapsed_time": elapsed,
                 "timestamp": time.time(),
             },
         }
 
-        self.batch = []
-        self.batch_start_time = None
+        # Only reset batch_start_time if the buffer is now empty
+        if len(self.batch) == 0:
+            self.batch_start_time = None
+        else:
+            # Reset start time so the remaining items get a fresh timeout window
+            self.batch_start_time = time.time()
 
         return batch_data
 

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1388,8 +1388,8 @@ class BatchCallbackWrapper:
         :return: Dictionary containing events and batch metadata
         """
         if self.batch_size:
-            extracted = self.batch[:self.batch_size]
-            self.batch = self.batch[self.batch_size:]
+            extracted = self.batch[: self.batch_size]
+            self.batch = self.batch[self.batch_size :]
         else:
             extracted = self.batch.copy()
             self.batch = []

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1382,7 +1382,11 @@ class BatchCallbackWrapper:
                 self._batch_ready_event.set()
 
     def _extract_batch_data(self, trigger_reason: str) -> dict:
-        """Extract batch data and reset batch state. Must be called with _lock held.
+        """Extract up to batch_size events and return batch data. Must be called with _lock held.
+
+        When batch_size is set, extracts at most batch_size items, leaving any
+        overflow in self.batch with a refreshed batch_start_time. When batch_size
+        is None, extracts all items and fully resets batch state.
 
         :param trigger_reason: What triggered batch processing
         :return: Dictionary containing events and batch metadata

--- a/client-python/tests/01-unit/connector_helper/test_batch_callback_wrapper.py
+++ b/client-python/tests/01-unit/connector_helper/test_batch_callback_wrapper.py
@@ -111,16 +111,22 @@ class TestBatchCallbackWrapper(TestCase):
             if len(batches) >= 3:
                 done.set()
 
-        wrapper = BatchCallbackWrapper(helper, callback, batch_size=5, batch_timeout=0.1)
+        wrapper = BatchCallbackWrapper(
+            helper, callback, batch_size=5, batch_timeout=0.1
+        )
         try:
             for i in range(12):
                 wrapper(DummyMessage(f"{i}-0"))
             self.assertTrue(done.wait(timeout=5))
             self.assertEqual(len(batches), 3)
             self.assertEqual(batches[0]["batch_metadata"]["batch_size"], 5)
-            self.assertEqual(batches[0]["batch_metadata"]["trigger_reason"], "size_limit")
+            self.assertEqual(
+                batches[0]["batch_metadata"]["trigger_reason"], "size_limit"
+            )
             self.assertEqual(batches[1]["batch_metadata"]["batch_size"], 5)
-            self.assertEqual(batches[1]["batch_metadata"]["trigger_reason"], "size_limit")
+            self.assertEqual(
+                batches[1]["batch_metadata"]["trigger_reason"], "size_limit"
+            )
             self.assertEqual(batches[2]["batch_metadata"]["batch_size"], 2)
             self.assertEqual(batches[2]["batch_metadata"]["trigger_reason"], "timeout")
         finally:
@@ -135,7 +141,9 @@ class TestBatchCallbackWrapper(TestCase):
             batches.append(batch_data)
             done.set()
 
-        wrapper = BatchCallbackWrapper(helper, callback, batch_size=None, batch_timeout=0.1)
+        wrapper = BatchCallbackWrapper(
+            helper, callback, batch_size=None, batch_timeout=0.1
+        )
         try:
             for i in range(8):
                 wrapper(DummyMessage(f"{i}-0"))
@@ -176,7 +184,7 @@ class TestBatchCallbackWrapper(TestCase):
         for i in range(8):
             wrapper.batch.append(DummyMessage(f"{i}-0"))
         wrapper.batch_start_time = time.time()
-        
+
         wrapper.stop()
 
         self.assertEqual(len(batches), 3)

--- a/client-python/tests/01-unit/connector_helper/test_batch_callback_wrapper.py
+++ b/client-python/tests/01-unit/connector_helper/test_batch_callback_wrapper.py
@@ -178,12 +178,12 @@ class TestBatchCallbackWrapper(TestCase):
         def callback(batch_data):
             batches.append(batch_data)
 
+        BatchCallbackWrapper._TIMER_CHECK_INTERVAL = 10.0
         wrapper = BatchCallbackWrapper(
-            helper, callback, batch_size=3, batch_timeout=10.0
+            helper, callback, batch_size=3, batch_timeout=100.0
         )
         for i in range(8):
-            wrapper.batch.append(DummyMessage(f"{i}-0"))
-        wrapper.batch_start_time = time.time()
+            wrapper(DummyMessage(f"{i}-0"))
 
         wrapper.stop()
 
@@ -193,6 +193,42 @@ class TestBatchCallbackWrapper(TestCase):
         self.assertEqual(batches[2]["batch_metadata"]["batch_size"], 2)
         for b in batches:
             self.assertEqual(b["batch_metadata"]["trigger_reason"], "shutdown")
+
+    def test_timer_drains_overflow_in_chunks(self):
+        """Verify the timer thread drains overflow via size_limit then timeout.
+
+        Adding 8 messages with batch_size=3 triggers _batch_ready_event at
+        message 3. The timer wakes, extracts a chunk of 3 ("size_limit"),
+        then the while-loop extracts another chunk of 3 ("size_limit"),
+        leaving 2 in the buffer with a fresh batch_start_time. On the next
+        timer iteration len(batch)=2 < batch_size=3, so the timeout path
+        fires after batch_timeout=0.1s, draining the last 2 as "timeout".
+        """
+        helper = DummyHelper()
+        batches = []
+        done = threading.Event()
+
+        def callback(batch_data):
+            batches.append(batch_data)
+            if len(batches) >= 3:
+                done.set()
+
+        wrapper = BatchCallbackWrapper(
+            helper, callback, batch_size=3, batch_timeout=0.1
+        )
+        try:
+            for i in range(8):
+                wrapper(DummyMessage(f"{i}-0"))
+            self.assertTrue(done.wait(timeout=5))
+            self.assertEqual(len(batches), 3)
+            self.assertEqual(batches[0]["batch_metadata"]["batch_size"], 3)
+            self.assertEqual(batches[0]["batch_metadata"]["trigger_reason"], "size_limit")
+            self.assertEqual(batches[1]["batch_metadata"]["batch_size"], 3)
+            self.assertEqual(batches[1]["batch_metadata"]["trigger_reason"], "size_limit")
+            self.assertEqual(batches[2]["batch_metadata"]["batch_size"], 2)
+            self.assertEqual(batches[2]["batch_metadata"]["trigger_reason"], "timeout")
+        finally:
+            wrapper.stop()
 
     def test_batch_callback_error_does_not_update_state(self):
         helper = DummyHelper()

--- a/client-python/tests/01-unit/connector_helper/test_batch_callback_wrapper.py
+++ b/client-python/tests/01-unit/connector_helper/test_batch_callback_wrapper.py
@@ -222,9 +222,13 @@ class TestBatchCallbackWrapper(TestCase):
             self.assertTrue(done.wait(timeout=5))
             self.assertEqual(len(batches), 3)
             self.assertEqual(batches[0]["batch_metadata"]["batch_size"], 3)
-            self.assertEqual(batches[0]["batch_metadata"]["trigger_reason"], "size_limit")
+            self.assertEqual(
+                batches[0]["batch_metadata"]["trigger_reason"], "size_limit"
+            )
             self.assertEqual(batches[1]["batch_metadata"]["batch_size"], 3)
-            self.assertEqual(batches[1]["batch_metadata"]["trigger_reason"], "size_limit")
+            self.assertEqual(
+                batches[1]["batch_metadata"]["trigger_reason"], "size_limit"
+            )
             self.assertEqual(batches[2]["batch_metadata"]["batch_size"], 2)
             self.assertEqual(batches[2]["batch_metadata"]["trigger_reason"], "timeout")
         finally:


### PR DESCRIPTION
### Proposed changes

Previously, batch_size act as a minimum threshold to trigger background processing rather than a strict limit. A race condition existed between the thread appending messages from the livestream and the timer thread attempting to acquire the lock to clear the buffer. As a result, the actual number of extracted events could significantly exceed the batch_size. This behavior was typically observed under high ingestion throughput with a low batch_size (< 10), or when fetching historical livestream data

Fix https://github.com/OpenCTI-Platform/opencti/issues/15187

Updated _extract_batch_data to extract at most   batch_size events, leaving any newly arrived overflow messages safely in the buffer (state not updated)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality