### PR TITLE
[frontend/backend] Add creators, creation date and modification date for Playbooks (#13943)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -247,15 +247,6 @@ const defaultColumns: DataTableProps['dataColumns'] = {
       return defaultRender(value);
     },
   },
-  creators: {
-    id: 'creators',
-    label: 'Creators',
-    percentWidth: 12,
-    render: ({ creators }) => {
-      const value = creators?.map((c: { name: string }) => c.name);
-      return defaultRender(value);
-    },
-  },
   coverage_information: {
     label: 'Coverage',
     percentWidth: 12,

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkContainer.tsx
@@ -60,7 +60,7 @@ const SearchBulkContainer = () => {
       isSortable: false,
     },
     createdBy: {},
-    creators: {},
+    creator: {},
     objectLabel: {},
     created_at: {
       percentWidth: 14,

--- a/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
@@ -45,6 +45,8 @@ const playbookFragment = graphql`
     description
     playbook_running
     queue_messages
+    created_at
+    updated_at
   }
 `;
 

--- a/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
@@ -47,6 +47,10 @@ const playbookFragment = graphql`
     queue_messages
     created_at
     updated_at
+    creators {
+      id
+      name
+    }
   }
 `;
 
@@ -154,23 +158,26 @@ const Playbooks: FunctionComponent = () => {
   const dataColumns: DataTableProps['dataColumns'] = {
     name: {
       label: 'Name',
-      percentWidth: 25,
+      percentWidth: 20,
     },
     description: {
       label: 'Description',
       percentWidth: 25,
       isSortable: false,
     },
+    creator: {
+      percentWidth: 12,
+    },
     created_at: {
-      percentWidth: 15,
+      percentWidth: 12,
     },
     updated_at: {
-      percentWidth: 15,
+      percentWidth: 12,
     },
     messages: {
       id: 'messages',
       label: 'Messages',
-      percentWidth: 10,
+      percentWidth: 8,
       isSortable: false,
       render: ({ queue_messages }) => n(queue_messages),
     },

--- a/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Playbooks.tsx
@@ -156,20 +156,26 @@ const Playbooks: FunctionComponent = () => {
     },
     description: {
       label: 'Description',
-      percentWidth: 30,
+      percentWidth: 25,
       isSortable: false,
+    },
+    created_at: {
+      percentWidth: 15,
+    },
+    updated_at: {
+      percentWidth: 15,
     },
     messages: {
       id: 'messages',
       label: 'Messages',
-      percentWidth: 20,
+      percentWidth: 10,
       isSortable: false,
       render: ({ queue_messages }) => n(queue_messages),
     },
     playbook_running: {
       id: 'playbook_running',
       label: 'Playbook running',
-      percentWidth: 25,
+      percentWidth: 10,
       isSortable: true,
       render: ({ playbook_running }) => (
         <ItemBoolean

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -13471,6 +13471,8 @@ type Playbook implements InternalObject & BasicObject {
   metrics: [Metric]
   name: String!
   description: String
+  created_at: DateTime
+  updated_at: DateTime
   playbook_running: Boolean
   playbook_definition: String
   last_executions: [PlayBookExecution!]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -13505,6 +13505,8 @@ type PlaybookInsertResult {
 enum PlaybooksOrdering {
   name
   playbook_running
+  created_at
+  updated_at
   _score
 }
 

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -13473,6 +13473,7 @@ type Playbook implements InternalObject & BasicObject {
   description: String
   created_at: DateTime
   updated_at: DateTime
+  creators: [Creator!]
   playbook_running: Boolean
   playbook_definition: String
   last_executions: [PlayBookExecution!]

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23216,6 +23216,7 @@ export type PlayBookExecutionStep = {
 
 export type Playbook = BasicObject & InternalObject & {
   __typename?: 'Playbook';
+  created_at?: Maybe<Scalars['DateTime']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -23228,6 +23229,7 @@ export type Playbook = BasicObject & InternalObject & {
   queue_messages: Scalars['Int']['output'];
   standard_id: Scalars['String']['output'];
   toConfigurationExport: Scalars['String']['output'];
+  updated_at?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type PlaybookAddInput = {
@@ -47939,6 +47941,7 @@ export type PlayBookExecutionStepResolvers<ContextType = any, ParentType extends
 }>;
 
 export type PlaybookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Playbook'] = ResolversParentTypes['Playbook']> = ResolversObject<{
+  created_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -47951,6 +47954,7 @@ export type PlaybookResolvers<ContextType = any, ParentType extends ResolversPar
   queue_messages?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   toConfigurationExport?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updated_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23217,6 +23217,7 @@ export type PlayBookExecutionStep = {
 export type Playbook = BasicObject & InternalObject & {
   __typename?: 'Playbook';
   created_at?: Maybe<Scalars['DateTime']['output']>;
+  creators?: Maybe<Array<Creator>>;
   description?: Maybe<Scalars['String']['output']>;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -47942,6 +47943,7 @@ export type PlayBookExecutionStepResolvers<ContextType = any, ParentType extends
 
 export type PlaybookResolvers<ContextType = any, ParentType extends ResolversParentTypes['Playbook'] = ResolversParentTypes['Playbook']> = ResolversObject<{
   created_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  creators?: Resolver<Maybe<Array<ResolversTypes['Creator']>>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23289,8 +23289,10 @@ export type PlaybookInsertResult = {
 
 export enum PlaybooksOrdering {
   Score = '_score',
+  CreatedAt = 'created_at',
   Name = 'name',
-  PlaybookRunning = 'playbook_running'
+  PlaybookRunning = 'playbook_running',
+  UpdatedAt = 'updated_at'
 }
 
 export type Position = BasicObject & Location & StixCoreObject & StixDomainObject & StixObject & {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-resolvers.ts
@@ -37,6 +37,7 @@ import {
 import { executePlaybookOnEntity, playbookStepExecution } from '../../manager/playbookManager/playbookManager';
 import { getLastPlaybookExecutions } from '../../database/redis';
 import { getConnectorQueueSize } from '../../database/rabbitmq';
+import { loadCreators } from '../../database/members';
 
 const playbookResolvers: Resolvers = {
   Query: {
@@ -48,6 +49,7 @@ const playbookResolvers: Resolvers = {
     playbookComponents: (_, __, context) => availableComponents(context),
   },
   Playbook: {
+    creators: async (current, _, context) => loadCreators(context, context.user, current),
     playbook_definition: async (current, _, context) => getPlaybookDefinition(context, current),
     last_executions: async (current) => getLastPlaybookExecutions(current.id),
     queue_messages: async (current, _, context) => getConnectorQueueSize(context, context.user, current.id),

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -25,6 +25,8 @@ type Playbook implements InternalObject & BasicObject {
     # Playbook
     name: String!
     description: String
+    created_at: DateTime
+    updated_at: DateTime
     playbook_running: Boolean
     playbook_definition: String
     last_executions: [PlayBookExecution!]

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -27,6 +27,7 @@ type Playbook implements InternalObject & BasicObject {
     description: String
     created_at: DateTime
     updated_at: DateTime
+    creators: [Creator!]
     playbook_running: Boolean
     playbook_definition: String
     last_executions: [PlayBookExecution!]

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -58,6 +58,8 @@ type PlaybookInsertResult {
 enum PlaybooksOrdering {
     name
     playbook_running
+    created_at
+    updated_at
     _score
 }
 

--- a/opencti-platform/opencti-graphql/src/schema/internalObject.ts
+++ b/opencti-platform/opencti-graphql/src/schema/internalObject.ts
@@ -14,6 +14,7 @@ import { ENTITY_TYPE_FORM } from '../modules/form/form-types';
 import { ENTITY_TYPE_FEED } from '../modules/dataSharing/feed-types';
 import { ENTITY_TYPE_TAXII_COLLECTION } from '../modules/dataSharing/taxiiCollection-types';
 import { ENTITY_TYPE_STREAM_COLLECTION } from '../modules/dataSharing/streamCollection-types';
+import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
 
 // Re-exported for backward compatibility (used by migrations)
 export { ENTITY_TYPE_FEED } from '../modules/dataSharing/feed-types';
@@ -62,6 +63,7 @@ const DATED_INTERNAL_OBJECTS = [
   ENTITY_TYPE_PIR,
   ENTITY_TYPE_FORM,
   ENTITY_TYPE_THEME,
+  ENTITY_TYPE_PLAYBOOK,
 ];
 const INTERNAL_OBJECTS = [
   ENTITY_TYPE_SETTINGS,

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
@@ -4,7 +4,7 @@ import { queryAsAdminWithError, queryAsAdminWithSuccess, queryAsUserIsExpectedFo
 import type { PlaybookAddLinkInput, PlaybookAddNodeInput } from '../../../src/generated/graphql';
 import { PLAYBOOK_INTERNAL_DATA_CRON, PLAYBOOK_MATCHING_COMPONENT } from '../../../src/modules/playbook/playbook-components';
 import { UNSUPPORTED_ERROR } from '../../../src/config/errors';
-import { ADMIN_USER, USER_PARTICIPATE, USER_SECURITY } from '../../utils/testQuery';
+import { USER_PARTICIPATE, USER_SECURITY } from '../../utils/testQuery';
 
 const LIST_PLAYBOOKS = gql`
   query playbooks(
@@ -251,10 +251,9 @@ describe('Playbook resolver standard behavior', () => {
       expect(playbook?.created_at).toBeDefined();
       expect(playbook?.updated_at).toBeDefined();
       expect(playbook?.created_at).toEqual(playbookCreatedAt);
-      // creators should be returned and contain the admin user who created the playbook
-      expect(playbook?.creators.length).toEqual(0);
-      expect(playbook?.creators[0].id).toEqual(ADMIN_USER.id);
-      expect(playbook?.creators[0].name).toEqual(ADMIN_USER.name);
+      // creators should be returned and contain the user who created the playbook
+      expect(playbook?.creators.length).toEqual(1);
+      expect(playbook?.creators[0].id).toEqual(USER_SECURITY.id);
     });
 
     it('should not update playbook if no Manage Playbooks capability', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
@@ -4,7 +4,7 @@ import { queryAsAdminWithError, queryAsAdminWithSuccess, queryAsUserIsExpectedFo
 import type { PlaybookAddLinkInput, PlaybookAddNodeInput } from '../../../src/generated/graphql';
 import { PLAYBOOK_INTERNAL_DATA_CRON, PLAYBOOK_MATCHING_COMPONENT } from '../../../src/modules/playbook/playbook-components';
 import { UNSUPPORTED_ERROR } from '../../../src/config/errors';
-import { USER_PARTICIPATE, USER_SECURITY } from '../../utils/testQuery';
+import { ADMIN_USER, USER_PARTICIPATE, USER_SECURITY } from '../../utils/testQuery';
 
 const LIST_PLAYBOOKS = gql`
   query playbooks(
@@ -54,6 +54,10 @@ const READ_PLAYBOOK = gql`
       playbook_definition
       created_at
       updated_at
+      creators {
+        id
+        name
+      }
     }
   }
 `;
@@ -243,9 +247,14 @@ describe('Playbook resolver standard behavior', () => {
       const playbook = queryResult.data?.playbook;
       expect(playbook?.name).toEqual('Playbook1');
       expect(playbook?.playbook_running).toEqual(false);
+      // created_at and updated_at should be returned and should match the original values
       expect(playbook?.created_at).toBeDefined();
       expect(playbook?.updated_at).toBeDefined();
       expect(playbook?.created_at).toEqual(playbookCreatedAt);
+      // creators should be returned and contain the admin user who created the playbook
+      expect(playbook?.creators.length).toEqual(0);
+      expect(playbook?.creators[0].id).toEqual(ADMIN_USER.id);
+      expect(playbook?.creators[0].name).toEqual(ADMIN_USER.name);
     });
 
     it('should not update playbook if no Manage Playbooks capability', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
@@ -4,7 +4,7 @@ import { queryAsAdminWithError, queryAsAdminWithSuccess, queryAsUserIsExpectedFo
 import type { PlaybookAddLinkInput, PlaybookAddNodeInput } from '../../../src/generated/graphql';
 import { PLAYBOOK_INTERNAL_DATA_CRON, PLAYBOOK_MATCHING_COMPONENT } from '../../../src/modules/playbook/playbook-components';
 import { UNSUPPORTED_ERROR } from '../../../src/config/errors';
-import { USER_PARTICIPATE, USER_SECURITY } from '../../utils/testQuery';
+import { getUserIdByEmail, USER_PARTICIPATE, USER_SECURITY } from '../../utils/testQuery';
 
 const LIST_PLAYBOOKS = gql`
   query playbooks(
@@ -253,7 +253,8 @@ describe('Playbook resolver standard behavior', () => {
       expect(playbook?.created_at).toEqual(playbookCreatedAt);
       // creators should be returned and contain the user who created the playbook
       expect(playbook?.creators.length).toEqual(1);
-      expect(playbook?.creators[0].id).toEqual(USER_SECURITY.id);
+      const securityUserId = await getUserIdByEmail(USER_SECURITY.email);
+      expect(playbook?.creators[0].id).toEqual(securityUserId);
     });
 
     it('should not update playbook if no Manage Playbooks capability', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
@@ -38,6 +38,8 @@ const CREATE_PLAYBOOK = gql`
     playbookAdd(input: $input){
       id
       name
+      created_at
+      updated_at
     }
   }
 `;
@@ -50,6 +52,8 @@ const READ_PLAYBOOK = gql`
       description
       playbook_running
       playbook_definition
+      created_at
+      updated_at
     }
   }
 `;
@@ -59,6 +63,7 @@ const UPDATE_PLAYBOOK = gql`
     playbookFieldPatch(id: $id, input: $input) {
       id
       name
+      updated_at
     }
   }
 `;
@@ -113,12 +118,12 @@ const EMPTY_STRING_FILTERS = JSON.stringify({
 
 // -- Helpers to build playbook state --
 
-const createPlaybook = async (name: string): Promise<string> => {
+const createPlaybook = async (name: string) => {
   const result = await queryAsUserWithSuccess(USER_SECURITY, {
     query: CREATE_PLAYBOOK,
     variables: { input: { name } },
   });
-  return result.data?.playbookAdd.id;
+  return result.data?.playbookAdd;
 };
 
 const deletePlaybook = async (id: string) => {
@@ -194,12 +199,17 @@ const clearPlaybook = async (playbookId: string) => {
 
 describe('Playbook resolver standard behavior', () => {
   let playbookId = '';
+  let playbookCreatedAt = '';
+  let playbookUpdatedAt = '';
   let entryNodeId = '';
   let matchingNodeId = '';
   let linkId = '';
 
   beforeAll(async () => {
-    playbookId = await createPlaybook('Playbook1');
+    const playbook = await createPlaybook('Playbook1');
+    playbookId = playbook.id;
+    playbookCreatedAt = playbook.created_at;
+    playbookUpdatedAt = playbook.updated_at;
   });
 
   afterAll(async () => {
@@ -208,6 +218,14 @@ describe('Playbook resolver standard behavior', () => {
   });
 
   describe('playbook CRUD', () => {
+    it('should have created_at and updated_at set on creation', () => {
+      expect(playbookCreatedAt).toBeDefined();
+      expect(playbookUpdatedAt).toBeDefined();
+      // Both timestamps should be valid ISO date strings
+      expect(new Date(playbookCreatedAt).getTime()).not.toBeNaN();
+      expect(new Date(playbookUpdatedAt).getTime()).not.toBeNaN();
+    });
+
     it('should list playbooks', async () => {
       const queryResult = await queryAsAdminWithSuccess({ query: LIST_PLAYBOOKS, variables: { first: 10 } });
       expect(queryResult.data?.playbooks.edges.length).toEqual(1);
@@ -222,8 +240,12 @@ describe('Playbook resolver standard behavior', () => {
 
     it('should read playbook', async () => {
       const queryResult = await queryAsAdminWithSuccess({ query: READ_PLAYBOOK, variables: { id: playbookId } });
-      expect(queryResult.data?.playbook.name).toEqual('Playbook1');
-      expect(queryResult.data?.playbook.playbook_running).toEqual(false);
+      const playbook = queryResult.data?.playbook;
+      expect(playbook?.name).toEqual('Playbook1');
+      expect(playbook?.playbook_running).toEqual(false);
+      expect(playbook?.created_at).toBeDefined();
+      expect(playbook?.updated_at).toBeDefined();
+      expect(playbook?.created_at).toEqual(playbookCreatedAt);
     });
 
     it('should not update playbook if no Manage Playbooks capability', async () => {
@@ -245,6 +267,16 @@ describe('Playbook resolver standard behavior', () => {
         },
       });
       expect(queryResult.data?.playbookFieldPatch.name).toEqual('Playbook1 - updated');
+    });
+
+    it('should have updated_at changed after update', async () => {
+      const queryResult = await queryAsAdminWithSuccess({ query: READ_PLAYBOOK, variables: { id: playbookId } });
+      const newUpdatedAt = queryResult.data?.playbook.updated_at;
+      expect(newUpdatedAt).toBeDefined();
+      // updated_at should be > the original value after an update
+      expect(new Date(newUpdatedAt).getTime()).toBeGreaterThan(new Date(playbookUpdatedAt).getTime());
+      // created_at should remain unchanged
+      expect(queryResult.data?.playbook.created_at).toEqual(playbookCreatedAt);
     });
   });
 


### PR DESCRIPTION
### Proposed changes
Add creation date (created_at), modification date (updated_at) and creators for Playbooks
- Add those attributes backend side (graphql types)
- Add those those attributes in playbook list columns in frontend
- backend tests

Note that creation and modification dates will be empty for playbooks created before the introduction of these two dates.

[Product: validated with Toby]

### Related issues
fixes #13943
fixes #15482

### UI

<img width="1720" height="486" alt="image" src="https://github.com/user-attachments/assets/9bb459f8-0c7b-49e2-af14-a602cb5b1c95" />
