### PR TITLE
[backend] Trim string values in standard_id computation to match indexing logic (#15510)

### DIFF
--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -388,7 +388,7 @@ const filteredIdContributions = (contrib, way, data) => {
     if (resolver) {
       objectData[destKey] = value ? resolver(value) : value;
     } else {
-      objectData[destKey] = value;
+      objectData[destKey] = R.is(String, value) ? value.trim() : value;
     }
   }
   return R.filter((keyValue) => !R.isEmpty(keyValue) && !R.isNil(keyValue), objectData);


### PR DESCRIPTION
### Proposed changes

* Trim string values in `filteredIdContributions` before they enter the `standard_id` hash, matching the same trim logic applied by `prepareElementForIndexing` before ES storage

### Related issues

* Closes #15510

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The indexing layer (`engine.ts`) trims all string values via `prepareElementForIndexing` before storing in ElasticSearch. However, `filteredIdContributions` (`identifier.js`) uses raw (untrimmed) string values when computing the `standard_id` hash. This means:

1. `standard_id` is computed from `"content\n"` (raw input)
2. ES stores `"content"` (trimmed)
3. Any code that reads back from ES and recomputes `standard_id` gets a different hash

This one-line change applies the same `R.is(String, value) ? value.trim() : value` pattern used in `prepareElementForIndexing` to the ID contribution values, ensuring `standard_id` is always computed from the trimmed form.

Existing tests are unaffected because their test inputs don't contain trailing whitespace.
