### PR TITLE
[frontend] fix VocabularyCategories usage of DataTableWithoutFragment by adding pageSize info (#14769)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -140,7 +140,7 @@ export interface DataTableProps {
   actions?: (row: any) => ReactNode;
   icon?: (row: any) => ReactNode;
   createButton?: ReactNode;
-  pageSize?: number;
+  pageSize?: string;
   disableNavigation?: boolean;
   disableLineSelection?: boolean;
   disableToolBar?: boolean;

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -140,7 +140,7 @@ export interface DataTableProps {
   actions?: (row: any) => ReactNode;
   icon?: (row: any) => ReactNode;
   createButton?: ReactNode;
-  pageSize?: string;
+  pageSize?: number;
   disableNavigation?: boolean;
   disableLineSelection?: boolean;
   disableToolBar?: boolean;

--- a/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
@@ -90,7 +90,7 @@ const VocabularyCategories = () => {
           dataColumns={dataColumns}
           getComputeLink={({ category }: { category: VocabularyDefinition }) => (category.key)}
           globalCount={categories.length}
-          pageSize={categories.length}
+          pageSize={categories.length.toString()}
           icon={() => (<ShortTextOutlined color="primary" />)}
           onSort={onSort}
         />

--- a/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/VocabularyCategories.tsx
@@ -90,6 +90,7 @@ const VocabularyCategories = () => {
           dataColumns={dataColumns}
           getComputeLink={({ category }: { category: VocabularyDefinition }) => (category.key)}
           globalCount={categories.length}
+          pageSize={categories.length}
           icon={() => (<ShortTextOutlined color="primary" />)}
           onSort={onSort}
         />


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  DataTableWithoutFragment was being used without specifying pageSize, making it only display default page size (i.e 25 rows) instead of the full page
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14769 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
