### PR TITLE
[backend] Introduce @ff GraphQL directive to restrict access based on feature flag value (#15330)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -8,6 +8,8 @@ directive @allowUnlicensedLTS on OBJECT | FIELD_DEFINITION
 
 directive @constraint(minLength: Int, maxLength: Int, startsWith: String, endsWith: String, notContains: String, pattern: String, format: String, min: Int, max: Int, exclusiveMin: Int, exclusiveMax: Int, multipleOf: Int) on INPUT_FIELD_DEFINITION
 
+directive @ff(flags: [String!]!, softFail: Boolean = false) on FIELD_DEFINITION
+
 """Controls the rate of traffic."""
 directive @rateLimit(
   """Number of occurrences allowed over duration."""

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -21,6 +21,7 @@ directive @constraint(
   exclusiveMax: Int
   multipleOf: Int
 ) on INPUT_FIELD_DEFINITION
+directive @ff(flags: [String!]!, softFail: Boolean = false) on FIELD_DEFINITION
 
 ### SCALAR
 

--- a/opencti-platform/opencti-graphql/script/script-generate-schema.js
+++ b/opencti-platform/opencti-graphql/script/script-generate-schema.js
@@ -3,7 +3,7 @@
 
 import fs from 'node:fs';
 import _ from '../src/modules/index';
-import { printSchema } from 'graphql/utilities';
+import { printSchema } from 'graphql';
 import createSchema from '../src/graphql/schema';
 
 const schema = createSchema();

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -10,7 +10,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { ProxyAgent } from 'undici';
 import { v4 as uuid } from 'uuid';
-import { GraphQLError } from 'graphql/index';
+import { GraphQLError } from 'graphql';
 import * as O from '../schema/internalObject';
 import * as M from '../schema/stixMetaObject';
 import {

--- a/opencti-platform/opencti-graphql/src/config/errors.js
+++ b/opencti-platform/opencti-graphql/src/config/errors.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql/index';
+import { GraphQLError } from 'graphql';
 
 const CATEGORY_TECHNICAL = 'TECHNICAL';
 const CATEGORY_BUSINESS = 'BUSINESS';

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import { GraphQLError } from 'graphql/index';
+import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 import { delEditContext, notify, setEditContext } from '../database/redis';
 import { createRelation, deleteElementById, deleteRelationsByFromAndTo, timeSeriesRelations, updateAttribute } from '../database/middleware';

--- a/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixRelationship.js
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import { GraphQLError } from 'graphql/index';
+import { GraphQLError } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 import { deleteElementById, distributionRelations, timeSeriesRelations } from '../database/middleware';
 import { ABSTRACT_STIX_RELATIONSHIP } from '../schema/general';

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -40780,6 +40780,13 @@ export type ConstraintDirectiveArgs = {
 
 export type ConstraintDirectiveResolver<Result, Parent, ContextType = any, Args = ConstraintDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
+export type FfDirectiveArgs = {
+  flags: Array<Scalars['String']['input']>;
+  softFail?: Maybe<Scalars['Boolean']['input']>;
+};
+
+export type FfDirectiveResolver<Result, Parent, ContextType = any, Args = FfDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+
 export type PublicDirectiveArgs = { };
 
 export type PublicDirectiveResolver<Result, Parent, ContextType = any, Args = PublicDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
@@ -52734,5 +52741,6 @@ export type DirectiveResolvers<ContextType = any> = ResolversObject<{
   allowUnprotectedOTP?: AllowUnprotectedOtpDirectiveResolver<any, any, ContextType>;
   auth?: AuthDirectiveResolver<any, any, ContextType>;
   constraint?: ConstraintDirectiveResolver<any, any, ContextType>;
+  ff?: FfDirectiveResolver<any, any, ContextType>;
   public?: PublicDirectiveResolver<any, any, ContextType>;
 }>;

--- a/opencti-platform/opencti-graphql/src/graphql/featureFlagDirective.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/featureFlagDirective.ts
@@ -23,7 +23,7 @@ interface FeatureFlagDirectiveArgs {
    * before feature flags being available in the client.
    * Defaults to `false`.
    */
-  softFail: boolean;
+  softFail?: boolean;
 }
 
 const FF_DIRECTIVE = 'ff';

--- a/opencti-platform/opencti-graphql/src/graphql/featureFlagDirective.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/featureFlagDirective.ts
@@ -49,7 +49,7 @@ export const makeFeatureFlagDirectiveTransformer = (): (schema: GraphQLSchema) =
           if (softFail) {
             return null;
           } else {
-            throw ForbiddenAccess();
+            throw ForbiddenAccess('Feature is disabled', { flags });
           }
         }
         return resolve(source, args, context, info);

--- a/opencti-platform/opencti-graphql/src/graphql/featureFlagDirective.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/featureFlagDirective.ts
@@ -1,0 +1,60 @@
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
+import { defaultFieldResolver } from 'graphql';
+import type { GraphQLFieldConfig, GraphQLSchema } from 'graphql';
+import { ForbiddenAccess } from '../config/errors';
+import type { AuthContext } from '../types/user';
+import { isFeatureEnabled } from '../config/conf';
+
+/**
+ * Arguments passed to the feature-flagging directive in GraphQL schema
+ * @example @ff(flags: ["SOME_FLAG", "SOME_OTHER_FLAG"], softFail: true)
+ */
+interface FeatureFlagDirectiveArgs {
+  /**
+   * Array of feature flags that allow access to the endpoint.
+   * If at least one flag is set for current user then access
+   * is granted. (i.e. an `or` operator is used between each one of them)
+   */
+  flags: string[];
+  /**
+   * If true indicates that a lack of enabled flag won't result
+   * in an error but in returning the value `null`.
+   * Can be useful for instance when querying very early in the app lifecycle
+   * before feature flags being available in the client.
+   * Defaults to `false`.
+   */
+  softFail: boolean;
+}
+
+const FF_DIRECTIVE = 'ff';
+
+export const makeFeatureFlagDirectiveTransformer = (): (schema: GraphQLSchema) => GraphQLSchema => {
+  return (schema: GraphQLSchema) => mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: (fieldConfig: GraphQLFieldConfig<any, any>, _fieldName: string) => {
+      const directive = getDirective(schema, fieldConfig, FF_DIRECTIVE);
+      const ffDirective = directive?.[0] as FeatureFlagDirectiveArgs | undefined;
+
+      if (!ffDirective) {
+        return fieldConfig;
+      }
+
+      const { flags, softFail } = ffDirective;
+      if (!flags) {
+        return fieldConfig;
+      }
+
+      const { resolve = defaultFieldResolver } = fieldConfig;
+      fieldConfig.resolve = (source: any, args: any, context: AuthContext, info: any) => {
+        if (!flags.some((flag) => isFeatureEnabled(flag))) {
+          if (softFail) {
+            return null;
+          } else {
+            throw ForbiddenAccess();
+          }
+        }
+        return resolve(source, args, context, info);
+      };
+      return fieldConfig;
+    },
+  });
+};

--- a/opencti-platform/opencti-graphql/src/graphql/graphql.js
+++ b/opencti-platform/opencti-graphql/src/graphql/graphql.js
@@ -2,7 +2,7 @@ import { ApolloServer } from '@apollo/server';
 import { ApolloArmor } from '@escape.tech/graphql-armor';
 import { dissocPath } from 'ramda';
 import { createValidation as createAliasBatch } from 'graphql-no-alias';
-import { GraphQLError } from 'graphql/error';
+import { GraphQLError } from 'graphql';
 import { createApollo4QueryValidationPlugin } from 'graphql-constraint-directive/apollo4';
 import createSchema from './schema';
 import conf, { DEV_MODE, ENABLED_METRICS, ENABLED_TRACING, GRAPHQL_ARMOR_DISABLED, logApp, PLAYGROUND_ENABLED, PLAYGROUND_INTROSPECTION_DISABLED } from '../config/conf';

--- a/opencti-platform/opencti-graphql/src/graphql/loggerPlugin.js
+++ b/opencti-platform/opencti-graphql/src/graphql/loggerPlugin.js
@@ -1,5 +1,5 @@
 import { filter, head, isEmpty, isNil } from 'ramda';
-import { stripIgnoredCharacters } from 'graphql/utilities';
+import { stripIgnoredCharacters } from 'graphql';
 import { ApolloServerErrorCode } from '@apollo/server/errors';
 import conf, { appLogExtendedErrors, booleanConf, logApp } from '../config/conf';
 import { isNotEmptyField } from '../database/utils';

--- a/opencti-platform/opencti-graphql/src/graphql/schema.js
+++ b/opencti-platform/opencti-graphql/src/graphql/schema.js
@@ -72,6 +72,7 @@ import stixMetaObjectResolvers from '../resolvers/stixMetaObject';
 import filterKeysSchemaResolver from '../resolvers/filterKeysSchema';
 import basicObjectResolvers from '../resolvers/basicObject';
 import { FunctionalError } from '../config/errors';
+import { makeFeatureFlagDirectiveTransformer } from './featureFlagDirective';
 
 const schemaTypeDefs = [globalTypeDefs];
 
@@ -280,6 +281,7 @@ const createSchema = () => {
   });
   schema = constraintDirectiveDocumentation()(schema);
   schema = rateLimitDirectiveTransformer(authDirectiveTransformer(schema));
