### PR TITLE
[backend] Fix query in setting index fails when internal_object has rollover (#12138)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -529,8 +529,10 @@ export const setPlatformId = async (context, platformId) => {
     if (platformSettings.id !== platformId) {
       logApp.warn(`[INIT] Switching platform identifier from [${platformSettings.id}] to [${platformId}]`);
       // to change the id in elastic, we have no choice but to create a patched copy and delete the old document
+      // Use the concrete index name from the loaded entity (_index) instead of the alias (INDEX_INTERNAL_OBJECTS).
+      const settingCurrentIndex = platformSettings._index;
       const response = await elRawGet({
-        index: INDEX_INTERNAL_OBJECTS,
+        index: settingCurrentIndex,
         id: platformSettings.id,
       });
       await elRawIndex({
@@ -544,7 +546,7 @@ export const setPlatformId = async (context, platformId) => {
         refresh: true,
       });
       await elRawDelete({
-        index: INDEX_INTERNAL_OBJECTS,
+        index: settingCurrentIndex,
         id: platformSettings.id,
         refresh: true,
       });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use current setting index full name instead of alias.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fixes #12138 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
