### PR TITLE
[backend] handle decay excluded indicators in indicatorEditField (#14347)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -449,6 +449,11 @@ export const indicatorEditField = async (context: AuthContext, user: AuthUser, i
   }
   // END Region Validation
 
+  const isDecayExcluded = indicatorBeforeUpdate.decay_exclusion_applied_rule !== undefined;
+  // If indicator is under decay exclusion, we just send the input as is for the update
+  if (isDecayExcluded) {
+    return stixDomainObjectEditField(context, user, id, input, opts);
+  }
   // Region Decay and {Score, Valid until, Revoke} computation
   // We keep everything EXCEPT fields that can be changed by decay computation
   const finalInput = input.filter((editInput) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* indicatorEditField has a lot of buisness logic for handling updates on indicators impacted by decay. When a decay exclusion rule is applied, user should be able to update the indicator as he wants instead
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14347 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
