### PR TITLE
[backend] Implement JWT authentication with trusted issuers and JWKS endpoint (#15323)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -222,7 +222,10 @@
     "opengrc_token": "",
     "xtmhub_url": "https://hub.filigran.io",
     "xtmhub_to_email": "no-reply@filigran.io",
-    "xtmhub_connectivity_email_enabled": true
+    "xtmhub_connectivity_email_enabled": true,
+    "auth": {
+      "token_ttl": 600
+    }
   },
   "data_sharing": {
     "max_csv_feed_result": 5000

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -104,10 +104,8 @@ import { safeRender } from '../utils/safeEjs.client';
 import { totp } from '../utils/totp';
 import { pushAll } from '../utils/arrayUtil';
 import { apiTokens } from '../modules/attributes/internalObject-registrationAttributes';
-import { decodeJwt, SignJWT } from 'jose';
-import { getPlatformCrypto } from '../utils/platformCrypto';
 import { addUserTokenByAdmin, generateTokenHmac } from '../modules/user/user-domain';
-import { memoize } from '../utils/memoize';
+import { verifyXtmJwt, isOwnIssuer } from './xtm-auth';
 import { getSettings } from './settings';
 import passport from 'passport';
 import {
@@ -121,7 +119,6 @@ import {
 } from '../modules/authenticationProvider/providers-configuration';
 import { addOrganization } from '../modules/organization/organization-domain';
 import validator from 'validator';
-import xtmOneClient from '../modules/xtm/one/xtm-one-client';
 import { logAuthInfo } from '../modules/authenticationProvider/providers-logger';
 
 const BEARER = 'Bearer ';
@@ -1772,46 +1769,36 @@ export const authenticateUserByBasicAuth = async (context, req, basicAuth) => {
   throw FunctionalError('Cannot identify user with basic auth');
 };
 
-const getJWTKeyPair = memoize(async () => {
-  const factory = await getPlatformCrypto();
-  return factory.deriveEd25519KeyPair(['authentication', 'xtm1'], 1);
-});
+export const authenticateUserByJWT = async (context, req, token) => {
+  const verified = await verifyXtmJwt(token);
+  const { iss, sub, email } = verified.payload;
 
-export const issueAuthenticationJWT = async (user, duration = '1h') => {
-  const xmt1DerivationKeyPair = await getJWTKeyPair();
-  const jwt = new SignJWT({ sub: user.id, name: user.name, email: user.user_email })
-    .setIssuer('opencti')
-    .setIssuedAt()
-    .setExpirationTime(duration);
-  return await xmt1DerivationKeyPair.signJwt(jwt);
+  // Own token: sub is the user id
+  if (isOwnIssuer(iss)) {
+    if (!sub) {
+      throw AuthenticationFailure('JWT missing sub claim');
+    }
+    return await authenticateUserByUserId(context, req, sub);
+  }
+
+  // External trusted issuer: resolve user through email claim
+  if (!email) {
+    throw AuthenticationFailure('Trusted issuer JWT missing email claim');
+  }
+  return await authenticateUserByEmail(context, req, email);
 };
 
-export const authenticateUserByJWT = async (context, req, token) => {
-  // Peek at the payload without signature verification to check the issuer
-  const unverifiedPayload = decodeJwt(token);
-  // This authentication shortcut is only for tokens issued by xtm-one,
-  // which are used in testing environments and are not signature-verified.
-  // For all other tokens, we require signature verification.
-  // Will be removed soon after introduction of xtm-one.
-  if (xtmOneClient.isConfigured() && unverifiedPayload.iss === 'filigran-copilot') {
-    // Copilot tokens are not signature-verified (testing purpose)
-    const email = unverifiedPayload.email;
-    if (!email) {
-      throw AuthenticationFailure('Copilot JWT missing email claim');
-    }
-    const user = await getUserByEmail(email);
-    if (!user) {
-      throw AuthenticationFailure('Copilot JWT email does not match any user');
-    }
-    const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-    const cacheUser = platformUsers.get(user.id);
-    return internalAuthenticateUser(context, req, cacheUser);
+const authenticateUserByEmail = async (context, req, email) => {
+  const user = await getUserByEmail(email);
+  if (!user) {
+    throw AuthenticationFailure('JWT email does not match any user', { email });
   }
-  // Standard path: verify signature then authenticate by user id
-  const xmt1DerivationKeyPair = await getJWTKeyPair();
-  const verified = await xmt1DerivationKeyPair.verifyJwt(token);
-  const userId = verified.payload.sub;
-  return await authenticateUserByUserId(context, req, userId);
+  const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  const cacheUser = platformUsers.get(user.id);
+  if (!cacheUser) {
+    throw AuthenticationFailure('Cannot identify user with email', { email });
+  }
+  return internalAuthenticateUser(context, req, cacheUser);
 };
 
 export const authenticateUserByToken = async (context, req, token) => {

--- a/opencti-platform/opencti-graphql/src/domain/xtm-auth.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-auth.ts
@@ -1,0 +1,109 @@
+import { v4 as uuidv4 } from 'uuid';
+import { createRemoteJWKSet, type FlattenedJWSInput, type JWTHeaderParameters, jwtVerify, SignJWT } from 'jose';
+import conf, { getBaseUrl, logApp } from '../config/conf';
+import { getPlatformCrypto } from '../utils/platformCrypto';
+import { memoize } from '../utils/memoize';
+import { AuthenticationFailure } from '../config/errors';
+
+const getJWTKeyPair = memoize(async () => {
+  const factory = await getPlatformCrypto();
+  return factory.deriveEd25519KeyPair(['authentication', 'xtm'], 1);
+});
+
+export const getXtmJwks = async () => {
+  const keyPair = await getJWTKeyPair();
+  return keyPair.jwks;
+};
+
+// -- Trusted issuers ---------------------------------------------------------
+
+const normaliseUrl = (url: string) => (url.endsWith('/') ? url.slice(0, -1) : url);
+
+const platformIssuer = normaliseUrl(getBaseUrl());
+export const isOwnIssuer = (issuer: string): boolean => issuer === platformIssuer;
+
+const trustedIssuers: Set<string> = new Set(
+  [conf.get('xtm:xtm_one_url')]
+    .filter((url): url is string => typeof url === 'string' && url.length > 0)
+    .map(normaliseUrl),
+);
+
+export const isTrustedIssuer = (issuer: string): boolean => {
+  return trustedIssuers.has(issuer);
+};
+
+// -- JWKS cache for remote issuers -------------------------------------------
+
+const JWKS_CACHE_MAX_AGE = 3_600_000;
+
+const issuerCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+const getRemoteJwks = (issuerBaseUrl: string) => {
+  let getKey = issuerCache.get(issuerBaseUrl);
+  if (!getKey) {
+    const jwksUrl = `${issuerBaseUrl}/xtm/auth/jwks`;
+    logApp.debug('[XTM_AUTH] Creating remote JWKS set', { issuer: issuerBaseUrl, jwksUrl });
+    getKey = createRemoteJWKSet(new URL(jwksUrl), { cacheMaxAge: JWKS_CACHE_MAX_AGE });
+    issuerCache.set(issuerBaseUrl, getKey);
+  }
+  return getKey;
+};
+
+// -- Single key resolver for jwtVerify ---------------------------------------
+
+const resolveKey = async (header: JWTHeaderParameters, token: FlattenedJWSInput) => {
+  // Decode iss from the flattened token payload (base64url-encoded)
+  const raw = typeof token.payload === 'string'
+    ? token.payload
+    : Buffer.from(token.payload).toString('base64url');
+  const { iss } = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+  if (!iss) {
+    throw AuthenticationFailure('JWT missing iss claim');
+  }
+  if (isOwnIssuer(iss)) {
+    const keyPair = await getJWTKeyPair();
+    const { kid } = header;
+    const publicKey = kid && keyPair.publicKeys[kid];
+    if (!publicKey) {
+      throw AuthenticationFailure('JWT kid does not match any platform key', { kid });
+    }
+    return publicKey;
+  }
+  if (!isTrustedIssuer(iss)) {
+    throw AuthenticationFailure('JWT issuer is not trusted', { issuer: iss });
+  }
+  // Delegate to jose's remote JWKS resolver (handles kid matching + auto-refresh)
+  return getRemoteJwks(iss)(header, token);
+};
+
+// -- JWT issue and verify -------------------------------------------
+
+const tokenTtl = Math.min(Number(conf.get('xtm:auth:token_ttl') ?? 600), 600);
+
+export const issueXtmJwt = async (user: { id: string; user_email: string }, audience: string): Promise<string> => {
+  const now = new Date();
+  const exp = new Date(now.getTime() + (tokenTtl * 1000));
+  const jwt = new SignJWT({ email: user.user_email })
+    .setSubject(user.id)
+    .setIssuer(platformIssuer)
+    .setAudience(audience)
+    .setIssuedAt(now)
+    .setNotBefore(now)
+    .setExpirationTime(exp)
+    .setJti(uuidv4());
+  const keyPair = await getJWTKeyPair();
+  const token = await keyPair.signJwt(jwt);
+  logApp.debug('[XTM_AUTH] Issued cross-platform JWT', { issuer: platformIssuer, subject: user.id, audience, ttl: tokenTtl });
+  return token;
+};
+
+export const verifyXtmJwt = async (token: string) => {
+  try {
+    return await jwtVerify(token, resolveKey, { algorithms: ['EdDSA'] });
+  } catch (err: any) {
+    if (err?.name === 'AuthenticationFailure' || err?.attributes?.reason) {
+      throw err;
+    }
+    throw AuthenticationFailure('JWT signature verification failed');
+  }
+};

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -11,7 +11,7 @@ import type { BasicStoreSettings } from '../types/settings';
 import { setCookieError } from './httpUtils';
 import { getDiscoveredIntentCatalog } from '../modules/xtm/one/xtm-one';
 import xtmOneClient from '../modules/xtm/one/xtm-one-client';
-import { issueAuthenticationJWT } from '../domain/user';
+import { issueXtmJwt } from '../domain/xtm-auth';
 
 const XTM_ONE_URL = nconf.get('xtm:xtm_one_url');
 export const XTM_ONE_CHATBOT_URL = `${XTM_ONE_URL}/chatbot`;
@@ -96,10 +96,10 @@ export const getChatbotAgents = async (req: Express.Request, res: Express.Respon
 export const postChatbotSession = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);
-    if (!context) return;
+    if (!context?.user) return;
 
     const url = `${XTM_ONE_URL}/api/v1/platform/chat/sessions`;
-    const jwt = await issueAuthenticationJWT(context.user);
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
     const response = await axios.post(url, req.body, {
       headers: {
         Authorization: `Bearer ${jwt}`,
@@ -128,7 +128,7 @@ export const postChatbotSession = async (req: Express.Request, res: Express.Resp
 export const postChatbotMessage = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);
-    if (!context) return;
+    if (!context?.user) return;
 
     if (!req.body) {
       res.status(400).json({ error: 'Request body is missing' });
@@ -137,7 +137,7 @@ export const postChatbotMessage = async (req: Express.Request, res: Express.Resp
 
     const url = `${XTM_ONE_URL}/api/v1/platform/chat/messages`;
 
-    const jwt = await issueAuthenticationJWT(context.user);
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
     const response = await axios.post(url, req.body, {
       headers: {
         Authorization: `Bearer ${jwt}`,
@@ -232,7 +232,7 @@ export const postChatbotMessage = async (req: Express.Request, res: Express.Resp
 export const postAgentMessage = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);
-    if (!context) return;
+    if (!context?.user) return;
 
     const { agent_slug, content } = req.body || {};
     if (!agent_slug || !content) {
@@ -241,7 +241,7 @@ export const postAgentMessage = async (req: Express.Request, res: Express.Respon
     }
 
     const url = `${XTM_ONE_URL}/api/v1/platform/chat/messages`;
-    const jwt = await issueAuthenticationJWT(context.user);
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
     const response = await axios.post(url, {
       agent_slug,
       content,
@@ -302,7 +302,7 @@ export const getLegacyChatbotProxy = async (req: Express.Request, res: Express.R
       return;
     }
 
-    const jwt = await issueAuthenticationJWT(context.user);
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
     const vars = {
       OPENCTI_URL: getChatbotUrl(req),
       OPENCTI_TOKEN: jwt,

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -16,6 +16,7 @@ import contentDisposition from 'content-disposition';
 import { printSchema } from 'graphql';
 import { basePath, DEV_MODE, ENABLED_UI, logApp, OPENCTI_SESSION, PLATFORM_VERSION, AUTH_PAYLOAD_BODY_SIZE, getBaseUrl } from '../config/conf';
 import { sessionAuthenticateUser, userWithOrigin } from '../domain/user';
+import { getXtmJwks } from '../domain/xtm-auth';
 import { downloadFile, getFileContent, isStorageAlive } from '../database/raw-file-storage';
 import { loadFile } from '../database/file-storage';
 import { DEFAULT_INVALID_CONF_VALUE, executionContext, SYSTEM_USER } from '../utils/access';
@@ -181,6 +182,19 @@ const createApp = async (app, schema) => {
 
   // -- Init rolling feeds rest api
   initHttpRollingFeeds(app);
+
+  // -- Init XTM cross-platform auth api (JWKS endpoint, public, no authentication required)
+  app.get(`${basePath}/xtm/auth/jwks`, async (_req, res) => {
+    try {
+      const jwks = await getXtmJwks();
+      res.set('Content-Type', 'application/json');
+      res.set('Cache-Control', 'public, max-age=3600'); // 1 hour cache
+      res.json(jwks);
+    } catch (e) {
+      logApp.error('[XTM_AUTH] Error serving JWKS', { cause: e });
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
 
   // -- Register the encryption module
   archiver.registerFormat('zip-encrypted', archiverZipEncrypted);

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/user-test.ts
@@ -1,17 +1,29 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { DateTime } from 'luxon';
 import { OPENCTI_ADMIN_UUID } from '../../../src/schema/general';
 import { updateAttribute } from '../../../src/database/middleware';
 import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
 import type { AuthContext, AuthUser } from '../../../src/types/user';
 import { TokenDuration, type UserTokenAddInput } from '../../../src/generated/graphql';
-import { checkPasswordInlinePolicy, isSensitiveChangesAllowed } from '../../../src/domain/user';
+import { authenticateUserByJWT, authenticateUserByToken, authenticateUserByUserId, checkPasswordInlinePolicy, isSensitiveChangesAllowed } from '../../../src/domain/user';
 import { addUserToken, generateSecureToken } from '../../../src/modules/user/user-domain';
 import { testContext } from '../../utils/testQuery';
+import { isUserHasCapability } from '../../../src/utils/access';
+import { getEntitiesMapFromCache, getEntityFromCache } from '../../../src/database/cache';
+import { verifyXtmJwt, isOwnIssuer } from '../../../src/domain/xtm-auth';
+import { elLoadBy } from '../../../src/database/engine';
+import { generateTokenHmac } from '../../../src/modules/user/user-domain';
+import { updateTokenUsage } from '../../../src/database/redis/token_usage';
 
 vi.mock('../../../src/database/middleware', () => ({
   patchAttribute: vi.fn(),
-  updateAttribute: vi.fn().mockResolvedValue({ element: { id: 'mock-id' } }),
+  updateAttribute: vi.fn().mockResolvedValue({ element: { id: 'mock-id', user_email: 'test@test.com' } }),
+}));
+
+vi.mock('../../../src/database/cache', () => ({
+  getEntitiesListFromCache: vi.fn().mockResolvedValue([]),
+  getEntitiesMapFromCache: vi.fn().mockResolvedValue(new Map()),
+  getEntityFromCache: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../../../src/listener/UserActionListener', () => ({
@@ -27,6 +39,30 @@ vi.mock('../../../src/utils/access', async () => {
   return {
     ...actual,
     isUserHasCapability: vi.fn().mockReturnValue(true),
+  };
+});
+
+vi.mock('../../../src/domain/xtm-auth', () => ({
+  verifyXtmJwt: vi.fn(),
+  isOwnIssuer: vi.fn(),
+}));
+
+vi.mock('../../../src/database/engine', () => ({
+  elLoadBy: vi.fn(),
+  elRawDeleteByQuery: vi.fn(),
+}));
+
+vi.mock('../../../src/database/redis/token_usage', () => ({
+  getTokensUsage: vi.fn().mockResolvedValue([]),
+  updateTokenUsage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../src/modules/user/user-domain', async () => {
+  const actual = await vi.importActual('../../../src/modules/user/user-domain');
+  return {
+    ...actual,
+    generateTokenHmac: vi.fn(),
+    addUserTokenByAdmin: vi.fn(),
   };
 });
 
@@ -398,5 +434,262 @@ describe('API Token Generation', () => {
     const diff = expires.diff(now, 'days').days;
     // expect(diff).toBeCloseTo(30, 0); // 30.0 days
     expect(Math.abs(diff - 30)).toBeLessThan(0.1);
+  });
+});
+
+// --- Helper for building a minimal mock request ---
+const buildMockReq = (overrides: Record<string, any> = {}) => ({
+  ip: '127.0.0.1',
+  headers: {},
+  header: () => undefined,
+  socket: { remoteAddress: '127.0.0.1' },
+  ...overrides,
+});
+
+// --- Helper for a minimal valid cached user ---
+const buildCachedUser = (id: string, extra: Record<string, any> = {}) => ({
+  id,
+  account_status: 'Active',
+  groups: [],
+  organizations: [],
+  headers_audit: [],
+  ...extra,
+});
+
+// --- Minimal settings object required by validateUser / internalAuthenticateUser ---
+const MOCK_SETTINGS = { platform_organization: null };
+
+// --- Tests for authentication methods ---
+
+describe('authenticateUserByUserId', () => {
+  const mockContext = testContext;
+  const mockReq = buildMockReq();
+
+  it('should return the authenticated user when found in cache', async () => {
+    const cachedUser = buildCachedUser('user-abc');
+    const usersMap = new Map([['user-abc', cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue(MOCK_SETTINGS as any);
+
+    const result = await authenticateUserByUserId(mockContext, mockReq, 'user-abc');
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe('user-abc');
+    expect(result.origin).toBeDefined();
+  });
+
+  it('should throw FunctionalError when user id is not found in cache', async () => {
+    const usersMap = new Map();
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+
+    await expect(
+      authenticateUserByUserId(mockContext, mockReq, 'unknown-user'),
+    ).rejects.toThrow('Cannot identify user with id');
+  });
+});
+
+describe('authenticateUserByJWT', () => {
+  const mockContext = testContext;
+  const mockReq = buildMockReq();
+
+  beforeEach(() => {
+    vi.mocked(verifyXtmJwt).mockReset();
+    vi.mocked(isOwnIssuer).mockReset();
+    vi.mocked(elLoadBy).mockReset();
+  });
+
+  it('should authenticate by userId when issuer is own platform', async () => {
+    vi.mocked(verifyXtmJwt).mockResolvedValue({
+      payload: { iss: 'https://opencti.example.com', sub: 'user-jwt-1', email: 'u@test.com' },
+    } as any);
+    vi.mocked(isOwnIssuer).mockReturnValue(true);
+
+    const cachedUser = buildCachedUser('user-jwt-1');
+    const usersMap = new Map([['user-jwt-1', cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue(MOCK_SETTINGS as any);
+
+    const result = await authenticateUserByJWT(mockContext, mockReq, 'eyFakeToken');
+
+    expect(verifyXtmJwt).toHaveBeenCalledWith('eyFakeToken');
+    expect(isOwnIssuer).toHaveBeenCalledWith('https://opencti.example.com');
+    expect(result.id).toBe('user-jwt-1');
+  });
+
+  it('should throw AuthenticationFailure when own issuer JWT has no sub claim', async () => {
+    vi.mocked(verifyXtmJwt).mockResolvedValue({
+      payload: { iss: 'https://opencti.example.com', sub: undefined, email: 'u@test.com' },
+    } as any);
+    vi.mocked(isOwnIssuer).mockReturnValue(true);
+
+    await expect(
+      authenticateUserByJWT(mockContext, mockReq, 'eyFakeToken'),
+    ).rejects.toThrow('JWT missing sub claim');
+  });
+
+  it('should authenticate by email when issuer is external trusted issuer', async () => {
+    vi.mocked(verifyXtmJwt).mockResolvedValue({
+      payload: { iss: 'https://xtm.example.com', sub: 'ext-user', email: 'trusted@test.com' },
+    } as any);
+    vi.mocked(isOwnIssuer).mockReturnValue(false);
+
+    // getUserByEmail -> elLoadBy returns a user
+    vi.mocked(elLoadBy).mockResolvedValue({ id: 'email-user-1', user_email: 'trusted@test.com' } as any);
+
+    // Cache has this user
+    const cachedUser = buildCachedUser('email-user-1');
+    const usersMap = new Map([['email-user-1', cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue(MOCK_SETTINGS as any);
+
+    const result = await authenticateUserByJWT(mockContext, mockReq, 'eyExternalToken');
+
+    expect(result.id).toBe('email-user-1');
+  });
+
+  it('should throw when external trusted issuer JWT has no email claim', async () => {
+    vi.mocked(verifyXtmJwt).mockResolvedValue({
+      payload: { iss: 'https://xtm.example.com', sub: 'ext-user', email: undefined },
+    } as any);
+    vi.mocked(isOwnIssuer).mockReturnValue(false);
+
+    await expect(
+      authenticateUserByJWT(mockContext, mockReq, 'eyNoEmailToken'),
+    ).rejects.toThrow('Trusted issuer JWT missing email claim');
+  });
+
+  it('should throw when email from external JWT does not match any user', async () => {
+    vi.mocked(verifyXtmJwt).mockResolvedValue({
+      payload: { iss: 'https://xtm.example.com', sub: 'ext-user', email: 'unknown@test.com' },
+    } as any);
+    vi.mocked(isOwnIssuer).mockReturnValue(false);
+
+    // getUserByEmail -> elLoadBy returns null (no match)
+    vi.mocked(elLoadBy).mockResolvedValue(null as any);
+
+    await expect(
+      authenticateUserByJWT(mockContext, mockReq, 'eyUnknownEmail'),
+    ).rejects.toThrow('JWT email does not match any user');
+  });
+
+  it('should throw when email user is found in DB but not in cache', async () => {
+    vi.mocked(verifyXtmJwt).mockResolvedValue({
+      payload: { iss: 'https://xtm.example.com', sub: 'ext-user', email: 'nocache@test.com' },
+    } as any);
+    vi.mocked(isOwnIssuer).mockReturnValue(false);
+
+    vi.mocked(elLoadBy).mockResolvedValue({ id: 'nocache-user', user_email: 'nocache@test.com' } as any);
+
+    // Cache does NOT have this user
+    const usersMap = new Map();
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+
+    await expect(
+      authenticateUserByJWT(mockContext, mockReq, 'eyNoCacheToken'),
+    ).rejects.toThrow('Cannot identify user with email');
+  });
+});
+
+describe('authenticateUserByToken', () => {
+  const mockContext = testContext;
+  const mockReq = buildMockReq();
+
+  beforeEach(() => {
+    vi.mocked(generateTokenHmac).mockReset();
+    vi.mocked(isUserHasCapability).mockReturnValue(true);
+    vi.mocked(updateTokenUsage).mockResolvedValue(undefined as any);
+  });
+
+  it('should authenticate user with a valid non-expired token', async () => {
+    const hashedToken = 'hashed-abc-123';
+    vi.mocked(generateTokenHmac).mockResolvedValue(hashedToken);
+
+    const futureDate = DateTime.now().plus({ days: 30 }).toISO();
+    const cachedUser = buildCachedUser('token-user-1', {
+      api_tokens: [{ hash: hashedToken, name: 'My Token', expires_at: futureDate }],
+    });
+    const usersMap = new Map([[hashedToken, cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue(MOCK_SETTINGS as any);
+
+    const result = await authenticateUserByToken(mockContext, mockReq, 'plaintext-token');
+
+    expect(generateTokenHmac).toHaveBeenCalledWith('plaintext-token');
+    expect(updateTokenUsage).toHaveBeenCalled();
+    expect(result.id).toBe('token-user-1');
+  });
+
+  it('should authenticate user with an UNLIMITED (no expiration) token', async () => {
+    const hashedToken = 'hashed-unlimited';
+    vi.mocked(generateTokenHmac).mockResolvedValue(hashedToken);
+
+    const cachedUser = buildCachedUser('unlimited-user', {
+      api_tokens: [{ hash: hashedToken, name: 'Unlimited Token', expires_at: null }],
+    });
+    const usersMap = new Map([[hashedToken, cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue(MOCK_SETTINGS as any);
+
+    const result = await authenticateUserByToken(mockContext, mockReq, 'unlimited-plaintext');
+
+    expect(result.id).toBe('unlimited-user');
+  });
+
+  it('should throw FunctionalError when token is expired', async () => {
+    const hashedToken = 'hashed-expired';
+    vi.mocked(generateTokenHmac).mockResolvedValue(hashedToken);
+
+    const pastDate = DateTime.now().minus({ days: 1 }).toISO();
+    const cachedUser = buildCachedUser('expired-user', {
+      api_tokens: [{ hash: hashedToken, name: 'Expired Token', expires_at: pastDate }],
+    });
+    const usersMap = new Map([[hashedToken, cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+
+    await expect(
+      authenticateUserByToken(mockContext, mockReq, 'expired-plaintext'),
+    ).rejects.toThrow('Token expired');
+  });
+
+  it('should throw FunctionalError when no user matches the hashed token', async () => {
+    vi.mocked(generateTokenHmac).mockResolvedValue('hashed-unknown');
+
+    const usersMap = new Map();
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+
+    await expect(
+      authenticateUserByToken(mockContext, mockReq, 'no-match-token'),
+    ).rejects.toThrow('Cannot identify user with token');
+  });
+
+  it('should throw ForbiddenAccess when user lacks APIACCESS_USETOKEN capability', async () => {
+    const hashedToken = 'hashed-no-cap';
+    vi.mocked(generateTokenHmac).mockResolvedValue(hashedToken);
+    vi.mocked(isUserHasCapability).mockReturnValue(false);
+
+    const cachedUser = buildCachedUser('nocap-user', {
+      api_tokens: [{ hash: hashedToken, name: 'Token', expires_at: null }],
+    });
+    const usersMap = new Map([[hashedToken, cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+
+    await expect(
+      authenticateUserByToken(mockContext, mockReq, 'nocap-plaintext'),
+    ).rejects.toThrow('You are not allowed to use API Access Tokens');
+  });
+
+  it('should throw FunctionalError when user has no api_tokens array and hash not comparable', async () => {
+    const hashedToken = 'hashed-no-tokens';
+    vi.mocked(generateTokenHmac).mockResolvedValue(hashedToken);
+
+    const cachedUser = buildCachedUser('notokens-user', {
+      api_tokens: [],
+    });
+    const usersMap = new Map([[hashedToken, cachedUser]]);
+    vi.mocked(getEntitiesMapFromCache).mockResolvedValue(usersMap as any);
+
+    await expect(
+      authenticateUserByToken(mockContext, mockReq, 'notokens-plaintext'),
+    ).rejects.toThrow('Cannot identify user with not comparable token');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/xtmAuth-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/xtmAuth-test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi, beforeAll } from 'vitest';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+
+// --- Mocks (hoisted before module evaluation) ---
+
+vi.mock('../../../src/config/conf', () => ({
+  default: {
+    get: (key: string) => {
+      const config: Record<string, any> = {
+        'xtm:xtm_one_url': 'https://xtm-one.example.com',
+        'xtm:auth:token_ttl': 300,
+      };
+      return config[key];
+    },
+  },
+  getBaseUrl: () => 'https://opencti.example.com',
+  logApp: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+  DEV_MODE: false,
+  ENABLED_DEMO_MODE: false,
+  logAudit: { info: vi.fn() },
+  booleanConf: (_key: string, defaultValue: boolean): boolean => defaultValue,
+}));
+
+vi.mock('../../../src/utils/platformCrypto', () => ({
+  getPlatformCrypto: vi.fn(),
+}));
+
+// --- Imports (resolved after mocks are set up) ---
+
+import { getPlatformCrypto } from '../../../src/utils/platformCrypto';
+import { getXtmJwks, isOwnIssuer, isTrustedIssuer, issueXtmJwt, verifyXtmJwt } from '../../../src/domain/xtm-auth';
+
+// --- Constants ---
+
+const PLATFORM_URL = 'https://opencti.example.com';
+const TRUSTED_XTM_URL = 'https://xtm-one.example.com';
+const KID = 'test-kid-1';
+
+// --- Test key pair setup ---
+
+beforeAll(async () => {
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA');
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = KID;
+  jwk.alg = 'EdDSA';
+
+  const mockKeyPair = {
+    jwks: { keys: [jwk] },
+    publicKeys: { [KID]: publicKey },
+    signJwt: async (jwtBuilder: SignJWT) => {
+      return jwtBuilder
+        .setProtectedHeader({ alg: 'EdDSA', kid: KID, typ: 'JWT' })
+        .sign(privateKey);
+    },
+  };
+
+  const mockFactory = {
+    deriveEd25519KeyPair: vi.fn().mockResolvedValue(mockKeyPair),
+  };
+
+  vi.mocked(getPlatformCrypto).mockResolvedValue(mockFactory as any);
+});
+
+// --- Tests ---
+
+describe('XTM Authentication', () => {
+  // -- Pure helper tests --
+
+  describe('isOwnIssuer', () => {
+    it('should return true for the platform URL', () => {
+      expect(isOwnIssuer(PLATFORM_URL)).toBe(true);
+    });
+
+    it('should return false for a different URL', () => {
+      expect(isOwnIssuer('https://other.example.com')).toBe(false);
+    });
+
+    it('should return false for a trusted issuer URL', () => {
+      expect(isOwnIssuer(TRUSTED_XTM_URL)).toBe(false);
+    });
+  });
+
+  describe('isTrustedIssuer', () => {
+    it('should return true for the configured trusted issuer', () => {
+      expect(isTrustedIssuer(TRUSTED_XTM_URL)).toBe(true);
+    });
+
+    it('should return false for an unknown URL', () => {
+      expect(isTrustedIssuer('https://unknown.example.com')).toBe(false);
+    });
+
+    it('should return false for the platform own URL', () => {
+      expect(isTrustedIssuer(PLATFORM_URL)).toBe(false);
+    });
+  });
+
+  // -- JWKS --
+
+  describe('getXtmJwks', () => {
+    it('should return the JWKS from the derived key pair', async () => {
+      const jwks = await getXtmJwks();
+      expect(jwks).toBeDefined();
+      expect(jwks.keys).toHaveLength(1);
+      expect(jwks.keys[0].kid).toBe(KID);
+      expect(jwks.keys[0].alg).toBe('EdDSA');
+    });
+  });
+
+  // -- JWT issuance --
+
+  describe('issueXtmJwt', () => {
+    it('should issue a valid three-part JWT string', async () => {
+      const user = { id: 'user-123', user_email: 'test@example.com' };
+      const token = await issueXtmJwt(user, 'https://audience.example.com');
+
+      expect(token).toBeDefined();
+      expect(typeof token).toBe('string');
+      expect(token.split('.')).toHaveLength(3);
+    });
+
+    it('should include correct claims in the JWT payload', async () => {
+      const user = { id: 'user-456', user_email: 'user@test.com' };
+      const audience = 'https://target.example.com';
+      const token = await issueXtmJwt(user, audience);
+
+      const [, payloadB64] = token.split('.');
+      const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+
+      expect(payload.sub).toBe('user-456');
+      expect(payload.email).toBe('user@test.com');
+      expect(payload.iss).toBe(PLATFORM_URL);
+      expect(payload.aud).toBe(audience);
+      expect(payload.jti).toBeDefined();
+      expect(payload.iat).toBeDefined();
+      expect(payload.nbf).toBeDefined();
+      expect(payload.exp).toBeDefined();
+    });
+
+    it('should set expiration based on the configured TTL (capped at 600s)', async () => {
+      const user = { id: 'user-ttl', user_email: 'ttl@test.com' };
+      const token = await issueXtmJwt(user, 'https://audience.example.com');
+
+      const [, payloadB64] = token.split('.');
+      const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+
+      // tokenTtl = Math.min(300, 600) = 300
+      expect(payload.exp - payload.iat).toBe(300);
+    });
+
+    it('should generate unique JTI for each issued token', async () => {
+      const user = { id: 'user-jti', user_email: 'jti@test.com' };
+      const audience = 'https://audience.example.com';
+
+      const token1 = await issueXtmJwt(user, audience);
+      const token2 = await issueXtmJwt(user, audience);
+
+      const decodePayload = (t: string) => {
+        const [, payloadB64] = t.split('.');
+        return JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+      };
+
+      expect(decodePayload(token1).jti).not.toBe(decodePayload(token2).jti);
+    });
+  });
+
+  // -- JWT verification --
+
+  describe('verifyXtmJwt', () => {
+    it('should verify a JWT issued by the platform (round-trip)', async () => {
+      const user = { id: 'user-verify', user_email: 'verify@test.com' };
+      const audience = 'https://audience.example.com';
+      const token = await issueXtmJwt(user, audience);
+
+      const result = await verifyXtmJwt(token);
+
+      expect(result).toBeDefined();
+      expect(result.payload.sub).toBe('user-verify');
+      expect(result.payload.email).toBe('verify@test.com');
+      expect(result.payload.iss).toBe(PLATFORM_URL);
+      expect(result.payload.aud).toBe(audience);
+    });
+
+    it('should throw for an invalid/malformed token', async () => {
+      await expect(verifyXtmJwt('not.a.valid-jwt'))
+        .rejects.toThrow('JWT signature verification failed');
+    });
+
+    it('should throw when issuer is not trusted', async () => {
+      const { privateKey } = await generateKeyPair('EdDSA');
+      const token = await new SignJWT({ email: 'bad@test.com' })
+        .setSubject('bad-user')
+        .setIssuer('https://untrusted.example.com')
+        .setAudience('https://audience.example.com')
+        .setIssuedAt()
+        .setExpirationTime('5m')
+        .setProtectedHeader({ alg: 'EdDSA', kid: 'some-kid' })
+        .sign(privateKey);
+
+      await expect(verifyXtmJwt(token))
+        .rejects.toThrow('JWT signature verification failed');
+    });
+
+    it('should throw when JWT has no iss claim', async () => {
+      const { privateKey } = await generateKeyPair('EdDSA');
+      const token = await new SignJWT({ email: 'no-iss@test.com' })
+        .setSubject('no-iss-user')
+        .setAudience('https://audience.example.com')
+        .setIssuedAt()
+        .setExpirationTime('5m')
+        .setProtectedHeader({ alg: 'EdDSA', kid: 'no-iss-kid' })
+        .sign(privateKey);
+
+      await expect(verifyXtmJwt(token))
+        .rejects.toThrow('JWT signature verification failed');
+    });
+
+    it('should throw when kid does not match any platform key', async () => {
+      const { privateKey } = await generateKeyPair('EdDSA');
+      const token = await new SignJWT({ email: 'wrong-kid@test.com' })
+        .setSubject('wrong-kid-user')
+        .setIssuer(PLATFORM_URL)
+        .setAudience('https://audience.example.com')
+        .setIssuedAt()
+        .setExpirationTime('5m')
+        .setProtectedHeader({ alg: 'EdDSA', kid: 'non-existent-kid' })
+        .sign(privateKey);
+
+      await expect(verifyXtmJwt(token))
+        .rejects.toThrow('JWT signature verification failed');
+    });
+
+    it('should throw generic failure for a token signed with a different key', async () => {
+      const { privateKey: wrongKey } = await generateKeyPair('EdDSA');
+      const token = await new SignJWT({ email: 'tampered@test.com' })
+        .setSubject('tampered-user')
+        .setIssuer(PLATFORM_URL)
+        .setAudience('https://audience.example.com')
+        .setIssuedAt()
+        .setExpirationTime('5m')
+        .setProtectedHeader({ alg: 'EdDSA', kid: KID })
+        .sign(wrongKey);
+
+      await expect(verifyXtmJwt(token))
+        .rejects.toThrow('JWT signature verification failed');
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new cross-platform JWT authentication mechanism for XTM integrations, centralizing JWT issuing and verification logic in a new `xtm-auth` module. It updates the authentication flow to support trusted external issuers, exposes a JWKS endpoint for public key discovery, and updates the chatbot proxy to use the new JWT issuance. Unit tests are added to ensure correct JWKS generation and issuer trust logic.

Fix #15323

**Cross-platform JWT authentication and verification:**

* Introduced a new `xtm-auth` module (`xtm-auth.ts`) that handles JWT issuing, verification, trusted issuer management, and remote JWKS caching. This module centralizes all JWT logic for cross-platform authentication.
* Added a public JWKS endpoint at `/xtm/auth/jwks` to expose the platform's signing keys for JWT verification by external services.
* Updated the configuration (`default.json`) to include a new `auth.token_ttl` setting for JWT expiration control.

**Authentication flow updates:**

* Refactored user authentication by JWT to use the new verification logic, supporting both platform-issued and trusted external JWTs. The logic now distinguishes between own and trusted issuers and resolves users by `sub` or `email` as appropriate.
* Removed legacy JWT issuing and verification code from `user.js`, delegating all such functionality to the new `xtm-auth` module. [[1]](diffhunk://#diff-6909f8feec02e9c8ba8aa0cc2a8bab255cc5678df9b388468f45949a3a577be2L106-R107) [[2]](diffhunk://#diff-6909f8feec02e9c8ba8aa0cc2a8bab255cc5678df9b388468f45949a3a577be2L123)

**Chatbot proxy integration:**

* Updated the chatbot proxy (`httpChatbotProxy.ts`) to use the new JWT issuance function (`issueXtmJwt`) when communicating with XTM One, ensuring tokens are correctly signed and scoped. [[1]](diffhunk://#diff-ad67dae5a1e5080a9649448a6a2240c1ca56d06ed34db1d2b9d0343bfb243f2eL14-R14) [[2]](diffhunk://#diff-ad67dae5a1e5080a9649448a6a2240c1ca56d06ed34db1d2b9d0343bfb243f2eL102-R102) [[3]](diffhunk://#diff-ad67dae5a1e5080a9649448a6a2240c1ca56d06ed34db1d2b9d0343bfb243f2eL140-R140) [[4]](diffhunk://#diff-ad67dae5a1e5080a9649448a6a2240c1ca56d06ed34db1d2b9d0343bfb243f2eL244-R244) [[5]](diffhunk://#diff-ad67dae5a1e5080a9649448a6a2240c1ca56d06ed34db1d2b9d0343bfb243f2eL305-R305)

**Testing:**

* Added unit tests for JWKS endpoint validity and trusted issuer logic in `xtmAuth-test.ts`.
