### PR TITLE
[backend] move script usage to internal_script and remove by default from API (#15267)(#15218)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine-config.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine-config.ts
@@ -1,0 +1,6 @@
+import { booleanConf } from '../config/conf';
+
+const ES_SCRIPT_FILTER_ENABLED: boolean = booleanConf('elasticsearch:unsecure_script_filter_enabled', false);
+export const isEsScriptFilterEnabled = () => {
+  return ES_SCRIPT_FILTER_ENABLED;
+};

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -194,6 +194,7 @@ import type { FiltersWithNested } from './middleware-loader';
 import { pushAll, unshiftAll } from '../utils/arrayUtil';
 import { getRoleAssumerWithWebIdentity } from '../utils/awsSdk';
 import { elConvertHits, elConvertHitsToMap, INNER_HITS_WINDOWS_SIZE } from './engine-data-converter';
+import { isEsScriptFilterEnabled } from './engine-config';
 
 const ELK_ENGINE = 'elk';
 const OPENSEARCH_ENGINE = 'opensearch';
@@ -2538,12 +2539,16 @@ export const buildLocalMustFilter = (validFilter: any) => {
                 fields: arrayKeys.map((k) => `${k}.keyword`),
               },
             });
-          } else if (operator === 'script') {
-            valuesFiltering.push({
-              script: {
-                script: values[i].toString(),
-              },
-            });
+          } else if (operator === 'script' || operator === 'internal_script') {
+            if (operator === 'script' && !isEsScriptFilterEnabled()) {
+              throw UnsupportedError('Filter script is not allowed', { filter: validFilter });
+            } else {
+              valuesFiltering.push({
+                script: {
+                  script: values[i].toString(),
+                },
+              });
+            }
           } else if (operator === 'search') {
             const shouldSearch = elGenerateFieldTextSearchShould(values[i].toString(), arrayKeys);
             const bool = {

--- a/opencti-platform/opencti-graphql/src/domain/report.js
+++ b/opencti-platform/opencti-graphql/src/domain/report.js
@@ -133,7 +133,7 @@ const buildReportDeleteElementsFilter = (reportId) => {
     mode: 'and',
     filters: [
       { key: [refKey], values: [reportId] },
-      { key: [refKey], values: [`doc['${refKey}.keyword'].length == 1`], operator: 'script' },
+      { key: [refKey], values: [`doc['${refKey}.keyword'].length == 1`], operator: 'internal_script' },
     ],
     filterGroups: [],
   };

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { prepareElementForIndexing } from '../../../src/database/engine';
+import { describe, expect, it, vi } from 'vitest';
+import { buildLocalMustFilter, prepareElementForIndexing } from '../../../src/database/engine';
+import * as engineConfig from '../../../src/database/engine-config';
 
 describe('prepareElementForIndexing testing', () => {
   it('should base trim applied', async () => {
@@ -23,5 +24,70 @@ describe('prepareElementForIndexing testing', () => {
     const now = new Date();
     const element = await prepareElementForIndexing({ date: now });
     expect(element.date).toEqual(now);
+  });
+});
+
+describe('buildLocalMustFilter testing', () => {
+  it('should buildLocalMustFilter with script be refused by default', () => {
+    const scriptFilter = {
+      key: ['name'],
+      values: [
+        'doc.containsKey(\'name.keyword\')',
+      ],
+      operator: 'script',
+    };
+
+    expect(() => buildLocalMustFilter(scriptFilter)).toThrow(/Filter script is not allowed/);
+  });
+
+  it('should buildLocalMustFilter with internal_script should work', () => {
+    const scriptFilter = {
+      key: ['name'],
+      values: [
+        'doc.containsKey(\'name.keyword\')',
+      ],
+      operator: 'internal_script',
+    };
+
+    const result = buildLocalMustFilter(scriptFilter);
+
+    expect(result).toStrictEqual({
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          {
+            script: {
+              script: "doc.containsKey('name.keyword')",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('buildLocalMustFilter with script should work when enabled', () => {
+    vi.spyOn(engineConfig, 'isEsScriptFilterEnabled').mockResolvedValue(true);
+    const scriptFilter = {
+      key: ['name'],
+      values: [
+        'doc.containsKey(\'name.keyword\')',
+      ],
+      operator: 'script',
+    };
+
+    const result = buildLocalMustFilter(scriptFilter);
+
+    expect(result).toStrictEqual({
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          {
+            script: {
+              script: "doc.containsKey('name.keyword')",
+            },
+          },
+        ],
+      },
+    });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
@@ -86,7 +86,7 @@ it('should buildLocalMustFilter build query from ids filter with terms', () => {
         { terms: { 'standard_id.keyword': ['ID1', 'ID2', 'ID3'] } },
         { terms: { 'x_opencti_stix_ids.keyword': ['ID1', 'ID2', 'ID3'] } },
         { terms: { 'i_aliases_ids.keyword': ['ID1', 'ID2', 'ID3'] } }],
-      minimum_should_match: 1 }
+      minimum_should_match: 1 },
   };
   expect(query).toEqual(expectedQuery);
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove script filter usage by default, but add an option to enable it if needed.
* add an internal_script filter not exposed in API

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15267 
* closes #15218

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
