### PR TITLE
[task] Restores the labels of issues created from the Github issue template (#14924)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report OpenCTI
 about: Create a bug report to help us improve OpenCTI
 title: ''
-labels: needs triage
+labels: needs triage,bug
 assignees: ''
 type: bug
 

--- a/.github/ISSUE_TEMPLATE/bug_report_pycti.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pycti.yaml
@@ -6,6 +6,7 @@ type: bug
 labels:
   - needs triage
   - client-python
+  - bug
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request OpenCTI
 about: Ask for a new feature to be implemented in OpenCTI
 title: ''
-labels: needs triage
+labels: needs triage,feature
 assignees: ''
 type: feature
 

--- a/.github/ISSUE_TEMPLATE/feature_request_pycti.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_pycti.yaml
@@ -6,6 +6,7 @@ type: feature
 labels:
   - needs triage
   - client-python
+  - feature
 assignees: []
 body:
   - type: textarea


### PR DESCRIPTION
### Proposed changes

* Restores the labels of issues created from the Github issue template

