### PR TITLE
[backend] Configure proxy on AWS SDK (#14703)

### DIFF
--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -57,6 +57,7 @@ Here are the configuration keys, for both containers (environment variables) and
 | http_proxy                                          | HTTP_PROXY                                             |                                                                                                                                    | Proxy URL for HTTP connection (example: http://proxy:80080)                                                         |
 | https_proxy                                         | HTTPS_PROXY                                            |                                                                                                                                    | Proxy URL for HTTPS connection (example: http://proxy:80080)                                                        |
 | no_proxy                                            | NO_PROXY                                               |                                                                                                                                    | Comma separated list of hostnames for proxy exception (example: localhost,127.0.0.0/8,internal.opencti.io)          |
+| aws:proxy_enabled                                   | AWS__PROXY_ENABLED                                     | false                                                                                                                              | When enabled, routes all AWS SDK traffic (STS and S3) through the HTTP/HTTPS proxy above.                           |
 | app:https_cert:cookie_secure                        | APP__HTTPS_CERT__COOKIE_SECURE                         | false                                                                                                                              | Set the flag "secure" for session cookies                                                                           |
 | app:https_cert:ca                                   | APP__HTTPS_CERT__CA                                    | Empty list []                                                                                                                      | Certificate authority paths or content, only if the client uses a self-signed certificate                           |
 | app:https_cert:key                                  | APP__HTTPS_CERT__KEY                                   |                                                                                                                                    | Certificate key path or content                                                                                     |
@@ -169,6 +170,11 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 | elasticsearch:ssl:ca                  | ELASTICSEARCH__SSL__CA                  |                       | Custom certificate path or content                                                                                                                                                                                                                                     |
 | elasticsearch:search_wildcard_prefix  | ELASTICSEARCH__SEARCH_WILDCARD_PREFIX   | `false`               | Search includes words with automatic fuzzy comparison                                                                                                                                                                                                                  |
 | elasticsearch:search_fuzzy            | ELASTICSEARCH__SEARCH_FUZZY             | `false`               | Search will include words not starting with the search keyword                                                                                                                                                                                                         |
+| opensearch:region                     | OPENSEARCH__REGION                      |                       | AWS region when using AWS OpenSearch with IAM (e.g. `us-east-1`). When set, requests are signed with SigV4 using the default credential chain (env, instance role, etc.). Omit for self‑hosted Elasticsearch/OpenSearch. |
+
+!!! note "Using a proxy for AWS OpenSearch STS credentials"
+
+    When using AWS credentials (e.g. IAM roles), the backend calls AWS STS to obtain credentials; that STS traffic does not use the system proxy by default. Set `aws:proxy_enabled` to `true` and set `http_proxy` and/or `https_proxy` in the **Network and security** section above to route STS calls through a proxy. The proxy does not apply to traffic to the OpenSearch cluster itself.
 
 #### Redis
 
@@ -225,6 +231,10 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 | minio:bucket_name   | MINIO__BUCKET_NAME   | opencti-bucket | S3 bucket name. Useful to change if you use AWS.                                                                                                                                                                            |
 | minio:bucket_region | MINIO__BUCKET_REGION | us-east-1      | Region of the S3 bucket if you are using AWS. This parameter value can be omitted if you use Minio as an S3 Bucket Service.                                                                                                 |
 | minio:use_aws_role  | MINIO__USE_AWS_ROLE  | `false`        | Indicates whether to use AWS role auto credentials. When this parameter is configured, the `minio:access_key` and `minio:secret_key` parameters are not necessary.                                                          |
+
+!!! note "Using a proxy for AWS S3"
+
+    To route both STS (credential) calls and S3 traffic from the backend through an HTTP or HTTPS proxy, set `http_proxy` and/or `https_proxy` in the **Network and security** section above, then set `aws:proxy_enabled` to `true`.
 
 #### SMTP Service
 

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -411,6 +411,9 @@
     "forced_sender_email": "",
     "email_max_cc_size": 500
   },
+  "aws": {
+    "proxy_enabled": false
+  },
   "providers": {
     "local": {
       "strategy": "LocalStrategy"

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -95,6 +95,7 @@
     "archiver": "7.0.1",
     "archiver-zip-encrypted": "2.0.0",
     "async-lock": "1.4.1",
+    "aws-sdk-v3-proxy": "2.2.0",
     "axios": "1.13.5",
     "axios-cookiejar-support": "6.0.5",
     "bcryptjs": "3.0.3",

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -1,5 +1,4 @@
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { getDefaultRoleAssumerWithWebIdentity } from '@aws-sdk/client-sts';
 import { Client as ElkClient } from '@elastic/elasticsearch';
 import { Client as OpenClient } from '@opensearch-project/opensearch';
 import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
@@ -197,6 +196,7 @@ import { IDS_ATTRIBUTES } from '../domain/attribute-utils';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import type { FiltersWithNested } from './middleware-loader';
 import { pushAll, unshiftAll } from '../utils/arrayUtil';
+import { getRoleAssumerWithWebIdentity } from '../utils/awsSdk';
 
 const ELK_ENGINE = 'elk';
 const OPENSEARCH_ENGINE = 'opensearch';
@@ -391,7 +391,7 @@ export const searchEngineInit = async (): Promise<boolean> => {
       service: conf.get('opensearch:service') || 'es',
       getCredentials: () => {
         const credentialsProvider = defaultProvider({
-          roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity({ region }),
+          roleAssumerWithWebIdentity: getRoleAssumerWithWebIdentity({ region }),
         });
         return credentialsProvider();
       },

--- a/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
@@ -8,7 +8,6 @@ import {
   S3Client,
   type S3ClientConfig,
 } from '@aws-sdk/client-s3';
-import { getDefaultRoleAssumerWithWebIdentity } from '@aws-sdk/client-sts';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { Upload } from '@aws-sdk/lib-storage';
 import type { Readable } from 'stream';
@@ -16,6 +15,7 @@ import { enrichWithRemoteCredentials } from '../config/credentials';
 import conf, { booleanConf, logApp, logS3Debug } from '../config/conf';
 import { UnsupportedError } from '../config/errors';
 import type { AuthUser } from '../types/user';
+import { getRoleAssumerWithWebIdentity, setupAwsClient } from '../utils/awsSdk';
 
 // Minio configuration
 const clientEndpoint = conf.get('minio:endpoint');
@@ -52,7 +52,7 @@ const buildCredentialProvider = async () => {
   if (useAwsRole) {
     return () => {
       return defaultProvider({
-        roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity({
+        roleAssumerWithWebIdentity: getRoleAssumerWithWebIdentity({
           // You must explicitly pass a region if you are not using us-east-1
           region: bucketRegion,
         }),
@@ -91,7 +91,7 @@ export const initializeFileStorageClient = async () => {
   if (useAwsLogs) {
     s3Config.logger = logS3Debug;
   }
-  s3Client = new s3.S3Client(s3Config);
+  s3Client = setupAwsClient(new s3.S3Client(s3Config));
 };
 
 export const initializeBucket = async () => {

--- a/opencti-platform/opencti-graphql/src/utils/awsSdk.ts
+++ b/opencti-platform/opencti-graphql/src/utils/awsSdk.ts
@@ -1,0 +1,37 @@
+import { addProxyToClient } from 'aws-sdk-v3-proxy';
+import type { HttpHandlerOptions, RequestHandler } from '@aws-sdk/types';
+import { getDefaultRoleAssumerWithWebIdentity } from '@aws-sdk/client-sts';
+import conf, { booleanConf } from '../config/conf';
+
+type ConfigWithRequestHandler = {
+  requestHandler: RequestHandler<any, any, HttpHandlerOptions>;
+};
+
+type ClientWithConfig<T> = T extends { config: ConfigWithRequestHandler } ? T : never;
+
+const proxyOptions = booleanConf('aws:proxy_enabled', false)
+  ? {
+      httpProxy: conf.get('http_proxy'),
+      httpsProxy: conf.get('https_proxy'),
+    }
+  : undefined;
+
+export const setupAwsClient = <T>(client: ClientWithConfig<T>) => {
+  return proxyOptions ? addProxyToClient(client, proxyOptions) : client;
+};
+
+const addProxyToConfiguration = <T>(config: T) => {
+  if (proxyOptions) {
+    // aws-sdk-v3-proxy only works on client and doesn't permit to enrich directly a configuration.
+    // We create a fake client to be able to let it configured by addProxyToClient and then return the updated configuration.
+
+    // The cast is safe since aws-sdk-v3-proxy doesn't read 'requestHandler' in the configuration and only need to be able to set it
+    const fakeClient = { config: (config ?? {}) as ConfigWithRequestHandler };
+    return addProxyToClient(fakeClient, proxyOptions).config;
+  }
+  return config;
+};
+
+export const getRoleAssumerWithWebIdentity = (stsOptions?: Parameters<typeof getDefaultRoleAssumerWithWebIdentity>[0]) => {
+  return getDefaultRoleAssumerWithWebIdentity(addProxyToConfiguration(stsOptions));
+};

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -3785,6 +3785,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/abort-controller@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/abort-controller@npm:2.2.0"
+  dependencies:
+    "@smithy/types": "npm:^2.12.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/87bf79591d2b2b289dadf2ed04f082232b44e39bd92c188bae5fe3d11cdc4e4d54f0962a7865c159f4c7f914b8d093fe2744f5ab9de07a0b4cc13f9da4a6cf48
+  languageName: node
+  linkType: hard
+
 "@smithy/abort-controller@npm:^4.2.10, @smithy/abort-controller@npm:^4.2.8":
   version: 4.2.10
   resolution: "@smithy/abort-controller@npm:4.2.10"
@@ -4078,6 +4088,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/node-http-handler@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "@smithy/node-http-handler@npm:2.5.0"
+  dependencies:
+    "@smithy/abort-controller": "npm:^2.2.0"
+    "@smithy/protocol-http": "npm:^3.3.0"
+    "@smithy/querystring-builder": "npm:^2.2.0"
+    "@smithy/types": "npm:^2.12.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5f9688549ac9b374b2837db24b955e265eef77f76354fc676a78741613f6c60feee49908c4883e25e2e20fb3083d45723bb690070d0a6f7cc0682e74287fbad7
+  languageName: node
+  linkType: hard
+
 "@smithy/node-http-handler@npm:^4.4.10, @smithy/node-http-handler@npm:^4.4.12":
   version: 4.4.12
   resolution: "@smithy/node-http-handler@npm:4.4.12"
@@ -4101,6 +4124,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/protocol-http@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@smithy/protocol-http@npm:3.3.0"
+  dependencies:
+    "@smithy/types": "npm:^2.12.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a32895fc7318d964e53069ae185f03b26fe9c76560451578e21b09c09e7b443a16a2dda348c1a8cde18bddf4b5ba1f72a715c57239ceb93a7539dd1f9f44a7b9
+  languageName: node
+  linkType: hard
+
 "@smithy/protocol-http@npm:^5.3.10, @smithy/protocol-http@npm:^5.3.8":
   version: 5.3.10
   resolution: "@smithy/protocol-http@npm:5.3.10"
@@ -4108,6 +4141,17 @@ __metadata:
     "@smithy/types": "npm:^4.13.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/9c801aa785a17a1904e88570ece5ee6e035b24ab9fb2231886f7ce444942954268849692c8b46909ad021bb75cfc23266f1baeecd530db6f9acef6dedd778f70
+  languageName: node
+  linkType: hard
+
+"@smithy/querystring-builder@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/querystring-builder@npm:2.2.0"
+  dependencies:
+    "@smithy/types": "npm:^2.12.0"
+    "@smithy/util-uri-escape": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/45f33a053314c68541fa8571fec7398b4d67d98d3f846fda905f75489e08b0581405eb0bc0a8fe55177996e820df301ee275ab9529e9cdc3ea8e33cbb1a2abf4
   languageName: node
   linkType: hard
 
@@ -4179,6 +4223,15 @@ __metadata:
     "@smithy/util-stream": "npm:^4.5.15"
     tslib: "npm:^2.6.2"
   checksum: 10c0/f1310d57fff750d25395bfe2338e48501429069fa9cb495e7882a06f27211c7538edfbc930b8a1ab24c0bca5eb0418ef00c0d7403cb6e4c9efc84308686c2f87
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^2.12.0":
+  version: 2.12.0
+  resolution: "@smithy/types@npm:2.12.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3530ba5b4f4e52a4028679f73e133af928cf6ea22a16d29669b8c67ea540ed46ab15dc6d391598fbdfd476884cdc57881c480168e2dbe7c5bb007f5afad01531
   languageName: node
   linkType: hard
 
@@ -4341,6 +4394,15 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.2.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e40d55065a022c6556a3f5f8d11d029c9c7ffd24e7dbd36c74c7f65ad184289b540d80d91b3b7930eedf1e701abdd9a7b47d64f685a643040774c34a2bbb0ba3
+  languageName: node
+  linkType: hard
+
+"@smithy/util-uri-escape@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-uri-escape@npm:2.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a2b33c698dd894d1b9a3ff6a660ddc7ffb3adf1f2a9c66fbf9a8ee5960f4fa74f832b87dfedb7ca4992fd9f1853af8547f545b4185590dff6fe2509c7e97d7dc
   languageName: node
   linkType: hard
 
@@ -5906,6 +5968,17 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
+  languageName: node
+  linkType: hard
+
+"aws-sdk-v3-proxy@npm:2.2.0":
+  version: 2.2.0
+  resolution: "aws-sdk-v3-proxy@npm:2.2.0"
+  dependencies:
+    "@smithy/node-http-handler": "npm:^2.5.0"
+    "@smithy/protocol-http": "npm:^3.3.0"
+    hpagent: "npm:^1.2.0"
+  checksum: 10c0/fd3d2350f964f2fbcb3286508335ab80016519e8d4ff6ecb62ed1ce9b8779d9a905be32cf0851c02514393704ee267204fa5c01f22799b4a393c8f3fd08533a4
   languageName: node
   linkType: hard
 
@@ -10785,6 +10858,7 @@ __metadata:
     archiver: "npm:7.0.1"
     archiver-zip-encrypted: "npm:2.0.0"
     async-lock: "npm:1.4.1"
+    aws-sdk-v3-proxy: "npm:2.2.0"
     axios: "npm:1.13.5"
     axios-cookiejar-support: "npm:6.0.5"
     bcryptjs: "npm:3.0.3"


### PR DESCRIPTION
### Proposed changes

* use `aws-sdk-v3-proxy` to configure AWS clients with proxies
* activate only if `aws:proxy_enabled` / `AWS__PROXY_ENABLED` is set to true

### Related issues
* Fix #14703 

### Checklist
- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
