### PR TITLE
[frontend] Reintroduce AI Insights button in Report (#14622)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -30,6 +30,7 @@ import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
 import ReportEdition from './ReportEdition';
 import ReportDeletion from './ReportDeletion';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
+import AIInsights from '@components/common/ai/AIInsights';
 
 const subscription = graphql`
   subscription RootReportSubscription($id: ID!) {
@@ -187,6 +188,7 @@ const RootReport = () => {
                     </Tabs>
                     {!isKnowledgeOrContent && (
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+                        <AIInsights id={report.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
                         <StixCoreObjectSecurityCoverage id={report.id} coverage={report.securityCoverage} />
                       </div>
                     )}

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
@@ -132,9 +132,10 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick }: AiInsi
   const { t_i18n } = useFormatter();
   const { bannerSettings: { bannerHeightNumber } } = useAuth();
   const classes = useStyles({ bannerHeightNumber });
+  const buttonLabel = t_i18n('AI Insights');
 
   return (
-    <Tooltip title={t_i18n('AI Insights')}>
+    <Tooltip title={buttonLabel}>
       {onlyIcon ? (
         <IconButton
           size="small"
@@ -149,9 +150,10 @@ const AiInsightButton = ({ onlyIcon = false, floating = false, onClick }: AiInsi
           size="small"
           onClick={onClick}
           intent="ai"
+          aria-label={buttonLabel}
           startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" />}
         >
-          {t_i18n('AI Insights')}
+          {buttonLabel}
         </Button>
       )}
     </Tooltip>

--- a/opencti-platform/opencti-front/tests_e2e/model/reportDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/reportDetails.pageModel.ts
@@ -24,6 +24,10 @@ export default class ReportDetailsPage {
     return this.page.getByLabel('Update', { exact: true });
   }
 
+  getAiInsightsButton() {
+    return this.page.getByLabel('AI Insights', { exact: true });
+  }
+
   getContentFile(fileName: string) {
     return this.page.getByLabel(fileName);
   }

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -129,6 +129,9 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation', '@ce'] }, asyn
   // region Control data on report details page
   // ------------------------------------------
 
+  const aiInsightsButton = reportDetailsPage.getAiInsightsButton();
+  await expect(aiInsightsButton).toBeVisible();
+
   let description = reportDetailsPage.getTextForHeading('Description', 'Test e2e Description');
   await expect(description).toBeVisible();
 


### PR DESCRIPTION
### Proposed changes
- Reintroduce AI Insights button in Report
- Add e2e

### Related issues
#14622


<img width="1857" height="511" alt="image" src="https://github.com/user-attachments/assets/2212608f-7c7e-48d2-8cab-bcb3a6ce11db" />
