### PR TITLE
[backend] Reducing allowed content in CSP (#14169)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -132,7 +132,7 @@ const createApp = async (app, schema) => {
   const ancestorsFromConfig = nconf.get('app:public_dashboard_authorized_domains')?.trim() ?? '';
   const frameAncestorDomains = ancestorsFromConfig === '' ? "'none'" : ancestorsFromConfig;
   const allowedFrameSrc = ["'self'"];
-  const scriptSrc = ["'self'"];
+  const scriptSrc = ["'self'", "'unsafe-inline'"];
   const connectSrc = ["'self'", 'wss://*', 'data:', 'https://*'];
   const objectSrc = ["'self'", 'data:', 'https://*'];
   const manifestSrc = ["'self'", 'data:', 'https://*', 'http://*'];

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -116,7 +116,7 @@ const createApp = async (app, schema) => {
         defaultSrc: ["'self'"],
         scriptSrc: opts.scriptSrc,
         styleSrc: ["'self'", "'unsafe-inline'"],
-        scriptSrcAttr: ["'self'"],
+        scriptSrcAttr: ["'none'"],
         fontSrc: ["'self'", 'data:'],
         imgSrc: ["'self'", 'data:', 'https://*', 'http://*'],
         manifestSrc: ["'self'", 'data:', 'https://*', 'http://*'],

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -115,23 +115,13 @@ const createApp = async (app, schema) => {
       directives: {
         defaultSrc: ["'self'"],
         scriptSrc: opts.scriptSrc,
-        styleSrc: [
-          "'self'",
-          "'unsafe-inline'",
-          'http://cdn.jsdelivr.net/npm/@apollographql/',
-          'https://fonts.googleapis.com/',
-        ],
-        scriptSrcAttr: [
-          "'self'",
-          "'unsafe-inline'",
-          'http://cdn.jsdelivr.net/npm/@apollographql/',
-          'https://fonts.googleapis.com/',
-        ],
-        fontSrc: ["'self'", 'data:', 'https://fonts.gstatic.com/'],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrcAttr: ["'self'"],
+        fontSrc: ["'self'", 'data:'],
         imgSrc: ["'self'", 'data:', 'https://*', 'http://*'],
-        manifestSrc: ["'self'", 'data:', 'https://*', 'http://*'],
-        connectSrc: ["'self'", 'wss://*', 'ws://*', 'data:', 'http://*', 'https://*'],
-        objectSrc: ["'self'", 'data:', 'http://*', 'https://*'],
+        manifestSrc: opts.manifestSrc,
+        connectSrc: opts.connectSrc,
+        objectSrc: opts.objectSrc,
         frameSrc: opts.allowedFrameSrc,
         frameAncestors: opts.frameAncestorDomains,
       },
@@ -142,14 +132,26 @@ const createApp = async (app, schema) => {
   const ancestorsFromConfig = nconf.get('app:public_dashboard_authorized_domains')?.trim() ?? '';
   const frameAncestorDomains = ancestorsFromConfig === '' ? "'none'" : ancestorsFromConfig;
   const allowedFrameSrc = ["'self'"];
-  const scriptSrc = ["'self'", "'unsafe-inline'", 'http://cdn.jsdelivr.net/npm/@apollographql/', 'https://www.googletagmanager.com/'];
+  const scriptSrc = ["'self'"];
+  const connectSrc = ["'self'", 'wss://*', 'data:', 'https://*'];
+  const objectSrc = ["'self'", 'data:', 'https://*'];
+  const manifestSrc = ["'self'", 'data:', 'https://*', 'http://*'];
+
   if (DEV_MODE) {
     scriptSrc.push("'unsafe-eval'");
+    connectSrc.push('http://*');
+    connectSrc.push('ws://*');
+    objectSrc.push('http://*');
+    manifestSrc.push('http://*');
   }
+
   const securityOpts = {
     frameAncestorDomains: "'none'",
     allowedFrameSrc,
     scriptSrc,
+    connectSrc,
+    objectSrc,
+    manifestSrc,
     isIframeAllowed: false,
   };
 

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -132,7 +132,7 @@ const createApp = async (app, schema) => {
   const ancestorsFromConfig = nconf.get('app:public_dashboard_authorized_domains')?.trim() ?? '';
   const frameAncestorDomains = ancestorsFromConfig === '' ? "'none'" : ancestorsFromConfig;
   const allowedFrameSrc = ["'self'"];
-  const scriptSrc = ["'self'"];
+  const scriptSrc = ["'self'", "'unsafe-inline'"];
   if (DEV_MODE) {
     scriptSrc.push("'unsafe-eval'");
   }

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -119,9 +119,9 @@ const createApp = async (app, schema) => {
         scriptSrcAttr: ["'self'"],
         fontSrc: ["'self'", 'data:'],
         imgSrc: ["'self'", 'data:', 'https://*', 'http://*'],
-        manifestSrc: opts.manifestSrc,
-        connectSrc: opts.connectSrc,
-        objectSrc: opts.objectSrc,
+        manifestSrc: ["'self'", 'data:', 'https://*', 'http://*'],
+        connectSrc: ["'self'", 'wss://*', 'ws://*', 'data:', 'http://*', 'https://*'],
+        objectSrc: ["'self'", 'data:', 'http://*', 'https://*'],
         frameSrc: opts.allowedFrameSrc,
         frameAncestors: opts.frameAncestorDomains,
       },
@@ -132,26 +132,14 @@ const createApp = async (app, schema) => {
   const ancestorsFromConfig = nconf.get('app:public_dashboard_authorized_domains')?.trim() ?? '';
   const frameAncestorDomains = ancestorsFromConfig === '' ? "'none'" : ancestorsFromConfig;
   const allowedFrameSrc = ["'self'"];
-  const scriptSrc = ["'self'", "'unsafe-inline'"];
-  const connectSrc = ["'self'", 'wss://*', 'data:', 'https://*'];
-  const objectSrc = ["'self'", 'data:', 'https://*'];
-  const manifestSrc = ["'self'", 'data:', 'https://*', 'http://*'];
-
+  const scriptSrc = ["'self'"];
   if (DEV_MODE) {
     scriptSrc.push("'unsafe-eval'");
-    connectSrc.push('http://*');
-    connectSrc.push('ws://*');
-    objectSrc.push('http://*');
-    manifestSrc.push('http://*');
   }
-
   const securityOpts = {
     frameAncestorDomains: "'none'",
     allowedFrameSrc,
     scriptSrc,
-    connectSrc,
-    objectSrc,
-    manifestSrc,
     isIframeAllowed: false,
   };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removes previously allowed external CSP sources (Apollo CDN / Google Fonts) from relevant directives.
* Tightens script-src-attr and font-src directives.
* Simplifies the non-dev script-src allowlist (removes third-party origins).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #14169 

### Manual tests checklist

- [x] Application is working fine
- [x] Chatbot is working fine (uses wss)
- [x] graphiql is working fine
- [x] using a base path is working fine
- [x] SSO is working fine
- [x] OpenCTI in iframe is working fine
- [x] public dashboard is working fine
- [x] Export dashboard to pdf and png
- [x] Generate a fintel template

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
