### PR TITLE
[frontend] FIx sourcemaps config, add React.StrictMode, avoid minifying (#15096)

### DIFF
--- a/opencti-platform/opencti-front/builder/dev/dev.js
+++ b/opencti-platform/opencti-front/builder/dev/dev.js
@@ -49,7 +49,7 @@ const middleware = (target, ws = false) => createProxyMiddleware({
       },
       assetNames: "[dir]/[name]-[hash]",
       target: ["chrome58"],
-      minify: true,
+      minify: false,
       keepNames: true,
       sourcemap: "linked",
       outdir: "builder/dev/build",

--- a/opencti-platform/opencti-front/builder/dev/dev.js
+++ b/opencti-platform/opencti-front/builder/dev/dev.js
@@ -51,7 +51,7 @@ const middleware = (target, ws = false) => createProxyMiddleware({
       target: ["chrome58"],
       minify: true,
       keepNames: true,
-      sourcemap: true,
+      sourcemap: "linked",
       outdir: "builder/dev/build",
     })
   await builder.rebuild();
@@ -119,6 +119,12 @@ const middleware = (target, ws = false) => createProxyMiddleware({
   app.use(basePath + `/static`, express.static(path.join(__dirname, "./build/static")));
   app.use(`/css`, express.static(path.join(__dirname, "./build")));
   app.use(`/js`, express.static(path.join(__dirname, "./build")));
+  // Source maps are expected to be served from the root
+  // given `publicPath` is prefixed to the sourceMappingURL by esbuild.
+  app.use(`/:any.map`, async (req, res) => {
+    const data = await readFile(path.join(__dirname, `./build/${req.params.any}.map`), "utf8");
+    return res.send(data);
+  });
   app.get("*any", async (req, res) => {
     const data = await readFile(`${__dirname}/index.html`, "utf8");
     const withOptionValued = data

--- a/opencti-platform/opencti-front/src/front.tsx
+++ b/opencti-platform/opencti-front/src/front.tsx
@@ -41,9 +41,11 @@ const container = document.getElementById('root');
 const root = createRoot(container!);
 
 root.render(
-  <RelayEnvironmentProvider environment={environment}>
-    <Suspense fallback={<Loading />}>
-      <App />
-    </Suspense>
-  </RelayEnvironmentProvider>,
+  <React.StrictMode>
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback={<Loading />}>
+        <App />
+      </Suspense>
+    </RelayEnvironmentProvider>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
### Proposed changes

* Fix sourcemaps config
* Add `React.StrictMode` to the root to show potential React problems
* Avoid minifying code in dev mode given it hides warnings/errors

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/15096
Fixes #15096

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
