### PR TITLE
[backend] Fix work status transitioning to complete too early (#8224)

### DIFF
--- a/client-python/pycti/api/opencti_api_work.py
+++ b/client-python/pycti/api/opencti_api_work.py
@@ -179,28 +179,56 @@ class OpenCTIApiWork:
             except Exception:
                 self.api.app_logger.error("Cannot add draft context")
 
-    def initiate_work(self, connector_id: str, friendly_name: str) -> Optional[str]:
+    def initiate_work(
+        self,
+        connector_id: str,
+        friendly_name: str,
+        is_multipart: bool = False,
+    ) -> Optional[str]:
         """Initiate a new work for a connector.
 
-        :param connector_id: the connector id
-        :type connector_id: str
-        :param friendly_name: the friendly name for the work
-        :type friendly_name: str
-        :return: the work id or None if bundle_send_to_queue is False
+        :param connector_id:    the connector id
+        :type connector_id:     str
+        :param friendly_name:   the friendly name for the work
+        :type friendly_name:    str
+        :param is_multipart:    indicates whether multiple calls to `add_expectations`
+                                are to be expected during the lifetime of the work.
+                                In consequence the work won't automatically
+                                transition to `complete` when the number of calls
+                                to `report_expectation` matches the expectations
+                                but only when an explicit call to `to_processed`
+                                is made.
+                                Should be set to `True` when sending multiple
+                                STIX bundles consecutively via `send_stix2_bundle`
+                                during the work's lifetime.
+                                Defaults to `False`.
+        :type is_multipart:     bool
+        :return:                the work id or None if bundle_send_to_queue is False
         :rtype: str or None
         """
         if self.api.bundle_send_to_queue:
-            self.api.app_logger.info("Initiate work", {"connector_id": connector_id})
+            self.api.app_logger.info(
+                "Initiate work",
+                {
+                    "connector_id": connector_id,
+                    "friendly_name": friendly_name,
+                    "is_multipart": is_multipart,
+                },
+            )
             query = """
-                mutation workAdd($connectorId: String!, $friendlyName: String) {
-                    workAdd(connectorId: $connectorId, friendlyName: $friendlyName) {
+                mutation workAdd($connectorId: String!, $friendlyName: String, $isMultiPartWork: Boolean) {
+                    workAdd(connectorId: $connectorId, friendlyName: $friendlyName, isMultiPartWork: $isMultiPartWork) {
                       id
                     }
                 }
                """
             work = self.api.query(
                 query,
-                {"connectorId": connector_id, "friendlyName": friendly_name},
+                {
+                    "connectorId": connector_id,
+                    "friendlyName": friendly_name,
+                    "isMultiPartWork": is_multipart,
+                },
                 True,
             )
             return work["data"]["workAdd"]["id"]

--- a/docs/docs/development/connectors.md
+++ b/docs/docs/development/connectors.md
@@ -354,29 +354,90 @@ By implementing the work registration, they will show up as shown in this screen
 
 ```python
 def run() -> None:
-		# Anounce upcoming work
-		timestamp = int(time.time())
-		now = datetime.utcfromtimestamp(timestamp)
-    friendly_name = "Template run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
-    work_id = self.helper.api.work.initiate_work(
-				self.helper.connect_id, friendly_name
-		)
+    work_id = None
+    message = ""
+    in_error = False
+    try:
+        # Announce upcoming work
+        timestamp = int(time.time())
+        now = datetime.utcfromtimestamp(timestamp)
+        friendly_name = "Template run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id, friendly_name
+        )
 
-		[...]
-		# Send Stix bundle
-		self.helper.send_stix2_bundle(
-				bundle,
-				entities_types=self.helper.connect_scope,
-				update=True,
-				work_id=work_id,
-		)
-		# Finish the work
-		self.helper.log_info(
-			f"Connector successfully run, storing last_run as {str(timestamp)}"
-    )              
-		message = "Last_run stored, next run in: {str(round(self.get_interval() / 60 / 60 / 24, 2))} days"
-		self.helper.api.work.to_processed(work_id, message)
+        # [...]
+
+        # Send Stix bundle
+        self.helper.send_stix2_bundle(
+            bundle,
+            entities_types=self.helper.connect_scope,
+            update=True,
+            work_id=work_id,
+        )
+        # Finish the work
+        self.helper.log_info(
+            f"Connector successfully run, storing last_run as {str(timestamp)}"
+        )              
+        message = f"Last_run stored, next run in: {str(round(self.get_interval() / 60 / 60 / 24, 2))} days"
+    except Exception as ex:
+        in_error = True
+        message = f"Failed: {str(ex)}"
+    finally:
+        if work_id is not None:
+            self.helper.api.work.to_processed(work_id, message, in_error=in_error)
 ```
+
+Connectors sending multiple bundles during a single `work` need to pass the
+`is_multipart=True` option when initiating the work:
+
+```python
+def run() -> None:
+    work_id = None
+    message = ""
+    in_error = False
+    try:
+        # Announce upcoming work
+        timestamp = int(time.time())
+        now = datetime.utcfromtimestamp(timestamp)
+        friendly_name = "Template run @ " + now.strftime("%Y-%m-%d %H:%M:%S")
+        work_id = self.helper.api.work.initiate_work(
+            self.helper.connect_id,
+            friendly_name,
+            is_multipart=True,
+        )
+
+        # [...]
+
+        # Send the bundles (could be in a loop)
+        # Send first Stix bundle
+        self.helper.send_stix2_bundle(
+            bundleOne,
+            entities_types=self.helper.connect_scope,
+            update=True,
+            work_id=work_id,
+        )
+        # Send second Stix bundle
+        self.helper.send_stix2_bundle(
+            bundleTwo,
+            entities_types=self.helper.connect_scope,
+            update=True,
+            work_id=work_id,
+        )
+
+        # Finish the work
+        self.helper.log_info(
+            f"Connector successfully run, storing last_run as {str(timestamp)}"
+        )              
+        message = f"Last_run stored, next run in: {str(round(self.get_interval() / 60 / 60 / 24, 2))} days"
+    except Exception as ex:
+        in_error = True
+        message = f"Failed {str(ex)}"
+    finally:
+        if work_id is not None:
+            self.helper.api.work.to_processed(work_id, message, in_error=in_error)
+```
+
 
 #### Interval handling
 

--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -448,6 +448,7 @@
   "Include inferences": "Schlussfolgerungen einbeziehen",
   "Included IDs": "Enthaltene IDs",
   "Index date": "Index Datum",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "Gibt an, ob für diese Arbeit mehrere Aufrufe von add_expectations zu erwarten sind",
   "Indicator decay manager": "Indikator Abklingmanager",
   "Indicator filters": "Indikator-Filter",
   "Indicator observable types": "Indikator beobachtbare Typen",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "XTM One Registrierungsmanager",
   "XTM1 CGU acceptance status": "XTM1 CGU-Annahmestatus"
 }
