### PR TITLE
[frontend] Fix default max width for markings chips (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemMarkings.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemMarkings.tsx
@@ -82,6 +82,7 @@ const ChipMarking = ({
           onClick?.(markingDefinition);
         },
       }}
+      maxWidth={100}
     />
   );
 };


### PR DESCRIPTION
### Proposed changes
Fix max width for marking chips

To avoid this UI behavior in Global kill chain tab of a malware knowledge : 
<img width="2048" height="1006" alt="image" src="https://github.com/user-attachments/assets/3587a72f-0df3-40fa-a829-cf08a08cfc8b" />


### Related issues
#13303