### PR TITLE
[backend] ensure currentValueArray is always an array (#15364)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
+++ b/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
@@ -311,7 +311,8 @@ const generateFileInputsForUpsert = async (context, user, resolvedElement, updat
 };
 
 const mergeUpsertOperations = (upsertKey, elementCurrentValue, upsertOperations) => {
-  let currentValueArray = elementCurrentValue ?? [];
+  const currentValue = elementCurrentValue ?? [];
+  const currentValueArray = Array.isArray(currentValue) ? currentValue : [currentValue];
   let mergedUpsertOperationValue = [...currentValueArray];
   let mergedUpsertOperationOperation;
   for (let i = 0; i < upsertOperations.length; i++) {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js
@@ -309,6 +309,29 @@ describe('middleware upsertElement test', () => {
       expect(input.value.some((v) => v.value === labelToAdd.value)).toBe(true);
       expect(input.value.some((v) => v.value === labelToReplace.value)).toBe(true);
     });
+    it('should mergeUpsertInput with indicator : handles non-array elementCurrentValue', () => {
+      const updatePatchInput = {
+        operation: 'add',
+        key: 'indicator_types',
+        value: ['indicator-type-to-add'],
+      };
+      const upsertOperation = {
+        operation: 'remove',
+        key: 'indicator_types',
+        value: ['indicator-type-to-remove'],
+      };
+      // elementCurrentValue is a scalar string, not an array
+      const elementCurrentValue = 'indicator-type-current';
+      const upsertCurrentValue = ['indicator-type-current', 'indicator-type-to-add'];
+      const input = mergeUpsertInput(elementCurrentValue, upsertCurrentValue, updatePatchInput, upsertOperation);
+
+      // The scalar should be wrapped into an array, then the remove filter applied (no match), then add applied
+      expect(input.key).toEqual('indicator_types');
+      expect(input.operation).toEqual('replace');
+      expect(input.value.length).toEqual(2);
+      expect(input.value.includes('indicator-type-current')).toBe(true);
+      expect(input.value.includes('indicator-type-to-add')).toBe(true);
+    });
     it('should mergeUpsertInput with indicator : upsert adds label and operation add labels', () => {
       const labelToAddId = 'eda3b7d5-b722-4c34-9dd5-d70cea8f5cfc';
       const labelToAdd = { ...labelToRemove, value: 'label-to-add', id: labelToAddId, internal_id: labelToAddId, standard_id: labelToAddId };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  ensure currentValueArray is always an array
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15364 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
