### PR TITLE
[backend] abort engine ES operations when http request is aborted (#14872)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/draft-engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/draft-engine.ts
@@ -47,7 +47,7 @@ const completeDeleteElementsFromDraft = async (context: AuthContext, user: AuthU
   if (!draftContext) {
     return;
   }
-  await elDeleteInstances(elements);
+  await elDeleteInstances(context, elements);
   const elementsIds = elements.map((e) => e.internal_id);
   await elRemoveDraftIdFromElements(context, user, draftContext, elementsIds);
 };
@@ -70,7 +70,7 @@ const elRemoveCreateElementFromDraft = async (context: AuthContext, user: AuthUs
   // Clean up all denormalized rel impact of relations deletion, then delete all relations
   // TODO: clean up UPDATE_LINKED impacted elements that no longer need to be in draft => how to know that an update_linked element can be safely removed?
   await elRemoveRelationConnection(context, user, draftRelationsElementsImpact);
-  await elDeleteInstances([element, ...draftCreatedRelations]);
+  await elDeleteInstances(context, [element, ...draftCreatedRelations]);
 };
 
 const elRemoveUpdateElementFromDraft = async (context: AuthContext, user: AuthUser, element: BasicStoreCommon): Promise<void> => {
@@ -93,7 +93,7 @@ const elRemoveUpdateElementFromDraft = async (context: AuthContext, user: AuthUs
   const draftCreatedOrDeletedRelations = relations.filter((f) => f.draft_change && isCreateOrDraftDelete(f.draft_change.draft_operation));
   if (draftCreatedOrDeletedRelations.length > 0) {
     const newDraftChange = { draft_change: { draft_operation: DRAFT_OPERATION_UPDATE_LINKED } };
-    await elReplace(element._index, element._id, { doc: newDraftChange });
+    await elReplace(context, element._index, element._id, { doc: newDraftChange });
   } else {
     await completeDeleteElementsFromDraft(context, user, [element]);
   }
@@ -130,7 +130,7 @@ const removeDraftDeleteLinkedRelations = async (
     R.dissoc('_index', doc.data),
   ]);
   if (bodyUpdate.length > 0) {
-    const bulkPromise = elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
+    const bulkPromise = elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
     await Promise.all([bulkPromise]);
   }
 
@@ -149,7 +149,7 @@ const elRemoveDeleteElementFromDraft = async (context: AuthContext, user: AuthUs
     const relationshipElement = element as StoreRelation;
     if (isDraftIndex(relationshipElement.from?._index) || isDraftIndex(relationshipElement.to?._index)) {
       const newDraftChange = { draft_change: { draft_operation: DRAFT_OPERATION_DELETE_LINKED } };
-      await elReplace(element._index, element._id, { doc: newDraftChange });
+      await elReplace(context, element._index, element._id, { doc: newDraftChange });
       return;
     }
   }
@@ -206,7 +206,7 @@ const elRemoveDeleteElementFromDraft = async (context: AuthContext, user: AuthUs
     await completeDeleteElementsFromDraft(context, user, [element]);
   } else {
     const newDraftChange = { draft_change: { draft_operation: DRAFT_OPERATION_UPDATE_LINKED } };
-    await elReplace(element._index, element._id, { doc: newDraftChange });
+    await elReplace(context, element._index, element._id, { doc: newDraftChange });
   }
 };
 

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -489,6 +489,31 @@ export const searchEngineInit = async (): Promise<boolean> => {
 };
 export const isRuntimeSortEnable = (): boolean => isRuntimeSortingEnable;
 
+/**
+ * Executes an engine operation with proper abort signal handling for both ElkClient and OpenSearch.
+ * - ElkClient: passes the signal as an option natively.
+ * - OpenSearch: manually hooks up the abort signal to call .abort() on the promise.
+ */
+const elExecuteWithAbortSignal = async (
+  abortSignal: AbortSignal | undefined,
+  elkOperation: (opts: { signal: AbortSignal | undefined }) => Promise<any>,
+  openSearchOperation: () => Promise<any>,
+): Promise<any> => {
+  if (engine instanceof ElkClient) {
+    const r = await elkOperation({ signal: abortSignal });
+    return oebp(r);
+  }
+  const promise = openSearchOperation();
+  if (abortSignal) {
+    abortSignal.addEventListener('abort', () => {
+      // OpenSearch client does not support abort signal, so we need to manually abort the request
+      (promise as any).abort();
+    });
+  }
+  const r_1 = await promise;
+  return oebp(r_1);
+};
+
 const BULK_MAX_RETRIES = 5;
 const BULK_INITIAL_DELAY_MS = 500;
 
@@ -529,20 +554,24 @@ export const retryElOperations = async (operation: () => Promise<any>): Promise<
 };
 
 export const elRawSearch = (context: AuthContext, user: AuthUser, types: string[] | string | null, query: any) => {
-  // Add signal to prevent unwanted warning
+  // Add default signal to prevent unwanted warning
   // Waiting for https://github.com/elastic/elastic-transport-js/issues/63
-  const searchOpts = { signal: new AbortController().signal };
-  const elRawSearchFn = async () => (engine instanceof ElkClient ? engine.search(query, searchOpts) : engine.search(query)).then((r: any) => {
-    const parsedSearch = oebp(r);
+  const requestAbortSignal = context?.requestAbortSignal ?? new AbortController().signal;
+  const elRawSearchFn = async () => {
+    const parsedSearch = await elExecuteWithAbortSignal(
+      requestAbortSignal,
+      (opts) => (engine as ElkClient).search(query, opts),
+      () => (engine as OpenClient).search(query),
+    );
     if (parsedSearch._shards.failed > 0) {
-      // We do not support response with shards failure.
-      // Result must be always accurate to prevent data duplication and unwanted behaviors
-      // If any shard fail during query, engine throw a shard exception with shards information
+    // We do not support response with shards failure.
+    // Result must be always accurate to prevent data duplication and unwanted behaviors
+    // If any shard fail during query, engine throw a shard exception with shards information
       throw EngineShardsError({ shards: parsedSearch._shards });
     }
     // Return result of the search if everything goes well
     return parsedSearch;
-  });
+  };
   const retriedElRawSearchFn = async () => {
     const searchOperation = async () => elRawSearchFn();
     return retryElOperations(searchOperation);
@@ -600,12 +629,11 @@ export const elRawDeleteByQuery = async (query: any) => {
 };
 export const elRawBulk = async (args: any) => {
   const bulkOperation = async () => {
-    if (engine instanceof ElkClient) {
-      const r = await engine.bulk(args);
-      return oebp(r);
-    }
-    const r_1 = await engine.bulk(args);
-    return oebp(r_1);
+    return await elExecuteWithAbortSignal(
+      context?.requestAbortSignal,
+      (opts) => (engine as ElkClient).bulk(args, opts),
+      () => (engine as OpenClient).bulk(args),
+    );
   };
   return retryElOperations(bulkOperation);
 };
@@ -3856,8 +3884,8 @@ export const elAttributeValues = async (
 };
 // endregion
 
-export const elBulk = async (args: any) => {
-  return elRawBulk(args).then((data) => {
+export const elBulk = async (context: AuthContext, args: any) => {
+  return elRawBulk(context, args).then((data) => {
     if (data.errors) {
       const errors = data.items.map((i: any) => i.index?.error || i.update?.error).filter((f: any) => f !== undefined);
       if (errors.filter((err: any) => err.type !== DOCUMENT_MISSING_EXCEPTION).length > 0) {
@@ -3901,6 +3929,7 @@ export const elIndex = async (
 };
 /* v8 ignore next */
 export const elUpdate = async (
+  context: AuthContext,
   indexName: string,
   documentId: string,
   documentBody: any,
@@ -3917,10 +3946,11 @@ export const elUpdate = async (
       body: documentBody,
     };
     try {
-      if (engine instanceof ElkClient) {
-        return await engine.update(updateRequest);
-      }
-      return await engine.update(updateRequest);
+        return await elExecuteWithAbortSignal(
+            context?.requestAbortSignal,
+            (opts) => (engine as ElkClient).update(updateRequest, opts),
+            () => (engine as OpenClient).update(updateRequest),
+        );
     } catch (err: any) {
       throw DatabaseError('Update indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
     }
@@ -3928,6 +3958,7 @@ export const elUpdate = async (
   return retryElOperations(updateOperation);
 };
 export const elReplace = async (
+  context: AuthContext,
   indexName: string,
   documentId: string,
   documentBody: any,
@@ -3945,7 +3976,7 @@ export const elReplace = async (
     }
   }
   const source = R.join(';', rawSources);
-  return elUpdate(indexName, documentId, {
+  return elUpdate(context, indexName, documentId, {
     script: { source, params: doc },
   });
 };
@@ -4023,6 +4054,7 @@ export const getRelationsToRemove = async <T extends BasicStoreBase>(
   return { relations: R.flatten(relationsToRemove), relationsToRemoveMap };
 };
 export const elDeleteInstances = async <T extends BasicStoreBase>(
+  context: AuthContext,
   instances: T[],
   opts: { forceRefresh?: boolean } = {},
 ) => {
@@ -4036,7 +4068,7 @@ export const elDeleteInstances = async <T extends BasicStoreBase>(
       const bodyDelete = instancesBulk.flatMap((doc) => {
         return [{ delete: { _index: doc._index, _id: doc._id ?? doc.internal_id, retry_on_conflict: ES_RETRY_ON_CONFLICT } }];
       });
-      await elBulk({ refresh: forceRefresh, timeout: BULK_TIMEOUT, body: bodyDelete });
+      await elBulk(context, { refresh: forceRefresh, timeout: BULK_TIMEOUT, body: bodyDelete });
     }
   }
 };
@@ -4120,7 +4152,7 @@ export const elRemoveRelationConnection = async (
       });
       const bodyUpdate = R.flatten(bodyUpdateRaw);
       if (bodyUpdate.length > 0) {
-        await elBulk({ refresh: forceRefresh, timeout: BULK_TIMEOUT, body: bodyUpdate });
+        await elBulk(context, { refresh: forceRefresh, timeout: BULK_TIMEOUT, body: bodyUpdate });
       }
     }
   }
@@ -4305,7 +4337,7 @@ export const copyLiveElementToDraft = async (
       params: { allDraftIds },
     },
   };
-  await elUpdate(element._index, element.internal_id, addDraftIdScript);
+  await elUpdate(context, element._index, element.internal_id, addDraftIdScript);
 
   return updatedElement;
 };
@@ -4374,11 +4406,11 @@ export const elMarkElementsAsDraftDelete = async (context: AuthContext, user: Au
   const draftNonCreatedElements = elements.filter((f) => isDraftIndex(f._index) && f.draft_change?.draft_operation !== DRAFT_OPERATION_CREATE);
 
   const copyLiveElementsPromise = liveElements.map((e) => copyLiveElementToDraft(context, user, e, DRAFT_OPERATION_DELETE));
-  const deleteDraftCreatedElementsPromise = elDeleteInstances(draftCreatedElements);
+  const deleteDraftCreatedElementsPromise = elDeleteInstances(context, draftCreatedElements);
   const updateDraftElementsPromise = draftNonCreatedElements.map((draftE) => {
     // TODO we might want to apply the reverse patch to draft updated elements
     const newDraftChange = { draft_change: { draft_operation: DRAFT_OPERATION_DELETE } };
-    return elReplace(draftE._index, draftE._id, { doc: newDraftChange });
+    return elReplace(context, draftE._index, draftE._id, { doc: newDraftChange });
   });
   const copiedLiveElements = await Promise.all(copyLiveElementsPromise);
   const allDraftElements = [...copiedLiveElements, ...draftCreatedElements, ...draftNonCreatedElements];
@@ -4389,12 +4421,12 @@ export const elMarkElementsAsDraftDelete = async (context: AuthContext, user: Au
   const draftCreatedRelations = relations.filter((f) => isDraftIndex(f._index) && f.draft_change?.draft_operation === DRAFT_OPERATION_CREATE);
   const draftNonCreatedRelations = relations.filter((f) => isDraftIndex(f._index) && f.draft_change?.draft_operation !== DRAFT_OPERATION_CREATE);
 
-  const deleteDraftCreatedRelationsPromise = elDeleteInstances(draftCreatedRelations);
+  const deleteDraftCreatedRelationsPromise = elDeleteInstances(context, draftCreatedRelations);
   const copyLiveRelationsPromise = liveRelations.map((e) => copyLiveElementToDraft(context, user, e, DRAFT_OPERATION_DELETE_LINKED));
   const updateDraftRelationsPromise = draftNonCreatedRelations.map((draftR) => {
     // TODO we might want to apply the reverse patch to draft updated elements
     const newDraftChange = { draft_change: { draft_operation: DRAFT_OPERATION_DELETE_LINKED } };
-    return elReplace(draftR._index, draftR._id, { doc: newDraftChange });
+    return elReplace(context, draftR._index, draftR._id, { doc: newDraftChange });
   });
   await Promise.all([deleteDraftCreatedElementsPromise, ...updateDraftElementsPromise]);
   await Promise.all([...copyLiveRelationsPromise, deleteDraftCreatedRelationsPromise, ...updateDraftRelationsPromise]);
@@ -4594,7 +4626,7 @@ export const elIndexElements = async (
       });
       if (body.length > 0) {
         meterManager.directBulk(body.length, { type: indexingType });
-        await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body });
+        await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body });
       }
     }
     // 02. If relation, generate impacts for from and to sides
@@ -4710,7 +4742,7 @@ export const elIndexElements = async (
         ]);
         if (bodyUpdate.length > 0) {
           meterManager.sideBulk(bodyUpdate.length, { type: indexingType });
-          const bulkPromise = elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
+          const bulkPromise = elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
           await Promise.all([bulkPromise]);
         }
       }
@@ -4723,7 +4755,7 @@ export const elIndexElements = async (
   }, elIndexElementsFn);
 };
 
