### PR TITLE
[frontend] Mutualize to StixDomainObjectTabsBox (#13389)

### DIFF
--- a/opencti-platform/opencti-front/builder/dev/dev.js
+++ b/opencti-platform/opencti-front/builder/dev/dev.js
@@ -64,10 +64,12 @@ const middleware = (target, ws = false) => createProxyMiddleware({
 
   // Listen change for hot recompile
   if (!process.env.E2E_TEST) {
-    chokidar.watch("src/**/*.{js,jsx,ts,tsx}", {
+    chokidar.watch("src", {
       awaitWriteFinish: true,
       ignoreInitial: true,
     })
+      .on('error', (error) => console.log(`[HOT RELOAD] Watcher error: ${error}`))
+      .on('ready', () => console.log('[HOT RELOAD] Initial scan complete. Ready for changes'))
       .on(
         "all",
         debounce(() => {

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -137,6 +137,7 @@ const RootGrouping = () => {
                   />
                   <StixDomainObjectTabsBox
                     basePath="/dashboard/analyses/groupings"
+                    entity={grouping}
                     tabs={[
                       'overview',
                       'knowledge',

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -2,14 +2,12 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootReportSubscription } from '@components/analyses/reports/__generated__/RootReportSubscription.graphql';
 import Security from 'src/utils/Security';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import GroupingDeletion from '@components/analyses/groupings/GroupingDeletion';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';
@@ -27,7 +25,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import GroupingEdition from './GroupingEdition';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 
@@ -137,63 +135,23 @@ const RootGrouping = () => {
                     enableEnricher={true}
                     enableEnrollPlaybook={true}
                   />
-                  <Box
-                    sx={{
-                      borderBottom: 1,
-                      borderColor: 'divider',
-                      marginBottom: 3,
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItem: 'center',
-                    }}
-                  >
-                    <Tabs
-                      value={getCurrentTab(location.pathname, grouping.id, '/dashboard/analyses/groupings')}
-                    >
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/groupings/${grouping.id}`}
-                        value={`/dashboard/analyses/groupings/${grouping.id}`}
-                        label={t_i18n('Overview')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/groupings/${grouping.id}/knowledge/graph`}
-                        value={`/dashboard/analyses/groupings/${grouping.id}/knowledge`}
-                        label={t_i18n('Knowledge')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/groupings/${grouping.id}/content`}
-                        value={`/dashboard/analyses/groupings/${grouping.id}/content`}
-                        label={t_i18n('Content')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/groupings/${grouping.id}/entities`}
-                        value={`/dashboard/analyses/groupings/${grouping.id}/entities`}
-                        label={t_i18n('Entities')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/groupings/${grouping.id}/observables`}
-                        value={`/dashboard/analyses/groupings/${grouping.id}/observables`}
-                        label={t_i18n('Observables')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/groupings/${grouping.id}/files`}
-                        value={`/dashboard/analyses/groupings/${grouping.id}/files`}
-                        label={t_i18n('Data')}
-                      />
-                    </Tabs>
-                    {!isKnowledgeOrContent && (
-                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+                  <StixDomainObjectTabsBox
+                    basePath="/dashboard/analyses/groupings"
+                    tabs={[
+                      'overview',
+                      'knowledge',
+                      'content',
+                      'entities',
+                      'observables',
+                      'files',
+                    ]}
+                    extraActions={!isKnowledgeOrContent && (
+                      <>
                         <AIInsights id={grouping.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
                         <StixCoreObjectSecurityCoverage id={grouping.id} coverage={grouping.securityCoverage} />
-                      </div>
+                      </>
                     )}
-                  </Box>
+                  />
                   <Routes>
                     <Route
                       path="/"

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/Root.tsx
@@ -2,13 +2,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { graphql, useSubscription } from 'react-relay';
-import { Link, Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router-dom';
 import React, { useMemo } from 'react';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import Security from 'src/utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from 'src/utils/hooks/useGranted';
 import MalwareAnalysisDeletion from '@components/analyses/malware_analyses/MalwareAnalysisDeletion';
@@ -28,7 +26,7 @@ import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreR
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import MalwareAnalysisEdition from './MalwareAnalysisEdition';
 
 const subscription = graphql`
@@ -132,48 +130,17 @@ const RootMalwareAnalysis = () => {
                     redirectToContent={true}
                     enableEnrollPlaybook={true}
                   />
-                  <Box
-                    sx={{
-                      borderBottom: 1,
-                      borderColor: 'divider',
-                      marginBottom: 3,
-                    }}
-                  >
-                    <Tabs
-                      value={getCurrentTab(location.pathname, malwareAnalysis.id, '/dashboard/analyses/malware_analyses')}
-                    >
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}`}
-                        value={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}`}
-                        label={t_i18n('Overview')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/knowledge`}
-                        value={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/knowledge`}
-                        label={t_i18n('Knowledge')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/content`}
-                        value={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/content`}
-                        label={t_i18n('Content')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/files`}
-                        value={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/files`}
-                        label={t_i18n('Data')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/history`}
-                        value={`/dashboard/analyses/malware_analyses/${malwareAnalysis.id}/history`}
-                        label={t_i18n('History')}
-                      />
-                    </Tabs>
-                  </Box>
+                  <StixDomainObjectTabsBox
+                    basePath="/dashboard/analyses/malware_analyses"
+                    entity={malwareAnalysis}
+                    tabs={[
+                      'overview',
+                      'knowledge',
+                      'content',
+                      'files',
+                      'history',
+                    ]}
+                  />
                   <Routes>
                     <Route
                       path="/"

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router-dom';
 import { graphql, useSubscription } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
@@ -66,7 +66,6 @@ const RootNote = () => {
     }),
     [noteId],
   );
-  const location = useLocation();
   const { t_i18n } = useFormatter();
   useSubscription(subConfig);
   return (

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -1,11 +1,9 @@
-import React, { useMemo } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { useMemo } from 'react';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import { QueryRenderer } from '../../../../relay/environment';
 import Note from './Note';
@@ -128,28 +126,15 @@ const RootNote = () => {
                       enableEnrollPlaybook={true}
                     />
                   </CollaborativeSecurity>
-                  <Box sx={{ borderBottom: 1, borderColor: 'divider', marginBottom: 3 }}>
-                    <Tabs value={location.pathname}>
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/notes/${note.id}`}
-                        value={`/dashboard/analyses/notes/${note.id}`}
-                        label={t_i18n('Overview')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/notes/${note.id}/files`}
-                        value={`/dashboard/analyses/notes/${note.id}/files`}
-                        label={t_i18n('Data')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/notes/${note.id}/history`}
-                        value={`/dashboard/analyses/notes/${note.id}/history`}
-                        label={t_i18n('History')}
-                      />
-                    </Tabs>
-                  </Box>
+                  <StixDomainObjectTabsBox
+                    basePath="/dashboard/analyses/notes"
+                    entity={note}
+                    tabs={[
+                      'overview',
+                      'files',
+                      'history',
+                    ]}
+                  />
                   <Routes>
                     <Route
                       path="/"

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -3,12 +3,10 @@
 // @ts-nocheck
 import React, { useMemo } from 'react';
 import { graphql, useSubscription } from 'react-relay';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import Security from 'src/utils/Security';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';
 import { QueryRenderer } from '../../../../relay/environment';
@@ -26,7 +24,7 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import ReportEdition from './ReportEdition';
 import ReportDeletion from './ReportDeletion';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
@@ -137,61 +135,24 @@ const RootReport = () => {
                     redirectToContent={true}
                     enableEnricher={true}
                   />
-                  <Box
-                    sx={{
-                      borderBottom: 1,
-                      borderColor: 'divider',
-                      marginBottom: 3,
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItem: 'center',
-                    }}
-                  >
-                    <Tabs value={getCurrentTab(location.pathname, report.id, '/dashboard/analyses/reports')}>
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/reports/${report.id}`}
-                        value={`/dashboard/analyses/reports/${report.id}`}
-                        label={t_i18n('Overview')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/reports/${report.id}/knowledge/graph`}
-                        value={`/dashboard/analyses/reports/${report.id}/knowledge`}
-                        label={t_i18n('Knowledge')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/reports/${report.id}/content`}
-                        value={`/dashboard/analyses/reports/${report.id}/content`}
-                        label={t_i18n('Content')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/reports/${report.id}/entities`}
-                        value={`/dashboard/analyses/reports/${report.id}/entities`}
-                        label={t_i18n('Entities')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/reports/${report.id}/observables`}
-                        value={`/dashboard/analyses/reports/${report.id}/observables`}
-                        label={t_i18n('Observables')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/analyses/reports/${report.id}/files`}
-                        value={`/dashboard/analyses/reports/${report.id}/files`}
-                        label={t_i18n('Data')}
-                      />
-                    </Tabs>
-                    {!isKnowledgeOrContent && (
-                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+                  <StixDomainObjectTabsBox
+                    basePath="/dashboard/analyses/reports"
+                    entity={report}
+                    tabs={[
+                      'overview',
+                      'knowledge-graph',
+                      'content',
+                      'entities',
+                      'observables',
+                      'files',
+                    ]}
+                    extraActions={!isKnowledgeOrContent && (
+                      <>
                         <AIInsights id={report.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
                         <StixCoreObjectSecurityCoverage id={report.id} coverage={report.securityCoverage} />
-                      </div>
+                      </>
                     )}
-                  </Box>
+                  />
                   <Routes>
                     <Route
                       path="/"

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -1,9 +1,6 @@
-import React, { Suspense, useMemo, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import Security from 'src/utils/Security';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import FileManager from '@components/common/files/FileManager';
@@ -12,13 +9,14 @@ import SecurityCoverageKnowledge from '@components/analyses/security_coverages/S
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';
 import SecurityCoverage from './SecurityCoverage';
 import { RootSecurityCoverageQuery } from './__generated__/RootSecurityCoverageQuery.graphql';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../components/i18n';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import { getCurrentTab, getPaddingRight, isNotEmptyField } from '../../../../utils/utils';
+import { getPaddingRight, isNotEmptyField } from '../../../../utils/utils';
 import SecurityCoverageEdition from './SecurityCoverageEdition';
 import SecurityCoverageDeletion from './SecurityCoverageDeletion';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
@@ -122,43 +120,16 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
             noAliases={true}
             enableEnrollPlaybook={true}
           />
-          <Box
-            sx={{
-              borderBottom: 1,
-              borderColor: 'divider',
-              marginBottom: 3,
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItem: 'center',
-            }}
-          >
-            <Tabs value={getCurrentTab(location.pathname, securityCoverage.id, '/dashboard/analyses/security_coverages')}>
-              <Tab
-                component={Link}
-                to={`/dashboard/analyses/security_coverages/${securityCoverage.id}`}
-                value={`/dashboard/analyses/security_coverages/${securityCoverage.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/analyses/security_coverages/${securityCoverage.id}/content`}
-                value={`/dashboard/analyses/security_coverages/${securityCoverage.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/analyses/security_coverages/${securityCoverage.id}/files`}
-                value={`/dashboard/analyses/security_coverages/${securityCoverage.id}/files`}
-                label={t_i18n('Data')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/analyses/security_coverages/${securityCoverage.id}/history`}
-                value={`/dashboard/analyses/security_coverages/${securityCoverage.id}/history`}
-                label={t_i18n('History')}
-              />
-            </Tabs>
-            {!isContent && (
+          <StixDomainObjectTabsBox
+            basePath="/dashboard/analyses/security_coverages"
+            entity={securityCoverage}
+            tabs={[
+              'overview',
+              'content',
+              'files',
+              'history',
+            ]}
+            extraActions={!isContent && (
               <>
                 <Button
                   disabled={!hasExternalUri}
@@ -178,7 +149,7 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
                 />
               </>
             )}
-          </Box>
+          />
           <Routes>
             <Route
               path="/"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/Root.tsx
@@ -1,12 +1,10 @@
-import React, { Suspense, useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -21,7 +19,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import { RootChannelSubscription } from './__generated__/RootChannelSubscription.graphql';
 import { RootChannelQuery } from './__generated__/RootChannelQuery.graphql';
 import Security from '../../../../utils/Security';
@@ -164,54 +162,18 @@ const RootChannel = ({ queryRef, channelId }: RootChannelProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, channel.id, '/dashboard/arsenal/channels')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/channels/${channel.id}`}
-                  value={`/dashboard/arsenal/channels/${channel.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/channels/${channel.id}/knowledge/overview`}
-                  value={`/dashboard/arsenal/channels/${channel.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/channels/${channel.id}/content`}
-                  value={`/dashboard/arsenal/channels/${channel.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/channels/${channel.id}/analyses`}
-                  value={`/dashboard/arsenal/channels/${channel.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/channels/${channel.id}/files`}
-                  value={`/dashboard/arsenal/channels/${channel.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/channels/${channel.id}/history`}
-                  value={`/dashboard/arsenal/channels/${channel.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/arsenal/channels"
+              entity={channel}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -1,13 +1,11 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useParams, useLocation } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useParams, useLocation } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import AIInsights from '@components/common/ai/AIInsights';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -22,7 +20,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import { RootMalwareQuery } from './__generated__/RootMalwareQuery.graphql';
 import { RootMalwareSubscription } from './__generated__/RootMalwareSubscription.graphql';
 import Security from '../../../../utils/Security';
@@ -170,62 +168,19 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, malware.id, '/dashboard/arsenal/malwares')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/malwares/${malware.id}`}
-                  value={`/dashboard/arsenal/malwares/${malware.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/malwares/${malware.id}/knowledge/overview`}
-                  value={`/dashboard/arsenal/malwares/${malware.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/malwares/${malware.id}/content`}
-                  value={`/dashboard/arsenal/malwares/${malware.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/malwares/${malware.id}/analyses`}
-                  value={`/dashboard/arsenal/malwares/${malware.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/malwares/${malware.id}/files`}
-                  value={`/dashboard/arsenal/malwares/${malware.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/malwares/${malware.id}/history`}
-                  value={`/dashboard/arsenal/malwares/${malware.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-                  <AIInsights id={malware.id} />
-                </div>
-              )}
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/arsenal/malwares"
+              entity={malware}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && <AIInsights id={malware.id} />}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/Root.tsx
@@ -1,13 +1,11 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import ToolEdition from '@components/arsenal/tools/ToolEdition';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -21,7 +19,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import { RootToolQuery } from './__generated__/RootToolQuery.graphql';
 import { RootToolSubscription } from './__generated__/RootToolSubscription.graphql';
 import Security from '../../../../utils/Security';
@@ -164,54 +162,18 @@ const RootTool = ({ queryRef, toolId }: RootToolProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, tool.id, '/dashboard/arsenal/tools')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/tools/${tool.id}`}
-                  value={`/dashboard/arsenal/tools/${tool.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/tools/${tool.id}/knowledge/overview`}
-                  value={`/dashboard/arsenal/tools/${tool.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/tools/${tool.id}/content`}
-                  value={`/dashboard/arsenal/tools/${tool.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/tools/${tool.id}/analyses`}
-                  value={`/dashboard/arsenal/tools/${tool.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/tools/${tool.id}/files`}
-                  value={`/dashboard/arsenal/tools/${tool.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/tools/${tool.id}/history`}
-                  value={`/dashboard/arsenal/tools/${tool.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/arsenal/tools"
+              entity={tool}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/Root.tsx
@@ -1,12 +1,10 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -21,7 +19,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import { RootVulnerabilityQuery } from './__generated__/RootVulnerabilityQuery.graphql';
 import { RootVulnerabilitySubscription } from './__generated__/RootVulnerabilitySubscription.graphql';
 import Security from '../../../../utils/Security';
@@ -165,54 +163,18 @@ const RootVulnerability = ({ queryRef, vulnerabilityId }: RootVulnerabilityProps
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, vulnerability.id, '/dashboard/arsenal/vulnerabilities')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}`}
-                  value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/knowledge/overview`}
-                  value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/content`}
-                  value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/analyses`}
-                  value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/files`}
-                  value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/history`}
-                  value={`/dashboard/arsenal/vulnerabilities/${vulnerability.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/arsenal/vulnerabilities"
+              entity={vulnerability}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -3,11 +3,9 @@
 // @ts-nocheck
 import React, { useMemo } from 'react';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';
 import Security from 'src/utils/Security';
@@ -28,7 +26,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import CaseIncidentEdition from './CaseIncidentEdition';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import CaseIncidentDeletion from './CaseIncidentDeletion';
@@ -135,63 +133,24 @@ const RootCaseIncidentComponent = ({ queryRef, caseId }) => {
         redirectToContent={true}
         enableEnricher={true}
       />
-      <Box
-        sx={{
-          borderBottom: 1,
-          borderColor: 'divider',
-          marginBottom: 3,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItem: 'center',
-        }}
-      >
-        <Tabs
-          value={getCurrentTab(location.pathname, caseData.id, '/dashboard/cases/incidents')}
-        >
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/incidents/${caseData.id}`}
-            value={`/dashboard/cases/incidents/${caseData.id}`}
-            label={t_i18n('Overview')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/incidents/${caseData.id}/knowledge/graph`}
-            value={`/dashboard/cases/incidents/${caseData.id}/knowledge`}
-            label={t_i18n('Knowledge')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/incidents/${caseData.id}/content`}
-            value={`/dashboard/cases/incidents/${caseData.id}/content`}
-            label={t_i18n('Content')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/incidents/${caseData.id}/entities`}
-            value={`/dashboard/cases/incidents/${caseData.id}/entities`}
-            label={t_i18n('Entities')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/incidents/${caseData.id}/observables`}
-            value={`/dashboard/cases/incidents/${caseData.id}/observables`}
-            label={t_i18n('Observables')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/incidents/${caseData.id}/files`}
-            value={`/dashboard/cases/incidents/${caseData.id}/files`}
-            label={t_i18n('Data')}
-          />
-        </Tabs>
-        {!isKnowledgeOrContent && (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+      <StixDomainObjectTabsBox
+        basePath="/dashboard/cases/incidents"
+        entity={caseData}
+        tabs={[
+          'overview',
+          'knowledge-graph',
+          'content',
+          'entities',
+          'observables',
+          'files',
+        ]}
+        extraActions={!isKnowledgeOrContent && (
+          <>
             <AIInsights id={caseData.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
             <StixCoreObjectSecurityCoverage id={caseData.id} coverage={caseData.securityCoverage} />
-          </div>
+          </>
         )}
-      </Box>
+      />
       <Routes>
         <Route
           path="/"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -2,12 +2,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import Security from 'src/utils/Security';
 import AIInsights from '@components/common/ai/AIInsights';
@@ -27,7 +25,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import CaseRfiEdition from './CaseRfiEdition';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import CaseRfiDeletion from './CaseRfiDeletion';
@@ -127,62 +125,19 @@ const RootCaseRfiComponent = ({ queryRef, caseId }) => {
         redirectToContent={true}
         enableEnricher={true}
       />
-      <Box
-        sx={{
-          borderBottom: 1,
-          borderColor: 'divider',
-          marginBottom: 3,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItem: 'center',
-        }}
-      >
-        <Tabs
-          value={getCurrentTab(location.pathname, caseData.id, '/dashboard/cases/rfis')}
-        >
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfis/${caseData.id}`}
-            value={`/dashboard/cases/rfis/${caseData.id}`}
-            label={t_i18n('Overview')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfis/${caseData.id}/knowledge/graph`}
-            value={`/dashboard/cases/rfis/${caseData.id}/knowledge`}
-            label={t_i18n('Knowledge')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfis/${caseData.id}/content`}
-            value={`/dashboard/cases/rfis/${caseData.id}/content`}
-            label={t_i18n('Content')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfis/${caseData.id}/entities`}
-            value={`/dashboard/cases/rfis/${caseData.id}/entities`}
-            label={t_i18n('Entities')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfis/${caseData.id}/observables`}
-            value={`/dashboard/cases/rfis/${caseData.id}/observables`}
-            label={t_i18n('Observables')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfis/${caseData.id}/files`}
-            value={`/dashboard/cases/rfis/${caseData.id}/files`}
-            label={t_i18n('Data')}
-          />
-        </Tabs>
-        {!isKnowledgeOrContent && (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-            <AIInsights id={caseData.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
-          </div>
-        )}
-      </Box>
+      <StixDomainObjectTabsBox
+        basePath="/dashboard/cases/rfis"
+        entity={caseData}
+        tabs={[
+          'overview',
+          'knowledge-graph',
+          'content',
+          'entities',
+          'observables',
+          'files',
+        ]}
+        extraActions={!isKnowledgeOrContent && <AIInsights id={caseData.id} tabs={['containers']} defaultTab="containers" isContainer={true} />}
+      />
       <Routes>
         <Route
           path="/"

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
@@ -2,12 +2,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import Security from 'src/utils/Security';
 import AIInsights from '@components/common/ai/AIInsights';
@@ -26,7 +24,7 @@ import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import CaseRftEdition from './CaseRftEdition';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import CaseRftDeletion from './CaseRftDeletion';
@@ -125,62 +123,19 @@ const RootCaseRftComponent = ({ queryRef, caseId }) => {
         redirectToContent={true}
         enableEnricher={true}
       />
-      <Box
-        sx={{
-          borderBottom: 1,
-          borderColor: 'divider',
-          marginBottom: 3,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItem: 'center',
-        }}
-      >
-        <Tabs
-          value={getCurrentTab(location.pathname, caseData.id, '/dashboard/cases/rfts')}
-        >
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfts/${caseData.id}`}
-            value={`/dashboard/cases/rfts/${caseData.id}`}
-            label={t_i18n('Overview')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfts/${caseData.id}/knowledge/graph`}
-            value={`/dashboard/cases/rfts/${caseData.id}/knowledge`}
-            label={t_i18n('Knowledge')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfts/${caseData.id}/content`}
-            value={`/dashboard/cases/rfts/${caseData.id}/content`}
-            label={t_i18n('Content')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfts/${caseData.id}/entities`}
-            value={`/dashboard/cases/rfts/${caseData.id}/entities`}
-            label={t_i18n('Entities')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfts/${caseData.id}/observables`}
-            value={`/dashboard/cases/rfts/${caseData.id}/observables`}
-            label={t_i18n('Observables')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/rfts/${caseData.id}/files`}
-            value={`/dashboard/cases/rfts/${caseData.id}/files`}
-            label={t_i18n('Data')}
-          />
-        </Tabs>
-        {!isKnowledgeOrContent && (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-            <AIInsights id={caseData.id} tabs={['containers']} defaultTab="containers" isContainer={true} />
-          </div>
-        )}
-      </Box>
+      <StixDomainObjectTabsBox
+        basePath="/dashboard/cases/rfts"
+        entity={caseData}
+        tabs={[
+          'overview',
+          'knowledge-graph',
+          'content',
+          'entities',
+          'observables',
+          'files',
+        ]}
+        extraActions={!isKnowledgeOrContent && <AIInsights id={caseData.id} tabs={['containers']} defaultTab="containers" isContainer={true} />}
+      />
       <Routes>
         <Route
           path="/"

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -133,7 +133,7 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
         redirectToContent={true}
       />
       <StixDomainObjectTabsBox
-        basePath="/dashboard/incidents/feedbacks"
+        basePath="/dashboard/cases/feedbacks"
         entity={feedbackData}
         tabs={[
           'overview',

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -1,15 +1,13 @@
 // TODO Remove this when V6
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import Box from '@mui/material/Box';
 import React, { useMemo } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreRelationship from '@components/common/stix_core_relationships/StixCoreRelationship';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import Security from 'src/utils/Security';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from 'src/utils/hooks/useGranted';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
@@ -24,7 +22,7 @@ import Feedback from './Feedback';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import FeedbackEdition from './FeedbackEdition';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
 import FeedbackDeletion from './FeedbackDeletion';
@@ -134,42 +132,16 @@ const RootFeedbackComponent = ({ queryRef, caseId }) => {
         enableQuickSubscription
         redirectToContent={true}
       />
-      <Box
-        sx={{
-          borderBottom: 1,
-          borderColor: 'divider',
-          marginBottom: 3,
-        }}
-      >
-        <Tabs
-          value={getCurrentTab(location.pathname, feedbackData.id, '/dashboard/incidents/feedbacks')}
-        >
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/feedbacks/${feedbackData.id}`}
-            value={`/dashboard/cases/feedbacks/${feedbackData.id}`}
-            label={t_i18n('Overview')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/feedbacks/${feedbackData.id}/content`}
-            value={`/dashboard/cases/feedbacks/${feedbackData.id}/content`}
-            label={t_i18n('Content')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/feedbacks/${feedbackData.id}/files`}
-            value={`/dashboard/cases/feedbacks/${feedbackData.id}/files`}
-            label={t_i18n('Data')}
-          />
-          <Tab
-            component={Link}
-            to={`/dashboard/cases/feedbacks/${feedbackData.id}/history`}
-            value={`/dashboard/cases/feedbacks/${feedbackData.id}/history`}
-            label={t_i18n('History')}
-          />
-        </Tabs>
-      </Box>
+      <StixDomainObjectTabsBox
+        basePath="/dashboard/incidents/feedbacks"
+        entity={feedbackData}
+        tabs={[
+          'overview',
+          'content',
+          'files',
+          'history',
+        ]}
+      />
       <Routes>
         <Route
           path="/"

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -2,13 +2,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import Security from 'src/utils/Security';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from 'src/utils/hooks/useGranted';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
@@ -23,7 +21,7 @@ import { RootTaskSubscription } from './__generated__/RootTaskSubscription.graph
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import TaskEdition from './TaskEdition';
 import TaskDeletion from './TaskDeletion';
 
@@ -115,42 +113,16 @@ const RootTaskComponent = ({ queryRef, taskId }) => {
             disableAuthorizedMembers={true}
             enableEnrollPlaybook={true}
           />
-          <Box
-            sx={{
-              borderBottom: 1,
-              borderColor: 'divider',
-              marginBottom: 3,
-            }}
-          >
-            <Tabs
-              value={getCurrentTab(location.pathname, data.id, '/dashboard/cases/tasks')}
-            >
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/tasks/${data.id}`}
-                value={`/dashboard/cases/tasks/${data.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/tasks/${data.id}/content`}
-                value={`/dashboard/cases/tasks/${data.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/tasks/${data.id}/files`}
-                value={`/dashboard/cases/tasks/${data.id}/files`}
-                label={t_i18n('Data')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/cases/tasks/${data.id}/history`}
-                value={`/dashboard/cases/tasks/${data.id}/history`}
-                label={t_i18n('History')}
-              />
-            </Tabs>
-          </Box>
+          <StixDomainObjectTabsBox
+            basePath="/dashboard/cases/tasks"
+            entity={data}
+            tabs={[
+              'overview',
+              'content',
+              'files',
+              'history',
+            ]}
+          />
           <Routes>
             <Route
               path="/"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import testRender from '../../../../utils/tests/test-render';
+import StixDomainObjectTabsBox from './StixDomainObjectTabsBox';
+
+const TABS_TEST_DATA = [
+  ['Overview', 'overview', ''],
+  ['Knowledge', 'knowledge', '/knowledge'],
+  ['Knowledge', 'knowledge-graph', '/knowledge/graph'],
+  ['Knowledge', 'knowledge-overview', '/knowledge/overview'],
+  ['Content', 'content', '/content'],
+  ['Analyses', 'analyses', '/analyses'],
+  ['Sightings', 'sightings', '/sightings'],
+  ['Entities', 'entities', '/entities'],
+  ['Observables', 'observables', '/observables'],
+  ['Data', 'files', '/files'],
+  ['History', 'history', '/history'],
+] as const;
+
+describe('StixDomainObjectTabsBox', () => {
+  const entityId = 'entity-id';
+  const entityType = 'entity-type';
+  const basePath = `base/${entityType}`;
+  it.each(TABS_TEST_DATA)('renders a %s link when %s prop is passed targeting %s', (tabName, prop, subroute) => {
+    testRender(
+      <StixDomainObjectTabsBox
+        tabs={[prop]}
+        entity={{
+          id: entityId,
+          entity_type: entityType,
+        }}
+        basePath={basePath}
+      />,
+    );
+    const tabElem = screen.getByText(new RegExp(tabName, 'i'));
+    expect(tabElem).toBeInTheDocument();
+    expect(tabElem).toBeInstanceOf(HTMLAnchorElement);
+    expect((tabElem as HTMLAnchorElement).href).toMatch(new RegExp(`${basePath}/${entityId}${subroute}$`));
+  });
+
+  it('renders components passed as extraActions', () => {
+    testRender(
+      <StixDomainObjectTabsBox
+        tabs={[]}
+        entity={{
+          id: entityId,
+          entity_type: entityType,
+        }}
+        basePath={basePath}
+        extraActions={<>Some Extra Action</>}
+      />,
+    );
+    expect(screen.getByText(/some extra action/i)).toBeInTheDocument();
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.test.tsx
@@ -32,10 +32,12 @@ describe('StixDomainObjectTabsBox', () => {
         basePath={basePath}
       />,
     );
-    const tabElem = screen.getByText(new RegExp(tabName, 'i'));
+    const tabElem = screen.getByRole('tab', { name: new RegExp(tabName, 'i') });
     expect(tabElem).toBeInTheDocument();
-    expect(tabElem).toBeInstanceOf(HTMLAnchorElement);
-    expect((tabElem as HTMLAnchorElement).href).toMatch(new RegExp(`${basePath}/${entityId}${subroute}$`));
+    expect(tabElem).toHaveAttribute(
+      'href',
+      expect.stringMatching(new RegExp(`${basePath}/${entityId}${subroute}$`)),
+    );
   });
 
   it('renders components passed as extraActions', () => {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
@@ -6,11 +6,8 @@ import React from 'react';
 import { getCurrentTab } from '../../../../utils/utils';
 import { useFormatter } from '../../../../components/i18n';
 
-interface StixDomainObjectTabsBoxProps {
-  entity: { id: string; entity_type: string };
-  basePath: string;
-  tabs: (
-    | 'overview'
+type StixDomainObjectTabsBoxTab
+  = | 'overview'
     | 'knowledge'
     | 'knowledge-graph'
     | 'knowledge-overview'
@@ -20,7 +17,12 @@ interface StixDomainObjectTabsBoxProps {
     | 'entities'
     | 'observables'
     | 'files'
-    | 'history')[];
+    | 'history';
+
+interface StixDomainObjectTabsBoxProps {
+  entity: { id: string; entity_type: string };
+  basePath: string;
+  tabs: StixDomainObjectTabsBoxTab[];
   extraActions?: React.ReactNode;
 }
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
@@ -1,0 +1,142 @@
+import Box from '@mui/material/Box';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import { Link, useLocation } from 'react-router-dom';
+import React from 'react';
+import { getCurrentTab } from '../../../../utils/utils';
+import { useFormatter } from '../../../../components/i18n';
+
+interface StixDomainObjectTabsBoxProps {
+  entity: { id: string; entity_type: string };
+  basePath: string;
+  tabs: (
+    | 'overview'
+    | 'knowledge'
+    | 'knowledge-graph'
+    | 'knowledge-overview'
+    | 'content'
+    | 'analyses'
+    | 'sightings'
+    | 'entities'
+    | 'observables'
+    | 'files'
+    | 'history')[];
+  extraActions?: React.ReactNode;
+}
+
+const StixDomainObjectTabsBox = ({ basePath, entity, extraActions, tabs }: StixDomainObjectTabsBoxProps) => {
+  const { t_i18n } = useFormatter();
+  const location = useLocation();
+  return (
+    <Box
+      sx={{
+        borderBottom: 1,
+        borderColor: 'divider',
+        marginBottom: 3,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <Tabs
+        value={getCurrentTab(location.pathname, entity.id, basePath)}
+      >
+        {tabs.includes('overview') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}`}
+            value={`${basePath}/${entity.id}`}
+            label={t_i18n('Overview')}
+          />
+        )}
+        {tabs.includes('knowledge') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/knowledge`}
+            value={`${basePath}/${entity.id}/knowledge`}
+            label={t_i18n('Knowledge')}
+          />
+        )}
+        {tabs.includes('knowledge-overview') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/knowledge/overview`}
+            value={`${basePath}/${entity.id}/knowledge`}
+            label={t_i18n('Knowledge')}
+          />
+        )}
+        {tabs.includes('knowledge-graph') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/knowledge/graph`}
+            value={`${basePath}/${entity.id}/knowledge`}
+            label={t_i18n('Knowledge')}
+          />
+        )}
+        {tabs.includes('content') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/content`}
+            value={`${basePath}/${entity.id}/content`}
+            label={t_i18n('Content')}
+          />
+        )}
+        {tabs.includes('analyses') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/analyses`}
+            value={`${basePath}/${entity.id}/analyses`}
+            label={t_i18n('Analyses')}
+          />
+        )}
+        {tabs.includes('sightings') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/sightings`}
+            value={`${basePath}/${entity.id}/sightings`}
+            label={t_i18n('Sightings')}
+          />
+        )}
+        {tabs.includes('entities') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/entities`}
+            value={`${basePath}/${entity.id}/entities`}
+            label={t_i18n('Entities')}
+          />
+        )}
+        {tabs.includes('observables') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/observables`}
+            value={`${basePath}/${entity.id}/observables`}
+            label={t_i18n('Observables')}
+          />
+        )}
+        {tabs.includes('files') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/files`}
+            value={`${basePath}/${entity.id}/files`}
+            label={t_i18n('Data')}
+          />
+        )}
+        {tabs.includes('history') && (
+          <Tab
+            component={Link}
+            to={`${basePath}/${entity.id}/history`}
+            value={`${basePath}/${entity.id}/history`}
+            label={t_i18n('History')}
+          />
+        )}
+      </Tabs>
+      {extraActions ? (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+          {extraActions}
+        </div>
+      ) : null}
+    </Box>
+  );
+};
+
+export default StixDomainObjectTabsBox;

--- a/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/Root.tsx
@@ -1,14 +1,12 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootEventQuery } from '@components/entities/events/__generated__/RootEventQuery.graphql';
 import { RootEventsSubscription } from '@components/entities/events/__generated__/RootEventsSubscription.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -24,7 +22,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import EventEdition from './EventEdition';
@@ -160,60 +158,19 @@ const RootEvent = ({ eventId, queryRef }: RootEventProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, event.id, '/dashboard/entities/events')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}`}
-                  value={`/dashboard/entities/events/${event.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}/knowledge/overview`}
-                  value={`/dashboard/entities/events/${event.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}/content`}
-                  value={`/dashboard/entities/events/${event.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}/analyses`}
-                  value={`/dashboard/entities/events/${event.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}/sightings`}
-                  value={`/dashboard/entities/events/${event.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}/files`}
-                  value={`/dashboard/entities/events/${event.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/events/${event.id}/history`}
-                  value={`/dashboard/entities/events/${event.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/entities/events"
+              entity={event}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/Root.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo, Suspense, useState } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { propOr } from 'ramda';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootIndividualQuery } from '@components/entities/individuals/__generated__/RootIndividualQuery.graphql';
 import { RootIndicatorSubscription } from '@components/observations/indicators/__generated__/RootIndicatorSubscription.graphql';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -26,7 +24,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import IndividualEdition from './IndividualEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -198,60 +196,19 @@ const RootIndividual = ({ individualId, queryRef }: RootIndividualProps) => {
               disableSharing={individual.isUser}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, individual.id, '/dashboard/entities/individuals')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}`}
-                  value={`/dashboard/entities/individuals/${individual.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}/knowledge/overview`}
-                  value={`/dashboard/entities/individuals/${individual.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}/content`}
-                  value={`/dashboard/entities/individuals/${individual.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}/analyses`}
-                  value={`/dashboard/entities/individuals/${individual.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}/sightings`}
-                  value={`/dashboard/entities/individuals/${individual.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}/files`}
-                  value={`/dashboard/entities/individuals/${individual.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/individuals/${individual.id}/history`}
-                  value={`/dashboard/entities/individuals/${individual.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/entities/individuals"
+              entity={individual}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -1,15 +1,13 @@
+import { propOr } from 'ramda';
 import React, { useMemo, Suspense, useState } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootOrganizationQuery } from '@components/entities/organizations/__generated__/RootOrganizationQuery.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import { RootOrganizationSubscription } from '@components/entities/organizations/__generated__/RootOrganizationSubscription.graphql';
-import { propOr } from 'ramda';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -26,7 +24,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import OrganizationEdition from './OrganizationEdition';
@@ -208,60 +206,19 @@ const RootOrganization = ({ organizationId, queryRef }: RootOrganizationProps) =
               enableEnricher={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, organization.id, '/dashboard/entities/organizations')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}`}
-                  value={`/dashboard/entities/organizations/${organization.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}/knowledge/overview`}
-                  value={`/dashboard/entities/organizations/${organization.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}/content`}
-                  value={`/dashboard/entities/organizations/${organization.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}/analyses`}
-                  value={`/dashboard/entities/organizations/${organization.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}/sightings`}
-                  value={`/dashboard/entities/organizations/${organization.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}/files`}
-                  value={`/dashboard/entities/organizations/${organization.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/organizations/${organization.id}/history`}
-                  value={`/dashboard/entities/organizations/${organization.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/entities/organizations"
+              entity={organization}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -1,15 +1,13 @@
-import React, { Suspense, useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootSectorQuery } from '@components/entities/sectors/__generated__/RootSectorQuery.graphql';
 import { RootSectorSubscription } from '@components/entities/sectors/__generated__/RootSectorSubscription.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import AIInsights from '@components/common/ai/AIInsights';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -25,7 +23,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import SectorEdition from './SectorEdition';
@@ -165,68 +163,20 @@ const RootSector = ({ sectorId, queryRef }: RootSectorProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, sector.id, '/dashboard/entities/sectors')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}`}
-                  value={`/dashboard/entities/sectors/${sector.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}/knowledge/overview`}
-                  value={`/dashboard/entities/sectors/${sector.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}/content`}
-                  value={`/dashboard/entities/sectors/${sector.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}/analyses`}
-                  value={`/dashboard/entities/sectors/${sector.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}/sightings`}
-                  value={`/dashboard/entities/sectors/${sector.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}/files`}
-                  value={`/dashboard/entities/sectors/${sector.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/sectors/${sector.id}/history`}
-                  value={`/dashboard/entities/sectors/${sector.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-                  <AIInsights id={sector.id} />
-                </div>
-              )}
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/entities/sectors"
+              entity={sector}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && <AIInsights id={sector.id} />}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/Root.tsx
@@ -1,10 +1,7 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import { RootSecurityPlatformSubscription } from '@components/entities/securityPlatforms/__generated__/RootSecurityPlatformSubscription.graphql';
@@ -13,6 +10,7 @@ import SecurityPlatformKnowledge from '@components/entities/securityPlatforms/Se
 import SecurityPlatformEdition from '@components/entities/securityPlatforms/SecurityPlatformEdition';
 import SecurityPlatformAnalysis from '@components/entities/securityPlatforms/SecurityPlatformAnalysis';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import SecurityPlatform from './SecurityPlatform';
@@ -24,7 +22,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import SecurityPlatformDeletion from './SecurityPlatformDeletion';
@@ -158,54 +156,18 @@ const RootSecurityPlatform = ({ securityPlatformId, queryRef }: RootSecurityPlat
               enableEnricher={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, securityPlatform.id, '/dashboard/entities/security_platforms')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/security_platforms/${securityPlatform.id}`}
-                  value={`/dashboard/entities/security_platforms/${securityPlatform.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/security_platforms/${securityPlatform.id}/knowledge/overview`}
-                  value={`/dashboard/entities/security_platforms/${securityPlatform.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/security_platforms/${securityPlatform.id}/content`}
-                  value={`/dashboard/entities/security_platforms/${securityPlatform.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/security_platforms/${securityPlatform.id}/analyses`}
-                  value={`/dashboard/entities/security_platforms/${securityPlatform.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/security_platforms/${securityPlatform.id}/files`}
-                  value={`/dashboard/entities/security_platforms/${securityPlatform.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/security_platforms/${securityPlatform.id}/history`}
-                  value={`/dashboard/entities/security_platforms/${securityPlatform.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/entities/security_platforms"
+              entity={securityPlatform}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/Root.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo, Suspense, useState } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom';
+import { Route, Routes, Navigate, useLocation, useParams, useNavigate } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { propOr } from 'ramda';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootSystemQuery } from '@components/entities/systems/__generated__/RootSystemQuery.graphql';
 import { RootSystemsSubscription } from '@components/entities/systems/__generated__/RootSystemsSubscription.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -26,7 +24,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import SystemEdition from './SystemEdition';
@@ -191,60 +189,19 @@ const RootSystem = ({ systemId, queryRef }: RootSystemProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, system.id, '/dashboard/entities/systems')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}`}
-                  value={`/dashboard/entities/systems/${system.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}/knowledge/overview`}
-                  value={`/dashboard/entities/systems/${system.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}/content`}
-                  value={`/dashboard/entities/systems/${system.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}/analyses`}
-                  value={`/dashboard/entities/systems/${system.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}/sightings`}
-                  value={`/dashboard/entities/systems/${system.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}/files`}
-                  value={`/dashboard/entities/systems/${system.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/entities/systems/${system.id}/history`}
-                  value={`/dashboard/entities/systems/${system.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/entities/systems"
+              entity={system}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -2,12 +2,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Route, Routes, useParams, useLocation, Navigate } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation, Navigate } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import Security from 'src/utils/Security';
@@ -30,7 +28,6 @@ import { RootIncidentQuery } from './__generated__/RootIncidentQuery.graphql';
 import { RootIncidentSubscription } from './__generated__/RootIncidentSubscription.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab } from '../../../../utils/utils';
 import IncidentEdition from './IncidentEdition';
 import IncidentDeletion from './IncidentDeletion';
 
@@ -175,63 +172,24 @@ const RootIncidentComponent = ({ queryRef }) => {
               enableEnricher={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, incident.id, '/dashboard/events/incidents')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/events/incidents/${incident.id}`}
-                  value={`/dashboard/events/incidents/${incident.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/events/incidents/${incident.id}/knowledge/overview`}
-                  value={`/dashboard/events/incidents/${incident.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/events/incidents/${incident.id}/content`}
-                  value={`/dashboard/events/incidents/${incident.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/events/incidents/${incident.id}/analyses`}
-                  value={`/dashboard/events/incidents/${incident.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/events/incidents/${incident.id}/files`}
-                  value={`/dashboard/events/incidents/${incident.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/events/incidents/${incident.id}/history`}
-                  value={`/dashboard/events/incidents/${incident.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/events/incidents"
+              entity={incident}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && (
+                <>
                   <AIInsights id={incident.id} />
                   <StixCoreObjectSecurityCoverage id={incident.id} coverage={incident.securityCoverage} />
-                </div>
+                </>
               )}
-            </Box>
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
@@ -1,15 +1,13 @@
-import React, { Suspense, useMemo } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootObservedDataSubscription } from './__generated__/RootObservedDataSubscription.graphql';
 import { RootObservedDataQuery } from './__generated__/RootObservedDataQuery.graphql';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import ObservedData from './ObservedData';
 import FileManager from '../../common/files/FileManager';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import ContainerHeader from '../../common/containers/ContainerHeader';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -116,48 +114,17 @@ const RootObservedData = ({ queryRef, observedDataId }: RootObservedDataProps) =
           disableAuthorizedMembers={true}
           enableEnricher={false}
         />
-        <Box
-          sx={{
-            borderBottom: 1,
-            borderColor: 'divider',
-            marginBottom: 3,
-          }}
-        >
-          <Tabs
-            value={location.pathname}
-          >
-            <Tab
-              component={Link}
-              to={`/dashboard/events/observed_data/${observedData.id}`}
-              value={`/dashboard/events/observed_data/${observedData.id}`}
-              label={t_i18n('Overview')}
-            />
-            <Tab
-              component={Link}
-              to={`/dashboard/events/observed_data/${observedData.id}/entities`}
-              value={`/dashboard/events/observed_data/${observedData.id}/entities`}
-              label={t_i18n('Entities')}
-            />
-            <Tab
-              component={Link}
-              to={`/dashboard/events/observed_data/${observedData.id}/observables`}
-              value={`/dashboard/events/observed_data/${observedData.id}/observables`}
-              label={t_i18n('Observables')}
-            />
-            <Tab
-              component={Link}
-              to={`/dashboard/events/observed_data/${observedData.id}/files`}
-              value={`/dashboard/events/observed_data/${observedData.id}/files`}
-              label={t_i18n('Data')}
-            />
-            <Tab
-              component={Link}
-              to={`/dashboard/events/observed_data/${observedData.id}/history`}
-              value={`/dashboard/events/observed_data/${observedData.id}/history`}
-              label={t_i18n('History')}
-            />
-          </Tabs>
-        </Box>
+        <StixDomainObjectTabsBox
+          basePath="/dashboard/events/observed_data"
+          entity={observedData}
+          tabs={[
+            'overview',
+            'entities',
+            'observables',
+            'files',
+            'history',
+          ]}
+        />
         <Routes>
           <Route
             path="/"

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo } from 'react';
-import { Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Route, Routes, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootObservedDataSubscription } from './__generated__/RootObservedDataSubscription.graphql';
@@ -75,7 +75,6 @@ const RootObservedData = ({ queryRef, observedDataId }: RootObservedDataProps) =
   }), [observedDataId]);
 
   const { t_i18n } = useFormatter();
-  const location = useLocation();
 
   useSubscription<RootObservedDataSubscription>(subConfig);
 

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -2,13 +2,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -27,7 +25,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import AdministrativeAreaEdition from './AdministrativeAreaEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -162,60 +160,19 @@ const RootAdministrativeAreaComponent = ({ queryRef, administrativeAreaId }) => 
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, administrativeArea.id, '/dashboard/locations/administrative_areas')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/knowledge/overview`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/content`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/analyses`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/sightings`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/files`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/administrative_areas/${administrativeArea.id}/history`}
-                  value={`/dashboard/locations/administrative_areas/${administrativeArea.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/locations/administrative_areas"
+              entity={administrativeArea}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -2,12 +2,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
@@ -27,7 +25,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import CityEdition from './CityEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -158,60 +156,19 @@ const RootCityComponent = ({ queryRef, cityId }) => {
               enableEnrollPlaybook={true}
               redirectToContent={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, city.id, '/dashboard/locations/cities')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}`}
-                  value={`/dashboard/locations/cities/${city.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}/knowledge/overview`}
-                  value={`/dashboard/locations/cities/${city.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}/content`}
-                  value={`/dashboard/locations/cities/${city.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}/analyses`}
-                  value={`/dashboard/locations/cities/${city.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}/sightings`}
-                  value={`/dashboard/locations/cities/${city.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}/files`}
-                  value={`/dashboard/locations/cities/${city.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/cities/${city.id}/history`}
-                  value={`/dashboard/locations/cities/${city.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/locations/cities"
+              entity={city}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -2,13 +2,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Route, Routes, useParams, Link, useLocation, Navigate } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation, Navigate } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import AIInsights from '@components/common/ai/AIInsights';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
@@ -28,7 +26,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import CountryEdition from './CountryEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -162,68 +160,20 @@ const RootCountryComponent = ({ queryRef, countryId }) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, country.id, '/dashboard/locations/countries')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}`}
-                  value={`/dashboard/locations/countries/${country.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}/knowledge/overview`}
-                  value={`/dashboard/locations/countries/${country.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}/content`}
-                  value={`/dashboard/locations/countries/${country.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}/analyses`}
-                  value={`/dashboard/locations/countries/${country.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}/sightings`}
-                  value={`/dashboard/locations/countries/${country.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}/files`}
-                  value={`/dashboard/locations/countries/${country.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/countries/${country.id}/history`}
-                  value={`/dashboard/locations/countries/${country.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-                  <AIInsights id={country.id} />
-                </div>
-              )}
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/locations/countries"
+              entity={country}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && <AIInsights id={country.id} />}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/Root.tsx
@@ -1,14 +1,12 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootPositionQuery } from '@components/locations/positions/__generated__/RootPositionQuery.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootPositionsSubscription } from '@components/locations/positions/__generated__/RootPositionsSubscription.graphql';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
@@ -24,7 +22,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import PositionEdition from './PositionEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -165,60 +163,19 @@ const RootPosition = ({ positionId, queryRef }: RootPositionProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, position.id, '/dashboard/locations/positions')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}`}
-                  value={`/dashboard/locations/positions/${position.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}/knowledge/overview`}
-                  value={`/dashboard/locations/positions/${position.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}/content`}
-                  value={`/dashboard/locations/positions/${position.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}/analyses`}
-                  value={`/dashboard/locations/positions/${position.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}/sightings`}
-                  value={`/dashboard/locations/positions/${position.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}/files`}
-                  value={`/dashboard/locations/positions/${position.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/positions/${position.id}/history`}
-                  value={`/dashboard/locations/positions/${position.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/locations/positions"
+              entity={position}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -163,7 +163,7 @@ const RootRegionComponent = ({ queryRef, regionId }) => {
             />
             <StixDomainObjectTabsBox
               basePath="/dashboard/locations/regions"
-              entity={position}
+              entity={region}
               tabs={[
                 'overview',
                 'knowledge-overview',

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -2,13 +2,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Route, Routes, useParams, Link, useLocation, Navigate } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation, Navigate } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import AIInsights from '@components/common/ai/AIInsights';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
@@ -28,7 +26,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import RegionEdition from './RegionEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -163,68 +161,20 @@ const RootRegionComponent = ({ queryRef, regionId }) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, region.id, '/dashboard/locations/regions')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}`}
-                  value={`/dashboard/locations/regions/${region.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}/knowledge/overview`}
-                  value={`/dashboard/locations/regions/${region.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}/content`}
-                  value={`/dashboard/locations/regions/${region.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}/analyses`}
-                  value={`/dashboard/locations/regions/${region.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}/sightings`}
-                  value={`/dashboard/locations/regions/${region.id}/sightings`}
-                  label={t_i18n('Sightings')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}/files`}
-                  value={`/dashboard/locations/regions/${region.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/locations/regions/${region.id}/history`}
-                  value={`/dashboard/locations/regions/${region.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-                  <AIInsights id={region.id} />
-                </div>
-              )}
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/locations/regions"
+              entity={position}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'sightings',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && <AIInsights id={region.id} />}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/Root.jsx
@@ -1,11 +1,8 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Route, Routes, Link } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { graphql } from 'react-relay';
 import * as R from 'ramda';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import withRouter from '../../../../utils/compat_router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
@@ -15,13 +12,14 @@ import StixCyberObservableKnowledge from '../stix_cyber_observables/StixCyberObs
 import Loader from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCyberObservableHeader from '../stix_cyber_observables/StixCyberObservableHeader';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import EntityStixSightingRelationships from '../../events/stix_sighting_relationships/EntityStixSightingRelationships';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import FileManager from '../../common/files/FileManager';
 import StixSightingRelationship from '../../events/stix_sighting_relationships/StixSightingRelationship';
 import inject18n from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import StixCyberObservableDeletion from '../stix_cyber_observables/StixCyberObservableDeletion';
@@ -121,60 +119,19 @@ class RootArtifact extends Component {
                         </Security>
                       )}
                     />
-                    <Box
-                      sx={{
-                        borderBottom: 1,
-                        borderColor: 'divider',
-                        marginBottom: 3,
-                      }}
-                    >
-                      <Tabs
-                        value={getCurrentTab(location.pathname, stixCyberObservable.id, '/dashboard/observations/artifacts')}
-                      >
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}`}
-                          label={t('Overview')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/knowledge`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/knowledge`}
-                          label={t('Knowledge')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/content`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/content`}
-                          label={t('Content')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/analyses`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/analyses`}
-                          label={t('Analyses')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/sightings`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/sightings`}
-                          label={t('Sightings')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/files`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/files`}
-                          label={t('Data')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/observations/artifacts/${stixCyberObservable.id}/history`}
-                          value={`/dashboard/observations/artifacts/${stixCyberObservable.id}/history`}
-                          label={t('History')}
-                        />
-                      </Tabs>
-                    </Box>
+                    <StixDomainObjectTabsBox
+                      basePath="/dashboard/observations/artifacts"
+                      entity={stixCyberObservable}
+                      tabs={[
+                        'overview',
+                        'knowledge',
+                        'content',
+                        'analyses',
+                        'sightings',
+                        'files',
+                        'history',
+                      ]}
+                    />
                     <Routes>
                       <Route
                         path="/"

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/Root.tsx
@@ -1,15 +1,13 @@
-import React, { Suspense, useMemo } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootIndicatorQuery } from '@components/observations/indicators/__generated__/RootIndicatorQuery.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootIndicatorSubscription } from '@components/observations/indicators/__generated__/RootIndicatorSubscription.graphql';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
@@ -25,7 +23,7 @@ import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainO
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import IndicatorEdition from './IndicatorEdition';
@@ -137,60 +135,19 @@ const RootIndicator = ({ indicatorId, queryRef }: RootIndicatorProps) => {
             enableEnrollPlaybook={true}
             redirectToContent={true}
           />
-          <Box
-            sx={{
-              borderBottom: 1,
-              borderColor: 'divider',
-              marginBottom: 3,
-            }}
-          >
-            <Tabs
-              value={getCurrentTab(location.pathname, indicator.id, '/dashboard/observations/indicators')}
-            >
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}`}
-                value={`/dashboard/observations/indicators/${indicator.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}/knowledge`}
-                value={`/dashboard/observations/indicators/${indicator.id}/knowledge`}
-                label={t_i18n('Knowledge')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}/content`}
-                value={`/dashboard/observations/indicators/${indicator.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}/analyses`}
-                value={`/dashboard/observations/indicators/${indicator.id}/analyses`}
-                label={t_i18n('Analyses')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}/sightings`}
-                value={`/dashboard/observations/indicators/${indicator.id}/sightings`}
-                label={t_i18n('Sightings')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}/files`}
-                value={`/dashboard/observations/indicators/${indicator.id}/files`}
-                label={t_i18n('Data')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/indicators/${indicator.id}/history`}
-                value={`/dashboard/observations/indicators/${indicator.id}/history`}
-                label={t_i18n('History')}
-              />
-            </Tabs>
-          </Box>
+          <StixDomainObjectTabsBox
+            basePath="/dashboard/observations/indicators"
+            entity={indicator}
+            tabs={[
+              'overview',
+              'knowledge',
+              'content',
+              'analyses',
+              'sightings',
+              'files',
+              'history',
+            ]}
+          />
           <Routes>
             <Route
               path="/"

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -2,13 +2,11 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Route, useParams, Routes, Link, useLocation, Navigate } from 'react-router-dom';
+import { Route, useParams, Routes, useLocation, Navigate } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
@@ -25,7 +23,6 @@ import Infrastructure from './Infrastructure';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import InfrastructureEdition from './InfrastructureEdition';
@@ -135,50 +132,18 @@ const RootInfrastructureComponent = ({ queryRef, infrastructureId }) => {
             redirectToContent={true}
             enableEnrollPlaybook={true}
           />
-          <Box
-            sx={{ borderBottom: 1, borderColor: 'divider', marginBottom: 3 }}
-          >
-            <Tabs
-              value={getCurrentTab(location.pathname, infrastructure.id, '/dashboard/observations/infrastructures')}
-            >
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/infrastructures/${infrastructure.id}`}
-                value={`/dashboard/observations/infrastructures/${infrastructure.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/infrastructures/${infrastructure.id}/knowledge/overview`}
-                value={`/dashboard/observations/infrastructures/${infrastructure.id}/knowledge`}
-                label={t_i18n('Knowledge')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/infrastructures/${infrastructure.id}/content`}
-                value={`/dashboard/observations/infrastructures/${infrastructure.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/infrastructures/${infrastructure.id}/analyses`}
-                value={`/dashboard/observations/infrastructures/${infrastructure.id}/analyses`}
-                label={t_i18n('Analyses')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/infrastructures/${infrastructure.id}/files`}
-                value={`/dashboard/observations/infrastructures/${infrastructure.id}/files`}
-                label={t_i18n('Data')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/infrastructures/${infrastructure.id}/history`}
-                value={`/dashboard/observations/infrastructures/${infrastructure.id}/history`}
-                label={t_i18n('History')}
-              />
-            </Tabs>
-          </Box>
+          <StixDomainObjectTabsBox
+            basePath="/dashboard/observations/infrastructures"
+            entity={infrastructure}
+            tabs={[
+              'overview',
+              'knowledge-overview',
+              'content',
+              'analyses',
+              'files',
+              'history',
+            ]}
+          />
           <Routes>
             <Route
               path="/"

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/Root.tsx
@@ -1,14 +1,12 @@
-import React, { Suspense, useMemo } from 'react';
-import { Link, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootStixCyberObservableQuery } from '@components/observations/stix_cyber_observables/__generated__/RootStixCyberObservableQuery.graphql';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootStixCyberObservableSubscription } from '@components/observations/stix_cyber_observables/__generated__/RootStixCyberObservableSubscription.graphql';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 import StixCyberObservable from './StixCyberObservable';
@@ -23,7 +21,7 @@ import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/contain
 import FileManager from '../../common/files/FileManager';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import StixCyberObservableDeletion from './StixCyberObservableDeletion';
@@ -118,60 +116,19 @@ const RootStixCyberObservable = ({ observableId, queryRef }: RootStixCyberObserv
               </Security>
             )}
           />
-          <Box
-            sx={{
-              borderBottom: 1,
-              borderColor: 'divider',
-              marginBottom: 3,
-            }}
-          >
-            <Tabs
-              value={getCurrentTab(location.pathname, stixCyberObservable.id, '/dashboard/observations/observables')}
-            >
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}/knowledge`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}/knowledge`}
-                label={t_i18n('Knowledge')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}/content`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}/analyses`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}/analyses`}
-                label={t_i18n('Analyses')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}/sightings`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}/sightings`}
-                label={t_i18n('Sightings')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}/files`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}/files`}
-                label={t_i18n('Data')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/observations/observables/${stixCyberObservable.id}/history`}
-                value={`/dashboard/observations/observables/${stixCyberObservable.id}/history`}
-                label={t_i18n('History')}
-              />
-            </Tabs>
-          </Box>
+          <StixDomainObjectTabsBox
+            basePath="/dashboard/observations/observables"
+            entity={stixCyberObservable}
+            tabs={[
+              'overview',
+              'knowledge',
+              'content',
+              'analyses',
+              'sightings',
+              'files',
+              'history',
+            ]}
+          />
           <Routes>
             <Route
               path="/"

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/Root.tsx
@@ -1,15 +1,13 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootAttackPatternQuery } from '@components/techniques/attack_patterns/__generated__/RootAttackPatternQuery.graphql';
 import { RootAttackPatternSubscription } from '@components/techniques/attack_patterns/__generated__/RootAttackPatternSubscription.graphql';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import AttackPattern from './AttackPattern';
@@ -23,7 +21,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import AttackPatternEdition from './AttackPatternEdition';
@@ -160,54 +158,18 @@ const RootAttackPattern = ({ attackPatternId, queryRef }: RootAttackPatternProps
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, attackPattern.id, '/dashboard/techniques/attack_patterns')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}`}
-                  value={`/dashboard/techniques/attack_patterns/${attackPattern.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/knowledge/overview`}
-                  value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/content`}
-                  value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/analyses`}
-                  value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/files`}
-                  value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/attack_patterns/${attackPattern.id}/history`}
-                  value={`/dashboard/techniques/attack_patterns/${attackPattern.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/techniques/attack_patterns"
+              entity={attackPattern}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/Root.jsx
@@ -1,12 +1,10 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import * as PropTypes from 'prop-types';
-import { Link, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { graphql } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import * as R from 'ramda';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import withRouter from '../../../../utils/compat_router/withRouter';
 import { QueryRenderer, requestSubscription } from '../../../../relay/environment';
 import CourseOfAction from './CourseOfAction';
@@ -18,7 +16,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import CourseOfActionKnowledge from './CourseOfActionKnowledge';
 import inject18n from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import CourseOfActionEdition from './CourseOfActionEdition';
@@ -127,42 +125,16 @@ class RootCourseOfAction extends Component {
                       redirectToContent={true}
                       enableEnrollPlaybook={true}
                     />
-                    <Box
-                      sx={{
-                        borderBottom: 1,
-                        borderColor: 'divider',
-                        marginBottom: 3,
-                      }}
-                    >
-                      <Tabs
-                        value={getCurrentTab(location.pathname, courseOfAction.id, '/dashboard/techniques/courses_of_action')}
-                      >
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/techniques/courses_of_action/${courseOfAction.id}`}
-                          value={`/dashboard/techniques/courses_of_action/${courseOfAction.id}`}
-                          label={t('Overview')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/content`}
-                          value={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/content`}
-                          label={t('Content')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/files`}
-                          value={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/files`}
-                          label={t('Data')}
-                        />
-                        <Tab
-                          component={Link}
-                          to={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/history`}
-                          value={`/dashboard/techniques/courses_of_action/${courseOfAction.id}/history`}
-                          label={t('History')}
-                        />
-                      </Tabs>
-                    </Box>
+                    <StixDomainObjectTabsBox
+                      basePath="/dashboard/techniques/courses_of_action"
+                      entity={courseOfAction}
+                      tabs={[
+                        'overview',
+                        'content',
+                        'files',
+                        'history',
+                      ]}
+                    />
                     <Routes>
                       <Route
                         path="/"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -2,12 +2,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router-dom';
 import { graphql, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import { QueryRenderer } from '../../../../relay/environment';
 import Loader from '../../../../components/Loader';
@@ -21,7 +19,7 @@ import DataComponentKnowledge from './DataComponentKnowledge';
 import { RootDataComponentSubscription } from './__generated__/RootDataComponentSubscription.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import DataComponentEdition from './DataComponentEdition';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -122,42 +120,16 @@ const RootDataComponent = () => {
                     redirectToContent={true}
                     enableEnrollPlaybook={true}
                   />
-                  <Box
-                    sx={{
-                      borderBottom: 1,
-                      borderColor: 'divider',
-                      marginBottom: 3,
-                    }}
-                  >
-                    <Tabs
-                      value={getCurrentTab(location.pathname, dataComponent.id, '/dashboard/arsenal/techniques')}
-                    >
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/techniques/data_components/${dataComponent.id}`}
-                        value={`/dashboard/techniques/data_components/${dataComponent.id}`}
-                        label={t_i18n('Overview')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/techniques/data_components/${dataComponent.id}/content`}
-                        value={`/dashboard/techniques/data_components/${dataComponent.id}/content`}
-                        label={t_i18n('Content')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/techniques/data_components/${dataComponent.id}/files`}
-                        value={`/dashboard/techniques/data_components/${dataComponent.id}/files`}
-                        label={t_i18n('Data')}
-                      />
-                      <Tab
-                        component={Link}
-                        to={`/dashboard/techniques/data_components/${dataComponent.id}/history`}
-                        value={`/dashboard/techniques/data_components/${dataComponent.id}/history`}
-                        label={t_i18n('History')}
-                      />
-                    </Tabs>
-                  </Box>
+                  <StixDomainObjectTabsBox
+                    basePath="/dashboard/techniques/data_components"
+                    entity={dataComponent}
+                    tabs={[
+                      'overview',
+                      'content',
+                      'files',
+                      'history',
+                    ]}
+                  />
                   <Routes>
                     <Route
                       path="/"

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -2,12 +2,10 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
-import { Link, Route, Routes, useParams, useLocation } from 'react-router-dom';
+import { Route, Routes, useParams, useLocation } from 'react-router-dom';
 import { graphql, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
-import Box from '@mui/material/Box';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import FileManager from '../../common/files/FileManager';
@@ -21,7 +19,7 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import DataSourceEdition from './DataSourceEdition';
@@ -115,38 +113,16 @@ const RootDataSourceComponent = ({ queryRef, dataSourceId }) => {
             redirectToContent={true}
             enableEnrollPlaybook={true}
           />
-          <Box
-            sx={{ borderBottom: 1, borderColor: 'divider', marginBottom: 4 }}
-          >
-            <Tabs
-              value={getCurrentTab(location.pathname, dataSource.id, '/dashboard/techniques/data_sources')}
-            >
-              <Tab
-                component={Link}
-                to={`/dashboard/techniques/data_sources/${dataSource.id}`}
-                value={`/dashboard/techniques/data_sources/${dataSource.id}`}
-                label={t_i18n('Overview')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/techniques/data_sources/${dataSource.id}/content`}
-                value={`/dashboard/techniques/data_sources/${dataSource.id}/content`}
-                label={t_i18n('Content')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/techniques/data_sources/${dataSource.id}/files`}
-                value={`/dashboard/techniques/data_sources/${dataSource.id}/files`}
-                label={t_i18n('Data')}
-              />
-              <Tab
-                component={Link}
-                to={`/dashboard/techniques/data_sources/${dataSource.id}/history`}
-                value={`/dashboard/techniques/data_sources/${dataSource.id}/history`}
-                label={t_i18n('History')}
-              />
-            </Tabs>
-          </Box>
+          <StixDomainObjectTabsBox
+            basePath="/dashboard/techniques/data_sources"
+            entity={dataSource}
+            tabs={[
+              'overview',
+              'content',
+              'files',
+              'history',
+            ]}
+          />
           <Routes>
             <Route
               path="/"

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/Root.tsx
@@ -1,16 +1,14 @@
-import React, { useMemo, Suspense } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { useMemo, Suspense } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import { RootNarrativeQuery } from '@components/techniques/narratives/__generated__/RootNarrativeQuery.graphql';
 import { RootNarrativeSubscription } from '@components/techniques/narratives/__generated__/RootNarrativeSubscription.graphql';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import CreateRelationshipContextProvider from '@components/common/stix_core_relationships/CreateRelationshipContextProvider';
 import StixCoreRelationshipCreationFromEntityHeader from '@components/common/stix_core_relationships/StixCoreRelationshipCreationFromEntityHeader';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import Narrative from './Narrative';
 import NarrativeKnowledge from './NarrativeKnowledge';
@@ -23,7 +21,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import NarrativeEdition from './NarrativeEdition';
@@ -155,54 +153,18 @@ const RootNarrative = ({ narrativeId, queryRef }: RootNarrativeProps) => {
                 </Security>
               )}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, narrative.id, '/dashboard/techniques/narratives')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${narrative.id}`}
-                  value={`/dashboard/techniques/narratives/${narrative.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${narrative.id}/knowledge/overview`}
-                  value={`/dashboard/techniques/narratives/${narrative.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${narrative.id}/content`}
-                  value={`/dashboard/techniques/narratives/${narrative.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${narrative.id}/analyses`}
-                  value={`/dashboard/techniques/narratives/${narrative.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${narrative.id}/files`}
-                  value={`/dashboard/techniques/narratives/${narrative.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/techniques/narratives/${narrative.id}/history`}
-                  value={`/dashboard/techniques/narratives/${narrative.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/techniques/narratives"
+              entity={narrative}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -1,9 +1,6 @@
-import React, { Suspense, useMemo } from 'react';
-import { Route, Routes, Link, Navigate, useParams, useLocation } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Route, Routes, Navigate, useParams, useLocation } from 'react-router-dom';
 import { graphql, PreloadedQuery, useSubscription, usePreloadedQuery } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
 import { RootCampaignSubscription } from '@components/threats/campaigns/__generated__/RootCampaignSubscription.graphql';
@@ -14,6 +11,7 @@ import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreOb
 import Campaign from './Campaign';
 import CampaignKnowledge from './CampaignKnowledge';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import FileManager from '../../common/files/FileManager';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
@@ -22,7 +20,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import { RootCampaignQuery } from './__generated__/RootCampaignQuery.graphql';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -172,63 +170,24 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, campaign.id, '/dashboard/threats/campaigns')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/campaigns/${campaign.id}`}
-                  value={`/dashboard/threats/campaigns/${campaign.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/campaigns/${campaign.id}/knowledge/overview`}
-                  value={`/dashboard/threats/campaigns/${campaign.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/campaigns/${campaign.id}/content`}
-                  value={`/dashboard/threats/campaigns/${campaign.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/campaigns/${campaign.id}/analyses`}
-                  value={`/dashboard/threats/campaigns/${campaign.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/campaigns/${campaign.id}/files`}
-                  value={`/dashboard/threats/campaigns/${campaign.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/campaigns/${campaign.id}/history`}
-                  value={`/dashboard/threats/campaigns/${campaign.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/threats/campaigns"
+              entity={campaign}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && (
+                <>
                   <AIInsights id={campaign.id} />
                   <StixCoreObjectSecurityCoverage id={campaign.id} coverage={campaign.securityCoverage} />
-                </div>
+                </>
               )}
-            </Box>
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -1,13 +1,11 @@
-import React, { Suspense, useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import AIInsights from '@components/common/ai/AIInsights';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixCoreObjectSecurityCoverage from '@components/common/stix_core_objects/StixCoreObjectSecurityCoverage';
 import StixCoreObjectContentRoot from '../../common/stix_core_objects/StixCoreObjectContentRoot';
 import IntrusionSet from './IntrusionSet';
@@ -21,7 +19,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import { RootIntrusionSetQuery } from './__generated__/RootIntrusionSetQuery.graphql';
 import { RootIntrusionSetSubscription } from './__generated__/RootIntrusionSetSubscription.graphql';
 import Security from '../../../../utils/Security';
@@ -178,63 +176,24 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, intrusionSet.id, '/dashboard/threats/intrusion_sets')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}`}
-                  value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/knowledge/overview`}
-                  value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/content`}
-                  value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/analyses`}
-                  value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/files`}
-                  value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/history`}
-                  value={`/dashboard/threats/intrusion_sets/${intrusionSet.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/threats/intrusion_sets"
+              entity={intrusionSet}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && (
+                <>
                   <AIInsights id={intrusionSet.id} />
                   <StixCoreObjectSecurityCoverage id={intrusionSet.id} coverage={intrusionSet.securityCoverage} />
-                </div>
+                </>
               )}
-            </Box>
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -1,9 +1,6 @@
-import React, { Suspense, useMemo } from 'react';
-import { Route, Routes, Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { Suspense, useMemo } from 'react';
+import { Route, Routes, Navigate, useLocation, useParams } from 'react-router-dom';
 import { graphql, useSubscription, usePreloadedQuery, PreloadedQuery } from 'react-relay';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import useQueryLoading from 'src/utils/hooks/useQueryLoading';
 import { RootThreatActorGroupQuery } from '@components/threats/threat_actors_group/__generated__/RootThreatActorGroupQuery.graphql';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
@@ -15,6 +12,7 @@ import ThreatActorGroup from './ThreatActorGroup';
 import ThreatActorGroupKnowledge from './ThreatActorGroupKnowledge';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import FileManager from '../../common/files/FileManager';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObjectHistory';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
@@ -22,7 +20,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import ThreatActorGroupEdition from './ThreatActorGroupEdition';
@@ -170,62 +168,19 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, threatActorGroup.id, '/dashboard/threats/threat_actors_group')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}`}
-                  value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/knowledge/overview`}
-                  value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/content`}
-                  value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/analyses`}
-                  value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/files`}
-                  value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/history`}
-                  value={`/dashboard/threats/threat_actors_group/${threatActorGroup.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-                  <AIInsights id={threatActorGroup.id} />
-                </div>
-              )}
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/threats/threat_actors_group"
+              entity={threatActorGroup}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && <AIInsights id={threatActorGroup.id} />}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -1,10 +1,7 @@
 import React, { useMemo } from 'react';
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { GraphQLSubscriptionConfig } from 'relay-runtime';
-import Box from '@mui/material/Box';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
 import StixCoreObjectContentRoot from '@components/common/stix_core_objects/StixCoreObjectContentRoot';
 import useForceUpdate from '@components/common/bulk/useForceUpdate';
 import AIInsights from '@components/common/ai/AIInsights';
@@ -15,6 +12,7 @@ import StixCoreObjectHistory from '../../common/stix_core_objects/StixCoreObject
 import { RootThreatActorIndividualQuery } from './__generated__/RootThreatActorIndividualQuery.graphql';
 import { RootThreatActorIndividualSubscription } from './__generated__/RootThreatActorIndividualSubscription.graphql';
 import ThreatActorIndividual from './ThreatActorIndividual';
+import StixDomainObjectTabsBox from '@components/common/stix_domain_objects/StixDomainObjectTabsBox';
 import StixDomainObjectHeader from '../../common/stix_domain_objects/StixDomainObjectHeader';
 import FileManager from '../../common/files/FileManager';
 import StixCoreObjectOrStixCoreRelationshipContainers from '../../common/containers/StixCoreObjectOrStixCoreRelationshipContainers';
@@ -22,7 +20,7 @@ import ThreatActorIndividualKnowledge from './ThreatActorIndividualKnowledge';
 import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreObjectKnowledgeBar';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
-import { getCurrentTab, getPaddingRight } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import ThreatActorIndividualEdition from './ThreatActorIndividualEdition';
@@ -184,62 +182,19 @@ const RootThreatActorIndividualComponent = ({
               redirectToContent={true}
               enableEnrollPlaybook={true}
             />
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                marginBottom: 3,
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItem: 'center',
-              }}
-            >
-              <Tabs
-                value={getCurrentTab(location.pathname, threatActorIndividual.id, '/dashboard/threats/threat_actors_individual')}
-              >
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}`}
-                  value={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}`}
-                  label={t_i18n('Overview')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/knowledge/overview`}
-                  value={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/knowledge`}
-                  label={t_i18n('Knowledge')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/content`}
-                  value={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/content`}
-                  label={t_i18n('Content')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/analyses`}
-                  value={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/analyses`}
-                  label={t_i18n('Analyses')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/files`}
-                  value={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/files`}
-                  label={t_i18n('Data')}
-                />
-                <Tab
-                  component={Link}
-                  to={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/history`}
-                  value={`/dashboard/threats/threat_actors_individual/${threatActorIndividual.id}/history`}
-                  label={t_i18n('History')}
-                />
-              </Tabs>
-              {isOverview && (
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '10px' }}>
-                  <AIInsights id={threatActorIndividual.id} />
-                </div>
-              )}
-            </Box>
+            <StixDomainObjectTabsBox
+              basePath="/dashboard/threats/threat_actors_individual"
+              entity={threatActorIndividual}
+              tabs={[
+                'overview',
+                'knowledge-overview',
+                'content',
+                'analyses',
+                'files',
+                'history',
+              ]}
+              extraActions={isOverview && <AIInsights id={threatActorIndividual.id} />}
+            />
             <Routes>
               <Route
                 path="/"

--- a/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
+++ b/opencti-platform/opencti-front/src/utils/tests/test-render.tsx
@@ -1,6 +1,7 @@
 import { createTheme, ThemeOptions, ThemeProvider } from '@mui/material/styles';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import React, { ReactNode } from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { render, renderHook } from '@testing-library/react';
 import { createMockEnvironment } from 'relay-test-utils';
 import { EnvironmentConfig } from 'relay-runtime';
@@ -79,15 +80,17 @@ export const ProvidersWrapper = ({ children, relayEnv, userContext }: ProvidersW
   const defaultUserContext = userContext ?? createMockUserContext();
 
   return (
-    <RelayEnvironmentProvider environment={relayEnv}>
-      <AppIntlProvider settings={{ platform_language: 'auto', platform_translations: '{}' }}>
-        <ThemeProvider theme={createTheme(ThemeDark() as ThemeOptions)}>
-          <UserContext.Provider value={defaultUserContext as UserContextType}>
-            {children}
-          </UserContext.Provider>
-        </ThemeProvider>
-      </AppIntlProvider>
-    </RelayEnvironmentProvider>
+    <BrowserRouter>
+      <RelayEnvironmentProvider environment={relayEnv}>
+        <AppIntlProvider settings={{ platform_language: 'auto', platform_translations: '{}' }}>
+          <ThemeProvider theme={createTheme(ThemeDark() as ThemeOptions)}>
+            <UserContext.Provider value={defaultUserContext as UserContextType}>
+              {children}
+            </UserContext.Provider>
+          </ThemeProvider>
+        </AppIntlProvider>
+      </RelayEnvironmentProvider>
+    </BrowserRouter>
   );
 };
 


### PR DESCRIPTION
### Proposed changes

* Creates a `StixDomainObjectTabsBox` component that mutualizes the main tabs for all STIX Domain Object pages along with its parent `Box` and potential extra action components displayed on the right side.
* Applies the new component to SDOs
* While doing so I remarked a few bugs due to copy/pastes of the pattern (in link values, in CSS)
* Added unit test suite for the new component
* BONUS: fixes frontend hot reload. (`chokidar` doesn't support glob paths apparently)

<img width="1275" height="165" alt="stix-domain-object-tabs-box" src="https://github.com/user-attachments/assets/0c2e4279-147d-4922-ac9e-2b0651491b37" />

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/13389

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Feature branch deploy

https://feat-issue-13389-cus.octi.staging.filigran.io/