+

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -448,6 +448,7 @@
   "Include inferences": "Include inferences",
   "Included IDs": "Included IDs",
   "Index date": "Index date",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "Indicates whether multiple calls to add_expectations are expected for this work",
   "Indicator decay manager": "Indicator decay manager",
   "Indicator filters": "Indicator filters",
   "Indicator observable types": "Indicator observable types",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "XTM One registration manager",
   "XTM1 CGU acceptance status": "XTM1 CGU acceptance status"
 }
+

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -448,6 +448,7 @@
   "Include inferences": "Incluir inferencias",
   "Included IDs": "IDs incluidos",
   "Index date": "Fecha índice",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "Indica si se esperan múltiples llamadas a add_expectations para este trabajo",
   "Indicator decay manager": "Indicador gestor de decaimiento",
   "Indicator filters": "Filtros indicadores",
   "Indicator observable types": "Indicador de tipos observables",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "Gestor de inscripciones XTM One",
   "XTM1 CGU acceptance status": "XTM1 Estado de aceptación de la UGC"
 }
+

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -448,6 +448,7 @@
   "Include inferences": "Inclure les inférences",
   "Included IDs": "ID inclus",
   "Index date": "Date d'indexation",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "Indique si plusieurs appels à add_expectations sont prévus pour ce travail",
   "Indicator decay manager": "Gestionnaire de la décroissance de l'indicateur",
   "Indicator filters": "Filtres indicateurs",
   "Indicator observable types": "Types d'indicateurs observables",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "Gestionnaire d'enregistrement XTM One",
   "XTM1 CGU acceptance status": "XTM1 Statut d'acceptation des CGU"
 }
+

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -448,6 +448,7 @@
   "Include inferences": "Includi inferenze",
   "Included IDs": "ID inclusi",
   "Index date": "Data di indicizzazione",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "Indica se per questo lavoro sono previste più chiamate a add_expectations",
   "Indicator decay manager": "Gestore del decadimento degli indicatori",
   "Indicator filters": "Filtri indicatori",
   "Indicator observable types": "Tipi di osservabili degli indicatori",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "Gestore delle registrazioni XTM One",
   "XTM1 CGU acceptance status": "XTM1 Stato di accettazione della CGU"
 }
+

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -448,6 +448,7 @@
   "Include inferences": "推論を含む",
   "Included IDs": "含まれるID",
   "Index date": "添付ファイル",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "この作品に複数のadd_expectationsの呼び出しが予想されるかどうかを示す。",
   "Indicator decay manager": "インジケーター・ディケイ・マネージャー",
   "Indicator filters": "インジケーターフィルター",
   "Indicator observable types": "インジケータの観測可能なタイプ",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "XTM One登録マネージャー",
   "XTM1 CGU acceptance status": "XTM1 CGU受入状況"
 }
+

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -448,6 +448,7 @@
   "Include inferences": "추론 포함",
   "Included IDs": "포함된 ID",
   "Index date": "인덱스 날짜",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "이 작업에 대해 추가_기대치에 대한 여러 호출이 예상되는지 여부를 나타냅니다",
   "Indicator decay manager": "지표 감쇠 관리자",
   "Indicator filters": "표시기 필터",
   "Indicator observable types": "지표 관찰 가능 유형",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "XTM One 등록 관리자",
   "XTM1 CGU acceptance status": "XTM1 CGU 승인 상태"
 }
