### PR TITLE
[frontend] should prevent crash on live streams screen (#13303)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Feed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Feed.tsx
@@ -84,6 +84,7 @@ const Feed = () => {
     };
     return (
       <ListLines
+        iconExtension
         sortBy={sortBy}
         orderAsc={orderAsc}
         dataColumns={dataColumns}

--- a/opencti-platform/opencti-front/src/private/components/data/Stream.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Stream.tsx
@@ -99,6 +99,7 @@ const Stream = () => {
     };
     return (
       <ListLines
+        iconExtension
         sortBy={sortBy}
         orderAsc={orderAsc}
         dataColumns={dataColumns}

--- a/opencti-platform/opencti-front/src/private/components/data/Taxii.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Taxii.tsx
@@ -85,6 +85,7 @@ const Taxii = () => {
     };
     return (
       <ListLines
+        iconExtension
         sortBy={sortBy}
         orderAsc={orderAsc}
         dataColumns={dataColumns}

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamLine.jsx
@@ -176,8 +176,8 @@ class StreamLineLineComponent extends Component {
                   />
                 </div>
                 <div
-                  className={classes.filtersItem}
-                  style={{ width: dataColumns.filters.width }}
+                  className={classes.consumersItem}
+                  style={{ width: dataColumns.consumers.width }}
                 >
                   {isFilterGroupNotEmpty(filters)
                     ? (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Filters have been renamed to consumers in Live Stream component but it children component still use data.filters.width which is undefined
* Fix icon position in the lists adding iconExtension prop

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13303 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
