### PR TITLE
[backend] Fix path fallbacks in migration converter (#14996)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-migration-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-migration-converter.ts
@@ -394,7 +394,7 @@ const buildOidcGroupsExpr = (gm: EnvGroupsManagement | undefined): string[] => {
   // Always populate with defaults — in the new model we never hide default paths.
   // Old default: groups_path=['groups'], token_reference='access_token', read_userinfo=false
   if (!gm?.groups_mapping || gm.groups_mapping.length === 0) return [];
-  const paths = gm?.groups_path ?? ['groups'];
+  const paths = gm?.groups_path || ['groups'];
   const readUserinfo = gm?.read_userinfo ?? false;
   const tokenRef = gm?.token_reference ?? 'access_token';
   const prefix = readUserinfo ? 'user_info' : `tokens.${tokenRef}`;
@@ -405,7 +405,7 @@ const buildOidcOrgsExpr = (om: EnvOrganizationsManagement | undefined): string[]
   // Always populate with defaults — in the new model we never hide default paths.
   // Old default: organizations_path=['organizations'], token_reference='access_token', read_userinfo=false
   if (!om || Object.keys(om).length === 0) return [];
-  const paths = om?.organizations_path ?? ['organizations'];
+  const paths = om?.organizations_path || ['organizations'];
   const readUserinfo = om?.read_userinfo ?? false;
   const tokenRef = om?.token_reference ?? 'access_token';
   const prefix = readUserinfo ? 'user_info' : `tokens.${tokenRef}`;
@@ -566,7 +566,7 @@ export const convertSamlEnvConfig = (envKey: string, entry: EnvProviderEntry): C
   const preventDefaultGroups = ext.get<boolean>('prevent_default_groups', false);
   const gm = resolveGroupsManagement(ext, 'saml', warnings);
   const groupsExpr = (gm?.groups_mapping && gm.groups_mapping.length > 0)
-    ? (gm.group_attributes ?? ['groups']).map(quotePathSegment)
+    ? (gm.group_attributes || ['groups']).map(quotePathSegment)
     : [];
   const groupsMapping: GroupsMappingInput = {
     auto_create_groups: autoCreateGroup,
@@ -588,7 +588,7 @@ export const convertSamlEnvConfig = (envKey: string, entry: EnvProviderEntry): C
     auto_create_organizations: false,
     default_organizations: organizationsDefault,
     organizations_expr: (om && Object.keys(om).length > 0)
-      ? [(om.organizations_path ?? ['organizations']).map(quotePathSegment).join('.')]
+      ? [(om.organizations_path || ['organizations']).map(quotePathSegment).join('.')]
       : [],
     organizations_mapping: convertMappingEntries(om?.organizations_mapping),
   };
@@ -691,7 +691,7 @@ export const convertLdapEnvConfig = (envKey: string, entry: EnvProviderEntry): C
     auto_create_organizations: false,
     default_organizations: organizationsDefault,
     organizations_expr: (om && Object.keys(om).length > 0)
-      ? (om.organizations_path ?? ['organizations']).map(quotePathSegment)
+      ? (om.organizations_path || ['organizations']).map(quotePathSegment)
       : [],
     organizations_mapping: convertMappingEntries(om?.organizations_mapping),
   };


### PR DESCRIPTION
Fix path fallbacks in migration converter to match legacy behavior

### Proposed changes

* `??` only falls back on `null`/`undefined. uising `||` instead treats an empty array as falsy and
correctly applies the default (`['groups']` or `['organizations']`), matching the original behavior of `providers-env-deprecated.js`.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/14996

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
