### PR TITLE
[backend/frontend] User deletion and Public sharing - Chunk D (#14918)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Alle Benachrichtigungen, Trigger und Digests, die mit dem Benutzer verbunden sind, werden gelöscht.",
   "All observables": "Alle Observablen",
   "All other filters": "Alle anderen Filter",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Alle öffentlichen Streams, taxii, csv, die dieses Benutzerrecht zur gemeinsamen Nutzung von Daten verwenden, funktionieren nicht mehr.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "Alle öffentlichen Streams, taxii, csv, die dieses Benutzerrecht zur gemeinsamen Nutzung von Daten verwenden, funktionieren nicht mehr.",
   "All reports": "Alle Berichte",
   "All rule targets": "Alle Regelziele",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Für diese Filterwerte werden möglicherweise nicht alle Ergebnisse angezeigt, {link} für weitere Informationen",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Alle Benachrichtigungen, Trigger und Digests, die mit dem Benutzer verbunden sind, werden gelöscht.",
   "All observables": "Alle Observablen",
   "All other filters": "Alle anderen Filter",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Alle öffentlichen Streams, taxii, csv, die dieses Benutzerrecht zur gemeinsamen Nutzung von Daten verwenden, funktionieren nicht mehr.",
   "All reports": "Alle Berichte",
   "All rule targets": "Alle Regelziele",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Für diese Filterwerte werden möglicherweise nicht alle Ergebnisse angezeigt, {link} für weitere Informationen",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "All notifications, triggers and digests associated with the user will be deleted.",
   "All observables": "All observables",
   "All other filters": "All other filters",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "All public streams, taxii, csv using this user right to share data will not work anymore.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.",
   "All reports": "All reports",
   "All rule targets": "All rule targets",
   "All the results may not be displayed for these filter values, read documentation for more information.": "All the results may not be displayed for these filter values, {link} for more information",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "All notifications, triggers and digests associated with the user will be deleted.",
   "All observables": "All observables",
   "All other filters": "All other filters",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "All public streams, taxii, csv using this user right to share data will not work anymore.",
   "All reports": "All reports",
   "All rule targets": "All rule targets",
   "All the results may not be displayed for these filter values, read documentation for more information.": "All the results may not be displayed for these filter values, {link} for more information",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Se eliminarán todas las notificaciones, activadores y resúmenes asociados con el usuario.",
   "All observables": "Todos los observables",
   "All other filters": "Todos los demás filtros",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Todos los streams públicos, taxii, csv que utilicen este derecho de usuario para compartir datos dejarán de funcionar.",
   "All reports": "Todos los informes",
   "All rule targets": "Todos los objetivos de las reglas",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Puede que no se muestren todos los resultados para estos valores de filtro, {link} para más información",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Se eliminarán todas las notificaciones, activadores y resúmenes asociados con el usuario.",
   "All observables": "Todos los observables",
   "All other filters": "Todos los demás filtros",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Todos los streams públicos, taxii, csv que utilicen este derecho de usuario para compartir datos dejarán de funcionar.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "Todos los streams públicos, taxii, csv que utilicen este derecho de usuario para compartir datos dejarán de funcionar.",
   "All reports": "Todos los informes",
   "All rule targets": "Todos los objetivos de las reglas",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Puede que no se muestren todos los resultados para estos valores de filtro, {link} para más información",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Toutes les notifications, déclencheurs et résumés associés à l’utilisateur seront supprimés.",
   "All observables": "Tous les observables",
   "All other filters": "Tous les autres filtres",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Tout les stream, taxii et csv publics utilisant les droit de cet utilisateur pour partager de la donnée ne fonctionneront plus.",
   "All reports": "Tous les rapports",
   "All rule targets": "Toutes les cibles de règles",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Tous les résultats peuvent ne pas être affichés pour ces valeurs de filtre, {link} pour plus d'informations",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Toutes les notifications, déclencheurs et résumés associés à l’utilisateur seront supprimés.",
   "All observables": "Tous les observables",
   "All other filters": "Tous les autres filtres",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Tout les stream, taxii et csv publics utilisant les droit de cet utilisateur pour partager de la donnée ne fonctionneront plus.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "Tout les stream, taxii et csv publics publics utilisant les droit de cet utilisateur pour partager de la donnée seront désactivés et deviendront privés. Veuillez les modifier pour les rendre public de nouveau.",
   "All reports": "Tous les rapports",
   "All rule targets": "Toutes les cibles de règles",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Tous les résultats peuvent ne pas être affichés pour ces valeurs de filtre, {link} pour plus d'informations",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Tutte le notifiche, i trigger e i riepiloghi associati all'utente verranno eliminati.",
   "All observables": "Tutti gli osservabili",
   "All other filters": "Tutti gli altri filtri",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Tutti i flussi pubblici, taxii, csv che utilizzano questo diritto dell'utente per condividere i dati non funzioneranno più.",
   "All reports": "Tutti i report",
   "All rule targets": "Tutti i target della regola",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Non tutti i risultati potrebbero essere visualizzati per questi valori di filtro, leggere {link} per ulteriori informazioni.",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Tutte le notifiche, i trigger e i riepiloghi associati all'utente verranno eliminati.",
   "All observables": "Tutti gli osservabili",
   "All other filters": "Tutti gli altri filtri",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Tutti i flussi pubblici, taxii, csv che utilizzano questo diritto dell'utente per condividere i dati non funzioneranno più.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "Tutti i flussi pubblici, taxii, csv che utilizzano questo diritto dell'utente per condividere i dati non funzioneranno più.",
   "All reports": "Tutti i report",
   "All rule targets": "Tutti i target della regola",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Non tutti i risultati potrebbero essere visualizzati per questi valori di filtro, leggere {link} per ulteriori informazioni.",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "ユーザーに関連付けられているすべての通知、トリガー、ダイジェストが削除されます",
   "All observables": "観測結果",
   "All other filters": "その他のフィルター",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "データを共有するためにこのユーザー権限を使用したすべてのパブリックストリーム、taxii、csvは機能しなくなります。",
   "All reports": "レポート",
   "All rule targets": "すべてのルールターゲット",
   "All the results may not be displayed for these filter values, read documentation for more information.": "これらのフィルター値では、すべての結果が表示されない場合があります。",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "ユーザーに関連付けられているすべての通知、トリガー、ダイジェストが削除されます",
   "All observables": "観測結果",
   "All other filters": "その他のフィルター",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "データを共有するためにこのユーザー権限を使用したすべてのパブリックストリーム、taxii、csvは機能しなくなります。",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "データを共有するためにこのユーザー権限を使用したすべてのパブリックストリーム、taxii、csvは機能しなくなります。",
   "All reports": "レポート",
   "All rule targets": "すべてのルールターゲット",
   "All the results may not be displayed for these filter values, read documentation for more information.": "これらのフィルター値では、すべての結果が表示されない場合があります。",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "사용자와 연결된 모든 알림, 트리거 및 요약이 삭제됩니다.",
   "All observables": "모든 관찰 가능 항목",
   "All other filters": "다른 모든 필터",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "이 사용자 권한을 사용하여 데이터를 공유하는 모든 공개 스트림, 택시, CSV는 더 이상 작동하지 않습니다.",
   "All reports": "모든 보고서",
   "All rule targets": "모든 규칙 대상",
   "All the results may not be displayed for these filter values, read documentation for more information.": "이러한 필터 값에 대해 모든 결과가 표시되지 않을 수 있습니다. 자세한 내용은 {link}을 참조하세요",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "사용자와 연결된 모든 알림, 트리거 및 요약이 삭제됩니다.",
   "All observables": "모든 관찰 가능 항목",
   "All other filters": "다른 모든 필터",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "이 사용자 권한을 사용하여 데이터를 공유하는 모든 공개 스트림, 택시, CSV는 더 이상 작동하지 않습니다.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "이 사용자 권한을 사용하여 데이터를 공유하는 모든 공개 스트림, 택시, CSV는 더 이상 작동하지 않습니다.",
   "All reports": "모든 보고서",
   "All rule targets": "모든 규칙 대상",
   "All the results may not be displayed for these filter values, read documentation for more information.": "이러한 필터 값에 대해 모든 결과가 표시되지 않을 수 있습니다. 자세한 내용은 {link}을 참조하세요",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Все уведомления, триггеры и дайджесты, связанные с этим пользователем, будут удалены.",
   "All observables": "Все наблюдаемые объекты",
   "All other filters": "Все остальные фильтры",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Все публичные потоки, taxii, csv, использующие это право пользователя для обмена данными, больше не будут работать.",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "Все публичные потоки, taxii, csv, использующие это право пользователя для обмена данными, больше не будут работать.",
   "All reports": "Все отчёты",
   "All rule targets": "Все цели правил",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Для этих значений фильтра могут отображаться не все результаты, для получения дополнительной информации читайте документацию.",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "Все уведомления, триггеры и дайджесты, связанные с этим пользователем, будут удалены.",
   "All observables": "Все наблюдаемые объекты",
   "All other filters": "Все остальные фильтры",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "Все публичные потоки, taxii, csv, использующие это право пользователя для обмена данными, больше не будут работать.",
   "All reports": "Все отчёты",
   "All rule targets": "Все цели правил",
   "All the results may not be displayed for these filter values, read documentation for more information.": "Для этих значений фильтра могут отображаться не все результаты, для получения дополнительной информации читайте документацию.",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -230,6 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "与用户关联的所有通知、触发器和摘要都将被删除",
   "All observables": "所有可观测数据",
   "All other filters": "所有其他筛选器",
+  "All public streams, taxii, csv using this user right to share data will not work anymore.": "使用此用户权限共享数据的所有公共数据流、taxii、csv 将不再有效。",
   "All reports": "所有报告",
   "All rule targets": "所有规则目标",
   "All the results may not be displayed for these filter values, read documentation for more information.": "这些过滤值可能无法显示所有结果，{link} 获取更多信息",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -230,7 +230,7 @@
   "All notifications, triggers and digests associated with the user will be deleted.": "与用户关联的所有通知、触发器和摘要都将被删除",
   "All observables": "所有可观测数据",
   "All other filters": "所有其他筛选器",
-  "All public streams, taxii, csv using this user right to share data will not work anymore.": "使用此用户权限共享数据的所有公共数据流、taxii、csv 将不再有效。",
+  "All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.": "使用此用户权限共享数据的所有公共数据流、taxii、csv 将不再有效。",
   "All reports": "所有报告",
   "All rule targets": "所有规则目标",
   "All the results may not be displayed for these filter values, read documentation for more information.": "这些过滤值可能无法显示所有结果，{link} 获取更多信息",

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.tsx
@@ -126,7 +126,7 @@ const StreamCollectionEditionContainer: FunctionComponent<{ streamCollection: St
       initialValues={initialValues}
       validationSchema={streamCollectionValidation(t_i18n('This field is required'))}
     >
-      {() => (
+      {({ values, setFieldValue }) => (
         <Form>
           <Field
             component={TextField}
@@ -163,12 +163,17 @@ const StreamCollectionEditionContainer: FunctionComponent<{ streamCollection: St
               {t_i18n('Make this stream public and available to anyone')}
             </AlertTitle>
             <FormControlLabel
-              control={<Switch defaultChecked={!!initialValues.stream_public} disabled={!isGrantedToSetAccesses} />}
+              control={<Switch checked={!!values.stream_public} disabled={!isGrantedToSetAccesses} />}
               style={{ marginLeft: 1 }}
-              onChange={(_, checked) => handleSubmitField('stream_public', checked.toString())}
+              onChange={(_, checked) => {
+                setFieldValue('stream_public', checked);
+                if (!checked) {
+                  handleSubmitField('stream_public', 'false');
+                }
+              }}
               label={t_i18n('Public stream')}
             />
-            {!initialValues.stream_public && (
+            {!values.stream_public && (
               <ObjectMembersField
                 label="Accessible for"
                 style={fieldSpacingContainerStyle}
@@ -178,13 +183,35 @@ const StreamCollectionEditionContainer: FunctionComponent<{ streamCollection: St
                 name="restricted_members"
               />
             )}
-            {initialValues.stream_public && (
+            {values.stream_public && (
               <CreatorField
                 name="stream_public_user_id"
                 label={t_i18n('Share data corresponding to permissions associated with this user')}
                 containerStyle={fieldSpacingContainerStyle}
                 disabled={!isGrantedToSetAccesses}
-                onChange={(_, value) => handleSubmitField('stream_public_user_id', (value as FieldOption)?.value ?? '')}
+                onChange={(_, value) => {
+                  const userId = (value as FieldOption)?.value ?? '';
+                  if (!streamCollection.stream_public) {
+                    commitMutation({
+                      mutation: streamCollectionMutationFieldPatch,
+                      variables: {
+                        id: streamCollection.id,
+                        input: [
+                          { key: 'stream_public_user_id', value: userId },
+                          { key: 'stream_public', value: 'true' },
+                        ],
+                      },
+                      setSubmitting: undefined,
+                      onCompleted: undefined,
+                      onError: undefined,
+                      optimisticResponse: undefined,
+                      optimisticUpdater: undefined,
+                      updater: undefined,
+                    });
+                  } else {
+                    handleSubmitField('stream_public_user_id', userId);
+                  }
+                }}
               />
             )}
           </Alert>

--- a/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/taxii/TaxiiCollectionEdition.tsx
@@ -135,7 +135,7 @@ const TaxiiCollectionEditionContainer: FunctionComponent<{ taxiiCollection: Taxi
       initialValues={initialValues}
       validationSchema={taxiiCollectionValidation(t_i18n('This field is required'))}
     >
-      {() => (
+      {({ values, setFieldValue }) => (
         <Form>
           <Field
             component={TextField}
@@ -172,12 +172,17 @@ const TaxiiCollectionEditionContainer: FunctionComponent<{ taxiiCollection: Taxi
               {t_i18n('Make this TAXII collection public and available to anyone')}
             </AlertTitle>
             <FormControlLabel
-              control={<Switch defaultChecked={!!initialValues.taxii_public} disabled={!isGrantedToSetAccesses} />}
+              control={<Switch checked={!!values.taxii_public} disabled={!isGrantedToSetAccesses} />}
               style={{ marginLeft: 1 }}
-              onChange={(_, checked) => handleSubmitField('taxii_public', checked.toString())}
+              onChange={(_, checked) => {
+                setFieldValue('taxii_public', checked);
+                if (!checked) {
+                  handleSubmitField('taxii_public', 'false');
+                }
+              }}
               label={t_i18n('Public collection')}
             />
-            {!initialValues.taxii_public && (
+            {!values.taxii_public && (
               <ObjectMembersField
                 label="Accessible for"
                 style={fieldSpacingContainerStyle}
@@ -187,13 +192,35 @@ const TaxiiCollectionEditionContainer: FunctionComponent<{ taxiiCollection: Taxi
                 name="restricted_members"
               />
             )}
-            {initialValues.taxii_public && (
+            {values.taxii_public && (
               <CreatorField
                 name="taxii_public_user_id"
                 label={t_i18n('Share data corresponding to permissions associated with this user')}
                 containerStyle={fieldSpacingContainerStyle}
                 disabled={!isGrantedToSetAccesses}
-                onChange={(_, value) => handleSubmitField('taxii_public_user_id', (value as FieldOption)?.value ?? '')}
+                onChange={(_, value) => {
+                  const userId = (value as FieldOption)?.value ?? '';
+                  if (!taxiiCollection.taxii_public) {
+                    commitMutation({
+                      mutation: taxiiCollectionMutationFieldPatch,
+                      variables: {
+                        id: taxiiCollection.id,
+                        input: [
+                          { key: 'taxii_public_user_id', value: userId },
+                          { key: 'taxii_public', value: 'true' },
+                        ],
+                      },
+                      setSubmitting: undefined,
+                      onCompleted: undefined,
+                      onError: undefined,
+                      optimisticResponse: undefined,
+                      optimisticUpdater: undefined,
+                      updater: undefined,
+                    });
+                  } else {
+                    handleSubmitField('taxii_public_user_id', userId);
+                  }
+                }}
               />
             )}
           </Alert>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserDeletionDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserDeletionDialog.tsx
@@ -59,7 +59,7 @@ const UserDeletionDialog: FunctionComponent<UserDeletionDialogProps> = ({
       <ul>
         <li>{t_i18n('All notifications, triggers and digests associated with the user will be deleted.')}</li>
         <li>{t_i18n('All investigations and dashboard where the user is the only admin, will be deleted.')}</li>
-        <li>{t_i18n('All public streams, taxii, csv using this user right to share data will not work anymore.')}</li>
+        <li>{t_i18n('All public streams, taxii, csv using this user right to share data will be stopped and turn private. Please update them with a new user to turn them public again.')}</li>
       </ul>
       {t_i18n('If you want to keep the associated information, we recommend deactivating the user instead.')}
       <DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserDeletionDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserDeletionDialog.tsx
@@ -59,6 +59,7 @@ const UserDeletionDialog: FunctionComponent<UserDeletionDialogProps> = ({
       <ul>
         <li>{t_i18n('All notifications, triggers and digests associated with the user will be deleted.')}</li>
         <li>{t_i18n('All investigations and dashboard where the user is the only admin, will be deleted.')}</li>
+        <li>{t_i18n('All public streams, taxii, csv using this user right to share data will not work anymore.')}</li>
       </ul>
       {t_i18n('If you want to keep the associated information, we recommend deactivating the user instead.')}
       <DialogActions>

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -98,6 +98,7 @@ import { sendMail, smtpComputeFrom } from '../database/smtp';
 import { checkEnterpriseEdition } from '../enterprise-edition/ee';
 import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../modules/emailTemplate/emailTemplate-types';
 import { doYield } from '../utils/eventloop-utils';
+import { disablePublicSharingForDeletedUser } from '../modules/dataSharing/dataSharing-utils';
 import { sanitizeUser } from '../utils/templateContextSanitizer';
 import { safeRender } from '../utils/safeEjs.client';
 import { totp } from '../utils/totp';
@@ -1201,6 +1202,7 @@ export const userDelete = async (context, user, userId) => {
   await deleteAllTriggerAndDigestByUser(userId);
   await deleteAllNotificationByUser(userId);
   await deleteAllWorkspaceForUser(context, user, userId);
+  await disablePublicSharingForDeletedUser(context, userId);
 
   const deleted = await deleteElementById(context, user, userId, ENTITY_TYPE_USER);
   const actionEmail = ENABLED_DEMO_MODE ? REDACTED_USER.user_email : deleted.user_email;

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
@@ -1,9 +1,14 @@
 import { getEntitiesMapFromCache } from '../../database/cache';
 import { INTERNAL_USERS, SYSTEM_USER } from '../../utils/access';
 import { ENTITY_TYPE_USER } from '../../schema/internalObject';
-import { FunctionalError } from '../../config/errors';
+import { DatabaseError, FunctionalError } from '../../config/errors';
 import { logApp } from '../../config/conf';
 import type { AuthContext, AuthUser } from '../../types/user';
+import { elRawUpdateByQuery } from '../../database/engine';
+import { READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
+import { ENTITY_TYPE_FEED } from './feed-types';
+import { ENTITY_TYPE_TAXII_COLLECTION } from './taxiiCollection-types';
+import { ENTITY_TYPE_STREAM_COLLECTION } from './streamCollection-types';
 
 /**
  * Internal helper: fetches and validates a non-internal, existing platform user from cache.
@@ -39,4 +44,51 @@ export const resolvePublicUser = async (context: AuthContext, userId: string | n
     return SYSTEM_USER;
   }
   return resolveValidUser(context, userId);
+};
+
+type SharingConfig = {
+  entityType: string;
+  publicField: string;
+  userIdField: string;
+  liveField?: string;
+};
+
+const PUBLIC_SHARING_CONFIGS: SharingConfig[] = [
+  { entityType: ENTITY_TYPE_FEED, publicField: 'feed_public', userIdField: 'feed_public_user_id' },
+  { entityType: ENTITY_TYPE_TAXII_COLLECTION, publicField: 'taxii_public', userIdField: 'taxii_public_user_id' },
+  { entityType: ENTITY_TYPE_STREAM_COLLECTION, publicField: 'stream_public', userIdField: 'stream_public_user_id', liveField: 'stream_live' },
+];
+
+/**
+ * When a user is deleted, disables all public sharing entities (CSV feed, TAXII collection, live stream)
+ * that referenced that user as their public impersonation user.
+ * The public flag is set to false, stream_live is set to false for streams, and the user id field is cleared.
+ */
+export const disablePublicSharingForDeletedUser = async (context: AuthContext, userId: string): Promise<void> => {
+  await Promise.all(
+    PUBLIC_SHARING_CONFIGS.map(({ entityType, publicField, userIdField, liveField }) => {
+      const liveScript = liveField ? ` ctx._source.${liveField} = false;` : '';
+      return elRawUpdateByQuery({
+        index: READ_INDEX_INTERNAL_OBJECTS,
+        refresh: true,
+        body: {
+          script: {
+            source: `ctx._source.${publicField} = false;${liveScript} ctx._source.remove('${userIdField}');`,
+            lang: 'painless',
+          },
+          query: {
+            bool: {
+              must: [
+                { term: { 'entity_type.keyword': { value: entityType } } },
+                { term: { [`${userIdField}.keyword`]: { value: userId } } },
+              ],
+            },
+          },
+        },
+      }).catch((err: Error) => {
+        throw DatabaseError(`[DATA_SHARING] Error disabling public sharing for deleted user on ${entityType}`, { cause: err, userId });
+      });
+    }),
+  );
+  logApp.info('[DATA_SHARING] Disabled public sharing for all entities referencing deleted user', { userId });
 };

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
@@ -94,7 +94,7 @@ export const disablePublicSharingForDeletedUser = async (context: AuthContext, u
               message: `updates \`${liveField}\` for ${entityLabel} \`${entity.name}\``,
               context_data: { id: entity.id, entity_type: entityType, input: [{ key: liveField, value: ['false'] }] },
             });
-            await notify((BUS_TOPICS as Record<string, { EDIT_TOPIC: string }>)[entityType].EDIT_TOPIC, liveElement, SYSTEM_USER);
+            await notify(BUS_TOPICS[ENTITY_TYPE_STREAM_COLLECTION].EDIT_TOPIC, liveElement, SYSTEM_USER);
           }
 
           // Log 2: make it private and clear the user id
@@ -109,7 +109,10 @@ export const disablePublicSharingForDeletedUser = async (context: AuthContext, u
             message: `updates \`${publicField}\` for ${entityLabel} \`${entity.name}\``,
             context_data: { id: entity.id, entity_type: entityType, input: [{ key: publicField, value: ['false'] }] },
           });
-          await notify((BUS_TOPICS as Record<string, { EDIT_TOPIC: string }>)[entityType].EDIT_TOPIC, element, SYSTEM_USER);
+          const busTopic = (BUS_TOPICS as Record<string, { EDIT_TOPIC?: string } | undefined>)[entityType];
+          if (busTopic?.EDIT_TOPIC) {
+            await notify(busTopic.EDIT_TOPIC, element, SYSTEM_USER);
+          }
         }),
       );
     }),

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
@@ -1,11 +1,15 @@
 import { getEntitiesMapFromCache } from '../../database/cache';
 import { INTERNAL_USERS, SYSTEM_USER } from '../../utils/access';
 import { ENTITY_TYPE_USER } from '../../schema/internalObject';
-import { DatabaseError, FunctionalError } from '../../config/errors';
-import { logApp } from '../../config/conf';
+import { FunctionalError } from '../../config/errors';
+import { BUS_TOPICS, logApp } from '../../config/conf';
 import type { AuthContext, AuthUser } from '../../types/user';
-import { elRawUpdateByQuery } from '../../database/engine';
-import { READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
+import { fullEntitiesList } from '../../database/middleware-loader';
+import { patchAttribute } from '../../database/middleware';
+import { notify } from '../../database/redis';
+import { publishUserAction } from '../../listener/UserActionListener';
+import { FilterMode } from '../../generated/graphql';
+import type { BasicStoreEntity } from '../../types/store';
 import { ENTITY_TYPE_FEED } from './feed-types';
 import { ENTITY_TYPE_TAXII_COLLECTION } from './taxiiCollection-types';
 import { ENTITY_TYPE_STREAM_COLLECTION } from './streamCollection-types';
@@ -51,43 +55,63 @@ type SharingConfig = {
   publicField: string;
   userIdField: string;
   liveField?: string;
+  label: string;
 };
 
 const PUBLIC_SHARING_CONFIGS: SharingConfig[] = [
-  { entityType: ENTITY_TYPE_FEED, publicField: 'feed_public', userIdField: 'feed_public_user_id' },
-  { entityType: ENTITY_TYPE_TAXII_COLLECTION, publicField: 'taxii_public', userIdField: 'taxii_public_user_id' },
-  { entityType: ENTITY_TYPE_STREAM_COLLECTION, publicField: 'stream_public', userIdField: 'stream_public_user_id', liveField: 'stream_live' },
+  { entityType: ENTITY_TYPE_FEED, publicField: 'feed_public', userIdField: 'feed_public_user_id', label: 'csv feed' },
+  { entityType: ENTITY_TYPE_TAXII_COLLECTION, publicField: 'taxii_public', userIdField: 'taxii_public_user_id', label: 'Taxii collection' },
+  { entityType: ENTITY_TYPE_STREAM_COLLECTION, publicField: 'stream_public', userIdField: 'stream_public_user_id', liveField: 'stream_live', label: 'live stream' },
 ];
 
 /**
  * When a user is deleted, disables all public sharing entities (CSV feed, TAXII collection, live stream)
  * that referenced that user as their public impersonation user.
  * The public flag is set to false, stream_live is set to false for streams, and the user id field is cleared.
+ * The cache is invalidated via notify for each updated entity.
  */
 export const disablePublicSharingForDeletedUser = async (context: AuthContext, userId: string): Promise<void> => {
   await Promise.all(
-    PUBLIC_SHARING_CONFIGS.map(({ entityType, publicField, userIdField, liveField }) => {
-      const liveScript = liveField ? ` ctx._source.${liveField} = false;` : '';
-      return elRawUpdateByQuery({
-        index: READ_INDEX_INTERNAL_OBJECTS,
-        refresh: true,
-        body: {
-          script: {
-            source: `ctx._source.${publicField} = false;${liveScript} ctx._source.remove('${userIdField}');`,
-            lang: 'painless',
-          },
-          query: {
-            bool: {
-              must: [
-                { term: { 'entity_type.keyword': { value: entityType } } },
-                { term: { [`${userIdField}.keyword`]: { value: userId } } },
-              ],
-            },
-          },
-        },
-      }).catch((err: Error) => {
-        throw DatabaseError(`[DATA_SHARING] Error disabling public sharing for deleted user on ${entityType}`, { cause: err, userId });
-      });
+    PUBLIC_SHARING_CONFIGS.map(async ({ entityType, publicField, userIdField, liveField, label }) => {
+      const filters = {
+        mode: FilterMode.And,
+        filterGroups: [],
+        filters: [{ key: [userIdField], values: [userId] }],
+      };
+      const entities = await fullEntitiesList<BasicStoreEntity>(context, SYSTEM_USER, [entityType], { filters });
+      if (entities.length === 0) return;
+
+      await Promise.all(
+        entities.map(async (entity) => {
+          // Log 1 (streams only): stop the live stream
+          if (liveField) {
+            const { element: liveElement } = await patchAttribute(context, SYSTEM_USER, entity.id, entityType, { [liveField]: false });
+            await publishUserAction({
+              user: SYSTEM_USER,
+              event_type: 'mutation',
+              event_scope: 'update',
+              event_access: 'administration',
+              message: `updates \`${liveField}\` for ${label} \`${entity.name}\``,
+              context_data: { id: entity.id, entity_type: entityType, input: [{ key: liveField, value: ['false'] }] },
+            });
+            await notify((BUS_TOPICS as Record<string, { EDIT_TOPIC: string }>)[entityType].EDIT_TOPIC, liveElement, SYSTEM_USER);
+          }
+
+          // Log 2: make it private and clear the user id
+          const publicPatch: Record<string, string | boolean | null> = { [publicField]: false, [userIdField]: null };
+          const operations: Record<string, 'replace' | 'remove'> = { [userIdField]: 'remove' };
+          const { element } = await patchAttribute(context, SYSTEM_USER, entity.id, entityType, publicPatch, { operations });
+          await publishUserAction({
+            user: SYSTEM_USER,
+            event_type: 'mutation',
+            event_scope: 'update',
+            event_access: 'administration',
+            message: `updates \`${publicField}\` for ${label} \`${entity.name}\``,
+            context_data: { id: entity.id, entity_type: entityType, input: [{ key: publicField, value: ['false'] }] },
+          });
+          await notify((BUS_TOPICS as Record<string, { EDIT_TOPIC: string }>)[entityType].EDIT_TOPIC, element, SYSTEM_USER);
+        }),
+      );
     }),
   );
   logApp.info('[DATA_SHARING] Disabled public sharing for all entities referencing deleted user', { userId });

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/dataSharing-utils.ts
@@ -55,13 +55,13 @@ type SharingConfig = {
   publicField: string;
   userIdField: string;
   liveField?: string;
-  label: string;
+  entityLabel: string;
 };
 
 const PUBLIC_SHARING_CONFIGS: SharingConfig[] = [
-  { entityType: ENTITY_TYPE_FEED, publicField: 'feed_public', userIdField: 'feed_public_user_id', label: 'csv feed' },
-  { entityType: ENTITY_TYPE_TAXII_COLLECTION, publicField: 'taxii_public', userIdField: 'taxii_public_user_id', label: 'Taxii collection' },
-  { entityType: ENTITY_TYPE_STREAM_COLLECTION, publicField: 'stream_public', userIdField: 'stream_public_user_id', liveField: 'stream_live', label: 'live stream' },
+  { entityType: ENTITY_TYPE_FEED, publicField: 'feed_public', userIdField: 'feed_public_user_id', entityLabel: 'csv feed' },
+  { entityType: ENTITY_TYPE_TAXII_COLLECTION, publicField: 'taxii_public', userIdField: 'taxii_public_user_id', entityLabel: 'Taxii collection' },
+  { entityType: ENTITY_TYPE_STREAM_COLLECTION, publicField: 'stream_public', userIdField: 'stream_public_user_id', liveField: 'stream_live', entityLabel: 'live stream' },
 ];
 
 /**
@@ -72,7 +72,7 @@ const PUBLIC_SHARING_CONFIGS: SharingConfig[] = [
  */
 export const disablePublicSharingForDeletedUser = async (context: AuthContext, userId: string): Promise<void> => {
   await Promise.all(
-    PUBLIC_SHARING_CONFIGS.map(async ({ entityType, publicField, userIdField, liveField, label }) => {
+    PUBLIC_SHARING_CONFIGS.map(async ({ entityType, publicField, userIdField, liveField, entityLabel }) => {
       const filters = {
         mode: FilterMode.And,
         filterGroups: [],
@@ -91,7 +91,7 @@ export const disablePublicSharingForDeletedUser = async (context: AuthContext, u
               event_type: 'mutation',
               event_scope: 'update',
               event_access: 'administration',
-              message: `updates \`${liveField}\` for ${label} \`${entity.name}\``,
+              message: `updates \`${liveField}\` for ${entityLabel} \`${entity.name}\``,
               context_data: { id: entity.id, entity_type: entityType, input: [{ key: liveField, value: ['false'] }] },
             });
             await notify((BUS_TOPICS as Record<string, { EDIT_TOPIC: string }>)[entityType].EDIT_TOPIC, liveElement, SYSTEM_USER);
@@ -106,7 +106,7 @@ export const disablePublicSharingForDeletedUser = async (context: AuthContext, u
             event_type: 'mutation',
             event_scope: 'update',
             event_access: 'administration',
-            message: `updates \`${publicField}\` for ${label} \`${entity.name}\``,
+            message: `updates \`${publicField}\` for ${entityLabel} \`${entity.name}\``,
             context_data: { id: entity.id, entity_type: entityType, input: [{ key: publicField, value: ['false'] }] },
           });
           await notify((BUS_TOPICS as Record<string, { EDIT_TOPIC: string }>)[entityType].EDIT_TOPIC, element, SYSTEM_USER);

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/feed-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/feed-resolver.ts
@@ -10,7 +10,7 @@ const feedResolvers: Resolvers = {
   },
   Feed: {
     authorized_members: (feed, _, context) => getAuthorizedMembers(context, context.user, feed),
-    feed_public_user: (feed, _, context) => loadCreator(context, context.user, feed.feed_public_user_id ?? undefined),
+    feed_public_user: (feed, _, context) => feed.feed_public_user_id ? loadCreator(context, context.user, feed.feed_public_user_id) : null,
   },
   Mutation: {
     feedAdd: (_, { input }, context) => createFeed(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-domain.ts
@@ -81,6 +81,14 @@ export const streamCollectionEditField = async (context: AuthContext, user: Auth
   if (publicUserIdItem?.value?.[0]) {
     await validatePublicUserId(context, publicUserIdItem.value[0]);
   }
+  const settingPublicTrue = input.find((item) => item.key === 'stream_public' && item.value?.[0] === 'true');
+  if (settingPublicTrue) {
+    const existingCollection = await findById(context, user, collectionId);
+    const effectiveUserId = publicUserIdItem?.value?.[0] ?? existingCollection?.stream_public_user_id;
+    if (!effectiveUserId) {
+      throw FunctionalError('A user must be configured when the stream collection is public');
+    }
+  }
   const finalInput = input.map(({ key, value }) => {
     const item = { key, value };
     if (key === authorizedMembers.name) {

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-resolver.ts
@@ -22,7 +22,7 @@ const streamCollectionResolvers: Resolvers = {
   StreamCollection: {
     authorized_members: (stream, _, context) => getAuthorizedMembers(context, context.user, stream),
     consumers: (stream) => getStreamCollectionConsumers(stream.id),
-    stream_public_user: (stream, _, context) => loadCreator(context, context.user, stream.stream_public_user_id ?? undefined),
+    stream_public_user: (stream, _, context) => stream.stream_public_user_id ? loadCreator(context, context.user, stream.stream_public_user_id) : null,
   },
   Mutation: {
     streamCollectionAdd: (_, { input }, context) => createStreamCollection(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/taxiiCollection-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/taxiiCollection-domain.ts
@@ -77,6 +77,14 @@ export const taxiiCollectionEditField = async (context: AuthContext, user: AuthU
   if (publicUserIdItem?.value?.[0]) {
     await validatePublicUserId(context, publicUserIdItem.value[0]);
   }
+  const settingPublicTrue = input.find((item) => item.key === 'taxii_public' && item.value?.[0] === 'true');
+  if (settingPublicTrue) {
+    const existingCollection = await findById(context, user, collectionId);
+    const effectiveUserId = publicUserIdItem?.value?.[0] ?? existingCollection?.taxii_public_user_id;
+    if (!effectiveUserId) {
+      throw FunctionalError('A user must be configured when the Taxii collection is public');
+    }
+  }
   const finalInput = input.map(({ key, value }) => {
     const item = { key, value };
     if (key === authorizedMembers.name) {

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/taxiiCollection-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/taxiiCollection-resolver.ts
@@ -18,7 +18,7 @@ const taxiiCollectionResolvers: Resolvers = {
   },
   TaxiiCollection: {
     authorized_members: (taxii, _, context) => getAuthorizedMembers(context, context.user, taxii),
-    taxii_public_user: (taxii, _, context) => loadCreator(context, context.user, taxii.taxii_public_user_id ?? undefined),
+    taxii_public_user: (taxii, _, context) => taxii.taxii_public_user_id ? loadCreator(context, context.user, taxii.taxii_public_user_id) : null,
   },
   Mutation: {
     taxiiCollectionAdd: (_, { input }, context) => createTaxiiCollection(context, context.user, input),

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-domain-test.ts
@@ -202,6 +202,20 @@ describe('streamCollectionEditField validation', () => {
     expect(Middleware.updateAttribute).toHaveBeenCalled();
     expect(Cache.getEntitiesMapFromCache).not.toHaveBeenCalled();
   });
+
+  it('should throw when setting stream_public to true but no user ID in input and no user ID on existing collection', async () => {
+    vi.mocked(MiddlewareLoader.storeLoadById).mockResolvedValue({ id: 'col-id', name: 'S', stream_public_user_id: undefined } as any);
+    const input = [{ key: 'stream_public', value: ['true'] }];
+    await expect(streamCollectionEditField(mockContext, mockUser, 'col-id', input)).rejects.toThrow('A user must be configured when the stream collection is public');
+  });
+
+  it('should proceed when setting stream_public to true and existing collection already has a user ID', async () => {
+    vi.mocked(MiddlewareLoader.storeLoadById).mockResolvedValue({ id: 'col-id', name: 'S', stream_public_user_id: VALID_USER_ID } as any);
+    vi.mocked(Middleware.updateAttribute).mockResolvedValue({ element: { name: 'S', id: 'col-id' } } as any);
+    const input = [{ key: 'stream_public', value: ['true'] }];
+    await streamCollectionEditField(mockContext, mockUser, 'col-id', input);
+    expect(Middleware.updateAttribute).toHaveBeenCalled();
+  });
 });
 
 // ---------- TaxiiCollection ----------
@@ -265,5 +279,19 @@ describe('taxiiCollectionEditField validation', () => {
     await taxiiCollectionEditField(mockContext, mockUser, 'col-id', input);
     expect(Middleware.updateAttribute).toHaveBeenCalled();
     expect(Cache.getEntitiesMapFromCache).not.toHaveBeenCalled();
+  });
+
+  it('should throw when setting taxii_public to true but no user ID in input and no user ID on existing collection', async () => {
+    vi.mocked(MiddlewareLoader.storeLoadById).mockResolvedValue({ id: 'col-id', name: 'T', taxii_public_user_id: undefined } as any);
+    const input = [{ key: 'taxii_public', value: ['true'] }];
+    await expect(taxiiCollectionEditField(mockContext, mockUser, 'col-id', input)).rejects.toThrow('A user must be configured when the Taxii collection is public');
+  });
+
+  it('should proceed when setting taxii_public to true and existing collection already has a user ID', async () => {
+    vi.mocked(MiddlewareLoader.storeLoadById).mockResolvedValue({ id: 'col-id', name: 'T', taxii_public_user_id: VALID_USER_ID } as any);
+    vi.mocked(Middleware.updateAttribute).mockResolvedValue({ element: { name: 'T', id: 'col-id' } } as any);
+    const input = [{ key: 'taxii_public', value: ['true'] }];
+    await taxiiCollectionEditField(mockContext, mockUser, 'col-id', input);
+    expect(Middleware.updateAttribute).toHaveBeenCalled();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-utils-test.ts
@@ -99,7 +99,7 @@ describe('disablePublicSharingForDeletedUser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(Middleware.patchAttribute).mockResolvedValue({ element: { id: 'entity-id', name: 'Entity' } } as any);
-    vi.mocked(UserActionListener.publishUserAction).mockResolvedValue(undefined);
+    vi.mocked(UserActionListener.publishUserAction).mockResolvedValue([]);
     vi.mocked(Redis.notify).mockResolvedValue(undefined as any);
   });
 
@@ -116,7 +116,7 @@ describe('disablePublicSharingForDeletedUser', () => {
   it('should disable a public feed referencing the deleted user (no liveField)', async () => {
     const mockFeed = { id: 'feed-1', name: 'My CSV Feed', _index: 'feeds' };
     vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
-      if (types[0] === 'Feed') return [mockFeed] as any;
+      if (types?.[0] === 'Feed') return [mockFeed] as any;
       return [];
     });
 
@@ -140,7 +140,7 @@ describe('disablePublicSharingForDeletedUser', () => {
   it('should disable a public taxii collection referencing the deleted user (no liveField)', async () => {
     const mockTaxii = { id: 'taxii-1', name: 'My Taxii', _index: 'taxii' };
     vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
-      if (types[0] === 'TaxiiCollection') return [mockTaxii] as any;
+      if (types?.[0] === 'TaxiiCollection') return [mockTaxii] as any;
       return [];
     });
 
@@ -162,7 +162,7 @@ describe('disablePublicSharingForDeletedUser', () => {
   it('should disable a public stream collection and stop the live stream (with liveField)', async () => {
     const mockStream = { id: 'stream-1', name: 'My Live Stream', _index: 'streams' };
     vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
-      if (types[0] === 'StreamCollection') return [mockStream] as any;
+      if (types?.[0] === 'StreamCollection') return [mockStream] as any;
       return [];
     });
 
@@ -196,9 +196,9 @@ describe('disablePublicSharingForDeletedUser', () => {
     const mockTaxii = { id: 'taxii-1', name: 'Taxii 1', _index: 'taxii' };
     const mockStream = { id: 'stream-1', name: 'Stream 1', _index: 'streams' };
     vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
-      if (types[0] === 'Feed') return [mockFeed] as any;
-      if (types[0] === 'TaxiiCollection') return [mockTaxii] as any;
-      if (types[0] === 'StreamCollection') return [mockStream] as any;
+      if (types?.[0] === 'Feed') return [mockFeed] as any;
+      if (types?.[0] === 'TaxiiCollection') return [mockTaxii] as any;
+      if (types?.[0] === 'StreamCollection') return [mockStream] as any;
       return [];
     });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-utils-test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as Cache from '../../../../src/database/cache';
+import * as Middleware from '../../../../src/database/middleware';
+import * as MiddlewareLoader from '../../../../src/database/middleware-loader';
+import * as Redis from '../../../../src/database/redis';
+import * as UserActionListener from '../../../../src/listener/UserActionListener';
 import { SYSTEM_USER } from '../../../../src/utils/access';
-import { resolvePublicUser, validatePublicUserId } from '../../../../src/modules/dataSharing/dataSharing-utils';
+import { disablePublicSharingForDeletedUser, resolvePublicUser, validatePublicUserId } from '../../../../src/modules/dataSharing/dataSharing-utils';
 
 vi.mock('../../../../src/database/cache');
 vi.mock('../../../../src/database/redis');
+vi.mock('../../../../src/database/middleware', () => ({
+  patchAttribute: vi.fn(),
+}));
+vi.mock('../../../../src/database/middleware-loader', () => ({
+  fullEntitiesList: vi.fn(),
+}));
+vi.mock('../../../../src/listener/UserActionListener', () => ({
+  publishUserAction: vi.fn(),
+}));
 vi.mock('../../../../src/config/conf', async () => {
   const actual = await vi.importActual('../../../../src/config/conf');
   return {
@@ -76,5 +89,126 @@ describe('validatePublicUserId', () => {
     const realUserId = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
     vi.mocked(Cache.getEntitiesMapFromCache).mockResolvedValue(new Map([[realUserId, { id: realUserId }]]) as any);
     await expect(validatePublicUserId(mockContext, realUserId)).resolves.toBeUndefined();
+  });
+});
+
+describe('disablePublicSharingForDeletedUser', () => {
+  const mockContext = { source: 'testing' } as any;
+  const DELETED_USER_ID = 'dddddddd-dddd-4ddd-dddd-dddddddddddd';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Middleware.patchAttribute).mockResolvedValue({ element: { id: 'entity-id', name: 'Entity' } } as any);
+    vi.mocked(UserActionListener.publishUserAction).mockResolvedValue(undefined);
+    vi.mocked(Redis.notify).mockResolvedValue(undefined as any);
+  });
+
+  it('should do nothing when no entities reference the deleted user', async () => {
+    vi.mocked(MiddlewareLoader.fullEntitiesList).mockResolvedValue([]);
+
+    await disablePublicSharingForDeletedUser(mockContext, DELETED_USER_ID);
+
+    expect(Middleware.patchAttribute).not.toHaveBeenCalled();
+    expect(UserActionListener.publishUserAction).not.toHaveBeenCalled();
+    expect(Redis.notify).not.toHaveBeenCalled();
+  });
+
+  it('should disable a public feed referencing the deleted user (no liveField)', async () => {
+    const mockFeed = { id: 'feed-1', name: 'My CSV Feed', _index: 'feeds' };
+    vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
+      if (types[0] === 'Feed') return [mockFeed] as any;
+      return [];
+    });
+
+    await disablePublicSharingForDeletedUser(mockContext, DELETED_USER_ID);
+
+    // One patchAttribute call: set feed_public=false and clear feed_public_user_id
+    expect(Middleware.patchAttribute).toHaveBeenCalledTimes(1);
+    expect(Middleware.patchAttribute).toHaveBeenCalledWith(
+      mockContext,
+      SYSTEM_USER,
+      mockFeed.id,
+      'Feed',
+      expect.objectContaining({ feed_public: false, feed_public_user_id: null }),
+      expect.objectContaining({ operations: expect.objectContaining({ feed_public_user_id: 'remove' }) }),
+    );
+    expect(UserActionListener.publishUserAction).toHaveBeenCalledTimes(1);
+    // Feed has no EDIT_TOPIC in BUS_TOPICS, so notify is NOT called
+    expect(Redis.notify).not.toHaveBeenCalled();
+  });
+
+  it('should disable a public taxii collection referencing the deleted user (no liveField)', async () => {
+    const mockTaxii = { id: 'taxii-1', name: 'My Taxii', _index: 'taxii' };
+    vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
+      if (types[0] === 'TaxiiCollection') return [mockTaxii] as any;
+      return [];
+    });
+
+    await disablePublicSharingForDeletedUser(mockContext, DELETED_USER_ID);
+
+    expect(Middleware.patchAttribute).toHaveBeenCalledTimes(1);
+    expect(Middleware.patchAttribute).toHaveBeenCalledWith(
+      mockContext,
+      SYSTEM_USER,
+      mockTaxii.id,
+      'TaxiiCollection',
+      expect.objectContaining({ taxii_public: false, taxii_public_user_id: null }),
+      expect.anything(),
+    );
+    expect(UserActionListener.publishUserAction).toHaveBeenCalledTimes(1);
+    expect(Redis.notify).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable a public stream collection and stop the live stream (with liveField)', async () => {
+    const mockStream = { id: 'stream-1', name: 'My Live Stream', _index: 'streams' };
+    vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
+      if (types[0] === 'StreamCollection') return [mockStream] as any;
+      return [];
+    });
+
+    await disablePublicSharingForDeletedUser(mockContext, DELETED_USER_ID);
+
+    // Two patchAttribute calls: first to stop stream_live, second to make it private
+    expect(Middleware.patchAttribute).toHaveBeenCalledTimes(2);
+    expect(Middleware.patchAttribute).toHaveBeenNthCalledWith(
+      1,
+      mockContext,
+      SYSTEM_USER,
+      mockStream.id,
+      'StreamCollection',
+      { stream_live: false },
+    );
+    expect(Middleware.patchAttribute).toHaveBeenNthCalledWith(
+      2,
+      mockContext,
+      SYSTEM_USER,
+      mockStream.id,
+      'StreamCollection',
+      expect.objectContaining({ stream_public: false, stream_public_user_id: null }),
+      expect.anything(),
+    );
+    expect(UserActionListener.publishUserAction).toHaveBeenCalledTimes(2);
+    expect(Redis.notify).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle multiple entity types in parallel and disable all found entities', async () => {
+    const mockFeed = { id: 'feed-1', name: 'Feed 1', _index: 'feeds' };
+    const mockTaxii = { id: 'taxii-1', name: 'Taxii 1', _index: 'taxii' };
+    const mockStream = { id: 'stream-1', name: 'Stream 1', _index: 'streams' };
+    vi.mocked(MiddlewareLoader.fullEntitiesList).mockImplementation(async (_ctx, _user, types) => {
+      if (types[0] === 'Feed') return [mockFeed] as any;
+      if (types[0] === 'TaxiiCollection') return [mockTaxii] as any;
+      if (types[0] === 'StreamCollection') return [mockStream] as any;
+      return [];
+    });
+
+    await disablePublicSharingForDeletedUser(mockContext, DELETED_USER_ID);
+
+    // feed: 1 patch (no notify), taxii: 1 patch + 1 notify, stream: 2 patches + 2 notifies = 4 patches total
+    expect(Middleware.patchAttribute).toHaveBeenCalledTimes(4);
+    // feed: 1 action, taxii: 1 action, stream: 2 actions = 4 total
+    expect(UserActionListener.publishUserAction).toHaveBeenCalledTimes(4);
+    // feed: 0 notify (no EDIT_TOPIC), taxii: 1 notify, stream: 2 notifies = 3 total
+    expect(Redis.notify).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*This chunk handles cleaning up public configs when a user is deleted and fixes UX issues in the edition forms.

**Backend**
 - Cleanup on user deletion: Added disablePublicSharingForDeletedUser inside userDelete. It automatically sets *_public = false (and stream_live = false) on any Feed, TAXII, or Stream using the deleted user, and clears *_public_user_id. 
 - Fix "System" UI display: *_public_user resolvers now properly return null instead of falling back to SYSTEM_USER when *_public_user_id is empty.
 - Edition validation: Backend now strictly rejects passing *_public = true during fieldPatch mutations if no *_public_user_id is defined. 

**Frontend**
 - Controlled Public Switch: Stream and TAXII edition forms now use controlled Formik state for the public switch.
 - Batched Save on Enable: Toggling public ON merely shows the user selector. Selecting a user then triggers a single mutation sending both *_public_user_id and *_public = true.
- Immediate Save on Disable: Toggling OFF disables public sharing immediately.
- Delete Warning: Added an alert in UserDeletionDialog.tsx warning that associated public feeds and streams will be disabled.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixed #14918

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
