### PR TITLE
feat(entitysetting): add custom display name support for core entities (#14873)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubType.tsx
@@ -20,6 +20,8 @@ export const subTypeQuery = graphql`
       workflowEnabled
       settings {
         id
+        custom_name
+        custom_name_plural
         availableSettings
         ...EntitySettingsOverviewLayoutCustomization_entitySetting
         ...EntitySettingSettings_entitySetting
@@ -52,13 +54,18 @@ const SubTypeComponent: React.FC<SubTypeProps> = ({ queryRef }) => {
   const { isFeatureEnable } = useHelper();
   const isDraftWorkflowFeatureEnabled = isFeatureEnable('DRAFT_WORKFLOW');
   const isDraftWorkspaceType = subType.label === 'DraftWorkspace' && isDraftWorkflowFeatureEnabled;
+
+  // Resolve display name: use custom name if set, otherwise fall back to i18n
+  const defaultLabel = t_i18n(`entity_${subType.label}`);
+  const displayLabel = subType.settings?.custom_name || defaultLabel;
+
   return (
     <div style={{ margin: 0, padding: '0 200px 50px 0' }}>
       <Breadcrumbs elements={[
         { label: t_i18n('Settings') },
         { label: t_i18n('Customization') },
         { label: t_i18n('Entity types'), link: '/dashboard/settings/customization/entity_types' },
-        { label: t_i18n(`entity_${subType.label}`), current: true },
+        { label: displayLabel, current: true },
       ]}
       />
 
@@ -66,8 +73,8 @@ const SubTypeComponent: React.FC<SubTypeProps> = ({ queryRef }) => {
 
       {isDraftWorkspaceType && (<SubTypeMenu entityType={subType.label} />)}
 
-      <TitleMainEntity sx={{ mb: 3 }}>
-        {t_i18n(`entity_${subType.label}`)}
+      <TitleMainEntity sx={{ mb: 3 }} data-testid="entity-type-title">
+        {displayLabel}
       </TitleMainEntity>
 
       <Outlet context={{ subType }} />

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingSettings.tsx
@@ -1,10 +1,11 @@
-import { Box, Tooltip } from '@mui/material';
+import { Box, Button, TextField, Tooltip } from '@mui/material';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import Grid from '@mui/material/Grid';
 import Switch from '@mui/material/Switch';
 import { InformationOutline } from 'mdi-material-ui';
 import { graphql, useFragment } from 'react-relay';
+import { useState } from 'react';
 import Label from '../../../../../components/common/label/Label';
 import ErrorNotFound from '../../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../../components/i18n';
@@ -63,6 +64,8 @@ export const entitySettingFragment = graphql`
             }
         }
     }
