### PR TITLE
fix: restore AI Insights button on Reports

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -11,6 +11,7 @@ import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import Security from 'src/utils/Security';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';
+import AIInsights from '@components/common/ai/AIInsights';
 import { QueryRenderer } from '../../../../relay/environment';
 import Report from './Report';
 import { RootReportSubscription } from './__generated__/RootReportSubscription.graphql';
@@ -132,7 +133,6 @@ const RootReport = () => {
                     enableQuickSubscription={true}
                     enableQuickExport={true}
                     enableEnrollPlaybook={true}
-                    enableAskAi={false}
                     overview={isOverview}
                     redirectToContent={true}
                     enableEnricher={true}
@@ -187,6 +187,7 @@ const RootReport = () => {
                     </Tabs>
                     {!isKnowledgeOrContent && (
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+                        <AIInsights id={report.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
                         <StixCoreObjectSecurityCoverage id={report.id} coverage={report.securityCoverage} />
                       </div>
                     )}


### PR DESCRIPTION
## Summary

Restores the **AI Insights** button on Report detail pages, which was accidentally removed during the v7 UI overhaul.

Closes #14625

## Changes

**File:** `opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx`

| What | Before | After |
|------|--------|-------|
| `AIInsights` import | ❌ Missing | ✅ Added |
| `<AIInsights>` render | ❌ Missing | ✅ Rendered next to `StixCoreObjectSecurityCoverage` |
| `enableAskAi` on `ContainerHeader` | `enableAskAi={false}` | Removed (defaults to enabled) |

## Context

The Groupings `Root.tsx` still has the correct implementation with both `AIInsights` and `StixCoreObjectSecurityCoverage` rendered in the tab bar area. This PR aligns Reports to match.

## Testing

1. Navigate to any Report detail page
2. Verify the AI Insights button appears in the top-right next to Security Coverage
3. Click the AI Insights button — confirm the panel opens and functions correctly
4. Verify Groupings still work as before (no regression)