### PR TITLE
fix(frontend): resolve connector popover danger zone hover tooltip glitch (#14799)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
@@ -13,6 +13,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { PopoverProps } from '@mui/material/Popover';
 import ToggleButton from '@mui/material/ToggleButton';
+import Tooltip from '@mui/material/Tooltip';
 import { useTheme } from '@mui/styles';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -168,11 +169,23 @@ const ConnectorPopover = ({ connector, onRefreshData }: ConnectorPopoverProps) =
           <DangerZoneBlock
             type="connector_reset"
             sx={{ title: { display: 'none' } }}
-            component={(
-              <MenuItem onClick={handleOpenResetState} sx={{ color: theme.palette.dangerZone.main, gap: 1 }}>
-                <span>{t_i18n('Reset')}</span>
-                <DangerZoneChip />
-              </MenuItem>
+            component={({ disabled, style }) => (
+              <Tooltip
+                title={t_i18n('Resetting the connector state enables you to restart the ingestion process from the very beginning. This can lead to a significant amount of data to re-process.')}
+                placement="left"
+              >
+                <span>
+                  <MenuItem
+                    onClick={handleOpenResetState}
+                    disabled={disabled}
+                    sx={{ color: theme.palette.dangerZone.main, gap: 1 }}
+                    style={style}
+                  >
+                    <span>{t_i18n('Reset')}</span>
+                    <DangerZoneChip />
+                  </MenuItem>
+                </span>
+              </Tooltip>
             )}
           />
         ) : (


### PR DESCRIPTION
## Summary\n\nFixes #14799 — Connector detail view UI bug on hovering the \"danger zone\" in menu.\n\n## Root Cause\n\nWhen `isSensitive` is true, the Reset `MenuItem` was wrapped by `DangerZoneBlock` as a `ReactNode` via the `component` prop. `DangerZoneBlock` used `React.cloneElement` to inject `title`, `disabled`, and `style` props. The `title` prop (a React JSX element) was passed through to the native HTML `<li>` element, causing the browser to render `[object Object]` as a native tooltip on hover.\n\n## Fix\n\n- Changed the `component` prop from a `ReactNode` to a **render function** `({ disabled, style }) => ReactElement`\n- This uses the function branch of `DangerZoneBlock` which calls the function instead of `cloneElement`, giving full control over which props are applied\n- Only `disabled` and `style` are destructured and applied — `title` is intentionally omitted\n- Added a proper MUI `Tooltip` with a meaningful description of the reset action's impact\n- Added `Tooltip` import from `@mui/material/Tooltip`\n\n## Testing\n\n1. Go to Data → Ingestion → Connectors\n2. Click on a managed connector\n3. Open the menu (top right ⋮ button)\n4. Hover over the \"Reset\" danger zone item\n5. ✅ A proper MUI tooltip appears with a helpful description\n6. ✅ No garbled native browser tooltip