### PR TITLE
[docs] Update with minimal OpenCTI version for the composer catalog (#14724)

### DIFF
--- a/docs/docs/deployment/integration-manager.md
+++ b/docs/docs/deployment/integration-manager.md
@@ -23,6 +23,8 @@ The OpenCTI Integration Manager is a deployment tool that simplifies the managem
 
 ### Prerequisites
 
+- The OpenCTI Integration Manager is available starting from OpenCTI version 6.8.17.
+
 - An **Enterprise Edition license** is required to use this feature. Without it, the catalog is available in read-only mode. You can enter the license key from:
     - the **Deploy** action on a connector card,
     - the connector’s detail view,


### PR DESCRIPTION
Update the documentation with this information: The Connector Catalog is available starting from OpenCTI version 6.8.17.

- Closes #14724