### PR TITLE
[frontend/backend] Playbooks: add filter for component Security Coverage (#14285)

### DIFF
--- a/docs/docs/usage/automation.md
+++ b/docs/docs/usage/automation.md
@@ -453,6 +453,22 @@ It will allow you to continue only if some specific conditions are met.
 - No-match: if none of the entity/observable contained in the bundle passes the matching condition, then the STIX bundle will follow the **no-match** route.
 - Out: if at least one of the entity/observable contained in the bundle passes the matching condition, then the STIX bundle will follow the **out** route.
 
+### Security coverage
+
+Will create a new security coverage for the entities (with compatible types) contained in the received STIX 2.1 bundle and send out the modified bundle. The bundle will contain the initial entities plus the created security coverages.
+
+By default, creation is applied for the entity triggering the playbook. You can change this behavior with the following options:
+
+- all elements in the bundle (elements that might result from enrichment for example)
+- all elements except the entity triggering the playbook
+
+![Enroll entity in playbook](assets/playbook_select_bundle_scope.png)
+
+**Specificities of the component**
+
+**Operations filtering:**
+You have the possibility to add filters at the component level. The elements in the bundle will be filtered so only matching elements will be concerned by the operations of the component. This filtering has no impact on the output of the component, the bundle elements remain the same, they are only filtered to determine if the operations should be applied or not.
+
 ## Enroll manually an entity into a playbook
 
 You can enroll individual entities in playbooks by using the action "Enroll in playbook" from the entity details view.

--- a/docs/docs/usage/automation.md
+++ b/docs/docs/usage/automation.md
@@ -248,14 +248,19 @@ When the primary entity you listen to is an incident & then use the "Container W
 
 ### Security coverage
 
-Will create a security coverage for the given elements when type is compatible.
+Will create a new security coverage for the entities (with compatible types) contained in the received STIX 2.1 bundle and send out the modified bundle. The bundle will contain the initial entities plus the created security coverages.
 
-By default, creation is applied to the entity triggering the playbook. You can change this behavior with the following options:
+By default, creation is applied for the entity triggering the playbook. You can change this behavior with the following options:
 
 - all elements in the bundle (elements that might result from enrichment for example)
 - all elements except the entity triggering the playbook
 
 ![Enroll entity in playbook](assets/playbook_select_bundle_scope.png)
+
+**Specificities of the component**
+
+**Operations filtering:**
+You have the possibility to add filters at the component level. The elements in the bundle will be filtered so only matching elements will be concerned by the operations of the component. This filtering has no impact on the output of the component, the bundle elements remain the same, they are only filtered to determine if the operations should be applied or not.
 
 ### Share with organizations
 
@@ -452,22 +457,6 @@ It will allow you to continue only if some specific conditions are met.
 
 - No-match: if none of the entity/observable contained in the bundle passes the matching condition, then the STIX bundle will follow the **no-match** route.
 - Out: if at least one of the entity/observable contained in the bundle passes the matching condition, then the STIX bundle will follow the **out** route.
-
-### Security coverage
-
-Will create a new security coverage for the entities (with compatible types) contained in the received STIX 2.1 bundle and send out the modified bundle. The bundle will contain the initial entities plus the created security coverages.
-
-By default, creation is applied for the entity triggering the playbook. You can change this behavior with the following options:
-
-- all elements in the bundle (elements that might result from enrichment for example)
-- all elements except the entity triggering the playbook
-
-![Enroll entity in playbook](assets/playbook_select_bundle_scope.png)
-
-**Specificities of the component**
-
-**Operations filtering:**
-You have the possibility to add filters at the component level. The elements in the bundle will be filtered so only matching elements will be concerned by the operations of the component. This filtering has no impact on the output of the component, the bundle elements remain the same, they are only filtered to determine if the operations should be applied or not.
 
 ## Enroll manually an entity into a playbook
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/security-coverage-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/security-coverage-component.ts
@@ -10,10 +10,12 @@ import type { StixDomainObject } from '../../../types/stix-2-1-common';
 import { extractStixRepresentative } from '../../../database/stix-representative';
 import { convertStoreToStix_2_1 } from '../../../database/stix-2-1-converter';
 import { ENTITY_TYPE_SECURITY_COVERAGE, INPUT_COVERED, type StixSecurityCoverage, type StoreEntitySecurityCoverage } from '../../securityCoverage/securityCoverage-types';
-import { isBundleElementInScope } from '../playbook-utils';
+import { filterBundleElements, isBundleElementInScope } from '../playbook-utils';
+import { executionContext } from '../../../utils/access';
 
 export interface SecurityCoverageConfiguration {
   applyToElements: PlaybookBundleElementsToApply;
+  applyWithFilters?: string;
   auto_enrichment_disable: boolean;
   periodicity: string;
   duration: string;
@@ -33,6 +35,11 @@ const PLAYBOOK_SECURITY_COVERAGE_COMPONENT_SCHEMA: JSONSchemaType<SecurityCovera
         { const: playbookBundleElementsToApply.allElements.value, title: playbookBundleElementsToApply.allElements.title },
         { const: playbookBundleElementsToApply.allExceptMain.value, title: playbookBundleElementsToApply.allExceptMain.title },
       ],
+    },
+    applyWithFilters: {
+      type: 'string',
+      nullable: true,
+      default: '',
     },
     auto_enrichment_disable: { type: 'boolean', $ref: 'Force manual coverage (prevent enrichment connectors from running)', default: false },
     periodicity: { type: 'string', $ref: 'Coverage recurrence (every x)', default: 'P1D' },
