### PR TITLE
[backend/pycti] Add attribute_abstract to Note standard_id contribution (#15493)

### DIFF
--- a/client-python/pycti/entities/opencti_note.py
+++ b/client-python/pycti/entities/opencti_note.py
@@ -480,13 +480,15 @@ class Note:
         """
 
     @staticmethod
-    def generate_id(created, content):
+    def generate_id(created, content, abstract=None):
         """Generate a STIX ID for a Note.
 
         :param created: The creation date of the note
         :type created: datetime or str or None
         :param content: The content of the note (required)
         :type content: str
+        :param abstract: A brief summary of the note content
+        :type abstract: str or None
         :return: STIX ID for the note
         :rtype: str
         :raises ValueError: If content is None
@@ -499,6 +501,8 @@ class Note:
             data = {"content": content.strip(), "created": created}
         else:
             data = {"content": content.strip()}
+        if abstract is not None and abstract.strip():
+            data["attribute_abstract"] = abstract.strip()
         data = canonicalize(data, utf8=False)
         id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
         return "note--" + id
@@ -507,12 +511,17 @@ class Note:
     def generate_id_from_data(data):
         """Generate a STIX ID from note data.
 
-        :param data: Dictionary containing 'content' and optionally 'created' keys
+        :param data: Dictionary containing 'content' and optionally 'created'
+            and 'attribute_abstract' keys
         :type data: dict
         :return: STIX ID for the note
         :rtype: str
         """
-        return Note.generate_id(data.get("created"), data["content"])
+        return Note.generate_id(
+            data.get("created"),
+            data["content"],
+            abstract=data.get("attribute_abstract"),
+        )
 
     def list(self, **kwargs):
         """List Note objects.

--- a/opencti-platform/opencti-graphql/src/migrations/1776164753048-note_standard_id_abstract.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776164753048-note_standard_id_abstract.js
@@ -1,0 +1,51 @@
+import * as R from 'ramda';
+import { Promise } from 'bluebird';
+import { READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
+import { ENTITY_TYPE_CONTAINER_NOTE } from '../schema/stixDomainObject';
+import { BULK_TIMEOUT, elBulk, elList, ES_MAX_CONCURRENCY, MAX_BULK_OPERATIONS } from '../database/engine';
+import { generateStandardId } from '../schema/identifier';
+import { logApp, logMigration } from '../config/conf';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { pushAll } from '../utils/arrayUtil';
+
+const message = '[MIGRATION] Rewriting standard ids for Notes to include attribute_abstract';
+
+export const up = async (next) => {
+  const context = executionContext('migration');
+  const start = new Date().getTime();
+  logMigration.info(`${message} > started`);
+  const bulkOperations = [];
+  const callback = (notes) => {
+    const op = notes
+      .map((note) => {
+        const newId = generateStandardId(note.entity_type, note);
+        if (newId === note.standard_id) {
+          return [];
+        }
+        const previousStixIds = note.x_opencti_stix_ids ?? [];
+        const updatedStixIds = R.uniq([...previousStixIds, note.standard_id]);
+        return [
+          { update: { _index: note._index, _id: note._id } },
+          { doc: { standard_id: newId, x_opencti_stix_ids: updatedStixIds } },
+        ];
+      })
+      .flat();
+    pushAll(bulkOperations, op);
+  };
+  const opts = { types: [ENTITY_TYPE_CONTAINER_NOTE], callback };
+  await elList(context, SYSTEM_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, opts);
+  let currentProcessing = 0;
+  const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
+  const concurrentUpdate = async (bulk) => {
+    await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+    currentProcessing += bulk.length;
+    logApp.info(`[OPENCTI] Rewriting Note standard ids: ${currentProcessing} / ${bulkOperations.length}`);
+  };
+  await Promise.map(groupsOfOperations, concurrentUpdate, { concurrency: ES_MAX_CONCURRENCY });
+  logMigration.info(`${message} > done in ${new Date().getTime() - start} ms`);
+  next();
+};
+
+export const down = async (next) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -197,7 +197,7 @@ const stixBaseEntityContribution = {
     // Entities
     [D.ENTITY_TYPE_ATTACK_PATTERN]: [[{ src: X_MITRE_ID_FIELD }], [{ src: NAME_FIELD }]],
     [D.ENTITY_TYPE_CAMPAIGN]: [{ src: NAME_FIELD }],
-    [D.ENTITY_TYPE_CONTAINER_NOTE]: [{ src: 'content' }, { src: 'created', dependencies: ['content'] }],
+    [D.ENTITY_TYPE_CONTAINER_NOTE]: [{ src: 'content' }, { src: 'created', dependencies: ['content'] }, { src: 'attribute_abstract', dependencies: ['content'] }],
     [D.ENTITY_TYPE_CONTAINER_OBSERVED_DATA]: [{ src: 'objects' }],
     [D.ENTITY_TYPE_CONTAINER_OPINION]: [{ src: 'opinion' }, { src: 'created', dependencies: ['opinion'] }],
     [D.ENTITY_TYPE_CONTAINER_REPORT]: [{ src: NAME_FIELD }, { src: 'published' }],

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/identifier-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/identifier-test.js
@@ -69,6 +69,8 @@ describe('identifier', () => {
     // note
     expect(generateStandardId(ENTITY_TYPE_CONTAINER_NOTE, { content: 'My note content!' })).toEqual('note--2b4ab5af-2307-58e1-8862-a6a269aae798');
     expect(generateStandardId(ENTITY_TYPE_CONTAINER_NOTE, { content: 'My note content!', created: '2022-11-25T19:00:05.000Z' })).toEqual('note--10861e5c-049e-54f6-9736-81c106e39a0b');
+    expect(generateStandardId(ENTITY_TYPE_CONTAINER_NOTE, { content: 'My note content!', attribute_abstract: 'Summary' })).toEqual('note--f0dc3eac-1c64-53dd-a5e2-a3d7b5480245');
+    expect(generateStandardId(ENTITY_TYPE_CONTAINER_NOTE, { content: 'My note content!', created: '2022-11-25T19:00:05.000Z', attribute_abstract: 'Summary' })).toEqual('note--4f87e4e4-8ac8-59a5-a026-6909c86e03a8');
     // observed-data
     expect(generateStandardId(ENTITY_TYPE_CONTAINER_OBSERVED_DATA, { objects: [{ standard_id: 'id' }] })).toEqual('observed-data--4765c523-81bc-54c8-b1af-ee81d961dad1');
     // opinion

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/identifier-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/identifier-test.js
@@ -185,7 +185,7 @@ describe('Function allFieldsContributingToStandardId', () => {
     fields = allFieldsContributingToStandardId({ entity_type: ENTITY_HASHED_OBSERVABLE_STIX_FILE });
     expect(fields).toEqual(['hashes', 'name']);
     fields = allFieldsContributingToStandardId({ entity_type: ENTITY_TYPE_CONTAINER_NOTE });
-    expect(fields).toEqual(['content', 'created']);
+    expect(fields).toEqual(['content', 'created', 'attribute_abstract']);
   });
 });
 


### PR DESCRIPTION
### Proposed changes

* Add `attribute_abstract` to the Note `standard_id` contribution so that Notes with different abstracts but identical content/created are treated as distinct entities
* Update pycti `Note.generate_id()` with a backward-compatible `abstract` parameter to align client-side ID generation with the platform
* Add a data migration to recompute `standard_id` for existing Notes that have an `attribute_abstract` (preserves old ID in `x_opencti_stix_ids`)

### Related issues

* Closes #15493

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Root cause:** The Note `standard_id` contribution in `identifier.js` only uses `(content, created)`. When connectors produce multiple Notes with the same body text and creation date (e.g., different vulnerabilities sharing an identical title), they collide on `standard_id` and trigger `FUNCTIONAL_ERROR: "This update will produce a duplicate"`.

**Fix:** Adding `attribute_abstract` (with `dependencies: ['content']`) to the contribution means:
- Notes with different abstracts get different `standard_id` values, even with identical content
- Notes without an abstract gracefully fall back to the current `(content, created)` dedup (nil values are filtered out)
- The pycti `generate_id()` change is backward-compatible (`abstract=None` by default)

**Migration:** The included migration recomputes `standard_id` for all Note entities. Unlike previous similar migrations, it **preserves the old `standard_id` in `x_opencti_stix_ids`** so that in-flight references from connectors still resolve correctly. Notes without `attribute_abstract` are skipped (their ID doesn't change).

A companion PR on the connectors repo updates the S3 connector and connectors-sdk to pass the abstract when generating Note IDs.