+

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -448,6 +448,7 @@
   "Include inferences": "Включите умозаключения",
   "Included IDs": "Включенные идентификаторы",
   "Index date": "Дата индекса",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "Указывает, ожидается ли несколько вызовов add_expectations для этой работы",
   "Indicator decay manager": "Менеджер по распаду индикаторов",
   "Indicator filters": "Индикаторные фильтры",
   "Indicator observable types": "Наблюдаемые типы индикаторов",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "Менеджер регистрации XTM One",
   "XTM1 CGU acceptance status": "Статус принятия XTM1 CGU"
 }
+

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -448,6 +448,7 @@
   "Include inferences": "包含推论",
   "Included IDs": "包含的 ID",
   "Index date": "索引日期",
+  "Indicates whether multiple calls to add_expectations are expected for this work": "表示该工作是否需要多次调用 add_expectations",
   "Indicator decay manager": "指标衰减管理器",
   "Indicator filters": "指标筛选器",
   "Indicator observable types": "指标观察物类型",
@@ -1073,3 +1074,4 @@
   "XTM One registration manager": "XTM One 注册管理器",
   "XTM1 CGU acceptance status": "XTM1 CGU 验收状态"
 }
+

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10258,7 +10258,7 @@ type Mutation {
   synchronizerStart(id: ID!): Synchronizer
   synchronizerStop(id: ID!): Synchronizer
   synchronizerTest(input: SynchronizerAddInput): String
-  workAdd(connectorId: String!, friendlyName: String): Work!
+  workAdd(connectorId: String!, friendlyName: String, isMultiPartWork: Boolean = false): Work!
   workEdit(id: ID!): WorkEditMutations
   workDelete(connectorId: String!): Boolean
   deleteBackgroundTask(id: ID!): ID!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -16403,7 +16403,7 @@ type Mutation {
   synchronizerTest(input: SynchronizerAddInput): String @auth(for: [CONNECTORAPI, INGESTION_SETINGESTIONS])
 
   ### WORK
-  workAdd(connectorId: String!, friendlyName: String): Work! @auth(for: [CONNECTORAPI, MODULES_MODMANAGE, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNGETEXPORT_KNASKEXPORT])
+  workAdd(connectorId: String!, friendlyName: String, isMultiPartWork: Boolean = false): Work! @auth(for: [CONNECTORAPI, MODULES_MODMANAGE, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNGETEXPORT_KNASKEXPORT])
   workEdit(id: ID!): WorkEditMutations @auth(for: [CONNECTORAPI, MODULES_MODMANAGE])
   workDelete(connectorId: String!): Boolean @auth(for: [CONNECTORAPI, MODULES_MODMANAGE])
 

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -497,11 +497,13 @@ export const redisGetWorkCompletionState = async (workId: string) => {
     import_processed_number: pn,
     import_expected_number: en,
     is_processed,
+    is_multipart,
   } = await redisGetWork(workId);
   const total = parseInt(pn, 10);
   const expected = parseInt(en, 10);
   const isProcessed = is_processed === 'true';
-  return { total, expected, isProcessed };
+  const isMultiPartWork = is_multipart === 'true';
+  return { total, expected, isProcessed, isMultiPartWork };
 };
 export const redisUpdateWorkFigures = async (workId: string) => {
   const timestamp = now();
@@ -524,9 +526,12 @@ export const redisUpdateActionExpectation = async (user: AuthUser, workId: strin
   });
   return workId;
 };
