### PR TITLE
[backend/frontend] fix Service account name normalization in the catalog(#12845)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -57,7 +57,7 @@ const ingestionCatalogConnectorCreationMutation = graphql`
 `;
 
 // Sanitize name for K8s/Docker compatibility
-const sanitizeContainerName = (label: string): string => {
+export const sanitizeContainerName = (label: string): string => {
   let sanitized = label
     .replace(/[^a-zA-Z0-9]+/g, '-')
     .toLowerCase()

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionCatalogConnectorCreation.tsx
@@ -58,8 +58,7 @@ const ingestionCatalogConnectorCreationMutation = graphql`
 
 // Sanitize name for K8s/Docker compatibility
 const sanitizeContainerName = (label: string): string => {
-  const withHyphens = label.replace(/([a-z])([A-Z])/g, '$1-$2');
-  let sanitized = withHyphens
+  let sanitized = label
     .replace(/[^a-zA-Z0-9]+/g, '-')
     .toLowerCase()
     .replace(/^-+/, '')

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCreationUserHandling.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCreationUserHandling.tsx
@@ -36,6 +36,7 @@ interface IngestionCreationUserHandlingComponentProps extends IngestionCreationU
 
 export interface BasicUserHandlingValues {
   name: string;
+  display_name?: string;
   user_id: string | FieldOption;
   automatic_user?: boolean;
   confidence_level?: string;
@@ -50,13 +51,14 @@ const IngestionCreationUserHandlingComponent = ({ queryRef, default_confidence_l
   const data = usePreloadedQuery(ingestionCreationUserHandlingDefaultGroupForIngestionUsersQuery, queryRef);
 
   useEffect(() => {
+    const userName = values.display_name ?? values.name;
     setFieldValue(
       'user_id',
       values.automatic_user === false
         ? ''
-        : { label: `[${labelTag}] ${values.name}`, value: `[${labelTag}] ${values.name}` },
+        : { label: `[${labelTag}] ${userName}`, value: `[${labelTag}] ${userName}` },
     );
-  }, [values.name, values.automatic_user, labelTag]);
+  }, [values.display_name, values.name, values.automatic_user, labelTag]);
 
   useEffect(() => {
     setFieldValue(

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCreationUserHandling.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCreationUserHandling.tsx
@@ -42,7 +42,7 @@ export interface BasicUserHandlingValues {
   confidence_level?: string;
 }
 
-const IngestionCreationUserHandlingComponent = ({ queryRef, default_confidence_level, labelTag, isSensitive }: IngestionCreationUserHandlingComponentProps) => {
+export const IngestionCreationUserHandlingComponent = ({ queryRef, default_confidence_level, labelTag, isSensitive }: IngestionCreationUserHandlingComponentProps) => {
   const { t_i18n } = useFormatter();
   const setAccess = useGranted([SETTINGS_SETACCESSES]);
   const { values, setFieldValue, validateField } = useFormikContext<BasicUserHandlingValues>();

--- a/opencti-platform/opencti-graphql/src/domain/connector.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector.ts
@@ -71,8 +71,7 @@ import type { FileHandle } from 'fs/promises';
 const MINIMAL_SYNCHRONIZER_COMPATIBLE_VERSION = '6.9.6';
 // Sanitize name for K8s/Docker
 const sanitizeContainerName = (label: string): string => {
-  const withHyphens = label.replace(/([a-z])([A-Z])/g, '$1-$2');
-  let sanitized = withHyphens
+  let sanitized = label
     .replace(/[^a-zA-Z0-9]+/g, '-')
     .toLowerCase()
     .replace(/^-+/, '')

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
@@ -1239,7 +1239,7 @@ describe('Connector Composer and Managed Connectors', () => {
       expect(managedConnectorAdd).not.toBeNull();
       managedConnectorId = managedConnectorAdd.id;
       createdConnectorIds.add(managedConnectorId);
-      expect(managedConnectorAdd.name).toEqual('test-ip-info-connector');
+      expect(managedConnectorAdd.name).toEqual('test-ipinfo-connector');
       expect(managedConnectorAdd.connector_user_id).toBeDefined();
       expect(managedConnectorAdd.manager_requested_status).toEqual('stopped');
       expect(managedConnectorAdd.manager_contract_hash).toBeDefined();

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-composer-test.ts
@@ -231,7 +231,7 @@ describe('Connector Composer and Managed Connectors', () => {
       const catalogId = catalogHelper.getCatalogId();
 
       const testCases = [
-        { input: 'ServiceNow Connector', expected: 'service-now-connector' },
+        { input: 'ServiceNow Connector', expected: 'servicenow-connector' },
         { input: '-Test@Connector#2024!', expected: 'test-connector-2024' },
         { input: 'Very___Long---Name__With$$Special##Chars@@That--Exceeds--The--Maximum--Length--Limit--Of--63--Characters', expected: 'very-long-name-with-special-chars-that-exceeds-the-maximum-leng' },
       ];


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removal of CamelCase word splitting ($1-$2) in sanitizeContainerName
* Using the connector’s original display name (display_name) when creating the service account, rather than the standardised ‘name’ in IngestionCreationUserHandling.tsx

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* resolves #12845 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
