### PR TITLE
[frontend] SCO colors are now different based on their name (#15421)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/Colors.ts
+++ b/opencti-platform/opencti-front/src/utils/Colors.ts
@@ -253,6 +253,11 @@ export const itemColor = (
 ): string => {
   const family = type ? ENTITY_TYPE_TO_FAMILY[type] : null;
 
+  // SCO colors are generated based on their type to differentiate them
+  if (type && family === 'observables') {
+    return stringToColour(type);
+  }
+
   if (family) {
     return COLOR_FAMILIES[family];
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
<img width="1495" height="716" alt="Screenshot 2026-04-09 at 11 53 22" src="https://github.com/user-attachments/assets/50bd5bac-e644-4421-95d6-5236c55a3c43" />


* Restoring the behaviour for SCOs color as in v6 to differentiate them more easily


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15421 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
