### PR TITLE
[frontend] Fix markdown not correctly display (#14640)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/drawer/HistoryDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/HistoryDrawer.tsx
@@ -7,6 +7,7 @@ import ChangesTable, { Change } from '../../../../components/common/table/Change
 import Loader from '../../../../components/Loader';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { HistoryDrawerQuery } from './__generated__/HistoryDrawerQuery.graphql';
+import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 
 interface HistoryDrawerProps {
   open: boolean;
@@ -58,7 +59,11 @@ const HistoryDrawerContent: FunctionComponent<HistoryDrawerContentProps> = ({ lo
       <Alert
         content={(
           <>
-            <strong>{data?.log?.user?.name}</strong> {data?.log?.context_data?.message ?? ''}
+            <MarkdownDisplay
+              content={data?.log?.context_data?.message ?? ''}
+              remarkGfmPlugin={true}
+              commonmark={true}
+            />
           </>
         )}
       />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectHistoryLine.jsx
@@ -155,7 +155,11 @@ const StixCoreObjectHistoryLine = ({ node, isRelation }) => {
           </div>
           <Tooltip sx={{ maxWidth: '80%', lineHeight: 2, padding: 10 }} title={<><b>{data.user?.name}</b> {data.context_data.message}</>}>
             <div style={{ height: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-              <b>{data.user?.name}</b> {data.context_data.message}
+              <MarkdownDisplay
+                content={`\`${data.user?.name}\` ${data.context_data.message}`}
+                remarkGfmPlugin={true}
+                commonmark={true}
+              />
             </div>
           </Tooltip>
           {hasExternalRefs && (

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditDrawer.tsx
@@ -11,6 +11,7 @@ import { useFormatter } from '../../../../../components/i18n';
 import { useGenerateAuditMessage } from '../../../../../utils/history';
 import useAuth from '../../../../../utils/hooks/useAuth';
 import { AuditDrawerQuery } from './__generated__/AuditDrawerQuery.graphql';
+import MarkdownDisplay from '../../../../../components/MarkdownDisplay';
 
 interface AuditDrawerProps {
   open: boolean;
@@ -77,7 +78,13 @@ const AuditDrawerContent: FunctionComponent<{ logId: string }> = ({ logId }) => 
       <Alert
         content={(
           <>
-            <strong>{data?.audit?.user?.name}</strong> {message}
+            <div>
+              <MarkdownDisplay
+                content={`\`${data?.audit?.user?.name}\` ${message}`}
+                remarkGfmPlugin={true}
+                commonmark={true}
+              />
+            </div>
           </>
         )}
       />

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/AuditLine.tsx
@@ -16,6 +16,7 @@ import { useGenerateAuditMessage } from '../../../../../utils/history';
 import { HandleAddFilter } from '../../../../../utils/hooks/useLocalStorage';
 import AuditDrawer from './AuditDrawer';
 import { EMPTY_VALUE } from '../../../../../utils/String';
+import MarkdownDisplay from '../../../../../components/MarkdownDisplay';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -135,7 +136,11 @@ export const AuditLine: FunctionComponent<AuditLineProps> = ({
                 style={{ width: dataColumns.message.width }}
               >
                 <span style={{ color }}>
-                  <b>{data.user?.name}</b> {message}
+                  <MarkdownDisplay
+                    content={`\`${data.user?.name}\` ${message}`}
+                    remarkGfmPlugin={true}
+                    commonmark={true}
+                  />
                 </span>
               </div>
             </div>

--- a/opencti-platform/opencti-front/tests_e2e/incidentResponse/incidentResponse.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/incidentResponse/incidentResponse.spec.ts
@@ -172,10 +172,7 @@ test('Incident Response Creation', { tag: ['@ce'] }, async ({ page }) => {
   const updateDate = incidentResponseDetailsPage.getTextForHeading('Modification date', now);
   await expect(updateDate).toBeVisible();
 
-  const historyDescription = cardPage.getTextInCard(
-    'Most recent history',
-    new RegExp(`creates a Case-Incident\\s+${incidentResponseName}`),
-  );
+  const historyDescription = cardPage.getTextInCard('Most recent history', `creates a Case-Incident ${incidentResponseName}`);
   await expect(historyDescription).toBeVisible();
   const historyDate = cardPage.getTextInCard('Most recent history', format(new Date(), 'MMM d, yyyy'));
   await expect(historyDate).toBeVisible();

--- a/opencti-platform/opencti-front/tests_e2e/incidentResponse/incidentResponse.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/incidentResponse/incidentResponse.spec.ts
@@ -172,7 +172,10 @@ test('Incident Response Creation', { tag: ['@ce'] }, async ({ page }) => {
   const updateDate = incidentResponseDetailsPage.getTextForHeading('Modification date', now);
   await expect(updateDate).toBeVisible();
 
-  const historyDescription = cardPage.getTextInCard('Most recent history', `creates a Case-Incident \`${incidentResponseName}\``);
+  const historyDescription = cardPage.getTextInCard(
+    'Most recent history',
+    new RegExp(`creates a Case-Incident\\s+${incidentResponseName}`),
+  );
   await expect(historyDescription).toBeVisible();
   const historyDate = cardPage.getTextInCard('Most recent history', format(new Date(), 'MMM d, yyyy'));
   await expect(historyDate).toBeVisible();

--- a/opencti-platform/opencti-front/tests_e2e/model/card.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/card.pageModel.ts
@@ -7,7 +7,7 @@ export default class CardPage {
     return this.page.getByText(title).locator('../..');
   }
 
-  getTextInCard(title: string, text: string) {
+  getTextInCard(title: string, text: string | RegExp) {
     const card = this.getCard(title);
     return card.getByText(text);
   }

--- a/opencti-platform/opencti-front/tests_e2e/model/card.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/card.pageModel.ts
@@ -7,7 +7,7 @@ export default class CardPage {
     return this.page.getByText(title).locator('../..');
   }
 
-  getTextInCard(title: string, text: string | RegExp) {
+  getTextInCard(title: string, text: string) {
     const card = this.getCard(title);
     return card.getByText(text);
   }

--- a/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/report/report.spec.ts
@@ -181,7 +181,7 @@ test('Report CRUD', { tag: ['@report', '@knowledge', '@mutation', '@ce'] }, asyn
   const updateDate = reportDetailsPage.getTextForHeading('Modification date', now);
   await expect(updateDate).toBeVisible();
 
-  const historyDescription = reportDetailsPage.getTextForCard('Most recent history', `creates a Report \`${reportName}\``);
+  const historyDescription = reportDetailsPage.getTextForCard('Most recent history', `creates a Report ${reportName}`);
   await expect(historyDescription).toBeVisible();
   const historyDate = reportDetailsPage.getTextForCard('Most recent history', format(new Date(), 'MMM d, yyyy'));
   await expect(historyDate).toBeVisible();


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use `Markdown` component as it was before to format History and Activity messages instead of having backticks (back send message formated with backticks because we want to have the markdown formatting)
* introduced by https://github.com/OpenCTI-Platform/opencti/pull/13775

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/14640


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
