### PR TITLE
[frontend] Hide Register/Unregister XTM Hub buttons in demo mode (#14758)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
@@ -53,6 +53,7 @@ const XtmHubTab: React.FC<XtmHubTabProps> = ({ registrationStatus }) => {
   const { settings, about } = useContext(UserContext);
   const eeSettings = settings?.platform_enterprise_edition;
   const isEnterpriseEdition = eeSettings?.license_validated;
+  const isDemo = settings?.platform_demo ?? false;
   const registrationHubUrl = settings?.platform_xtmhub_url ?? 'https://hub.filigran.io/app';
   const [processStep, setProcessStep] = useState<ProcessSteps>(
     ProcessSteps.INSTRUCTIONS,
@@ -261,6 +262,10 @@ const XtmHubTab: React.FC<XtmHubTabProps> = ({ registrationStatus }) => {
     }
     return t_i18n('Register in XTM Hub');
   };
+
+  if (isDemo) {
+    return null;
+  }
 
   if (isRegistered) {
     if (isEnterpriseEdition && eeSettings?.license_type === LICENSE_OPTION_TRIAL) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Hide "Register in XTM Hub" and "Unregister from XTM Hub" buttons when the platform is running in demo mode
* Early return `null` from `XtmHubTab` component when `platform_demo` is `true`

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #14758
* https://github.com/FiligranHQ/xtm-hub/issues/1784

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the overall quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Follows the same pattern already used for trial mode (where the "Unregister" button is hidden when `license_type === LICENSE_OPTION_TRIAL`). The check is placed right after all hooks and before any JSX rendering to respect React's rules of hooks.
