### PR TITLE
[frontend] fix rectangle selection (#15432)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/RectangleSelection.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/RectangleSelection.tsx
@@ -40,14 +40,18 @@ const RectangleSelection = ({
       const graphCanvas = document.querySelector(`#${graphId} canvas`);
       if (graphCanvas) {
         const { left, top } = graphCanvas.getBoundingClientRect();
+        // The library provides page coordinates (pageX/pageY) but
+        // getBoundingClientRect() is viewport-relative; account for scroll.
+        const offsetLeft = left + window.scrollX;
+        const offsetTop = top + window.scrollY;
         setCoords({
           origin: [
-            Math.min(selectionCoords.origin[0], selectionCoords.target[0]) - left,
-            Math.min(selectionCoords.origin[1], selectionCoords.target[1]) - top,
+            Math.min(selectionCoords.origin[0], selectionCoords.target[0]) - offsetLeft,
+            Math.min(selectionCoords.origin[1], selectionCoords.target[1]) - offsetTop,
           ],
           target: [
-            Math.max(selectionCoords.origin[0], selectionCoords.target[0]) - left,
-            Math.max(selectionCoords.origin[1], selectionCoords.target[1]) - top,
+            Math.max(selectionCoords.origin[0], selectionCoords.target[0]) - offsetLeft,
+            Math.max(selectionCoords.origin[1], selectionCoords.target[1]) - offsetTop,
           ],
         });
       }
@@ -59,17 +63,42 @@ const RectangleSelection = ({
     setCoords(null);
   };
 
+  const overlayColor = theme.palette.background?.accent
+    ? hexToRGB(theme.palette.background.accent, 0.3)
+    : theme.palette.warn.main;
+  const borderColor = theme.palette.warn.main;
+
   return (
     <RectangleSelectionLib
       style={{
-        backgroundColor: theme.palette.background?.accent ? hexToRGB(theme.palette.background.accent, 0.3) : theme.palette.warn.main,
-        borderColor: theme.palette.warn.main,
+        // Hide the library's built-in selection box: it uses pageX/pageY as
+        // CSS left/top which is incorrect when the graph is not at the
+        // document origin (e.g. behind a side-nav or top-bar).
+        display: 'none',
       }}
       disabled={disabled}
       onMouseUp={sendState}
       onSelect={updateStateOnSelect}
     >
-      {children}
+      <div style={{ position: 'relative', height: 'inherit', width: 'inherit' }}>
+        {/* Render our own overlay positioned relative to the graph container */}
+        {coords && (
+          <div
+            style={{
+              position: 'absolute',
+              left: coords.origin[0],
+              top: coords.origin[1],
+              width: coords.target[0] - coords.origin[0],
+              height: coords.target[1] - coords.origin[1],
+              backgroundColor: overlayColor,
+              border: `1px dashed ${borderColor}`,
+              pointerEvents: 'none',
+              zIndex: 10,
+            }}
+          />
+        )}
+        {children}
+      </div>
     </RectangleSelectionLib>
   );
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

**Root cause**
The react-rectangle-selection library positions its visual selection box using pageX/pageY as CSS left/top on a position: absolute div. These are document-relative coordinates, but the CSS positioning resolves relative to the nearest positioned ancestor — not the document origin. Since the graph is nested inside the OpenCTI layout (with a side nav, top bar, etc.), the visual box was offset from the actual cursor position.

Fix in RectangleSelection.tsx:
1. Hidden the library's built-in selection box (display: 'none' via the style prop) since it can't be positioned correctly.
2. Render our own overlay div using the already-computed canvas-relative coords state. This overlay is positioned inside a new position: relative wrapper div, so position: absolute on the overlay resolves correctly relative to the graph area.
3. Added scroll offset correction (window.scrollX/window.scrollY) when computing canvas-relative coordinates from the library's pageX/pageY values and getBoundingClientRect() (viewport-relative), ensuring correctness even if the page is scrolled.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15432 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
