### PR TITLE
[backend] Improve platform startup and shutdown time (#14898)

### DIFF
--- a/opencti-platform/opencti-graphql/src/boot.js
+++ b/opencti-platform/opencti-graphql/src/boot.js
@@ -7,6 +7,7 @@ import { initLockFork } from './lock/master-lock';
 
 // region platform start and stop
 export const platformStart = async () => {
+  const startTime = Date.now();
   logApp.info('[OPENCTI] Starting platform', { environment });
   try {
     checkFeatureFlags();
@@ -45,6 +46,7 @@ export const platformStart = async () => {
       logApp.error('[OPENCTI] Modules startup failed', { cause: modulesError });
       throw modulesError;
     }
+    logApp.info(`[OPENCTI] Platform started ${Date.now() - startTime} ms`);
   } catch (_mainError) {
     process.exit(1);
   }

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -503,18 +503,21 @@ export const initializeData = async (context, withMarkings = true) => {
       },
     },
   });
+
+  // Run independent initialization operations in parallel
   await initCreateEntitySettings(context, SYSTEM_USER);
-  await initManagerConfigurations(context, SYSTEM_USER);
-  await initDecayRules(context, SYSTEM_USER);
-  await createDefaultStatusTemplates(context);
-  await createInitialRequestAccessFlow(context);
-  await createBasicRolesAndCapabilities(context);
-  await createVocabularies(context);
-  await addEmailTemplate(context, SYSTEM_USER, DEFAULT_EMAIL_TEMPLATE_INPUT, false);
-  await createDefaultRetentionRules(context);
-  if (withMarkings) {
-    await createMarkingDefinitions(context);
-  }
+  await Promise.all([
+    initManagerConfigurations(context, SYSTEM_USER),
+    initDecayRules(context, SYSTEM_USER),
+    createDefaultStatusTemplates(context),
+    createInitialRequestAccessFlow(context),
+    createBasicRolesAndCapabilities(context),
+    createVocabularies(context),
+    addEmailTemplate(context, SYSTEM_USER, DEFAULT_EMAIL_TEMPLATE_INPUT, false),
+    createDefaultRetentionRules(context),
+    withMarkings ? createMarkingDefinitions(context) : Promise.resolve(),
+  ]);
+
   logApp.info('[INIT] Platform default initialized');
   return true;
 };

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -503,21 +503,18 @@ export const initializeData = async (context, withMarkings = true) => {
       },
     },
   });
-
-  // Run independent initialization operations in parallel
   await initCreateEntitySettings(context, SYSTEM_USER);
