### PR TITLE
[frontend] Display option labels instead of IDs in PlaybookFlowFieldArray (#14619)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -59,6 +59,7 @@ const AutocompleteField = <
     getOptionLabel,
     endAdornment,
     disabled,
+    renderTags,
   } = muiProps;
 
   const [, meta] = useField(name);
@@ -92,6 +93,20 @@ const AutocompleteField = <
       ? truncate(option.label, optionLength)
       : truncate(option, optionLength);
   };
+
+  const defaultRenderTags: MuiProps['renderTags'] = (values, getTagProps) => (
+    values.map((option, index) => {
+      const { label, value } = getOptionData(option);
+      return (
+        <Tag
+          {...getTagProps({ index })}
+          labelTextTransform={preserveCase ? 'none' : 'capitalize'}
+          key={value}
+          label={label}
+        />
+      );
+    })
+  );
 
   const getOptionData = (option: Value) => {
     return typeof option === 'object' && option !== null
@@ -134,19 +149,7 @@ const AutocompleteField = <
         noOptionsText={noOptionsText}
         {...fieldProps}
         renderOption={renderOption}
-        renderTags={(values, getTagProps) => (
-          values.map((option, index) => {
-            const { label, value } = getOptionData(option);
-            return (
-              <Tag
-                {...getTagProps({ index })}
-                labelTextTransform={preserveCase ? 'none' : 'capitalize'}
-                key={value}
-                label={label}
-              />
-            );
-          })
-        )}
+        renderTags={renderTags ?? defaultRenderTags}
         onChange={internalOnChange}
         onFocus={internalOnFocus}
         onBlur={internalOnBlur}

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldArray.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldArray.tsx
@@ -13,10 +13,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import { MenuItem, Tooltip, TooltipProps } from '@mui/material';
 import { Field } from 'formik';
 import AutocompleteField from '../../../../../../components/AutocompleteField';
-import { fieldSpacingContainerStyle } from '../../../../../../utils/field';
+import { FieldOption, fieldSpacingContainerStyle } from '../../../../../../utils/field';
 import useEntityTranslation from '../../../../../../utils/hooks/useEntityTranslation';
 
 interface Option {
@@ -38,17 +37,16 @@ const PlaybookFlowFieldArray = ({
   multiple = false,
 }: PlaybookFlowFieldArrayProps) => {
   const { translateEntityType } = useEntityTranslation();
-  const fieldOptions = [...options]
+  const fieldOptions: FieldOption[] = [...options]
     .sort((a, b) =>
       translateEntityType(a?.title ?? '').localeCompare(
         translateEntityType(b?.title ?? ''),
       ),
     )
-    .map((o) => o.const);
-
-  const findOption = (value: string) => {
-    return options.find((o) => o.const === value);
-  };
+    .map((o) => ({
+      value: o.const,
+      label: translateEntityType(o.title),
+    }));
 
   return (
     <Field
@@ -62,28 +60,6 @@ const PlaybookFlowFieldArray = ({
       }}
       name={name}
       options={fieldOptions}
-      isOptionEqualToValue={(o: string, val: string) => o === val}
-      renderOption={(props: TooltipProps, value: string) => {
-        const option = findOption(value);
-        if (!option) return null;
-        return (
-          <Tooltip
-            {...props}
-            key={option.const}
-            title={translateEntityType(option.title)}
-            placement="bottom-start"
-          >
-            <MenuItem value={option.const}>
-              {/* value might be an entity type, we try to translate it */}
-              {translateEntityType(option.title)}
-            </MenuItem>
-          </Tooltip>
-        );
-      }}
-      getOptionLabel={(val: string) => {
-        const option = findOption(val);
-        return option ? translateEntityType(option.title) : '';
-      }}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldArray.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldArray.tsx
@@ -13,10 +13,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
+import { AutocompleteRenderGetTagProps, MenuItem, Tooltip, TooltipProps } from '@mui/material';
 import { Field } from 'formik';
 import AutocompleteField from '../../../../../../components/AutocompleteField';
-import { FieldOption, fieldSpacingContainerStyle } from '../../../../../../utils/field';
+import { fieldSpacingContainerStyle } from '../../../../../../utils/field';
 import useEntityTranslation from '../../../../../../utils/hooks/useEntityTranslation';
+import Tag from '../../../../../../components/common/tag/Tag';
 
 interface Option {
   const: string;
@@ -37,16 +39,17 @@ const PlaybookFlowFieldArray = ({
   multiple = false,
 }: PlaybookFlowFieldArrayProps) => {
   const { translateEntityType } = useEntityTranslation();
-  const fieldOptions: FieldOption[] = [...options]
+  const fieldOptions = [...options]
     .sort((a, b) =>
       translateEntityType(a?.title ?? '').localeCompare(
         translateEntityType(b?.title ?? ''),
       ),
     )
-    .map((o) => ({
-      value: o.const,
-      label: translateEntityType(o.title),
-    }));
+    .map((o) => o.const);
+
+  const findOption = (value: string) => {
+    return options.find((o) => o.const === value);
+  };
 
   return (
     <Field
@@ -60,6 +63,39 @@ const PlaybookFlowFieldArray = ({
       }}
       name={name}
       options={fieldOptions}
+      renderTags={(values: string[], getTagProps: AutocompleteRenderGetTagProps) => (
+        values.map((value, index) => {
+          const option = findOption(value);
+          return (
+            <Tag
+              {...getTagProps({ index })}
+              key={value}
+              label={option?.title}
+            />
+          );
+        })
+      )}
+      renderOption={(props: TooltipProps, value: string) => {
+        const option = findOption(value);
+        if (!option) return null;
+        return (
+          <Tooltip
+            {...props}
+            key={option.const}
+            title={translateEntityType(option.title)}
+            placement="bottom-start"
+          >
+            <MenuItem value={option.const}>
+              {/* value might be an entity type, we try to translate it */}
+              {translateEntityType(option.title)}
+            </MenuItem>
+          </Tooltip>
+        );
+      }}
+      getOptionLabel={(val: string) => {
+        const option = findOption(val);
+        return option ? translateEntityType(option.title) : '';
+      }}
     />
   );
 };


### PR DESCRIPTION
### Proposed changes

* Convert playbook field array options to { label, value } format so AutocompleteField can display the option names instead of their IDs after selection.

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/14619