### PR TITLE
[backend] normalize stix pattern(#13803)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/syntax.js
+++ b/opencti-platform/opencti-graphql/src/utils/syntax.js
@@ -11,11 +11,10 @@ export const STIX_PATTERN_TYPE = 'stix';
 
 const unflatten = (data) => {
   const result = {};
-  // eslint-disable-next-line no-restricted-syntax,guard-for-in
+
   for (const i in data) {
     const keys = i.split('.');
     keys.reduce((r, e, j) => {
-      // eslint-disable-next-line no-nested-ternary,no-param-reassign,no-return-assign
       return r[e] || (r[e] = Number.isNaN(Number(keys[j + 1])) ? (keys.length - 1 === j ? data[i] : {}) : []);
     }, result);
   }
@@ -110,31 +109,47 @@ export const extractValidObservablesFromIndicatorPattern = (pattern) => {
   return observables.filter((obs) => validateObservableGeneration(obs.type, pattern));
 };
 
-export const cleanupIndicatorPattern = (patternType, pattern) => {
-  if (pattern && patternType.toLowerCase() === STIX_PATTERN_TYPE) {
-    const grabInterestingTokens = (ctx, parser, acc) => {
-      const operators = [...parser.symbolicNames, '=', '!=', '<', '>', '<=', '>='];
-      const numberOfTokens = ctx.getChildCount();
-      for (let i = 0; i < numberOfTokens; i += 1) {
-        const child = ctx.getChild(i);
-        const subCount = child.getChildCount();
-        if (subCount > 0) {
-          grabInterestingTokens(child, parser, acc);
-        } else if (operators.includes(child.getText())) {
-          acc.push(` ${child.getText()} `);
-        } else {
-          acc.push(child.getText());
-        }
+// Due to ANTLR parser, property names with hyphens (e.g. 'SHA-256') must remain quoted in the pattern syntax.
+const UNQUOTABLE_IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const isValidUnquotedPropertyName = (name) => UNQUOTABLE_IDENTIFIER_REGEX.test(name);
+
+const normalizePropertyName = (quotedToken) => {
+  const unquotedName = quotedToken.slice(1, -1);
+  return isValidUnquotedPropertyName(unquotedName) ? unquotedName : quotedToken;
+};
+
+const isQuotedToken = (text) => text.startsWith("'") && text.endsWith("'");
+
+// Recursively walk the ANTLR parse tree and collect normalized tokens.
+const collectNormalizedTokens = (ctx, operators, tokens) => {
+  const childCount = ctx.getChildCount();
+  for (let i = 0; i < childCount; i += 1) {
+    const child = ctx.getChild(i);
+    if (child.getChildCount() > 0) {
+      collectNormalizedTokens(child, operators, tokens);
+    } else {
+      const tokenText = child.getText();
+      if (operators.includes(tokenText)) {
+        tokens.push(` ${tokenText} `);
+      } else {
+        const prevToken = tokens.length > 0 ? tokens[tokens.length - 1] : '';
+        const isPropertyNameAfterDot = prevToken === '.' && isQuotedToken(tokenText);
+        tokens.push(isPropertyNameAfterDot ? normalizePropertyName(tokenText) : tokenText);
       }
-    };
-    const { parser, parsedPattern } = parsePattern(pattern);
-    const patternContext = parsedPattern.getChild(0);
-    const patternTokens = [];
-    grabInterestingTokens(patternContext, parser, patternTokens);
-    return patternTokens.join('').trim();
+    }
   }
-  // For other pattern type, cleanup is not yet implemented
-  return pattern;
+};
+
+export const cleanupIndicatorPattern = (patternType, pattern) => {
+  if (!pattern || patternType.toLowerCase() !== STIX_PATTERN_TYPE) {
+    // For non-STIX pattern types (yara, pcre, etc.), cleanup is not yet implemented.
+    return pattern;
+  }
+  const { parser, parsedPattern } = parsePattern(pattern);
+  const operators = [...parser.symbolicNames, '=', '!=', '<', '>', '<=', '>='];
+  const tokens = [];
+  collectNormalizedTokens(parsedPattern.getChild(0), operators, tokens);
+  return tokens.join('').trim();
 };
 
 export const systemChecker = /^\d{0,10}$/;

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/syntax-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/syntax-test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { systemChecker, domainChecker, hostnameChecker, emailChecker, ipv6Checker, macAddrChecker, ipv4Checker, cpeChecker } from '../../../src/utils/syntax';
+import {
+  systemChecker,
+  domainChecker,
+  hostnameChecker,
+  emailChecker,
+  ipv6Checker,
+  macAddrChecker,
+  ipv4Checker,
+  cpeChecker,
+  cleanupIndicatorPattern,
+} from '../../../src/utils/syntax';
 
 describe('Regex Pattern Tests', () => {
   it('should match a valid system pattern', () => {
@@ -66,14 +76,14 @@ describe('Regex Pattern Tests', () => {
     expect('10.0.0.1').toMatch(ipv4Checker);
     expect('172.16.0.1').toMatch(ipv4Checker);
     expect('8.8.8.8').toMatch(ipv4Checker);
-    
+
     // Valid IPv4 with CIDR notation
     expect('192.168.0.1/24').toMatch(ipv4Checker);
     expect('10.0.0.0/8').toMatch(ipv4Checker);
     expect('172.16.0.0/12').toMatch(ipv4Checker);
     expect('192.168.1.1/32').toMatch(ipv4Checker);
     expect('0.0.0.0/0').toMatch(ipv4Checker);
-    
+
     // Invalid formats
     expect('invalid_ipv4').not.toMatch(ipv4Checker);
     expect('256.1.1.1').not.toMatch(ipv4Checker);
@@ -83,7 +93,7 @@ describe('Regex Pattern Tests', () => {
     expect('999.999.999.999').not.toMatch(ipv4Checker);
     expect('192.168.0').not.toMatch(ipv4Checker);
     expect('192.168.0.1.1').not.toMatch(ipv4Checker);
-    
+
     // Invalid - Leading zeros (issue #12494)
     expect('01.1.1.1').not.toMatch(ipv4Checker);
     expect('1.01.1.1').not.toMatch(ipv4Checker);
@@ -92,7 +102,7 @@ describe('Regex Pattern Tests', () => {
     expect('001.1.1.1').not.toMatch(ipv4Checker);
     expect('192.168.001.1').not.toMatch(ipv4Checker);
     expect('010.010.010.010').not.toMatch(ipv4Checker);
-    
+
     // Invalid CIDR
     expect('192.168.0.1/33').not.toMatch(ipv4Checker);
     expect('192.168.0.1/99').not.toMatch(ipv4Checker);
@@ -104,5 +114,109 @@ describe('Regex Pattern Tests', () => {
     expect('cpe:/a:example:ie').toMatch(cpeChecker);
     expect('cpe:/a:example:internet_explorer:8.0.6001:beta').toMatch(cpeChecker);
     expect('invalid_cpe').not.toMatch(cpeChecker);
+  });
+});
+
+describe('cleanupIndicatorPattern - STIX pattern normalization', () => {
+  // --- Property name quoting normalization ---
+
+  it('should normalize quoted MD5 property name to unquoted form to avoid duplicates', () => {
+    const patternWithQuotedKey = "[file:hashes.'MD5' = 'e1d9c90de2568f34ad689c71dac09c62']";
+    const patternWithUnquotedKey = "[file:hashes.MD5 = 'e1d9c90de2568f34ad689c71dac09c62']";
+
+    const normalizedWithQuotes = cleanupIndicatorPattern('stix', patternWithQuotedKey);
+    const normalizedWithoutQuotes = cleanupIndicatorPattern('stix', patternWithUnquotedKey);
+
+    expect(normalizedWithQuotes).toBe(normalizedWithoutQuotes);
+  });
+
+  it('should normalize quoted property names that are valid identifiers (letters, digits, underscore)', () => {
+    const patternWithQuotedKey = "[file:hashes.'MD5' = 'abc123']";
+    const normalizedPattern = cleanupIndicatorPattern('stix', patternWithQuotedKey);
+
+    expect(normalizedPattern).toContain('.MD5');
+    expect(normalizedPattern).not.toContain(".'MD5'");
+  });
+
+  it('should keep quotes on property names that require them (containing hyphens like SHA-256)', () => {
+    const patternWithSHA256 = "[file:hashes.'SHA-256' = 'a3f1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1']";
+    const normalized = cleanupIndicatorPattern('stix', patternWithSHA256);
+
+    expect(normalized).toContain(".'SHA-256'");
+  });
+
+  it('should produce the same normalized pattern regardless of property name quoting for multiple hash types', () => {
+    const patternA = "[file:hashes.'MD5' = 'e1d9c90de2568f34ad689c71dac09c62'] AND [file:hashes.'SHA-256' = 'abc']";
+    const patternB = "[file:hashes.MD5 = 'e1d9c90de2568f34ad689c71dac09c62'] AND [file:hashes.'SHA-256' = 'abc']";
+
+    const normalizedA = cleanupIndicatorPattern('stix', patternA);
+    const normalizedB = cleanupIndicatorPattern('stix', patternB);
+
+    expect(normalizedA).toBe(normalizedB);
+  });
+
+  // --- Non-STIX pattern types ---
+
+  it('should not alter non-STIX pattern types', () => {
+    const yaraPattern = 'rule test { strings: $a = /md5/ condition: $a }';
+    expect(cleanupIndicatorPattern('yara', yaraPattern)).toBe(yaraPattern);
+    expect(cleanupIndicatorPattern('pcre', yaraPattern)).toBe(yaraPattern);
+  });
+
+  it('should handle patternType case-insensitivity (STIX, Stix, stix)', () => {
+    const pattern = "[file:hashes.'MD5' = 'abc123']";
+    const normalizedLower = cleanupIndicatorPattern('stix', pattern);
+    const normalizedUpper = cleanupIndicatorPattern('STIX', pattern);
+    const normalizedMixed = cleanupIndicatorPattern('Stix', pattern);
+
+    expect(normalizedLower).toBe(normalizedUpper);
+    expect(normalizedLower).toBe(normalizedMixed);
+  });
+
+  // --- Value preservation ---
+
+  it('should not strip quotes from string literal values (after = operator)', () => {
+    const pattern = "[file:hashes.MD5 = 'e1d9c90de2568f34ad689c71dac09c62']";
+    const normalized = cleanupIndicatorPattern('stix', pattern);
+
+    expect(normalized).toContain("'e1d9c90de2568f34ad689c71dac09c62'");
+  });
+
+  // --- Edge cases & robustness ---
+
+  it('should return pattern unchanged when pattern is null or empty for STIX type', () => {
+    expect(cleanupIndicatorPattern('stix', null)).toBeNull();
+    expect(cleanupIndicatorPattern('stix', undefined)).toBeUndefined();
+    expect(cleanupIndicatorPattern('stix', '')).toBe('');
+  });
+
+  it('should be idempotent - normalizing an already normalized pattern should return the same result', () => {
+    const pattern = "[file:hashes.'MD5' = 'e1d9c90de2568f34ad689c71dac09c62']";
+    const firstPass = cleanupIndicatorPattern('stix', pattern);
+    const secondPass = cleanupIndicatorPattern('stix', firstPass);
+
+    expect(firstPass).toBe(secondPass);
+  });
+
+  it('should normalize whitespace around operators and keywords', () => {
+    const messyPattern = "[ipv4-addr:value   =   '198.51.100.1/32']";
+    const normalized = cleanupIndicatorPattern('stix', messyPattern);
+
+    expect(normalized).toBe("[ipv4-addr:value = '198.51.100.1/32']");
+  });
+
+  it('should trim leading and trailing whitespace from the pattern', () => {
+    const pattern = "   [ipv4-addr:value = '1.2.3.4']   ";
+    const normalized = cleanupIndicatorPattern('stix', pattern);
+
+    expect(normalized).toBe("[ipv4-addr:value = '1.2.3.4']");
+  });
+
+  it('should handle windows-pebinary-ext quoted extension name (contains hyphens)', () => {
+    const pattern = "[file:extensions.'windows-pebinary-ext'.sections[*].entropy > 7.0]";
+    const normalized = cleanupIndicatorPattern('stix', pattern);
+
+    // 'windows-pebinary-ext' must stay quoted (contains hyphens)
+    expect(normalized).toContain(".'windows-pebinary-ext'");
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Adds `normalizePropertyName `method
* refactor `cleanupIndicatorPattern`
* rename  `grabInterestingTokens` =>  `collectNormalizedTokens`
*  FIX : Normalize .'MD5' → .MD5 to avoid duplication
(Keeps  .'SHA-256' → .'SHA-256'  because according to STIX grammar, the hyphen cannot be used without quotation marks)
* Adds unit tests

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/13803

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
