### PR TITLE
[backend] fix livestreamhandler monitoring fail on redis pipeline (#14604)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/streamConsumerRegistry.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/streamConsumerRegistry.ts
@@ -14,8 +14,8 @@ const CONSUMER_TTL_SECONDS = 60; // Redis key TTL; refreshed on each flush
 const STALE_CUTOFF_MS = CONSUMER_TTL_SECONDS * 1000;
 
 // Redis key prefixes
-const CONSUMER_KEY_PREFIX = '{stream_consumer}:';
-const COLLECTION_SET_PREFIX = '{stream_consumers}:';
+const CONSUMER_KEY_PREFIX = '{stream_monitoring}:consumer:';
+const COLLECTION_SET_PREFIX = '{stream_monitoring}:collection:';
 
 // -- Types --
 


### PR DESCRIPTION
### Proposed changes
* update the slot prefix to execute pipeline on a single slot

### Related issues
* Fix #14604

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
