### PR TITLE
[frontend] changed body background end gradient color (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -9,7 +9,7 @@ import { alpha, darken, lighten } from '@mui/material';
 const EE_COLOR = '#00f18d';
 
 export const THEME_DARK_DEFAULT_BACKGROUND = '#070d19';
-export const THEME_DARK_DEFAULT_BODY_END_GRADIENT = '#0C1524';
+const THEME_DARK_DEFAULT_BODY_END_GRADIENT = '#08101D';
 export const THEME_DARK_DEFAULT_PRIMARY = '#0fbcff';
 export const THEME_DARK_DEFAULT_SECONDARY = '#00f18d';
 export const THEME_DARK_DEFAULT_ACCENT = '#0f1e38';

--- a/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/TopBar.tsx
@@ -36,7 +36,7 @@ import { CGUStatus } from '../settings/Experience';
 import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
 import { TopBarNotificationNumberSubscription$data } from './__generated__/TopBarNotificationNumberSubscription.graphql';
 import { TopBarQuery } from './__generated__/TopBarQuery.graphql';
-import { THEME_DARK_DEFAULT_BACKGROUND, THEME_DARK_DEFAULT_BODY_END_GRADIENT } from '../../../components/ThemeDark';
+import { THEME_DARK_DEFAULT_BACKGROUND } from '../../../components/ThemeDark';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -196,9 +196,9 @@ const TopBarComponent: FunctionComponent<TopBarProps> = ({
   const keyword = decodeSearchKeyword(location.pathname.match(/(?:\/dashboard\/search\/(?:knowledge|files)\/(.*))/)?.[1] ?? '');
 
   const getAppTopBarGradient = (): string => {
-    const defaultGradientDark = `${alpha(THEME_DARK_DEFAULT_BACKGROUND, 0.9)} 0%, ${alpha(THEME_DARK_DEFAULT_BODY_END_GRADIENT, 0.9)}`;
-    if (theme.palette.background.gradient?.start && theme.palette.background.gradient?.start) {
-      return `${alpha(theme.palette.background.gradient?.start, 0.9)} 0%, ${alpha(theme.palette.background.gradient?.end, 0.9)}`;
+    const defaultGradientDark = `${alpha(THEME_DARK_DEFAULT_BACKGROUND, 0.9)} 0%, ${alpha(theme.palette.designSystem.background.bg1, 0.9)}`;
+    if (theme.palette.background.gradient?.start && theme.palette.background.gradient?.end) {
+      return `${alpha(theme.palette.background.gradient.start, 0.9)} 0%, ${alpha(theme.palette.background.gradient.end, 0.9)}`;
     }
     return defaultGradientDark;
   };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Changed body background end gradient color from #0C1524 to #08101D
* Corrected condition in topBar + replaced the THEME_DARK_DEFAULT_BODY_END_GRADIENT constant with theme.palette.designSystem.background.bg1 to keep the same original color : #0C1524

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13303
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
