### PR TITLE
[frontend] Fix available filter keys for connector trigger filters (#15039)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -331,7 +331,7 @@ const ConnectorComponent: FunctionComponent<ConnectorComponentProps> = ({ connec
                   }}
                   >
                     <Filters
-                      availableFilterKeys={['entity_type']}
+                      availableFilterKeys={connectorAvailableFilterKeys}
                       helpers={helpers}
                       searchContext={filtersSearchContext}
                     />


### PR DESCRIPTION
### Proposed changes
The connector trigger filters UI only exposes Entity type as an available filter key. All other supported filter keys (labels, markings, created by, confidence, severity, priority, workflow status, etc.) are missing from the filter dropdown.

This is a regression introduced during the UI v7 design system refactor.

### Related issues
#15039