### PR TITLE
[frontend] fix Infinite loading of cards (#14848)

### DIFF
--- a/opencti-platform/opencti-front/src/components/list_cards/ListCardsContent.jsx
+++ b/opencti-platform/opencti-front/src/components/list_cards/ListCardsContent.jsx
@@ -20,6 +20,7 @@ const styles = () => ({
 class ListCardsContent extends Component {
   constructor(props) {
     super(props);
+    this.containerRef = React.createRef();
     this._isCellLoaded = this._isCellLoaded.bind(this);
     this._loadMoreRows = this._loadMoreRows.bind(this);
     this._onSectionRendered = this._onSectionRendered.bind(this);
@@ -29,10 +30,39 @@ class ListCardsContent extends Component {
     this.gridRef = React.createRef();
     this.state = {
       loadingCardCount: 0,
+      computedScrollElement: null,
+      isScrollElementResolved: false,
     };
   }
 
+  componentDidMount() {
+    this.updateScrollElement();
+    if (this._windowScroller) {
+      this._windowScroller.updatePosition();
+    }
+  }
+
+  updateScrollElement() {
+    if (this.containerRef.current) {
+      let node = this.containerRef.current.parentNode;
+      while (node && node !== document.body && node !== document.documentElement) {
+        if (node instanceof HTMLElement) {
+          const { overflowY } = window.getComputedStyle(node);
+          if (overflowY === 'auto' || overflowY === 'scroll') {
+            this.setState({ computedScrollElement: node, isScrollElementResolved: true });
+            return;
+          }
+        }
+        node = node.parentNode;
+      }
+      this.setState({ isScrollElementResolved: true });
+    }
+  }
+
   componentDidUpdate(prevProps) {
+    if (!this.state.isScrollElementResolved) {
+      this.updateScrollElement();
+    }
     if (
       !R.equals(prevProps.dataList, this.props.dataList)
       || !R.equals(prevProps.bookmarkList, this.props.bookmarkList)
@@ -160,60 +190,67 @@ class ListCardsContent extends Component {
       ? nbLineForCards + this.state.loadingCardCount
       : nbLineForCards;
     const rowCount = initialLoading ? nbOfLinesToLoad : nbLinesWithLoading;
+    const scrollElement = this.state.computedScrollElement || window;
     return (
-      <WindowScroller ref={this._setRef} scrollElement={window}>
-        {({ height, isScrolling, onChildScroll, scrollTop }) => (
-          <div className={styles.windowScrollerWrapper}>
-            <InfiniteLoader
-              isRowLoaded={this._isCellLoaded}
-              loadMoreRows={this._loadMoreRows}
-              rowCount={globalCount}
-            >
-              {({ onRowsRendered, registerChild }) => {
-                this._onRowsRendered = onRowsRendered;
-                return (
-                  <AutoSizer disableHeight>
-                    {({ width }) => (
-                      <ColumnSizer
-                        columnCount={numberOfCardsPerLine}
-                        width={width}
-                      >
-                        {({ adjustedWidth, getColumnWidth }) => {
-                          const columnWidth = getColumnWidth();
-                          return (
-                            <Grid
-                              ref={(ref) => {
-                                this.gridRef = ref;
-                                registerChild(ref);
-                              }}
-                              autoHeight={true}
-                              height={height}
-                              onRowsRendered={onRowsRendered}
-                              isScrolling={isScrolling}
-                              onScroll={onChildScroll}
-                              columnWidth={columnWidth}
-                              columnCount={numberOfCardsPerLine}
-                              rowHeight={rowHeight || 195}
-                              overscanColumnCount={numberOfCardsPerLine}
-                              overscanRowCount={2}
-                              rowCount={rowCount}
-                              cellRenderer={this._cellRenderer}
-                              onSectionRendered={this._onSectionRendered}
-                              scrollToIndex={-1}
-                              scrollTop={scrollTop}
-                              width={adjustedWidth}
-                            />
-                          );
-                        }}
-                      </ColumnSizer>
-                    )}
-                  </AutoSizer>
-                );
-              }}
-            </InfiniteLoader>
-          </div>
-        )}
-      </WindowScroller>
+      <div ref={this.containerRef}>
+        <WindowScroller
+          key={scrollElement === window ? 'window' : 'element'}
+          ref={this._setRef}
+          scrollElement={scrollElement}
+        >
+          {({ height, isScrolling, onChildScroll, scrollTop }) => (
+            <div className={styles.windowScrollerWrapper}>
+              <InfiniteLoader
+                isRowLoaded={this._isCellLoaded}
+                loadMoreRows={this._loadMoreRows}
+                rowCount={globalCount}
+              >
+                {({ onRowsRendered, registerChild }) => {
+                  this._onRowsRendered = onRowsRendered;
+                  return (
+                    <AutoSizer disableHeight>
+                      {({ width }) => (
+                        <ColumnSizer
+                          columnCount={numberOfCardsPerLine}
+                          width={width}
+                        >
+                          {({ adjustedWidth, getColumnWidth }) => {
+                            const columnWidth = getColumnWidth();
+                            return (
+                              <Grid
+                                ref={(ref) => {
+                                  this.gridRef = ref;
+                                  registerChild(ref);
+                                }}
+                                autoHeight={true}
+                                height={height || 0}
+                                onRowsRendered={onRowsRendered}
+                                isScrolling={isScrolling}
+                                onScroll={onChildScroll}
+                                columnWidth={columnWidth}
+                                columnCount={numberOfCardsPerLine}
+                                rowHeight={rowHeight || 195}
+                                overscanColumnCount={numberOfCardsPerLine}
+                                overscanRowCount={2}
+                                rowCount={rowCount}
+                                cellRenderer={this._cellRenderer}
+                                onSectionRendered={this._onSectionRendered}
+                                scrollToIndex={-1}
+                                scrollTop={scrollTop}
+                                width={adjustedWidth}
+                              />
+                            );
+                          }}
+                        </ColumnSizer>
+                      )}
+                    </AutoSizer>
+                  );
+                }}
+              </InfiniteLoader>
+            </div>
+          )}
+        </WindowScroller>
+      </div>
     );
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* **ListCardContent aligned with ListLinesContent**
* componentDidMount + updateScrollElement(): find the element in the DOM, overflowY: 'auto' ou overflowY: 'scroll' and store with this.state.computedScrollElement
* scrollElement of the WindowScroller, with a dynamic key to force re-rendering when the element changes

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #14848 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