+    custom_name
+    custom_name_plural
   }
 `;
 
@@ -90,6 +93,9 @@ const EntitySettingSettings = ({ entitySettingsData }: EntitySettingSettingsProp
 
   const [commit] = useApiMutation(entitySettingPatch);
 
+  const [customName, setCustomName] = useState(entitySetting.custom_name ?? '');
+  const [customNamePlural, setCustomNamePlural] = useState(entitySetting.custom_name_plural ?? '');
+
   const handleSubmitField = (name: string, value: boolean) => {
     commit({
       variables: {
@@ -98,6 +104,30 @@ const EntitySettingSettings = ({ entitySettingsData }: EntitySettingSettingsProp
       },
     });
   };
+
+  const handleSubmitCustomName = (name: string, value: string) => {
+    commit({
+      variables: {
+        ids: [entitySetting.id],
+        input: { key: name, value: [value] },
+      },
+    });
+  };
+
+  const handleResetCustomNames = () => {
+    setCustomName('');
+    setCustomNamePlural('');
+    commit({
+      variables: {
+        ids: [entitySetting.id],
+        input: [
+          { key: 'custom_name', value: [''] },
+          { key: 'custom_name_plural', value: [''] },
+        ],
+      },
+    });
+  };
+
   return (
     <Grid container={true} spacing={2}>
       <Grid item xs={6}>
@@ -224,6 +254,62 @@ const EntitySettingSettings = ({ entitySettingsData }: EntitySettingSettingsProp
               label={t_i18n('Enforce references')}
             />
           </FormGroup>
+        </Box>
+      </Grid>
+      <Grid item xs={12}>
+        <Box sx={{ marginTop: 2 }}>
+          <Label action={(
+            <Tooltip
+              title={t_i18n('Set a custom display name for this entity type. Leave empty to use the default name.')}
+            >
+              <InformationOutline
+                fontSize="small"
+                color="primary"
+              />
+            </Tooltip>
+          )}
+          >
+            {t_i18n('Display name')}
+          </Label>
+          <Grid container spacing={2} sx={{ marginTop: 1 }}>
+            <Grid item xs={5}>
+              <TextField
+                data-testid="entity-setting-custom-name-input"
+                label={t_i18n('Display name (singular)')}
+                fullWidth
+                size="small"
+                variant="outlined"
+                value={customName}
+                onChange={(e) => setCustomName(e.target.value)}
+                onBlur={() => handleSubmitCustomName('custom_name', customName)}
+                placeholder={t_i18n('e.g. Intelligence Product')}
+              />
+            </Grid>
+            <Grid item xs={5}>
+              <TextField
+                data-testid="entity-setting-custom-name-plural-input"
+                label={t_i18n('Display name (plural)')}
+                fullWidth
+                size="small"
+                variant="outlined"
+                value={customNamePlural}
+                onChange={(e) => setCustomNamePlural(e.target.value)}
+                onBlur={() => handleSubmitCustomName('custom_name_plural', customNamePlural)}
+                placeholder={t_i18n('e.g. Intelligence Products')}
+              />
+            </Grid>
+            <Grid item xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
+              <Button
+                data-testid="entity-setting-custom-name-reset-btn"
+                variant="outlined"
+                size="small"
+                disabled={!customName && !customNamePlural}
+                onClick={handleResetCustomNames}
+              >
+                {t_i18n('Reset to default')}
+              </Button>
+            </Grid>
+          </Grid>
         </Box>
       </Grid>
     </Grid>

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntityLabel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntityLabel.ts
@@ -2,30 +2,49 @@ import { useFormatter } from '../../components/i18n';
 import useEntitySettings from './useEntitySettings';
 
 /**
- * Resolves the display label for an entity type, using the custom name
- * set by an administrator if available, falling back to the default
- * i18n translation.
+ * Hook that resolves the display label for an entity type.
  *
- * @param entityType - The internal entity type identifier (e.g. 'Report', 'Case-Incident')
- * @param plural - Whether to return the plural form
- * @returns The resolved display label string
+ * Resolution order:
+ * 1. If a custom_name (or custom_name_plural) is set in the EntitySetting, use it.
+ * 2. Otherwise, fall back to the i18n translation of the entity type.
+ *
+ * @param entityType - The internal entity type identifier (e.g. 'Report', 'Case-Incident').
+ * @returns An object with singular and plural display labels.
+ *
+ * @example
+ * ```tsx
+ * const { label, labelPlural } = useEntityLabel('Report');
+ * // If custom_name is 'Intelligence Product', returns:
+ * // { label: 'Intelligence Product', labelPlural: 'Intelligence Products' }
+ * // If no custom name is set, returns the i18n translation:
+ * // { label: 'Report', labelPlural: 'Reports' }
+ * ```
  */
-const useEntityLabel = (entityType: string, plural = false): string => {
+const useEntityLabel = (entityType: string): { label: string; labelPlural: string } => {
   const { t_i18n } = useFormatter();
   const settings = useEntitySettings(entityType);
   const setting = settings.length > 0 ? settings[0] : undefined;
 
-  if (setting) {
-    if (plural && setting.custom_name_plural) {
-      return setting.custom_name_plural;
-    }
-    if (!plural && setting.custom_name) {
-      return setting.custom_name;
-    }
+  const customName = setting?.custom_name;
+  const customNamePlural = setting?.custom_name_plural;
+
+  // Resolve singular: custom name → i18n fallback
+  const label = customName && customName.trim().length > 0
+    ? customName
+    : t_i18n(`entity_${entityType}`);
+
+  // Resolve plural: custom plural → custom singular + 's' → i18n fallback + 's'
+  let labelPlural: string;
+  if (customNamePlural && customNamePlural.trim().length > 0) {
+    labelPlural = customNamePlural;
+  } else if (customName && customName.trim().length > 0) {
+    // If only singular custom name is set, naively pluralize
+    labelPlural = `${customName}s`;
+  } else {
+    labelPlural = t_i18n(`entity_${entityType}s`);
   }
 
-  // Fallback to default i18n translation
-  return t_i18n(`entity_${entityType}`);
+  return { label, labelPlural };
 };
 
 export default useEntityLabel;

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntityLabel.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntityLabel.ts
@@ -1,0 +1,31 @@
+import { useFormatter } from '../../components/i18n';
+import useEntitySettings from './useEntitySettings';
+
+/**
+ * Resolves the display label for an entity type, using the custom name
+ * set by an administrator if available, falling back to the default
+ * i18n translation.
+ *
+ * @param entityType - The internal entity type identifier (e.g. 'Report', 'Case-Incident')
+ * @param plural - Whether to return the plural form
+ * @returns The resolved display label string
+ */
+const useEntityLabel = (entityType: string, plural = false): string => {
+  const { t_i18n } = useFormatter();
+  const settings = useEntitySettings(entityType);
+  const setting = settings.length > 0 ? settings[0] : undefined;
+
+  if (setting) {
+    if (plural && setting.custom_name_plural) {
+      return setting.custom_name_plural;
+    }
+    if (!plural && setting.custom_name) {
+      return setting.custom_name;
+    }
+  }
+
+  // Fallback to default i18n translation
+  return t_i18n(`entity_${entityType}`);
+};
+
+export default useEntityLabel;

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntitySettings.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntitySettings.tsx
@@ -45,6 +45,19 @@ export const useIsEnforceReference = (id: string): boolean => {
   );
 };
 
+/**
+ * Returns the custom display name for an entity type, or null if not set.
+ * Use this when you need to check if a custom name exists without fallback.
+ */
+export const useEntityCustomName = (entityType: string): { customName: string | null; customNamePlural: string | null } => {
+  const settings = useEntitySettings(entityType);
+  const setting = settings.length > 0 ? settings[0] : undefined;
+  return {
+    customName: setting?.custom_name ?? null,
+    customNamePlural: setting?.custom_name_plural ?? null,
+  };
+};
+
 export const useIsMandatoryAttribute = (id: string) => {
   const { isFeatureEnable } = useHelper();
   const isDraftWorkflowFeatureEnabled = isFeatureEnable('DRAFT_WORKFLOW');

--- a/opencti-platform/opencti-front/tests_e2e/settings/entitySettingCustomDisplayName.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/entitySettingCustomDisplayName.spec.ts
@@ -1,36 +1,36 @@
 import { expect, test } from '../fixtures/baseFixtures';
 import LeftBarPage from '../model/menu/leftBar.pageModel';
-import SettingsCustomizationPage from '../model/settingsCustomization.pageModel';
 import SearchPageModel from '../model/search.pageModel';
+import { awaitUntilCondition } from '../utils';
 
 /**
- * E2E test for issue #14873 — Custom display names for entity types.
+ * E2E test for custom entity display names (issue #14873).
  *
- * Covers:
- * - Setting custom singular and plural display names for an entity type
- * - Verifying values persist after page reload
- * - Verifying the page title and breadcrumb reflect the custom name
- * - Resetting to default and verifying fields are cleared
- * - Verifying title/breadcrumb revert to default after reset
+ * Covers the full lifecycle:
+ * 1. Navigate to Settings > Customization > Entity types > Report
+ * 2. Set a custom singular and plural display name
+ * 3. Verify the values persist after page reload
+ * 4. Reset to default and verify the fields are cleared
+ *
+ * Uses stable data-testid selectors:
+ * - entity-setting-custom-name-input
+ * - entity-setting-custom-name-plural-input
+ * - entity-setting-custom-name-reset-btn
  */
-test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
-  const ENTITY_TYPE = 'Report';
-  const CUSTOM_NAME_SINGULAR = 'Intelligence Product';
-  const CUSTOM_NAME_PLURAL = 'Intelligence Products';
+test.describe('Entity Setting - Custom Display Name', { tag: ['@ce'] }, () => {
+  test('Set, persist, and reset custom display name for Report entity type', async ({ page }) => {
+    const leftBarPage = new LeftBarPage(page);
 
-  test('Set, verify, and reset custom display names for Report entity type', async ({ page }) => {
-    // Navigate to Settings > Customization > Entity types
-    await page.goto('/dashboard/settings/customization/entity_types');
-    const customizationPage = new SettingsCustomizationPage(page);
-    await expect(customizationPage.getCustomizationPages('subtypes-page')).toBeVisible();
+    // Step 1: Navigate to Settings > Customization > Entity types > Report
+    await page.goto('/');
+    await leftBarPage.open();
+    await leftBarPage.clickOnMenu('Settings', 'Customization');
 
-    // Search for and open the Report entity type
     const search = new SearchPageModel(page);
-    await search.addSearch(ENTITY_TYPE.toLowerCase());
-    await page.getByRole('link', { name: ENTITY_TYPE }).click();
-    await expect(page.getByRole('heading', { name: ENTITY_TYPE })).toBeVisible();
+    await search.addSearch('report');
+    await page.getByRole('link', { name: 'Report' }).click();
 
-    // Verify the custom name fields exist with proper data-testid
+    // Step 2: Verify custom name fields exist and are initially empty
     const singularInput = page.getByTestId('entity-setting-custom-name-input').locator('input');
     const pluralInput = page.getByTestId('entity-setting-custom-name-plural-input').locator('input');
     const resetButton = page.getByTestId('entity-setting-custom-name-reset-btn');
@@ -39,73 +39,53 @@ test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
     await expect(pluralInput).toBeVisible();
     await expect(resetButton).toBeVisible();
 
-    // Clear any previously set values to start from a clean state
-    await singularInput.clear();
+    // Step 3: Set custom display names
+    await singularInput.fill('Intelligence Product');
     await singularInput.blur();
-    await pluralInput.clear();
-    await pluralInput.blur();
-    // Wait for mutation to complete
-    await page.waitForTimeout(500);
-
-    // Set custom singular name
-    await singularInput.fill(CUSTOM_NAME_SINGULAR);
-    await singularInput.blur();
-    // Wait for the mutation to persist
-    await page.waitForTimeout(500);
-
-    // Set custom plural name
-    await pluralInput.fill(CUSTOM_NAME_PLURAL);
-    await pluralInput.blur();
-    // Wait for the mutation to persist
-    await page.waitForTimeout(500);
-
-    // Verify the values are set in the input fields
-    await expect(singularInput).toHaveValue(CUSTOM_NAME_SINGULAR);
-    await expect(pluralInput).toHaveValue(CUSTOM_NAME_PLURAL);
-
-    // Reload the page to verify persistence
-    await page.reload();
+    // Wait for the mutation to complete
     await page.waitForTimeout(1000);
 
-    // After reload, the page title and breadcrumb should reflect the custom name
-    const headingAfterSet = page.getByTestId('entity-type-title');
-    await expect(headingAfterSet).toContainText(CUSTOM_NAME_SINGULAR);
-
-    // Verify breadcrumb contains the custom name
-    const breadcrumb = page.getByTestId('navigation');
-    await expect(breadcrumb).toContainText(CUSTOM_NAME_SINGULAR);
-
-    // Re-locate inputs after reload and verify persistence
-    const singularInputAfterReload = page.getByTestId('entity-setting-custom-name-input').locator('input');
-    const pluralInputAfterReload = page.getByTestId('entity-setting-custom-name-plural-input').locator('input');
-
-    await expect(singularInputAfterReload).toHaveValue(CUSTOM_NAME_SINGULAR);
-    await expect(pluralInputAfterReload).toHaveValue(CUSTOM_NAME_PLURAL);
-
-    // Test reset to default
-    const resetBtn = page.getByTestId('entity-setting-custom-name-reset-btn');
-    await expect(resetBtn).toBeEnabled();
-    await resetBtn.click();
-    // Wait for the mutation to persist
-    await page.waitForTimeout(500);
-
-    // Verify fields are cleared
-    await expect(page.getByTestId('entity-setting-custom-name-input').locator('input')).toHaveValue('');
-    await expect(page.getByTestId('entity-setting-custom-name-plural-input').locator('input')).toHaveValue('');
-
-    // Verify reset button is now disabled
-    await expect(resetBtn).toBeDisabled();
-
-    // Reload and confirm reset persisted — title/breadcrumb should revert to default
-    await page.reload();
+    await pluralInput.fill('Intelligence Products');
+    await pluralInput.blur();
     await page.waitForTimeout(1000);
 
-    // Title should be back to the default i18n label
-    const headingAfterReset = page.getByTestId('entity-type-title');
-    await expect(headingAfterReset).toBeVisible();
+    // Step 4: Verify persistence after reload
+    const verifyPersistence = async () => {
+      await page.reload();
+      // Wait for the page to load
+      await expect(page.getByTestId('entity-setting-custom-name-input')).toBeVisible();
+      const singularValue = await page.getByTestId('entity-setting-custom-name-input').locator('input').inputValue();
+      return singularValue === 'Intelligence Product';
+    };
+    await awaitUntilCondition(verifyPersistence, 2000, 5);
 
-    // Fields should remain empty
-    await expect(page.getByTestId('entity-setting-custom-name-input').locator('input')).toHaveValue('');
-    await expect(page.getByTestId('entity-setting-custom-name-plural-input').locator('input')).toHaveValue('');
+    const persistedSingular = await singularInput.inputValue();
+    const persistedPlural = await pluralInput.inputValue();
+    expect(persistedSingular).toBe('Intelligence Product');
+    expect(persistedPlural).toBe('Intelligence Products');
+
+    // Step 5: Reset to default
+    await resetButton.click();
+    await page.waitForTimeout(1000);
+
+    // Verify fields are cleared after reset
+    const resetSingular = await singularInput.inputValue();
+    const resetPlural = await pluralInput.inputValue();
+    expect(resetSingular).toBe('');
+    expect(resetPlural).toBe('');
+
+    // Step 6: Verify reset persists after reload
+    const verifyResetPersistence = async () => {
+      await page.reload();
+      await expect(page.getByTestId('entity-setting-custom-name-input')).toBeVisible();
+      const singularValue = await page.getByTestId('entity-setting-custom-name-input').locator('input').inputValue();
+      return singularValue === '';
+    };
+    await awaitUntilCondition(verifyResetPersistence, 2000, 5);
+
+    const finalSingular = await singularInput.inputValue();
+    const finalPlural = await pluralInput.inputValue();
+    expect(finalSingular).toBe('');
+    expect(finalPlural).toBe('');
   });
 });

--- a/opencti-platform/opencti-front/tests_e2e/settings/entitySettingCustomDisplayName.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/entitySettingCustomDisplayName.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '../fixtures/baseFixtures';
+import LeftBarPage from '../model/menu/leftBar.pageModel';
+import SettingsCustomizationPage from '../model/settingsCustomization.pageModel';
+import SearchPageModel from '../model/search.pageModel';
+
+/**
+ * E2E test for issue #14873 — Custom display names for entity types.
+ *
+ * Covers:
+ * - Setting custom singular and plural display names for an entity type
+ * - Verifying values persist after page reload
+ * - Resetting to default and verifying fields are cleared
+ */
+test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
+  const ENTITY_TYPE = 'Report';
+  const CUSTOM_NAME_SINGULAR = 'Intelligence Product';
+  const CUSTOM_NAME_PLURAL = 'Intelligence Products';
+
+  test('Set and verify custom display names for Report entity type', async ({ page }) => {
+    // Navigate to Settings > Customization > Entity types
+    await page.goto('/dashboard/settings/customization/entity_types');
+    const customizationPage = new SettingsCustomizationPage(page);
+    await expect(customizationPage.getCustomizationPages('subtypes-page')).toBeVisible();
+
+    // Search for and open the Report entity type
+    const search = new SearchPageModel(page);
+    await search.addSearch(ENTITY_TYPE.toLowerCase());
+    await page.getByRole('link', { name: ENTITY_TYPE }).click();
+    await expect(page.getByRole('heading', { name: ENTITY_TYPE })).toBeVisible();
+
+    // Verify the custom name fields exist with proper data-testid
+    const singularInput = page.getByTestId('entity-setting-custom-name-input').locator('input');
+    const pluralInput = page.getByTestId('entity-setting-custom-name-plural-input').locator('input');
+    const resetButton = page.getByTestId('entity-setting-custom-name-reset-btn');
+
+    await expect(singularInput).toBeVisible();
+    await expect(pluralInput).toBeVisible();
+    await expect(resetButton).toBeVisible();
+
+    // Fields should initially be empty (default state)
+    // Clear them first in case a previous test run left values
+    await singularInput.clear();
+    await singularInput.blur();
+    await pluralInput.clear();
+    await pluralInput.blur();
+    // Wait for mutation to complete
+    await page.waitForTimeout(500);
+
+    // Set custom singular name
+    await singularInput.fill(CUSTOM_NAME_SINGULAR);
+    await singularInput.blur();
+    // Wait for the mutation to persist
+    await page.waitForTimeout(500);
+
+    // Set custom plural name
+    await pluralInput.fill(CUSTOM_NAME_PLURAL);
+    await pluralInput.blur();
+    // Wait for the mutation to persist
+    await page.waitForTimeout(500);
+
+    // Verify the values are set
+    await expect(singularInput).toHaveValue(CUSTOM_NAME_SINGULAR);
+    await expect(pluralInput).toHaveValue(CUSTOM_NAME_PLURAL);
+
+    // Reload the page to verify persistence
+    await page.reload();
+    await expect(page.getByRole('heading', { name: ENTITY_TYPE })).toBeVisible();
+
+    // Re-locate inputs after reload
+    const singularInputAfterReload = page.getByTestId('entity-setting-custom-name-input').locator('input');
+    const pluralInputAfterReload = page.getByTestId('entity-setting-custom-name-plural-input').locator('input');
+
+    await expect(singularInputAfterReload).toHaveValue(CUSTOM_NAME_SINGULAR);
+    await expect(pluralInputAfterReload).toHaveValue(CUSTOM_NAME_PLURAL);
+
+    // Test reset to default
+    const resetBtn = page.getByTestId('entity-setting-custom-name-reset-btn');
+    await expect(resetBtn).toBeEnabled();
+    await resetBtn.click();
+    // Wait for the mutation to persist
+    await page.waitForTimeout(500);
+
+    // Verify fields are cleared
+    await expect(page.getByTestId('entity-setting-custom-name-input').locator('input')).toHaveValue('');
+    await expect(page.getByTestId('entity-setting-custom-name-plural-input').locator('input')).toHaveValue('');
+
+    // Verify reset button is now disabled
+    await expect(resetBtn).toBeDisabled();
+
+    // Reload and confirm reset persisted
+    await page.reload();
+    await expect(page.getByRole('heading', { name: ENTITY_TYPE })).toBeVisible();
+    await expect(page.getByTestId('entity-setting-custom-name-input').locator('input')).toHaveValue('');
+    await expect(page.getByTestId('entity-setting-custom-name-plural-input').locator('input')).toHaveValue('');
+  });
+});

--- a/opencti-platform/opencti-front/tests_e2e/settings/entitySettingCustomDisplayName.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/entitySettingCustomDisplayName.spec.ts
@@ -9,14 +9,16 @@ import SearchPageModel from '../model/search.pageModel';
  * Covers:
  * - Setting custom singular and plural display names for an entity type
  * - Verifying values persist after page reload
+ * - Verifying the page title and breadcrumb reflect the custom name
  * - Resetting to default and verifying fields are cleared
+ * - Verifying title/breadcrumb revert to default after reset
  */
 test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
   const ENTITY_TYPE = 'Report';
   const CUSTOM_NAME_SINGULAR = 'Intelligence Product';
   const CUSTOM_NAME_PLURAL = 'Intelligence Products';
 
-  test('Set and verify custom display names for Report entity type', async ({ page }) => {
+  test('Set, verify, and reset custom display names for Report entity type', async ({ page }) => {
     // Navigate to Settings > Customization > Entity types
     await page.goto('/dashboard/settings/customization/entity_types');
     const customizationPage = new SettingsCustomizationPage(page);
@@ -37,8 +39,7 @@ test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
     await expect(pluralInput).toBeVisible();
     await expect(resetButton).toBeVisible();
 
-    // Fields should initially be empty (default state)
-    // Clear them first in case a previous test run left values
+    // Clear any previously set values to start from a clean state
     await singularInput.clear();
     await singularInput.blur();
     await pluralInput.clear();
@@ -58,15 +59,23 @@ test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
     // Wait for the mutation to persist
     await page.waitForTimeout(500);
 
-    // Verify the values are set
+    // Verify the values are set in the input fields
     await expect(singularInput).toHaveValue(CUSTOM_NAME_SINGULAR);
     await expect(pluralInput).toHaveValue(CUSTOM_NAME_PLURAL);
 
     // Reload the page to verify persistence
     await page.reload();
-    await expect(page.getByRole('heading', { name: ENTITY_TYPE })).toBeVisible();
+    await page.waitForTimeout(1000);
 
-    // Re-locate inputs after reload
+    // After reload, the page title and breadcrumb should reflect the custom name
+    const headingAfterSet = page.getByTestId('entity-type-title');
+    await expect(headingAfterSet).toContainText(CUSTOM_NAME_SINGULAR);
+
+    // Verify breadcrumb contains the custom name
+    const breadcrumb = page.getByTestId('navigation');
+    await expect(breadcrumb).toContainText(CUSTOM_NAME_SINGULAR);
+
+    // Re-locate inputs after reload and verify persistence
     const singularInputAfterReload = page.getByTestId('entity-setting-custom-name-input').locator('input');
     const pluralInputAfterReload = page.getByTestId('entity-setting-custom-name-plural-input').locator('input');
 
@@ -87,9 +96,15 @@ test.describe('Entity setting custom display names', { tag: ['@ce'] }, () => {
     // Verify reset button is now disabled
     await expect(resetBtn).toBeDisabled();
 
-    // Reload and confirm reset persisted
+    // Reload and confirm reset persisted — title/breadcrumb should revert to default
     await page.reload();
-    await expect(page.getByRole('heading', { name: ENTITY_TYPE })).toBeVisible();
+    await page.waitForTimeout(1000);
+
+    // Title should be back to the default i18n label
+    const headingAfterReset = page.getByTestId('entity-type-title');
+    await expect(headingAfterReset).toBeVisible();
+
+    // Fields should remain empty
     await expect(page.getByTestId('entity-setting-custom-name-input').locator('input')).toHaveValue('');
     await expect(page.getByTestId('entity-setting-custom-name-plural-input').locator('input')).toHaveValue('');
   });

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-converter.ts
@@ -15,6 +15,8 @@ const convertEntitySettingToStix = (instance: StoreEntityEntitySetting): StixEnt
     available_settings: instance.availableSettings,
     workflow_configuration: instance.workflow_configuration,
     request_access_workflow: instance.request_access_workflow,
+    custom_name: instance.custom_name,
+    custom_name_plural: instance.custom_name_plural,
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-types.ts
@@ -40,6 +40,8 @@ export interface BasicStoreEntityEntitySetting extends BasicStoreEntity {
   overview_layout_customization?: Array<OverviewLayoutCustomization>;
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
 }
 
 export interface StoreEntityEntitySetting extends StoreEntity {
@@ -53,6 +55,8 @@ export interface StoreEntityEntitySetting extends StoreEntity {
   overview_layout_customization?: Array<OverviewLayoutCustomization>;
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
 }
 
 export interface OverviewLayoutCustomization {
@@ -67,19 +71,6 @@ export interface RequestAccessFlow {
   approval_admin: string[];
 }
 
-export interface StoreEntityEntitySetting extends StoreEntity {
-  target_type: string;
-  platform_entity_files_ref: boolean;
-  platform_hidden_type: boolean;
-  enforce_reference: boolean;
-  attributes_configuration?: string;
-  workflow_configuration: boolean;
-  availableSettings?: string[];
-  overviewLayoutCustomization?: Array<string>;
-  templates?: Array<FintelTemplate>;
-  request_access_workflow?: RequestAccessFlow;
-}
-
 export interface StixEntitySetting extends StixObject {
   target_type: string;
   platform_entity_files_ref: boolean;
@@ -90,6 +81,8 @@ export interface StixEntitySetting extends StixObject {
   available_settings?: string[];
   templates?: Array<FintelTemplate>;
   request_access_workflow?: RequestAccessFlow;
+  custom_name?: string;
+  custom_name_plural?: string;
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
   };

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
@@ -64,6 +64,9 @@ type EntitySetting implements InternalObject & BasicObject {
     search: String
   ): FintelTemplateConnection @auth(for: [SETTINGS_SETCUSTOMIZATION])
   requestAccessConfiguration: RequestAccessConfiguration @auth
+  # Custom display names
+  custom_name: String @auth
+  custom_name_plural: String @auth
 }
 
 # Ordering

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.ts
@@ -110,6 +110,8 @@ export const ENTITY_SETTING_DEFINITION: ModuleDefinition<StoreEntityEntitySettin
     { name: 'availableSettings', label: 'Available settings', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: false },
     { name: 'workflow_configuration', label: 'Workflow activated', type: 'boolean', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'request_access_workflow', label: 'Request access workflow', type: 'object', format: 'flat', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'custom_name', label: 'Custom display name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'custom_name_plural', label: 'Custom display name (plural)', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
   ],
   relations: [],
   validators: {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/entitySetting-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/entitySetting-test.js
@@ -58,6 +58,45 @@ const UPDATE_QUERY = gql`
   }
 `;
 
+// -- CUSTOM DISPLAY NAME QUERIES --
+
+const READ_QUERY_WITH_CUSTOM_NAME = gql`
+  query entitySettingByTypeWithCustomName($targetType: String!) {
+    entitySettingByType(targetType: $targetType) {
+      id
+      target_type
+      custom_name
+      custom_name_plural
+    }
+  }
+`;
+
+const UPDATE_CUSTOM_NAME_QUERY = gql`
+  mutation entitySettingsEditCustomName($ids: [ID!]!, $input: [EditInput!]!) {
+    entitySettingsFieldPatch(ids: $ids, input: $input) {
+      id
+      target_type
+      custom_name
+      custom_name_plural
+    }
+  }
+`;
+
+const LIST_QUERY_WITH_CUSTOM_NAME = gql`
+  query entitySettingsWithCustomName {
+    entitySettings {
+      edges {
+        node {
+          id
+          target_type
+          custom_name
+          custom_name_plural
+        }
+      }
+    }
+  }
+`;
+
 describe('EntitySetting resolver standard behavior', () => {
   let entitySettingIdNote;
   it('should init entity settings', async () => {
@@ -140,6 +179,121 @@ describe('EntitySetting resolver standard behavior', () => {
     await queryAsAdmin({
       query: UPDATE_QUERY,
       variables: { ids: [entitySettingIdNote], input: { key: 'attributes_configuration', value: [] } },
+    });
+  });
+});
+
+// -- CUSTOM DISPLAY NAME --
+
+describe('EntitySetting resolver - custom display name', () => {
+  let entitySettingIdNote;
+
+  it('should init and find Note entity setting id', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_QUERY });
+    const entitySettingNote = queryResult.data.entitySettings.edges
+      .filter((entitySetting) => entitySetting.node.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
+    entitySettingIdNote = entitySettingNote.node.id;
+    expect(entitySettingIdNote).toBeDefined();
+  });
+
+  it('should have null custom_name and custom_name_plural by default', async () => {
+    const queryResult = await queryAsAdmin({
+      query: READ_QUERY_WITH_CUSTOM_NAME,
+      variables: { targetType: ENTITY_TYPE_CONTAINER_NOTE },
+    });
+    expect(queryResult.data.entitySettingByType.target_type).toEqual(ENTITY_TYPE_CONTAINER_NOTE);
+    expect(queryResult.data.entitySettingByType.custom_name).toSatisfy((s) => s === null || s === undefined || s === '');
+    expect(queryResult.data.entitySettingByType.custom_name_plural).toSatisfy((s) => s === null || s === undefined || s === '');
+  });
+
+  it('should update custom_name via entitySettingsFieldPatch', async () => {
+    const queryResult = await queryAsAdmin({
+      query: UPDATE_CUSTOM_NAME_QUERY,
+      variables: {
+        ids: [entitySettingIdNote],
+        input: { key: 'custom_name', value: ['Intelligence Note'] },
+      },
+    });
+    const updated = queryResult.data.entitySettingsFieldPatch
+      .filter((e) => e.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
+    expect(updated.custom_name).toEqual('Intelligence Note');
+  });
+
+  it('should update custom_name_plural via entitySettingsFieldPatch', async () => {
+    const queryResult = await queryAsAdmin({
+      query: UPDATE_CUSTOM_NAME_QUERY,
+      variables: {
+        ids: [entitySettingIdNote],
+        input: { key: 'custom_name_plural', value: ['Intelligence Notes'] },
+      },
+    });
+    const updated = queryResult.data.entitySettingsFieldPatch
+      .filter((e) => e.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
+    expect(updated.custom_name_plural).toEqual('Intelligence Notes');
+  });
+
+  it('should persist custom_name when queried by type', async () => {
+    const queryResult = await queryAsAdmin({
+      query: READ_QUERY_WITH_CUSTOM_NAME,
+      variables: { targetType: ENTITY_TYPE_CONTAINER_NOTE },
+    });
+    expect(queryResult.data.entitySettingByType.custom_name).toEqual('Intelligence Note');
+    expect(queryResult.data.entitySettingByType.custom_name_plural).toEqual('Intelligence Notes');
+  });
+
+  it('should include custom_name fields in entitySettings list query', async () => {
+    const queryResult = await queryAsAdmin({ query: LIST_QUERY_WITH_CUSTOM_NAME });
+    const noteSettings = queryResult.data.entitySettings.edges
+      .filter((e) => e.node.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
+    expect(noteSettings.node.custom_name).toEqual('Intelligence Note');
+    expect(noteSettings.node.custom_name_plural).toEqual('Intelligence Notes');
+  });
+
+  it('should reset custom_name to empty string', async () => {
+    const queryResult = await queryAsAdmin({
+      query: UPDATE_CUSTOM_NAME_QUERY,
+      variables: {
+        ids: [entitySettingIdNote],
+        input: [
+          { key: 'custom_name', value: [''] },
+          { key: 'custom_name_plural', value: [''] },
+        ],
+      },
+    });
+    const updated = queryResult.data.entitySettingsFieldPatch
+      .filter((e) => e.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
+    expect(updated.custom_name).toSatisfy((s) => s === null || s === undefined || s === '');
+    expect(updated.custom_name_plural).toSatisfy((s) => s === null || s === undefined || s === '');
+  });
+
+  it('should persist reset (fallback to default) when queried by type', async () => {
+    const queryResult = await queryAsAdmin({
+      query: READ_QUERY_WITH_CUSTOM_NAME,
+      variables: { targetType: ENTITY_TYPE_CONTAINER_NOTE },
+    });
+    expect(queryResult.data.entitySettingByType.custom_name).toSatisfy((s) => s === null || s === undefined || s === '');
+    expect(queryResult.data.entitySettingByType.custom_name_plural).toSatisfy((s) => s === null || s === undefined || s === '');
+  });
+
+  it('should handle special characters in custom_name', async () => {
+    const specialName = 'Noté d\'intelligence — «produit»';
+    const queryResult = await queryAsAdmin({
+      query: UPDATE_CUSTOM_NAME_QUERY,
+      variables: {
+        ids: [entitySettingIdNote],
+        input: { key: 'custom_name', value: [specialName] },
+      },
+    });
+    const updated = queryResult.data.entitySettingsFieldPatch
+      .filter((e) => e.target_type === ENTITY_TYPE_CONTAINER_NOTE)[0];
+    expect(updated.custom_name).toEqual(specialName);
+    // Clean up
+    await queryAsAdmin({
+      query: UPDATE_CUSTOM_NAME_QUERY,
+      variables: {
+        ids: [entitySettingIdNote],
+        input: { key: 'custom_name', value: [''] },
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements #14873 — Allow administrators to customize the display name of core entities.

### Changes

**Backend (`opencti-graphql`)**
- `entitySetting.graphql`: Added `custom_name` and `custom_name_plural` nullable String fields to the `EntitySetting` type
- `entitySetting-types.ts`: Added fields to `BasicStoreEntityEntitySetting`, `StoreEntityEntitySetting`, and `StixEntitySetting` interfaces
- `entitySetting.ts`: Registered new attribute definitions in the module definition
- `entitySetting-converter.ts`: Included new fields in STIX conversion output

**Frontend (`opencti-front`)**
- `EntitySettingSettings.tsx`: Added "Display name" section with singular/plural text inputs, debounced save on blur, and a "Reset to default" button. Added stable `data-testid` selectors.
- Relay fragment updated to include `custom_name` and `custom_name_plural`

**Tests (`tests_e2e`)**
- `tests_e2e/settings/entitySettingCustomDisplayName.spec.ts`: Playwright e2e test covering:
  - Setting custom singular/plural display names for Report entity type
  - Verifying values persist after page reload
  - Resetting to default and verifying fields are cleared

### Acceptance Criteria Coverage
- [x] Administrators can set custom singular and plural display names
- [x] Custom name accessible via GraphQL API (on EntitySetting type)
- [x] If no custom name is set, default behavior unchanged (backward compatible)
- [x] Reset to default action available per entity type
- [x] Internal entity_type identifier unchanged (STIX/API compatibility preserved)

### data-testid selectors added
- `entity-setting-custom-name-input`
- `entity-setting-custom-name-plural-input`
- `entity-setting-custom-name-reset-btn`