-export const elUpdateRelationConnections = async (elements: any[]) => {
+export const elUpdateRelationConnections = async (context: AuthContext, elements: any[]) => {
   if (elements.length > 0) {
     const source = 'def conn = ctx._source.connections.find(c -> c.internal_id == params.id); '
       + 'for (change in params.changes.entrySet()) { conn[change.getKey()] = change.getValue() }';
@@ -4731,11 +4763,11 @@ export const elUpdateRelationConnections = async (elements: any[]) => {
       { update: { _index: doc._index, _id: doc._id ?? doc.id, retry_on_conflict: ES_RETRY_ON_CONFLICT } },
       { script: { source, params: { id: doc.toReplace, changes: doc.data } } },
     ]);
-    const bulkPromise = elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
+    const bulkPromise = elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
     await Promise.all([bulkPromise]);
   }
 };
-export const elUpdateEntityConnections = async (elements: any[]) => {
+export const elUpdateEntityConnections = async (context: AuthContext, elements: any[]) => {
   if (elements.length > 0) {
     const source = `if (ctx._source[params.key] == null) {
       ctx._source[params.key] = params.to;
@@ -4769,7 +4801,7 @@ export const elUpdateEntityConnections = async (elements: any[]) => {
         },
       ];
     });
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bodyUpdate });
   }
 };
 
@@ -4877,10 +4909,10 @@ export const elDeleteElements = async (
   await elRemoveRelationConnection(context, user, elementsImpact, opts);
   // 02. Remove all related relations and elements
   logApp.debug('[SEARCH] Deleting related relations', { size: relations.length });
-  await elDeleteInstances(relations, opts);
+  await elDeleteInstances(context, relations, opts);
   // 03/ Remove all elements
   logApp.debug('[SEARCH] Deleting elements', { size: elements.length });
-  await elDeleteInstances(elements, opts);
+  await elDeleteInstances(context, elements, opts);
 };
 const getInstanceToUpdate = async (context: AuthContext, user: AuthUser, instance: BasicStoreBase) => {
   const draftContext = getDraftContext(context, user);
@@ -4895,7 +4927,7 @@ export const elUpdateElement = async (context: AuthContext, user: AuthUser, inst
   const esData = await prepareElementForIndexing(instanceToUse);
   validateDataBeforeIndexing(esData);
   const dataToReplace = R.pipe(R.dissoc('representative'), R.dissoc('_id'))(esData);
-  const replacePromise = elReplace(instanceToUse._index, instanceToUse._id ?? instanceToUse.internal_id, { doc: dataToReplace });
+  const replacePromise = elReplace(context, instanceToUse._index, instanceToUse._id ?? instanceToUse.internal_id, { doc: dataToReplace });
   // If entity with a name, must update connections
   let connectionPromise = Promise.resolve();
   if (esData.name && isStixObject(instanceToUse.entity_type)) {

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -503,15 +503,24 @@ const elExecuteWithAbortSignal = async (
     const r = await elkOperation({ signal: abortSignal });
     return oebp(r);
   }
-  const promise = openSearchOperation();
-  if (abortSignal) {
-    abortSignal.addEventListener('abort', () => {
-      // OpenSearch client does not support abort signal, so we need to manually abort the request
-      (promise as any).abort();
-    });
+  const openSearchOperationPromise = openSearchOperation();
+  const abortRequest = () => {
+    // OpenSearch client does not support abort signal natively, so abort the request when possible.
+    (openSearchOperationPromise as any).abort?.();
+  };
+  if (abortSignal?.aborted) {
+    abortRequest();
+  } else if (abortSignal) {
+    abortSignal.addEventListener('abort', abortRequest, { once: true });
   }
-  const r_1 = await promise;
-  return oebp(r_1);
+  try {
+    const r_1 = await openSearchOperationPromise;
+    return oebp(r_1);
+  } finally {
+    if (abortSignal && !abortSignal.aborted) {
+      abortSignal.removeEventListener('abort', abortRequest);
+    }
+  }
 };
 
 const BULK_MAX_RETRIES = 5;

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -638,7 +638,7 @@ export const elRawDeleteByQuery = async (query: any) => {
   };
   return retryElOperations(rawDeleteOperation);
 };
-export const elRawBulk = async (args: any) => {
+export const elRawBulk = async (context: AuthContext, args: any) => {
   const bulkOperation = async () => {
     return await elExecuteWithAbortSignal(
       context?.requestAbortSignal,
@@ -3957,11 +3957,11 @@ export const elUpdate = async (
       body: documentBody,
     };
     try {
-        return await elExecuteWithAbortSignal(
-            context?.requestAbortSignal,
-            (opts) => (engine as ElkClient).update(updateRequest, opts),
-            () => (engine as OpenClient).update(updateRequest),
-        );
+      return await elExecuteWithAbortSignal(
+        context?.requestAbortSignal,
+        (opts) => (engine as ElkClient).update(updateRequest, opts),
+        () => (engine as OpenClient).update(updateRequest),
+      );
     } catch (err: any) {
       throw DatabaseError('Update indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
     }

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -196,6 +196,7 @@ import { pushAll, unshiftAll } from '../utils/arrayUtil';
 import { getRoleAssumerWithWebIdentity } from '../utils/awsSdk';
 import { elConvertHits, elConvertHitsToMap, INNER_HITS_WINDOWS_SIZE } from './engine-data-converter';
 import { isEsScriptFilterEnabled } from './engine-config';
+import { AbortError } from 'node-fetch';
 
 const ELK_ENGINE = 'elk';
 const OPENSEARCH_ENGINE = 'opensearch';
@@ -503,21 +504,22 @@ const elExecuteWithAbortSignal = async (
     const r = await elkOperation({ signal: abortSignal });
     return oebp(r);
   }
+  if (abortSignal?.aborted) {
+    throw new AbortError('The http call was aborted before el request started.');
+  }
   const openSearchOperationPromise = openSearchOperation();
   const abortRequest = () => {
     // OpenSearch client does not support abort signal natively, so abort the request when possible.
     (openSearchOperationPromise as any).abort?.();
   };
-  if (abortSignal?.aborted) {
-    abortRequest();
-  } else if (abortSignal) {
+  if (abortSignal) {
     abortSignal.addEventListener('abort', abortRequest, { once: true });
   }
   try {
     const r_1 = await openSearchOperationPromise;
     return oebp(r_1);
   } finally {
-    if (abortSignal && !abortSignal.aborted) {
+    if (abortSignal) {
       abortSignal.removeEventListener('abort', abortRequest);
     }
   }

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -500,12 +500,12 @@ const elExecuteWithAbortSignal = async (
   elkOperation: (opts: { signal: AbortSignal | undefined }) => Promise<any>,
   openSearchOperation: () => Promise<any>,
 ): Promise<any> => {
+  if (abortSignal?.aborted) {
+    throw new AbortError('The http call was aborted before el request started.');
+  }
   if (engine instanceof ElkClient) {
     const r = await elkOperation({ signal: abortSignal });
     return oebp(r);
-  }
-  if (abortSignal?.aborted) {
-    throw new AbortError('The http call was aborted before el request started.');
   }
   const openSearchOperationPromise = openSearchOperation();
   const abortRequest = () => {

--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -1694,7 +1694,7 @@ const mergeEntitiesRaw = async (
   let currentRelsUpdateCount = 0;
   const groupsOfRelsUpdate = R.splitEvery(MAX_BULK_OPERATIONS, updateConnections);
   const concurrentRelsUpdate = async (connsToUpdate: UpdateConnection[]) => {
-    await elUpdateRelationConnections(connsToUpdate);
+    await elUpdateRelationConnections(context, connsToUpdate);
     currentRelsUpdateCount += connsToUpdate.length;
     logApp.info(`[OPENCTI] Merging, updating relations ${currentRelsUpdateCount} / ${updateConnections.length}`);
   };
@@ -1707,7 +1707,7 @@ const mergeEntitiesRaw = async (
   const updateBulkEntities = entries.filter(([, values]) => values?.length === 1).map(([, values]) => values).flat();
   const groupsOfEntityUpdate = R.splitEvery(MAX_BULK_OPERATIONS, updateBulkEntities);
   const concurrentEntitiesUpdate = async (entitiesToUpdate: UpdateEntity[]) => {
-    await elUpdateEntityConnections(entitiesToUpdate);
+    await elUpdateEntityConnections(context, entitiesToUpdate);
     currentEntUpdateCount += entitiesToUpdate.length;
     logApp.info(`[OPENCTI] Merging updating bulk entities ${currentEntUpdateCount} / ${updateBulkEntities.length}`);
   };
@@ -1733,7 +1733,7 @@ const mergeEntitiesRaw = async (
       // then execute each other one by one
       for (let index = 0; index < operations.length; index += 1) {
         const operation = operations[index];
-        await elUpdateEntityConnections([operation]);
+        await elUpdateEntityConnections(context, [operation]);
       }
     },
     { concurrency: ES_MAX_CONCURRENCY },

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -186,7 +186,7 @@ export const deleteTask = async (context, user, taskId) => {
   if (taskToDelete.work_id) {
     const taskWork = await loadWorkById(context, user, taskToDelete.work_id);
     if (taskWork) {
-      await deleteWorksRaw([taskWork]);
+      await deleteWorksRaw(context, [taskWork]);
     }
   }
   return taskId;

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -123,9 +123,9 @@ export const loadExportWorksAsProgressFiles = async (context, user, sourceId) =>
   return filterSuccessCompleted.map((item) => workToExportFile(item));
 };
 
-export const deleteWorksRaw = async (works) => {
+export const deleteWorksRaw = async (context, works) => {
   const workIds = works.map((w) => w.internal_id);
-  await elDeleteInstances(works);
+  await elDeleteInstances(context, works);
   await redisDeleteWorks(workIds);
   return workIds;
 };
@@ -133,7 +133,7 @@ export const deleteWorksRaw = async (works) => {
 export const deleteWork = async (context, user, workId) => {
   const work = await loadWorkById(context, user, workId);
   if (work) {
-    await deleteWorksRaw([work]);
+    await deleteWorksRaw(context, [work]);
     await publishUserAction({
       user,
       event_type: 'mutation',
@@ -150,7 +150,7 @@ export const pingWork = async (context, user, workId) => {
   const currentWork = await loadWorkById(context, user, workId);
   const params = { updated_at: now() };
   const source = 'ctx._source["updated_at"] = params.updated_at;';
-  await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
+  await elUpdate(context, currentWork._index, workId, { script: { source, lang: 'painless', params } });
   return workId;
 };
 
@@ -168,7 +168,7 @@ export const deleteWorkForConnector = async (context, user, connectorId) => {
   }
   let works = await worksForConnector(context, user, connectorId, { first: 500 });
   while (works.length > 0) {
-    await deleteWorksRaw(works);
+    await deleteWorksRaw(context, works);
     works = await worksForConnector(context, user, connectorId, { first: 500 });
   }
   await publishUserAction({
@@ -185,7 +185,7 @@ export const deleteWorkForConnector = async (context, user, connectorId) => {
 export const deleteWorkForFile = async (context, user, fileId) => {
   const works = await worksForSource(context, user, fileId);
   if (works.length > 0) {
-    await deleteWorksRaw(works);
+    await deleteWorksRaw(context, works);
   }
   return true;
 };
@@ -273,7 +273,7 @@ const updateWorkTaskToComplete = async (context, user, work) => {
   const associatedTask = await internalLoadById(context, user, associatedTaskId, { type: ENTITY_TYPE_BACKGROUND_TASK });
   if (associatedTask) {
     const sourceScriptUpdateWork = 'ctx._source["work_completed"] = "true"';
-    await elUpdate(associatedTask._index, associatedTaskId, { script: { source: sourceScriptUpdateWork, lang: 'painless' } });
+    await elUpdate(context, associatedTask._index, associatedTaskId, { script: { source: sourceScriptUpdateWork, lang: 'painless' } });
   } else {
     logApp.warn('The task associated to work cannot be found in database, task work status cannot be updated.', { associatedTaskId });
   }
@@ -318,7 +318,7 @@ export const reportExpectation = async (context, user, workId, errorData) => {
     // Update elastic
     const currentWork = await loadWorkById(context, user, workId);
     if (currentWork) {
-      await elUpdate(currentWork._index, workId, { script: { source: sourceScript, lang: 'painless', params } });
+      await elUpdate(context, currentWork._index, workId, { script: { source: sourceScript, lang: 'painless', params } });
       // If work is associated to a task, we also need to update work to completed on the task
       if (isComplete) {
         await updateWorkTaskToComplete(context, user, currentWork);
@@ -365,8 +365,7 @@ export const updateExpectationsNumber = async (context, user, workId, expectatio
   const params = { updated_at: now(), import_expected_number: expectations };
   let source = 'ctx._source.updated_at = params.updated_at;';
   source += 'ctx._source["import_expected_number"] = ctx._source["import_expected_number"] + params.import_expected_number;';
-  await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
-
+  await elUpdate(context, currentWork._index, workId, { script: { source, lang: 'painless', params } });
   return workId;
 };
 
@@ -387,7 +386,7 @@ export const addDraftContext = async (context, user, workId, draftContext) => {
   const params = { updated_at: now(), draft_context: draftContext };
   let source = 'ctx._source.updated_at = params.updated_at;';
   source += 'ctx._source["draft_context"] =  params.draft_context;';
-  await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
+  await elUpdate(context, currentWork._index, workId, { script: { source, lang: 'painless', params } });
   return workId;
 };
 
@@ -404,7 +403,7 @@ export const updateReceivedTime = async (context, user, workId, message) => {
     source += 'ctx._source.messages.add(["timestamp": params.received_time, "message": params.message]); ';
   }
   // Update elastic
-  await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
+  await elUpdate(context, currentWork._index, workId, { script: { source, lang: 'painless', params } });
   return workId;
 };
 
@@ -428,6 +427,6 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
     }
   }
   // Update elastic
-  await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
+  await elUpdate(context, currentWork._index, workId, { script: { source, lang: 'painless', params } });
   return workId;
 };

--- a/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
+++ b/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
@@ -39,10 +39,11 @@ export const computeLoaders = (executeContext, user) => {
   };
 };
 
-export const createAuthenticatedContext = async (req, res, contextName) => {
+export const createAuthenticatedContext = async (req, res, contextName, requestAbortSignal) => {
   const executeContext = executionContext(contextName);
   executeContext.req = req;
   executeContext.res = res;
+  executeContext.requestAbortSignal = requestAbortSignal;
   const settings = await getEntityFromCache(executeContext, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   executeContext.otp_mandatory = settings?.otp_mandatory ?? false; // Null check fixes 500 error on platform theme selection
   executeContext.workId = req.headers['opencti-work-id']; // Api call comes from a worker processing

--- a/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
+++ b/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
@@ -46,13 +46,17 @@ const createRequestAbortSignal = (req, res) => {
       abortController.abort();
     }
   };
-  req.once('aborted', abort);
-  res.once('close', () => {
+  if (req.once) {
+    req.once('aborted', abort);
+  }
+  if (res.once) {
+    res.once('close', () => {
     // `close` is emitted for both success and disconnect; only abort on disconnect.
-    if (!res.writableEnded) {
-      abort();
-    }
-  });
+      if (!res.writableEnded) {
+        abort();
+      }
+    });
+  }
   return abortController.signal;
 };
 

--- a/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
+++ b/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
@@ -39,8 +39,26 @@ export const computeLoaders = (executeContext, user) => {
   };
 };
 
-export const createAuthenticatedContext = async (req, res, contextName, requestAbortSignal) => {
+const createRequestAbortSignal = (req, res) => {
+  const abortController = new AbortController();
+  const abort = () => {
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+  };
+  req.once('aborted', abort);
+  res.once('close', () => {
+    // `close` is emitted for both success and disconnect; only abort on disconnect.
+    if (!res.writableEnded) {
+      abort();
+    }
+  });
+  return abortController.signal;
+};
+
+export const createAuthenticatedContext = async (req, res, contextName) => {
   const executeContext = executionContext(contextName);
+  const requestAbortSignal = createRequestAbortSignal(req, res);
   executeContext.req = req;
   executeContext.res = res;
   executeContext.requestAbortSignal = requestAbortSignal;

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -34,23 +34,6 @@ const CERT_KEY_CERT = conf.get('app:https_cert:crt');
 const CA_CERTS = conf.get('app:https_cert:ca');
 const rejectUnauthorized = booleanConf('app:https_cert:reject_unauthorized', true);
 
-const createRequestAbortSignal = (req, res) => {
-  const abortController = new AbortController();
-  const abort = () => {
-    if (!abortController.signal.aborted) {
-      abortController.abort();
-    }
-  };
-  req.once('aborted', abort);
-  res.once('close', () => {
-    // `close` is emitted for both success and disconnect; only abort on disconnect.
-    if (!res.writableEnded) {
-      abort();
-    }
-  });
-  return abortController.signal;
-};
-
 export const extractWsSessionContext = async (context) => {
   const req = context.extra.request;
   const webSocket = context.extra.socket;
@@ -164,8 +147,7 @@ const createHttpServer = async () => {
       app,
       path: `${basePath}/graphql`,
       context: async ({ req, res }) => {
-        const requestAbortSignal = createRequestAbortSignal(req, res);
-        const executeContext = await createAuthenticatedContext(req, res, 'api', requestAbortSignal);
+        const executeContext = await createAuthenticatedContext(req, res, 'api');
         // When context is related to a work, we need to check work status
         if (executeContext.workId) {
           const workStillAlive = await isWorkAlive(executeContext, executeContext.user, executeContext.workId);

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -36,18 +36,18 @@ const rejectUnauthorized = booleanConf('app:https_cert:reject_unauthorized', tru
 
 const createRequestAbortSignal = (req, res) => {
   const abortController = new AbortController();
-  const abortIfDisconnected = () => {
-    // `close` is emitted for both success and disconnect; only abort on disconnect.
-    if (!res.writableEnded && !abortController.signal.aborted) {
-      abortController.abort();
-    }
-  };
-  req.once('aborted', () => {
+  const abort = () => {
     if (!abortController.signal.aborted) {
       abortController.abort();
     }
+  };
+  req.once('aborted', abort);
+  res.once('close', () => {
+    // `close` is emitted for both success and disconnect; only abort on disconnect.
+    if (!res.writableEnded) {
+      abort();
+    }
   });
-  res.once('close', abortIfDisconnected);
   return abortController.signal;
 };
 

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -34,6 +34,23 @@ const CERT_KEY_CERT = conf.get('app:https_cert:crt');
 const CA_CERTS = conf.get('app:https_cert:ca');
 const rejectUnauthorized = booleanConf('app:https_cert:reject_unauthorized', true);
 
+const createRequestAbortSignal = (req, res) => {
+  const abortController = new AbortController();
+  const abortIfDisconnected = () => {
+    // `close` is emitted for both success and disconnect; only abort on disconnect.
+    if (!res.writableEnded && !abortController.signal.aborted) {
+      abortController.abort();
+    }
+  };
+  req.once('aborted', () => {
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+  });
+  res.once('close', abortIfDisconnected);
+  return abortController.signal;
+};
+
 export const extractWsSessionContext = async (context) => {
   const req = context.extra.request;
   const webSocket = context.extra.socket;
@@ -147,7 +164,8 @@ const createHttpServer = async () => {
       app,
       path: `${basePath}/graphql`,
       context: async ({ req, res }) => {
-        const executeContext = await createAuthenticatedContext(req, res, 'api');
+        const requestAbortSignal = createRequestAbortSignal(req, res);
+        const executeContext = await createAuthenticatedContext(req, res, 'api', requestAbortSignal);
         // When context is related to a work, we need to check work status
         if (executeContext.workId) {
           const workStillAlive = await isWorkAlive(executeContext, executeContext.user, executeContext.workId);

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -45,7 +45,7 @@ const closeOldWorks = async (context, connector) => {
             const sourceScript = `ctx._source['status'] = "complete";
                 ctx._source['completed_time'] = params.completed_time;
                 ctx._source['completed_number'] = params.completed_number;`;
-            await elUpdate(element._index, element.internal_id, {
+            await elUpdate(context, element._index, element.internal_id, {
               script: {
                 source: sourceScript,
                 lang: 'painless',
@@ -85,7 +85,7 @@ export const deleteCompletedWorks = async (context, connector) => {
   const queryCallback = async (elements) => {
     const message = `[WORKS] Deleting ${elements.length} works for ${connector.name}`;
     logApp.info(message);
-    await deleteWorksRaw(elements);
+    await deleteWorksRaw(context, elements);
   };
   await elList(context, SYSTEM_USER, [READ_INDEX_HISTORY], {
     filters,

--- a/opencti-platform/opencti-graphql/src/migrations/1611671597858-standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1611671597858-standard_id.js
@@ -31,7 +31,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Rewriting standard ids: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1612381566895-clear_indicates_indexation.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1612381566895-clear_indicates_indexation.js
@@ -37,7 +37,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Cleaning indicates indexation: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1612999232704-fix_attack_patterns.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1612999232704-fix_attack_patterns.js
@@ -29,7 +29,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Cleaning aliases and STIX IDs ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1613150325865-clear_aliases.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1613150325865-clear_aliases.js
@@ -29,7 +29,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Cleaning aliases and STIX IDs (pass 2) ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1614942944848-fix_locations_identities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1614942944848-fix_locations_identities.js
@@ -31,7 +31,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Rewriting standard ids: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1616890781521-fix_aliases.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1616890781521-fix_aliases.js
@@ -60,7 +60,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Rewriting i_aliases_ids: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1619270898754-migrate_incidents.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1619270898754-migrate_incidents.js
@@ -38,7 +38,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Rewriting IDs and types: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1620980638439-fix_attack_patterns.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1620980638439-fix_attack_patterns.js
@@ -29,7 +29,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Cleaning aliases and STIX IDs ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1630337822820-report_status.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1630337822820-report_status.js
@@ -64,7 +64,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Migrating reports ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1637328713848-system_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1637328713848-system_standard_id.js
@@ -31,7 +31,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Rewriting standard ids: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1643894590312-change_resolves-to.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1643894590312-change_resolves-to.js
@@ -3,17 +3,19 @@ import { Promise } from 'bluebird';
 import { READ_RELATIONSHIPS_INDICES } from '../database/utils';
 import { BULK_TIMEOUT, elBulk, elUpdateByQueryForMigration, ES_MAX_CONCURRENCY, MAX_BULK_OPERATIONS } from '../database/engine';
 import { logApp } from '../config/conf';
+import { executionContext } from '../utils/access';
 
 export const up = async (next) => {
   const start = new Date().getTime();
   logApp.info('[MIGRATION] Rewriting resolves-to relationships');
+  const context = executionContext('migration');
   const bulkOperations = [];
   // Old type
   // Apply operations.
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logApp.info(`[OPENCTI] Rewriting IDs and types: ${currentProcessing} / ${bulkOperations.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1672652100502-entity-settings-mapping.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1672652100502-entity-settings-mapping.js
@@ -51,7 +51,7 @@ export const up = async (next) => {
   settingsFromEl.platform_hidden_types = null;
 
   const esData = await prepareElementForIndexing(settingsFromEl);
-  await elReplace(settingsFromEl._index, settingsFromEl.internal_id, { doc: esData });
+  await elReplace(context, settingsFromEl._index, settingsFromEl.internal_id, { doc: esData });
 
   next();
 };

--- a/opencti-platform/opencti-graphql/src/migrations/1688710489709-add_order_to_opinion_ov.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1688710489709-add_order_to_opinion_ov.js
@@ -59,7 +59,7 @@ export const up = async (next) => {
     const defaultVocabulary = defaultVocabularies.get(vocabulary.name);
     if (defaultVocabulary) {
       const patch = { order: defaultVocabulary.order };
-      await elReplace(vocabulary._index, vocabulary.id, { doc: patch });
+      await elReplace(context, vocabulary._index, vocabulary.id, { doc: patch });
     }
   };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1691495378997-migrate-hidden-types-from-role-to-group.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1691495378997-migrate-hidden-types-from-role-to-group.js
@@ -23,7 +23,7 @@ export const up = async (next) => {
       .flat()
       .filter((hiddenTypes) => isNotEmptyField(hiddenTypes));
     const patch = { default_hidden_types: defaultHiddenTypes };
-    await elReplace(group._index, group.id, { doc: patch });
+    await elReplace(context, group._index, group.id, { doc: patch });
   };
   await Promise.map(groups, updateGroup, { concurrency: ES_MAX_CONCURRENCY });
   // Remove default_hidden_types for role

--- a/opencti-platform/opencti-graphql/src/migrations/1694352490408-stream-access.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1694352490408-stream-access.js
@@ -16,7 +16,7 @@ export const up = async (next) => {
     if (relations.length > 0) {
       const restricted_members = relations.map((r) => ({ id: r.fromId, access_right: 'view' }));
       const patch = { restricted_members, authorized_authorities: [TAXIIAPI_SETCOLLECTIONS] };
-      await elReplace(stream._index, stream.internal_id, { doc: patch });
+      await elReplace(context, stream._index, stream.internal_id, { doc: patch });
       await elDeleteElements(context, SYSTEM_USER, relations);
     }
   }
@@ -24,11 +24,11 @@ export const up = async (next) => {
   // ------ Access data sharing
   const accessTaxii = await elLoadById(context, SYSTEM_USER, 'capability--d258afde-7a8a-5917-8b4b-83119d3f8e52');
   const accessPatch = { description: 'Access data sharing' };
-  await elReplace(accessTaxii._index, accessTaxii.internal_id, { doc: accessPatch });
+  await elReplace(context, accessTaxii._index, accessTaxii.internal_id, { doc: accessPatch });
   // ------ Manage data sharing
   const manageTaxii = await elLoadById(context, SYSTEM_USER, 'capability--24f9401c-8a77-59d5-8a8f-4ea21a1a733b');
   const managePatch = { description: 'Manage data sharing' };
-  await elReplace(manageTaxii._index, manageTaxii.internal_id, { doc: managePatch });
+  await elReplace(context, manageTaxii._index, manageTaxii.internal_id, { doc: managePatch });
   // ------ Roles that contains STREAMAPI must now contain TAXIIAPI
   const streamApi = await elLoadById(context, SYSTEM_USER, 'capability--beaa8173-6da3-5930-a0df-00e8feac9d52');
   const capabilityRelations = await fullRelationsList(context, SYSTEM_USER, RELATION_HAS_CAPABILITY, { toId: streamApi.internal_id });

--- a/opencti-platform/opencti-graphql/src/migrations/1707808059963-rename-data-sharing-capability-description.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1707808059963-rename-data-sharing-capability-description.js
@@ -6,11 +6,11 @@ export const up = async (next) => {
   // ------ Access data sharing
   const accessTaxii = await elLoadById(context, SYSTEM_USER, 'capability--d258afde-7a8a-5917-8b4b-83119d3f8e52');
   const accessPatch = { description: 'Access data sharing & ingestion' };
-  await elReplace(accessTaxii._index, accessTaxii.internal_id, { doc: accessPatch });
+  await elReplace(context, accessTaxii._index, accessTaxii.internal_id, { doc: accessPatch });
   // ------ Manage data sharing
   const manageTaxii = await elLoadById(context, SYSTEM_USER, 'capability--24f9401c-8a77-59d5-8a8f-4ea21a1a733b');
   const managePatch = { description: 'Manage data sharing & ingestion' };
-  await elReplace(manageTaxii._index, manageTaxii.internal_id, { doc: managePatch });
+  await elReplace(context, manageTaxii._index, manageTaxii.internal_id, { doc: managePatch });
   next();
 };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1713449762000-investigations-and-dashboards-capabilities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1713449762000-investigations-and-dashboards-capabilities.js
@@ -8,7 +8,7 @@ export const up = async (next) => {
   const managePublicDashboardsCapability = await elLoadById(context, SYSTEM_USER, 'capability--40892bfe-13c2-5e3e-96a3-531760950451');
   if (managePublicDashboardsCapability) {
     const managePublicDashboardsCapabilityPatch = { description: 'Manage Public Dashboards' };
-    await elReplace(managePublicDashboardsCapability._index, managePublicDashboardsCapability.internal_id, { doc: managePublicDashboardsCapabilityPatch });
+    await elReplace(context, managePublicDashboardsCapability._index, managePublicDashboardsCapability.internal_id, { doc: managePublicDashboardsCapabilityPatch });
   } else {
     await addCapability(context, SYSTEM_USER, {
       name: 'EXPLORE_EXUPDATE_PUBLISH',
@@ -20,15 +20,15 @@ export const up = async (next) => {
   // ------ Access exploration renaming
   const accessCapability = await elLoadById(context, SYSTEM_USER, 'capability--c2f6d8be-29c7-5e7f-ab17-dfa14a349025');
   const accessCapabilityPatch = { description: 'Access Dashboards and investigations' };
-  await elReplace(accessCapability._index, accessCapability.internal_id, { doc: accessCapabilityPatch });
+  await elReplace(context, accessCapability._index, accessCapability.internal_id, { doc: accessCapabilityPatch });
   // ------ Create / Update exploration renaming
   const updateCapability = await elLoadById(context, SYSTEM_USER, 'capability--722e8727-5e8a-5b5e-8c1e-3b71b8415170');
   const updateCapabilityPatch = { description: 'Create / Update Dashboards and investigations' };
-  await elReplace(updateCapability._index, updateCapability.internal_id, { doc: updateCapabilityPatch });
+  await elReplace(context, updateCapability._index, updateCapability.internal_id, { doc: updateCapabilityPatch });
   // ------ Delete exploration renaming
   const deleteCapability = await elLoadById(context, SYSTEM_USER, 'capability--287d57a8-5e9a-573f-8f22-ea321f5cbc90');
   const deleteCapabilityPatch = { description: 'Delete Dashboards and investigations' };
-  await elReplace(deleteCapability._index, deleteCapability.internal_id, { doc: deleteCapabilityPatch });
+  await elReplace(context, deleteCapability._index, deleteCapability.internal_id, { doc: deleteCapabilityPatch });
   next();
 };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1716392968110-alias_migration.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1716392968110-alias_migration.js
@@ -27,7 +27,7 @@ export const up = async (next) => {
         { doc: { [iAliasedIds.name]: aliasIds } },
       ];
     }).flat();
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulkOperations });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulkOperations });
     logApp.info(`${message} > progress, ${totalIndex}/${total}`);
   };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1718809173008-update-data-sharing-ingestion-capabilities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1718809173008-update-data-sharing-ingestion-capabilities.js
@@ -57,18 +57,18 @@ export const up = async (next) => {
       attribute_order: 2700,
       standard_id: generateStandardId(ENTITY_TYPE_CAPABILITY, { name: 'CSVMAPPERS' }),
     };
-    await elReplace(CSVCapability._index, CSVCapability.internal_id, { doc: CSVCapabilityPatch });
+    await elReplace(context, CSVCapability._index, CSVCapability.internal_id, { doc: CSVCapabilityPatch });
   }
 
   // ------ Update description of Access data sharing & ingestion => Access data sharing
   const accessDataCapability = await elLoadById(context, SYSTEM_USER, 'capability--d258afde-7a8a-5917-8b4b-83119d3f8e52');
   const accessDataCapabilityPatch = { description: 'Access data sharing' };
-  await elReplace(accessDataCapability._index, accessDataCapability.internal_id, { doc: accessDataCapabilityPatch });
+  await elReplace(context, accessDataCapability._index, accessDataCapability.internal_id, { doc: accessDataCapabilityPatch });
 
   // ------ Update description of Manage data sharing & ingestion => Manage data sharing
   const manageDataCapability = await elLoadById(context, SYSTEM_USER, 'capability--24f9401c-8a77-59d5-8a8f-4ea21a1a733b');
   const manageDataCapabilityPatch = { description: 'Manage data sharing' };
-  await elReplace(manageDataCapability._index, manageDataCapability.internal_id, { doc: manageDataCapabilityPatch });
+  await elReplace(context, manageDataCapability._index, manageDataCapability.internal_id, { doc: manageDataCapabilityPatch });
 
   // ------ Update name + description + attribute_order of BYPASSREFERENCE
   const byPassRefCapability = await elLoadById(context, SYSTEM_USER, 'capability--7ad2a72e-8dcd-569c-8d3f-469dce6fa6b0');
@@ -79,13 +79,13 @@ export const up = async (next) => {
       attribute_order: 320,
       standard_id: generateStandardId(ENTITY_TYPE_CAPABILITY, { name: 'KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE' }),
     };
-    await elReplace(byPassRefCapability._index, byPassRefCapability.internal_id, { doc: byPassRefCapabilityPatch });
+    await elReplace(context, byPassRefCapability._index, byPassRefCapability.internal_id, { doc: byPassRefCapabilityPatch });
   }
 
   // ------ Update attribute_order of Connector API usage
   const connectorAPICapability = await elLoadById(context, SYSTEM_USER, 'capability--3b45a9ef-b336-5539-be9a-58e3509648e9');
   const connectorAPICapabilityPatch = { attribute_order: 2300 };
