### PR TITLE
[client-python] fix <code> tags conversion to backticks (#15374)

### DIFF
--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import random
+import re
 import time
 import traceback
 import uuid
@@ -158,7 +159,10 @@ class OpenCTIStix2:
         :rtype: str
         """
         if text is not None:
-            return text.replace("<code>", "`").replace("</code>", "`")
+            # (.*?) → lazy match captures the content between the tags (shortest possible, so nested/adjacent pairs don't bleed into each other)
+            # re.DOTALL → allows . to match newlines, so multi-line code content inside the tags still works
+            # \1 in the replacement → puts the captured content back between the backticks
+            return re.sub(r"<code>(.*?)</code>", r"`\1`", text, flags=re.DOTALL)
         else:
             return None
 

--- a/client-python/tests/01-unit/utils/test_opencti_stix2.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2.py
@@ -18,17 +18,37 @@ def test_unknown_type(opencti_stix2: OpenCTIStix2, caplog):
 
 
 def test_convert_markdown(opencti_stix2: OpenCTIStix2):
+    # Matched pair is converted to backticks
     result = opencti_stix2.convert_markdown(
         " my <code> is very </special> </code> to me"
     )
     assert " my ` is very </special> ` to me" == result
 
 
+def test_convert_markdown_multiple_pairs(opencti_stix2: OpenCTIStix2):
+    # Multiple matched pairs are all converted
+    result = opencti_stix2.convert_markdown("<code>foo</code> and <code>bar</code>")
+    assert "`foo` and `bar`" == result
+
+
 def test_convert_markdown_typo(opencti_stix2: OpenCTIStix2):
-    result = opencti_stix2.convert_markdown(
-        " my <code is very </special> </code> to me"
-    )
-    assert " my <code is very </special> ` to me" == result
+    # Malformed opening tag (<code missing closing >) means no valid pair exists; nothing should be replaced
+    text = " my <code is very </special> </code> to me"
+    result = opencti_stix2.convert_markdown(text)
+    assert text == result
+
+
+def test_convert_markdown_literal_code_tag(opencti_stix2: OpenCTIStix2):
+    # A lone <code> without a matching </code> is literal content and must not be altered
+    text = 'Run python3 -c "<code>" and pass it to subprocess.run(..., shell=True)'
+    result = opencti_stix2.convert_markdown(text)
+    assert text == result
+
+
+def test_convert_markdown_mixed_matched_and_lone(opencti_stix2: OpenCTIStix2):
+    # A matched pair is converted, but a trailing lone <code> is left untouched
+    result = opencti_stix2.convert_markdown("<code>foo</code> and <code>")
+    assert "`foo` and <code>" == result
 
 
 def test_format_date_with_tz(opencti_stix2: OpenCTIStix2):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- a lone `<code>` with no closing tag is preserved (original bug report case)
- a malformed `<code`  tag (missing >) with a lone `</code>` is no longer partially replaced
- multiple matched pairs in the same string are all correctly converted
- a matched pair is converted while a trailing lone `<code>` is left untouched

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* https://github.com/OpenCTI-Platform/opencti/issues/15374

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
