### PR TITLE
[frontend] fix vocabulary attributes handling in forms (#15214)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
+++ b/opencti-platform/opencti-front/src/components/AutocompleteField.tsx
@@ -47,7 +47,6 @@ const AutocompleteField = <
   ...muiProps
 }: AutocompleteFieldProps<M, Value, DC, FSolo>) => {
   type MuiProps = AutocompleteProps<Value, M, DC, FSolo>;
-
   const {
     form: { setFieldValue, setFieldTouched, submitCount },
     field: { name },
@@ -137,6 +136,13 @@ const AutocompleteField = <
       />
     ),
   });
+
+  // When multiple is true, MUI Autocomplete expects value to be an array.
+  // Formik fields may be initialized as null/undefined/empty string, causing
+  // a "value.some is not a function" crash in useAutocomplete.
+  if (fieldProps.multiple && !Array.isArray(fieldProps.value)) {
+    fieldProps.value = (fieldProps.value != null && fieldProps.value !== '' ? [fieldProps.value] : []) as unknown as typeof fieldProps.value;
+  }
 
   return (
     <div style={{ position: 'relative' }}>

--- a/opencti-platform/opencti-front/src/private/components/common/form/OpenVocabField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/OpenVocabField.tsx
@@ -130,7 +130,7 @@ const OpenVocabFieldComponent = ({
       )}
       groupBy={Array.isArray(type) ? (o: VocabFieldOption) => o.category : undefined}
       getOptionDisabled={(o: VocabFieldOption) => disabledOptions.includes(o.value)}
-      isOptionEqualToValue={(o: VocabFieldOption, value: string) => o.value === value}
+      isOptionEqualToValue={(o: VocabFieldOption, v: VocabFieldOption | string) => o.value === (typeof v === 'string' ? v : v?.value)}
       textfieldprops={{
         label,
         helperText,

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormSchemaEditor.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormSchemaEditor.tsx
@@ -788,7 +788,7 @@ const FormSchemaEditor: FunctionComponent<FormSchemaEditorProps> = ({
           fullWidth
           variant="standard"
           style={{ marginTop: 20 }}
-          disabled={!field.attributeMapping.attributeName}
+          disabled={!field.attributeMapping.attributeName || !!getVocabularyMappingByAttribute(field.attributeMapping.attributeName)}
         >
           <InputLabel>{t_i18n('Field Type')}</InputLabel>
           <Select

--- a/opencti-platform/opencti-front/src/utils/vocabularyMapping.ts
+++ b/opencti-platform/opencti-front/src/utils/vocabularyMapping.ts
@@ -67,7 +67,7 @@ export const OPENVOCAB_FIELD_MAPPINGS: VocabularyMapping[] = [
   { attribute: 'collection_layers', vocabularyType: 'collection_layers_ov', label: 'Layers', multiple: true },
 
   // Channel attributes
-  { attribute: 'channel_types', vocabularyType: 'channel_type_ov', label: 'Channel types', multiple: true },
+  { attribute: 'channel_types', vocabularyType: 'channel_types_ov', label: 'Channel types', multiple: true },
 
   // Tool attributes
   { attribute: 'tool_types', vocabularyType: 'tool_type_ov', label: 'Tool types', multiple: true },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* open vocab attributes are now forced to be of open vocab type
* fixed channel type openvocab
* fixed autocomplete use in open vocab field component

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15214 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
