### PR TITLE
[ci]  Revert Update CI workflow to ignore changes on Docs and .md files (#15351)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -2,16 +2,8 @@ name: OpenCTI CI
 on:
   workflow_dispatch:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '.github/*.md'
   pull_request:
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '.github/*.md'
 
 jobs:
   wf-build-image:


### PR DESCRIPTION
Reverts OpenCTI-Platform/opencti#15352

Additional efforts are needed to ensure that ignored tasks do not block the merge.

un closes #15351 