-  await elReplace(connectorAPICapability._index, connectorAPICapability.internal_id, { doc: connectorAPICapabilityPatch });
+  await elReplace(context, connectorAPICapability._index, connectorAPICapability.internal_id, { doc: connectorAPICapabilityPatch });
 
   logApp.info(`${message} > done`);
   next();

--- a/opencti-platform/opencti-graphql/src/migrations/1719208368256-settingscapabilities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1719208368256-settingscapabilities.js
@@ -66,15 +66,15 @@ export const up = async (next) => {
   // ------ Update description of Access Administration
   const adminCapability = await elLoadById(context, SYSTEM_USER, 'capability--bb5ec6d0-0ffb-5b04-8fcf-c0d4447209a6');
   const adminCapabilityPatch = { description: 'Access to admin functionalities' };
-  await elReplace(adminCapability._index, adminCapability.internal_id, { doc: adminCapabilityPatch });
+  await elReplace(context, adminCapability._index, adminCapability.internal_id, { doc: adminCapabilityPatch });
   // ------ Update description of Manage labels & Attributes
   const taxonomiesCapability = await elLoadById(context, SYSTEM_USER, 'capability--0f78ff7d-7197-568f-ac8c-5d7842c07f0f');
   const taxonomiesCapabilityPatch = { description: 'Manage taxonomies' };
-  await elReplace(taxonomiesCapability._index, taxonomiesCapability.internal_id, { doc: taxonomiesCapabilityPatch });
+  await elReplace(context, taxonomiesCapability._index, taxonomiesCapability.internal_id, { doc: taxonomiesCapabilityPatch });
   // ------ Update description of Access security activity
   const activityCapability = await elLoadById(context, SYSTEM_USER, 'capability--3d467062-f044-50da-902c-627cfa739444');
   const activityCapabilityPatch = { description: 'Access security activity' };
-  await elReplace(activityCapability._index, activityCapability.internal_id, { doc: activityCapabilityPatch });
+  await elReplace(context, activityCapability._index, activityCapability.internal_id, { doc: activityCapabilityPatch });
 
   logApp.info(`${message} > done`);
   next();

--- a/opencti-platform/opencti-graphql/src/migrations/1719208388531-notifier_authorized_authorities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1719208388531-notifier_authorized_authorities.js
@@ -15,7 +15,7 @@ export const up = async (next) => {
     for (let i = 0; i < notifiers.length; i += 1) {
       const notifier = notifiers[i];
       const patch = { authorized_authorities: ['SETTINGS_SETCUSTOMIZATION'] };
-      await elReplace(notifier._index, notifier.internal_id, { doc: patch });
+      await elReplace(context, notifier._index, notifier.internal_id, { doc: patch });
     }
   };
   const opts = { types: [ENTITY_TYPE_NOTIFIER], callback };

--- a/opencti-platform/opencti-graphql/src/migrations/1719321008908-dashboard-and-investigations-capabilities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1719321008908-dashboard-and-investigations-capabilities.js
@@ -63,17 +63,17 @@ export const up = async (next) => {
   // ------ Update description of Access dashboard & investigation => Access dashboard
   const accessDashboardCapability = await elLoadById(context, SYSTEM_USER, 'capability--c2f6d8be-29c7-5e7f-ab17-dfa14a349025');
   const accessDashboardCapabilityPatch = { description: 'Access dashboards' };
-  await elReplace(accessDashboardCapability._index, accessDashboardCapability.internal_id, { doc: accessDashboardCapabilityPatch });
+  await elReplace(context, accessDashboardCapability._index, accessDashboardCapability.internal_id, { doc: accessDashboardCapabilityPatch });
 
   // ------ Update description of Create / Update dashboard & investigation => Create / Update dashboard
   const createUpdateDashboardCapability = await elLoadById(context, SYSTEM_USER, 'capability--722e8727-5e8a-5b5e-8c1e-3b71b8415170');
   const createUpdateDashboardCapabilityPatch = { description: 'Create / Update dashboards' };
-  await elReplace(createUpdateDashboardCapability._index, createUpdateDashboardCapability.internal_id, { doc: createUpdateDashboardCapabilityPatch });
+  await elReplace(context, createUpdateDashboardCapability._index, createUpdateDashboardCapability.internal_id, { doc: createUpdateDashboardCapabilityPatch });
 
   // ------ Update description of Delete dashboard & investigation => Delete dashboard
   const deleteDashboardCapability = await elLoadById(context, SYSTEM_USER, 'capability--287d57a8-5e9a-573f-8f22-ea321f5cbc90');
   const deleteDashboardCapabilityPatch = { description: 'Delete dashboards' };
-  await elReplace(deleteDashboardCapability._index, deleteDashboardCapability.internal_id, { doc: deleteDashboardCapabilityPatch });
+  await elReplace(context, deleteDashboardCapability._index, deleteDashboardCapability.internal_id, { doc: deleteDashboardCapabilityPatch });
 
   logApp.info(`${message} > done`);
   next();

--- a/opencti-platform/opencti-graphql/src/migrations/1726472121823-delete-files-duplicates.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1726472121823-delete-files-duplicates.js
@@ -33,7 +33,7 @@ export const up = async (next) => {
     const finalFilesToDelete = filesToDelete.map((h) => ({ _index: h._index, internal_id: h.internal_id }));
     logApp.info(`Deleting ${finalFilesToDelete.length} files that have duplicates.`);
     // delete the files
-    await elDeleteInstances(finalFilesToDelete);
+    await elDeleteInstances(context, finalFilesToDelete);
   } else {
     logApp.info(`${message} > no multiple indices found for internal objects, no need to run migration`);
   }

--- a/opencti-platform/opencti-graphql/src/migrations/1733912620469-clean-deprecated-rels.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1733912620469-clean-deprecated-rels.js
@@ -73,7 +73,7 @@ export const up = async (next) => {
   let currentProcessingRelatedTo = 0;
   const groupsOfOperationsRelatedTo = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperationsRelatedTo);
   const concurrentUpdateRelatedTo = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessingRelatedTo += bulk.length;
     logMigration.info(`[OPENCTI] Cleaning deprecated rels for observable related-to ${currentProcessingRelatedTo} / ${bulkOperationsRelatedTo.length}`);
   };
@@ -123,7 +123,7 @@ export const up = async (next) => {
   let currentProcessing = 0;
   const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperationsLocatedAt);
   const concurrentUpdate = async (bulk) => {
-    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
     currentProcessing += bulk.length;
     logMigration.info(`[OPENCTI] Cleaning deprecated rels for located-at to country / region ${currentProcessing} / ${bulkOperationsLocatedAt.length}`);
   };

--- a/opencti-platform/opencti-graphql/src/migrations/1742812645319-migrate-authorized-members-default-values.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1742812645319-migrate-authorized-members-default-values.js
@@ -25,7 +25,7 @@ export const up = async (next) => {
       });
       const patch = { attributes_configuration: JSON.stringify(attributesConfiguration) };
       logMigration.info(`${message} > replacing attributes configuration for entity setting ${entitySetting.id}`);
