### PR TITLE
[frontend/backend] Introduce filter on description in streams/playbooks/triggers (#14288)

### DIFF
--- a/docs/docs/reference/filters.md
+++ b/docs/docs/reference/filters.md
@@ -585,6 +585,7 @@ For filters used in this context, only some keys are supported for the moment:
 - ``toId`` (the instance in the "to" of a relationship)
 - ``toTypes`` (the entity type in the "to" of a relationship)
 - ``representative``
+- ``description``
 - ``x_opencti_cisa_kev``
 - ``x_opencti_epss_score``
 - ``x_opencti_epss_percentile``

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -458,7 +458,8 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
   };
 
   const displayOperatorAndFilter = (fKey: string, subKey?: string, disabled = false) => {
-    const availableOperators = getAvailableOperatorForFilter(filterDefinition, subKey);
+    const isStixFiltering = entityTypes?.includes('Stix-Filtering');
+    const availableOperators = getAvailableOperatorForFilter(filterDefinition, subKey, { isStixFiltering });
     const finalFilterDefinition = useFilterDefinition(fKey, entityTypes, subKey);
     return (
       <>

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -759,7 +759,7 @@ export const getAvailableOperatorForFilterKey = (
     return ['eq', 'not_eq'];
   }
   if (isBasicTextFilter(filterDefinition)) {
-    if (filterDefinition.type === 'string' || opts?.isStixFiltering) {
+    if (filterDefinition.type === 'string' || opts?.isStixFiltering) { // all the string operators are available for short string or in stix filtering
       return ['eq', 'not_eq', 'nil', 'not_nil', 'contains', 'not_contains',
         'starts_with', 'not_starts_with', 'ends_with', 'not_ends_with', 'search'];
     }

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -147,6 +147,7 @@ export const stixFilters = [
   'takedown_types',
   'note_types',
   'incident_type',
+  'description',
 ];
 
 // ----------------------------------------------------------------------------------------------------------------------
@@ -739,6 +740,7 @@ export const getAvailableOperatorForFilterSubKey = (filterKey: string, subKey: s
  */
 export const getAvailableOperatorForFilterKey = (
   filterDefinition: FilterDefinition | undefined,
+  opts?: { isStixFiltering?: boolean },
 ): string[] => {
   if (!filterDefinition) {
     return ['eq'];
@@ -757,7 +759,7 @@ export const getAvailableOperatorForFilterKey = (
     return ['eq', 'not_eq'];
   }
   if (isBasicTextFilter(filterDefinition)) {
-    if (filterDefinition.type === 'string') {
+    if (filterDefinition.type === 'string' || opts?.isStixFiltering) {
       return ['eq', 'not_eq', 'nil', 'not_nil', 'contains', 'not_contains',
         'starts_with', 'not_starts_with', 'ends_with', 'not_ends_with', 'search'];
     }
@@ -780,9 +782,11 @@ export const getAvailableOperatorForFilterKey = (
 export const getAvailableOperatorForFilter = (
   filterDefinition: FilterDefinition | undefined,
   subKey?: string,
+  opts?: { isStixFiltering?: boolean },
 ): string[] => {
+  const isStixFiltering = opts?.isStixFiltering ?? false;
   if (filterDefinition && subKey) return getAvailableOperatorForFilterSubKey(filterDefinition.filterKey, subKey);
-  return getAvailableOperatorForFilterKey(filterDefinition);
+  return getAvailableOperatorForFilterKey(filterDefinition, { isStixFiltering });
 };
 
 export const useFetchFilterKeysSchema = () => {

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -70,6 +70,7 @@ export const REQUEST_FOR_INFORMATION_TYPES_FILTER = 'information_types';
 export const REQUEST_FOR_TAKEDOWN_TYPES_FILTER = 'takedown_types';
 export const NOTE_TYPES_FILTER = 'note_types';
 export const INCIDENT_TYPE_FILTER = 'incident_type';
+export const DESCRIPTION_FILTER = 'description';
 
 // special cases
 export const IDS_FILTER = 'ids';

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
@@ -48,6 +48,7 @@ import {
   PIR_SCORE_FILTER,
   PIR_SCORE_SUBFILTER,
   PIR_IDS_SUBFILTER,
+  DESCRIPTION_FILTER,
 } from '../filtering-constants';
 import type { Filter } from '../../../generated/graphql';
 import { STIX_RESOLUTION_MAP_PATHS } from '../filtering-resolution';
@@ -476,6 +477,12 @@ export const testPirScore = (stix: any, filter: Filter) => {
   return stixValues.some((stixValue) => testNumericFilter(pirScoreFilter, stixValue));
 };
 
+export const testDescription = (stix: any, filter: Filter) => {
+  const stixValue: string | null = stix.description ?? stix.extensions?.[STIX_EXT_OCTI_SCO]?.description ?? null;
+  const value = stixValue ? [stixValue] : [];
+  return testStringFilter(filter, value);
+};
+
 /**
  * TODO: This mapping could be given by the schema, like we do with stix converters
  */
@@ -514,6 +521,7 @@ export const FILTER_KEY_TESTERS_MAP: Record<string, TesterFunction> = {
   [CVSS_BASE_SCORE_FILTER]: testCvssScore,
   [CVSS_BASE_SEVERITY_FILTER]: testCvssSeverity,
   [PIR_SCORE_FILTER]: testPirScore,
+  [DESCRIPTION_FILTER]: testDescription,
 
   // special keys (more complex behavior)
   [CONNECTED_TO_INSTANCE_FILTER]: testConnectedTo, // instance trigger, direct events

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/stix-filtering-testers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/stix-filtering-testers-test.ts
@@ -28,7 +28,7 @@ describe('Stix filter testers', () => {
         key: ['objectMarking'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9']
+        values: ['<some-id>', 'marking-definition--613f2e26-407d-48c7-9eca-b8e91df99dc9'],
       } as Filter;
       expect(testers.testMarkingFilter(stixWithMarkings, filter)).toEqual(true);
       expect(testers.testMarkingFilter(stixWithoutMarkings, filter)).toEqual(false);
@@ -37,7 +37,7 @@ describe('Stix filter testers', () => {
         key: ['objectMarking'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>']
+        values: ['<some-id>'],
       } as Filter;
       expect(testers.testMarkingFilter(stixWithMarkings, filter)).toEqual(false);
       expect(testers.testMarkingFilter(stixWithoutMarkings, filter)).toEqual(false);
@@ -53,7 +53,7 @@ describe('Stix filter testers', () => {
         key: ['entity_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Report', 'Note']
+        values: ['Report', 'Note'],
       } as Filter;
       expect(testers.testEntityType(report, filter)).toEqual(true);
 
@@ -61,7 +61,7 @@ describe('Stix filter testers', () => {
         key: ['entity_type'],
         mode: 'and',
         operator: 'eq',
-        values: ['Report', 'Note']
+        values: ['Report', 'Note'],
       } as Filter;
       expect(testers.testEntityType(report, filter)).toEqual(false);
     });
@@ -71,7 +71,7 @@ describe('Stix filter testers', () => {
         key: ['entity_type'],
         mode: 'and',
         operator: 'eq',
-        values: ['Indicator']
+        values: ['Indicator'],
       } as Filter;
       expect(testers.testEntityType(stixWithExtType, filter)).toEqual(true);
 
@@ -79,7 +79,7 @@ describe('Stix filter testers', () => {
         key: ['entity_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Note', 'Report']
+        values: ['Note', 'Report'],
       } as Filter;
       expect(testers.testEntityType(stixWithExtType, filter)).toEqual(false);
     });
@@ -89,7 +89,7 @@ describe('Stix filter testers', () => {
         key: ['entity_type'],
         mode: 'and',
         operator: 'eq',
-        values: ['Stix-Object', 'Stix-Core-Object', 'Stix-Domain-Object', 'Report']
+        values: ['Stix-Object', 'Stix-Core-Object', 'Stix-Domain-Object', 'Report'],
       } as Filter;
       expect(testers.testEntityType(report, filter)).toEqual(true);
 
@@ -97,7 +97,7 @@ describe('Stix filter testers', () => {
         key: ['entity_type'],
         mode: 'and',
         operator: 'eq',
-        values: ['Stix-Object', 'Stix-Cyber-Observable', 'Report']
+        values: ['Stix-Object', 'Stix-Cyber-Observable', 'Report'],
       } as Filter;
       expect(testers.testEntityType(report, filter)).toEqual(false);
     });
@@ -112,7 +112,7 @@ describe('Stix filter testers', () => {
         key: ['indicator_types'],
         mode: 'and',
         operator: 'eq',
-        values: ['unknown']
+        values: ['unknown'],
       } as Filter;
       expect(testers.testIndicatorTypes(stixWithIndicatorTypes, filter)).toEqual(true);
       expect(testers.testIndicatorTypes(stixWithoutIndicatorTypes, filter)).toEqual(false);
@@ -121,7 +121,7 @@ describe('Stix filter testers', () => {
         key: ['indicator_types'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>', '<some-other-id>']
+        values: ['<some-id>', '<some-other-id>'],
       } as Filter;
       expect(testers.testIndicatorTypes(stixWithIndicatorTypes, filter)).toEqual(false);
       expect(testers.testIndicatorTypes(stixWithoutIndicatorTypes, filter)).toEqual(false);
@@ -137,7 +137,7 @@ describe('Stix filter testers', () => {
         key: ['report_types'],
         mode: 'or',
         operator: 'nil',
-        values: []
+        values: [],
       } as Filter;
       expect(testers.testReportTypes(stixReportWithThreatReportTypes, filter)).toEqual(false);
       expect(testers.testReportTypes(stixIndicator, filter)).toEqual(true);
@@ -146,7 +146,7 @@ describe('Stix filter testers', () => {
         key: ['report_types'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>', '<some-other-id>']
+        values: ['<some-id>', '<some-other-id>'],
       } as Filter;
       expect(testers.testReportTypes(stixReportWithThreatReportTypes, filter)).toEqual(false);
       expect(testers.testReportTypes(stixIndicator, filter)).toEqual(false);
@@ -155,7 +155,7 @@ describe('Stix filter testers', () => {
         key: ['report_types'],
         mode: 'and',
         operator: 'eq',
-        values: ['threat-report']
+        values: ['threat-report'],
       } as Filter;
       expect(testers.testReportTypes(stixReportWithThreatReportTypes, filter)).toEqual(true);
       expect(testers.testReportTypes(stixIndicator, filter)).toEqual(false);
@@ -171,7 +171,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_workflow_id'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'bd156107-1f9a-43df-9595-574c467e9e21']
+        values: ['<some-id>', 'bd156107-1f9a-43df-9595-574c467e9e21'],
       } as Filter;
       expect(testers.testWorkflow(reportWithWorkflow, filter)).toEqual(true);
       expect(testers.testWorkflow(reportWithoutWorkflow, filter)).toEqual(false);
@@ -180,7 +180,7 @@ describe('Stix filter testers', () => {
         key: ['createdBy'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>', '<some-other-id>']
+        values: ['<some-id>', '<some-other-id>'],
       } as Filter;
       expect(testers.testWorkflow(reportWithWorkflow, filter)).toEqual(false);
       expect(testers.testWorkflow(reportWithoutWorkflow, filter)).toEqual(false);
@@ -196,7 +196,7 @@ describe('Stix filter testers', () => {
         key: ['createdBy'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'identity--4f347cc9-4658-59ee-9707-134f434f9d1c']
+        values: ['<some-id>', 'identity--4f347cc9-4658-59ee-9707-134f434f9d1c'],
       } as Filter;
       expect(testers.testCreatedBy(stixWithCreatedBy, filter)).toEqual(true);
       expect(testers.testCreatedBy(stixWithoutCreatedBy, filter)).toEqual(false);
@@ -205,7 +205,7 @@ describe('Stix filter testers', () => {
         key: ['createdBy'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>', '<some-other-id>']
+        values: ['<some-id>', '<some-other-id>'],
       } as Filter;
       expect(testers.testCreatedBy(stixWithCreatedBy, filter)).toEqual(false);
       expect(testers.testCreatedBy(stixWithoutCreatedBy, filter)).toEqual(false);
@@ -220,7 +220,7 @@ describe('Stix filter testers', () => {
         key: ['creator'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', '88ec0c6a-13ce-5e39-b486-354fe4a7084f']
+        values: ['<some-id>', '88ec0c6a-13ce-5e39-b486-354fe4a7084f'],
       } as Filter;
       expect(testers.testCreator(stixWithCreator, filter)).toEqual(true);
 
@@ -228,7 +228,7 @@ describe('Stix filter testers', () => {
         key: ['creator'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>', '<some-other-id>']
+        values: ['<some-id>', '<some-other-id>'],
       } as Filter;
       expect(testers.testCreator(stixWithCreator, filter)).toEqual(false);
     });
@@ -244,7 +244,7 @@ describe('Stix filter testers', () => {
         key: ['objectAssignee'],
         mode: 'and',
         operator: 'eq',
-        values: ['88ec0c6a-13ce-5e39-b486-354fe4a7084f']
+        values: ['88ec0c6a-13ce-5e39-b486-354fe4a7084f'],
       } as Filter;
       expect(testers.testAssignee(stixWithAssignee, filter)).toEqual(true);
       expect(testers.testIndicatorTypes(stixWithoutAssignee, filter)).toEqual(false);
@@ -253,7 +253,7 @@ describe('Stix filter testers', () => {
         key: ['indicator_types'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', '<some-other-id>']
+        values: ['<some-id>', '<some-other-id>'],
       } as Filter;
       expect(testers.testIndicatorTypes(stixWithAssignee, filter)).toEqual(false);
       expect(testers.testIndicatorTypes(stixWithoutAssignee, filter)).toEqual(false);
@@ -269,7 +269,7 @@ describe('Stix filter testers', () => {
         key: ['labelledBy'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-label>', 'test-label']
+        values: ['<some-label>', 'test-label'],
       } as Filter;
       expect(testers.testLabel(stixWithLabel, filter)).toEqual(true);
       expect(testers.testLabel(stixWithoutLabel, filter)).toEqual(false);
@@ -278,7 +278,7 @@ describe('Stix filter testers', () => {
         key: ['labelledBy'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-label>', '<some-other-label>']
+        values: ['<some-label>', '<some-other-label>'],
       } as Filter;
       expect(testers.testLabel(stixWithLabel, filter)).toEqual(false);
       expect(testers.testLabel(stixWithoutLabel, filter)).toEqual(false);
@@ -293,7 +293,7 @@ describe('Stix filter testers', () => {
         key: ['revoked'],
         mode: 'or',
         operator: 'eq',
-        values: ['true']
+        values: ['true'],
       } as Filter;
       expect(testers.testRevoked(stixWithRevoked, filter)).toEqual(true);
 
@@ -301,7 +301,7 @@ describe('Stix filter testers', () => {
         key: ['revoked'],
         mode: 'and',
         operator: 'eq',
-        values: ['false']
+        values: ['false'],
       } as Filter;
       expect(testers.testRevoked(stixWithRevoked, filter)).toEqual(false);
     });
@@ -316,7 +316,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_detection'],
         mode: 'or',
         operator: 'eq',
-        values: ['true']
+        values: ['true'],
       } as Filter;
       expect(testers.testDetection(stixWithDetection, filter)).toEqual(true);
       expect(testers.testDetection(stixWithoutDetection, filter)).toEqual(false);
@@ -325,7 +325,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_detection'],
         mode: 'and',
         operator: 'eq',
-        values: ['false']
+        values: ['false'],
       } as Filter;
       expect(testers.testDetection(stixWithDetection, filter)).toEqual(false);
       expect(testers.testDetection(stixWithoutDetection, filter)).toEqual(false);
@@ -341,7 +341,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_score'],
         mode: 'or',
         operator: 'lt',
-        values: ['75']
+        values: ['75'],
       } as Filter;
       expect(testers.testScore(stixWithScore, filter)).toEqual(true);
       expect(testers.testScore(stixWithoutScore, filter)).toEqual(false);
@@ -350,7 +350,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_score'],
         mode: 'and',
         operator: 'lt',
-        values: ['25']
+        values: ['25'],
       } as Filter;
       expect(testers.testScore(stixWithScore, filter)).toEqual(false);
       expect(testers.testScore(stixWithoutScore, filter)).toEqual(false);
@@ -366,7 +366,7 @@ describe('Stix filter testers', () => {
         key: ['confidence'],
         mode: 'or',
         operator: 'gt',
-        values: ['50']
+        values: ['50'],
       } as Filter;
       expect(testers.testConfidence(stixWithConfidence75, filter)).toEqual(true);
       expect(testers.testConfidence(stixWithConfidence0, filter)).toEqual(false);
@@ -375,7 +375,7 @@ describe('Stix filter testers', () => {
         key: ['confidence'],
         mode: 'and',
         operator: 'lt',
-        values: ['50']
+        values: ['50'],
       } as Filter;
       expect(testers.testConfidence(stixWithConfidence75, filter)).toEqual(false);
       expect(testers.testConfidence(stixWithConfidence0, filter)).toEqual(true);
@@ -391,7 +391,7 @@ describe('Stix filter testers', () => {
         key: ['pattern_type'],
         mode: 'or',
         operator: 'eq',
-        values: [stixWithPatternType.pattern_type]
+        values: [stixWithPatternType.pattern_type],
       } as Filter;
       expect(testers.testPatternType(stixWithPatternType, filter)).toEqual(true);
     });
@@ -401,7 +401,7 @@ describe('Stix filter testers', () => {
         key: ['pattern_type'],
         mode: 'or',
         operator: 'eq',
-        values: [`${stixWithPatternType.pattern_type}-not-matching`]
+        values: [`${stixWithPatternType.pattern_type}-not-matching`],
       } as Filter;
       expect(testers.testPatternType(stixWithPatternType, filter)).toEqual(false);
     });
@@ -411,7 +411,7 @@ describe('Stix filter testers', () => {
         key: ['pattern_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['anything']
+        values: ['anything'],
       } as Filter;
       expect(testers.testPatternType(stixWithoutPatternType, filter)).toEqual(false);
     });
@@ -426,7 +426,7 @@ describe('Stix filter testers', () => {
         key: ['pattern'],
         mode: 'or',
         operator: 'eq',
-        values: [stixWithPattern.pattern]
+        values: [stixWithPattern.pattern],
       } as Filter;
       expect(testers.testPattern(stixWithPattern, filter)).toEqual(true);
     });
@@ -436,7 +436,7 @@ describe('Stix filter testers', () => {
         key: ['pattern'],
         mode: 'or',
         operator: 'eq',
-        values: [`${stixWithPattern.pattern}-not-matching`]
+        values: [`${stixWithPattern.pattern}-not-matching`],
       } as Filter;
       expect(testers.testPattern(stixWithPattern, filter)).toEqual(false);
     });
@@ -446,7 +446,7 @@ describe('Stix filter testers', () => {
         key: ['pattern_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['anything']
+        values: ['anything'],
       } as Filter;
       expect(testers.testPattern(stixWithoutPattern, filter)).toEqual(false);
     });
@@ -461,7 +461,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_main_observable_type'],
         mode: 'or',
         operator: 'eq',
-        values: ['Unknown']
+        values: ['Unknown'],
       } as Filter;
       expect(testers.testMainObservableType(stixWithMOT, filter)).toEqual(true);
       expect(testers.testMainObservableType(stixWithoutMOT, filter)).toEqual(false);
@@ -470,7 +470,7 @@ describe('Stix filter testers', () => {
         key: ['x_opencti_main_observable_type'],
         mode: 'and',
         operator: 'eq',
-        values: ['IPv4']
+        values: ['IPv4'],
       } as Filter;
       expect(testers.testMainObservableType(stixWithMOT, filter)).toEqual(false);
       expect(testers.testMainObservableType(stixWithoutMOT, filter)).toEqual(false);
@@ -486,7 +486,7 @@ describe('Stix filter testers', () => {
         key: ['objectContains'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'incident--572ee294-04a6-548f-a091-a4502a44c342']
+        values: ['<some-id>', 'incident--572ee294-04a6-548f-a091-a4502a44c342'],
       } as Filter;
       expect(testers.testObjectContains(stixWithObjectRefs, filter)).toEqual(true);
       expect(testers.testObjectContains(stixWithoutObjectRefs, filter)).toEqual(false);
@@ -495,7 +495,7 @@ describe('Stix filter testers', () => {
         key: ['objectContains'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>']
+        values: ['<some-id>'],
       } as Filter;
       expect(testers.testObjectContains(stixWithObjectRefs, filter)).toEqual(false);
       expect(testers.testObjectContains(stixWithoutObjectRefs, filter)).toEqual(false);
@@ -511,7 +511,7 @@ describe('Stix filter testers', () => {
         key: ['severity'],
         mode: 'or',
         operator: 'eq',
-        values: ['medium']
+        values: ['medium'],
       } as Filter;
       expect(testers.testSeverity(stixWithSeverity, filter)).toEqual(true);
       expect(testers.testSeverity(stixWithoutSeverity, filter)).toEqual(false);
@@ -520,7 +520,7 @@ describe('Stix filter testers', () => {
         key: ['severity'],
         mode: 'and',
         operator: 'eq',
-        values: ['low']
+        values: ['low'],
       } as Filter;
       expect(testers.testSeverity(stixWithSeverity, filter)).toEqual(false);
       expect(testers.testSeverity(stixWithoutSeverity, filter)).toEqual(false);
@@ -536,7 +536,7 @@ describe('Stix filter testers', () => {
         key: ['priority'],
         mode: 'or',
         operator: 'eq',
-        values: ['p3', 'p4']
+        values: ['p3', 'p4'],
       } as Filter;
       expect(testers.testPriority(stixWithPriority, filter)).toEqual(true);
       expect(testers.testPriority(stixWithoutPriority, filter)).toEqual(false);
@@ -545,7 +545,7 @@ describe('Stix filter testers', () => {
         key: ['priority'],
         mode: 'and',
         operator: 'lt',
-        values: ['p3']
+        values: ['p3'],
       } as Filter;
       expect(testers.testPriority(stixWithPriority, filter)).toEqual(false);
       expect(testers.testPriority(stixWithoutPriority, filter)).toEqual(false);
@@ -561,7 +561,7 @@ describe('Stix filter testers', () => {
           key: ['fromId'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'threat-actor--fd6b0e6f-96e0-568d-ba24-8a140d0428cd']
+          values: ['<some-id>', 'threat-actor--fd6b0e6f-96e0-568d-ba24-8a140d0428cd'],
         } as Filter;
         expect(testers.testRelationFrom(stixRelationship, filter)).toEqual(true);
 
@@ -569,7 +569,7 @@ describe('Stix filter testers', () => {
           key: ['fromId'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationFrom(stixRelationship, filter)).toEqual(false);
       });
@@ -581,7 +581,7 @@ describe('Stix filter testers', () => {
           key: ['toId'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'grouping--e09ce86e-0bd0-5a09-a5e9-4ebd76b79bd4']
+          values: ['<some-id>', 'grouping--e09ce86e-0bd0-5a09-a5e9-4ebd76b79bd4'],
         } as Filter;
         expect(testers.testRelationTo(stixRelationship, filter)).toEqual(true);
 
@@ -589,7 +589,7 @@ describe('Stix filter testers', () => {
           key: ['toId'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationTo(stixRelationship, filter)).toEqual(false);
       });
@@ -601,7 +601,7 @@ describe('Stix filter testers', () => {
           key: ['fromTypes'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'Threat-Actor-Group']
+          values: ['<some-id>', 'Threat-Actor-Group'],
         } as Filter;
         expect(testers.testRelationFromTypes(stixRelationship, filter)).toEqual(true);
 
@@ -609,7 +609,7 @@ describe('Stix filter testers', () => {
           key: ['fromTypes'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationFromTypes(stixRelationship, filter)).toEqual(false);
       });
@@ -621,7 +621,7 @@ describe('Stix filter testers', () => {
           key: ['toTypes'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'Grouping']
+          values: ['<some-id>', 'Grouping'],
         } as Filter;
         expect(testers.testRelationToTypes(stixRelationship, filter)).toEqual(true);
 
@@ -629,7 +629,7 @@ describe('Stix filter testers', () => {
           key: ['toTypes'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationToTypes(stixRelationship, filter)).toEqual(false);
       });
@@ -645,7 +645,7 @@ describe('Stix filter testers', () => {
           key: ['fromId'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'indicator--4099edd7-1efd-54aa-9736-7bcd7219b78b']
+          values: ['<some-id>', 'indicator--4099edd7-1efd-54aa-9736-7bcd7219b78b'],
         } as Filter;
         expect(testers.testRelationFrom(stixSighting, filter)).toEqual(true);
 
@@ -653,7 +653,7 @@ describe('Stix filter testers', () => {
           key: ['fromId'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationFrom(stixSighting, filter)).toEqual(false);
       });
@@ -665,7 +665,7 @@ describe('Stix filter testers', () => {
           key: ['toId'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'location--b8d0549f-de06-5ebd-a6e9-d31a581dba5d']
+          values: ['<some-id>', 'location--b8d0549f-de06-5ebd-a6e9-d31a581dba5d'],
         } as Filter;
         expect(testers.testRelationTo(stixSighting, filter)).toEqual(true);
 
@@ -673,7 +673,7 @@ describe('Stix filter testers', () => {
           key: ['toId'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationTo(stixSighting, filter)).toEqual(false);
       });
@@ -685,7 +685,7 @@ describe('Stix filter testers', () => {
           key: ['fromTypes'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'Indicator']
+          values: ['<some-id>', 'Indicator'],
         } as Filter;
         expect(testers.testRelationFromTypes(stixSighting, filter)).toEqual(true);
 
@@ -693,7 +693,7 @@ describe('Stix filter testers', () => {
           key: ['fromTypes'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationFromTypes(stixSighting, filter)).toEqual(false);
       });
@@ -705,7 +705,7 @@ describe('Stix filter testers', () => {
           key: ['toTypes'],
           mode: 'or',
           operator: 'eq',
-          values: ['<some-id>', 'Country']
+          values: ['<some-id>', 'Country'],
         } as Filter;
         expect(testers.testRelationToTypes(stixSighting, filter)).toEqual(true);
 
@@ -713,7 +713,7 @@ describe('Stix filter testers', () => {
           key: ['toTypes'],
           mode: 'and',
           operator: 'eq',
-          values: ['<some-id>']
+          values: ['<some-id>'],
         } as Filter;
         expect(testers.testRelationToTypes(stixSighting, filter)).toEqual(false);
       });
@@ -729,7 +729,7 @@ describe('Stix filter testers', () => {
         key: ['connectedToId'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'f13cd64f-9268-4d77-9850-eb6fbe322463']
+        values: ['<some-id>', 'f13cd64f-9268-4d77-9850-eb6fbe322463'],
       } as Filter;
       expect(testers.testConnectedTo(stixReport, filter)).toEqual(true);
       expect(testers.testConnectedTo(stixSighting, filter)).toEqual(false);
@@ -738,7 +738,7 @@ describe('Stix filter testers', () => {
         key: ['connectedToId'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>']
+        values: ['<some-id>'],
       } as Filter;
       expect(testers.testConnectedTo(stixReport, filter)).toEqual(false);
       expect(testers.testConnectedTo(stixSighting, filter)).toEqual(false);
@@ -754,7 +754,7 @@ describe('Stix filter testers', () => {
         key: ['connectedToId_sideEvents'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'threat-actor--fd6b0e6f-96e0-568d-ba24-8a140d0428cd']
+        values: ['<some-id>', 'threat-actor--fd6b0e6f-96e0-568d-ba24-8a140d0428cd'],
       } as Filter;
       expect(testers.testConnectedToSideEvents(stixRelationship, filter)).toEqual(true);
 
@@ -762,7 +762,7 @@ describe('Stix filter testers', () => {
         key: ['connectedToId_sideEvents'],
         mode: 'or',
         operator: 'eq',
-        values: ['<some-id>', 'location--b8d0549f-de06-5ebd-a6e9-d31a581dba5d']
+        values: ['<some-id>', 'location--b8d0549f-de06-5ebd-a6e9-d31a581dba5d'],
       } as Filter;
       expect(testers.testConnectedToSideEvents(stixSighting, filter)).toEqual(true);
 
@@ -770,7 +770,7 @@ describe('Stix filter testers', () => {
         key: ['connectedToId_sideEvents'],
         mode: 'and',
         operator: 'eq',
-        values: ['<some-id>']
+        values: ['<some-id>'],
       } as Filter;
       expect(testers.testConnectedToSideEvents(stixRelationship, filter)).toEqual(false);
       expect(testers.testConnectedToSideEvents(stixSighting, filter)).toEqual(false);
@@ -788,7 +788,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'and',
         operator: 'eq',
-        values: ['www.xolod-teplo.ru']
+        values: ['www.xolod-teplo.ru'],
       } as Filter;
       expect(testers.testRepresentative(indicator, filter)).toEqual(true);
       expect(testers.testRepresentative(observableEqualTest, filter)).toEqual(false);
@@ -797,7 +797,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'and',
         operator: 'eq',
-        values: ['www.xolod-teplo.ru', 'test']
+        values: ['www.xolod-teplo.ru', 'test'],
       } as Filter;
       expect(testers.testRepresentative(indicator, filter)).toEqual(false);
       expect(testers.testRepresentative(observableEqualTest, filter)).toEqual(false);
@@ -806,7 +806,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'or',
         operator: 'eq',
-        values: ['www.xolod-teplo.ru', 'test']
+        values: ['www.xolod-teplo.ru', 'test'],
       } as Filter;
       expect(testers.testRepresentative(indicator, filter)).toEqual(true);
       expect(testers.testRepresentative(observableEqualTest, filter)).toEqual(true);
@@ -815,7 +815,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'and',
         operator: 'contains',
-        values: ['test']
+        values: ['test'],
       } as Filter;
       expect(testers.testRepresentative(reportContainingTest, filter)).toEqual(true);
       expect(testers.testRepresentative(rfiEndingWithTest, filter)).toEqual(true);
@@ -826,7 +826,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'and',
         operator: 'ends_with',
-        values: ['test']
+        values: ['test'],
       } as Filter;
       expect(testers.testRepresentative(reportContainingTest, filter)).toEqual(false);
       expect(testers.testRepresentative(rfiEndingWithTest, filter)).toEqual(true);
@@ -837,7 +837,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'and',
         operator: 'not_ends_with',
-        values: ['test']
+        values: ['test'],
       } as Filter;
       expect(testers.testRepresentative(reportContainingTest, filter)).toEqual(true);
       expect(testers.testRepresentative(rfiEndingWithTest, filter)).toEqual(false);
@@ -848,7 +848,7 @@ describe('Stix filter testers', () => {
         key: ['representative'],
         mode: 'and',
         operator: 'starts_with',
-        values: ['Disco Team']
+        values: ['Disco Team'],
       } as Filter;
       expect(testers.testRepresentative(stixRelationships[0], filter)).toEqual(true);
       expect(testers.testRepresentative(rfiEndingWithTest, filter)).toEqual(false);
@@ -869,14 +869,14 @@ describe('Stix filter testers', () => {
           {
             key: 'score',
             values: ['50'],
-            operator: 'gt'
+            operator: 'gt',
           },
           {
             key: 'pir_ids',
             values: [
               '0481ef01-b2a5-4001-a3d1-6110dc579e2a',
-              '12345678-1234-1234-1234-123456789012'
-            ]
+              '12345678-1234-1234-1234-123456789012',
+            ],
           },
         ],
       } as Filter;
@@ -894,11 +894,11 @@ describe('Stix filter testers', () => {
           {
             key: 'score',
             values: ['50'],
-            operator: 'gt'
+            operator: 'gt',
           },
           {
             key: 'pir_ids',
-            values: []
+            values: [],
           },
         ],
       } as Filter;
@@ -907,6 +907,72 @@ describe('Stix filter testers', () => {
       expect(testers.testPirScore(stixWithNotMatchingPir, filter)).toEqual(false);
       expect(testers.testPirScore(stixWithMatchingPirButLowScore, filter)).toEqual(true);
       expect(testers.testPirScore(stixWithMatchingPirAndHighScore, filter)).toEqual(true);
+    });
+  });
+
+  describe('by description (key=description)', () => {
+    const stixWithoutCMSTAR = stixIndicators[0];
+    const stixWithCMSTAR = stixIndicators[1];
+    const stixObservableWithDescription = stixObservables[0];
+    const stixSightingWithoutDescription = stixSightings[0];
+
+    it('should test valid for a filter with the contains operator', () => {
+      const filter: Filter = {
+        key: ['description'],
+        mode: 'or',
+        operator: 'contains',
+        values: ['CMST'],
+      } as Filter;
+      const filter2: Filter = {
+        key: ['description'],
+        mode: 'or',
+        operator: 'contains',
+        values: ['CMSTAR test'],
+      } as Filter;
+      expect(testers.testDescription(stixWithCMSTAR, filter)).toEqual(true);
+      expect(testers.testDescription(stixWithoutCMSTAR, filter)).toEqual(false);
+      expect(testers.testDescription(stixWithCMSTAR, filter2)).toEqual(false);
+    });
+
+    it('should test valid for a filter with the not_contains operator', () => {
+      const filter: Filter = {
+        key: ['description'],
+        mode: 'or',
+        operator: 'not_contains',
+        values: ['CMST'],
+      } as Filter;
+      expect(testers.testDescription(stixWithCMSTAR, filter)).toEqual(false);
+      expect(testers.testDescription(stixWithoutCMSTAR, filter)).toEqual(true);
+    });
+
+    it('should test valid for a filter with the search operator', () => {
+      const filter1: Filter = {
+        key: ['description'],
+        mode: 'or',
+        operator: 'contains',
+        values: ['CMST'],
+      } as Filter;
+      const filter2: Filter = {
+        key: ['description'],
+        mode: 'or',
+        operator: 'search',
+        values: ['CMSTAR test'],
+      } as Filter;
+      expect(testers.testDescription(stixWithCMSTAR, filter1)).toEqual(true);
+      expect(testers.testDescription(stixWithoutCMSTAR, filter1)).toEqual(false);
+      expect(testers.testDescription(stixWithCMSTAR, filter2)).toEqual(true);
+    });
+
+    it('should test valid for a filter with the nil operator', () => {
+      const filter: Filter = {
+        key: ['description'],
+        mode: 'or',
+        operator: 'nil',
+        values: [],
+      } as Filter;
+      expect(testers.testDescription(stixWithCMSTAR, filter)).toEqual(false);
+      expect(testers.testDescription(stixObservableWithDescription, filter)).toEqual(false);
+      expect(testers.testDescription(stixSightingWithoutDescription, filter)).toEqual(true);
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook-utils-test.ts
@@ -38,7 +38,7 @@ describe('Playbook utils: checkPlaybookFiltersAndBuildConfigWithCorrectFilters',
     const filters = {
       mode: 'or',
       filters: [
-        { key: ['description'], values: ['test'] }, // key not compatible with stix filtering
+        { key: ['name'], values: ['test'] }, // key not compatible with stix filtering
       ],
       filterGroups: [],
     };


### PR DESCRIPTION
### Proposed changes
Introduce the 'description' filter for streams, playbooks and triggers :

- add 'description' in stix filtering testers, with all the operators for strings
- add backend tests
- update documentation

### Related issues
#14288

### Screenshot
<img width="1047" height="640" alt="image" src="https://github.com/user-attachments/assets/b0d5e401-9e72-40d0-ab25-28a2822260c5" />