-export const redisInitializeWork = async (workId: string) => {
+export const redisInitializeWork = async (workId: string, isMultiPartWork: boolean) => {
   await redisTx(getClientBase(), async (tx) => {
-    await updateObjectRaw(tx, workId, { is_initialized: true });
+    await updateObjectRaw(tx, workId, {
+      is_initialized: true,
+      is_multipart: isMultiPartWork,
+    });
   });
 };
 // endregion

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -499,8 +499,8 @@ export const redisGetWorkCompletionState = async (workId: string) => {
     is_processed,
     is_multipart,
   } = await redisGetWork(workId);
-  const total = parseInt(pn, 10);
-  const expected = parseInt(en, 10);
+  const total = pn ? parseInt(pn, 10) : 0;
+  const expected = en ? parseInt(en, 10) : 0;
   const isProcessed = is_processed === 'true';
   const isMultiPartWork = is_multipart === 'true';
   return { total, expected, isProcessed, isMultiPartWork };

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -486,11 +486,22 @@ export const redisDeleteWorks = async (internalIds: Array<string>) => {
 export const redisGetWork = async (internalId: string) => {
   return getClientBase().hgetall(internalId);
 };
-export const isWorkCompleted = async (workId: string) => {
-  const { import_processed_number: pn, import_expected_number: en } = await redisGetWork(workId);
+export const redisMarkWorkAsProcessed = async (workId: string) => {
+  const clientBase = getClientBase();
+  await redisTx(clientBase, async (tx) => {
+    await updateObjectRaw(tx, workId, { is_processed: true });
+  });
+};
+export const redisGetWorkCompletionState = async (workId: string) => {
+  const {
+    import_processed_number: pn,
+    import_expected_number: en,
+    is_processed,
+  } = await redisGetWork(workId);
   const total = parseInt(pn, 10);
   const expected = parseInt(en, 10);
-  return { isComplete: total === expected, total, expected };
+  const isProcessed = is_processed === 'true';
+  return { total, expected, isProcessed };
 };
 export const redisUpdateWorkFigures = async (workId: string) => {
   const timestamp = now();
@@ -503,7 +514,6 @@ export const redisUpdateWorkFigures = async (workId: string) => {
     await updateObjectCounterRaw(tx, workId, 'import_processed_number', 1);
     await updateObjectRaw(tx, workId, { import_last_processed: timestamp });
   });
-  return isWorkCompleted(workId);
 };
 export const redisGetConnectorStatus = async (connectorId: string) => {
   return getClientBase().get(`work:${connectorId}`);

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -331,11 +331,11 @@ export const updateExpectationsNumber = async (context, user, workId, expectatio
     logApp.warn('The work cannot be found in database, expectation cannot be updated.', { workId, expectations });
     return workId;
   }
+  await redisUpdateActionExpectation(user, workId, expectations);
   const params = { updated_at: now(), import_expected_number: expectations };
   let source = 'ctx._source.updated_at = params.updated_at;';
   source += 'ctx._source["import_expected_number"] = ctx._source["import_expected_number"] + params.import_expected_number;';
   await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
-  await redisUpdateActionExpectation(user, workId, expectations);
   // Ensure that work hasn't been deleted in the meantime in case of race condition
   const workAlive = await isWorkAlive(context, user, workId);
   if (!workAlive) {
@@ -389,11 +389,10 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
     return workId;
   }
   const { expected, total, isMultiPartWork } = await redisGetWorkCompletionState(workId);
-  const workIsFinished = isWorkFinished(expected, total);
-  if (isMultiPartWork && !workIsFinished) {
+  const isComplete = isWorkFinished(expected, total);
+  if (isMultiPartWork && !isComplete) {
     await redisMarkWorkAsProcessed(workId);
   }
-  const isComplete = currentWork.import_expected_number === 0 || workIsFinished;
   const params = { processed_time: now(), message };
   let source = 'ctx._source["processed_time"] = params.processed_time;';
   if (isComplete) {

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -384,9 +384,9 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
   await redisMarkWorkAsProcessed(workId);
   const params = { processed_time: now(), message };
   const { expected, total } = await redisGetWorkCompletionState(workId);
-  const isComplete = isWorkFinished(expected, total);
+  const isComplete = currentWork.import_expected_number === 0 || isWorkFinished(expected, total);
   let source = 'ctx._source["processed_time"] = params.processed_time;';
-  if (currentWork.import_expected_number === 0 || isComplete) {
+  if (isComplete) {
     params.completed_number = total && !Number.isNaN(total) ? total : 1;
     source += `ctx._source['status'] = "complete";
                ctx._source['import_expected_number'] = params.completed_number;

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -388,7 +388,9 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
     logApp.warn('The work cannot be found in database, processed time cannot be updated.', { workId });
     return workId;
   }
-  await redisMarkWorkAsProcessed(workId);
+  if (currentWork.is_multipart && currentWork.status !== 'complete') {
+    await redisMarkWorkAsProcessed(workId);
+  }
   const params = { processed_time: now(), message };
   const { expected, total } = await redisGetWorkCompletionState(workId);
   const isComplete = currentWork.import_expected_number === 0 || isWorkFinished(expected, total);

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -211,7 +211,13 @@ export const deleteWorkForSource = async (sourceId) => {
 
 export const createWork = async (context, user, connector, friendlyName, sourceId, args = {}) => {
   // Create the new work
-  const { receivedTime = null, background_task_id, fileMarkings = [], draftContext } = args;
+  const {
+    receivedTime = null,
+    background_task_id,
+    fileMarkings = [],
+    draftContext,
+  } = args;
+  const isMultiPartWork = args.isMultiPartWork === true;
   // Create the work and an initial job
   const { id: workId, timestamp } = generateWorkId(connector.internal_id);
   const work = {
@@ -234,6 +240,7 @@ export const createWork = async (context, user, connector, friendlyName, sourceI
     processed_time: null,
     completed_time: null,
     completed_number: 0,
+    is_multipart: isMultiPartWork,
     messages: [],
     errors: [],
     [buildRefRelationKey(RELATION_OBJECT_MARKING)]: [...fileMarkings],
@@ -245,7 +252,7 @@ export const createWork = async (context, user, connector, friendlyName, sourceI
   const createdWork = await loadWorkById(context, user, workId);
   // If work was created, initialize work on redis
   if (createdWork) {
-    await redisInitializeWork(createdWork.id);
+    await redisInitializeWork(createdWork.id, isMultiPartWork);
   }
   return createdWork;
 };
@@ -271,8 +278,8 @@ const isWorkFinished = (expected, total) => total >= expected;
 export const reportExpectation = async (context, user, workId, errorData) => {
   const timestamp = now();
   await redisUpdateWorkFigures(workId);
-  const { expected, total, isProcessed } = await redisGetWorkCompletionState(workId);
-  const isComplete = isProcessed && isWorkFinished(expected, total);
+  const { expected, total, isProcessed, isMultiPartWork } = await redisGetWorkCompletionState(workId);
+  const isComplete = (!isMultiPartWork || isProcessed) && isWorkFinished(expected, total);
   // Ensure that work hasn't been deleted in the meantime
   const workAlive = await isWorkAlive(context, user, workId);
   if (!workAlive) {

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -3,7 +3,15 @@ import * as R from 'ramda';
 import { elDeleteInstances, elIndex, elLoadById, elPaginate, elRawDeleteByQuery, elUpdate, ES_MINIMUM_FIXED_PAGINATION } from '../database/engine';
 import { generateWorkId } from '../schema/identifier';
 import { INDEX_HISTORY, isNotEmptyField, READ_INDEX_HISTORY } from '../database/utils';
-import { isWorkCompleted, redisDeleteWorks, redisGetWork, redisInitializeWork, redisUpdateActionExpectation, redisUpdateWorkFigures } from '../database/redis';
+import {
+  redisDeleteWorks,
+  redisGetWork,
+  redisGetWorkCompletionState,
+  redisInitializeWork,
+  redisMarkWorkAsProcessed,
+  redisUpdateActionExpectation,
+  redisUpdateWorkFigures,
+} from '../database/redis';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_WORK } from '../schema/internalObject';
 import { now, sinceNowInMinutes } from '../utils/format';
 import { buildRefRelationKey, CONNECTOR_INTERNAL_EXPORT_FILE } from '../schema/general';
@@ -258,9 +266,13 @@ const updateWorkTaskToComplete = async (context, user, work) => {
   }
 };
 
+const isWorkFinished = (expected, total) => total >= expected;
+
 export const reportExpectation = async (context, user, workId, errorData) => {
   const timestamp = now();
-  const { isComplete, total } = await redisUpdateWorkFigures(workId);
+  await redisUpdateWorkFigures(workId);
+  const { expected, total, isProcessed } = await redisGetWorkCompletionState(workId);
+  const isComplete = isProcessed && isWorkFinished(expected, total);
   // Ensure that work hasn't been deleted in the meantime
   const workAlive = await isWorkAlive(context, user, workId);
   if (!workAlive) {
@@ -369,9 +381,11 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
     logApp.warn('The work cannot be found in database, processed time cannot be updated.', { workId });
     return workId;
   }
+  await redisMarkWorkAsProcessed(workId);
   const params = { processed_time: now(), message };
+  const { expected, total } = await redisGetWorkCompletionState(workId);
+  const isComplete = isWorkFinished(expected, total);
   let source = 'ctx._source["processed_time"] = params.processed_time;';
-  const { isComplete, total } = await isWorkCompleted(workId);
   if (currentWork.import_expected_number === 0 || isComplete) {
     params.completed_number = total && !Number.isNaN(total) ? total : 1;
     source += `ctx._source['status'] = "complete";

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -388,12 +388,13 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
     logApp.warn('The work cannot be found in database, processed time cannot be updated.', { workId });
     return workId;
   }
-  if (currentWork.is_multipart && currentWork.status !== 'complete') {
+  const { expected, total, isMultiPartWork } = await redisGetWorkCompletionState(workId);
+  const workIsFinished = isWorkFinished(expected, total);
+  if (isMultiPartWork && !workIsFinished) {
     await redisMarkWorkAsProcessed(workId);
   }
+  const isComplete = currentWork.import_expected_number === 0 || workIsFinished;
   const params = { processed_time: now(), message };
-  const { expected, total } = await redisGetWorkCompletionState(workId);
-  const isComplete = currentWork.import_expected_number === 0 || isWorkFinished(expected, total);
   let source = 'ctx._source["processed_time"] = params.processed_time;';
   if (isComplete) {
     params.completed_number = total && !Number.isNaN(total) ? total : 1;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -19862,6 +19862,7 @@ export type MutationVulnerabilityEditArgs = {
 export type MutationWorkAddArgs = {
   connectorId: Scalars['String']['input'];
   friendlyName?: InputMaybe<Scalars['String']['input']>;
+  isMultiPartWork?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -46917,7 +46918,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   vocabularyFieldPatch?: Resolver<Maybe<ResolversTypes['Vocabulary']>, ParentType, ContextType, RequireFields<MutationVocabularyFieldPatchArgs, 'id' | 'input'>>;
   vulnerabilityAdd?: Resolver<Maybe<ResolversTypes['Vulnerability']>, ParentType, ContextType, RequireFields<MutationVulnerabilityAddArgs, 'input'>>;
   vulnerabilityEdit?: Resolver<Maybe<ResolversTypes['VulnerabilityEditMutations']>, ParentType, ContextType, RequireFields<MutationVulnerabilityEditArgs, 'id'>>;
-  workAdd?: Resolver<ResolversTypes['Work'], ParentType, ContextType, RequireFields<MutationWorkAddArgs, 'connectorId'>>;
+  workAdd?: Resolver<ResolversTypes['Work'], ParentType, ContextType, RequireFields<MutationWorkAddArgs, 'connectorId' | 'isMultiPartWork'>>;
   workDelete?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationWorkDeleteArgs, 'connectorId'>>;
   workEdit?: Resolver<Maybe<ResolversTypes['WorkEditMutations']>, ParentType, ContextType, RequireFields<MutationWorkEditArgs, 'id'>>;
   workspaceAdd?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceAddArgs, 'input'>>;

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -487,6 +487,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition<any>> 
     { name: 'received_time', label: 'Reception date', type: 'date', editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: true },
     { name: 'completed_time', label: 'Completion date', type: 'date', editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: true },
     { name: 'completed_number', label: 'Completed number', type: 'numeric', precision: 'integer', editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: true },
+    { name: 'is_multipart', label: 'Indicates whether multiple calls to add_expectations are expected for this work', type: 'boolean', editDefault: false, mandatoryType: 'no', multiple: false, upsert: false, isFilterable: false },
     {
       name: 'messages',
       label: 'Messages',

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -178,9 +178,12 @@ const connectorResolvers = {
     },
     // endregion
     // Work part
-    workAdd: async (_, { connectorId, friendlyName }, context) => {
+    workAdd: async (_, { connectorId, friendlyName, isMultiPartWork }, context) => {
       const connectorEntity = await connector(context, context.user, connectorId);
-      return createWork(context, context.user, connectorEntity, friendlyName, connectorEntity.id, { receivedTime: now() });
+      return createWork(context, context.user, connectorEntity, friendlyName, connectorEntity.id, {
+        receivedTime: now(),
+        isMultiPartWork: isMultiPartWork ?? false,
+      });
     },
     workEdit: (_, { id }, context) => ({
       delete: () => deleteWork(context, context.user, id),

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
@@ -489,6 +489,33 @@ describe('Connector using the default work isMultiPartWork=false option', () => 
   });
 });
 
+describe('Connector completing without actual work', () => {
+  it('should mark work as completed', async () => {
+    let queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, {
+      query: CREATE_WORK_QUERY,
+      variables: {
+        connectorId: TEST_CN_ID,
+        friendlyName: 'TestConnectorNoWork',
+      },
+    });
+    const workId = queryResult.data.workAdd.id;
+
+    // Admin sees 'progress' status
+    queryResult = await queryAsAdminWithSuccess({ query: READ_WORK_QUERY, variables: { id: workId } });
+    expect(queryResult.data.work.status).toEqual('progress');
+
+    // Connector notifies backend it's done
+    await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_QUERY, variables: {
+      id: workId,
+      message: 'Done',
+    } });
+
+    // Admin sees status changed to `complete`
+    queryResult = await queryAsAdminWithSuccess({ query: READ_WORK_QUERY, variables: { id: workId } });
+    expect(queryResult.data.work.status).toEqual('complete');
+  });
+});
+
 describe('Capability checks', () => {
   it('Editor user should not be allowed to see connector details', async () => {
     await queryAsUserIsExpectedForbidden(USER_EDITOR, { query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
@@ -51,6 +51,7 @@ const READ_WORK_QUERY = gql`
       id
       name
       status
+      completed_number
     }
   }
 `;
@@ -59,6 +60,22 @@ const UPDATE_WORK_QUERY = gql`
   mutation workToProcessed($id: ID!, $message: String, $inError: Boolean) {
     workEdit(id: $id) {
       toProcessed(message: $message, inError: $inError)
+    }
+  }
+`;
+
+const UPDATE_WORK_ADD_EXPECTATIONS_QUERY = gql`
+  mutation workAddExpectations($id: ID!, $expectations: Int) {
+    workEdit(id: $id) {
+      addExpectations(expectations: $expectations)
+    }
+  }
+`;
+
+const UPDATE_WORK_REPORT_EXPECTATION_QUERY = gql`
+  mutation workReportExpectation($id: ID!, $error: WorkErrorInput) {
+    workEdit(id: $id) {
+      reportExpectation(error: $error)
     }
   }
 `;
@@ -300,6 +317,130 @@ describe('Connector resolver standard behaviour', () => {
     expect(queryResult.data.pingConnector.connector_info.queue_threshold).toBe(490.2);
     expect(queryResult.data.pingConnector.connector_info.next_run_datetime.toISOString()).toBe(datetimeNextRun.toISOString());
     expect(queryResult.data.pingConnector.connector_info.last_run_datetime.toISOString()).toBe(datetimeLastRun.toISOString());
+  });
+});
+
+describe('Connector sending multiple bundles during the same work', () => {
+  describe('when worker finishes all work items before connector', () => {
+    it('should mark work as completed when connector calls to_processed', async () => {
+      let queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, {
+        query: CREATE_WORK_QUERY,
+        variables: {
+          connectorId: TEST_CN_ID,
+          friendlyName: 'TestConnectorMultipleBundlesFastWorker',
+        },
+      });
+      const workId = queryResult.data.workAdd.id;
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('progress');
+
+      // Connector sends bundle #1: increase expectation count
+      await queryAsAdminWithSuccess({
+        query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
+        variables: { id: workId, expectations: 3 },
+      });
+
+      // Worker treats all 3 work items
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: {
+        id: workId,
+        error: {
+          error: 'woups',
+          source: 'code',
+        },
+      } });
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+
+      // Status should still be `progress`
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('progress');
+
+      // Connector sends bundle #2: increase expectation count
+      await queryAsAdminWithSuccess({
+        query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
+        variables: { id: workId, expectations: 2 },
+      });
+
+      // Worker treats all 2 work items
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+
+      // Status should still be `progress`
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('progress');
+
+      // Connector notifies backend it processed all bundles
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_QUERY, variables: {
+        id: workId,
+        message: 'Done',
+      } });
+
+      // Status should have changed to `complete`
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('complete');
+      expect(queryResult.data.work.completed_number).toEqual(5);
+    });
+  });
+
+  describe('when connector notifies to_processed before worker finished items', () => {
+    it('should mark work as completed after worker finished last item', async () => {
+      let queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, {
+        query: CREATE_WORK_QUERY,
+        variables: {
+          connectorId: TEST_CN_ID,
+          friendlyName: 'TestConnectorMultipleBundles',
+        },
+      });
+      const workId = queryResult.data.workAdd.id;
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('progress');
+
+      // Connector sends bundle #1: increase expectation count
+      await queryAsAdminWithSuccess({
+        query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
+        variables: { id: workId, expectations: 3 },
+      });
+
+      // Worker treats all 3 work items
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: {
+        id: workId,
+        error: {
+          error: 'woups',
+          source: 'code',
+        },
+      } });
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+
+      // Status should still be `progress`
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('progress');
+
+      // Connector sends bundle #2: increase expectation count
+      await queryAsAdminWithSuccess({
+        query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
+        variables: { id: workId, expectations: 2 },
+      });
+
+      // Connector notifies backend it processed all bundles
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_QUERY, variables: {
+        id: workId,
+        message: 'Done',
+      } });
+
+      // Status should still be `progress`
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('progress');
+
+      // Worker treats all remaining items
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+      await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+
+      // Status should have changed to `complete`
+      queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+      expect(queryResult.data.work.status).toEqual('complete');
+      expect(queryResult.data.work.completed_number).toEqual(5);
+    });
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
@@ -10,8 +10,8 @@ import { IMPORT_CSV_CONNECTOR } from '../../../src/connector/importCsv/importCsv
 import { DRAFT_VALIDATION_CONNECTOR } from '../../../src/modules/draftWorkspace/draftWorkspace-connector';
 
 const CREATE_WORK_QUERY = gql`
-  mutation workAdd($connectorId: String!, $friendlyName: String) {
-    workAdd(connectorId: $connectorId, friendlyName: $friendlyName) {
+  mutation workAdd($connectorId: String!, $friendlyName: String, $isMultiPartWork: Boolean) {
+    workAdd(connectorId: $connectorId, friendlyName: $friendlyName, isMultiPartWork: $isMultiPartWork) {
       id
     }
   }
@@ -320,14 +320,15 @@ describe('Connector resolver standard behaviour', () => {
   });
 });
 
-describe('Connector sending multiple bundles during the same work', () => {
+describe('Connector sending multiple bundles during the same multi-part work', () => {
   describe('when worker finishes all work items before connector', () => {
     it('should mark work as completed when connector calls to_processed', async () => {
       let queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, {
         query: CREATE_WORK_QUERY,
         variables: {
           connectorId: TEST_CN_ID,
-          friendlyName: 'TestConnectorMultipleBundlesFastWorker',
+          friendlyName: 'TestConnectorMultipleBundles',
+          isMultiPartWork: true,
         },
       });
       const workId = queryResult.data.workAdd.id;
@@ -335,7 +336,7 @@ describe('Connector sending multiple bundles during the same work', () => {
       expect(queryResult.data.work.status).toEqual('progress');
 
       // Connector sends bundle #1: increase expectation count
-      await queryAsAdminWithSuccess({
+      await queryAsUserWithSuccess(USER_CONNECTOR, {
         query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
         variables: { id: workId, expectations: 3 },
       });
@@ -356,7 +357,7 @@ describe('Connector sending multiple bundles during the same work', () => {
       expect(queryResult.data.work.status).toEqual('progress');
 
       // Connector sends bundle #2: increase expectation count
-      await queryAsAdminWithSuccess({
+      await queryAsUserWithSuccess(USER_CONNECTOR, {
         query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
         variables: { id: workId, expectations: 2 },
       });
@@ -389,6 +390,7 @@ describe('Connector sending multiple bundles during the same work', () => {
         variables: {
           connectorId: TEST_CN_ID,
           friendlyName: 'TestConnectorMultipleBundles',
+          isMultiPartWork: true,
         },
       });
       const workId = queryResult.data.workAdd.id;
@@ -417,7 +419,7 @@ describe('Connector sending multiple bundles during the same work', () => {
       expect(queryResult.data.work.status).toEqual('progress');
 
       // Connector sends bundle #2: increase expectation count
-      await queryAsAdminWithSuccess({
+      await queryAsUserWithSuccess(USER_CONNECTOR, {
         query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
         variables: { id: workId, expectations: 2 },
       });
@@ -441,6 +443,49 @@ describe('Connector sending multiple bundles during the same work', () => {
       expect(queryResult.data.work.status).toEqual('complete');
       expect(queryResult.data.work.completed_number).toEqual(5);
     });
+  });
+});
+
+describe('Connector using the default work isMultiPartWork=false option', () => {
+  it('should mark work as completed when all items are processed', async () => {
+    let queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, {
+      query: CREATE_WORK_QUERY,
+      variables: {
+        connectorId: TEST_CN_ID,
+        friendlyName: 'TestConnectorSinglePart',
+      },
+    });
+    const workId = queryResult.data.workAdd.id;
+    queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+    expect(queryResult).not.toBeNull();
+    expect(queryResult.data.work.status).toEqual('progress');
+
+    // Add expectation count
+    await queryAsAdminWithSuccess({
+      query: UPDATE_WORK_ADD_EXPECTATIONS_QUERY,
+      variables: { id: workId, expectations: 5 },
+    });
+
+    // Report as many expectations
+    await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+    await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+    await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: {
+      id: workId,
+      error: {
+        error: 'woups',
+        source: 'code',
+      },
+    } });
+    await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+
+    queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+    expect(queryResult.data.work.status).toEqual('progress');
+
+    await queryAsUserWithSuccess(USER_CONNECTOR, { query: UPDATE_WORK_REPORT_EXPECTATION_QUERY, variables: { id: workId } });
+
+    // Status should have changed to `complete` without the need to call `toProcessed`
+    queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
+    expect(queryResult.data.work.status).toEqual('complete');
   });
 });
 


### PR DESCRIPTION
### Problem analysis

Here's a rough sequence diagram about what happens between the Connector, the Backend, the Worker, the Queue:

```mermaid
sequenceDiagram
    autonumber

    participant C as Connector
    participant B as Backend
    participant MQ as RabbitMQ
    participant W as Worker

    rect rgb(220, 235, 255)
        note over C, B: 1. Work Initiation
        C->>+B: initiate_work()<br/>→ mutation workAdd
        B-->>-C: work_id
    end

    rect rgb(220, 255, 225)
        note over C, MQ: 2. Bundle Submission
        C->>+B: send_stix2_bundle()<br/>→ mutation workEdit.addExpectations(work_id, count)
        B-->>-C: ack

        loop For each STIX2 bundle chunk
            C->>MQ: send_stix2_bundle()<br/>→ publish bundle to queue
        end
    end

    rect rgb(255, 245, 200)
        note over C, B: 3. Work Completion Signal
        C->>+B: to_processed()<br/>→ mutation workEdit.toProcessed(work_id)
        B-->>-C: ack
    end

    rect rgb(255, 225, 220)
        note over W, B: 4. Bundle Processing (per bundle)
        loop For each bundle in queue
            W->>+MQ: consume message
            MQ-->>-W: STIX2 bundle

            loop For each STIX2 object in bundle
                W->>+B: import object<br/>→ REST / GraphQL mutation
                B-->>-W: ack
            end

            W->>+B: mutation workEdit.reportExpectation(work_id)
            B-->>-W: ack
        end
    end
```

The steps are the following:
- The "Connector" calls the "workAdd" mutation on the "Backend", via the "initiate_work()" python helper
- The  "Connector" calls the "send_stix2_bundle" python helper that does two things:  calls the "workEdit.addExpectations" mutation on the "Backend" and puts multiple bundles on the "RabbitMQ" queue.
- The "Connector" calls the "workEdit.toProcessed" mutation on the "Backend", via the "to_processed" python helper
- The "Worker" gets an item on the "RabbitMQ" queue to treat it: for each item in the bundle it imports it into the "Backend" and then calls "workEdit.reportExpectation"

There is a race between the connector and the workers: the issue arises when the worker(s) finish all ongoing work (i.e. handle all items of the bundles on the queue, section `4` in the diagramm) before the connector has time to send all bundles (or more precisely, before the connector has time to increase the expectation count to its final value, section `2` in the diagram).
This race only happens when multiple bundles are sent during a work as the connector calls `workEdit.addExpectations` once per bundle in `send_stix2_bundle`.

### Proposed changes

We can fix the race by waiting for both the Connector and the Workers to have finished before proceeding to changing the status to `complete`:
- the Connector signals it has finished by calling the `workEdit.toProcessed` endpoint
- the Workers have finished when all expected items have been processed

Backend:
* Set a `is_processed` flag in redis when the connector calls `workEdit.toProcessed`. Access this flag in `workEdit.reportExpectation` and use as a gate to change the work status to `complete`.
* Add integrations tests to cover the race between connector and workers

### Potential BREAKING CHANGES

This fix could affect some connectors that don't correctly call `api.work.to_processed()` as said by the documentation (see here: https://docs.opencti.io/latest/development/connectors/?h=send_stix2_bundle#initiating-a-work-before-pushing-data) or the provided dev template (see here: https://github.com/OpenCTI-Platform/connectors/blob/master/templates/external-import/src/connector/connector.py#L181).
For those the Work could remain blocked in the `progress` state. We do however have a mechanism to clean up all old works so it's not a big deal IMO.

Also, I've opened another PR to fix all `3` external-import connectors that don't call `to_processed()`.

I suggest we advertise this change as potentially a breaking change to let on-prem admins fix their connectors if needed.
It's still a better solution than an alternative

### Related issues

* Fixes https://github.com/OpenCTI-Platform/opencti/issues/8224

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
