### PR TITLE
[backend] Fixes for improve data sharing in public (#14918)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -24,7 +24,15 @@ import {
   READ_INDEX_STIX_SIGHTING_RELATIONSHIPS,
   READ_STIX_INDICES,
 } from '../database/utils';
-import { BYPASS, computeUserMemberAccessIds, isUserCanAccessStixElement, isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT, SYSTEM_USER } from '../utils/access';
+import {
+  BYPASS,
+  computeUserMemberAccessIds,
+  isUserCanAccessStixElement,
+  isUserHasCapability,
+  isUserInPlatformOrganization,
+  KNOWLEDGE_ORGANIZATION_RESTRICT,
+  SYSTEM_USER,
+} from '../utils/access';
 import { FROM_START_STR, streamEventId, utcDate } from '../utils/format';
 import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_OBJECT, buildRefRelationKey, ENTITY_TYPE_CONTAINER, STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
@@ -36,8 +44,9 @@ import { getParentTypes } from '../schema/schemaUtils';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import { fullRelationsList } from '../database/middleware-loader';
 import { RELATION_OBJECT } from '../schema/stixRefRelationship';
-import { getEntitiesListFromCache } from '../database/cache';
+import { getEntitiesListFromCache, getEntityFromCache } from '../database/cache';
 import { ENTITY_TYPE_STREAM_COLLECTION } from '../modules/dataSharing/streamCollection-types';