-  await Promise.all([
-    initManagerConfigurations(context, SYSTEM_USER),
-    initDecayRules(context, SYSTEM_USER),
-    createDefaultStatusTemplates(context),
-    createInitialRequestAccessFlow(context),
-    createBasicRolesAndCapabilities(context),
-    createVocabularies(context),
-    addEmailTemplate(context, SYSTEM_USER, DEFAULT_EMAIL_TEMPLATE_INPUT, false),
-    createDefaultRetentionRules(context),
-    withMarkings ? createMarkingDefinitions(context) : Promise.resolve(),
-  ]);
-
+  await initManagerConfigurations(context, SYSTEM_USER);
+  await initDecayRules(context, SYSTEM_USER);
+  await createDefaultStatusTemplates(context);
+  await createInitialRequestAccessFlow(context);
+  await createBasicRolesAndCapabilities(context);
+  await createVocabularies(context);
+  await addEmailTemplate(context, SYSTEM_USER, DEFAULT_EMAIL_TEMPLATE_INPUT, false);
+  await createDefaultRetentionRules(context);
+  if (withMarkings) {
+    await createMarkingDefinitions(context);
+  }
   logApp.info('[INIT] Platform default initialized');
   return true;
 };

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -403,6 +403,7 @@ export const searchEngineVersion = async () => {
 };
 
 export const searchEngineInit = async (): Promise<boolean> => {
+  logApp.info('[CHECK] Checking if Search engine is available');
   // Build the engine configuration
   const ca = conf.get('elasticsearch:ssl:ca')
     ? loadCert(conf.get('elasticsearch:ssl:ca'))
@@ -481,7 +482,7 @@ export const searchEngineInit = async (): Promise<boolean> => {
   const runtimeStatus = isRuntimeSortingEnable ? 'enabled' : 'disabled';
   // configure attachment processor
   attachmentProcessorEnabled = await elConfigureAttachmentProcessor();
-  logApp.info(`[SEARCH] ${enginePlatform} (${engineVersion}) client selected / runtime sorting ${runtimeStatus} / attachment processor ${attachmentProcessorEnabled ? 'enabled' : 'disabled'}`);
+  logApp.info(`[SEARCH][CHECK] Search Engine is alive. ${enginePlatform} (${engineVersion}) client selected / runtime sorting ${runtimeStatus} / attachment processor ${attachmentProcessorEnabled ? 'enabled' : 'disabled'}`);
   // Everything is fine, return true
   return true;
 };

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -675,7 +675,8 @@ export const unregisterExchanges = async () => {
 };
 
 export const rabbitMQIsAlive = async () => {
-  return amqpExecute(async (channel) => {
+  logApp.info('[CHECK] Checking if RabbitMq is available');
+  const assertExchangeResult = amqpExecute(async (channel) => {
     const assertExchange = util.promisify(channel.assertExchange).bind(channel);
     return assertExchange(CONNECTOR_EXCHANGE, 'direct', { durable: true });
   }).catch(
@@ -683,6 +684,8 @@ export const rabbitMQIsAlive = async () => {
       throw DatabaseError('RabbitMQ seems down', { cause: e });
     },
   );
+  logApp.info('[CHECK] RabbitMq is alive');
+  return assertExchangeResult;
 };
 
 export const pushToWorkerForConnector = (connectorId, message) => {

--- a/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
@@ -118,8 +118,10 @@ export const deleteBucket = async () => {
 };
 
 export const storageInit = async () => {
+  logApp.info('[CHECK] Checking if Storage is available');
   await initializeFileStorageClient();
   await initializeBucket();
+  logApp.info('[CHECK] Storage is alive');
 };
 
 export const isStorageAlive = () => initializeBucket();

--- a/opencti-platform/opencti-graphql/src/database/redis-stream.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis-stream.ts
@@ -126,10 +126,14 @@ const rawCreateStreamProcessor = <T extends BaseEvent> (
         await processStreamResult([], callback, opts.withInternal);
       }
       const bufferTime = opts.bufferTime ?? 50;
-      if (bufferTime > 0) {
+      if (bufferTime > 0 && streamListening) {
         await wait(bufferTime);
       }
     } catch (err) {
+      // During shutdown, connection errors are expected (client is disconnected to cancel blocking XREAD)
+      if (!streamListening) {
+        return false;
+      }
       logApp.error('Redis stream consume fail', { cause: err, provider });
       if (opts.autoReconnect) {
         await waitInSec(5);
@@ -172,6 +176,10 @@ const rawCreateStreamProcessor = <T extends BaseEvent> (
     shutdown: async () => {
       logApp.info('[STREAM] Shutdown stream processor', { provider });
       streamListening = false;
+      // Disconnect the Redis client to immediately cancel any blocking XREAD
+      if (client) {
+        client.disconnect();
+      }
       if (processingLoopPromise) {
         await processingLoopPromise;
       }

--- a/opencti-platform/opencti-graphql/src/database/redis-stream.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis-stream.ts
@@ -175,7 +175,7 @@ const rawCreateStreamProcessor = <T extends BaseEvent> (
       if (processingLoopPromise) {
         await processingLoopPromise;
       }
-      logApp.info('[STREAM] Stream processor current promise terminated');
+      logApp.info('[STREAM] Stream processor current promise terminated', { provider });
     },
   };
 };

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -309,11 +309,12 @@ export const redisIsAlive = async () => {
   }
 };
 export const redisInit = async () => {
+  logApp.info('[CHECK] Checking if Search engine is available');
   try {
     await initializeRedisClients();
     await redisIsAlive();
     const redisMode: string = conf.get('redis:mode');
-    logApp.info('[REDIS] Clients initialized', { redisMode });
+    logApp.info('[REDIS] Clients initialized, Redis is alive', { redisMode });
     return true;
   } catch {
     throw DatabaseError('Redis seems down');

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -46,12 +46,16 @@ export const smtpComputeFrom = async (from) => {
 };
 
 export const smtpIsAlive = async () => {
+  logApp.info('[CHECK] Checking if SMTP is available');
   if (SMTP_ENABLE) {
     try {
       await transporter.verify();
+      logApp.info('[CHECK] SMTP is alive');
     } catch {
       logApp.warn('SMTP seems down, email notification may not work');
     }
+  } else {
+    logApp.info('[CHECK] SMTP disabled by configuration');
   }
   return true;
 };

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -40,24 +40,14 @@ export const checkFeatureFlags = () => {
 export const checkSystemDependencies = async () => {
   logApp.info('[OPENCTI] Checking dependencies statuses');
   const context = executionContext('system_dependencies');
-
-  // Run checks sequentially to stop startup immediately on first failure.
-  const checks = [
-    { dependencyName: 'Search engine', run: () => searchEngineInit() },
-    { dependencyName: 'File storage', run: () => storageInit() },
-    { dependencyName: 'RabbitMQ', run: () => rabbitMQIsAlive() },
-    { dependencyName: 'Redis', run: () => redisInit() },
-    { dependencyName: 'SMTP', run: () => smtpIsAlive() },
-    { dependencyName: 'Python3', run: () => checkPythonAvailability(context, SYSTEM_USER) },
-  ];
-
-  for (const check of checks) {
-    logApp.info(`[CHECK] checking if ${check.dependencyName} is alive`);
-    await check.run();
-    logApp.info(`[CHECK] ${check.dependencyName} is alive`);
-  }
-
-  logApp.info('[CHECK] All dependencies are alive');
+  const checkDependenciesPromises = [];
+  checkDependenciesPromises.push(searchEngineInit());
+  checkDependenciesPromises.push(storageInit());
+  checkDependenciesPromises.push(rabbitMQIsAlive());
+  checkDependenciesPromises.push(redisInit());
+  checkDependenciesPromises.push(smtpIsAlive());
+  checkDependenciesPromises.push(checkPythonAvailability(context, SYSTEM_USER));
+  await Promise.all(checkDependenciesPromises);
   return true;
 };
 

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -43,18 +43,18 @@ export const checkSystemDependencies = async () => {
 
   // Run checks sequentially to stop startup immediately on first failure.
   const checks = [
-    { label: 'Search engine', run: () => searchEngineInit() },
-    { label: 'File storage', run: () => storageInit() },
-    { label: 'RabbitMQ', run: () => rabbitMQIsAlive() },
-    { label: 'Redis', run: () => redisInit() },
-    { label: 'SMTP', run: () => smtpIsAlive() },
-    { label: 'Python3', run: () => checkPythonAvailability(context, SYSTEM_USER) },
+    { dependencyName: 'Search engine', run: () => searchEngineInit() },
+    { dependencyName: 'File storage', run: () => storageInit() },
+    { dependencyName: 'RabbitMQ', run: () => rabbitMQIsAlive() },
+    { dependencyName: 'Redis', run: () => redisInit() },
+    { dependencyName: 'SMTP', run: () => smtpIsAlive() },
+    { dependencyName: 'Python3', run: () => checkPythonAvailability(context, SYSTEM_USER) },
   ];
 
   for (const check of checks) {
-    logApp.info(`[CHECK] checking if ${check.label} is alive`);
+    logApp.info(`[CHECK] checking if ${check.dependencyName} is alive`);
     await check.run();
-    logApp.info(`[CHECK] ${check.label} is alive`);
+    logApp.info(`[CHECK] ${check.dependencyName} is alive`);
   }
 
   logApp.info('[CHECK] All dependencies are alive');

--- a/opencti-platform/opencti-graphql/src/initialization.js
+++ b/opencti-platform/opencti-graphql/src/initialization.js
@@ -39,26 +39,25 @@ export const checkFeatureFlags = () => {
 // Check every dependency
 export const checkSystemDependencies = async () => {
   logApp.info('[OPENCTI] Checking dependencies statuses');
-  // Check if elasticsearch is available
-  logApp.info('[CHECK] checking if Search engine is alive');
-  await searchEngineInit();
-  // Check if minio is here
-  logApp.info('[CHECK] Search engine ok, checking if File storage is alive');
-  await storageInit();
-  // Check if RabbitMQ is here and create the logs exchange/queue
-  logApp.info('[CHECK] File storage ok, checking if RabbitMQ is alive');
-  await rabbitMQIsAlive();
-  logApp.info('[CHECK] RabbitMQ ok, checking if Redis is alive');
-  // Check if redis is here
-  await redisInit();
-  logApp.info('[CHECK] Redis ok, checking if SMTP is alive');
-  // Check if SMTP is here
-  await smtpIsAlive();
-  // Check if Python is available
-  logApp.info('[CHECK] SMTP done, checking if python is available');
   const context = executionContext('system_dependencies');
-  await checkPythonAvailability(context, SYSTEM_USER);
-  logApp.info('[CHECK] Python3 is available');
+
+  // Run checks sequentially to stop startup immediately on first failure.
+  const checks = [
+    { label: 'Search engine', run: () => searchEngineInit() },
+    { label: 'File storage', run: () => storageInit() },
+    { label: 'RabbitMQ', run: () => rabbitMQIsAlive() },
+    { label: 'Redis', run: () => redisInit() },
+    { label: 'SMTP', run: () => smtpIsAlive() },
+    { label: 'Python3', run: () => checkPythonAvailability(context, SYSTEM_USER) },
+  ];
+
+  for (const check of checks) {
+    logApp.info(`[CHECK] checking if ${check.label} is alive`);
+    await check.run();
+    logApp.info(`[CHECK] ${check.label} is alive`);
+  }
+
+  logApp.info('[CHECK] All dependencies are alive');
   return true;
 };
 

--- a/opencti-platform/opencti-graphql/src/manager/activityManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityManager.ts
@@ -37,6 +37,7 @@ import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import { lockResources } from '../lock/master-lock';
 import { ACTIVITY_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const ACTIVITY_ENGINE_KEY = conf.get('activity_manager:lock_key');
 const SCHEDULE_TIME = 10000;
@@ -147,20 +148,7 @@ const initActivityManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  let wakeWait: (() => void) | null = null;
-  const waitOrShutdown = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWait = null;
-        resolve();
-      }, ms);
-      wakeWait = () => {
-        clearTimeout(timer);
-        wakeWait = null;
-        resolve();
-      };
-    });
-  };
+  const waitTimer = new SkippableTimer();
   const activityHandler = async (lastEventId: string) => {
     let lock;
     try {
@@ -173,7 +161,7 @@ const initActivityManager = () => {
       await streamProcessor.start(lastEventId);
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await waitOrShutdown(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of Activity manager processing');
     } catch (e: any) {
@@ -227,7 +215,7 @@ const initActivityManager = () => {
       const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping activity manager');
       shutdown = true;
-      wakeWait?.();
+      waitTimer.skip();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/activityManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityManager.ts
@@ -37,7 +37,7 @@ import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import { lockResources } from '../lock/master-lock';
 import { ACTIVITY_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const ACTIVITY_ENGINE_KEY = conf.get('activity_manager:lock_key');
 const SCHEDULE_TIME = 10000;
@@ -148,7 +148,7 @@ const initActivityManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const waitTimer = new SkippableTimer();
+  const waitTimer = new InterruptibleTimer();
   const activityHandler = async (lastEventId: string) => {
     let lock;
     try {
@@ -215,7 +215,7 @@ const initActivityManager = () => {
       const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping activity manager');
       shutdown = true;
-      waitTimer.skip();
+      waitTimer.interrupt();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/activityManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityManager.ts
@@ -147,9 +147,18 @@ const initActivityManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
+  let wakeWait: (() => void) | null = null;
+  const waitOrShutdown = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWait = null;
+        resolve();
+      }, ms);
+      wakeWait = () => {
+        clearTimeout(timer);
+        wakeWait = null;
+        resolve();
+      };
     });
   };
   const activityHandler = async (lastEventId: string) => {
@@ -164,7 +173,7 @@ const initActivityManager = () => {
       await streamProcessor.start(lastEventId);
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitOrShutdown(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of Activity manager processing');
     } catch (e: any) {
@@ -215,11 +224,14 @@ const initActivityManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping activity manager');
       shutdown = true;
+      wakeWait?.();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Activity manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -383,6 +383,7 @@ const initCacheManager = () => {
       logApp.info('[OPENCTI-MODULE] Cache manager pub sub listener initialized');
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping cache manager');
       try {
         subscribeAdd.unsubscribe();
@@ -393,6 +394,7 @@ const initCacheManager = () => {
       try {
         subscribeDelete.unsubscribe();
       } catch { /* dont care */ }
+      logApp.info(`[OPENCTI-MODULE] Cache manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
@@ -54,10 +54,12 @@ const initClusterManager = () => {
       }, SCHEDULE_TIME);
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping cluster manager');
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Cluster manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -39,6 +39,7 @@ import { allFilesForPaths, getIndexFromDate } from '../modules/internal/document
 import { buildOptionsFromFileManager } from '../domain/file';
 import { internalLoadById } from '../database/middleware-loader';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const FILE_INDEX_MANAGER_KEY = conf.get('file_index_manager:lock_key');
 const SCHEDULE_TIME = conf.get('file_index_manager:interval') || 60000; // 1 minute
@@ -143,20 +144,7 @@ const initFileIndexManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  let wakeWait: (() => void) | null = null;
-  const waitOrShutdown = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWait = null;
-        resolve();
-      }, ms);
-      wakeWait = () => {
-        clearTimeout(timer);
-        wakeWait = null;
-        resolve();
-      };
-    });
-  };
+  const waitTimer = new SkippableTimer();
   const fileIndexHandler = async () => {
     const context = executionContext(FILE_INDEX_MANAGER_NAME);
     const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
@@ -203,7 +191,7 @@ const initFileIndexManager = () => {
         await streamProcessor.start(lastEventState ?? 'live');
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
-          await waitOrShutdown(WAIT_TIME_ACTION);
+          await waitTimer.start(WAIT_TIME_ACTION);
         }
         logApp.info('[OPENCTI-MODULE] End of file index manager stream handler');
       } catch (e: any) {
@@ -241,7 +229,7 @@ const initFileIndexManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping file index manager');
       shutdown = true;
-      wakeWait?.();
+      waitTimer.skip();
       if (scheduler) await clearIntervalAsync(scheduler);
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -39,7 +39,7 @@ import { allFilesForPaths, getIndexFromDate } from '../modules/internal/document
 import { buildOptionsFromFileManager } from '../domain/file';
 import { internalLoadById } from '../database/middleware-loader';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const FILE_INDEX_MANAGER_KEY = conf.get('file_index_manager:lock_key');
 const SCHEDULE_TIME = conf.get('file_index_manager:interval') || 60000; // 1 minute
@@ -144,7 +144,7 @@ const initFileIndexManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const waitTimer = new SkippableTimer();
+  const waitTimer = new InterruptibleTimer();
   const fileIndexHandler = async () => {
     const context = executionContext(FILE_INDEX_MANAGER_NAME);
     const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
@@ -229,7 +229,7 @@ const initFileIndexManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping file index manager');
       shutdown = true;
-      waitTimer.skip();
+      waitTimer.interrupt();
       if (scheduler) await clearIntervalAsync(scheduler);
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -143,9 +143,18 @@ const initFileIndexManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
+  let wakeWait: (() => void) | null = null;
+  const waitOrShutdown = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWait = null;
+        resolve();
+      }, ms);
+      wakeWait = () => {
+        clearTimeout(timer);
+        wakeWait = null;
+        resolve();
+      };
     });
   };
   const fileIndexHandler = async () => {
@@ -194,7 +203,7 @@ const initFileIndexManager = () => {
         await streamProcessor.start(lastEventState ?? 'live');
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
-          await wait(WAIT_TIME_ACTION);
+          await waitOrShutdown(WAIT_TIME_ACTION);
         }
         logApp.info('[OPENCTI-MODULE] End of file index manager stream handler');
       } catch (e: any) {
@@ -232,6 +241,7 @@ const initFileIndexManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping file index manager');
       shutdown = true;
+      wakeWait?.();
       if (scheduler) await clearIntervalAsync(scheduler);
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -28,6 +28,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organ
 import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
 import { RELATION_IN_PIR } from '../schema/internalRelationship';
 import { pushAll } from '../utils/arrayUtil';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const HISTORY_ENGINE_KEY = conf.get('history_manager:lock_key');
 const HISTORY_WITH_INFERENCES = booleanConf('history_manager:include_inferences', false);
@@ -283,20 +284,7 @@ const initHistoryManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  let wakeWait: (() => void) | null = null;
-  const waitOrShutdown = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWait = null;
-        resolve();
-      }, ms);
-      wakeWait = () => {
-        clearTimeout(timer);
-        wakeWait = null;
-        resolve();
-      };
-    });
-  };
+  const waitTimer = new SkippableTimer();
   const historyHandler = async (lastEventId: string) => {
     let lock;
     try {
@@ -308,7 +296,7 @@ const initHistoryManager = () => {
       await streamProcessor.start(lastEventId);
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await waitOrShutdown(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of history manager processing');
     } catch (e: any) {
@@ -360,7 +348,7 @@ const initHistoryManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping history manager');
       shutdown = true;
-      wakeWait?.();
+      waitTimer.skip();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -283,9 +283,18 @@ const initHistoryManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
+  let wakeWait: (() => void) | null = null;
+  const waitOrShutdown = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWait = null;
+        resolve();
+      }, ms);
+      wakeWait = () => {
+        clearTimeout(timer);
+        wakeWait = null;
+        resolve();
+      };
     });
   };
   const historyHandler = async (lastEventId: string) => {
@@ -299,7 +308,7 @@ const initHistoryManager = () => {
       await streamProcessor.start(lastEventId);
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitOrShutdown(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of history manager processing');
     } catch (e: any) {
@@ -351,6 +360,7 @@ const initHistoryManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping history manager');
       shutdown = true;
+      wakeWait?.();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -28,7 +28,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organ
 import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
 import { RELATION_IN_PIR } from '../schema/internalRelationship';
 import { pushAll } from '../utils/arrayUtil';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const HISTORY_ENGINE_KEY = conf.get('history_manager:lock_key');
 const HISTORY_WITH_INFERENCES = booleanConf('history_manager:include_inferences', false);
@@ -284,7 +284,7 @@ const initHistoryManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const waitTimer = new SkippableTimer();
+  const waitTimer = new InterruptibleTimer();
   const historyHandler = async (lastEventId: string) => {
     let lock;
     try {
@@ -348,7 +348,7 @@ const initHistoryManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping history manager');
       shutdown = true;
-      waitTimer.skip();
+      waitTimer.interrupt();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/interruptible-timer.ts
+++ b/opencti-platform/opencti-graphql/src/manager/interruptible-timer.ts
@@ -1,18 +1,18 @@
 /**
- * A timer that can be skipped early, resolving the promise immediately.
+ * A timer that can be interrupted, resolving the promise immediately.
  * Used in manager loops to allow clean shutdown without waiting for the full delay.
  *
  * Usage:
- *   const timer = new SkippableTimer();
+ *   const timer = new InterruptibleTimer();
  *   await timer.start(5_000); // waits up to 5 seconds
- *   timer.skip(); // resolves immediately from another context
+ *   timer.interrupt(); // resolves immediately from another context
  */
-export class SkippableTimer {
+export class InterruptibleTimer {
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   private resolve: (() => void) | null = null;
 
-  skip() {
+  interrupt() {
     if (this.timeoutId) {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -10,6 +10,7 @@ import { TYPE_LOCK_ERROR } from '../config/errors';
 import { utcDate } from '../utils/format';
 import type { DataEvent, SseEvent } from '../types/event';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 export interface HandlerInput {
   shutdown?: () => Promise<void>;
@@ -55,35 +56,8 @@ const initManager = (manager: ManagerDefinition) => {
   let running = false;
   let shutdown = false;
 
-  let wakeWaitCron: (() => void) | null = null;
-  const waitOrShutdownCron = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWaitCron = null;
-        resolve();
-      }, ms);
-      wakeWaitCron = () => {
-        clearTimeout(timer);
-        wakeWaitCron = null;
-        resolve();
-      };
-    });
-  };
-
-  let wakeWaitStream: (() => void) | null = null;
-  const waitOrShutdownStream = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWaitStream = null;
-        resolve();
-      }, ms);
-      wakeWaitStream = () => {
-        clearTimeout(timer);
-        wakeWaitStream = null;
-        resolve();
-      };
-    });
-  };
+  const cronTimer = new SkippableTimer();
+  const streamTimer = new SkippableTimer();
 
   const cronHandler = async (cronInputFn?: () => Promise<HandlerInput>) => {
     if (manager.cronSchedulerHandler) {
@@ -100,7 +74,7 @@ const initManager = (manager: ManagerDefinition) => {
           logApp.info(`[OPENCTI-MODULE] Running ${manager.label} infinite cron handler`);
           while (!shutdown) {
             await manager.cronSchedulerHandler.handler(cronInput);
-            await waitOrShutdownCron(manager.cronSchedulerHandler.infiniteInterval);
+            await cronTimer.start(manager.cronSchedulerHandler.infiniteInterval);
           }
         } else if (manager.cronSchedulerHandler.lockInHandlerParams) {
           await manager.cronSchedulerHandler.handler(lock);
@@ -138,7 +112,7 @@ const initManager = (manager: ManagerDefinition) => {
         await streamProcessor.start(startFrom);
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
-          await waitOrShutdownStream(WAIT_TIME_ACTION);
+          await streamTimer.start(WAIT_TIME_ACTION);
         }
         logApp.info(`[OPENCTI-MODULE] End of ${manager.label} stream handler`);
       } catch (e: any) {
@@ -186,8 +160,8 @@ const initManager = (manager: ManagerDefinition) => {
       const startTime = new Date().getTime();
       logApp.info(`[OPENCTI-MODULE] Stopping ${manager.label}`);
       shutdown = true;
-      wakeWaitCron?.();
-      wakeWaitStream?.();
+      cronTimer.skip();
+      streamTimer.skip();
       if (scheduler) {
         if (manager.cronSchedulerHandler?.shutdown) {
           manager.cronSchedulerHandler?.shutdown();

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -10,7 +10,7 @@ import { TYPE_LOCK_ERROR } from '../config/errors';
 import { utcDate } from '../utils/format';
 import type { DataEvent, SseEvent } from '../types/event';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 export interface HandlerInput {
   shutdown?: () => Promise<void>;
@@ -56,8 +56,8 @@ const initManager = (manager: ManagerDefinition) => {
   let running = false;
   let shutdown = false;
 
-  const cronTimer = new SkippableTimer();
-  const streamTimer = new SkippableTimer();
+  const cronTimer = new InterruptibleTimer();
+  const streamTimer = new InterruptibleTimer();
 
   const cronHandler = async (cronInputFn?: () => Promise<HandlerInput>) => {
     if (manager.cronSchedulerHandler) {
@@ -160,8 +160,8 @@ const initManager = (manager: ManagerDefinition) => {
       const startTime = new Date().getTime();
       logApp.info(`[OPENCTI-MODULE] Stopping ${manager.label}`);
       shutdown = true;
-      cronTimer.skip();
-      streamTimer.skip();
+      cronTimer.interrupt();
+      streamTimer.interrupt();
       if (scheduler) {
         if (manager.cronSchedulerHandler?.shutdown) {
           manager.cronSchedulerHandler?.shutdown();

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -8,7 +8,6 @@ import type { BasicStoreSettings } from '../types/settings';
 import { logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { utcDate } from '../utils/format';
-import { wait } from '../database/utils';
 import type { DataEvent, SseEvent } from '../types/event';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
 
@@ -56,6 +55,36 @@ const initManager = (manager: ManagerDefinition) => {
   let running = false;
   let shutdown = false;
 
+  let wakeWaitCron: (() => void) | null = null;
+  const waitOrShutdownCron = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWaitCron = null;
+        resolve();
+      }, ms);
+      wakeWaitCron = () => {
+        clearTimeout(timer);
+        wakeWaitCron = null;
+        resolve();
+      };
+    });
+  };
+
+  let wakeWaitStream: (() => void) | null = null;
+  const waitOrShutdownStream = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWaitStream = null;
+        resolve();
+      }, ms);
+      wakeWaitStream = () => {
+        clearTimeout(timer);
+        wakeWaitStream = null;
+        resolve();
+      };
+    });
+  };
+
   const cronHandler = async (cronInputFn?: () => Promise<HandlerInput>) => {
     if (manager.cronSchedulerHandler) {
       let lock;
@@ -71,7 +100,7 @@ const initManager = (manager: ManagerDefinition) => {
           logApp.info(`[OPENCTI-MODULE] Running ${manager.label} infinite cron handler`);
           while (!shutdown) {
             await manager.cronSchedulerHandler.handler(cronInput);
-            await wait(manager.cronSchedulerHandler.infiniteInterval);
+            await waitOrShutdownCron(manager.cronSchedulerHandler.infiniteInterval);
           }
         } else if (manager.cronSchedulerHandler.lockInHandlerParams) {
           await manager.cronSchedulerHandler.handler(lock);
@@ -109,7 +138,7 @@ const initManager = (manager: ManagerDefinition) => {
         await streamProcessor.start(startFrom);
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
-          await wait(WAIT_TIME_ACTION);
+          await waitOrShutdownStream(WAIT_TIME_ACTION);
         }
         logApp.info(`[OPENCTI-MODULE] End of ${manager.label} stream handler`);
       } catch (e: any) {
@@ -154,8 +183,11 @@ const initManager = (manager: ManagerDefinition) => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info(`[OPENCTI-MODULE] Stopping ${manager.label}`);
       shutdown = true;
+      wakeWaitCron?.();
+      wakeWaitStream?.();
       if (scheduler) {
         if (manager.cronSchedulerHandler?.shutdown) {
           manager.cronSchedulerHandler?.shutdown();
@@ -167,6 +199,7 @@ const initManager = (manager: ManagerDefinition) => {
       if (streamScheduler) {
         await clearIntervalAsync(streamScheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] ${manager.label} stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };
@@ -192,31 +225,30 @@ export const registerManager = (manager: ManagerDefinition) => {
   managersModule.add(managerModule);
 };
 
-export const getAllEnabledManagers = async () => {
+export const getAllEnabledManagers = () => {
   return managersModule.managers
     .filter((managerModule) => managerModule.manager.enabledToStart());
-}
+};
 
-export const getAllDisabledManagers = async () => {
+export const getAllDisabledManagers = () => {
   return managersModule.managers
     .filter((managerModule) => !managerModule.manager.enabledToStart());
-}
+};
 
 export const startAllManagers = async () => {
-  const managersToStart = await getAllEnabledManagers();
-  const disabledManagers = await getAllDisabledManagers();
+  const managersToStart = getAllEnabledManagers();
+  const disabledManagers = getAllDisabledManagers();
 
   for (let i = 0; i < disabledManagers.length; i += 1) {
-      logApp.info(`[OPENCTI-MODULE] ${disabledManagers[i].manager.label} not started (disabled by configuration)`);
+    logApp.info(`[OPENCTI-MODULE] ${disabledManagers[i].manager.label} not started (disabled by configuration)`);
   }
   await Promise.all(
     managersToStart.map((managerModule) => managerModule.start()),
   );
-
 };
 
 export const shutdownAllManagers = async () => {
-  const managersToShutdown = await getAllEnabledManagers();
+  const managersToShutdown = getAllEnabledManagers();
 
   await Promise.all(
     managersToShutdown.map((managerModule) => managerModule.shutdown()),

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -192,24 +192,35 @@ export const registerManager = (manager: ManagerDefinition) => {
   managersModule.add(managerModule);
 };
 
+export const getAllEnabledManagers = async () => {
+  return managersModule.managers
+    .filter((managerModule) => managerModule.manager.enabledToStart());
+}
+
+export const getAllDisabledManagers = async () => {
+  return managersModule.managers
+    .filter((managerModule) => !managerModule.manager.enabledToStart());
+}
+
 export const startAllManagers = async () => {
-  for (let i = 0; i < managersModule.managers.length; i += 1) {
-    const managerModule = managersModule.managers[i];
-    if (managerModule.manager.enabledToStart()) {
-      await managerModule.start();
-    } else {
-      logApp.info(`[OPENCTI-MODULE] ${managerModule.manager.label} not started (disabled by configuration)`);
-    }
+  const managersToStart = await getAllEnabledManagers();
+  const disabledManagers = await getAllDisabledManagers();
+
+  for (let i = 0; i < disabledManagers.length; i += 1) {
+      logApp.info(`[OPENCTI-MODULE] ${disabledManagers[i].manager.label} not started (disabled by configuration)`);
   }
+  await Promise.all(
+    managersToStart.map((managerModule) => managerModule.start()),
+  );
+
 };
 
 export const shutdownAllManagers = async () => {
-  for (let i = 0; i < managersModule.managers.length; i += 1) {
-    const managerModule = managersModule.managers[i];
-    if (managerModule.manager.enabledToStart()) {
-      await managerModule.shutdown();
-    }
-  }
+  const managersToShutdown = await getAllEnabledManagers();
+
+  await Promise.all(
+    managersToShutdown.map((managerModule) => managerModule.shutdown()),
+  );
 };
 
 export const getAllManagersStatuses = (settings: BasicStoreSettings) => {

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -36,6 +36,7 @@ import type { Representative } from '../types/store';
 import type { BasicStoreSettings } from '../types/settings';
 import { type BasicStoreEntityNotifier, ENTITY_TYPE_NOTIFIER } from '../modules/notifier/notifier-types';
 import { NOTIFIER_CONNECTOR_WEBHOOK } from '../modules/notifier/notifier-statics';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const NOTIFICATION_LIVE_KEY = conf.get('notification_manager:lock_live_key');
 const NOTIFICATION_DIGEST_KEY = conf.get('notification_manager:lock_digest_key');
@@ -650,35 +651,8 @@ const initNotificationManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  let wakeWaitLive: (() => void) | null = null;
-  const waitOrShutdownLive = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWaitLive = null;
-        resolve();
-      }, ms);
-      wakeWaitLive = () => {
-        clearTimeout(timer);
-        wakeWaitLive = null;
-        resolve();
-      };
-    });
-  };
-
-  let wakeWaitCron: (() => void) | null = null;
-  const waitOrShutdownCron = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWaitCron = null;
-        resolve();
-      }, ms);
-      wakeWaitCron = () => {
-        clearTimeout(timer);
-        wakeWaitCron = null;
-        resolve();
-      };
-    });
-  };
+  const liveTimer = new SkippableTimer();
+  const cronTimer = new SkippableTimer();
 
   const notificationLiveHandler = async () => {
     let lock;
@@ -692,7 +666,7 @@ const initNotificationManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await waitOrShutdownLive(WAIT_TIME_ACTION);
+        await liveTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of notification manager processing (live)');
     } catch (e: any) {
@@ -717,7 +691,7 @@ const initNotificationManager = () => {
       while (!shutdown) {
         lock.signal.throwIfAborted();
         await handleDigestNotifications(context);
-        await waitOrShutdownCron(CRON_SCHEDULE_TIME);
+        await cronTimer.start(CRON_SCHEDULE_TIME);
       }
       logApp.info('[OPENCTI-MODULE] End of notification manager processing (digest)');
     } catch (e: any) {
@@ -750,8 +724,8 @@ const initNotificationManager = () => {
       const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping notification manager');
       shutdown = true;
-      wakeWaitLive?.();
-      wakeWaitCron?.();
+      liveTimer.skip();
+      cronTimer.skip();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
       logApp.info(`[OPENCTI-MODULE] Notification manager stopped in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -650,11 +650,36 @@ const initNotificationManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
+  let wakeWaitLive: (() => void) | null = null;
+  const waitOrShutdownLive = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWaitLive = null;
+        resolve();
+      }, ms);
+      wakeWaitLive = () => {
+        clearTimeout(timer);
+        wakeWaitLive = null;
+        resolve();
+      };
     });
   };
+
+  let wakeWaitCron: (() => void) | null = null;
+  const waitOrShutdownCron = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWaitCron = null;
+        resolve();
+      }, ms);
+      wakeWaitCron = () => {
+        clearTimeout(timer);
+        wakeWaitCron = null;
+        resolve();
+      };
+    });
+  };
+
   const notificationLiveHandler = async () => {
     let lock;
     try {
@@ -667,7 +692,7 @@ const initNotificationManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitOrShutdownLive(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of notification manager processing (live)');
     } catch (e: any) {
@@ -692,7 +717,7 @@ const initNotificationManager = () => {
       while (!shutdown) {
         lock.signal.throwIfAborted();
         await handleDigestNotifications(context);
-        await wait(CRON_SCHEDULE_TIME);
+        await waitOrShutdownCron(CRON_SCHEDULE_TIME);
       }
       logApp.info('[OPENCTI-MODULE] End of notification manager processing (digest)');
     } catch (e: any) {
@@ -722,10 +747,14 @@ const initNotificationManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping notification manager');
       shutdown = true;
+      wakeWaitLive?.();
+      wakeWaitCron?.();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
+      logApp.info(`[OPENCTI-MODULE] Notification manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -36,7 +36,7 @@ import type { Representative } from '../types/store';
 import type { BasicStoreSettings } from '../types/settings';
 import { type BasicStoreEntityNotifier, ENTITY_TYPE_NOTIFIER } from '../modules/notifier/notifier-types';
 import { NOTIFIER_CONNECTOR_WEBHOOK } from '../modules/notifier/notifier-statics';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const NOTIFICATION_LIVE_KEY = conf.get('notification_manager:lock_live_key');
 const NOTIFICATION_DIGEST_KEY = conf.get('notification_manager:lock_digest_key');
@@ -651,8 +651,8 @@ const initNotificationManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const liveTimer = new SkippableTimer();
-  const cronTimer = new SkippableTimer();
+  const liveTimer = new InterruptibleTimer();
+  const cronTimer = new InterruptibleTimer();
 
   const notificationLiveHandler = async () => {
     let lock;
@@ -724,8 +724,8 @@ const initNotificationManager = () => {
       const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping notification manager');
       shutdown = true;
-      liveTimer.skip();
-      cronTimer.skip();
+      liveTimer.interrupt();
+      cronTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
       logApp.info(`[OPENCTI-MODULE] Notification manager stopped in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -28,7 +28,6 @@ import type { StixBundle, StixObject } from '../../types/stix-2-1-common';
 import { streamEventId, utcDate } from '../../utils/format';
 import { findById, findPlaybooksForEntity } from '../../modules/playbook/playbook-domain';
 import { type CronConfiguration, PLAYBOOK_INTERNAL_DATA_CRON, type StreamConfiguration } from '../../modules/playbook/playbook-components';
-import { SkippableTimer } from '../../utils/skippable-timer';
 import { PLAYBOOK_COMPONENTS } from '../../modules/playbook/playbook-components';
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from '../../modules/playbook/playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from '../../modules/playbook/playbook-types';
@@ -48,6 +47,7 @@ import { listenPirEvents } from './listenPirEventsUtils';
 import { isValidEventType } from './playbookManagerUtils';
 import { playbookExecutor } from './playbookExecutor';
 import type { BasicConnection, BasicStoreBase } from '../../types/store';
+import { InterruptibleTimer } from '../interruptible-timer';
 
 const PLAYBOOK_LIVE_KEY = conf.get('playbook_manager:lock_key');
 const PLAYBOOK_CRON_KEY = conf.get('playbook_manager:lock_cron_key');
@@ -187,8 +187,8 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   return false;
 };
 
-const cronTimer = new SkippableTimer();
-const streamTimer = new SkippableTimer();
+const cronTimer = new InterruptibleTimer();
+const streamTimer = new InterruptibleTimer();
 
 const initPlaybookManager = () => {
   const WAIT_TIME_ACTION = 2000;
@@ -404,8 +404,8 @@ const initPlaybookManager = () => {
       const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping playbook manager');
       shutdown = true;
-      streamTimer.skip();
-      cronTimer.skip();
+      streamTimer.interrupt();
+      cronTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
       logApp.info(`[OPENCTI-MODULE] Playbook manager stopped in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -28,6 +28,7 @@ import type { StixBundle, StixObject } from '../../types/stix-2-1-common';
 import { streamEventId, utcDate } from '../../utils/format';
 import { findById, findPlaybooksForEntity } from '../../modules/playbook/playbook-domain';
 import { type CronConfiguration, PLAYBOOK_INTERNAL_DATA_CRON, type StreamConfiguration } from '../../modules/playbook/playbook-components';
+import { SkippableTimer } from '../../utils/skippable-timer';
 import { PLAYBOOK_COMPONENTS } from '../../modules/playbook/playbook-components';
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from '../../modules/playbook/playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from '../../modules/playbook/playbook-types';
@@ -186,28 +187,8 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   return false;
 };
 
-let wakeWaitCron: (() => void) | null = null;
-
-const waitOrShutdownCron = (ms: number) => {
-  return new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    wakeWaitCron = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-  });
-};
-
-let wakeWaitStream: (() => void) | null = null;
-const waitOrShutdownStream = (ms: number) => {
-  return new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    wakeWaitStream = () => {
-      clearTimeout(timer);
-      resolve();
-    };
-  });
-};
+const cronTimer = new SkippableTimer();
+const streamTimer = new SkippableTimer();
 
 const initPlaybookManager = () => {
   const WAIT_TIME_ACTION = 2000;
@@ -229,7 +210,7 @@ const initPlaybookManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await waitOrShutdownStream(WAIT_TIME_ACTION);
+        await streamTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of playbook manager processing (live)');
     } catch (e: any) {
@@ -390,7 +371,7 @@ const initPlaybookManager = () => {
       while (!shutdown) {
         lock.signal.throwIfAborted();
         await handlePlaybookCrons(context);
-        await waitOrShutdownCron(CRON_SCHEDULE_TIME);
+        await cronTimer.start(CRON_SCHEDULE_TIME);
       }
       logApp.info('[OPENCTI-MODULE] End of playbook manager processing (cron)');
     } catch (e: any) {
@@ -423,8 +404,8 @@ const initPlaybookManager = () => {
       const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping playbook manager');
       shutdown = true;
-      wakeWaitStream?.();
-      wakeWaitCron?.();
+      streamTimer.skip();
+      cronTimer.skip();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
       logApp.info(`[OPENCTI-MODULE] Playbook manager stopped in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -186,6 +186,29 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   return false;
 };
 
+let wakeWaitCron: (() => void) | null = null;
+
+const waitOrShutdownCron = (ms: number) => {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    wakeWaitCron = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+  });
+};
+
+let wakeWaitStream: (() => void) | null = null;
+const waitOrShutdownStream = (ms: number) => {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    wakeWaitStream = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+  });
+};
+
 const initPlaybookManager = () => {
   const WAIT_TIME_ACTION = 2000;
   let streamScheduler: SetIntervalAsyncTimer<[]>;
@@ -193,11 +216,7 @@ const initPlaybookManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+
   const playbookHandler = async () => {
     let lock;
     try {
@@ -210,9 +229,9 @@ const initPlaybookManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitOrShutdownStream(WAIT_TIME_ACTION);
       }
-      logApp.info('[OPENCTI-MODULE] End of playbook manager processing');
+      logApp.info('[OPENCTI-MODULE] End of playbook manager processing (live)');
     } catch (e: any) {
       if (e.name === TYPE_LOCK_ERROR) {
         logApp.debug('[OPENCTI-MODULE] Playbook manager already started by another API');
@@ -371,7 +390,7 @@ const initPlaybookManager = () => {
       while (!shutdown) {
         lock.signal.throwIfAborted();
         await handlePlaybookCrons(context);
-        await wait(CRON_SCHEDULE_TIME);
+        await waitOrShutdownCron(CRON_SCHEDULE_TIME);
       }
       logApp.info('[OPENCTI-MODULE] End of playbook manager processing (cron)');
     } catch (e: any) {
@@ -401,10 +420,14 @@ const initPlaybookManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping playbook manager');
       shutdown = true;
+      wakeWaitStream?.();
+      wakeWaitCron?.();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
+      logApp.info(`[OPENCTI-MODULE] Playbook manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -515,9 +515,18 @@ const initPublisherManager = () => {
   let running = false;
   let shutdown = false;
   let isSmtpActive = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
+  let wakeWait: (() => void) | null = null;
+  const waitOrShutdown = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWait = null;
+        resolve();
+      }, ms);
+      wakeWait = () => {
+        clearTimeout(timer);
+        wakeWait = null;
+        resolve();
+      };
     });
   };
   const notificationHandler = async () => {
@@ -536,7 +545,7 @@ const initPublisherManager = () => {
         if (PUBLISHER_ENABLE_BUFFERING) {
           await handleEntityNotificationBuffer();
         }
-        await wait(WAIT_TIME_ACTION);
+        await waitOrShutdown(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of publisher manager processing');
     } catch (e: any) {
@@ -571,6 +580,7 @@ const initPublisherManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping publisher manager');
       shutdown = true;
+      wakeWait?.();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;
     },

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -42,7 +42,7 @@ import { EVENT_TYPE_UPDATE } from '../database/utils';
 import { sanitizeNotificationData } from '../utils/templateContextSanitizer';
 import { safeRender } from '../utils/safeEjs.client';
 import { NOTIFICATION_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const DOC_URI = 'https://docs.opencti.io';
 const PUBLISHER_ENGINE_KEY = conf.get('publisher_manager:lock_key');
@@ -516,7 +516,7 @@ const initPublisherManager = () => {
   let running = false;
   let shutdown = false;
   let isSmtpActive = false;
-  const waitTimer = new SkippableTimer();
+  const waitTimer = new InterruptibleTimer();
   const notificationHandler = async () => {
     let lock;
     try {
@@ -568,7 +568,7 @@ const initPublisherManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping publisher manager');
       shutdown = true;
-      waitTimer.skip();
+      waitTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;
     },

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -42,6 +42,7 @@ import { EVENT_TYPE_UPDATE } from '../database/utils';
 import { sanitizeNotificationData } from '../utils/templateContextSanitizer';
 import { safeRender } from '../utils/safeEjs.client';
 import { NOTIFICATION_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const DOC_URI = 'https://docs.opencti.io';
 const PUBLISHER_ENGINE_KEY = conf.get('publisher_manager:lock_key');
@@ -515,20 +516,7 @@ const initPublisherManager = () => {
   let running = false;
   let shutdown = false;
   let isSmtpActive = false;
-  let wakeWait: (() => void) | null = null;
-  const waitOrShutdown = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWait = null;
-        resolve();
-      }, ms);
-      wakeWait = () => {
-        clearTimeout(timer);
-        wakeWait = null;
-        resolve();
-      };
-    });
-  };
+  const waitTimer = new SkippableTimer();
   const notificationHandler = async () => {
     let lock;
     try {
@@ -545,7 +533,7 @@ const initPublisherManager = () => {
         if (PUBLISHER_ENABLE_BUFFERING) {
           await handleEntityNotificationBuffer();
         }
-        await waitOrShutdown(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of publisher manager processing');
     } catch (e: any) {
@@ -580,7 +568,7 @@ const initPublisherManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping publisher manager');
       shutdown = true;
-      wakeWait?.();
+      waitTimer.skip();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;
     },

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -43,6 +43,7 @@ import jsonCanonicalize from 'canonicalize';
 import { v5 as uuidv5 } from 'uuid';
 
 import { pushAll } from '../utils/arrayUtil';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const MIN_LIVE_STREAM_EVENT_VERSION = 4;
 
@@ -296,20 +297,7 @@ const initRuleManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  let wakeWait: (() => void) | null = null;
-  const waitOrShutdown = (ms: number) => {
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        wakeWait = null;
-        resolve();
-      }, ms);
-      wakeWait = () => {
-        clearTimeout(timer);
-        wakeWait = null;
-        resolve();
-      };
-    });
-  };
+  const waitTimer = new SkippableTimer();
   const ruleHandler = async () => {
     let lock;
     try {
@@ -332,7 +320,7 @@ const initRuleManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await waitOrShutdown(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of rule manager processing');
     } catch (e: any) {
@@ -364,7 +352,7 @@ const initRuleManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping rule engine');
       shutdown = true;
-      wakeWait?.();
+      waitTimer.skip();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -43,7 +43,7 @@ import jsonCanonicalize from 'canonicalize';
 import { v5 as uuidv5 } from 'uuid';
 
 import { pushAll } from '../utils/arrayUtil';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const MIN_LIVE_STREAM_EVENT_VERSION = 4;
 
@@ -297,7 +297,7 @@ const initRuleManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const waitTimer = new SkippableTimer();
+  const waitTimer = new InterruptibleTimer();
   const ruleHandler = async () => {
     let lock;
     try {
@@ -352,7 +352,7 @@ const initRuleManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping rule engine');
       shutdown = true;
-      waitTimer.skip();
+      waitTimer.interrupt();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -296,9 +296,18 @@ const initRuleManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
+  let wakeWait: (() => void) | null = null;
+  const waitOrShutdown = (ms: number) => {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        wakeWait = null;
+        resolve();
+      }, ms);
+      wakeWait = () => {
+        clearTimeout(timer);
+        wakeWait = null;
+        resolve();
+      };
     });
   };
   const ruleHandler = async () => {
@@ -323,7 +332,7 @@ const initRuleManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitOrShutdown(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of rule manager processing');
     } catch (e: any) {
@@ -340,6 +349,7 @@ const initRuleManager = () => {
   };
   return {
     start: async () => {
+      logApp.info('[OPENCTI-MODULE] Starting rule engine');
       scheduler = setIntervalAsync(async () => {
         await ruleHandler();
       }, SCHEDULE_TIME);
@@ -354,6 +364,7 @@ const initRuleManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping rule engine');
       shutdown = true;
+      wakeWait?.();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -21,6 +21,21 @@ const SYNC_MANAGER_KEY = conf.get('sync_manager:lock_key') || 'sync_manager_lock
 const SCHEDULE_TIME = conf.get('sync_manager:interval') || 10000;
 const WAIT_TIME_ACTION = 2000;
 
+let wakeWaitLoop = null;
+const waitOrShutdownLoop = (ms) => {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      wakeWaitLoop = null;
+      resolve();
+    }, ms);
+    wakeWaitLoop = () => {
+      clearTimeout(timer);
+      wakeWaitLoop = null;
+      resolve();
+    };
+  });
+};
+
 const syncManagerInstance = (syncId) => {
   // Variables
   let connectionId = null;
@@ -30,6 +45,7 @@ const syncManagerInstance = (syncId) => {
   let lastEventDate; // Track the last saved event date (ISO string) for reconnection
   let running = false;
   let abortController = null;
+
   // Async generator that yields SSE events from a raw HTTP stream.
   // Backpressure is natural: when the consumer is busy processing an event,
   // the generator is suspended, bytes are not read from the socket,
@@ -89,10 +105,13 @@ const syncManagerInstance = (syncId) => {
   return {
     id: syncId,
     stop: () => {
+      const startTime = new Date().getTime();
       logApp.info(`[OPENCTI] Sync ${syncId}: stopping manager`);
       running = false;
+      wakeWaitLoop?.();
       if (abortController) abortController.abort();
       clearSyncConsumerMetrics(syncId).catch(() => {});
+      logApp.info(`[OPENCTI] Sync ${syncId}: manager stopped in ${new Date().getTime() - startTime} ms`);
     },
     start: async (context) => {
       running = true;
@@ -190,6 +209,7 @@ const initSyncManager = () => {
   let scheduler;
   let syncListening = true;
   let managerRunning = false;
+
   const syncManagers = new Map();
   const processStep = async () => {
     // Get syncs definition
@@ -230,7 +250,7 @@ const initSyncManager = () => {
     while (syncListening) {
       lock.signal.throwIfAborted();
       await processStep();
-      await wait(WAIT_TIME_ACTION);
+      await waitOrShutdownLoop(WAIT_TIME_ACTION);
     }
     // Stopping
     for (const syncManager of syncManagers.values()) {
@@ -272,11 +292,13 @@ const initSyncManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping Sync manager');
       syncListening = false;
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Stopping Sync manager ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -16,25 +16,13 @@ import { createSyncHttpUri, httpBase } from '../domain/connector-utils';
 import { EVENT_CURRENT_VERSION } from '../database/stream/stream-utils';
 import { storeSyncConsumerMetrics, clearSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
 import { createParser } from 'eventsource-parser';
+import { SkippableTimer } from '../utils/skippable-timer';
 
 const SYNC_MANAGER_KEY = conf.get('sync_manager:lock_key') || 'sync_manager_lock';
 const SCHEDULE_TIME = conf.get('sync_manager:interval') || 10000;
 const WAIT_TIME_ACTION = 2000;
 
-let wakeWaitLoop = null;
-const waitOrShutdownLoop = (ms) => {
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      wakeWaitLoop = null;
-      resolve();
-    }, ms);
-    wakeWaitLoop = () => {
-      clearTimeout(timer);
-      wakeWaitLoop = null;
-      resolve();
-    };
-  });
-};
+const waitLoopTimer = new SkippableTimer();
 
 const syncManagerInstance = (syncId) => {
   // Variables
@@ -108,7 +96,7 @@ const syncManagerInstance = (syncId) => {
       const startTime = new Date().getTime();
       logApp.info(`[OPENCTI] Sync ${syncId}: stopping manager`);
       running = false;
-      wakeWaitLoop?.();
+      waitLoopTimer.skip();
       if (abortController) abortController.abort();
       clearSyncConsumerMetrics(syncId).catch(() => {});
       logApp.info(`[OPENCTI] Sync ${syncId}: manager stopped in ${new Date().getTime() - startTime} ms`);
@@ -250,7 +238,7 @@ const initSyncManager = () => {
     while (syncListening) {
       lock.signal.throwIfAborted();
       await processStep();
-      await waitOrShutdownLoop(WAIT_TIME_ACTION);
+      await waitLoopTimer.start(WAIT_TIME_ACTION);
     }
     // Stopping
     for (const syncManager of syncManagers.values()) {

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -16,13 +16,13 @@ import { createSyncHttpUri, httpBase } from '../domain/connector-utils';
 import { EVENT_CURRENT_VERSION } from '../database/stream/stream-utils';
 import { storeSyncConsumerMetrics, clearSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
 import { createParser } from 'eventsource-parser';
-import { SkippableTimer } from '../utils/skippable-timer';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const SYNC_MANAGER_KEY = conf.get('sync_manager:lock_key') || 'sync_manager_lock';
 const SCHEDULE_TIME = conf.get('sync_manager:interval') || 10000;
 const WAIT_TIME_ACTION = 2000;
 
-const waitLoopTimer = new SkippableTimer();
+const waitLoopTimer = new InterruptibleTimer();
 
 const syncManagerInstance = (syncId) => {
   // Variables
@@ -96,7 +96,7 @@ const syncManagerInstance = (syncId) => {
       const startTime = new Date().getTime();
       logApp.info(`[OPENCTI] Sync ${syncId}: stopping manager`);
       running = false;
-      waitLoopTimer.skip();
+      waitLoopTimer.interrupt();
       if (abortController) abortController.abort();
       clearSyncConsumerMetrics(syncId).catch(() => {});
       logApp.info(`[OPENCTI] Sync ${syncId}: manager stopped in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -147,6 +147,7 @@ export const addUserLoginCount = () => {
 // End Region user event counters
 
 const telemetryInitializer = async (): Promise<HandlerInput> => {
+  const startTime = new Date().getTime();
   const context = executionContext('telemetry_manager');
   const filigranMetricReaders = [];
   const collectorCallback = async () => {
@@ -214,10 +215,12 @@ const telemetryInitializer = async (): Promise<HandlerInput> => {
   const filigranMeterProvider = new MeterProvider(({ resource, readers: filigranMetricReaders }));
   const filigranTelemetryMeterManager = new TelemetryMeterManager(filigranMeterProvider);
   filigranTelemetryMeterManager.registerFiligranTelemetry();
+  logApp.info(`[TELEMETRY] Initialized in ${new Date().getTime() - startTime} ms`);
   return filigranTelemetryMeterManager;
 };
 
 export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
+  const startTime = new Date().getTime();
   try {
     const context = executionContext('telemetry_manager');
     // region Settings information
@@ -332,7 +335,7 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setFormIntakeSubmittedCount(formIntakeSubmittedCountInRedis);
     // end region Telemetry user events
 
-    logApp.debug('[TELEMETRY] Fetching telemetry data successfully');
+    logApp.debug(`[TELEMETRY] Fetching telemetry data successfully in ${new Date().getTime() - startTime} ms`);
   } catch (e) {
     logApp.error('[TELEMETRY] Error fetching platform information', { cause: e });
   }

--- a/opencti-platform/opencti-graphql/src/managers.js
+++ b/opencti-platform/opencti-graphql/src/managers.js
@@ -141,10 +141,6 @@ export const startModules = async () => {
     logApp.info('[OPENCTI-MODULE] File index manager not started (disabled by configuration)');
   }
 
-  // refactoring in module in progress
-  // all managers will be started only in this method
-  startingPromises.push(startAllManagers());
-
   // endregion
   // region Cluster manager
   startingPromises.push(clusterManager.start());
@@ -159,6 +155,10 @@ export const startModules = async () => {
   startingPromises.push(authenticationProviderListener.start());
 
   await Promise.all(startingPromises);
+
+  // refactoring in module in progress
+  // all managers will be started only in this method
+  await startAllManagers();
 };
 
 export const shutdownModules = async () => {
@@ -224,13 +224,9 @@ export const shutdownModules = async () => {
   // endregion
   // region file index manager
   if (ENABLED_FILE_INDEX_MANAGER && isAttachmentProcessorEnabled()) {
-    await fileIndexManager.shutdown();
+    stoppingPromises.push(fileIndexManager.shutdown());
   }
   // endregion
-
-  // refactoring in module in progress
-  // all managers will be started only in this method
-  await shutdownAllManagers();
 
   // endregion
   // region Cluster manager
@@ -243,5 +239,9 @@ export const shutdownModules = async () => {
   stoppingPromises.push(supportPackageListener.shutdown());
   stoppingPromises.push(authenticationProviderListener.shutdown());
   await Promise.all(stoppingPromises);
+
+  // refactoring in module in progress
+  // all managers will be shutdown only in this method
+  await shutdownAllManagers();
 };
 // endregion

--- a/opencti-platform/opencti-graphql/src/managers.js
+++ b/opencti-platform/opencti-graphql/src/managers.js
@@ -38,6 +38,8 @@ import authenticationProviderListener from './modules/authenticationProvider/aut
 import supportPackageListener from './modules/support/supportPackage-listener';
 
 export const startModules = async () => {
+  const startingPromises = [];
+
   // region API initialization
   if (ENABLED_API) {
     await httpServer.start();
@@ -46,84 +48,93 @@ export const startModules = async () => {
     logApp.info('[OPENCTI] API not started (disabled by configuration)');
   }
   // endregion
+
   // region Expiration manager
   if (ENABLED_EXPIRED_MANAGER) {
-    await expiredManager.start();
+    startingPromises.push(expiredManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Expiration manager not started (disabled by configuration)');
   }
   // endregion
+
   // region connector manager
   if (ENABLED_CONNECTOR_MANAGER) {
-    await connectorManager.start();
+    startingPromises.push(connectorManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Connector manager not started (disabled by configuration)');
   }
   // endregion
+
   // region import csv built in connector
   if (ENABLED_IMPORT_CSV_BUILT_IN_CONNECTOR) {
-    await importCsvConnector.start();
+    startingPromises.push(importCsvConnector.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Connector built in manager not started (disabled by configuration)');
   }
   // endregion
-  // region draft validation built in connector
-  await draftValidationConnector.start();
 
+  // region draft validation built in connector
+  startingPromises.push(draftValidationConnector.start());
   // endregion
+
   // region Task manager
   if (ENABLED_TASK_SCHEDULER) {
-    await taskManager.start();
+    startingPromises.push(taskManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Task manager not started (disabled by configuration)');
   }
   // endregion
+
   // region Inference engine
   if (ENABLED_RULE_ENGINE) {
-    await ruleEngine.start();
+    startingPromises.push(ruleEngine.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Rule engine not started (disabled by configuration)');
   }
   // endregion
+
   // region Sync manager
   if (ENABLED_SYNC_MANAGER) {
-    await syncManager.start();
+    startingPromises.push(syncManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Sync manager not started (disabled by configuration)');
   }
   if (ENABLED_INGESTION_MANAGER) {
-    await ingestionManager.start();
+    startingPromises.push(ingestionManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Ingestion manager not started (disabled by configuration)');
   }
   // endregion
+
   // region History manager
   if (ENABLED_HISTORY_MANAGER) {
-    await historyManager.start();
+    startingPromises.push(historyManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] History manager not started (disabled by configuration)');
   }
   // endregion
+
   // region notification
   if (ENABLED_NOTIFICATION_MANAGER) {
-    await notificationManager.start();
+    startingPromises.push(notificationManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Notification manager not started (disabled by configuration)');
   }
   if (ENABLED_PUBLISHER_MANAGER) {
-    await publisherManager.start();
+    startingPromises.push(publisherManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Publisher manager not started (disabled by configuration)');
   }
   // endregion
+
   // region playbook manager
   if (ENABLED_PLAYBOOK_MANAGER) {
-    await playbookManager.start();
+    startingPromises.push(playbookManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Playbook manager not started (disabled by configuration)');
   }
   if (ENABLED_FILE_INDEX_MANAGER && isAttachmentProcessorEnabled()) {
-    await fileIndexManager.start();
+    startingPromises.push(fileIndexManager.start());
   } else if (ENABLED_FILE_INDEX_MANAGER && !isAttachmentProcessorEnabled()) {
     logApp.info('[OPENCTI-MODULE] File index manager not started : attachment processor is not configured.');
   } else {
@@ -132,19 +143,22 @@ export const startModules = async () => {
 
   // refactoring in module in progress
   // all managers will be started only in this method
-  await startAllManagers();
+  startingPromises.push(startAllManagers());
 
   // endregion
   // region Cluster manager
-  await clusterManager.start();
-  // endregion
-  // region Audit
-  await activityListener.start();
-  await activityManager.start();
+  startingPromises.push(clusterManager.start());
   // endregion
 
-  await supportPackageListener.start();
-  await authenticationProviderListener.start();
+  // region Audit
+  startingPromises.push(activityListener.start());
+  startingPromises.push(activityManager.start());
+  // endregion
+
+  startingPromises.push(supportPackageListener.start());
+  startingPromises.push(authenticationProviderListener.start());
+
+  await Promise.all(startingPromises);
 };
 
 export const shutdownModules = async () => {

--- a/opencti-platform/opencti-graphql/src/python/pythonBridge.js
+++ b/opencti-platform/opencti-graphql/src/python/pythonBridge.js
@@ -173,9 +173,14 @@ export const checkIndicatorSyntax = async (context, user, patternType, indicator
   return checkChildIndicatorSyntax(context, user, patternType, indicatorValue);
 };
 export const checkPythonAvailability = async (context, user) => {
+  logApp.info('[CHECK] Checking if Python is available');
   if (USE_NATIVE_EXEC) {
-    return checkNativePythonAvailability(context, user);
+    const result = checkNativePythonAvailability(context, user);
+    logApp.info('[CHECK] Python is alive');
+    return result;
   }
-  return checkChildPythonAvailability(context, user);
+  const result = checkChildPythonAvailability(context, user);
+  logApp.info('[CHECK] Python is alive');
+  return result;
 };
 // endregion

--- a/opencti-platform/opencti-graphql/src/utils/skippable-timer.ts
+++ b/opencti-platform/opencti-graphql/src/utils/skippable-timer.ts
@@ -1,0 +1,39 @@
+/**
+ * A timer that can be skipped early, resolving the promise immediately.
+ * Used in manager loops to allow clean shutdown without waiting for the full delay.
+ *
+ * Usage:
+ *   const timer = new SkippableTimer();
+ *   await timer.start(5_000); // waits up to 5 seconds
+ *   timer.skip(); // resolves immediately from another context
+ */
+export class SkippableTimer {
+  private timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  private resolve: (() => void) | null = null;
+
+  skip() {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+    this.resolve?.();
+    this.resolve = null;
+  }
+
+  async start(timeMs: number): Promise<void> {
+    // Clean up any previous timer before starting a new one
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+    return new Promise<void>((resolve) => {
+      this.resolve = resolve;
+      this.timeoutId = setTimeout(() => {
+        this.resolve?.();
+        this.resolve = null;
+        this.timeoutId = null;
+      }, timeMs);
+    });
+  }
+}

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getAllEnabledManagers, getAllManagersStatuses, registerManager, shutdownAllManagers, startAllManagers } from '../../../../src/manager/managerModule';
+import { getSettings } from '../../../../src/domain/settings';
+import { testContext } from '../../../utils/testQuery';
+import type { BasicStoreSettings } from '../../../../src/types/settings';
+
+// Enable testManager to run
+import './testManager';
+import { TEST_MANAGER_DEFINITION } from './testManager';
+
+describe('Manager module tests ', () => {
+  it('should startup and shutdown and startup be a noop', async () => {
+    registerManager(TEST_MANAGER_DEFINITION);
+    await startAllManagers();
+
+    const allManagers = getAllEnabledManagers();
+    const myTestManager = allManagers.find((manager) => manager.manager.id === 'TEST_MANAGER');
+
+    // We should be able to check the running state, but there is an issue with this boolean.
+    expect(myTestManager?.manager.enabledByConfig).toBeTruthy();
+
+    const settings = await getSettings(testContext) as unknown as BasicStoreSettings;
+    const managerStatus = getAllManagersStatuses(settings);
+    const testManagerStatus1 = managerStatus.find((manager) => manager.id === 'TEST_MANAGER');
+    expect(testManagerStatus1?.enable).toBeTruthy();
+
+    await shutdownAllManagers();
+
+    await startAllManagers();
+    const managerStatusAtTheEnd = getAllManagersStatuses(settings);
+    const testManagerStatusAtTheEnd = managerStatusAtTheEnd.find((manager) => manager.id === 'TEST_MANAGER');
+    expect(testManagerStatusAtTheEnd?.enable).toBeTruthy();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/testManager.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/testManager.ts
@@ -1,0 +1,27 @@
+import { logApp } from '../../../../src/config/conf';
+import { type ManagerDefinition } from '../../../../src/manager/managerModule';
+
+/**
+ * This is an empty manager to validate manager module
+ */
+export const cronTestManager = async () => {
+  logApp.info('[TEST] test manager is running');
+};
+
+export const TEST_MANAGER_DEFINITION: ManagerDefinition = {
+  id: 'TEST_MANAGER',
+  label: 'Test manager',
+  executionContext: 'test_manager',
+  cronSchedulerHandler: {
+    handler: cronTestManager,
+    interval: 1000,
+    lockKey: 'test_manager_lock',
+  },
+  enabledByConfig: true,
+  enabledToStart(): boolean {
+    return this.enabledByConfig;
+  },
+  enabled(): boolean {
+    return this.enabledByConfig;
+  },
+};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Run some independent startup process with promises
* Same for tear down
* implement a circuit breaker in shutdown in manager to avoid having to wait until interval are done (InterruptibleWait). For some (like playbookManager) interval can be one minute.
* Add a condition on redis stream to stop and close properly if shutdown has been requested.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #14898 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
