### PR TITLE
[backend] added a timeout to rabbitMQ metrics queries (#12680)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -475,8 +475,8 @@ export const send = async (exchangeName, routingKey, message) => {
 export const metrics = async (context, user) => {
   const metricApi = async () => {
     const httpClient = await amqpHttpClient();
-    const overview = await httpClient.get('/api/overview').then((response) => response.data);
-    const queues = await httpClient.get(`/api/queues${VHOST_PATH}`).then((response) => response.data);
+    const overview = await httpClient.get('/api/overview', { timeout: 5000 }).then((response) => response.data);
+    const queues = await httpClient.get(`/api/queues${VHOST_PATH}`, { timeout: 5000 }).then((response) => response.data);
     // Compute number of push queues
     const platformQueues = queues.filter((q) => q.name.startsWith(RABBIT_QUEUE_PREFIX));
     const pushQueues = platformQueues.filter((q) => q.name.startsWith(`${RABBIT_QUEUE_PREFIX}push_`) && q.consumers > 0);

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -66,7 +66,108 @@ vi.mock('lru-cache', () => {
   return { LRUCache: FakeLRUCache };
 });
 
-import { getConnectorQueueSize } from '../../../src/database/rabbitmq';
+import { getConnectorQueueSize, metrics } from '../../../src/database/rabbitmq';
+
+describe('rabbitmq: metrics', () => {
+  const context = {};
+  const user = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return overview, consumers count and filtered platform queues', async () => {
+    const overviewData = { rabbitmq_version: '3.12.0', cluster_name: 'test' };
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: overviewData });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'opencti_push_connector-abc', messages: 42, consumers: 3 },
+            { name: 'opencti_listen_connector-abc', messages: 5, consumers: 0 },
+            { name: 'other_queue', messages: 100, consumers: 2 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await metrics(context, user);
+
+    expect(result.overview).toEqual(overviewData);
+    expect(result.consumers).toBe(3);
+    // Only platform queues (starting with 'opencti_') should be included
+    expect(result.queues).toHaveLength(2);
+    expect(result.queues.every((q: { name: string }) => q.name.startsWith('opencti_'))).toBe(true);
+  });
+
+  it('should return consumers as 0 when no push queues have consumers', async () => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'opencti_push_connector-abc', messages: 10, consumers: 0 },
+            { name: 'opencti_listen_connector-abc', messages: 5, consumers: 0 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await metrics(context, user);
+
+    expect(result.consumers).toBe(0);
+  });
+
+  it('should return empty queues when no platform queues exist', async () => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({
+          data: [
+            { name: 'some_other_queue', messages: 100, consumers: 5 },
+          ],
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const result = await metrics(context, user);
+
+    expect(result.overview).toEqual({ rabbitmq_version: '3.12.0' });
+    expect(result.consumers).toBe(0);
+    expect(result.queues).toHaveLength(0);
+  });
+
+  it('should pass a 5 seconds timeout to the GET requests', async () => {
+    mockHttpClient.get.mockImplementation(() => {
+      return Promise.resolve({ data: [] });
+    });
+
+    await metrics(context, user);
+
+    expect(mockHttpClient.get).toHaveBeenCalledTimes(2);
+    expect(mockHttpClient.get).toHaveBeenCalledWith('/api/overview', { timeout: 5000 });
+    expect(mockHttpClient.get).toHaveBeenCalledWith(expect.stringContaining('/api/queues'), { timeout: 5000 });
+  });
+
+  it('should propagate errors from the HTTP client', async () => {
+    mockHttpClient.get.mockRejectedValue(new Error('Connection refused'));
+
+    await expect(metrics(context, user)).rejects.toThrow('Connection refused');
+  });
+});
 
 describe('rabbitmq: getConnectorQueueSize', () => {
   const context = {};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* added a timeout to rabbitMQ metrics queries 
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #12680
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
