### PR TITLE
[frontend] Corrected security coverage UI after rebase (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -165,7 +165,9 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
                   startIcon={<OaevLogo />}
                   onClick={() => setDisplayExternalLink(true)}
                   title={hasExternalUri ? securityCoverage.external_uri : undefined}
-                  variant="secondary"
+                  variant="tertiary"
+                  size="small"
+                  sx={{ marginTop: '16px' }}
                 >
                   {hasExternalUri ? `${t_i18n('Go to OpenAEV')}` : `${t_i18n('Provisioning OpenAEV')}`}
                 </Button>

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -167,7 +167,7 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
                   title={hasExternalUri ? securityCoverage.external_uri : undefined}
                   variant="tertiary"
                   size="small"
-                  sx={{ marginTop: '16px' }}
+                  sx={{ mt: 2 }}
                 >
                   {hasExternalUri ? `${t_i18n('Go to OpenAEV')}` : `${t_i18n('Provisioning OpenAEV')}`}
                 </Button>

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -22,7 +22,7 @@ import { getCurrentTab, getPaddingRight, isNotEmptyField } from '../../../../uti
 import SecurityCoverageEdition from './SecurityCoverageEdition';
 import SecurityCoverageDeletion from './SecurityCoverageDeletion';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import Button from '@mui/material/Button';
+import Button from '@common/button/Button';
 import { OaevLogo } from '../../../../static/images/logo_oaev';
 import ExternalLinkPopover from '../../../../components/ExternalLinkPopover';
 import { RootSecurityCoverageSubscription } from '@components/analyses/security_coverages/__generated__/RootSecurityCoverageSubscription.graphql';
@@ -162,11 +162,10 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
               <>
                 <Button
                   disabled={!hasExternalUri}
-                  style={{ marginBottom: 8 }}
                   startIcon={<OaevLogo />}
-                  variant="outlined"
                   onClick={() => setDisplayExternalLink(true)}
                   title={hasExternalUri ? securityCoverage.external_uri : undefined}
+                  variant="secondary"
                 >
                   {hasExternalUri ? `${t_i18n('Go to OpenAEV')}` : `${t_i18n('Provisioning OpenAEV')}`}
                 </Button>

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
@@ -74,7 +74,7 @@ const SecurityCoverageDetails: FunctionComponent<SecurityCoverageDetailsProps> =
             <ExpandableMarkdown source={data.description} limit={300} />
           </Grid>
           <Grid item xs={12}>
-            <Label sx={{ marginBottom: '8px' }}>
+            <Label sx={{ mb: 1 }}>
               {t_i18n('Coverage information')}
             </Label>
             <SecurityCoverageInformation coverage_information={data.coverage_information ?? []} variant="details" />

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -75,12 +74,10 @@ const SecurityCoverageDetails: FunctionComponent<SecurityCoverageDetailsProps> =
             <ExpandableMarkdown source={data.description} limit={300} />
           </Grid>
           <Grid item xs={12}>
-            <Label>
+            <Label sx={{ marginBottom: '8px' }}>
               {t_i18n('Coverage information')}
             </Label>
-            <Paper variant="outlined" sx={{ padding: 2 }}>
-              <SecurityCoverageInformation coverage_information={data.coverage_information ?? []} variant="details" />
-            </Paper>
+            <SecurityCoverageInformation coverage_information={data.coverage_information ?? []} variant="details" />
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
@@ -7,12 +7,8 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import ListItemButton from '@mui/material/ListItemButton';
-import Typography from '@mui/material/Typography';
-import { Theme } from '@mui/material/styles/createTheme';
 import SecurityCoverageInformation from '@components/analyses/security_coverages/SecurityCoverageInformation';
 import { Link } from 'react-router-dom';
-import Button from '@common/button/Button';
-import { useTheme } from '@mui/styles';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
@@ -21,14 +17,10 @@ import { SecurityCoverageDetails_securityCoverage$key } from './__generated__/Se
 import SecurityCoverageSecurityPlatforms from './SecurityCoverageSecurityPlatforms';
 import SecurityCoverageVulnerabilities from './SecurityCoverageVulnerabilities';
 import { isNotEmptyField } from '../../../../utils/utils';
-import { fileUri } from '../../../../relay/environment';
-import oaevDark from '../../../../static/images/xtm/oaev_dark.png';
-import oaevLight from '../../../../static/images/xtm/oaev_light.png';
 import ExternalLinkPopover from '../../../../components/ExternalLinkPopover';
 import Card from '../../../../components/common/card/Card';
 import Label from '../../../../components/common/label/Label';
 import { EMPTY_VALUE } from '../../../../utils/String';
-import { Stack } from '@mui/material';
 
 const securityCoverageDetailsFragment = graphql`
   fragment SecurityCoverageDetails_securityCoverage on SecurityCoverage {
@@ -62,7 +54,6 @@ interface SecurityCoverageDetailsProps {
 const SecurityCoverageDetails: FunctionComponent<SecurityCoverageDetailsProps> = ({
   securityCoverage,
 }) => {
-  const theme = useTheme<Theme>();
   const { t_i18n, fndt } = useFormatter();
   const data = useFragment(securityCoverageDetailsFragment, securityCoverage);
   const [displayExternalLink, setDisplayExternalLink] = useState(false);
@@ -84,34 +75,11 @@ const SecurityCoverageDetails: FunctionComponent<SecurityCoverageDetailsProps> =
             <ExpandableMarkdown source={data.description} limit={300} />
           </Grid>
           <Grid item xs={12}>
-            <Typography variant="h3" gutterBottom={true}>
+            <Label>
               {t_i18n('Coverage information')}
-            </Typography>
-            <Paper variant="outlined" style={{ padding: 20, marginTop: 10 }}>
-              <Stack direction="row" gap={1} mb={1} alignItems="center">
-                <Label>
-                  {t_i18n('Coverage information')}
-                </Label>
-                {isNotEmptyField(data.external_uri) && (
-                  <Button
-                    startIcon={(
-                      <img
-                        style={{ width: 20 }}
-                        src={fileUri(theme.palette.mode === 'dark' ? oaevDark : oaevLight)}
-                        alt="OAEV"
-                      />
-                    )}
-                    variant="secondary"
-                    onClick={() => setDisplayExternalLink(true)}
-                    title={data.external_uri}
-                  >
-                    {t_i18n('Exposure validation')}
-                  </Button>
-                )}
-              </Stack>
-              <Paper variant="outlined" sx={{ padding: 2 }}>
-                <SecurityCoverageInformation coverage_information={data.coverage_information ?? []} variant="details" />
-              </Paper>
+            </Label>
+            <Paper variant="outlined" sx={{ padding: 2 }}>
+              <SecurityCoverageInformation coverage_information={data.coverage_information ?? []} variant="details" />
             </Paper>
           </Grid>
           <Grid item xs={6}>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* put the new secrurity coverage button in new UI v7 style using our button component
* Removed double card info in Entity Details > Coverage Information

BEFORE
<img width="1477" height="773" alt="Capture d’écran 2026-02-23 à 15 05 47" src="https://github.com/user-attachments/assets/c9c45b66-e01f-44bf-9e72-2fdcde114ded" />

AFTER
<img width="1476" height="701" alt="Capture d’écran 2026-02-23 à 15 05 11" src="https://github.com/user-attachments/assets/1442528a-d622-4c02-a69c-333caf83ec16" />

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13303

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