+import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { isStixDomainObjectContainer } from '../schema/stixDomainObject';
 import { STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
 import { generateCreateMessage } from '../database/data-changes';
@@ -168,7 +177,6 @@ const computeUserAndCollection = async (req, res, { context, user, id }) => {
 
 export const authenticateForPublic = async (req, res, next) => {
   const context = await createAuthenticatedContext(req, res, 'stream_authenticate');
-  req.context = context;
   req.expirationTime = utcDate().add(1, 'days').toDate();
   const { error, collection, streamFilters } = await computeUserAndCollection(req, res, {
     context,
@@ -187,11 +195,16 @@ export const authenticateForPublic = async (req, res, next) => {
       req.userId = user.id;
       req.capabilities = user.capabilities;
       req.allowed_marking = user.allowed_marking;
+      if (collection?.stream_public) {
+        const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+        context.user_inside_platform_organization = isUserInPlatformOrganization(user, settings);
+      }
     } catch (e) {
       res.statusMessage = e.message ?? 'Public stream configuration error';
       sendErrorStatus(req, res, 500);
       return;
     }
+    req.context = context;
     req.collection = collection;
     req.streamFilters = streamFilters;
     next();

--- a/opencti-platform/opencti-graphql/src/http/httpRollingFeed.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpRollingFeed.ts
@@ -8,6 +8,7 @@ import { isUserHasCapability, isUserInPlatformOrganization, SYSTEM_USER } from '
 import { resolvePublicUser } from '../modules/dataSharing/dataSharing-utils';
 import { getEntityFromCache } from '../database/cache';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
+import type { BasicStoreSettings } from '../types/settings';
 import { findById as findFeed } from '../modules/dataSharing/feed-domain';
 import { fullEntitiesOrRelationsList } from '../database/middleware';
 import { minutesAgo } from '../utils/format';
@@ -312,7 +313,7 @@ const initHttpRollingFeeds = (app: Express.Application) => {
       // User is available or feed is public
       const user = await resolveUserForFeed(context, feed);
       if (feed.feed_public) {
-        const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+        const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
         context.user_inside_platform_organization = isUserInPlatformOrganization(user, settings);
       }
       const filters = feed.filters ? JSON.parse(feed.filters) : undefined;

--- a/opencti-platform/opencti-graphql/src/http/httpRollingFeed.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpRollingFeed.ts
@@ -4,8 +4,10 @@ import nconf from 'nconf';
 import { TAXIIAPI } from '../domain/user';
 import { basePath } from '../config/conf';
 import { ForbiddenAccess } from '../config/errors';
-import { isUserHasCapability, SYSTEM_USER } from '../utils/access';
+import { isUserHasCapability, isUserInPlatformOrganization, SYSTEM_USER } from '../utils/access';
 import { resolvePublicUser } from '../modules/dataSharing/dataSharing-utils';
+import { getEntityFromCache } from '../database/cache';
+import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { findById as findFeed } from '../modules/dataSharing/feed-domain';
 import { fullEntitiesOrRelationsList } from '../database/middleware';
 import { minutesAgo } from '../utils/format';
@@ -277,8 +279,8 @@ export const buildCsvLines = (elements: any[], feed: BasicStoreEntityFeed, neigh
 };
 
 export const resolveUserForFeed = async (context: AuthContext, feed: BasicStoreEntityFeed): Promise<AuthUser> => {
-  if (context.user) return context.user;
   if (feed.feed_public) return resolvePublicUser(context, feed.feed_public_user_id);
+  if (context.user) return context.user;
   throw ForbiddenAccess();
 };
 
@@ -309,6 +311,10 @@ const initHttpRollingFeeds = (app: Express.Application) => {
       }
       // User is available or feed is public
       const user = await resolveUserForFeed(context, feed);
+      if (feed.feed_public) {
+        const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+        context.user_inside_platform_organization = isUserInPlatformOrganization(user, settings);
+      }
       const filters = feed.filters ? JSON.parse(feed.filters) : undefined;
       const fromDate = minutesAgo(feed.rolling_time);
       const field = feed.feed_date_attribute ?? 'created_at';

--- a/opencti-platform/opencti-graphql/src/http/httpTaxii.js
+++ b/opencti-platform/opencti-graphql/src/http/httpTaxii.js
@@ -10,8 +10,10 @@ import { basePath, getBaseUrl, logApp } from '../config/conf';
 import { AuthRequired, error, ForbiddenAccess, UNSUPPORTED_ERROR, UnsupportedError } from '../config/errors';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import { findById, restAllCollections, restBuildCollection, restCollectionManifest, restCollectionStix } from '../modules/dataSharing/taxiiCollection-domain';
-import { executionContext, isUserHasCapability, SYSTEM_USER } from '../utils/access';
+import { executionContext, isUserHasCapability, isUserInPlatformOrganization, SYSTEM_USER } from '../utils/access';
 import { resolvePublicUser } from '../modules/dataSharing/dataSharing-utils';
+import { getEntityFromCache } from '../database/cache';
+import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { findById as findTaxiiCollection } from '../modules/ingestion/ingestion-taxii-collection-domain';
 import { handleConfidenceToScoreTransformation, pushBundleToConnectorQueue } from '../manager/ingestionManager';
 import { now } from '../utils/format';
@@ -64,13 +66,16 @@ const getUpdatedAt = (obj) => {
 };
 
 export const extractUserAndCollection = async (req, res, id) => {
-  const findCollection = await findById(executionContext('taxii'), SYSTEM_USER, id);
+  const taxiiContext = executionContext('taxii');
+  const findCollection = await findById(taxiiContext, SYSTEM_USER, id);
   if (!findCollection) {
     throw ForbiddenAccess();
   }
   if (findCollection.taxii_public) {
-    const publicUser = await resolvePublicUser(executionContext('taxii'), findCollection.taxii_public_user_id);
-    return { user: publicUser, collection: findCollection };
+    const publicUser = await resolvePublicUser(taxiiContext, findCollection.taxii_public_user_id);
+    const settings = await getEntityFromCache(taxiiContext, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
+    taxiiContext.user_inside_platform_organization = isUserInPlatformOrganization(publicUser, settings);
+    return { context: taxiiContext, user: publicUser, collection: findCollection };
   }
   const context = await checkAuthenticationFromRequest(req, res);
   const userCollection = await findById(context, context.user, id);

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
@@ -108,9 +108,11 @@ describe('authenticateForPublic middleware', () => {
   });
 
   it('calls next() and sets req.user for a public stream with no auth user', async () => {
-    vi.mocked(createAuthenticatedContext).mockResolvedValue({ user: null } as any);
+    const mockContext: any = { user: null, user_inside_platform_organization: false };
+    vi.mocked(createAuthenticatedContext).mockResolvedValue(mockContext);
     vi.mocked(getEntitiesListFromCache).mockResolvedValue([MOCK_STREAM_COLLECTION] as any);
     vi.mocked(resolvePublicUser).mockResolvedValue(MOCK_PUBLIC_USER as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue({ platform_organization: null } as any);
 
     const req = makeMockReq({ id: 'stream-1' });
     const res = makeMockRes();
@@ -122,6 +124,31 @@ describe('authenticateForPublic middleware', () => {
     expect(req.user).toBe(MOCK_PUBLIC_USER);
     expect(req.userId).toBe('public-user-id');
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('recomputes user_inside_platform_organization for the resolved public user even when an admin is authenticated', async () => {
+    // Simulates an admin (bypass, inside platform org) accessing a public stream URL.
+    // user_inside_platform_organization must be overridden to reflect the *public user*, not the admin.
+    const adminUser = { id: 'admin-id', user_email: 'admin@test.com', capabilities: [], allowed_marking: [], organizations: [] };
+    const mockContext: any = { user: adminUser, user_inside_platform_organization: true };
+    vi.mocked(createAuthenticatedContext).mockResolvedValue(mockContext);
+    vi.mocked(getEntitiesListFromCache).mockResolvedValue([MOCK_STREAM_COLLECTION] as any);
+    vi.mocked(resolvePublicUser).mockResolvedValue({ ...MOCK_PUBLIC_USER, organizations: [{ internal_id: 'filigran-org' }] } as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue({ platform_organization: 'bae-org-id' } as any);
+    // isUserInPlatformOrganization returns false: public user (Filigran) is NOT in the platform org (BAE)
+    const { isUserInPlatformOrganization } = await import('../../../../src/utils/access');
+    vi.mocked(isUserInPlatformOrganization).mockReturnValue(false);
+
+    const req = makeMockReq({ id: 'stream-1' });
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticateForPublic(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).not.toBe(adminUser);
+    // Context must now reflect the public user's org membership, NOT the admin's
+    expect(mockContext.user_inside_platform_organization).toBe(false);
   });
 
   it('returns 401 when stream does not exist and user is unauthenticated', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
@@ -6,6 +6,7 @@ vi.mock('../../../../src/http/httpAuthenticatedContext', () => ({
 }));
 vi.mock('../../../../src/database/cache', () => ({
   getEntitiesListFromCache: vi.fn(),
+  getEntityFromCache: vi.fn(),
 }));
 vi.mock('../../../../src/modules/dataSharing/dataSharing-utils', () => ({
   resolvePublicUser: vi.fn(),
@@ -18,8 +19,9 @@ vi.mock('../../../../src/utils/access', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../src/utils/access')>();
   return {
     ...actual,
-    executionContext: vi.fn(() => ({ user: null })),
+    executionContext: vi.fn(() => ({ user: null, user_inside_platform_organization: false })),
     isUserHasCapability: vi.fn(() => true),
+    isUserInPlatformOrganization: vi.fn(() => false),
   };
 });
 vi.mock('../../../../src/config/conf', async () => {
@@ -41,7 +43,7 @@ vi.mock('../../../../src/schema/identifier', async (importOriginal) => {
 });
 
 import { createAuthenticatedContext } from '../../../../src/http/httpAuthenticatedContext';
-import { getEntitiesListFromCache } from '../../../../src/database/cache';
+import { getEntitiesListFromCache, getEntityFromCache } from '../../../../src/database/cache';
 import { resolvePublicUser } from '../../../../src/modules/dataSharing/dataSharing-utils';
 import { findById as findTaxiiCollection } from '../../../../src/modules/dataSharing/taxiiCollection-domain';
 import { authenticateForPublic } from '../../../../src/graphql/sseMiddleware.js';
@@ -194,15 +196,17 @@ describe('extractUserAndCollection middleware helper (TAXII)', () => {
     vi.clearAllMocks();
   });
 
-  it('returns public user and collection for a public taxii collection', async () => {
+  it('returns context, public user and collection for a public taxii collection', async () => {
     vi.mocked(findTaxiiCollection).mockResolvedValue(MOCK_TAXII_COLLECTION as any);
     vi.mocked(resolvePublicUser).mockResolvedValue(MOCK_PUBLIC_USER as any);
+    vi.mocked(getEntityFromCache).mockResolvedValue({ platform_organization: null } as any);
 
     const req = makeMockReq();
     const res = makeMockRes();
 
     const result = await extractUserAndCollection(req, res, 'taxii-1');
 
+    expect(result.context).toBeDefined();
     expect(result.user).toBe(MOCK_PUBLIC_USER);
     expect(result.collection).toBe(MOCK_TAXII_COLLECTION);
   });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
@@ -255,10 +255,10 @@ describe('resolveUserForFeed helper', () => {
     vi.clearAllMocks();
   });
 
-  it('returns authenticated user when context.user is set', async () => {
+  it('returns authenticated user when context.user is set and feed is private', async () => {
     const mockUser = { id: 'auth-user', user_email: 'auth@test.com' } as any;
     const context = { user: mockUser } as any;
-    const feed = { feed_public_user_id: 'public-id' } as any;
+    const feed = { feed_public: false, feed_public_user_id: undefined } as any;
 
     const result = await resolveUserForFeed(context, feed);
 
@@ -266,7 +266,21 @@ describe('resolveUserForFeed helper', () => {
     expect(resolvePublicUser).not.toHaveBeenCalled();
   });
 
-  it('calls resolvePublicUser when context.user is null (public feed)', async () => {
+  it('calls resolvePublicUser for a public feed even when an authenticated user is in context (admin session)', async () => {
+    // Admin is authenticated but the feed is public — the public user must always win.
+    const adminUser = { id: 'admin-id', user_email: 'admin@test.com' } as any;
+    vi.mocked(resolvePublicUser).mockResolvedValue({ id: 'public-user' } as any);
+    const context = { user: adminUser } as any;
+    const feed = { feed_public: true, feed_public_user_id: 'public-id' } as any;
+
+    const result = await resolveUserForFeed(context, feed);
+
+    expect(resolvePublicUser).toHaveBeenCalledWith(context, 'public-id');
+    expect(result).toEqual({ id: 'public-user' });
+    expect(result).not.toBe(adminUser);
+  });
+
+  it('calls resolvePublicUser when context.user is null (public feed, no session)', async () => {
     vi.mocked(resolvePublicUser).mockResolvedValue({ id: 'public-user' } as any);
     const context = { user: null } as any;
     const feed = { feed_public: true, feed_public_user_id: 'public-id' } as any;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Two bug fixes for public data sharing when a platform organization is configured and the impersonated public user belongs to a different organization:

**TAXII — no data returned on the target platform**

`extractUserAndCollection` was returning the resolved public user without a valid `context`. Because the actual user is not a bypass user (unlike the previous `SYSTEM_USER`), all downstream calls (`elPaginate`, `stixLoadByIds`) required a context with a correctly set `user_inside_platform_organization`. Without it, the calls threw a `TypeError` → 500 error → empty feed. Fixed by reusing a single `taxiiContext`, fetching platform settings, and computing `user_inside_platform_organization` for the public user before returning.

**Stream — data leaking to non-platform-org public user**

When an authenticated user (e.g. admin) accesses a public stream URL, `createAuthenticatedContext` sets `context.user_inside_platform_organization = true` (for the admin). The public user was then resolved correctly as `req.user`, but the context flag was never corrected. Every `isStixMatchFilterGroup` call in the stream event loop then short-circuited all org-restriction checks, making all data visible regardless of the public user's organization. Fixed by recomputing `context.user_inside_platform_organization = isUserInPlatformOrganization(publicUser, settings)` immediately after resolving the public user, so org-based data visibility is correctly enforced throughout the stream.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #14918 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
