### PR TITLE
[backend] remove LRU session cache in redis session store (#13855)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
+++ b/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
@@ -16,26 +16,20 @@ class RedisStore extends Store {
     this.prefix = options.prefix == null ? 'sess:' : options.prefix;
     this.scanCount = Number(options.scanCount) || 100;
     this.serializer = options.serializer || JSON;
-    this.cache = new LRUCache({ ttl: 2500, max: 1000 }); // Force refresh the session every 2.5 sec
     this.touchCache = new LRUCache({ ttl: 120000, max: 1000 }); // Touch the session every 2 minutes
     this.locker = new AsyncLock();
   }
 
   get(sid, cb = noop) {
     const key = this.prefix + sid;
-    const { cache } = this;
-    const sessionFetcher = (done) => {
-      const cachedSession = cache.get(`get-${key}`);
-      if (cachedSession) {
-        return done(null, cachedSession);
-      }
-      return getSession(key).then((data) => {
+    const sessionFetcher = async (done) => {
+      try {
+        let data = await getSession(key);
         if (!data) return done();
-        cache.set(`get-${key}`, data);
         return done(null, data);
-      }).catch((error) => {
+      } catch (error) {
         return done(error, null);
-      });
+      }
     };
     this.locker.acquire(key, sessionFetcher, (error, result) => {
       return cb(error, result);
@@ -44,12 +38,9 @@ class RedisStore extends Store {
 
   set(sid, sess, cb = noop) {
     const key = this.prefix + sid;
-    const { cache } = this;
-    const sessionSetter = (done) => {
-      return setSession(key, sess, this.ttl).then((data) => {
-        cache.set(`get-${key}`, data);
-        return done(null, data);
-      });
+    const sessionSetter = async (done) => {
+      const data = await setSession(key, sess, this.ttl);
+      return done(null, data);
     };
     return this.locker.acquire(key, sessionSetter, (error, result) => {
       return cb(error, result);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove LRU session cache in redis session store to prevent in memory session temporary desync
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #13855 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
