### PR TITLE
[backend] Fix dashboard export failing with dynamicRegardingOf filters (#14539, #14527)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workspace/workspace-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workspace/workspace-utils.ts
@@ -3,7 +3,7 @@ import type { AuthContext, AuthUser } from '../../types/user';
 import type { Filter, FilterGroup } from '../../generated/graphql';
 import type { BasicStoreObject } from '../../types/store';
 import { internalFindByIds } from '../../database/middleware-loader';
-import { INSTANCE_REGARDING_OF } from '../../utils/filtering/filtering-constants';
+import { INSTANCE_DYNAMIC_REGARDING_OF, INSTANCE_REGARDING_OF } from '../../utils/filtering/filtering-constants';
 import { isInternalId, isStixId } from '../../schema/schemaUtils';
 import { idsValuesRemap } from '../../database/stix-2-1-converter';
 import { isFilterGroupNotEmpty } from '../../utils/filtering/filtering-utils';
@@ -15,6 +15,11 @@ import { pushAll } from '../../utils/arrayUtil';
 
 const toKeys = (k: string | string[]) => (Array.isArray(k) ? k : [k]);
 
+const isRegardingOfKey = (key: string | string[]) => {
+  const keys = toKeys(key);
+  return keys.includes(INSTANCE_REGARDING_OF) || keys.includes(INSTANCE_DYNAMIC_REGARDING_OF);
+};
+
 const filterValuesRemap = (filter: Filter, resolvedMap: { [k: string]: BasicStoreObject }, from: 'internal' | 'stix') => {
   return idsValuesRemap(filter.values, resolvedMap, from);
 };
@@ -23,8 +28,18 @@ const extractFiltersIds = (filter: FilterGroup, from: 'internal' | 'stix') => {
   const internalIds: string[] = [];
   filter.filters.forEach((f) => {
     let innerValues = f.values;
-    if (toKeys(f.key).includes(INSTANCE_REGARDING_OF)) {
+    if (isRegardingOfKey(f.key)) {
       innerValues = innerValues.find((v) => toKeys(v.key).includes('id'))?.values ?? [];
+      // dynamicRegardingOf may contain a 'dynamic' subfilter with nested FilterGroups holding IDs
+      const dynamicSubfilter = f.values.find((v) => toKeys(v.key).includes('dynamic'));
+      if (dynamicSubfilter) {
+        dynamicSubfilter.values.forEach((dynamicFilterGroup: any) => {
+          if (isFilterGroupNotEmpty(dynamicFilterGroup)) {
+            const nestedIds = extractFiltersIds(dynamicFilterGroup as FilterGroup, from);
+            pushAll(internalIds, nestedIds);
+          }
+        });
+      }
     }
     const ids = innerValues.filter((value) => {
       if (from === 'internal') return isInternalId(value);
@@ -42,7 +57,7 @@ const extractFiltersIds = (filter: FilterGroup, from: 'internal' | 'stix') => {
 const replaceFiltersIds = (filter: FilterGroup, resolvedMap: { [k: string]: BasicStoreObject }, from: 'internal' | 'stix') => {
   filter.filters.forEach((f) => {
     // Explicit reassign working by references
-    if (toKeys(f.key).includes(INSTANCE_REGARDING_OF)) {
+    if (isRegardingOfKey(f.key)) {
       const regardingOfValues = [];
       const idInnerFilter = f.values.find((v) => toKeys(v.key).includes('id'));
       if (idInnerFilter) { // Id is not mandatory
@@ -52,6 +67,16 @@ const replaceFiltersIds = (filter: FilterGroup, resolvedMap: { [k: string]: Basi
       const typeInnerFilter = f.values.find((v) => toKeys(v.key).includes('relationship_type'));
       if (typeInnerFilter) { // Type is not mandatory
         regardingOfValues.push(typeInnerFilter);
+      }
+      // dynamicRegardingOf may contain a 'dynamic' subfilter with nested FilterGroups holding IDs
+      const dynamicSubfilter = f.values.find((v) => toKeys(v.key).includes('dynamic'));
+      if (dynamicSubfilter) {
+        dynamicSubfilter.values.forEach((dynamicFilterGroup: any) => {
+          if (isFilterGroupNotEmpty(dynamicFilterGroup)) {
+            replaceFiltersIds(dynamicFilterGroup as FilterGroup, resolvedMap, from);
+          }
+        });
+        regardingOfValues.push(dynamicSubfilter);
       }
       // eslint-disable-next-line no-param-reassign
       f.values = regardingOfValues;

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/workspace-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/workspace-utils-test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { convertWidgetsIds } from '../../../src/modules/workspace/workspace-utils';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
-import { INSTANCE_REGARDING_OF, TYPE_FILTER } from '../../../src/utils/filtering/filtering-constants';
+import { INSTANCE_DYNAMIC_REGARDING_OF, INSTANCE_REGARDING_OF, TYPE_FILTER } from '../../../src/utils/filtering/filtering-constants';
 import { emptyFilterGroup } from '../../../src/utils/filtering/filtering-utils';
 import { internalFindByIds } from '../../../src/database/middleware-loader';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_MALWARE } from '../../../src/schema/stixDomainObject';
@@ -97,6 +97,189 @@ describe('Workspace utils', () => {
       }
     ];
     // check the result
+    await convertWidgetsIds(testContext, ADMIN_USER, input, 'internal');
+    expect(input).toEqual(convertedInput);
+  });
+
+  it('should convert widget filters ids with dynamicRegardingOf', async () => {
+    const reportId = 'report--a445d22a-db0c-4b5d-9ec8-e9ad0b6dbdd7';
+    const malwareId = 'malware--faa5b705-cf44-4e50-8472-29e5fec43c3c';
+    const resolveOpts = { baseData: true, mapWithAllIds: true };
+    const objects = await internalFindByIds(testContext, ADMIN_USER, [reportId, malwareId], resolveOpts) as BasicStoreBase[];
+    const reportInternalId = objects.find((o) => o.entity_type === ENTITY_TYPE_CONTAINER_REPORT)?.internal_id;
+    const reportStandardId = objects.find((o) => o.entity_type === ENTITY_TYPE_CONTAINER_REPORT)?.standard_id;
+    const malwareInternalId = objects.find((o) => o.entity_type === ENTITY_TYPE_MALWARE)?.internal_id;
+    const malwareStandardId = objects.find((o) => o.entity_type === ENTITY_TYPE_MALWARE)?.standard_id;
+
+    const filters = {
+      mode: 'and',
+      filters: [
+        {
+          key: INSTANCE_DYNAMIC_REGARDING_OF,
+          values: [
+            { key: 'id', values: [reportInternalId] },
+            { key: 'relationship_type', values: ['related-to'] },
+            {
+              key: 'dynamic',
+              values: [
+                {
+                  mode: 'and',
+                  filters: [
+                    { key: 'entity_type', values: ['Report'] },
+                    { key: 'objectMarking', values: [malwareInternalId] },
+                  ],
+                  filterGroups: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      filterGroups: [],
+    };
+    const input = [
+      {
+        type: 'list',
+        perspective: 'entities',
+        parameters: {},
+        dataSelection: [{
+          number: 10,
+          attribute: 'entity_type',
+          date_attribute: 'created_at',
+          filters,
+          dynamicFrom: emptyFilterGroup,
+          dynamicTo: emptyFilterGroup,
+        }],
+      }
+    ];
+
+    const convertedFilters = {
+      mode: 'and',
+      filters: [
+        {
+          key: INSTANCE_DYNAMIC_REGARDING_OF,
+          values: [
+            { key: 'id', values: [reportStandardId] },
+            { key: 'relationship_type', values: ['related-to'] },
+            {
+              key: 'dynamic',
+              values: [
+                {
+                  mode: 'and',
+                  filters: [
+                    { key: 'entity_type', values: ['Report'] },
+                    { key: 'objectMarking', values: [malwareStandardId] },
+                  ],
+                  filterGroups: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      filterGroups: [],
+    };
+    const convertedInput = [
+      {
+        type: 'list',
+        perspective: 'entities',
+        parameters: {},
+        dataSelection: [{
+          number: 10,
+          attribute: 'entity_type',
+          date_attribute: 'created_at',
+          filters: convertedFilters,
+          dynamicFrom: emptyFilterGroup,
+          dynamicTo: emptyFilterGroup,
+        }],
+      }
+    ];
+
+    await convertWidgetsIds(testContext, ADMIN_USER, input, 'internal');
+    expect(input).toEqual(convertedInput);
+  });
+
+  it('should convert widget filters ids with dynamicRegardingOf without id subfilter', async () => {
+    const filters = {
+      mode: 'and',
+      filters: [
+        {
+          key: INSTANCE_DYNAMIC_REGARDING_OF,
+          values: [
+            { key: 'relationship_type', values: ['related-to'] },
+            {
+              key: 'dynamic',
+              values: [
+                {
+                  mode: 'and',
+                  filters: [
+                    { key: 'entity_type', values: ['Report'] },
+                  ],
+                  filterGroups: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      filterGroups: [],
+    };
+    const input = [
+      {
+        type: 'list',
+        perspective: 'entities',
+        parameters: {},
+        dataSelection: [{
+          number: 10,
+          attribute: 'entity_type',
+          date_attribute: 'created_at',
+          filters,
+          dynamicFrom: emptyFilterGroup,
+          dynamicTo: emptyFilterGroup,
+        }],
+      }
+    ];
+
+    const convertedFilters = {
+      mode: 'and',
+      filters: [
+        {
+          key: INSTANCE_DYNAMIC_REGARDING_OF,
+          values: [
+            { key: 'relationship_type', values: ['related-to'] },
+            {
+              key: 'dynamic',
+              values: [
+                {
+                  mode: 'and',
+                  filters: [
+                    { key: 'entity_type', values: ['Report'] },
+                  ],
+                  filterGroups: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      filterGroups: [],
+    };
+    const convertedInput = [
+      {
+        type: 'list',
+        perspective: 'entities',
+        parameters: {},
+        dataSelection: [{
+          number: 10,
+          attribute: 'entity_type',
+          date_attribute: 'created_at',
+          filters: convertedFilters,
+          dynamicFrom: emptyFilterGroup,
+          dynamicTo: emptyFilterGroup,
+        }],
+      }
+    ];
+
     await convertWidgetsIds(testContext, ADMIN_USER, input, 'internal');
     expect(input).toEqual(convertedInput);
   });


### PR DESCRIPTION
## Summary

- **Fixes #14527** - Dashboard export fails silently when a widget contains a dynamic `in regard of` filter
- **Fixes #14539** - Dashboard configuration export (JSON) fails with `INTERNAL_SERVER_ERROR: Expected a string but received a Object`

## Root Cause

The `extractFiltersIds` and `replaceFiltersIds` functions in `workspace-utils.ts` only handled the `regardingOf` filter key when processing nested subfilter objects (whose values are `{ key, values }` objects rather than plain strings). The `dynamicRegardingOf` filter has the same nested structure but was not handled, causing the code to pass these objects directly to `isInternalId()` / `isUUID()`, which expects a string - resulting in `TypeError: Expected a string but received a Object`.

## Changes

**`workspace-utils.ts`**:
- Added import for `INSTANCE_DYNAMIC_REGARDING_OF`
- Introduced `isRegardingOfKey()` helper to check for both `regardingOf` and `dynamicRegardingOf` filter keys
- Updated `extractFiltersIds` to handle `dynamicRegardingOf` subfilters (including recursive extraction from the `dynamic` subfilter's nested `FilterGroup` values)
- Updated `replaceFiltersIds` to handle `dynamicRegardingOf` subfilters (including recursive ID replacement in nested `FilterGroup` values and preservation of the `dynamic` subfilter)

**`workspace-utils-test.ts`**:
- Added test for `dynamicRegardingOf` with ID subfilter + dynamic nested FilterGroup (verifies both ID remapping layers)
- Added test for `dynamicRegardingOf` without ID subfilter (edge case where only relationship_type + dynamic are present)

## Test plan

- [ ] Existing test `should convert widget filters ids` still passes (no regression on `regardingOf`)
- [ ] New test `should convert widget filters ids with dynamicRegardingOf` passes
- [ ] New test `should convert widget filters ids with dynamicRegardingOf without id subfilter` passes
- [ ] Manual: Create dashboard with `In regard of (dynamic)` widget filter, export dashboard -> JSON file downloads
- [ ] Manual: Export individual widget with `In regard of (dynamic)` filter -> JSON file downloads
- [ ] Manual: Import the exported dashboard on another instance -> filter structure preserved
