### PR TITLE
[worker] Fix opencti_operation set to 'event' instead of actual operation type (#15017)

### DIFF
--- a/opencti-worker/src/push_handler.py
+++ b/opencti-worker/src/push_handler.py
@@ -210,7 +210,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                             )
                         )
                         merge_object = content["data"]
-                        merge_object["opencti_operation"] = event_type
+                        merge_object["opencti_operation"] = content["type"]
                         merge_object["merge_target_id"] = target_id
                         merge_object["merge_source_ids"] = source_ids
                         bundle = {
@@ -235,7 +235,7 @@ class PushHandler:  # pylint: disable=too-many-instance-attributes
                         | "revert_draft"  # Cancel draft modification (massive operation in UI)
                     ):
                         data_object = content["data"]
-                        data_object["opencti_operation"] = event_type
+                        data_object["opencti_operation"] = content["type"]
                         bundle = {
                             "type": "bundle",
                             "objects": [data_object],


### PR DESCRIPTION
## Description

Fixes #15017

Stream synchronization operations (merge, delete, restore, share, unshare, etc.) are broken due to a regression in `opencti-worker/src/push_handler.py` introduced in commit `5ccf532b74` ("[worker] Cleanup codebase" #12623, October 14, 2025).

### Root Cause

The cleanup refactor changed `match event_type:` to `match content["type"]:` but removed the `event_type = event_content["type"]` reassignment without updating lines 213 and 238. As a result, `opencti_operation` is always set to the literal string `"event"` instead of the actual operation type (`"merge"`, `"delete"`, `"restore"`, etc.).

### Fix

Replace `event_type` with `content["type"]` on both affected lines:
- Line 213: `merge_object["opencti_operation"] = content["type"]`
- Line 238: `data_object["opencti_operation"] = content["type"]`

### Impact

- **Affected**: all stream sync operations except create/update (merge, delete, restore, delete_force, share, unshare, rule_apply, rule_clear, rules_rescan, enrichment, clear_access_restriction, revert_draft)
- **Not affected**: regular connector bundle ingestion, task manager operations, create/update via sync

