### PR TITLE
[frontend] Fix promoted checkbox not showing in container observables screen (#14598)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -119,6 +119,7 @@ type DataTableInternalToolbarProps = Pick<DataTableProps,
   | 'entityTypes'
   | 'trashOperationsEnabled'
   | 'deleteDisable'
+  | 'container'
 > & {
   taskScope?: string;
   globalSearch?: string;
@@ -137,6 +138,7 @@ const DataTableInternalToolbar = ({
   displayEditButtons,
   trashOperationsEnabled,
   deleteDisable,
+  container,
 }: DataTableInternalToolbarProps) => {
   const theme = useTheme<Theme>();
 
@@ -178,6 +180,7 @@ const DataTableInternalToolbar = ({
         displayEditButtons={displayEditButtons}
         trashOperationsEnabled={trashOperationsEnabled}
         deleteDisable={deleteDisable}
+        container={container}
       />
     </div>
   );
@@ -208,7 +211,8 @@ type OCTIDataTableProps = Pick<DataTableProps,
   | 'selectOnLineClick'
   | 'createButton'
   | 'entityTypes'
-  | 'actionsColumnWidth'> & {
+  | 'actionsColumnWidth'
+  | 'container'> & {
     lineFragment: GraphQLTaggedNode;
     preloadedPaginationProps: UsePreloadedPaginationFragment<OperationType>;
     exportContext?: { entity_type: string; entity_id?: string };
@@ -242,6 +246,7 @@ const DataTable = (props: OCTIDataTableProps) => {
     markAsReadEnabled,
     trashOperationsEnabled,
     deleteDisable,
+    container,
   } = props;
 
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
@@ -289,6 +294,7 @@ const DataTable = (props: OCTIDataTableProps) => {
         )}
         dataTableToolBarComponent={(
           <DataTableInternalToolbar
+            container={container}
             entityTypes={entityTypes}
             handleCopy={handleCopy}
             taskScope={taskScope}

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -98,6 +98,7 @@ export interface DataTableProps {
   redirectionModeEnabled?: boolean;
   additionalFilterKeys?: string[];
   entityTypes?: string[];
+  container?: any;
   settingsMessagesBannerHeight?: number;
   storageHelpers?: UseLocalStorageHelpers;
   redirectionMode?: string | undefined;

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
@@ -337,6 +337,7 @@ const ContainerStixCyberObservablesComponent: FunctionComponent<
             exportContext={{ entity_id: container.id, entity_type: 'Stix-Cyber-Observable' }}
             availableEntityTypes={['Stix-Cyber-Observable']}
             searchContextFinal={{ entityTypes: ['Stix-Cyber-Observable'] }}
+            container={container}
             createButton={(
               <Security needs={[KNOWLEDGE_KNUPDATE]}>
                 <ContainerAddStixCoreObjectsInLine


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add `container` in `dataTable` props as it was undefined and the promoted checkbox is contionned on `container.id`


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/14598

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