@@ -74,9 +81,19 @@ export const PLAYBOOK_SECURITY_COVERAGE_COMPONENT: PlaybookComponent<SecurityCov
   configuration_schema: PLAYBOOK_SECURITY_COVERAGE_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_SECURITY_COVERAGE_COMPONENT_SCHEMA,
   executor: async ({ dataInstanceId, playbookNode, bundle }) => {
-    const { applyToElements, auto_enrichment_disable, periodicity, duration, type_affinity, platforms_affinity } = playbookNode.configuration;
+    const context = executionContext('playbook_components');
+    const {
+      applyToElements,
+      applyWithFilters,
+      auto_enrichment_disable,
+      periodicity,
+      duration,
+      type_affinity,
+      platforms_affinity,
+    } = playbookNode.configuration;
 
-    const elementsToApply = bundle.objects.filter((object) => isBundleElementInScope(object, applyToElements, dataInstanceId));
+    const inScopeElements = bundle.objects.filter((object) => isBundleElementInScope(object, applyToElements, dataInstanceId));
+    const elementsToApply = (await filterBundleElements(context, inScopeElements, applyWithFilters));
 
     for (let index = 0; index < elementsToApply.length; index += 1) {
       const element = elementsToApply[index] as StixDomainObject;

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/security-coverage-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/security-coverage-component.ts
@@ -93,7 +93,7 @@ export const PLAYBOOK_SECURITY_COVERAGE_COMPONENT: PlaybookComponent<SecurityCov
     } = playbookNode.configuration;
 
     const inScopeElements = bundle.objects.filter((object) => isBundleElementInScope(object, applyToElements, dataInstanceId));
-    const elementsToApply = (await filterBundleElements(context, inScopeElements, applyWithFilters));
+    const elementsToApply = await filterBundleElements(context, inScopeElements, applyWithFilters);
 
     for (let index = 0; index < elementsToApply.length; index += 1) {
       const element = elementsToApply[index] as StixDomainObject;

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/security-coverage-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/security-coverage-component-test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { PLAYBOOK_SECURITY_COVERAGE_COMPONENT } from '../../../../src/modules/playbook/components/security-coverage-component';
+import { PLAYBOOK_SECURITY_COVERAGE_COMPONENT, type SecurityCoverageConfiguration } from '../../../../src/modules/playbook/components/security-coverage-component';
 import { testBundleObject, testExecutor } from './playbook-components-test-utils';
 import type { StixSecurityCoverage } from '../../../../src/modules/securityCoverage/securityCoverage-types';
-import { playbookBundleElementsToApply, type PlaybookBundleElementsToApply } from '../../../../src/modules/playbook/playbook-types';
+import { playbookBundleElementsToApply } from '../../../../src/modules/playbook/playbook-types';
 
-const MAIN_ID = 'report--b4754e7d-88b4-51d9-aac4-86edaad66c4d';
+const REPORT_ID = 'report--b4754e7d-88b4-51d9-aac4-86edaad66c4d';
 const INTRUSION_SET_ID = 'intrusion-set--1ad04810-ab05-5873-96f5-a89d19607e1c';
 const CAMPAIGN_ID = 'campaign--c85bcdd3-1042-5f74-ab5d-05fddf30bdb8';
 
-const enteringBundleObjects = () => [
+const BUNDLE_OBJECTS = () => [
   testBundleObject({
-    id: MAIN_ID,
+    id: REPORT_ID,
     type: 'report',
     octiExtension: { type: 'Report' },
     object_refs: [
@@ -30,14 +30,15 @@ const enteringBundleObjects = () => [
   }),
 ];
 
-const componentConfig = ({ elementsToApply }: { elementsToApply: PlaybookBundleElementsToApply }) => {
+const componentConfig = (config: Partial<SecurityCoverageConfiguration>) => {
   return {
-    applyToElements: elementsToApply,
+    applyToElements: playbookBundleElementsToApply.onlyMain.value,
     auto_enrichment_disable: false,
     duration: 'P30D',
     periodicity: 'P1D',
     platforms_affinity: ['windows', 'linux', 'macos'],
     type_affinity: 'ENDPOINT',
+    ...config,
   };
 };
 
@@ -45,9 +46,9 @@ describe('Security coverage component', () => {
   it('should create a security coverage only for main element with the only main option', async () => {
     const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(
       testExecutor({
-        mainId: MAIN_ID,
-        bundleObjects: enteringBundleObjects(),
-        configuration: componentConfig({ elementsToApply: playbookBundleElementsToApply.onlyMain.value }),
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({ applyToElements: playbookBundleElementsToApply.onlyMain.value }),
       }),
     );
 
@@ -56,15 +57,15 @@ describe('Security coverage component', () => {
     ) as StixSecurityCoverage[];
 
     expect(securityCoverages).toHaveLength(1);
-    expect(securityCoverages[0].covered_ref).toEqual(MAIN_ID);
+    expect(securityCoverages[0].covered_ref).toEqual(REPORT_ID);
   });
 
   it('should create a security coverage for each element of the bundle with the all elements option', async () => {
     const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(
       testExecutor({
-        mainId: MAIN_ID,
-        bundleObjects: enteringBundleObjects(),
-        configuration: componentConfig({ elementsToApply: playbookBundleElementsToApply.allElements.value }),
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({ applyToElements: playbookBundleElementsToApply.allElements.value }),
       }),
     );
 
@@ -74,7 +75,7 @@ describe('Security coverage component', () => {
 
     expect(securityCoverages).toHaveLength(3);
 
-    const mainElementSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === MAIN_ID);
+    const mainElementSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === REPORT_ID);
     const intrusionSetSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === INTRUSION_SET_ID);
     const campaignSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === CAMPAIGN_ID);
 
@@ -86,9 +87,9 @@ describe('Security coverage component', () => {
   it('should create a security coverage for each element except main with the all except main option', async () => {
     const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(
       testExecutor({
-        mainId: MAIN_ID,
-        bundleObjects: enteringBundleObjects(),
-        configuration: componentConfig({ elementsToApply: playbookBundleElementsToApply.allExceptMain.value }),
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({ applyToElements: playbookBundleElementsToApply.allExceptMain.value }),
       }),
     );
 
@@ -98,12 +99,163 @@ describe('Security coverage component', () => {
 
     expect(securityCoverages).toHaveLength(2);
 
-    const mainElementSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === MAIN_ID);
+    const mainElementSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === REPORT_ID);
     const intrusionSetSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === INTRUSION_SET_ID);
     const campaignSecurityCoverage = securityCoverages.filter((o) => o.covered_ref === CAMPAIGN_ID);
 
     expect(mainElementSecurityCoverage).toHaveLength(0);
     expect(intrusionSetSecurityCoverage).toHaveLength(1);
     expect(campaignSecurityCoverage).toHaveLength(1);
+  });
+
+  describe('Filter elements manipulated', () => {
+    const filterGrounping = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Grouping"],"mode":"or"}],"filterGroups":[]}';
+    const filterReport = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Report"],"mode":"or"}],"filterGroups":[]}';
+    const filterReportCampaign = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Report", "Campaign"],"mode":"or"}],"filterGroups":[]}';
+    const filterAll = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Report", "Campaign", "Intrusion-Set"],"mode":"or"}],"filterGroups":[]}';
+
+    it('should create nothing if no match (only-main)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.onlyMain.value,
+          applyWithFilters: filterGrounping,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(0);
+    });
+
+    it('should create for only main if match (only-main)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.onlyMain.value,
+          applyWithFilters: filterAll,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(1);
+      expect(securityCoverages[0].covered_ref).toEqual(REPORT_ID);
+    });
+
+    it('should create nothing if no match (all-elements)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allElements.value,
+          applyWithFilters: filterGrounping,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(0);
+    });
+
+    it('should create only for report and campaign if partial match (all-elements)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allElements.value,
+          applyWithFilters: filterReportCampaign,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(2);
+      expect(securityCoverages[0].covered_ref).toEqual(REPORT_ID);
+      expect(securityCoverages[1].covered_ref).toEqual(CAMPAIGN_ID);
+    });
+
+    it('should create for all elements if full match (all-elements)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allElements.value,
+          applyWithFilters: filterAll,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(3);
+      expect(securityCoverages[0].covered_ref).toEqual(REPORT_ID);
+      expect(securityCoverages[1].covered_ref).toEqual(INTRUSION_SET_ID);
+      expect(securityCoverages[2].covered_ref).toEqual(CAMPAIGN_ID);
+    });
+
+    it('should create nothing if no match (all-except-main)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allExceptMain.value,
+          applyWithFilters: filterGrounping,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(0);
+    });
+
+    it('should create nothing if match only main (all-except-main)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allExceptMain.value,
+          applyWithFilters: filterReport,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(0);
+    });
+
+    it('should create only for campaign if partial match (all-except-main)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allExceptMain.value,
+          applyWithFilters: filterReportCampaign,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(1);
+      expect(securityCoverages[0].covered_ref).toEqual(CAMPAIGN_ID);
+    });
+
+    it('should create for all elements except main if full match (all-except-main)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: 'all-except-main',
+          applyWithFilters: filterAll,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(2);
+      expect(securityCoverages[0].covered_ref).toEqual(INTRUSION_SET_ID);
+      expect(securityCoverages[1].covered_ref).toEqual(CAMPAIGN_ID);
+    });
   });
 });


### PR DESCRIPTION
### Proposed changes

* Add new attribute `applyWithFilters` on component config
* Add backend tests for the logic
* Update documentation

### Related issues

* #14285 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality