### PR TITLE
[backend] send existing_users_count in auto-register (#15001)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -1,7 +1,7 @@
-import { getEntityFromCache } from '../database/cache';
+import {getEntitiesListFromCache, getEntityFromCache} from '../database/cache';
 import type { BasicStoreSettings } from '../types/settings';
 import type { AuthContext, AuthUser } from '../types/user';
-import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
+import {ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER} from '../schema/internalObject';
 import { xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
 import { type AutoRegisterInput, XtmHubRegistrationStatus } from '../generated/graphql';
 import { updateAttribute } from '../database/middleware';
@@ -77,6 +77,10 @@ export const autoRegisterOpenCTI = async (context: AuthContext, user: AuthUser, 
   if (!input.platform_token) {
     return { success: false };
   }
+
+  const users = await getEntitiesListFromCache(context, user, ENTITY_TYPE_USER) as AuthUser[];
+  const existing_users_count = users.filter((user) => !user.user_service_account).length;
+
   const response = await xtmHubClient.autoRegister(
     {
       platformId: settings.id,
@@ -85,6 +89,7 @@ export const autoRegisterOpenCTI = async (context: AuthContext, user: AuthUser, 
       platformTitle: settings.platform_title ?? '',
     },
     licenseInfo.license_type,
+    existing_users_count
   );
   if (!response.success) {
     return { success: false };

--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -1,7 +1,7 @@
-import {getEntitiesListFromCache, getEntityFromCache} from '../database/cache';
+import { getEntitiesListFromCache, getEntityFromCache } from '../database/cache';
 import type { BasicStoreSettings } from '../types/settings';
 import type { AuthContext, AuthUser } from '../types/user';
-import {ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER} from '../schema/internalObject';
+import { ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER } from '../schema/internalObject';
 import { xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
 import { type AutoRegisterInput, XtmHubRegistrationStatus } from '../generated/graphql';
 import { updateAttribute } from '../database/middleware';
@@ -89,7 +89,7 @@ export const autoRegisterOpenCTI = async (context: AuthContext, user: AuthUser, 
       platformTitle: settings.platform_title ?? '',
     },
     licenseInfo.license_type,
-    existing_users_count
+    existing_users_count,
   );
   if (!response.success) {
     return { success: false };

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
@@ -56,8 +56,8 @@ export const xtmHubClient = {
     }
   },
   autoRegister: async (platform: { platformId: string; platformToken: string; platformUrl: string; platformTitle: string },
-                       enterpriseLicense: string,
-                       existing_users_count: number): Promise<Success> => {
+    enterpriseLicense: string,
+    existing_users_count: number): Promise<Success> => {
     const query = `
        mutation AutoRegisterPlatform($input: AutoRegisterPlatformInput!) {
         autoRegisterPlatform(input: $input) {
@@ -75,8 +75,8 @@ export const xtmHubClient = {
           contract: enterpriseLicense,
           version: PLATFORM_VERSION,
         },
-        existing_users_count
-      }
+        existing_users_count,
+      },
     };
     const httpClient = getHttpClient({
       baseURL: HUB_BACKEND_URL,

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
@@ -55,23 +55,28 @@ export const xtmHubClient = {
       return 'inactive';
     }
   },
-  autoRegister: async (platform: { platformId: string; platformToken: string; platformUrl: string; platformTitle: string }, enterpriseLicense: string): Promise<Success> => {
+  autoRegister: async (platform: { platformId: string; platformToken: string; platformUrl: string; platformTitle: string },
+                       enterpriseLicense: string,
+                       existing_users_count: number): Promise<Success> => {
     const query = `
-       mutation AutoRegisterPlatform($platform: PlatformInput!) {
-        autoRegisterPlatform(platform: $platform) {
+       mutation AutoRegisterPlatform($input: AutoRegisterPlatformInput!) {
+        autoRegisterPlatform(input: $input) {
           success
         }
       }
     `;
 
     const variables = {
-      platform: {
-        id: platform.platformId,
-        url: platform.platformUrl,
-        title: platform.platformTitle,
-        contract: enterpriseLicense,
-        version: PLATFORM_VERSION,
-      },
+      input: {
+        platform: {
+          id: platform.platformId,
+          url: platform.platformUrl,
+          title: platform.platformTitle,
+          contract: enterpriseLicense,
+          version: PLATFORM_VERSION,
+        },
+        existing_users_count
+      }
     };
     const httpClient = getHttpClient({
       baseURL: HUB_BACKEND_URL,

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import * as cache from '../../../src/database/cache';
-import * as confModule from '../../../src/config/conf';
 import { autoRegisterOpenCTI, checkXTMHubConnectivity } from '../../../src/domain/xtm-hub';
 import { testContext } from '../../utils/testQuery';
 import { HUB_REGISTRATION_MANAGER_USER } from '../../../src/utils/access';
@@ -297,13 +296,13 @@ describe('XTM hub', () => {
   describe('autoRegisterOpenCTI', () => {
     let autoRegisterSpy: MockInstance;
     let settingsEditFieldSpy: MockInstance;
-    let confGetSpy: MockInstance;
     let getEntityFromCacheSpy: MockInstance;
+    let getEntitiesListFromCacheSpy: MockInstance;
     beforeEach(() => {
       autoRegisterSpy = vi.spyOn(xtmHubClient, 'autoRegister');
       settingsEditFieldSpy = vi.spyOn(settingsModule, 'settingsEditField');
       getEntityFromCacheSpy = vi.spyOn(cache, 'getEntityFromCache');
-      confGetSpy = vi.spyOn(confModule.default, 'get');
+      getEntitiesListFromCacheSpy = vi.spyOn(cache, 'getEntitiesListFromCache');
     });
 
     afterEach(() => {
@@ -320,12 +319,26 @@ describe('XTM hub', () => {
       });
 
       settingsEditFieldSpy.mockResolvedValue({});
-      confGetSpy.mockReturnValue('platform_id');
       getEntityFromCacheSpy.mockResolvedValue({
         id: 'settings_id'
       });
+      getEntitiesListFromCacheSpy.mockResolvedValue([
+        { user_service_account: false },
+        { user_service_account: true },
+        { user_service_account: false }
+      ]);
 
       await autoRegisterOpenCTI(testContext, HUB_REGISTRATION_MANAGER_USER, input);
+      expect(autoRegisterSpy).toHaveBeenCalledWith(
+        {
+          platformId: 'settings_id',
+          platformToken: 'test-token',
+          platformUrl: undefined,
+          platformTitle: ''
+        },
+        expect.any(String),
+        2
+      );
       expect(settingsEditFieldSpy).toHaveBeenCalledWith(
         testContext,
         HUB_REGISTRATION_MANAGER_USER,
@@ -346,6 +359,12 @@ describe('XTM hub', () => {
       });
 
       settingsEditFieldSpy.mockResolvedValue({});
+      getEntityFromCacheSpy.mockResolvedValue({
+        id: 'settings_id'
+      });
+      getEntitiesListFromCacheSpy.mockResolvedValue([
+        { user_service_account: false }
+      ]);
 
       await autoRegisterOpenCTI(testContext, HUB_REGISTRATION_MANAGER_USER, input);
       expect(settingsEditFieldSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Send existing_users_count when calling auto-register on xtmhub. 
- existing_users_count must be the same as [the count sent in telemetry events](https://github.com/OpenCTI-Platform/opencti/blob/a0beece1a54f31659d577447b2ac0e984b0bb042/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts#L234-L236)
- auto-register endpoint has been modified to support a 'input' parameter instead of 'platform' in https://github.com/FiligranHQ/xtm-hub/pull/1876


### Related issues
* #15001
* xtmhub issue: https://github.com/FiligranHQ/xtm-hub/issues/1849

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
