### PR TITLE
[backend/frontend] Add  “part of” relationship between 2 intrusion sets(#5241)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -279,6 +279,21 @@ const IntrusionSetKnowledgeComponent = ({
           )}
         />
         <Route
+          path="/intrusion_sets"
+          element={(
+            <EntityStixCoreRelationships
+              key={location.pathname}
+              entityId={intrusionSet.id}
+              relationshipTypes={['part-of', 'derived-from']}
+              stixCoreObjectTypes={['Intrusion-Set']}
+              entityLink={link}
+              defaultStartTime={intrusionSet.first_seen}
+              defaultStopTime={intrusionSet.last_seen}
+              allDirections
+            />
+          )}
+        />
+        <Route
           path="/sightings"
           element={(
             <EntityStixSightingRelationships

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -139,6 +139,7 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
                     'observables',
                     'infrastructures',
                     'sightings',
+                    'intrusion_sets',
                   ]}
                   data={intrusionSet}
                   attribution={['Threat-Actor-Individual', 'Threat-Actor-Group']}

--- a/opencti-platform/opencti-graphql/src/database/stix.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix.ts
@@ -648,6 +648,7 @@ export const stixCoreRelationshipsMapping: RelationshipMappings = {
   ],
   [`${ENTITY_TYPE_INTRUSION_SET}_${ENTITY_TYPE_INTRUSION_SET}`]: [
     { name: RELATION_DERIVED_FROM, type: REL_BUILT_IN },
+    { name: RELATION_PART_OF, type: REL_EXTENDED },
   ],
   [`${ENTITY_TYPE_INTRUSION_SET}_${ENTITY_TYPE_CAMPAIGN}`]: [
     { name: RELATION_ATTRIBUTED_TO, type: REL_EXTENDED },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*Add  “part of” relationship between 2 intrusion sets

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
*resolves #5241 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
