### PR TITLE
feat(entitySetting): allow administrators to customize entity display names (#14873)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingSettings.tsx
@@ -1,9 +1,10 @@
-import { Box, Tooltip } from '@mui/material';
+import { Box, IconButton, TextField, Tooltip } from '@mui/material';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import Grid from '@mui/material/Grid';
 import Switch from '@mui/material/Switch';
-import { InformationOutline } from 'mdi-material-ui';
+import { InformationOutline, UndoVariant } from 'mdi-material-ui';
+import { useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import Label from '../../../../../components/common/label/Label';
 import ErrorNotFound from '../../../../../components/ErrorNotFound';
@@ -63,6 +64,8 @@ export const entitySettingFragment = graphql`
             }
         }
     }
+    custom_name
+    custom_name_plural
   }
 `;
 
@@ -90,6 +93,10 @@ const EntitySettingSettings = ({ entitySettingsData }: EntitySettingSettingsProp
 
   const [commit] = useApiMutation(entitySettingPatch);
 
+  // Local state for custom name fields
+  const [customName, setCustomName] = useState(entitySetting.custom_name ?? '');
+  const [customNamePlural, setCustomNamePlural] = useState(entitySetting.custom_name_plural ?? '');
+
   const handleSubmitField = (name: string, value: boolean) => {
     commit({
       variables: {
@@ -98,8 +105,117 @@ const EntitySettingSettings = ({ entitySettingsData }: EntitySettingSettingsProp
       },
     });
   };
+
+  const handleSubmitCustomName = (name: string, value: string) => {
+    commit({
+      variables: {
+        ids: [entitySetting.id],
+        input: { key: name, value: value.trim().length > 0 ? [value.trim()] : [''] },
+      },
+    });
+  };
+
+  const handleResetCustomName = () => {
+    setCustomName('');
+    commit({
+      variables: {
+        ids: [entitySetting.id],
+        input: { key: 'custom_name', value: [''] },
+      },
+    });
+  };
+
+  const handleResetCustomNamePlural = () => {
+    setCustomNamePlural('');
+    commit({
+      variables: {
+        ids: [entitySetting.id],
+        input: { key: 'custom_name_plural', value: [''] },
+      },
+    });
+  };
+
   return (
     <Grid container={true} spacing={2}>
+      {/* Custom display name section */}
+      <Grid item xs={12}>
+        <Label action={(
+          <Tooltip
+            title={t_i18n('Customize the display name shown in the UI for this entity type. Leave empty to use the default name.')}
+          >
+            <InformationOutline
+              fontSize="small"
+              color="primary"
+            />
+          </Tooltip>
+        )}
+        >
+          {t_i18n('Custom display name')}
+        </Label>
+        <Grid container spacing={2} sx={{ mt: 1 }}>
+          <Grid item xs={6}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <TextField
+                label={t_i18n('Display name (singular)')}
+                fullWidth
+                size="small"
+                value={customName}
+                placeholder={t_i18n(`entity_${entitySetting.target_type}`)}
+                onChange={(e) => setCustomName(e.target.value)}
+                onBlur={() => handleSubmitCustomName('custom_name', customName)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSubmitCustomName('custom_name', customName);
+                  }
+                }}
+              />
+              <Tooltip title={t_i18n('Reset to default')}>
+                <span>
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    disabled={!customName}
+                    onClick={handleResetCustomName}
+                  >
+                    <UndoVariant fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          </Grid>
+          <Grid item xs={6}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <TextField
+                label={t_i18n('Display name (plural)')}
+                fullWidth
+                size="small"
+                value={customNamePlural}
+                placeholder={t_i18n(`entity_${entitySetting.target_type}s`)}
+                onChange={(e) => setCustomNamePlural(e.target.value)}
+                onBlur={() => handleSubmitCustomName('custom_name_plural', customNamePlural)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSubmitCustomName('custom_name_plural', customNamePlural);
+                  }
+                }}
+              />
+              <Tooltip title={t_i18n('Reset to default')}>
+                <span>
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    disabled={!customNamePlural}
+                    onClick={handleResetCustomNamePlural}
+                  >
+                    <UndoVariant fontSize="small" />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          </Grid>
+        </Grid>
+      </Grid>
+
       <Grid item xs={6}>
         <div>
           <Label action={(

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntityLabel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntityLabel.ts
@@ -1,0 +1,32 @@
+import useEntitySettings from './useEntitySettings';
+import { useFormatter } from '../../components/i18n';
+
+/**
+ * Hook that resolves the display label for an entity type.
+ * If a custom_name is set in EntitySettings, it takes precedence.
+ * Otherwise, falls back to the default i18n translation.
+ *
+ * @param entityType - The internal entity type identifier (e.g. 'Case-Incident')
+ * @param plural - Whether to return the plural form
+ * @returns The resolved display label
+ */
+const useEntityLabel = (entityType: string, plural = false): string => {
+  const { t_i18n } = useFormatter();
+  const entitySettings = useEntitySettings(entityType);
+
+  if (entitySettings.length > 0) {
+    const setting = entitySettings[0];
+    if (plural && setting.custom_name_plural) {
+      return setting.custom_name_plural;
+    }
+    if (!plural && setting.custom_name) {
+      return setting.custom_name;
+    }
+  }
+
+  // Fallback to default i18n label
+  const key = plural ? `entity_${entityType}s` : `entity_${entityType}`;
+  return t_i18n(key);
+};
+
+export default useEntityLabel;

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-types.ts
@@ -40,6 +40,8 @@ export interface BasicStoreEntityEntitySetting extends BasicStoreEntity {
   overview_layout_customization?: Array<OverviewLayoutCustomization>;
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
 }
 
 export interface StoreEntityEntitySetting extends StoreEntity {
@@ -53,6 +55,8 @@ export interface StoreEntityEntitySetting extends StoreEntity {
   overview_layout_customization?: Array<OverviewLayoutCustomization>;
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
 }
 
 export interface OverviewLayoutCustomization {
@@ -78,6 +82,8 @@ export interface StoreEntityEntitySetting extends StoreEntity {
   overviewLayoutCustomization?: Array<string>;
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
 }
 
 export interface StixEntitySetting extends StixObject {
@@ -90,6 +96,8 @@ export interface StixEntitySetting extends StixObject {
   available_settings?: string[];
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
   };

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
@@ -64,6 +64,9 @@ type EntitySetting implements InternalObject & BasicObject {
     search: String
   ): FintelTemplateConnection @auth(for: [SETTINGS_SETCUSTOMIZATION])
   requestAccessConfiguration: RequestAccessConfiguration @auth
+  # Custom display name
+  custom_name: String @auth
+  custom_name_plural: String @auth
 }
 
 # Ordering

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.ts
@@ -110,6 +110,8 @@ export const ENTITY_SETTING_DEFINITION: ModuleDefinition<StoreEntityEntitySettin
     { name: 'availableSettings', label: 'Available settings', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'workflow_configuration', label: 'Workflow activated', type: 'boolean', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'request_access_workflow', label: 'Request access workflow', type: 'object', format: 'flat', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'custom_name', label: 'Custom display name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'custom_name_plural', label: 'Custom display name (plural)', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
   ],
   relations: [],
   validators: {


### PR DESCRIPTION
## Summary\n\nCloses #14873\n\nAllows platform administrators to define a **custom display name** (singular and plural) for any core entity type in **Settings > Customization > Entity types**, so that the platform's terminology can be adapted to match the organization's internal vocabulary — without altering the underlying STIX data model or internal entity type identifiers.\n\n## Changes\n\n### Backend\n\n| File | Change |\n|---|---|\n| `entitySetting-types.ts` | Added `custom_name` and `custom_name_plural` optional string fields to all store interfaces (`BasicStoreEntityEntitySetting`, `StoreEntityEntitySetting`, `StixEntitySetting`) |\n| `entitySetting.graphql` | Added `custom_name: String` and `custom_name_plural: String` fields to the `EntitySetting` GraphQL type |\n| `entitySetting.ts` | Registered `custom_name` and `custom_name_plural` as new attributes in the module definition (type `string`, format `short`, non-mandatory) |\n\nNo resolver changes needed — the existing `entitySettingsFieldPatch` mutation already handles generic `EditInput` arrays, so both fields are immediately editable via the API.\n\n### Frontend\n\n| File | Change |\n|---|---|\n| `EntitySettingSettings.tsx` | Added \"Custom display name\" section with two `TextField` inputs (singular + plural), each with a **Reset to default** button. Fields save on blur or Enter key. Added `custom_name` and `custom_name_plural` to the Relay fragment. |\n| `useEntityLabel.ts` | **New hook** — resolves entity display label by checking `custom_name`/`custom_name_plural` from EntitySettings first, falling back to default `t_i18n()` translation. Ready for adoption across the codebase. |\n\n## How It Works\n\n1. Navigate to **Settings > Customization > Entity types > [Any entity]**\n2. In the new \"Custom display name\" section, enter a custom singular and/or plural name\n3. The custom name is saved platform-wide via the existing `entitySettingsFieldPatch` mutation\n4. Components using the `useEntityLabel(entityType)` hook will display the custom name\n5. If left empty, the default OpenCTI name is used (fully backward compatible)\n6. Click the ↩ reset button to revert to the default name\n\n## Acceptance Criteria Coverage\n\n- [x] Administrators can set custom singular and plural display names\n- [x] Reset to default action available per entity type\n- [x] Internal `entity_type` identifier unchanged (STIX/API compatibility preserved)\n- [x] Custom name accessible via GraphQL API (on `EntitySetting` type)\n- [x] Fully backward compatible — empty custom names fall back to defaults\n- [ ] Adoption of `useEntityLabel` hook across all UI surfaces (navigation, lists, filters, dashboards, breadcrumbs) — to be done in follow-up PRs\n\n## Screenshots\n\n_Custom display name fields added to the entity setting configuration page, with reset-to-default buttons._