### PR TITLE
[deps] Upgrade recharts to v3.8.0 (follow-up Renovate PR #12765) (#15063)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -116,7 +116,7 @@
     "react-virtualized": "9.22.6",
     "react-wordcloud": "1.2.7",
     "reactflow": "11.11.4",
-    "recharts": "3.2.0",
+    "recharts": "3.8.0",
     "relay-runtime": "20.1.1",
     "remark-flexible-markers": "1.3.3",
     "remark-gfm": "4.0.1",

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarTimeRange.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarTimeRange.tsx
@@ -1,4 +1,4 @@
-import { ResponsiveContainer, Scatter, ScatterChart, YAxis, ZAxis, Tooltip, TooltipProps } from 'recharts';
+import { ResponsiveContainer, Scatter, ScatterChart, YAxis, ZAxis, Tooltip, TooltipContentProps } from 'recharts';
 import React, { CSSProperties } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { computeTimeRangeValuesDomain, GraphTimeRange } from '../utils/graphTimeRange';
@@ -9,10 +9,10 @@ import TimeRange from '../../range_slider/RangeSlider';
 import { useFormatter } from '../../i18n';
 import useGraphInteractions from '../utils/useGraphInteractions';
 
-const TimeRangeTooltip: TooltipProps<number, string>['content'] = ({
+const TimeRangeTooltip = ({
   active,
   payload,
-}) => {
+}: TooltipContentProps) => {
   const { fldt } = useFormatter();
   const theme = useTheme<Theme>();
 

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -3823,7 +3823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@npm:1.x.x || 2.x.x":
+"@reduxjs/toolkit@npm:^1.9.0 || 2.x.x":
   version: 2.11.2
   resolution: "@reduxjs/toolkit@npm:2.11.2"
   dependencies:
@@ -12368,7 +12368,7 @@ __metadata:
     react-virtualized: "npm:9.22.6"
     react-wordcloud: "npm:1.2.7"
     reactflow: "npm:11.11.4"
-    recharts: "npm:3.2.0"
+    recharts: "npm:3.8.0"
     relay-compiler: "npm:20.1.1"
     relay-runtime: "npm:20.1.1"
     relay-test-utils: "npm:20.1.1"
@@ -13554,11 +13554,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"recharts@npm:3.2.0":
-  version: 3.2.0
-  resolution: "recharts@npm:3.2.0"
+"recharts@npm:3.8.0":
+  version: 3.8.0
+  resolution: "recharts@npm:3.8.0"
   dependencies:
-    "@reduxjs/toolkit": "npm:1.x.x || 2.x.x"
+    "@reduxjs/toolkit": "npm:^1.9.0 || 2.x.x"
     clsx: "npm:^2.1.1"
     decimal.js-light: "npm:^2.5.1"
     es-toolkit: "npm:^1.39.3"
@@ -13573,7 +13573,7 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/222bc5c21987b8fc81a844fc718a68b861a996f0c6c4ace40c69e70e6b750714c27fee725faba90e734dcde004c4e22fed1dc26f9b095a43e90fce4bd2e492c5
+  checksum: 10c0/ae8e60202138670211a9464ecd838600803044796570281978f3d79d02c3add39d6513fd943c29d62a1bdefe01c0b98287e12a2a6685da3617257969c6ef2290
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Proposed changes

* Upgrade `recharts` from `3.2.0` to `3.8.0`
* Fix TypeScript breaking change introduced by recharts v3.8.0 in `GraphToolbarTimeRange.tsx`: replace `TooltipProps<number, string>['content']` type annotation with `TooltipContentProps` (default generics) to satisfy the new `ContentType<ValueType, NameType>` constraint

### Related issues
* https://github.com/OpenCTI-Platform/opencti/issues/15063

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

This PR upgrades `recharts` to v3.8.0.

recharts v3.8.0 tightened TypeScript generics on the `Tooltip` component: `content` now expects `ContentType<ValueType, NameType>` where `ValueType = number | string | Array<...>`. A function typed with explicit `<number, string>` generics is no longer assignable due to contravariance on the `formatter` property.

The fix in `GraphToolbarTimeRange.tsx` uses the default (widest) `TooltipContentProps` generic, which matches exactly what recharts expects.

The changes are limited to `package.json`, `yarn.lock`, and `GraphToolbarTimeRange.tsx`.