+  schema = makeFeatureFlagDirectiveTransformer()(schema);
   return schema;
 };
 

--- a/opencti-platform/opencti-graphql/src/graphql/telemetryPlugin.js
+++ b/opencti-platform/opencti-graphql/src/graphql/telemetryPlugin.js
@@ -1,5 +1,5 @@
 import { head, includes } from 'ramda';
-import { stripIgnoredCharacters } from 'graphql/utilities';
+import { stripIgnoredCharacters } from 'graphql';
 import { meterManager } from '../config/tracing';
 import { AUTH_FAILURE, AUTH_REQUIRED, FORBIDDEN_ACCESS } from '../config/errors';
 import { isEmptyField } from '../database/utils';

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -13,7 +13,7 @@ import validator from 'validator';
 import archiverZipEncrypted from 'archiver-zip-encrypted';
 import rateLimit from 'express-rate-limit';
 import contentDisposition from 'content-disposition';
-import { printSchema } from 'graphql/utilities';
+import { printSchema } from 'graphql';
 import { basePath, DEV_MODE, ENABLED_UI, logApp, OPENCTI_SESSION, PLATFORM_VERSION, AUTH_PAYLOAD_BODY_SIZE, getBaseUrl } from '../config/conf';
 import { sessionAuthenticateUser, userWithOrigin } from '../domain/user';
 import { downloadFile, getFileContent, isStorageAlive } from '../database/raw-file-storage';

