### PR TITLE
[frontend] Import dialog should close when clicking elsewhere (#14809)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -512,6 +512,7 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
       open={open}
       size="large"
       title={t_i18n('Import data')}
+      onClose={handleClose}
     >
       {!uploadStatus ? (
         <>


### PR DESCRIPTION
### Proposed changes
The import data pop-up should close when clicking elsewhere or pressing Echap.

<img width="1848" height="876" alt="image" src="https://github.com/user-attachments/assets/7374a922-7239-436e-aabf-c7affcdd4105" />


### Related issues
#14809