### PR TITLE
[frontend] Disabled workflows can not be activated on entities (#14800)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemStatusTemplate.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemStatusTemplate.tsx
@@ -28,7 +28,10 @@ const ItemStatusTemplate = ({ statuses, disabled, actionComponent }: ItemStatusT
 
   if (disabled) {
     return (
-      <Tag label={t_i18n('Disabled')} disabled />
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Tag label={t_i18n('Disabled')} disabled />
+        {actionComponent}
+      </Stack>
     );
   }
 


### PR DESCRIPTION
### Proposed changes

* Allow the creation of a status even when disabled

The problem that occurs here is that to be allowed to manipulate workflow we set the attribute " workflow_configuration " at true during the initialization of the entity settings.
BUT, we are looking at the attribute "workflowEnabled" (which is a boolean telling us if there is status created on this entity or not) to allow the add/edit of the workflow.

This was a case of egg and chicken here, as the workflowEnabled could never be at true if we are not capable of creating a status in the first place...

My solution here is to allow the edition even if there is no status to allow the user to use workflow if the attribute worklow_configuration is set at true.

An other solution is to maybe look at the workflow_configuration in the backend (isGlobalWorkflowEnabled function)to allow workflow, instead of looking at if status exists.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/14800