--- a/opencti-platform/opencti-graphql/tests/01-unit/graphql/featureFlagDirective-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/graphql/featureFlagDirective-test.ts
@@ -33,8 +33,12 @@ describe('featureFlagDirective', () => {
     const result = await graphql({ schema, source: '{ flaggedFeature }' });
 
     expect(result.errors).not.toBeUndefined();
-    expect(result.errors?.[0].message).toMatch(/You are not allowed to do this/i);
+    expect(result.errors?.[0].message).toMatch(/Feature is disabled/i);
     expect(result.errors?.[0].extensions?.code).toMatch(/FORBIDDEN_ACCESS/i);
+    expect(result.errors?.[0].extensions?.data).toMatchObject({
+      flags: ['SOME_FLAG', 'SOME_OTHER_FLAG'],
+      http_status: 403,
+    });
   });
 
   it('calls the resolver when one of the flags is enabled', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/graphql/featureFlagDirective-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/graphql/featureFlagDirective-test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { graphql, parse } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { makeFeatureFlagDirectiveTransformer } from '../../../src/graphql/featureFlagDirective';
+import { isFeatureEnabled } from '../../../src/config/conf';
+
+vi.mock('../../../src/config/conf', () => ({
+  isFeatureEnabled: vi.fn(),
+}));
+
+describe('featureFlagDirective', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns a Forbidden error when none of the flags are enabled', async () => {
+    const typeDefs = parse(`
+      directive @ff(flags: [String!]!, softFail: Boolean = false) on FIELD_DEFINITION
+      type Query {
+        flaggedFeature: String @ff(flags: ["SOME_FLAG", "SOME_OTHER_FLAG"])
+      }
+    `);
+    const resolvers = {
+      Query: {
+        flaggedFeature: () => 'experimental content',
+      },
+    };
+    vi.mocked(isFeatureEnabled).mockReturnValue(false);
+
+    let schema = makeExecutableSchema({ typeDefs, resolvers });
+    schema = makeFeatureFlagDirectiveTransformer()(schema);
+
+    const result = await graphql({ schema, source: '{ flaggedFeature }' });
+
+    expect(result.errors).not.toBeUndefined();
+    expect(result.errors?.[0].message).toMatch(/You are not allowed to do this/i);
+    expect(result.errors?.[0].extensions?.code).toMatch(/FORBIDDEN_ACCESS/i);
+  });
+
+  it('calls the resolver when one of the flags is enabled', async () => {
+    const typeDefs = parse(`
+      directive @ff(flags: [String!]!, softFail: Boolean = false) on FIELD_DEFINITION
+      type Query {
+        flaggedFeature: String @ff(flags: ["SOME_FLAG", "SOME_OTHER_FLAG"])
+      }
+    `);
+    const resolvers = {
+      Query: {
+        flaggedFeature: () => 'experimental content',
+      },
+    };
+    vi.mocked(isFeatureEnabled).mockImplementation((flag: string) => {
+      return flag === 'SOME_FLAG';
+    });
+
+    let schema = makeExecutableSchema({ typeDefs, resolvers });
+    schema = makeFeatureFlagDirectiveTransformer()(schema);
+
+    const result = await graphql({ schema, source: '{ flaggedFeature }' });
+
+    expect(result.data?.flaggedFeature).toBe('experimental content');
+  });
+
+  it('returns null when none of the flags are enabled and softFail is set', async () => {
+    const typeDefs = parse(`
+      directive @ff(flags: [String!]!, softFail: Boolean = false) on FIELD_DEFINITION
+      type Query {
+        flaggedFeature: String @ff(flags: ["SOME_FLAG"], softFail: true)
+      }
+    `);
+    const resolvers = {
+      Query: {
+        flaggedFeature: () => 'experimental content',
+      },
+    };
+    vi.mocked(isFeatureEnabled).mockReturnValue(false);
+
+    let schema = makeExecutableSchema({ typeDefs, resolvers });
+    schema = makeFeatureFlagDirectiveTransformer()(schema);
+
+    const result = await graphql({ schema, source: '{ flaggedFeature }' });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.flaggedFeature).toBeNull();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/middleware-organization-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/middleware-organization-test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
 import { now } from 'moment';
-import { GraphQLError } from 'graphql/index';
+import { GraphQLError } from 'graphql';
 import { unSetOrganization, setOrganization } from '../../utils/testQueryHelper';
 import { ADMIN_USER, PLATFORM_ORGANIZATION, testContext, TEST_ORGANIZATION, GREEN_GROUP, inPlatformContext } from '../../utils/testQuery';
 import type { ThreatActorIndividualAddInput } from '../../../src/generated/graphql';

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/ingestion-taxii-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/ingestion-taxii-test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
-import type { GraphQLFormattedError } from 'graphql/error';
+import type { GraphQLFormattedError } from 'graphql';
 import { createUploadFromTestDataFile, queryAsAdminWithSuccess } from '../../utils/testQueryHelper';
 import { IngestionAuthType, TaxiiVersion } from '../../../src/generated/graphql';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';

--- a/opencti-platform/opencti-graphql/vitest.config.integration.ts
+++ b/opencti-platform/opencti-graphql/vitest.config.integration.ts
@@ -1,4 +1,5 @@
- import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
 import graphql from '@rollup/plugin-graphql';
 import type { PluginOption } from 'vite';
 import { BaseSequencer, type TestSpecification } from 'vitest/node';
@@ -26,15 +27,17 @@ export const buildIntegrationTestConfig = (include: string[]) => defineConfig({
     sequence: {
       shuffle: false,
       sequencer: class Sequencer extends BaseSequencer {
-         
         async shard(files: TestSpecification[]) {
           return files;
         }
-         
+
         async sort(files: TestSpecification[]) {
           return files.sort((testA, testB) => (testA.moduleId > testB.moduleId ? 1 : -1));
         }
       },
+    },
+    alias: {
+      graphql: path.resolve(__dirname, './node_modules/graphql/index.js'),
     },
   },
 });

