### PR TITLE
[frontend] Error on a widget should not prevent the widget edition (#14806)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
@@ -3,6 +3,7 @@ import { CSSProperties, FunctionComponent, ReactNode } from 'react';
 import Card, { CardProps } from '../common/card/Card';
 import Label from '../common/label/Label';
 import ChartExportPopover from '../../private/components/common/charts/ChartExportPopover';
+import { ErrorBoundary } from '@components/Error';
 
 interface WidgetContainerProps {
   children: ReactNode;
@@ -36,13 +37,18 @@ const WidgetContainer: FunctionComponent<WidgetContainerProps> = ({
                   {action}
                 </div>
               )}
-            >{children}
+            >
+              <ErrorBoundary>
+                {children}
+              </ErrorBoundary>
             </Card>
           )
         : (
             <>
               {title && <Label>{title}</Label>}
-              {children}
+              <ErrorBoundary>
+                {children}
+              </ErrorBoundary>
             </>
           )
       }


### PR DESCRIPTION
### Proposed changes
An error on a widget should not prevent the widget to be edited

<img width="458" height="526" alt="image" src="https://github.com/user-attachments/assets/3d0a8379-b548-4117-ae4a-9f4ea8f62a56" />


### Related issues
#14806