### PR TITLE
fix(backend): only keep target entity markings during a merge (#14855)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -209,7 +209,7 @@ import { fillDefaultValues, getAttributesConfiguration, getEntitySettingFromCach
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { validateInputCreation, validateInputUpdate } from '../schema/schema-validator';
 import { telemetry } from '../config/tracing';
-import { cleanMarkings, handleMarkingOperations } from '../utils/markingDefinition-utils';
+import { handleMarkingOperations } from '../utils/markingDefinition-utils';
 import { buildUpdatePatchForUpsert, generateInputsForUpsert } from '../utils/upsert-utils';
 import { buildChanges, generateCreateMessage, generateRestoreMessage } from './data-changes';
 import { authorizedMembers, authorizedMembersActivationDate, confidence, iAliasedIds, iAttributes, modified, type RefAttribute, updatedAt } from '../schema/attribute-definition';
@@ -1438,17 +1438,11 @@ const filterTargetByExisting = async (
   redirectSide: 'from' | 'to',
   sourcesDependencies: MergeEntitiesDependency,
   targetDependencies: MergeEntitiesDependency,
-): Promise<{ deletions: BasicStoreRelation[]; redirects: MergeEntityDependency[] }> => {
+): Promise<{ redirects: MergeEntityDependency[] }> => {
   const cache: string[] = [];
   const filtered: MergeEntityDependency[] = [];
   const sources = sourcesDependencies[`i_relations_${redirectSide}`];
   const targets = targetDependencies[`i_relations_${redirectSide}`];
-  const markingSources = sources.filter((r) => r.i_relation.entity_type === RELATION_OBJECT_MARKING);
-  const markingTargets = targets.filter((r) => r.i_relation.entity_type === RELATION_OBJECT_MARKING);
-  const markings = [...markingSources, ...markingTargets];
-  const filteredMarkings = await cleanMarkings(context, markings.map((m) => m.internal_id));
-  const filteredMarkingIds = filteredMarkings.map((m) => m.internal_id);
-  const markingTargetDeletions = markingTargets.filter((m) => !filteredMarkingIds.includes(m.internal_id)).map((m) => m.i_relation);
   for (let index = 0; index < sources.length; index += 1) {
     const source = sources[index];
     // If the relation source is already in target = filtered
@@ -1469,15 +1463,15 @@ const filterTargetByExisting = async (
     // Self ref relationships is not allowed, need to compare the side that will be kept with the target
     const relationSideToKeep = redirectSide === 'from' ? 'toId' : 'fromId';
     const isSelfMeta = isStixRefRelationship(source.i_relation.entity_type) && (targetEntity.internal_id === source.i_relation[relationSideToKeep]);
-    // Markings duplication definition group
-    const isMarkingToKeep = source.i_relation.entity_type === RELATION_OBJECT_MARKING ? filteredMarkingIds.includes(source.internal_id) : true;
+    // Markings are only kept on target entity
+    const isMarkingRel = source.i_relation.entity_type === RELATION_OBJECT_MARKING;
     // Check and add the relation in the processing list if needed
-    if (!existingSingleMeta && !isSelfMeta && isMarkingToKeep && !R.find(finder, targets) && !cache.includes(id)) {
+    if (!existingSingleMeta && !isSelfMeta && !isMarkingRel && !R.find(finder, targets) && !cache.includes(id)) {
       filtered.push(source);
       cache.push(id);
     }
   }
-  return { deletions: markingTargetDeletions, redirects: filtered };
+  return { redirects: filtered };
 };
 
 const mergeEntitiesRaw = async (
@@ -1553,9 +1547,9 @@ const mergeEntitiesRaw = async (
   // - EVERYTHING I TARGET (->to) ==> We change to relationship FROM -> TARGET ENTITY
   // - EVERYTHING TARGETING ME (-> from) ==> We change to relationship TO -> TARGET ENTITY
   // region CHANGING FROM
-  const { deletions: fromDeletions, redirects: relationsToRedirectFrom } = await filterTargetByExisting(context, targetEntity, 'from', sourcesDependencies, targetDependencies);
+  const { redirects: relationsToRedirectFrom } = await filterTargetByExisting(context, targetEntity, 'from', sourcesDependencies, targetDependencies);
   // region CHANGING TO
-  const { deletions: toDeletions, redirects: relationsFromRedirectTo } = await filterTargetByExisting(context, targetEntity, 'to', sourcesDependencies, targetDependencies);
+  const { redirects: relationsFromRedirectTo } = await filterTargetByExisting(context, targetEntity, 'to', sourcesDependencies, targetDependencies);
   type UpdateConnection = {
     _index: string;
     id: string;
@@ -1716,10 +1710,8 @@ const mergeEntitiesRaw = async (
     await deleteAllObjectFiles(context, SYSTEM_USER, sourceEntities[i]);
   }
 
-  // Take care of relations deletions to prevent duplicate marking definitions.
-  const elementToRemoves = [...sourceEntities, ...fromDeletions, ...toDeletions];
   // All not move relations will be deleted, so we need to remove impacted rel in entities.
-  await elDeleteElements(context, SYSTEM_USER, elementToRemoves);
+  await elDeleteElements(context, SYSTEM_USER, sourceEntities);
   // Everything if fine update remaining attributes
   const updateAttributes: EditInput[] = [];
   // 1. Update all possible attributes

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
@@ -1118,11 +1118,9 @@ describe('Upsert and merge entities', () => {
     expect(loadedThreat.goals).toEqual(['MY GOAL']);
     expect(loadedThreat.createdBy).not.toBeUndefined(); // [organizationThreatTarget]
     expect(loadedThreat.createdBy.name).toEqual('organizationThreatTarget'); // [organizationThreatTarget]
-    expect(loadedThreat.objectMarking.length).toEqual(3); // [testMarking (TLP:3), amberMarking (TLP:3), mitreMarking (STATEMENT)] clearMarking must be auto removed
+    expect(loadedThreat.objectMarking.length).toEqual(1); // [testMarking (TLP:3)] only target markings are kept
     const markingIds = loadedThreat.objectMarking.map((o) => o.standard_id);
     expect(markingIds.includes(testMarking)).toBeTruthy();
-    expect(markingIds.includes(amberMarking)).toBeTruthy();
-    expect(markingIds.includes(mitreMarking)).toBeTruthy();
     expect(loadedThreat.objectLabel.length).toEqual(5); // ['report', 'opinion', 'note', 'malware', 'identity']
     // expect(loadedThreat[INTERNAL_FROM_FIELD].uses.length).toEqual(3); // [MALWARE_TEST_01, MALWARE_TEST_02, MALWARE_TEST_03]
     const froms = await fullRelationsList(testContext, ADMIN_USER, 'stix-core-relationship', { fromId: loadedThreat.internal_id });

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/middleware-test.js
@@ -1302,10 +1302,9 @@ describe('Upsert and merge entities', () => {
     expect(reloadMd5.hashes.MD5).toEqual(MD5);
     expect(reloadMd5.hashes['SHA-1']).toEqual(SHA1);
     expect(reloadMd5.hashes['SHA-256']).toEqual(SHA256);
-    expect(reloadMd5.objectMarking.length).toEqual(2); // [testMarking, mitreMarking]
+    expect(reloadMd5.objectMarking.length).toEqual(1); // [clearMarking]
     const markingIds = reloadMd5.objectMarking.map((o) => o.standard_id);
-    expect(markingIds.includes(testMarking)).toBeTruthy();
-    expect(markingIds.includes(mitreMarking)).toBeTruthy();
+    expect(markingIds.includes(clearMarking)).toBeTruthy();
     // Cleanup
     await deleteElementById(testContext, ADMIN_USER, reloadMd5.id, ENTITY_HASHED_OBSERVABLE_STIX_FILE);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* now only keep target entity markings during a merge
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #14855 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
