### PR TITLE
[backend/frontend] add the relationship type "belongs to" between Organization and Infrastructure(#5376)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
@@ -297,6 +297,19 @@ const OrganizationKnowledgeComponent = ({
             />
           )}
         />
+        <Route
+          path="/infrastructures"
+          element={(
+            <EntityStixCoreRelationships
+              key={location.pathname}
+              entityId={organization.id}
+              relationshipTypes={['belongs-to']}
+              stixCoreObjectTypes={['Infrastructure']}
+              entityLink={link}
+              isRelationReversed={true}
+            />
+          )}
+        />
         <Route index element={<Navigate replace={true} to="overview" />} />
       </Routes>
     </div>

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/Root.tsx
@@ -164,6 +164,7 @@ const RootOrganization = ({ organizationId, queryRef }: RootOrganizationProps) =
                     'attack_patterns',
                     'tools',
                     'vulnerabilities',
+                    'infrastructures',
                     'observables',
                   ]}
                   data={organization}

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -52,6 +52,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
           'tools',
           'vulnerabilities',
           'infrastructures',
+          'organizations',
           'indicators',
           'observables',
           'observed_data',
@@ -340,6 +341,21 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
               isRelationReversed={true}
               defaultStartTime={infrastructureData.first_seen}
               defaultStopTime={infrastructureData.last_seen}
+            />
+          )}
+        />
+        <Route
+          path="/organizations"
+          element={(
+            <EntityStixCoreRelationships
+              key={location.pathname}
+              entityId={infrastructureData.id}
+              relationshipTypes={['belongs-to']}
+              stixCoreObjectTypes={['Organization']}
+              entityLink={link}
+              defaultStartTime={infrastructureData.first_seen}
+              defaultStopTime={infrastructureData.last_seen}
+              isRelationReversed={false}
             />
           )}
         />

--- a/opencti-platform/opencti-graphql/src/database/stix.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix.ts
@@ -571,6 +571,9 @@ export const stixCoreRelationshipsMapping: RelationshipMappings = {
     { name: RELATION_TECHNOLOGY_TO, type: REL_EXTENDED },
     { name: RELATION_TECHNOLOGY_FROM, type: REL_EXTENDED },
   ],
+  [`${ENTITY_TYPE_INFRASTRUCTURE}_${ENTITY_TYPE_IDENTITY_ORGANIZATION}`]: [
+    { name: RELATION_BELONGS_TO, type: REL_EXTENDED },
+  ],
   [`${ENTITY_TYPE_INFRASTRUCTURE}_${ENTITY_TYPE_ATTACK_PATTERN}`]: [
     { name: RELATION_DETECTS, type: REL_NEW },
   ],


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* [backend] add RELATION_BELONGS_TO between org and infrastructure in stix.ts
* [frontend] add  Infrastructure or Organization tabs in knowledge

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*resolves #5376 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
