### PR TITLE
[frontend] In SSO only, platform login message should be displayed (#15090)

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/login/LoginPage.tsx
+++ b/opencti-platform/opencti-front/src/public/components/login/LoginPage.tsx
@@ -67,27 +67,30 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({ settings }) => {
           </Card>
         )}
 
-        {consentOk && providers.filter((p) => p.type === 'FORM').length > 0 && (
-          <Card
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            {!!loginMessage && (
-              <LoginMarkdown sx={{ mb: 2 }}>
-                {loginMessage}
-              </LoginMarkdown>
-            )}
+        {!!loginMessage && (
+          <Typography textAlign="center" variant="body2">
+            <LoginMarkdown sx={{ mb: 2 }}>
+              {loginMessage}
+            </LoginMarkdown>
+          </Typography>
+        )}
 
-            {(showLoginForm || !!resetPwdStep) && (
+        {consentOk
+          && providers.filter((p) => p.type === 'FORM').length > 0
+          && (showLoginForm || !!resetPwdStep)
+          && (
+            <Card
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
               <div style={{ minHeight: 170 }}>
                 {!!resetPwdStep && <ResetPassword />}
                 {showLoginForm && <LoginForm />}
               </div>
-            )}
-          </Card>
-        )}
+            </Card>
+          )}
 
         <ExternalAuths
           data={settings}


### PR DESCRIPTION
### Proposed changes
If a platform login message is defined, it should be displayed in the login page.
In this PR I fix the case when the only login strategy is SSO (the message was not displayed).

### Related issues
#15090


### Screenshots
- only SSO
<img width="1833" height="875" alt="image" src="https://github.com/user-attachments/assets/b1604882-3b3f-44e1-b472-7a69c7d29fc7" />

