### PR TITLE
[frontend] Reintroduce AI Insights button in Report (#14622)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -31,6 +31,7 @@ import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
 import ReportEdition from './ReportEdition';
 import ReportDeletion from './ReportDeletion';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
+import AIInsights from '@components/common/ai/AIInsights';
 
 const subscription = graphql`
   subscription RootReportSubscription($id: ID!) {
@@ -188,6 +189,7 @@ const RootReport = () => {
                     </Tabs>
                     {!isKnowledgeOrContent && (
                       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+                        <AIInsights id={report.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
                         <StixCoreObjectSecurityCoverage id={report.id} coverage={report.securityCoverage} />
                       </div>
                     )}

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AIInsights.tsx
@@ -145,6 +145,7 @@ const AIInsights = ({
   const [containersBusId] = useState(uuid());
   const [loading, setLoading] = useState(false);
   const isAdmin = useGranted([SETTINGS_SETPARAMETERS]);
+  const buttonLabel = t_i18n('AI Insights');
 
   const { fullyActive, enabled } = useAI();
   const handleClose = () => {
@@ -180,7 +181,7 @@ const AIInsights = ({
   if (!isEnterpriseEdition && enabled) {
     return (
       <>
-        <Tooltip title={t_i18n('AI Insights')}>
+        <Tooltip title={buttonLabel}>
           {onlyIcon ? (
             <IconButton
               size="small"
@@ -197,7 +198,7 @@ const AIInsights = ({
               className={floating ? classes.chipFloating : classes.chip}
               startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" color="ai" />}
             >
-              {t_i18n('AI Insights')}
+              {buttonLabel}
             </Button>
           )}
         </Tooltip>
@@ -222,7 +223,7 @@ const AIInsights = ({
   if (isEnterpriseEdition && !fullyActive) {
     return (
       <>
-        <Tooltip title={t_i18n('AI Insights')}>
+        <Tooltip title={buttonLabel}>
           {onlyIcon ? (
             <IconButton
               size="small"
@@ -237,9 +238,10 @@ const AIInsights = ({
               size="small"
               onClick={() => setDisplayAIDialog(true)}
               className={floating ? classes.chipFloating : classes.chip}
+              aria-label={buttonLabel}
               startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" color="ai" />}
             >
-              {t_i18n('AI Insights')}
+              {buttonLabel}
             </Button>
           )}
         </Tooltip>
@@ -265,7 +267,7 @@ const AIInsights = ({
   }
   return (
     <>
-      <Tooltip title={t_i18n('AI Insights')}>
+      <Tooltip title={buttonLabel}>
         {onlyIcon ? (
           <IconButton
             size="small"
@@ -282,7 +284,7 @@ const AIInsights = ({
             className={floating ? classes.chipFloating : classes.chip}
             startIcon={<FiligranIcon icon={LogoXtmOneIcon} size="small" color="ai" />}
           >
-            {t_i18n('AI Insights')}
+            {buttonLabel}
           </Button>
         )}
       </Tooltip>
@@ -305,7 +307,7 @@ const AIInsights = ({
             <Close fontSize="small" color="primary" />
           </IconButton>
           <Typography variant="subtitle2" style={{ textWrap: 'nowrap' }}>
-            {t_i18n('AI Insights')}
+            {buttonLabel}
           </Typography>
           <Button
             variant="outlined"

--- a/opencti-platform/opencti-front/tests_e2e/model/reportDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/reportDetails.pageModel.ts
@@ -22,6 +22,10 @@ export default class ReportDetailsPage {
     return this.page.getByLabel('Update', { exact: true });
   }
 
+  getAiInsightsButton() {
+    return this.page.getByLabel('AI Insights', { exact: true });
+  }
+
   getContentFile(fileName: string) {
     return this.page.getByLabel(fileName);
   }

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -129,6 +129,9 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation', '@ce'] }, asyn
   // region Control data on report details page
   // ------------------------------------------
 
+  const aiInsightsButton = reportDetailsPage.getAiInsightsButton();
+  await expect(aiInsightsButton).toBeVisible();
+
   let description = reportDetailsPage.getTextForHeading('Description', 'Test e2e Description');
   await expect(description).toBeVisible();
 


### PR DESCRIPTION
### Proposed changes
- Reintroduce AI Insights button in Report
- Add e2e

### Related issues
#14622


<img width="1857" height="511" alt="image" src="https://github.com/user-attachments/assets/2212608f-7c7e-48d2-8cab-bcb3a6ce11db" />
