### PR TITLE
[backend] fix OpenIDConnect when token are not valid JWT (#14839)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -430,6 +430,13 @@ const createApp = async (app, schema) => {
     try {
       const { provider } = req.params;
       const strategy = passport._strategy(provider);
+      if (!strategy) {
+        setCookieError(res, `Unknown authentication provider '${provider}'`);
+        logApp.info('Unknown authentication provider', { provider });
+        res.status(503).send({ status: 'error' });
+        return;
+      }
+
       const referer = extractRefererPathFromReq(req);
 
       const isSaml = strategy._saml;

--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/provider-oidc.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/provider-oidc.ts
@@ -51,13 +51,24 @@ export const createOpenIdStrategy = async (logger: AuthenticationProviderLogger,
     ...extraConf,
   };
 
+  const tryJwtDecode = (token: string | undefined) => {
+    if (token) {
+      try {
+        return jwtDecode(token);
+      } catch {
+        return { error: 'Token is not a valid JWT' };
+      }
+    }
+    return undefined;
+  };
+
   const verify: VerifyFunction = async (tokens, verified: AuthenticateCallback) => {
     try {
       logger.info('Successfully logged on IdP', {
         tokens: {
-          access_token: tokens.access_token ? jwtDecode(tokens.access_token) : undefined,
-          id_token: tokens.id_token ? jwtDecode(tokens.id_token) : undefined,
-          refresh_token: tokens.refresh_token ? jwtDecode(tokens.refresh_token) : undefined,
+          access_token: tryJwtDecode(tokens.access_token),
+          id_token: tryJwtDecode(tokens.id_token),
+          refresh_token: tryJwtDecode(tokens.refresh_token),
         },
         scope: tokens.scope,
       });


### PR DESCRIPTION
### Proposed changes
* when decoding token for log purpose then catch jwtDecode error, and log error instead of blocking

### Related issues
* fix #14839

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
