### PR TITLE
[backend] backport of add sha256 to file metadata & use sha256 to check for duplicate upload (#14877)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -1,4 +1,5 @@
 import path, { join } from 'node:path';
+import crypto from 'node:crypto';
 import mime from 'mime-types';
 import nconf from 'nconf';
 import type { _Object } from '@aws-sdk/client-s3';
@@ -62,6 +63,7 @@ interface FileMetadata {
   mimetype?: string;
   encoding?: string;
   filename?: string;
+  sha256?: string;
   creator_id?: string;
   entity_id?: string;
   messages?: string[];
@@ -594,10 +596,24 @@ export const upload = async (
     const draftPrefix = getDraftFilePrefix(draftContext);
     key = `${draftPrefix}${key}`;
   }
+
+  // Stream the file content while incrementally computing the SHA256 hash to avoid holding the entire file twice in memory.
+  const hashReadStream = createReadStream();
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of hashReadStream) {
+    hash.update(chunk);
+  }
+  const sha256 = hash.digest('hex');
+
   const currentFile = await documentFindById(context, user, key);
   if (currentFile) {
     // If file exists, we want to use it's internal_id to use the same casing and keep it compatible
     key = currentFile.internal_id;
+    // If the file content is identical (same SHA256), skip the upload entirely
+    if ((currentFile.metaData as FileMetadata).sha256 === sha256) {
+      return { upload: { ...currentFile, information: '', uploadStatus: 'complete' } as LoadedFile, untouched: true };
+    }
+    // keep version handling backward compatible, if the existing file version is newer or equal than the uploaded one, we skip the upload
     if (utcDate((currentFile.metaData as FileMetadata).version as string).isSameOrAfter(utcDate(metadata.version as string))) {
       return { upload: { ...currentFile, information: '', uploadStatus: 'complete' } as LoadedFile, untouched: true };
     }
@@ -608,18 +624,19 @@ export const upload = async (
 
   const creatorId = (currentFile?.metaData as FileMetadata)?.creator_id ? (currentFile.metaData as FileMetadata).creator_id : user.id;
 
-  // Upload the data
-  const readStream = createReadStream();
+  // Upload the data from the buffered content
+  const uploadReadStream = createReadStream();
   const fileMime = metadata.mimetype ?? guessMimeType(key);
   const fullMetadata: FileMetadata = {
     ...metadata,
     filename: encodeURIComponent(truncatedFileName),
     mimetype: fileMime,
     encoding,
+    sha256,
     creator_id: creatorId as string,
     entity_id: (entity as BasicStoreEntity)?.internal_id,
   };
-  await rawUpload(key, readStream);
+  await rawUpload(key, uploadReadStream);
   const fileSize = await getFileSize(user, key);
 
   // Register in elastic

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document-types.ts
@@ -8,6 +8,7 @@ export interface BasicStoreEntityDocument extends BasicStoreEntity {
   metaData: {
     entity_id?: string;
     mimetype: string;
+    sha256?: string;
     order?: number;
     description?: string;
     inCarousel?: boolean;

--- a/opencti-platform/opencti-graphql/src/modules/internal/document/document.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/document/document.ts
@@ -34,6 +34,7 @@ const attributes: Array<AttributeDefinition> = [
     isFilterable: false,
     mappings: [
       { name: 'version', label: 'Version', type: 'date', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+      { name: 'sha256', label: 'SHA-256', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
       { name: 'description', label: 'Filename', type: 'string', format: 'text', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
       { name: 'list_filters', label: 'Filters', type: 'string', format: 'text', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
       { name: 'filename', label: 'Filename', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-helper-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-helper-test.ts
@@ -22,6 +22,9 @@ describe('File storage upload with marking', () => {
     expect(uploadedFileWithMarking.upload.id).toBeDefined();
     // and expect no exception.
 
+    const duplicateUploadedFile = await uploadToStorage(adminContext, ADMIN_USER, SUPPORT_STORAGE_PATH, file, { file_markings: [MARKING_TLP_CLEAR] });
+    expect(duplicateUploadedFile.untouched).toBeTruthy();
+
     const document = await findDocumentById(adminContext, ADMIN_USER, uploadedFileWithMarking.upload.id);
     expect(document.metaData.file_markings).toBeDefined();
     expect(document.metaData.file_markings?.length, 'One marking MARKING_TLP_CLEAR is expected on this document.').toBe(1);


### PR DESCRIPTION
(cherry picked from commit 956ba7c82c53bcac6bb2c13f9d50717aed48cece)

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
