### PR TITLE
[frontend] remove filtering on Notes and Opinions (#14426)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/GraphContext.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphContext.tsx
@@ -150,8 +150,7 @@ export const GraphProvider = ({
       })
       .sort((a, b) => a.label.localeCompare(b.label))
       .map((node) => node.entity_type)
-      .filter((v, i, a) => a.indexOf(v) === i)
-      .filter((v) => !['Note', 'Opinion'].includes(v));
+      .filter((v, i, a) => a.indexOf(v) === i);
   }, [graphData?.nodes]);
 
   // Dynamically compute all marking definitions in graphData.

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarRemoveConfirm.tsx
@@ -118,12 +118,6 @@ const GraphToolbarRemoveConfirm = ({
     const nodesToRemove: string[] = [];
     const linksToRemove: string[] = [];
 
-    const ignoredStixCoreObjectsTypes = ['Note', 'Opinion'];
-    // Containers checked when cascade delete.
-    const checkedContainerTypes = containerTypes.filter((type) => {
-      return !ignoredStixCoreObjectsTypes.includes(type);
-    });
-
     const allSelection = [...selectedNodes, ...selectedLinks];
     const selectedNodeIds = selectedNodes.map((n) => n.id);
     const associatedLinks = (graphData?.links ?? []).filter(({ source_id, target_id }) => {
@@ -141,7 +135,7 @@ const GraphToolbarRemoveConfirm = ({
 
       const data = (await fetchQuery(
         knowledgeGraphQueryCheckObjectQuery,
-        { id, entityTypes: checkedContainerTypes },
+        { id, entityTypes: containerTypes },
       ).toPromise()) as KnowledgeGraphQueryCheckObjectQuery$data;
       if (
         andDelete

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
@@ -58,12 +58,12 @@ const useGraphParser = () => {
   const getRelationshipName = (data: ObjectToParse, forNode = false) => {
     const key = forNode ? data.relationship_type : data.entity_type;
     const relTypeStr = `<strong>${t_i18n(`relationship_${key}`)}</strong>`;
-    const createdStr = `${t_i18n('Created the')} ${dateFormat(data.created)}`;
+    const createdStr = `${t_i18n('Created the')} ${dateFormat(data.created) ?? '-'}`;
     const start = data.start_time || data.first_seen;
     const startStr = `${t_i18n('Start time')} ${isNone(start) ? EMPTY_VALUE : dateFormat(start)}`;
     const end = data.stop_time || data.last_seen;
     const endStr = `${t_i18n('Stop time')} ${isNone(end) ? EMPTY_VALUE : dateFormat(end)}`;
-    return `${relTypeStr}\n${createdStr}\n${startStr}\n${endStr}`;
+    return `${relTypeStr}<br/>${createdStr}<br/>${startStr}<br/>${endStr}`;
   };
 
   const getMarkings = (data: ObjectToParse) => {
@@ -198,7 +198,7 @@ const useGraphParser = () => {
       relationship_type: data.relationship_type,
       label: t_i18n(`relationship_${data.entity_type}`),
       markedBy: getMarkings(data),
-      name: sanitize(getRelationshipName(data), true),
+      name: sanitize(getRelationshipName(data), false),
       createdBy: getCreatedBy(data),
       defaultDate: jsDate(defaultDate(data)),
       isNestedInferred: getIsNestedInferred(data),
@@ -210,8 +210,7 @@ const useGraphParser = () => {
   };
 
   const buildGraphData = (objects: ObjectToParse[], graphPositions: OctiGraphPositions) => {
-    const uniqObjects = R.uniqBy(R.prop('id'), objects)
-      .filter((object) => !['Note', 'Opinion'].includes(object.entity_type));
+    const uniqObjects = R.uniqBy(R.prop('id'), objects);
     const uniqIds = uniqObjects.map((o) => o.id);
     const relationshipsIdsInNestedRelationship = objects.flatMap((o) => {
       if (o.from && o.to && (o.from.relationship_type || o.to.relationship_type)) {


### PR DESCRIPTION
### Proposed changes

* Remove all filters in graph code that exclude Notes and Opinions
* Small improvement of relationship tool-tip display

### Related issues

* Closes #14426

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality