### PR TITLE
[frontend] also check third level in filters (#15488)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -70,7 +70,7 @@ import { hexToRGB } from '../../../utils/Colors';
 import Security from '../../../utils/Security';
 import { EMPTY_VALUE, truncate } from '../../../utils/String';
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
-import { getEntityTypeTwoFirstLevelsFilterValues, removeIdAndIncorrectKeysFromFilterGroupObject, serializeFilterGroupForBackend } from '../../../utils/filters/filtersUtils';
+import { getEntityTypeThreeFirstLevelsFilterValues, removeIdAndIncorrectKeysFromFilterGroupObject, serializeFilterGroupForBackend } from '../../../utils/filters/filtersUtils';
 import { UserContext } from '../../../utils/hooks/useAuth';
 import {
   BYPASS,
@@ -494,7 +494,7 @@ class DataTableToolBar extends Component {
   handleOpenEnrichment(stixCyberObservableSubTypes, stixDomainObjectSubTypes) {
     // Get enrich type
     let enrichType;
-    const entityTypeFilterValues = getEntityTypeTwoFirstLevelsFilterValues(this.props.filters, stixCyberObservableSubTypes, stixDomainObjectSubTypes);
+    const entityTypeFilterValues = getEntityTypeThreeFirstLevelsFilterValues(this.props.filters, stixCyberObservableSubTypes, stixDomainObjectSubTypes);
     if (this.props.selectAll) {
       enrichType = this.props.type ?? R.head(entityTypeFilterValues);
     } else {
@@ -2097,7 +2097,7 @@ class DataTableToolBar extends Component {
   }
 
   getSelectedTypes(observableTypes, domainObjectTypes) {
-    const entityTypeFilterValues = getEntityTypeTwoFirstLevelsFilterValues(this.props.filters, observableTypes, domainObjectTypes);
+    const entityTypeFilterValues = getEntityTypeThreeFirstLevelsFilterValues(this.props.filters, observableTypes, domainObjectTypes);
     const selectedElementsList = Object.values(this.props.selectedElements || {});
     const selectedTypes = R.uniq([...selectedElementsList.map((o) => o.entity_type), ...entityTypeFilterValues]
       .filter((entity_type) => entity_type !== undefined));

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -24,7 +24,7 @@ import { isNotEmptyField } from '../../../utils/utils';
 import { capitalizeFirstLetter } from '../../../utils/String';
 import MarkdownDisplay from '../../../components/MarkdownDisplay';
 import { useFormatter } from '../../../components/i18n';
-import { findFiltersFromKeys, getEntityTypeTwoFirstLevelsFilterValues, SELF_ID, SELF_ID_VALUE } from '../../../utils/filters/filtersUtils';
+import { findFiltersFromKeys, getEntityTypeThreeFirstLevelsFilterValues, SELF_ID, SELF_ID_VALUE } from '../../../utils/filters/filtersUtils';
 import useAttributes from '../../../utils/hooks/useAttributes';
 import type { WidgetColumn, WidgetParameters } from '../../../utils/widget/widget';
 import { getCurrentAvailableParameters, getCurrentCategory, getCurrentIsRelationships, isWidgetListOrTimeline, getMaxResultCount } from '../../../utils/widget/widgetUtils';
@@ -807,7 +807,7 @@ const WidgetCreationParameters = () => {
               const getEntityTypeFromFilters = (filterGroup?: FilterGroup | null): string | undefined => {
                 if (!filterGroup) return undefined;
 
-                const entityTypeFilters = getEntityTypeTwoFirstLevelsFilterValues(filterGroup);
+                const entityTypeFilters = getEntityTypeThreeFirstLevelsFilterValues(filterGroup);
                 const hasSingleEntityType = entityTypeFilters.length === 1;
                 const otherFiltersLength = filterGroup?.filters?.filter((filter) => filter.key !== 'entity_type')?.length;
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -461,6 +461,35 @@ describe('Filters utils', () => {
       const result3 = getEntityTypeThreeFirstLevelsFilterValues(filters3, ['File', 'Domain-Name'], []);
       expect(result3).toEqual(['Stix-Cyber-Observable', 'File']);
     });
+    it('should return only observable subtypes when filter with AND  in third level', () => {
+      // filters: Observable AND (labels AND (Domain-Name OR File))
+      // result: Domain-Name, File
+      const filters = {
+        mode: 'and',
+        filters: [
+          { key: 'entity_type', operator: 'eq', values: ['Stix-Cyber-Observable'] },
+        ],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: 'objectLabel', operator: 'eq', values: ['label1-id'] },
+            ],
+            filterGroups: [
+              {
+                mode: 'and',
+                filters: [
+                  { key: 'entity_type', operator: 'eq', values: ['Domain-Name', 'File'] },
+                ],
+                filterGroups: [],
+              },
+            ],
+          },
+        ],
+      };
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
+      expect(result).toEqual(['Domain-Name', 'File']);
+    });
   });
 
   describe('useBuildEntityTypeBasedFilterContext', () => {

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -4,7 +4,7 @@ import {
   emptyFilterGroup,
   findFiltersFromKeys,
   formatFiltersInPirContext,
-  getEntityTypeTwoFirstLevelsFilterValues,
+  getEntityTypeThreeFirstLevelsFilterValues,
   isRegardingOfFilterWarning,
   removeIdAndIncorrectKeysFromFilterGroupObject,
   removeIdFromFilterGroupObject,
@@ -179,7 +179,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File']);
       expect(result).toEqual(['Domain-Name']);
     });
 
@@ -199,7 +199,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Stix-Domain-Object']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Stix-Domain-Object']);
       expect(result).toEqual(['Stix-Cyber-Observable', 'Domain-Name']);
     });
 
@@ -211,7 +211,7 @@ describe('Filters utils', () => {
         filters: [{ key: 'entity_type', operator: 'eq', values: ['Domain-Name', 'Stix-Cyber-Observable'] }],
         filterGroups: [],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Stix-Domain-Object']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Stix-Domain-Object']);
       expect(result).toEqual(['Domain-Name', 'Stix-Cyber-Observable']);
     });
 
@@ -232,7 +232,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File']);
       expect(result).toEqual(['Domain-Name']);
     });
 
@@ -253,7 +253,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
       expect(result).toEqual(['Stix-Cyber-Observable']);
     });
 
@@ -275,7 +275,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Report', 'Malware']);
       expect(result).toEqual(['Domain-Name', 'File']);
     });
 
@@ -293,7 +293,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Malware', 'Artifact', 'Country', 'City']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['Domain-Name', 'File'], ['Malware', 'Artifact', 'Country', 'City']);
       expect(result).toEqual(['Malware']);
     });
 
@@ -308,7 +308,7 @@ describe('Filters utils', () => {
         ],
         filterGroups: [],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, [], ['Malware', 'Report', 'Country', 'City']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, [], ['Malware', 'Report', 'Country', 'City']);
       expect(result).toEqual(['Report', 'Malware']);
     });
 
@@ -323,7 +323,7 @@ describe('Filters utils', () => {
         ],
         filterGroups: [],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['File'], ['Malware', 'Report', 'Country', 'City']);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['File'], ['Malware', 'Report', 'Country', 'City']);
       expect(result).toEqual(['Report', 'File', 'Malware']);
     });
 
@@ -344,7 +344,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, [], []);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, [], []);
       expect(result).toEqual([]);
       // filters: (Malware) AND (label=label1 OR marking=marking1)
       // result: Malware
@@ -362,7 +362,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result2 = getEntityTypeTwoFirstLevelsFilterValues(filters2, [], []);
+      const result2 = getEntityTypeThreeFirstLevelsFilterValues(filters2, [], []);
       expect(result2).toEqual(['Malware']);
     });
 
@@ -384,7 +384,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, [], []);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, [], []);
       expect(result).toEqual(['Malware', 'City']);
       // filters: (Malware) AND (City OR label=label1)
       // result: Malware
@@ -402,7 +402,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result2 = getEntityTypeTwoFirstLevelsFilterValues(filters2, [], []);
+      const result2 = getEntityTypeThreeFirstLevelsFilterValues(filters2, [], []);
       expect(result2).toEqual(['Malware']);
     });
 
