### PR TITLE
[backend] clean up once listener in sendEvent after Promise.race has finished (#15007)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -304,7 +304,11 @@ const createSseMiddleware = () => {
         const message = buildMessage(eventId, topic, event);
         if (!res.write(message)) {
           logApp.debug('[STREAM] Buffer draining', { buffer: res.writableLength, limit: res.writableHighWaterMark });
-          await Promise.race([once(res, 'drain'), once(res, 'close')]);
+          const ac = new AbortController();
+          await Promise.race([
+            once(res, 'drain', { signal: ac.signal }),
+            once(res, 'close', { signal: ac.signal }),
+          ]).finally(() => ac.abort());
         }
         res.flush();
         // Track event delivery in consumer registry (skip heartbeat and connected events)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* once() registers a one-shot event listener on res. Promise.race settles when the first event fires, but the other once() listener is never removed. On a long-lived SSE connection, every time back-pressure occurs (res.write() returns false), a new orphaned listener accumulates on the res object.
Fix: Wrap both once() calls with an AbortController. When Promise.race settles, ac.abort() is called in the .finally(), which automatically removes the losing listener. This ensures no orphaned listeners accumulate over the lifetime of the connection.
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15007 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
