### PR TITLE
[frontend] refactor MarkdownField to tsx and move to dedicated folder (#7281)

### DIFF
--- a/opencti-platform/opencti-front/src/components/fields/markdownField/MarkdownField.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/markdownField/MarkdownField.tsx
@@ -1,15 +1,31 @@
-import React, { useState } from 'react';
+import React, { CSSProperties, FocusEvent, useState } from 'react';
 import ReactMde from 'react-mde';
-import { useField } from 'formik';
+import { FieldInputProps, FormikProps, useField } from 'formik';
 import InputLabel from '@mui/material/InputLabel';
 import FormHelperText from '@mui/material/FormHelperText';
 import { isNil } from 'ramda';
-import useAI from '../../utils/hooks/useAI';
-import TextFieldAskAI from '../../private/components/common/form/TextFieldAskAI';
-import { useFormatter } from '../i18n';
-import MarkdownDisplay from '../MarkdownDisplay';
+import useAI from '../../../utils/hooks/useAI';
+import TextFieldAskAI from '../../../private/components/common/form/TextFieldAskAI';
+import { useFormatter } from '../../i18n';
+import MarkdownDisplay from '../../MarkdownDisplay';
 
-const MarkdownField = (props) => {
+interface MarkdownFieldProps {
+  form: FormikProps<Record<string, unknown>>;
+  field: FieldInputProps<string>;
+  required?: boolean;
+  onFocus?: (name: string) => void;
+  onSubmit?: (name: string, value: string) => void;
+  onSelect?: (value: string) => void;
+  label?: string;
+  style?: CSSProperties;
+  disabled?: boolean;
+  controlledSelectedTab?: 'write' | 'preview';
+  controlledSetSelectTab?: (tab: 'write' | 'preview') => void;
+  height?: number;
+  askAi?: boolean;
+}
+
+const MarkdownField = (props: MarkdownFieldProps) => {
   const {
     form: { setFieldValue, setFieldTouched, submitCount },
     field: { name },
@@ -26,18 +42,20 @@ const MarkdownField = (props) => {
     askAi,
   } = props;
   const { t_i18n } = useFormatter();
-  const [selectedTab, setSelectedTab] = useState('write');
+  const [selectedTab, setSelectedTab] = useState<'write' | 'preview'>('write');
   const [field, meta] = useField(name);
   const { fullyActive } = useAI();
-  const internalOnFocus = (event) => {
-    const { nodeName } = event.relatedTarget || {};
+
+  const internalOnFocus = (event: FocusEvent<HTMLDivElement>) => {
+    const { nodeName } = (event.relatedTarget as HTMLElement) || {};
     if (nodeName === 'INPUT' || nodeName === undefined) {
       if (typeof onFocus === 'function') {
         onFocus(name);
       }
     }
   };
-  const internalOnBlur = (event) => {
+
+  const internalOnBlur = (event: FocusEvent<HTMLDivElement>) => {
     const isClickOutsideCurrentField = !event.currentTarget.contains(event.relatedTarget);
     if (isClickOutsideCurrentField) {
       setFieldTouched(name, true);
@@ -46,8 +64,9 @@ const MarkdownField = (props) => {
       }
     }
   };
+
   const internalOnSelect = () => {
-    const selection = window.getSelection().toString();
+    const selection = window.getSelection()?.toString() ?? '';
     if (typeof onSelect === 'function' && selection.length > 2 && disabled) {
       onSelect(selection.trim());
     }
@@ -73,7 +92,7 @@ const MarkdownField = (props) => {
         value={field.value ?? ''}
         readOnly={disabled}
         onChange={(value) => setFieldValue(name, value)}
-        selectedTab={controlledSelectedTab || selectedTab}
+        selectedTab={controlledSelectedTab ?? selectedTab}
         onTabChange={(tab) => (controlledSetSelectTab
           ? controlledSetSelectTab(tab)
           : setSelectedTab(tab))
@@ -97,8 +116,8 @@ const MarkdownField = (props) => {
         childProps={{
           textArea: { onSelect: internalOnSelect },
         }}
-        minEditorHeight={height || 100}
-        maxEditorHeight={height || 100}
+        minEditorHeight={height ?? 100}
+        maxEditorHeight={height ?? 100}
         minPreviewHeight={140}
       />
       {showError && (
@@ -107,7 +126,7 @@ const MarkdownField = (props) => {
       {askAi && fullyActive && (
         <TextFieldAskAI
           currentValue={field.value ?? ''}
-          setFieldValue={(val) => {
+          setFieldValue={(val: string) => {
             setFieldValue(name, val);
             if (typeof onSubmit === 'function') {
               onSubmit(name, val || '');
@@ -115,7 +134,7 @@ const MarkdownField = (props) => {
           }}
           format="markdown"
           variant="markdown"
-          disabled={props.disabled}
+          disabled={disabled}
         />
       )}
     </div>

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceCreation.tsx
@@ -13,7 +13,7 @@ import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import TextField from '../../../../components/TextField';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { insertNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEditionOverview.tsx
@@ -5,7 +5,7 @@ import { pick } from 'ramda';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { ExternalReferenceEditionOverview_externalReference$data } from './__generated__/ExternalReferenceEditionOverview_externalReference.graphql';

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingCreation.tsx
@@ -14,7 +14,7 @@ import * as Yup from 'yup';
 import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../components/fields/RichTextField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingEditionOverview.jsx
@@ -10,7 +10,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import ConfidenceField from '../../common/form/ConfidenceField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import StatusField from '../../common/form/StatusField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteCreation.tsx
@@ -14,7 +14,7 @@ import * as Yup from 'yup';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SliderField from '../../../../components/fields/SliderField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/NoteEditionOverview.tsx
@@ -4,7 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import ConfidenceField from '../../common/form/ConfidenceField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/StixCoreObjectOrStixCoreRelationshipNotesCards.tsx
@@ -15,7 +15,7 @@ import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNPARTICIPATE } from '../../../../utils/hooks/useGranted';
 import StixCoreObjectOrStixCoreRelationshipNoteCard from './StixCoreObjectOrStixCoreRelationshipNoteCard';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionCreation.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/OpinionEditionOverview.jsx
@@ -7,7 +7,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import ConfidenceField from '../../common/form/ConfidenceField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsRadarDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/StixCoreObjectOpinionsRadarDialog.tsx
@@ -11,7 +11,7 @@ import { graphql, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { PreloadedQuery } from 'react-relay/relay-hooks/EntryPointTypes';
 import * as Yup from 'yup';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { MESSAGING$ } from '../../../../relay/environment';
 import Security from '../../../../utils/Security';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportCreation.tsx
@@ -15,7 +15,7 @@ import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../components/fields/RichTextField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportEditionOverview.jsx
@@ -11,7 +11,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import ConfidenceField from '../../common/form/ConfidenceField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import StatusField from '../../common/form/StatusField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageCreation.tsx
@@ -17,7 +17,7 @@ import * as Yup from 'yup';
 import Card from '../../../../components/common/card/Card';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import PeriodicityField from '../../../../components/fields/PeriodicityField';
 import SelectField from '../../../../components/fields/SelectField';
 import SwitchField from '../../../../components/fields/SwitchField';

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageEditionOverview.tsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { adaptFieldValue } from '../../../../utils/String';
 import { useFormatter } from '../../../../components/i18n';
 import { SecurityCoverageEditionOverview_securityCoverage$key } from './__generated__/SecurityCoverageEditionOverview_securityCoverage.graphql';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelCreation.tsx
@@ -12,7 +12,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import StatusField from '../../common/form/StatusField';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareCreation.tsx
@@ -12,7 +12,7 @@ import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import KillChainPhasesField from '../../common/form/KillChainPhasesField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareEditionOverview.jsx
@@ -10,7 +10,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import KillChainPhasesField from '../../common/form/KillChainPhasesField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolCreation.tsx
@@ -13,7 +13,7 @@ import KillChainPhasesField from '../../common/form/KillChainPhasesField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityCreation.tsx
@@ -14,7 +14,7 @@ import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { insertNode } from '../../../../utils/store';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -16,7 +16,7 @@ import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../components/fields/RichTextField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertParticipants, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiCreation.tsx
@@ -16,7 +16,7 @@ import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../components/fields/RichTextField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiEditionOverview.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertParticipants, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftCreation.tsx
@@ -16,7 +16,7 @@ import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../components/fields/RichTextField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftEditionOverview.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertParticipants, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackEditionOverview.tsx
@@ -15,7 +15,7 @@ import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEditor';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RatingField from '../../../../components/fields/RatingField';
 import CommitMessage from '../../common/form/CommitMessage';
 import ObjectAssigneeField from '../../common/form/ObjectAssigneeField';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/CaseTaskCreation.tsx
@@ -7,7 +7,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskCreation.tsx
@@ -9,7 +9,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TasksEditionOverview.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { convertAssignees, convertMarkings, convertParticipants, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -20,7 +20,7 @@ import { commitMutation, defaultCommitMutation } from '../../../../relay/environ
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import useAuth from '../../../../utils/hooks/useAuth';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
 import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
 import CreatedByField from '@components/common/form/CreatedByField';

--- a/opencti-platform/opencti-front/src/private/components/common/files/PictureManagementEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/PictureManagementEdition.tsx
@@ -6,7 +6,7 @@ import { TextField } from 'formik-mui';
 import Button from '@common/button/Button';
 import makeStyles from '@mui/styles/makeStyles';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import type { Theme } from '../../../../components/Theme';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/draftWorkspace/DraftWorkspaceDialogCreation.tsx
@@ -17,7 +17,7 @@ import useApiMutation from '../../../../../utils/hooks/useApiMutation';
 import useAuth from '../../../../../utils/hooks/useAuth';
 import { insertNode } from '../../../../../utils/store';
 import { DraftWorkspaceDialogCreationMutation, DraftWorkspaceDialogCreationMutation$variables } from './__generated__/DraftWorkspaceDialogCreationMutation.graphql';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
 import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
 import CreatedByField from '@components/common/form/CreatedByField';

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesOptions.tsx
@@ -14,7 +14,7 @@ import TextField from '../../../../../components/TextField';
 import SelectField from '../../../../../components/fields/SelectField';
 import { DraftContext } from '../../../../../utils/hooks/useDraftContext';
 import useAuth from '../../../../../utils/hooks/useAuth';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
 import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
 import CreatedByField from '@components/common/form/CreatedByField';

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -30,7 +30,7 @@ import Breadcrumbs from '../../../../../components/Breadcrumbs';
 import TitleMainEntity from '../../../../../components/common/typography/TitleMainEntity';
 import DateTimePickerField from '../../../../../components/DateTimePickerField';
 import DeleteDialog from '../../../../../components/DeleteDialog';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../../components/fields/RichTextField';
 import SelectField from '../../../../../components/fields/SelectField';
 import SwitchField from '../../../../../components/fields/SwitchField';

--- a/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateTasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateTasks.tsx
@@ -8,7 +8,7 @@ import * as R from 'ramda';
 import { FunctionComponent, SyntheticEvent, useState } from 'react';
 import { graphql } from 'react-relay';
 import AutocompleteField, { AutocompleteFieldProps } from '../../../../components/AutocompleteField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateTasks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CaseTemplateTasks.tsx
@@ -174,9 +174,6 @@ const CaseTemplateTasks: FunctionComponent<TaskTemplateFieldProps> = ({
                 component={MarkdownField}
                 name="description"
                 label={t_i18n('Description')}
-                fullWidth={true}
-                multiline={true}
-                rows="4"
                 style={{ marginTop: 20, marginBottom: 20 }}
               />
               <DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/common/form/CommitMessage.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/CommitMessage.tsx
@@ -4,7 +4,7 @@ import DialogActions from '@mui/material/DialogActions';
 import makeStyles from '@mui/styles/makeStyles';
 import { Field } from 'formik';
 import { FunctionComponent, useState } from 'react';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';

--- a/opencti-platform/opencti-front/src/private/components/common/form/DefaultValueField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/DefaultValueField.tsx
@@ -12,7 +12,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { INPUT_AUTHORIZED_MEMBERS } from '../../../../utils/authorizedMembers';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import RichTextField from '../../../../components/fields/RichTextField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/common/identities/IdentityCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/identities/IdentityCreation.jsx
@@ -12,7 +12,7 @@ import { graphql } from 'react-relay';
 import { v4 as uuid } from 'uuid';
 import * as Yup from 'yup';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
 import inject18n from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/common/location/LocationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/location/LocationCreation.tsx
@@ -15,7 +15,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import TextField from '../../../../components/TextField';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesDissemination.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesDissemination.tsx
@@ -14,7 +14,7 @@ import Switch from '@mui/material/Switch';
 import DisseminationListField from '../../../../components/fields/DisseminationListField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
@@ -36,7 +36,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 import { useIsMandatoryAttribute } from '../../../../utils/hooks/useEntitySettings';
 import { DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
 import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
 import CreatedByField from '@components/common/form/CreatedByField';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
@@ -10,7 +10,7 @@ import { ContainerMappingContent_container$data } from '@components/common/conta
 import Typography from '@mui/material/Typography';
 import makeStyles from '@mui/styles/makeStyles';
 import { createStyles } from '@mui/styles';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import RichTextField from '../../../../components/fields/RichTextField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationForm.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreationForm.jsx
@@ -10,7 +10,7 @@ import SelectField from '../../../../components/fields/SelectField';
 import ConfidenceField from '../form/ConfidenceField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { hasKillChainPhase } from '../../../../utils/Relation';
 import KillChainPhasesField from '../form/KillChainPhasesField';
 import CreatedByField from '../form/CreatedByField';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
@@ -10,7 +10,7 @@ import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForE
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { SubscriptionFocus } from '../../../../components/Subscription';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { adaptFieldValue } from '../../../../utils/String';
 import { buildDate, formatDate } from '../../../../utils/Time';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectEditionOverview.jsx
@@ -5,7 +5,7 @@ import * as R from 'ramda';
 import * as Yup from 'yup';
 import { commitMutation, requestSubscription } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionAvatars, SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../form/CreatedByField';

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormFieldRenderer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormFieldRenderer.tsx
@@ -17,7 +17,7 @@ import TextField from '../../../../../components/TextField';
 import SelectField from '../../../../../components/fields/SelectField';
 import SwitchField from '../../../../../components/fields/SwitchField';
 import DateTimePickerField from '../../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import CreatedByField from '../../../common/form/CreatedByField';
 import ObjectMarkingField from '../../../common/form/ObjectMarkingField';
 import ObjectLabelField from '../../../common/form/ObjectLabelField';

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftCreation.tsx
@@ -20,7 +20,7 @@ import FormButtonContainer from '@common/form/FormButtonContainer';
 import useDefaultValues from '../../../utils/hooks/useDefaultValues';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../utils/hooks/useGranted';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../utils/hooks/useEntitySettings';
-import MarkdownField from '../../../components/fields/MarkdownField';
+import MarkdownField from '../../../components/fields/markdownField/MarkdownField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../utils/field';
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
 import ObjectParticipantField from '@components/common/form/ObjectParticipantField';

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventCreation.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { parse } from '../../../../utils/Time';
 import DateTimePickerField from '../../../../components/DateTimePickerField';

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import StatusField from '../../common/form/StatusField';

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -12,7 +12,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationCreation.tsx
@@ -12,7 +12,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -11,7 +11,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { adaptFieldValue } from '../../../../utils/String';
 import CommitMessage from '../../common/form/CommitMessage';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorCreation.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformCreationForm.tsx
@@ -23,7 +23,7 @@ import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
 import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextModal';
 import ProgressBar from '../../../../components/ProgressBar';
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useIsMandatoryAttribute } from '../../../../utils/hooks/useEntitySettings';
 import FormButtonContainer from '@common/form/FormButtonContainer';
 

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformEditionOverview.tsx
@@ -24,7 +24,7 @@ import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../ut
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 
 const securityPlatformMutationFieldPatch = graphql`
   mutation SecurityPlatformEditionOverviewFieldPatchMutation(

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemCreation.tsx
@@ -12,7 +12,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { useDynamicSchemaCreationValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import { insertNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentCreation.tsx
@@ -11,7 +11,7 @@ import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import TextField from '../../../../components/TextField';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionOverview.tsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationForm.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreationForm.jsx
@@ -12,7 +12,7 @@ import TextField from '../../../../components/TextField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import SwitchField from '../../../../components/fields/SwitchField';

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipEditionOverview.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaCreation.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { insertNode } from '../../../../utils/store';
 import { AdministrativeAreasLinesPaginationQuery$variables } from './__generated__/AdministrativeAreasLinesPaginationQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaEditionOverview.tsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import StatusField from '../../common/form/StatusField';

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityCreation.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { insertNode } from '../../../../utils/store';
 import { CitiesLinesPaginationQuery$variables } from './__generated__/CitiesLinesPaginationQuery.graphql';

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityEditionOverview.tsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import StatusField from '../../common/form/StatusField';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryCreation.tsx
@@ -11,7 +11,7 @@ import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { CountriesLinesPaginationQuery$variables } from './__generated__/CountriesLinesPaginationQuery.graphql';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryEditionOverview.tsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import { CountryEditionOverview_country$key } from './__generated__/CountryEditionOverview_country.graphql';

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionCreation.tsx
@@ -12,7 +12,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionCreation.tsx
@@ -11,7 +11,7 @@ import ConfidenceField from '@components/common/form/ConfidenceField';
 import { useFormatter } from '../../../../components/i18n';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { insertNode } from '../../../../utils/store';
 import { RegionsLinesPaginationQuery$variables } from './__generated__/RegionsLinesPaginationQuery.graphql';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionEditionOverview.tsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { graphql } from 'react-relay';
 import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorCreation.tsx
@@ -16,7 +16,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import TextField from '../../../../components/TextField';
 import type { Theme } from '../../../../components/Theme';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
@@ -8,7 +8,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import SwitchField from '../../../../components/fields/SwitchField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import KillChainPhasesField from '../../common/form/KillChainPhasesField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import OpenVocabField from '../../common/form/OpenVocabField';

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureCreation.tsx
@@ -11,7 +11,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureEditionOverview.tsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import KillChainPhasesField from '../../common/form/KillChainPhasesField';
 import OpenVocabField from '../../common/form/OpenVocabField';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -23,7 +23,7 @@ import TextField from '../../../../components/TextField';
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextModal';
 import BulkTextModalButton from '../../../../components/fields/BulkTextField/BulkTextModalButton';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm, QueryRenderer } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEditionOverview.jsx
@@ -13,7 +13,7 @@ import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import { stixCyberObservablesLinesAttributesQuery } from './StixCyberObservablesLines';
 import { buildDate } from '../../../../utils/Time';
 import SwitchField from '../../../../components/fields/SwitchField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ArtifactField from '../../common/form/ArtifactField';

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreationFormGeneralSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirCreationFormGeneralSettings.tsx
@@ -20,7 +20,7 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { PirCreationFormData } from '@components/pir/pir_form/pir-form-utils';
 import Alert from '@mui/material/Alert';
 import { AlertTitle } from '@mui/material';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirEditionForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_form/PirEditionForm.tsx
@@ -20,7 +20,7 @@ import { PirEditionFormData } from './pir-form-utils';
 import { useFormatter } from '../../../../components/i18n';
 import { PirEditionFragment$data } from './__generated__/PirEditionFragment.graphql';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 
 export type PirEditionFormInputKeys = keyof PirEditionFormData;

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerDigestCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerDigestCreation.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
 import * as Yup from 'yup';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerEditionOverview.tsx
@@ -11,7 +11,7 @@ import { instanceTriggerDescription } from '@components/profile/triggers/Trigger
 import AutocompleteField from '../../../../components/AutocompleteField';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
 import TextField from '../../../../components/TextField';
 import TimePickerField from '../../../../components/TimePickerField';

--- a/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/triggers/TriggerLiveCreation.tsx
@@ -18,7 +18,7 @@ import { Box, Stack } from '@mui/material';
 import AutocompleteField from '../../../../components/AutocompleteField';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import TextField from '../../../../components/TextField';
 import type { Theme } from '../../../../components/Theme';

--- a/opencti-platform/opencti-front/src/private/components/settings/Policies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Policies.tsx
@@ -13,7 +13,7 @@ import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-r
 import * as Yup from 'yup';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import Card from '../../../components/common/card/Card';
-import MarkdownField from '../../../components/fields/MarkdownField';
+import MarkdownField from '../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../components/fields/SelectField';
 import SwitchField from '../../../components/fields/SwitchField';
 

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestCreation.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
 import * as Yup from 'yup';
 import FormButtonContainer from '../../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertDigestEdition.tsx
@@ -3,7 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveCreation.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent } from 'react';
 import { graphql } from 'react-relay';
 import * as Yup from 'yup';
 import FormButtonContainer from '../../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import FilterIconButton from '../../../../../components/FilterIconButton';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/alerting/AlertLiveEdition.tsx
@@ -3,7 +3,7 @@ import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useEffect } from 'react';
 import { graphql, PreloadedQuery, useFragment, usePreloadedQuery } from 'react-relay';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import FilterIconButton from '../../../../../components/FilterIconButton';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateCreation.tsx
@@ -7,7 +7,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { commitMutation, defaultCommitMutation } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateEdition.tsx
@@ -6,7 +6,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import Drawer from '@components/common/drawer/Drawer';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import TextField from '../../../../components/TextField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { deleteNode, insertNode } from '../../../../utils/store';

--- a/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/case_templates/CaseTemplateTasksEdition.tsx
@@ -3,7 +3,7 @@ import { graphql } from 'react-relay';
 import React from 'react';
 import * as Yup from 'yup';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import TextField from '../../../../components/TextField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayExclusionRuleCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayExclusionRuleCreationForm.tsx
@@ -11,7 +11,7 @@ import Filters from '@components/common/lists/Filters';
 import FilterIconButton from 'src/components/FilterIconButton';
 import Box from '@mui/material/Box';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayExclusionRuleEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayExclusionRuleEdition.tsx
@@ -15,7 +15,7 @@ import { FilterGroup } from 'src/utils/filters/filtersHelpers-types';
 import Button from '@common/button/Button';
 import { handleErrorInForm } from '../../../../relay/environment';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import TextField from '../../../../components/TextField';
 import { enabledFilters } from './DecayExclusionRuleCreationForm';
 import { useTheme } from '@mui/material/styles';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleCreation.tsx
@@ -15,7 +15,7 @@ import { RecordSourceSelectorProxy } from 'relay-runtime';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import TextField from '../../../../components/TextField';
 import FormButtonContainer from '@common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleEdition.tsx
@@ -13,7 +13,7 @@ import { FormikConfig } from 'formik/dist/types';
 import ObservableTypesField from '@components/common/form/ObservableTypesField';
 import decayRuleValidator from './DecayRuleValidator';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import TextField from '../../../../components/TextField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/settings/dissemination_lists/DisseminationListForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/dissemination_lists/DisseminationListForm.tsx
@@ -7,7 +7,7 @@ import Button from '@common/button/Button';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { parseEmailList } from '../../../../utils/email';
 import { MESSAGING$ } from '../../../../relay/environment';
 import FormButtonContainer from '@common/form/FormButtonContainer';

--- a/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplateForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/email_template/EmailTemplateForm.tsx
@@ -7,7 +7,7 @@ import * as Yup from 'yup';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import FormButtonContainer from '@common/form/FormButtonContainer';
 
 export interface EmailTemplateFormInputs {

--- a/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListCreation.tsx
@@ -13,7 +13,7 @@ import { insertNode } from '../../../../utils/store';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import AutocompleteField from '../../../../components/AutocompleteField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListEdition.tsx
@@ -16,7 +16,7 @@ import { APP_BASE_PATH, handleErrorInForm } from '../../../../relay/environment'
 import AutocompleteField from '../../../../components/AutocompleteField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import TextField from '../../../../components/TextField';
 import { useFormatter } from '../../../../components/i18n';
 import useSchema from '../../../../utils/hooks/useSchema';

--- a/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesignCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesignCreation.tsx
@@ -16,7 +16,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { handleErrorInForm } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { resolveLink } from '../../../../utils/Entity';
 import type { Theme } from '../../../../components/Theme';
 import FormButtonContainer from '@common/form/FormButtonContainer';

--- a/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesignEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesignEditionOverview.tsx
@@ -4,7 +4,7 @@ import { Field, Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { FieldOption } from '../../../../utils/field';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { FintelDesignEditionOverview_fintelDesign$key } from './__generated__/FintelDesignEditionOverview_fintelDesign.graphql';

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupCreation.jsx
@@ -6,7 +6,7 @@ import { ConnectionHandler } from 'relay-runtime';
 import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionOverview.tsx
@@ -9,7 +9,7 @@ import { useTheme } from '@mui/styles';
 import { InformationOutline } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import SwitchField from '../../../../components/fields/SwitchField';
 import TextField from '../../../../components/TextField';

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationEdition.tsx
@@ -9,7 +9,7 @@ import { GenericContext } from '@components/common/model/GenericContextModel';
 import OpenVocabField from '@components/common/form/OpenVocabField';
 import EEField from '@components/common/entreprise_edition/EEField';
 import { useFormatter } from '../../../../components/i18n';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleCreation.tsx
@@ -6,7 +6,7 @@ import { DataID, RecordProxy, RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import FormButtonContainer from '@common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { PaginationOptions } from '../../../../components/list_lines';
 import { commitMutation, defaultCommitMutation } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionOverview.tsx
@@ -6,7 +6,7 @@ import * as Yup from 'yup';
 import { useTheme } from '@mui/styles';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { RoleEditionOverview_role$data } from './__generated__/RoleEditionOverview_role.graphql';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateForm.tsx
@@ -6,7 +6,7 @@ import { InformationOutline } from 'mdi-material-ui';
 import * as Yup from 'yup';
 import TextField from '../../../../../components/TextField';
 import FormButtonContainer from '../../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import SwitchField from '../../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../../components/i18n';
 import { fieldSpacingContainerStyle } from '../../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUserCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/SettingsOrganizationUserCreation.jsx
@@ -10,7 +10,7 @@ import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserCreation.jsx
@@ -10,7 +10,7 @@ import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import TextField from '../../../../components/TextField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import SelectField from '../../../../components/fields/SelectField';
 import SwitchField from '../../../../components/fields/SwitchField';
 import { useFormatter } from '../../../../components/i18n';

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionOverview.tsx
@@ -10,7 +10,7 @@ import { useTheme } from '@mui/styles';
 import TextField from '../../../../../components/TextField';
 import SelectField from '../../../../../components/fields/SelectField';
 import { SubscriptionFocus } from '../../../../../components/Subscription';
-import MarkdownField from '../../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import ObjectOrganizationField from '../../../common/form/ObjectOrganizationField';
 import { useFormatter } from '../../../../../components/i18n';
 import DateTimePickerField from '../../../../../components/DateTimePickerField';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternCreation.tsx
@@ -11,7 +11,7 @@ import { graphql } from 'react-relay';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionOverview.jsx
@@ -11,7 +11,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import KillChainPhasesField from '../../common/form/KillChainPhasesField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import StatusField from '../../common/form/StatusField';
 import { convertCreatedBy, convertKillChainPhases, convertMarkings, convertStatus } from '../../../../utils/edition';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionCreation.tsx
@@ -13,7 +13,7 @@ import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import TextField from '../../../../components/TextField';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentCreation.tsx
@@ -14,7 +14,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextModal';
 import BulkTextModalButton from '../../../../components/fields/BulkTextField/BulkTextModalButton';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import ProgressBar from '../../../../components/ProgressBar';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentEditionOverview.tsx
@@ -7,7 +7,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import { useFormatter } from '../../../../components/i18n';
 import { DataComponentEditionOverview_dataComponent$key } from './__generated__/DataComponentEditionOverview_dataComponent.graphql';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceCreation.tsx
@@ -15,7 +15,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextModal';
 import BulkTextModalButton from '../../../../components/fields/BulkTextField/BulkTextModalButton';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import ProgressBar from '../../../../components/ProgressBar';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceEditionOverview.tsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { convertCreatedBy, convertMarkings, convertStatus } from '../../../../utils/edition';
 import StatusField from '../../common/form/StatusField';
 import CommitMessage from '../../common/form/CommitMessage';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeCreation.tsx
@@ -14,7 +14,7 @@ import CreateEntityControlledDial from '../../../../components/CreateEntityContr
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import BulkTextModal from '../../../../components/fields/BulkTextField/BulkTextModal';
 import BulkTextModalButton from '../../../../components/fields/BulkTextField/BulkTextModalButton';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../components/i18n';
 import ProgressBar from '../../../../components/ProgressBar';
 import { handleErrorInForm } from '../../../../relay/environment';

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import StatusField from '../../common/form/StatusField';

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignCreation.tsx
@@ -11,7 +11,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetCreation.tsx
@@ -11,7 +11,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionOverview.jsx
@@ -9,7 +9,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupCreation.tsx
@@ -11,7 +11,7 @@ import { handleErrorInForm } from '../../../../relay/environment';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionOverview.jsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
@@ -18,7 +18,7 @@ import TextField from '../../../../components/TextField';
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import { insertNode } from '../../../../utils/store';
 import { ExternalReferencesField } from '../../common/form/ExternalReferencesField';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDemographics.tsx
@@ -13,7 +13,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { commitMutation, defaultCommitMutation } from '../../../../relay/environment';
 import { SubscriptionFocus } from '../../../../components/Subscription';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { buildDate } from '../../../../utils/Time';
 import { ThreatActorIndividualEditionDemographics_ThreatActorIndividual$key } from './__generated__/ThreatActorIndividualEditionDemographics_ThreatActorIndividual.graphql';

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionOverview.tsx
@@ -8,7 +8,7 @@ import TextField from '../../../../components/TextField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
-import MarkdownField from '../../../../components/fields/MarkdownField';
+import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import ConfidenceField from '../../common/form/ConfidenceField';
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceCreation.tsx
@@ -10,7 +10,7 @@ import CreateEntityControlledDial from '../../../components/CreateEntityControll
 import TextField from '../../../components/TextField';
 import IconButton from '../../../components/common/button/IconButton';
 import FormButtonContainer from '../../../components/common/form/FormButtonContainer';
-import MarkdownField from '../../../components/fields/MarkdownField';
+import MarkdownField from '../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../components/i18n';
 import { handleError, handleErrorInForm } from '../../../relay/environment';
 import { resolveLink } from '../../../utils/Entity';

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceEditionOverview.jsx
@@ -9,7 +9,7 @@ import inject18n, { useFormatter } from '../../../components/i18n';
 import TextField from '../../../components/TextField';
 import { SubscriptionFocus } from '../../../components/Subscription';
 import { commitMutation } from '../../../relay/environment';
-import MarkdownField from '../../../components/fields/MarkdownField';
+import MarkdownField from '../../../components/fields/markdownField/MarkdownField';
 
 const styles = (theme) => ({
   drawerPaper: {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* It only converts MarkdownField to tsx and moves it to its own folder ahead of upload feature refactor.
* High diff is only update import path


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #7281 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