-      await elReplace(entitySetting._index, entitySetting.id, { doc: patch });
+      await elReplace(context, entitySetting._index, entitySetting.id, { doc: patch });
     }
   }
   logMigration.info(`${message} > done`);

--- a/opencti-platform/opencti-graphql/src/migrations/1742823297613-reindex-targets-rel.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1742823297613-reindex-targets-rel.js
@@ -48,7 +48,7 @@ export const up = async (next) => {
   const concurrentUpdate = async (bulk) => {
     currentProcessing += bulk.length;
     logMigration.info(`[OPENCTI] Re-indexing targets for region / countries / sectors ${currentProcessing} / ${bulkOperationsTargets.length}`);
-    await elBulk({ refresh: true, timeout: MIGRATION_BULK_TIMEOUT, body: bulk });
+    await elBulk(context, { refresh: true, timeout: MIGRATION_BULK_TIMEOUT, body: bulk });
   };
   await Promise.map(groupsOfOperations, concurrentUpdate, { concurrency: MIGRATION_MAX_CONCURRENCY });
   logMigration.info(`[MIGRATION] Re-indexed targets for region / countries / sectors in ${new Date() - startTargets} ms`);

--- a/opencti-platform/opencti-graphql/src/migrations/1746054044682-rename-csvmapper-desc.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1746054044682-rename-csvmapper-desc.js
@@ -10,7 +10,7 @@ export const up = async (next) => {
   const CSVCapability = await elLoadById(context, SYSTEM_USER, 'capability--c3d1af09-14d2-5172-9673-200de7f7f386');
   if (CSVCapability) {
     const CSVCapabilityPatch = { description: 'Manage data mappers' };
-    await elReplace(CSVCapability._index, CSVCapability.internal_id, { doc: CSVCapabilityPatch });
+    await elReplace(context, CSVCapability._index, CSVCapability.internal_id, { doc: CSVCapabilityPatch });
   }
   logMigration.info(`${message} > done`);
   next();

--- a/opencti-platform/opencti-graphql/src/migrations/1758060978527-split-label-capabilities.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1758060978527-split-label-capabilities.js
@@ -15,7 +15,7 @@ export const up = async (next) => {
   // ------ Update description of Manage labels & Attributes
   const taxonomiesCapability = await elLoadById(context, SYSTEM_USER, 'capability--0f78ff7d-7197-568f-ac8c-5d7842c07f0f');
   const taxonomiesCapabilityPatch = { description: 'Manage labels' };
-  await elReplace(taxonomiesCapability._index, taxonomiesCapability.internal_id, { doc: taxonomiesCapabilityPatch });
+  await elReplace(context, taxonomiesCapability._index, taxonomiesCapability.internal_id, { doc: taxonomiesCapabilityPatch });
   // Add capability
   const setVocab = await addCapability(context, SYSTEM_USER, { name: 'SETTINGS_SETVOCABULARIES', description: 'Manage vocabularies', attribute_order: 3410 });
   const setCaseTemplate = await addCapability(context, SYSTEM_USER, { name: 'SETTINGS_SETCASETEMPLATES', description: 'Manage case templates', attribute_order: 3420 });

--- a/opencti-platform/opencti-graphql/src/migrations/1759087578937-rename-delete-capa.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1759087578937-rename-delete-capa.js
@@ -10,7 +10,7 @@ export const up = async (next) => {
   const deleteCapability = await elLoadById(context, SYSTEM_USER, 'capability--be60f4fc-8d91-59f6-925a-1b211a06d086');
   if (deleteCapability) {
     const deleteCapabilityPatch = { description: 'Delete / Merge knowledge' };
-    await elReplace(deleteCapability._index, deleteCapability.internal_id, { doc: deleteCapabilityPatch });
+    await elReplace(context, deleteCapability._index, deleteCapability.internal_id, { doc: deleteCapabilityPatch });
   }
   logMigration.info(`${message} > done`);
   next();

--- a/opencti-platform/opencti-graphql/src/migrations/1761037937217-split-delete-merge-capa.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1761037937217-split-delete-merge-capa.js
@@ -18,7 +18,7 @@ export const up = async (next) => {
   const deleteCapability = await elLoadById(context, SYSTEM_USER, deleteCapaStandardId);
   if (deleteCapability) {
     const deleteCapabilityPatch = { description: 'Delete knowledge' };
-    await elReplace(deleteCapability._index, deleteCapability.internal_id, { doc: deleteCapabilityPatch });
+    await elReplace(context, deleteCapability._index, deleteCapability.internal_id, { doc: deleteCapabilityPatch });
   }
   // Add Merge knowledge capability
   const mergeKnowledgeCapa = await addCapability(

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/feed-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/feed-domain.ts
@@ -114,7 +114,7 @@ export const editFeed = async (context: AuthContext, user: AuthUser, id: string,
     finalInput = { ...finalInput, restricted_members: finalInput.authorized_members } as FeedAddInput & { restricted_members: MemberAccessInput[] };
     delete finalInput.authorized_members;
   }
-  await elReplace(feed._index, feed.internal_id, { doc: finalInput });
+  await elReplace(context, feed._index, feed.internal_id, { doc: finalInput });
   await publishUserAction({
     user,
     event_type: 'mutation',

--- a/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
@@ -259,7 +259,7 @@ export const processDeleteOperation = async (context: AuthContext, user: AuthUse
     }
   }
   // delete elements
-  await elDeleteInstances([...deletedElements]);
+  await elDeleteInstances(context, [...deletedElements]);
   // finally delete deleteOperation
   await elDeleteElements(context, user, [deleteOperation]);
   return id;

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-domain.ts
@@ -77,7 +77,7 @@ export const indexFileToDocument = async (context: AuthContext, file: any) => {
 export const deleteDocumentIndex = async (context: AuthContext, user: AuthUser, id: string) => {
   const internalFile = await elFindByIds(context, user, [id], { type: ENTITY_TYPE_INTERNAL_FILE }) as BasicStoreEntityDocument[];
   if (internalFile.length > 0) {
-    await elDeleteInstances(internalFile);
+    await elDeleteInstances(context, internalFile);
   }
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/pir/pir-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/pir/pir-utils.ts
@@ -129,7 +129,7 @@ export const updatePirInformationOnEntity = async (context: AuthContext, user: A
       } else ctx._source['pir_information'] = params.new_pir_information;
     `;
   // call elUpdate directly to avoid generating stream events and modifying the updated_at of the entity
-  return elUpdate(stixDomainObject._index, entityId, { script: { source, lang: 'painless', params } });
+  return elUpdate(context, stixDomainObject._index, entityId, { script: { source, lang: 'painless', params } });
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/types/user.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/user.d.ts
@@ -83,5 +83,6 @@ interface AuthContext {
   synchronizedUpsert?: boolean;
   previousStandard?: string;
   req?: Express.Request;
+  requestAbortSignal?: AbortSignal;
   blocked_for_lts_validation?: boolean;
 }

--- a/opencti-platform/opencti-graphql/src/types/user.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/user.d.ts
@@ -83,6 +83,6 @@ interface AuthContext {
   synchronizedUpsert?: boolean;
   previousStandard?: string;
   req?: Express.Request;
-  requestAbortSignal: AbortSignal;
+  requestAbortSignal?: AbortSignal;
   blocked_for_lts_validation?: boolean;
 }

--- a/opencti-platform/opencti-graphql/src/types/user.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/user.d.ts
@@ -83,6 +83,6 @@ interface AuthContext {
   synchronizedUpsert?: boolean;
   previousStandard?: string;
   req?: Express.Request;
-  requestAbortSignal?: AbortSignal;
+  requestAbortSignal: AbortSignal;
   blocked_for_lts_validation?: boolean;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* forward http request abort to engine ES search/bulk/update request
* open question: maybe we want to forward the cancel to other ES requests also?

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14872
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
