### PR TITLE
[frontend] fix customization list rendering (#14601)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLines.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLines.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery } from 'react-relay';
-import usePreloadedFragment from '../../../../utils/hooks/usePreloadedFragment';
 import { useFormatter } from '../../../../components/i18n';
-import SubTypeLine from './SubTypesLine';
-import { SubTypesLinesQuery } from './__generated__/SubTypesLinesQuery.graphql';
-import { SubTypesLines_subTypes$key } from './__generated__/SubTypesLines_subTypes.graphql';
 import { DataColumns } from '../../../../components/list_lines';
 import ListLinesContent from '../../../../components/list_lines/ListLinesContent';
 import { UseLocalStorageHelpers } from '../../../../utils/hooks/useLocalStorage';
+import usePreloadedFragment from '../../../../utils/hooks/usePreloadedFragment';
+import SubTypeLine from './SubTypesLine';
+import { SubTypesLinesQuery } from './__generated__/SubTypesLinesQuery.graphql';
+import { SubTypesLines_subTypes$key } from './__generated__/SubTypesLines_subTypes.graphql';
 
 export const subTypesLinesQuery = graphql`
   query SubTypesLinesQuery {
@@ -80,11 +80,13 @@ const SubTypesLines: FunctionComponent<SubTypesLinesProps> = ({
   const subTypes = (data?.subTypes?.edges ?? [])
     .filter(filterOnSubType)
     .sort(sortOnSubType);
-  setNumberOfElements({
-    number: subTypes.length,
-    symbol: '',
-    original: subTypes.length,
-  });
+  React.useEffect(() => {
+    setNumberOfElements({
+      number: subTypes.length,
+      symbol: '',
+      original: subTypes.length,
+    });
+  }, [subTypes.length, setNumberOfElements]);
   return (
     <ListLinesContent
       initialLoading={false}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* ensure the customization page's entity types list is correctly re-rendered when the window size changes or is too small to display all list items

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes https://github.com/OpenCTI-Platform/opencti/issues/14601

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
