### PR TITLE
[ci] Switch LTS tag format from 7.260309.0-ltsx to 7.260309.0-lts.x and improve pycti check (#14878)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -946,7 +946,7 @@ workflows:
       - build_pycti:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
           requires:
@@ -957,7 +957,7 @@ workflows:
             - build_pycti
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
 # Build opencti
@@ -968,13 +968,13 @@ workflows:
       - wait_for_connector_release:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - build_platform:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
           requires:
@@ -998,7 +998,7 @@ workflows:
       - build_platform_musl:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
           requires:
@@ -1037,7 +1037,7 @@ workflows:
             - build_platform
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - tag_package_musl:
@@ -1045,7 +1045,7 @@ workflows:
             - build_platform_musl
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/              
       - docker_build_platform_rolling:
@@ -1096,7 +1096,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - docker_build_worker:
@@ -1105,7 +1105,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - docker_build_platform_fips:
@@ -1114,7 +1114,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - docker_build_worker_fips:
@@ -1123,7 +1123,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/
       - deploy_testing:
@@ -1155,6 +1155,6 @@ workflows:
             - docker_build_worker_fips
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts[0-9]*)?/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,23 +62,24 @@ jobs:
       - run:
           name: check version
           command: |
+            set -x
             cd client-python
             package_version="$(
                 python3 -c 'import pycti; print(pycti.__version__)'
             )"
             # Transform tag version to expected PEP 440 package version:
-            #   7.260309.0        -> 7.260309.0        (standard release)
-            #   7.260309.0-lts    -> 7.260309.0.post0  (lts base)
-            #   7.260309.0-lts1   -> 7.260309.0.post1  (lts bug fix 1)
-            #   7.260309.0-ltsN   -> 7.260309.0.postN  (lts bug fix N)
+            #   7.260309.0          -> 7.260309.0    (standard release)
+            #   7.260309.0-lts.1    -> 7.260309.0.1  (lts bug fix 1)
+            #   7.260309.0-lts.N    -> 7.260309.0.N  (lts bug fix N)
             expected_version="$(
                 echo "${CIRCLE_TAG}" \
-                  | sed 's/-lts$/\.post0/' \
-                  | sed 's/-lts\([0-9]\+\)$/\.post\1/'
+                  | sed 's/-lts\.\([0-9]\+\)$/.\1/'
             )"
-            [ "${expected_version}" = "${package_version}" ] \
-              || printf "Version mismatch: tag %s (expected package %s) is not equal to package version %s\n" \
-                 "${CIRCLE_TAG}" "${expected_version}" "${package_version}"
+            if [ "${expected_version}" != "${package_version}" ]; then
+              printf "Version mismatch: tag %s (expected package %s) is not equal to package version %s\n" \
+                "${CIRCLE_TAG}" "${expected_version}" "${package_version}"
+              exit 1
+            fi
       - run:
           name: build
           command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,7 +947,7 @@ workflows:
       - build_pycti:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
           requires:
@@ -958,7 +958,7 @@ workflows:
             - build_pycti
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
 # Build opencti
@@ -969,13 +969,13 @@ workflows:
       - wait_for_connector_release:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
       - build_platform:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
           requires:
@@ -999,7 +999,7 @@ workflows:
       - build_platform_musl:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
           requires:
@@ -1038,7 +1038,7 @@ workflows:
             - build_platform
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
       - tag_package_musl:
@@ -1046,7 +1046,7 @@ workflows:
             - build_platform_musl
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/              
       - docker_build_platform_rolling:
@@ -1097,7 +1097,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
       - docker_build_worker:
@@ -1106,7 +1106,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
       - docker_build_platform_fips:
@@ -1115,7 +1115,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
       - docker_build_worker_fips:
@@ -1124,7 +1124,7 @@ workflows:
             - wait_for_connector_release
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
       - deploy_testing:
@@ -1156,6 +1156,6 @@ workflows:
             - docker_build_worker_fips
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)*(-lts\.[0-9]*)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update tag regex to trigger Circle CI release build to replace format 7.260309.0-ltsx with  7.260309.0-lts.x 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/14878