@@ -423,7 +423,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result = getEntityTypeTwoFirstLevelsFilterValues(filters, ['File', 'Domain-Name'], []);
+      const result = getEntityTypeThreeFirstLevelsFilterValues(filters, ['File', 'Domain-Name'], []);
       expect(result).toEqual(['Stix-Cyber-Observable']);
       // filters: (Stix-Cyber-Observable) AND (File)
       // result: File
@@ -440,7 +440,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result2 = getEntityTypeTwoFirstLevelsFilterValues(filters2, ['File', 'Domain-Name'], []);
+      const result2 = getEntityTypeThreeFirstLevelsFilterValues(filters2, ['File', 'Domain-Name'], []);
       expect(result2).toEqual(['File']);
       // filters: (Stix-Cyber-Observable) OR (File AND label=label1)
       // result: Stix-Cyber-Observable
@@ -458,7 +458,7 @@ describe('Filters utils', () => {
           filterGroups: [],
         }],
       };
-      const result3 = getEntityTypeTwoFirstLevelsFilterValues(filters3, ['File', 'Domain-Name'], []);
+      const result3 = getEntityTypeThreeFirstLevelsFilterValues(filters3, ['File', 'Domain-Name'], []);
       expect(result3).toEqual(['Stix-Cyber-Observable', 'File']);
     });
   });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -278,12 +278,12 @@ export const removeEntityTypeAllFromFilterGroup = (inputFilters?: FilterGroup) =
   return inputFilters;
 };
 
-// fetch the entity type filters possible values of first and second levels
+// fetch the entity type filters possible values of first and second levels and third levels
 // and remove Observable if the filters target only some sub observable types
 // exemple: Observable AND (Domain-Name) --> [Domain-Name]
 // exemple: Domain-Name OR Observable --> [Domain-Name, Observable]
 // exemple: Stix-Domain-Object AND (Malware OR (Country AND City)) --> [Stix-Domain-Object, Malware]
-export const getEntityTypeTwoFirstLevelsFilterValues = (
+export const getEntityTypeThreeFirstLevelsFilterValues = (
   filters?: FilterGroup,
   observableTypes?: string[],
   domainObjectTypes?: string [],
@@ -318,6 +318,32 @@ export const getEntityTypeTwoFirstLevelsFilterValues = (
     }
     if (filters.mode === 'or') {
       return [];
+    }
+    // Check third level values
+    const subFilterGroupssSeparatedWithAnd = filters.filterGroups
+      .filter((fg) => fg.mode === 'and' || (fg.mode === 'or' && fg.filters.length === 1))
+      .map((fg) => fg.filterGroups)
+      .flat();
+    const thirdFiltersSeperatedWithAnd = subFilterGroupssSeparatedWithAnd
+      .filter((fg) => fg.mode === 'and' || (fg.mode === 'or' && fg.filters.length === 1))
+      .map((fg) => fg.filters)
+      .flat();
+    if (thirdFiltersSeperatedWithAnd.length > 0) {
+      const thirdLevelValues = findFiltersFromKeys(thirdFiltersSeperatedWithAnd, ['entity_type'], 'eq')
+        .map(({ values }) => values)
+        .flat();
+      if (thirdLevelValues.length > 0) {
+        if (filters.mode === 'and') {
+          // if all second values are observables sub types : remove observable from firstLevelValue
+          if (thirdLevelValues.every((type) => observableTypes?.includes(type))) {
+            firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Cyber-Observable');
+          }
+          if (thirdLevelValues.every((type) => domainObjectTypes?.includes(type))) {
+            firstLevelValues = firstLevelValues.filter((type) => type !== 'Stix-Domain-Object');
+          }
+        }
+        return [...firstLevelValues, ...thirdLevelValues];
+      }
     }
   }
   return firstLevelValues;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* also check third level in filters: it's needed in containers entities/observable page, where the user filters are nested in the third level (1st level filter is SDO/SCO, 2nd level filter is used for objects filter, and user filters are at 3rd level)
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15488
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
