### PR TITLE
[frontend] Connector reset menu item tooltip (#14799)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/danger_zone/DangerZoneChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/danger_zone/DangerZoneChip.tsx
@@ -13,6 +13,7 @@ const DangerZoneChip = () => {
       tooltipTitle={t_i18n('DangerZoneTooltip')}
       label={t_i18n('Danger Zone')}
       color={theme.palette.dangerZone.main}
+      labelTextTransform="none"
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
@@ -168,9 +168,13 @@ const ConnectorPopover = ({ connector, onRefreshData }: ConnectorPopoverProps) =
           <DangerZoneBlock
             type="connector_reset"
             sx={{ title: { display: 'none' } }}
-            component={(
-              <MenuItem onClick={handleOpenResetState} sx={{ color: theme.palette.dangerZone.main, gap: 1 }}>
-                <span>{t_i18n('Reset')}</span>
+            component={({ disabled }) => (
+              <MenuItem
+                onClick={handleOpenResetState}
+                disabled={disabled}
+                sx={{ color: theme.palette.dangerZone.main, gap: 1 }}
+              >
+                <div>{t_i18n('Reset')}</div>
                 <DangerZoneChip />
               </MenuItem>
             )}


### PR DESCRIPTION
### Proposed changes
Fix tooltip display in 'reset' menu item of a connector overview

<img width="372" height="234" alt="image" src="https://github.com/user-attachments/assets/e8a788a9-b6e1-49c4-b45a-3858697f06cb" />


<img width="552" height="282" alt="image" src="https://github.com/user-attachments/assets/53fbf68f-278d-4d99-8d6c-73d6da0c26ca" />


### Related issues
#14799