### PR TITLE
[frontend] fix: prevent using relay cache when checking connectivity (#15516)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -40,6 +40,7 @@ const XtmHubSettingsComponent = () => {
   const { settings: xtmHubSettings } = useLazyLoadQuery<XtmHubSettingsQuery>(
     xtmHubSettingsQuery,
     {},
+    { fetchPolicy: 'network-only' },
   );
   const isGrantedToXtmHub = useGranted([SETTINGS_SETMANAGEXTMHUB]);
   const { isXTMHubAccessible } = useContext(UserContext);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add network only to relay to prevent using cached data

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15516
* Refers to https://github.com/FiligranHQ/xtm-hub/issues/2112

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

https://github.com/user-attachments/assets/3c5ccb83-17d5-4503-9f48-e13d492a759b


