### PR TITLE
[backend] add representative on creators attribute (#14854)

### DIFF
--- a/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
+++ b/opencti-platform/opencti-graphql/src/schema/attribute-definition.ts
@@ -190,6 +190,9 @@ export const creators: IdAttribute = {
   multiple: true,
   upsert: true,
   isFilterable: true,
+  representative: (raw_creator_id: string, userIdToUserNameMap: Record<string, string>, _): string => {
+    return userIdToUserNameMap[raw_creator_id] ?? 'Restricted';
+  },
 };
 
 export const standardId: TextAttribute = {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/generate-message-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/generate-message-test.ts
@@ -3,7 +3,7 @@ import '../../../src/modules/index';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_MALWARE } from '../../../src/schema/stixDomainObject';
 import type { Change } from '../../../src/types/event';
 import { generateMessageFromChanges, humanizeRawValue } from '../../../src/database/data-changes';
-import { type AttributeDefinition, authorizedMembers, authorizedMembersActivationDate, files, revoked, xOpenctiAliases } from '../../../src/schema/attribute-definition';
+import { type AttributeDefinition, authorizedMembers, authorizedMembersActivationDate, creators, files, revoked, xOpenctiAliases } from '../../../src/schema/attribute-definition';
 import { DefaultFormating } from '../../../src/utils/humanize';
 import { height, type Measurement, weight } from '../../../src/modules/threatActorIndividual/threatActorIndividual';
 import { workflowId } from '../../../src/modules/attributes/stixDomainObject-registrationAttributes';
@@ -177,6 +177,14 @@ describe('generateUpdatePatchMessage tests', () => {
     measure = { measure: 20, date_seen: '2026-01-28T12:27:18Z' };
     human = humanizeRawValue({}, weight as AttributeDefinition, { raw: JSON.stringify(measure) }, DefaultFormating);
     expect(human).toEqual('20.00 (kg) at January 28 2026, 12:27:18 PM');
+  });
+  it('should humanize creators correctly handled', () => {
+    let human = humanizeRawValue({}, creators as AttributeDefinition, { raw: '-' }, DefaultFormating);
+    expect(human).toEqual('Restricted');
+    human = humanizeRawValue({
+      '5f6d506d-dd03-438e-b137-245933538f02': 'Admin',
+    }, workflowId as AttributeDefinition, { raw: '5f6d506d-dd03-438e-b137-245933538f02' }, DefaultFormating);
+    expect(human).toEqual('Admin');
   });
   it('should humanize workflow correctly handled', () => {
     let human = humanizeRawValue({}, workflowId as AttributeDefinition, { raw: '-' }, DefaultFormating);

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/generate-message-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/generate-message-test.ts
@@ -183,7 +183,7 @@ describe('generateUpdatePatchMessage tests', () => {
     expect(human).toEqual('Restricted');
     human = humanizeRawValue({
       '5f6d506d-dd03-438e-b137-245933538f02': 'Admin',
-    }, workflowId as AttributeDefinition, { raw: '5f6d506d-dd03-438e-b137-245933538f02' }, DefaultFormating);
+    }, creators as AttributeDefinition, { raw: '5f6d506d-dd03-438e-b137-245933538f02' }, DefaultFormating);
     expect(human).toEqual('Admin');
   });
   it('should humanize workflow correctly handled', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* the fix will not display 'itself', but will align creators behavior with other 'ref' behavior: it will no longer display 'admin add itself in Creators', but will display 'admin add admin in Creator instead'
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14854
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
