### PR TITLE
[backend] Entity restoration should restore former creation dates of relationships (#13115)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/data-builder.js
+++ b/opencti-platform/opencti-graphql/src/database/data-builder.js
@@ -29,7 +29,7 @@ import { RELATION_IN_PIR } from '../schema/internalRelationship';
 import { pushAll } from '../utils/arrayUtil';
 
 export const buildEntityData = async (context, user, input, type, opts = {}) => {
-  const { fromRule } = opts;
+  const { fromRule, restore } = opts;
   const internalId = input.internal_id || generateInternalId();
   const standardId = input.standard_id || generateStandardId(type, input);
   // Complete with identifiers
@@ -70,6 +70,9 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
     const haveStixId = isNotEmptyField(input.stix_id);
     if (haveStixId && input.stix_id !== standardId) {
       stixIds.push(input.stix_id.toLowerCase());
+    }
+    if (restore) {
+      input.created_at = input.created;
     }
     data = R.pipe(
       R.assoc(IDS_STIX, stixIds),

--- a/opencti-platform/opencti-graphql/src/database/data-builder.js
+++ b/opencti-platform/opencti-graphql/src/database/data-builder.js
@@ -60,7 +60,7 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
   // Some internal objects have dates
   if (isDatedInternalObject(type)) {
     data = R.pipe(
-      R.assoc('created_at', today),
+      R.assoc('created_at', restore ? input.created : today),
       R.assoc('updated_at', today),
     )(data);
   }
@@ -70,9 +70,6 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
     const haveStixId = isNotEmptyField(input.stix_id);
     if (haveStixId && input.stix_id !== standardId) {
       stixIds.push(input.stix_id.toLowerCase());
-    }
-    if (restore) {
-      input.created_at = input.created;
     }
     data = R.pipe(
       R.assoc(IDS_STIX, stixIds),


### PR DESCRIPTION
### Proposed changes

* As the entity is "re created" when using restore of the trash. I used the restore opts attribute to change the created_at attribute with the created attribute (the created one keeps the plateform creation date) on the data-building of the creation of an entity

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/13115