### PR TITLE
[frontend] Indicator pattern display for SIGMA/YARA pattern (#15014)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ExpandablePre.tsx
+++ b/opencti-platform/opencti-front/src/components/ExpandablePre.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
-import * as PropTypes from 'prop-types';
-import { ExpandMore, ExpandLess } from '@mui/icons-material';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
 import IconButton from '@common/button/IconButton';
 import { truncate } from '../utils/String';
 
-const ExpandablePre = (props) => {
+interface ExpandablePreProps {
+  source: string | null | undefined;
+  limit: number;
+}
+
+const ExpandablePre = ({ source, limit }: ExpandablePreProps) => {
   const [expand, setExpand] = useState(false);
 
   const onClick = () => setExpand(!expand);
 
-  const { source, limit } = props;
   const shouldBeTruncated = (source || '').length > limit;
 
   return (
@@ -24,11 +27,6 @@ const ExpandablePre = (props) => {
       <pre style={{ margin: 0 }}>{expand ? source : truncate(source, limit)}</pre>
     </div>
   );
-};
-
-ExpandablePre.propTypes = {
-  source: PropTypes.string.isRequired,
-  limit: PropTypes.number.isRequired,
 };
 
 export default ExpandablePre;

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -20,6 +20,7 @@ import StixCoreObjectKillChainPhasesView from '../../common/stix_core_objects/St
 import DecayDialogContent from './DecayDialogContent';
 import DecayExclusionDialogContent from './DecayExclusionDialogContent';
 import IndicatorObservables from './IndicatorObservables';
+import ExpandablePre from '../../../../components/ExpandablePre';
 
 interface IndicatorDetailsComponentProps {
   indicator: IndicatorDetails_indicator$data;
@@ -44,7 +45,9 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
         <Label>
           {t_i18n('Indicator pattern')}
         </Label>
-        <span>{indicator.pattern ?? ''}</span>
+        <FieldOrEmpty source={indicator.pattern}>
+          <ExpandablePre source={indicator.pattern} limit={300} />
+        </FieldOrEmpty>
         <Grid container={true} spacing={2} sx={{ mt: 0 }}>
           <Grid item xs={6}>
             <Label>


### PR DESCRIPTION
### Proposed changes
In Indicator Overview, indicator pattern should correctly be displayed for SIGMA and YARA patterns (indentations, etc).

### Related issues
#15014

### Screenshot

<img width="2596" height="1376" alt="image" src="https://github.com/user-attachments/assets/1ce66789-1bcc-4774-91ba-bbfb5efee26a" />
