### PR TITLE
[backend] Allow to quote path component in double quotes (#14781)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-migration-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-migration-converter.ts
@@ -365,6 +365,18 @@ const collectExtraConf = (
   return extraConf;
 };
 
+/**
+ * Quotes a path segment for dot-separated expressions when it contains '.' or '"',
+ * so that parseDotPath (mappings-utils) treats it as a single component (e.g. SAML HTTP URIs).
+ * Uses "" inside quoted strings to represent a literal double quote.
+ */
+const quotePathSegment = (segment: string): string => {
+  if (segment.includes('.') || segment.includes('"')) {
+    return `"${segment.replace(/"/g, '""')}"`;
+  }
+  return segment;
+};
+
 // ---------------------------------------------------------------------------
 // OIDC conversion
 // ---------------------------------------------------------------------------
@@ -428,10 +440,10 @@ export const convertOidcEnvConfig = (envKey: string, entry: EnvProviderEntry): C
   }
 
   const userInfoMapping: UserInfoMappingInput = {
-    email_expr: `${userInfoPrefix}.${ext.get<string>('email_attribute', 'email')}`,
-    name_expr: `${userInfoPrefix}.${ext.get<string>('name_attribute', 'name')}`,
-    firstname_expr: `${userInfoPrefix}.${ext.get<string>('firstname_attribute', 'given_name')}`,
-    lastname_expr: `${userInfoPrefix}.${ext.get<string>('lastname_attribute', 'family_name')}`,
+    email_expr: `${userInfoPrefix}.${quotePathSegment(ext.get<string>('email_attribute', 'email'))}`,
+    name_expr: `${userInfoPrefix}.${quotePathSegment(ext.get<string>('name_attribute', 'name'))}`,
+    firstname_expr: `${userInfoPrefix}.${quotePathSegment(ext.get<string>('firstname_attribute', 'given_name'))}`,
+    lastname_expr: `${userInfoPrefix}.${quotePathSegment(ext.get<string>('lastname_attribute', 'family_name'))}`,
   };
 
   // Groups mapping
@@ -531,10 +543,10 @@ export const convertSamlEnvConfig = (envKey: string, entry: EnvProviderEntry): C
 
   // User info mapping — SAML uses attribute names directly from SAML assertions
   const userInfoMapping: UserInfoMappingInput = {
-    email_expr: ext.get<string>('mail_attribute', 'nameID'),
-    name_expr: ext.get<string>('account_attribute', 'nameID'),
-    firstname_expr: ext.get<string | null>('firstname_attribute', null),
-    lastname_expr: ext.get<string | null>('lastname_attribute', null),
+    email_expr: quotePathSegment(ext.get<string>('mail_attribute', 'nameID')),
+    name_expr: quotePathSegment(ext.get<string>('account_attribute', 'nameID')),
+    firstname_expr: quotePathSegment(ext.get<string>('firstname_attribute', '')) || null,
+    lastname_expr: quotePathSegment(ext.get<string>('lastname_attribute', '')) || null,
   };
 
   // Groups mapping: SAML uses group_attributes (attribute names in SAML assertion)
@@ -542,7 +554,7 @@ export const convertSamlEnvConfig = (envKey: string, entry: EnvProviderEntry): C
   const autoCreateGroup = ext.get<boolean>('auto_create_group', false);
   const preventDefaultGroups = ext.get<boolean>('prevent_default_groups', false);
   const gm = resolveGroupsManagement(ext, 'saml', warnings);
