### PR TITLE
[backend/frontend] Fix useSubscription context initiation (#15004)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
@@ -81,7 +81,7 @@ class MalwareDetailsComponent extends Component {
               {t('Last seen')}
             </Label>
             {fldt(malware.last_seen)}
-            <StixCoreObjectKillChainPhasesView killChainPhases={malware.killChainPhases} />
+            <StixCoreObjectKillChainPhasesView killChainPhases={malware.killChainPhases ?? []} />
             <Label
               sx={{ marginTop: 2 }}
             >

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -26,6 +26,7 @@ import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWork
 import { createAuthenticatedContext } from './httpAuthenticatedContext';
 import { getSettings } from '../domain/settings';
 import { isWorkAlive } from '../domain/work';
+import { computeLoaders } from './httpAuthenticatedContext';
 import { buildRateLimiterOptions } from './httpUtils';
 
 const MIN_20 = 20 * 60 * 1000;
@@ -103,6 +104,7 @@ const createHttpServer = async () => {
         const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
         const logged = platformUsers.get(wsSession?.user.id);
         context.user = { ...wsSession?.user, ...logged, origin };
+        context.batch = computeLoaders(context, context.user);
         return context;
       }
       throw ForbiddenAccess('User must be authenticated');

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -36,6 +36,40 @@ const CERT_KEY_CERT = conf.get('app:https_cert:crt');
 const CA_CERTS = conf.get('app:https_cert:ca');
 const rejectUnauthorized = booleanConf('app:https_cert:reject_unauthorized', true);
 
+export const extractWsSessionContext = async (context) => {
+  const req = context.extra.request;
+  const webSocket = context.extra.socket;
+  // This will be run every time the client sends a subscription request
+  const wsSession = await new Promise((resolve) => {
+    // use same session parser as normal gql queries
+    const { session } = applicationSession;
+    session(req, {}, () => {
+      if (req.session) {
+        resolve(req.session);
+      }
+      return false;
+    });
+  });
+  // We have a good session. attach to context
+
+  if (wsSession?.user) {
+    const sessionContext = executionContext('api');
+    const origin = {
+      socket: 'subscription',
+      ip: webSocket._socket.remoteAddress,
+      user_id: wsSession.user?.id,
+      group_ids: wsSession.user?.groups?.map((g) => g.internal_id) ?? [],
+      organization_ids: wsSession.user?.organizations?.map((o) => o.internal_id) ?? [],
+    };
+    const platformUsers = await getEntitiesMapFromCache(sessionContext, SYSTEM_USER, ENTITY_TYPE_USER);
+    const logged = platformUsers.get(wsSession?.user.id);
+    sessionContext.user = { ...wsSession?.user, ...logged, origin };
+    sessionContext.batch = computeLoaders(sessionContext, sessionContext.user);
+    return sessionContext;
+  }
+  throw ForbiddenAccess('User must be authenticated');
+};
+
 const createHttpServer = async () => {
   logApp.info('[INIT] Configuring HTTP/HTTPS server');
   const app = express();
@@ -77,38 +111,7 @@ const createHttpServer = async () => {
   });
   const serverCleanup = useServer({
     schema,
-    context: async (ctx) => {
-      const req = ctx.extra.request;
-      const webSocket = ctx.extra.socket;
-      // This will be run every time the client sends a subscription request
-      const wsSession = await new Promise((resolve) => {
-        // use same session parser as normal gql queries
-        const { session } = applicationSession;
-        session(req, {}, () => {
-          if (req.session) {
-            resolve(req.session);
-          }
-          return false;
-        });
-      });
-      // We have a good session. attach to context
-      if (wsSession?.user) {
-        const context = executionContext('api');
-        const origin = {
-          socket: 'subscription',
-          ip: webSocket._socket.remoteAddress,
-          user_id: wsSession.user?.id,
-          group_ids: wsSession.user?.groups?.map((g) => g.internal_id) ?? [],
-          organization_ids: wsSession.user?.organizations?.map((o) => o.internal_id) ?? [],
-        };
-        const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-        const logged = platformUsers.get(wsSession?.user.id);
-        context.user = { ...wsSession?.user, ...logged, origin };
-        context.batch = computeLoaders(context, context.user);
-        return context;
-      }
-      throw ForbiddenAccess('User must be authenticated');
-    },
+    context: extractWsSessionContext,
   }, wsServer);
 
   apolloServer.addPlugin(ApolloServerPluginDrainHttpServer({ httpServer }));

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/httpServer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/httpServer-test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { extractWsSessionContext } from '../../../src/http/httpServer';
+import { ADMIN_USER } from '../../utils/testQuery';
+
+describe('httpServer', () => {
+  describe('extractWsSessionContext', async () => {
+    const context = {
+      extra: {
+        request: {
+          session: {
+            user: {
+              id: ADMIN_USER.id,
+            },
+          },
+        },
+        socket: {
+          _socket: {
+            remoteAddress: '::1',
+          },
+        } },
+    };
+
+    const brokenContext = {
+      extra: {
+        request: {
+          session: {
+            user: '',
+          },
+        },
+        socket: {
+          _socket: '',
+        },
+      },
+    };
+
+    it('should initialize context.user correctly and context.batch with required loaders for websocket subscriptions with correct context', async () => {
+      const sessionContext = await extractWsSessionContext(context);
+
+      // User is defined
+      expect(sessionContext?.user).toBeDefined();
+      expect(sessionContext?.user?.id).toEqual(ADMIN_USER.id);
+      // Batch is defined
+      expect(sessionContext?.batch).toBeDefined();
+      expect(sessionContext?.batch?.fileMarkingsBatchLoader.load).toBeTypeOf('function');
+      expect(sessionContext?.batch?.markingsBatchLoader.load).toBeTypeOf('function');
+    });
+
+    it('should throw an error with broken context', async () => {
+      await expect(extractWsSessionContext(brokenContext)).rejects.toThrow('User must be authenticated');
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added a fix to WebSocket context initialization in httpServer so that context.batch is correctly initialized with the DataLoaders required by Relay useSubscription

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15004 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
