### PR TITLE
[client] exclude src_ref and dst_ref handling in import_observable (#14597)

### DIFF
--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -1415,6 +1415,8 @@ class OpenCTIStix2:
                     "object_marking_refs",
                     "x_opencti_created_by_ref",
                     "x_opencti_granted_refs",
+                    "src_ref",
+                    "dst_ref",
                 ]:
                     if key.endswith("_ref"):
                         relationship_type = key.replace("_ref", "")


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  exclude src_ref and dst_ref handling in import_observable. They are already handled directly in observable creation in opencti_stix_cyber_observable's create
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14597 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
