### PR TITLE
[backend] Make SSO attribute mapping expressions case insensitive (#15026)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/mappings-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/mappings-utils.ts
@@ -3,6 +3,19 @@ import * as R from 'ramda';
 import { pushAll } from '../../utils/arrayUtil';
 import type { ProviderAuthInfo } from './providers';
 
+/**
+ * Looks up a property on a record: first case-sensitive, then case-insensitive fallback.
+ */
+const resolveRecordValue = (record: { [key: string]: unknown }, name: string): unknown => {
+  const exact = record[name];
+  if (exact !== undefined && exact !== null) {
+    return exact;
+  }
+  const lowerName = name.toLowerCase();
+  const key = Object.keys(record).find((k) => k.toLowerCase() === lowerName);
+  return key !== undefined ? record[key] : undefined;
+};
+
 export const resolvePath = (path: string[]) => async (obj: unknown): Promise<any | undefined> => {
   if (obj === undefined || obj === null) {
     return undefined;
@@ -20,7 +33,7 @@ export const resolvePath = (path: string[]) => async (obj: unknown): Promise<any
   }
 
   const [name, ...rest] = path;
-  const { [name]: value } = obj as { [key: string]: unknown };
+  const value = resolveRecordValue(obj as { [key: string]: unknown }, name);
   if (value === undefined || value === null) {
     return undefined;
   }
@@ -103,8 +116,14 @@ const extractSplitMapAndDeduplicate = async (
   }
 
   const mapped = allValues.map(
-    (g) => mapping.find(
-      ({ provider }) => provider === g)?.platform,
+    (g) => {
+      // First try case-sensitive match
+      const exactMatch = mapping.find(({ provider }) => provider === g);
+      if (exactMatch) return exactMatch.platform;
+      // Fallback to case-insensitive match
+      const lowerG = g.toLowerCase();
+      return mapping.find(({ provider }) => provider.toLowerCase() === lowerG)?.platform;
+    },
   ).filter((m): m is string => Boolean(m));
 
   return R.uniq([...defaultValues, ...mapped]);

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/authenticationProvider/mappings-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/authenticationProvider/mappings-utils-test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseDotPath, resolvePath, resolveDotPath } from '../../../../src/modules/authenticationProvider/mappings-utils';
+import { parseDotPath, resolvePath, resolveDotPath, createGroupsMapper, createOrganizationsMapper } from '../../../../src/modules/authenticationProvider/mappings-utils';
 
 describe('mappings-utils', () => {
   describe('parseDotPath', () => {
@@ -216,6 +216,116 @@ describe('mappings-utils', () => {
         const result = await resolvePath(['meta', 'id'])(rootArray);
         expect(result).toEqual(['id1', 'id2']);
       });
+    });
+
+    describe('case-insensitive fallback', () => {
+      it('should resolve exact case-sensitive property first', async () => {
+        const obj = { Email: 'upper@example.com', email: 'lower@example.com' };
+        const result = await resolvePath(['email'])(obj);
+        expect(result).toBe('lower@example.com');
+      });
+
+      it('should fall back to case-insensitive match when exact key is missing', async () => {
+        const obj = { Email: 'upper@example.com' };
+        const result = await resolvePath(['email'])(obj);
+        expect(result).toBe('upper@example.com');
+      });
+
+      it('should fall back to case-insensitive match for nested paths', async () => {
+        const obj = { UserInfo: { Email: 'user@example.com' } };
+        const result = await resolvePath(['userinfo', 'email'])(obj);
+        expect(result).toBe('user@example.com');
+      });
+
+      it('should return undefined when no case-insensitive match exists', async () => {
+        const obj = { name: 'test' };
+        const result = await resolvePath(['email'])(obj);
+        expect(result).toBeUndefined();
+      });
+
+      it('should work with resolveDotPath for case-insensitive fallback', async () => {
+        const obj = { User_Info: { EMAIL: 'user@example.com' } };
+        const result = await resolveDotPath('user_info.email')(obj);
+        expect(result).toBe('user@example.com');
+      });
+    });
+  });
+
+  describe('case-insensitive mapping in groups', () => {
+    const resolveExpr = (expr: string) => (obj: unknown) => {
+      const record = obj as Record<string, unknown>;
+      return record[expr] as string | string[] | undefined;
+    };
+
+    it('should match group mapping case-sensitively first', async () => {
+      const conf = {
+        default_groups: [],
+        groups_expr: ['groups'],
+        group_splitter: undefined,
+        groups_mapping: [
+          { provider: 'Admin', platform: 'Administrators' },
+          { provider: 'admin', platform: 'LowercaseAdmins' },
+        ],
+        auto_create_groups: false,
+        prevent_default_groups: false,
+      };
+      const mapper = createGroupsMapper(conf, resolveExpr);
+      const result = await mapper({ groups: 'admin' });
+      expect(result).toEqual(['LowercaseAdmins']);
+    });
+
+    it('should fall back to case-insensitive match when no exact match', async () => {
+      const conf = {
+        default_groups: [],
+        groups_expr: ['groups'],
+        group_splitter: undefined,
+        groups_mapping: [
+          { provider: 'Admin', platform: 'Administrators' },
+        ],
+        auto_create_groups: false,
+        prevent_default_groups: false,
+      };
+      const mapper = createGroupsMapper(conf, resolveExpr);
+      const result = await mapper({ groups: 'admin' });
+      expect(result).toEqual(['Administrators']);
+    });
+
+    it('should return default groups when no mapping matches at all', async () => {
+      const conf = {
+        default_groups: ['DefaultGroup'],
+        groups_expr: ['groups'],
+        group_splitter: undefined,
+        groups_mapping: [
+          { provider: 'Admin', platform: 'Administrators' },
+        ],
+        auto_create_groups: false,
+        prevent_default_groups: false,
+      };
+      const mapper = createGroupsMapper(conf, resolveExpr);
+      const result = await mapper({ groups: 'viewer' });
+      expect(result).toEqual(['DefaultGroup']);
+    });
+  });
+
+  describe('case-insensitive mapping in organizations', () => {
+    const resolveExpr = (expr: string) => (obj: unknown) => {
+      const record = obj as Record<string, unknown>;
+      return record[expr] as string | string[] | undefined;
+    };
+
+    it('should fall back to case-insensitive match for organizations', async () => {
+      const conf = {
+        default_organizations: [],
+        organizations_expr: ['orgs'],
+        organizations_splitter: undefined,
+        organizations_mapping: [
+          { provider: 'MyOrg', platform: 'My Organization' },
+        ],
+        auto_create_organizations: false,
+      };
+      const mapper = createOrganizationsMapper(conf, resolveExpr);
+      const result = await mapper({ orgs: 'myorg' });
+      expect(result).toEqual(['My Organization']);
     });
   });
 });


### PR DESCRIPTION
### Proposed changes

* expression mapping fallback on case insensitive search if case sensitive don't match
* org/group mapping fallback on case insensitive search if case sensitive don't match

### Related issues
* fix #15026

### Checklist
- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