--- a/opencti-platform/opencti-graphql/vitest.config.ts
+++ b/opencti-platform/opencti-graphql/vitest.config.ts
@@ -1,4 +1,5 @@
- import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
 import graphql from '@rollup/plugin-graphql';
 import type { PluginOption } from 'vite';
 
@@ -15,7 +16,10 @@ export const buildTestConfig = (include: string[]) => defineConfig({
       exclude: ['src/generated/**', 'src/migrations/**', 'src/stixpattern/**', 'src/python/**', '*.md'],
       reporter: ['text', 'json', 'html'],
       clean: false,
-    }
+    },
+    alias: {
+      graphql: path.resolve(__dirname, './node_modules/graphql/index.js'),
+    },
   },
 });
 


### PR DESCRIPTION
### Proposed changes

* Introduces new GraphQL directive to restrict access to endpoint based on Feature Flag values.

Example:
```
type Query {
  doSomething: String! @ff(flags: ["SOME_FLAG", "SOME_OTHER_FLAG"])
}
```
This definition will make queries to `doSomething` throw if neither one of the feature flags is set.

* Adds a `softFail` option that will resolve to `null` instead of returning an error:

```
type Query {
  doSomething: String @ff(flags: ["SOME_FLAG", "SOME_OTHER_FLAG"], softFail: true)
}
```

This can be helpful for queries happening super early, even before (or while) retrieving the FFs in the frontend.
Is used for the custom views feature as the new `customViewsDisplayContext` query is used in the `RootPrivateQuery` that itself fetches the FFs.

* Does a little refactoring of the `authDirective`
* Due to `Dual Package Hazard` issues happening when running vitest in the backend I had to add an `alias` to force using the CJS version.

### Related issues

* Fixes https://github.com/OpenCTI-Platform/opencti/issues/15330

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

TODO if/when merged:

- Update docs in Notion
- Update MD files