### PR TITLE
[frontend] fix NLQ message icon color (#15509)

### DIFF
--- a/opencti-platform/opencti-front/src/components/Message.tsx
+++ b/opencti-platform/opencti-front/src/components/Message.tsx
@@ -128,8 +128,11 @@ const Message = () => {
       case 'nlq':
         return (
           <Alert
-            icon={<FiligranIcon icon={LogoXtmOneIcon} size="small" />}
-            style={{ backgroundColor: theme.palette.ai.background, color: theme.palette.ai.light }}
+            icon={<FiligranIcon icon={LogoXtmOneIcon} size="small" style={{ color: theme.palette.ai.main }} />}
+            style={{
+              backgroundColor: theme.palette.ai.background,
+              color: theme.palette.ai.light,
+            }}
             onClose={() => handleCloseMessage()}
           >
             {text}


### PR DESCRIPTION
### Proposed changes
The error messages concerning NLQ should have purple background, text and icon.
The icon was green, fixed to purple in this PR : 

<img width="1153" height="286" alt="image" src="https://github.com/user-attachments/assets/ce1489d9-365c-4008-8e0e-5951f548ae27" />


### Related issues
fixes #15509