-  const groupsExpr = gm?.group_attributes ?? ['groups'];
+  const groupsExpr = (gm?.group_attributes ?? ['groups']).map(quotePathSegment);
   const groupsMapping: GroupsMappingInput = {
     auto_create_groups: autoCreateGroup,
     prevent_default_groups: preventDefaultGroups,
@@ -563,7 +575,7 @@ export const convertSamlEnvConfig = (envKey: string, entry: EnvProviderEntry): C
   const organizationsMapping: OrganizationsMappingInput = {
     auto_create_organizations: false,
     default_organizations: organizationsDefault,
-    organizations_expr: [rawOrgPath.join('.')],
+    organizations_expr: [rawOrgPath.map(quotePathSegment).join('.')],
     organizations_mapping: convertMappingEntries(om?.organizations_mapping),
   };
 
@@ -635,10 +647,10 @@ export const convertLdapEnvConfig = (envKey: string, entry: EnvProviderEntry): C
 
   // User info mapping — LDAP uses direct attribute names on the LDAP user object
   const userInfoMapping: UserInfoMappingInput = {
-    email_expr: ext.get<string>('mail_attribute', 'mail'),
-    name_expr: ext.get<string>('account_attribute', 'givenName'),
-    firstname_expr: ext.get<string | null>('firstname_attribute', null),
-    lastname_expr: ext.get<string | null>('lastname_attribute', null),
+    email_expr: quotePathSegment(ext.get<string>('mail_attribute', 'mail')),
+    name_expr: quotePathSegment(ext.get<string>('account_attribute', 'givenName')),
+    firstname_expr: quotePathSegment(ext.get<string>('firstname_attribute', '')) || null,
+    lastname_expr: quotePathSegment(ext.get<string>('lastname_attribute', '')) || null,
   };
 
   // Groups mapping: LDAP uses group_attribute (attribute name in _groups entries, default 'cn')
@@ -646,7 +658,7 @@ export const convertLdapEnvConfig = (envKey: string, entry: EnvProviderEntry): C
   const autoCreateGroup = ext.get<boolean>('auto_create_group', false);
   const preventDefaultGroups = ext.get<boolean>('prevent_default_groups', false);
   const gm = resolveGroupsManagement(ext, 'ldap', warnings);
-  const groupsExpr = [gm?.group_attribute ?? 'cn'];
+  const groupsExpr = [quotePathSegment(gm?.group_attribute ?? 'cn')];
   const groupsMapping: GroupsMappingInput = {
     auto_create_groups: autoCreateGroup,
     prevent_default_groups: preventDefaultGroups,
@@ -662,7 +674,7 @@ export const convertLdapEnvConfig = (envKey: string, entry: EnvProviderEntry): C
   const organizationsMapping: OrganizationsMappingInput = {
     auto_create_organizations: false,
     default_organizations: organizationsDefault,
-    organizations_expr: om?.organizations_path ?? ['organizations'],
+    organizations_expr: (om?.organizations_path ?? ['organizations']).map(quotePathSegment),
     organizations_mapping: convertMappingEntries(om?.organizations_mapping),
   };
 

--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-types.ts
@@ -7,7 +7,7 @@ export const ENTITY_TYPE_AUTHENTICATION_PROVIDER = 'AuthenticationProvider';
 // Mapping configuration
 //
 // All _expr fields use dot-separated notation (e.g. 'user_info.email', 'tokens.access_token.groups').
-// Resolution splits on '.' and traverses the path: resolvePath(root, expr.split('.'))
+// Path components that contain dots can be quoted with double quotes: "http://example.com/claims/email".
 //
 // OIDC:  context = { tokens: fn(name), user_info: fn() } — paths like 'user_info.email' or 'tokens.id_token.sub'
 // SAML:  context = profile.attributes ?? profile — paths like 'email' (flat) or 'org.list' (nested)

--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/mappings-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/mappings-utils.ts
@@ -36,7 +36,25 @@ export const resolvePath = (path: string[]) => async (obj: unknown): Promise<any
   return resolvePath(remaining)(resolvedValue);
 };
 
-export const resolveDotPath = (path: string) => resolvePath(path.split('.'));
+/**
+ * Parses a dot-separated path string into segments.
+ * Path components that contain dots (e.g. SAML HTTP claim URIs) can be quoted with double quotes.
+ * Inside quoted segments, use "" to represent a literal double quote.
+ * Example: user_info."http://example.com/claims/email" → ['user_info', 'http://example.com/claims/email']
+ */
+export const parseDotPath = (path: string): string[] => {
+  // Unquoted [^."]+ or quoted "((?:[^"]|"")*)", then . or end. "" inside quotes = literal ".
+  const re = /(?:([^."]+)|"((?:[^"]|"")*)")(?:\.|$)/g;
+  const segments: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(path)) !== null) {
+    const segment = m[1] !== undefined ? m[1] : m[2].replace(/""/g, '"');
+    segments.push(segment);
+  }
+  return segments;
+};
+
+export const resolveDotPath = (path: string) => resolvePath(parseDotPath(path));
 
 type ResolveExprFunction = (obj: unknown) => undefined | string | string[] | Promise<undefined | string | string[]>;
 type CreateResolveExprFunction = (expr: string) => ResolveExprFunction;

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/authenticationProvider/authenticationProvider-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/authenticationProvider/authenticationProvider-converter-test.ts
@@ -1396,9 +1396,9 @@ describe('Real-world configuration scenarios', () => {
     // extra_conf should be empty
     expect(result.configuration.extra_conf).toHaveLength(0);
 
-    // Groups
+    // Groups (URI claim is quoted so dot-separated path parser treats it as one segment)
     expect(result.configuration.groups_mapping.groups_expr).toStrictEqual([
-      'http://schemas.microsoft.com/ws/2008/06/identity/claims/groups',
+      '"http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"',
     ]);
 
     // Orgs

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/authenticationProvider/mappings-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/authenticationProvider/mappings-utils-test.ts
@@ -1,7 +1,55 @@
 import { describe, expect, it } from 'vitest';
-import { resolvePath } from '../../../../src/modules/authenticationProvider/mappings-utils';
+import { parseDotPath, resolvePath, resolveDotPath } from '../../../../src/modules/authenticationProvider/mappings-utils';
 
 describe('mappings-utils', () => {
+  describe('parseDotPath', () => {
+    it('should split simple dot-separated path', () => {
+      expect(parseDotPath('a.b.c')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should treat quoted segment as single component (SAML URI)', () => {
+      expect(parseDotPath('user_info."http://example.com/claims/email"')).toEqual(['user_info', 'http://example.com/claims/email']);
+    });
+
+    it('should support multiple quoted segments', () => {
+      expect(parseDotPath('"http://a".b."http://c"')).toEqual(['http://a', 'b', 'http://c']);
+    });
+
+    it('should allow escaped double quote inside quoted segment (double double quote)', () => {
+      expect(parseDotPath('"say ""hi"""')).toEqual(['say "hi"']);
+    });
+
+    it('should return single segment when no dots', () => {
+      expect(parseDotPath('mail')).toEqual(['mail']);
+    });
+
+    it('should handle empty path', () => {
+      expect(parseDotPath('')).toEqual([]);
+    });
+
+    it('should handle trailing dot (empty segment not pushed)', () => {
+      expect(parseDotPath('a.')).toEqual(['a']);
+    });
+  });
+
+  describe('resolveDotPath', () => {
+    it('should resolve path with quoted segment (SAML-style URI key)', async () => {
+      const obj = {
+        attributes: {
+          'http://example.com/claims/email': 'user@example.com',
+        },
+      };
+      const result = await resolveDotPath('attributes."http://example.com/claims/email"')(obj);
+      expect(result).toBe('user@example.com');
+    });
+
+    it('should resolve plain dot path as before (backward compatible)', async () => {
+      const obj = { user_info: { email: 'a@b.com' } };
+      const result = await resolveDotPath('user_info.email')(obj);
+      expect(result).toBe('a@b.com');
+    });
+  });
+
   describe('resolvePath', () => {
     it('should resolve simple property', async () => {
       const obj = { foo: 'bar' };


### PR DESCRIPTION
### Proposed changes

* Permit to quote (with ") path components to ignore . in it

### Related issues
* Fix #14781

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
