### PR TITLE
[frontend][backend] Enable/disable a custom view (#13389)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "Zugehörige öffentliche Dashboards anzeigen",
   "View draft": "Entwurf ansehen",
   "View full details": "Alle Details anzeigen",
+  "View is disabled": "Ansicht ist deaktiviert",
+  "View is enabled": "Ansicht ist aktiviert",
   "View rule": "Regel ansehen",
   "View the element": "Ansicht des Elements",
   "View the item": "Betrachten Sie das Element",
@@ -4909,4 +4911,3 @@
   "Zoom in": "Vergrößern",
   "Zoom out": "Verkleinern"
 }
-

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "Diesen Stream öffentlich und für jedermann zugänglich machen",
   "Make this taxii collection public and available to anyone": "Diese Taxii-Sammlung öffentlich und für jedermann zugänglich machen",
   "Make this TAXII collection public and available to anyone": "Diese TAXII-Sammlung öffentlich und für jedermann zugänglich machen",
+  "Make this view visible to users": "Diese Ansicht für Benutzer sichtbar machen",
   "Malicious": "Bösartig",
   "Maliciousness": "Bösartigkeit",
   "Malware": "Malware",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "Make this stream public and available to anyone",
   "Make this taxii collection public and available to anyone": "Make this taxii collection public and available to anyone",
   "Make this TAXII collection public and available to anyone": "Make this TAXII collection public and available to anyone",
+  "Make this view visible to users": "Make this view visible to users",
   "Malicious": "Malicious",
   "Maliciousness": "Maliciousness",
   "Malware": "Malware",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "View associated public dashboards",
   "View draft": "View draft",
   "View full details": "View full details",
+  "View is disabled": "View is disabled",
+  "View is enabled": "View is enabled",
   "View rule": "View rule",
   "View the element": "View the element",
   "View the item": "View the item",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "Haz que esta transmisión sea pública y esté disponible para todos.",
   "Make this taxii collection public and available to anyone": "Hacer esta colección taxii pública y disponible para cualquiera",
   "Make this TAXII collection public and available to anyone": "Hacer pública esta colección TAXII y ponerla a disposición de cualquiera",
+  "Make this view visible to users": "Hacer esta vista visible para los usuarios",
   "Malicious": "Malicioso",
   "Maliciousness": "Maldad",
   "Malware": "Malware",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "Ver los cuadros de mando públicos asociados",
   "View draft": "Ver borrador",
   "View full details": "Ver detalles completos",
+  "View is disabled": "Vista desactivada",
+  "View is enabled": "Vista activada",
   "View rule": "Ver regla",
   "View the element": "Ver el elemento",
   "View the item": "Ver el objeto",
@@ -4909,4 +4911,3 @@
   "Zoom in": "Ampliar",
   "Zoom out": "Alejar"
 }
-

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "Voir les tableaux de bord publics associés",
   "View draft": "Voir le brouillon",
   "View full details": "Voir tous les détails",
+  "View is disabled": "L'affichage est désactivé",
+  "View is enabled": "L'affichage est activé",
   "View rule": "Voir la règle",
   "View the element": "Voir l'élément",
   "View the item": "Voir l'object",
@@ -4909,4 +4911,3 @@
   "Zoom in": "Zoomer",
   "Zoom out": "Zoom arrière"
 }
-

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "Rendre ce stream public et accessible à tous",
   "Make this taxii collection public and available to anyone": "Rendre cette collection de taxii publique et accessible à tous",
   "Make this TAXII collection public and available to anyone": "Rendre cette collection TAXII publique et accessible à tous",
+  "Make this view visible to users": "Rendre cette vue visible aux utilisateurs",
   "Malicious": "Malveillant",
   "Maliciousness": "Niveau de malveillance",
   "Malware": "Code malveillant",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "Visualizza le dashboard pubbliche associate",
   "View draft": "Visualizza bozza",
   "View full details": "Visualizza tutti i dettagli",
+  "View is disabled": "La vista è disabilitata",
+  "View is enabled": "La vista è abilitata",
   "View rule": "Visualizza la regola",
   "View the element": "Visualizza l'elemento",
   "View the item": "Visualizza l'elemento",
@@ -4909,4 +4911,3 @@
   "Zoom in": "Ingrandisci",
   "Zoom out": "Riduci"
 }
-

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "Rendi questo flusso pubblico e disponibile a chiunque",
   "Make this taxii collection public and available to anyone": "Rendi questa raccolta TAXII pubblica",
   "Make this TAXII collection public and available to anyone": "Rendi questa raccolta TAXII pubblica",
+  "Make this view visible to users": "Rendere questa vista visibile agli utenti",
   "Malicious": "Malevole",
   "Maliciousness": "Malvagità",
   "Malware": "Malware",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "関連する公開ダッシュボードを見る",
   "View draft": "草案を見る",
   "View full details": "詳細を表示",
+  "View is disabled": "表示は無効",
+  "View is enabled": "表示が有効",
   "View rule": "ルールを見る",
   "View the element": "エレメントを見る",
   "View the item": "アイテムの表示",
@@ -4909,4 +4911,3 @@
   "Zoom in": "ズームイン",
   "Zoom out": "ズームアウト"
 }
-

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "このストリームを公開して誰でも利用できるようにする",
   "Make this taxii collection public and available to anyone": "このTaxiiコレクションを公開し、誰でも利用できるようにする",
   "Make this TAXII collection public and available to anyone": "このTAXIIコレクションを公開し、誰でも利用できるようにする。",
+  "Make this view visible to users": "このビューをユーザーに見せる",
   "Malicious": "悪性",
   "Maliciousness": "悪意がある",
   "Malware": "マルウェア",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "연결된 공개 대시보드 보기",
   "View draft": "초안 보기",
   "View full details": "전체 세부 정보 보기",
+  "View is disabled": "보기가 비활성화됨",
+  "View is enabled": "보기가 활성화됨",
   "View rule": "규칙 보기",
   "View the element": "요소 보기",
   "View the item": "항목 보기",
@@ -4909,4 +4911,3 @@
   "Zoom in": "확대",
   "Zoom out": "축소"
 }
-

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "이 스트림을 공개하고 누구나 사용할 수 있도록 설정",
   "Make this taxii collection public and available to anyone": "이 TAXII 컬렉션을 공개하고 누구나 사용할 수 있도록 설정",
   "Make this TAXII collection public and available to anyone": "이 TAXII 컬렉션을 공개하여 누구나 사용할 수 있도록 합니다",
+  "Make this view visible to users": "이 뷰를 사용자에게 표시하도록 설정",
   "Malicious": "악의적",
   "Maliciousness": "악의성",
   "Malware": "악성 소프트웨어",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "Просмотр связанных публичных информационных дашбордов",
   "View draft": "Посмотреть проект",
   "View full details": "Посмотреть все детали",
+  "View is disabled": "Вид отключен",
+  "View is enabled": "Просмотр включен",
   "View rule": "Правило просмотра",
   "View the element": "Посмотреть элемент",
   "View the item": "Посмотреть товар",
@@ -4909,4 +4911,3 @@
   "Zoom in": "Увеличить",
   "Zoom out": "Уменьшить масштаб"
 }
-

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "Сделайте этот поток открытым и доступным для всех желающих",
   "Make this taxii collection public and available to anyone": "Сделайте эту коллекцию Taxii открытой и доступной для всех желающих",
   "Make this TAXII collection public and available to anyone": "Сделать эту коллекцию TAXII открытой и доступной для всех желающих",
+  "Make this view visible to users": "Сделайте это представление видимым для пользователей",
   "Malicious": "Вредоносный",
   "Maliciousness": "Вредоносность",
   "Malware": "Вредоносные программы",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -4721,6 +4721,8 @@
   "View associated public dashboards": "查看相关的公共仪表板",
   "View draft": "查看草案",
   "View full details": "查看完整详情",
+  "View is disabled": "查看已禁用",
+  "View is enabled": "查看已启用",
   "View rule": "查看规则",
   "View the element": "查看元素",
   "View the item": "查看项目",
@@ -4909,4 +4911,3 @@
   "Zoom in": "放大",
   "Zoom out": "缩小"
 }
-

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2579,6 +2579,7 @@
   "Make this stream public and available to anyone": "将此流公开并提供给任何人",
   "Make this taxii collection public and available to anyone": "将此Taxii集合公开，任何人都可以使用",
   "Make this TAXII collection public and available to anyone": "公开 TAXII 数据库，供任何人使用",
+  "Make this view visible to users": "让用户看到此视图",
   "Malicious": "恶意",
   "Maliciousness": "恶意行为",
   "Malware": "恶意软件",

--- a/opencti-platform/opencti-front/src/components/ItemBoolean.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemBoolean.tsx
@@ -73,6 +73,7 @@ const ItemBoolean = ({
       <Tag
         label={label}
         color={reverse ? theme.palette.success.main : theme.palette.error.main}
+        labelTextTransform={labelTextTransform}
       />
     );
   };

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
@@ -30,6 +30,7 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -57,6 +58,7 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -83,6 +85,7 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -109,6 +112,7 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -126,5 +130,35 @@ describe('CustomViewRedirector', () => {
       },
     );
     expect(screen.getByText(CUSTOM_VIEW_MOCK_CONTENT)).toBeInTheDocument();
+  });
+
+  it('renders fallback when on custom view route but view is disabled', () => {
+    const customViewPath = 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3';
+    const id = '1504f07b-ee3f-4c09-ae66-b9550eb3abe3';
+    vi.mocked(useCustomViewsData).mockImplementation(() => ({
+      allCustomViews: [{
+        id,
+        name: 'My custom view',
+        path: customViewPath,
+        targetEntityType: 'Intrusion-Set',
+        default: false,
+        enabled: false,
+      }],
+      refetchCustomViews: () => ({ dispose: () => {} }),
+    }));
+    testRender(
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
+          }
+        />
+      </Routes>,
+      {
+        route: customViewPath,
+      },
+    );
+    expect(screen.getByText(/Not matched/i)).toBeInTheDocument();
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
@@ -131,34 +131,4 @@ describe('CustomViewRedirector', () => {
     );
     expect(screen.getByText(CUSTOM_VIEW_MOCK_CONTENT)).toBeInTheDocument();
   });
-
-  it('renders fallback when on custom view route but view is disabled', () => {
-    const customViewPath = 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3';
-    const id = '1504f07b-ee3f-4c09-ae66-b9550eb3abe3';
-    vi.mocked(useCustomViewsData).mockImplementation(() => ({
-      allCustomViews: [{
-        id,
-        name: 'My custom view',
-        path: customViewPath,
-        targetEntityType: 'Intrusion-Set',
-        default: false,
-        enabled: false,
-      }],
-      refetchCustomViews: () => ({ dispose: () => {} }),
-    }));
-    testRender(
-      <Routes>
-        <Route
-          path="*"
-          element={
-            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
-          }
-        />
-      </Routes>,
-      {
-        route: customViewPath,
-      },
-    );
-    expect(screen.getByText(/Not matched/i)).toBeInTheDocument();
-  });
 });

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
@@ -72,7 +72,7 @@ const TestWrapper = ({ entityType, basePath }: TestWrapperProps) => {
 
   return (
     <>
-      <Tabs value={currentCustomViewTab}>
+      <Tabs value={currentCustomViewTab || false}>
         {renderCustomViewTab()}
       </Tabs>
       {displayMode === 'dropdown' && (
@@ -98,6 +98,7 @@ describe('useCustomViewTabs', () => {
         name: customViewDisplayName,
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -131,11 +132,13 @@ describe('useCustomViewTabs', () => {
         name: 'My first custom view',
         path: 'some-path',
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }, {
         id: '90ebf22f-2c36-4836-b21a-e114ed4ca2ab',
         name: 'My second custom view',
         path: 'some-other-path',
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -176,11 +179,46 @@ describe('useCustomViewTabs', () => {
         name: customViewDisplayName,
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
+        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
     testRender(
       <TestWrapper entityType="Case-Rft" basePath="" />,
+      {
+        userContext: createMockUserContext({
+          settings: {
+            platform_feature_flags: [{
+              id: 'CUSTOM_VIEW',
+              enable: true,
+            }],
+          },
+        }),
+      },
+    );
+    expect(screen.queryByRole('tab', {
+      name: new RegExp(customViewDisplayName, 'i'),
+    })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', {
+      name: /Custom view/i,
+    })).not.toBeInTheDocument();
+  });
+
+  it('does not render another tab when custom view exists but is disabled', () => {
+    const customViewDisplayName = 'My custom view';
+    const customViewPath = 'some-path';
+    vi.mocked(useCustomViewsData).mockImplementation(() => ({
+      allCustomViews: [{
+        id: '1504f07b-ee3f-4c09-ae66-b9550eb3abe3',
+        name: customViewDisplayName,
+        path: customViewPath,
+        enabled: false,
+        default: false,
+      }],
+      refetchCustomViews: () => ({ dispose: () => {} }),
+    }));
+    testRender(
+      <TestWrapper entityType="Intrusion-Set" basePath="" />,
       {
         userContext: createMockUserContext({
           settings: {

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
@@ -98,7 +98,6 @@ describe('useCustomViewTabs', () => {
         name: customViewDisplayName,
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -132,13 +131,11 @@ describe('useCustomViewTabs', () => {
         name: 'My first custom view',
         path: 'some-path',
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
       }, {
         id: '90ebf22f-2c36-4836-b21a-e114ed4ca2ab',
         name: 'My second custom view',
         path: 'some-other-path',
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -179,46 +176,11 @@ describe('useCustomViewTabs', () => {
         name: customViewDisplayName,
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
     testRender(
       <TestWrapper entityType="Case-Rft" basePath="" />,
-      {
-        userContext: createMockUserContext({
-          settings: {
-            platform_feature_flags: [{
-              id: 'CUSTOM_VIEW',
-              enable: true,
-            }],
-          },
-        }),
-      },
-    );
-    expect(screen.queryByRole('tab', {
-      name: new RegExp(customViewDisplayName, 'i'),
-    })).not.toBeInTheDocument();
-    expect(screen.queryByRole('tab', {
-      name: /Custom view/i,
-    })).not.toBeInTheDocument();
-  });
-
-  it('does not render another tab when custom view exists but is disabled', () => {
-    const customViewDisplayName = 'My custom view';
-    const customViewPath = 'some-path';
-    vi.mocked(useCustomViewsData).mockImplementation(() => ({
-      allCustomViews: [{
-        id: '1504f07b-ee3f-4c09-ae66-b9550eb3abe3',
-        name: customViewDisplayName,
-        path: customViewPath,
-        enabled: false,
-        default: false,
-      }],
-      refetchCustomViews: () => ({ dispose: () => {} }),
-    }));
-    testRender(
-      <TestWrapper entityType="Intrusion-Set" basePath="" />,
       {
         userContext: createMockUserContext({
           settings: {

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.ts
@@ -11,6 +11,14 @@ export const customViewsFragment = graphql`
     customViews(
       orderBy: name
       orderMode: asc
+      filters: {
+        mode: and
+        filters: [{
+          key: ["enabled"]
+          values: [true]
+        }]
+        filterGroups: []
+      }
     ) {
       edges {
         node {

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Box, Tooltip } from '@mui/material';
+import Box from '@mui/material/Box';
+import Tooltip from '@mui/material/Tooltip';
 import Button from '@common/button/Button';
 import Tag from '@common/tag/Tag';
 import { useTheme } from '@mui/styles';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import IconButton from '@common/button/IconButton';
 import TitleMainEntity from '../../../../../components/common/typography/TitleMainEntity';
 import { CustomViewEditionHeader_customView$key } from './__generated__/CustomViewEditionHeader_customView.graphql';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
@@ -84,9 +86,9 @@ const CustomViewEditionHeader = ({ data, onCreateWidget, onImportWidget }: Custo
         />
         <Box sx={{ display: 'flex', alignItems: 'center', marginLeft: 'auto', gap: 1 }}>
           <Tooltip title={customView.enabled ? t_i18n('Disable') : t_i18n('Enable')}>
-            <Button variant="secondary" iconOnly disabled={mutating} onClick={handleToggleEnabled}>
+            <IconButton variant="secondary" size="default" disabled={mutating} onClick={handleToggleEnabled}>
               {customView.enabled ? <VisibilityOffIcon /> : <VisibilityIcon />}
-            </Button>
+            </IconButton>
           </Tooltip>
           <CustomViewMenu data={customView} />
           <DashboardWidgetConfig

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
@@ -1,7 +1,12 @@
 import { useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
-import { Box, Typography } from '@mui/material';
+import { Box, Tooltip } from '@mui/material';
 import Button from '@common/button/Button';
+import Tag from '@common/tag/Tag';
+import { useTheme } from '@mui/styles';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import StopIcon from '@mui/icons-material/Stop';
+import TitleMainEntity from '../../../../../components/common/typography/TitleMainEntity';
 import { CustomViewEditionHeader_customView$key } from './__generated__/CustomViewEditionHeader_customView.graphql';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../../components/i18n';
@@ -10,6 +15,8 @@ import useEntityTranslation from '../../../../../utils/hooks/useEntityTranslatio
 import DashboardWidgetConfig from 'src/components/dashboard/DashboardWidgetConfig';
 import type { Widget } from '../../../../../utils/widget/widget';
 import CustomViewMenu from './CustomViewMenu';
+import type { Theme } from '../../../../../components/Theme';
+import useCustomViewEdit from './useCustomViewEdit';
 
 const headerFragment = graphql`
   fragment CustomViewEditionHeader_customView on CustomView {
@@ -17,6 +24,7 @@ const headerFragment = graphql`
     name
     description
     targetEntityType
+    enabled
     ...CustomViewMenu_customView
   }
 `;
@@ -32,6 +40,8 @@ const CustomViewEditionHeader = ({ data, onCreateWidget, onImportWidget }: Custo
   const { translateEntityType } = useEntityTranslation();
   const [isFormOpen, setFormOpen] = useState(false);
   const customView = useFragment(headerFragment, data);
+  const theme = useTheme<Theme>();
+  const [commitCustomViewMutation, mutating] = useCustomViewEdit();
   const customizationLink = '/dashboard/settings/customization/entity_types';
   const subTypeLink = `${customizationLink}/${customView.targetEntityType}/custom-views`;
   const breadcrumb = [
@@ -42,16 +52,42 @@ const CustomViewEditionHeader = ({ data, onCreateWidget, onImportWidget }: Custo
     { label: t_i18n('Custom Views') },
     { label: customView.name },
   ];
-
+  const handleToggleEnabled = () => {
+    commitCustomViewMutation({
+      variables: {
+        id: customView.id,
+        input: [{
+          key: 'enabled',
+          value: [!customView.enabled],
+        }],
+      },
+    });
+  };
   return (
     <>
       <Breadcrumbs elements={breadcrumb} />
 
-      <Box sx={{ display: 'flex', gap: 1 }}>
-        <Typography variant="h1" sx={{ float: 'left' }}>
-          {customView.name}
-        </Typography>
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+        <TitleMainEntity>{customView.name}</TitleMainEntity>
+        <Tag
+          color={
+            customView.enabled
+              ? theme.palette.severity.low
+              : theme.palette.severity.critical
+          }
+          label={
+            customView.enabled
+              ? t_i18n('View is active')
+              : t_i18n('View is stopped')
+          }
+          labelTextTransform="none"
+        />
         <Box sx={{ display: 'flex', alignItems: 'center', marginLeft: 'auto', gap: 1 }}>
+          <Tooltip title={customView.enabled ? t_i18n('Disable') : t_i18n('Enable')}>
+            <Button variant="secondary" iconOnly disabled={mutating} onClick={handleToggleEnabled}>
+              {customView.enabled ? <StopIcon /> : <PlayArrowIcon />}
+            </Button>
+          </Tooltip>
           <CustomViewMenu data={customView} />
           <DashboardWidgetConfig
             onComplete={onCreateWidget}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
@@ -4,8 +4,8 @@ import { Box, Tooltip } from '@mui/material';
 import Button from '@common/button/Button';
 import Tag from '@common/tag/Tag';
 import { useTheme } from '@mui/styles';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import StopIcon from '@mui/icons-material/Stop';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import TitleMainEntity from '../../../../../components/common/typography/TitleMainEntity';
 import { CustomViewEditionHeader_customView$key } from './__generated__/CustomViewEditionHeader_customView.graphql';
 import Breadcrumbs from '../../../../../components/Breadcrumbs';
@@ -77,15 +77,15 @@ const CustomViewEditionHeader = ({ data, onCreateWidget, onImportWidget }: Custo
           }
           label={
             customView.enabled
-              ? t_i18n('View is active')
-              : t_i18n('View is stopped')
+              ? t_i18n('View is enabled')
+              : t_i18n('View is disabled')
           }
           labelTextTransform="none"
         />
         <Box sx={{ display: 'flex', alignItems: 'center', marginLeft: 'auto', gap: 1 }}>
           <Tooltip title={customView.enabled ? t_i18n('Disable') : t_i18n('Enable')}>
             <Button variant="secondary" iconOnly disabled={mutating} onClick={handleToggleEnabled}>
-              {customView.enabled ? <StopIcon /> : <PlayArrowIcon />}
+              {customView.enabled ? <VisibilityOffIcon /> : <VisibilityIcon />}
             </Button>
           </Tooltip>
           <CustomViewMenu data={customView} />

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
@@ -23,7 +23,11 @@ const DEFAULT_VALUES: CustomViewFormInputs = {
 interface CustomViewFormProps {
   onClose: () => void;
   onSubmit: FormikConfig<CustomViewFormInputs>['onSubmit'];
-  onSubmitField: (name: string, value: unknown) => void;
+  onSubmitField: (
+    name: string,
+    value: unknown,
+    { setSubmitting }: { setSubmitting: (isSubmitting: boolean) => void },
+  ) => void;
   values?: CustomViewFormInputs;
   isEdition?: boolean;
 }
@@ -47,8 +51,8 @@ const CustomViewForm = ({
   const handleFieldSubmit = (
     setSubmitting: (v: boolean) => void,
   ) => (name: keyof typeof validators, value: unknown) => {
-    onSubmitField(name, validators[name].cast(value));
-    setSubmitting(false);
+    setSubmitting(true);
+    onSubmitField(name, validators[name].cast(value), { setSubmitting });
   };
 
   const initialValues = values ?? DEFAULT_VALUES;

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
@@ -6,6 +6,7 @@ import FormButtonContainer from '../../../../../components/common/form/FormButto
 import MarkdownField from '../../../../../components/fields/markdownField/MarkdownField';
 import { useFormatter } from '../../../../../components/i18n';
 import { fieldSpacingContainerStyle } from '../../../../../utils/field';
+import { Stack } from '@mui/material';
 
 export interface CustomViewFormInputs {
   name: string;
@@ -36,13 +37,17 @@ const CustomViewForm = ({
 }: CustomViewFormProps) => {
   const { t_i18n } = useFormatter();
 
-  const validation = Yup.object().shape({
+  const validators = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
-  });
+  };
 
-  const handleFieldSubmit = (setSubmitting: (v: boolean) => void) => (name: string, value: unknown) => {
-    onSubmitField(name, value);
+  const validation = Yup.object().shape(validators);
+
+  const handleFieldSubmit = (
+    setSubmitting: (v: boolean) => void,
+  ) => (name: keyof typeof validators, value: unknown) => {
+    onSubmitField(name, validators[name].cast(value));
     setSubmitting(false);
   };
 
@@ -57,44 +62,46 @@ const CustomViewForm = ({
       {({ submitForm, handleReset, isSubmitting, setSubmitting }) => {
         return (
           <Form>
-            <Field
-              autoFocus
-              component={TextField}
-              name="name"
-              label={t_i18n('Name')}
-              fullWidth={true}
-              required
-              onSubmit={handleFieldSubmit(setSubmitting)}
-            />
-            <Field
-              component={MarkdownField}
-              name="description"
-              label={t_i18n('Description')}
-              style={fieldSpacingContainerStyle}
-              multiline={true}
-              rows="4"
-              onSubmit={handleFieldSubmit(setSubmitting)}
-            />
-            {!isEdition && (
-              <FormButtonContainer>
-                <Button
-                  variant="secondary"
-                  disabled={isSubmitting}
-                  onClick={() => {
-                    handleReset();
-                    onClose();
-                  }}
-                >
-                  {t_i18n('Cancel')}
-                </Button>
-                <Button
-                  onClick={submitForm}
-                  disabled={isSubmitting}
-                >
-                  {t_i18n('Create')}
-                </Button>
-              </FormButtonContainer>
-            )}
+            <Stack gap={1}>
+              <Field
+                autoFocus
+                component={TextField}
+                name="name"
+                label={t_i18n('Name')}
+                fullWidth={true}
+                required
+                onSubmit={handleFieldSubmit(setSubmitting)}
+              />
+              <Field
+                component={MarkdownField}
+                name="description"
+                label={t_i18n('Description')}
+                style={fieldSpacingContainerStyle}
+                multiline={true}
+                rows="4"
+                onSubmit={handleFieldSubmit(setSubmitting)}
+              />
+              {!isEdition && (
+                <FormButtonContainer>
+                  <Button
+                    variant="secondary"
+                    disabled={isSubmitting}
+                    onClick={() => {
+                      handleReset();
+                      onClose();
+                    }}
+                  >
+                    {t_i18n('Cancel')}
+                  </Button>
+                  <Button
+                    onClick={submitForm}
+                    disabled={isSubmitting}
+                  >
+                    {t_i18n('Create')}
+                  </Button>
+                </FormButtonContainer>
+              )}
+            </Stack>
           </Form>
         );
       }}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewFormDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewFormDrawer.tsx
@@ -33,7 +33,10 @@ const CustomViewFormDrawer = ({
     values,
     { setSubmitting, resetForm },
   ) => {
-    if (isEdition) return;
+    if (isEdition) {
+      setSubmitting(false);
+      return;
+    }
     commitAddMutation({
       variables: {
         input: {
@@ -58,12 +61,23 @@ const CustomViewFormDrawer = ({
     });
   };
 
-  const handleEditField = (field: string, value: unknown) => {
-    if (!isEdition) return;
+  const handleEditField = (
+    field: string,
+    value: unknown,
+    { setSubmitting }: { setSubmitting: (isSubmitting: boolean) => void },
+  ) => {
+    if (!isEdition) {
+      setSubmitting(false);
+      return;
+    }
     const input: { key: string; value: [unknown] } = { key: field, value: [value] };
     commitEditMutation({
       variables: { id: customView.id, input: [input] },
+      onCompleted: () => {
+        setSubmitting(false);
+      },
       onError: () => {
+        setSubmitting(false);
         MESSAGING$.notifyError(t_i18n('Failed to update custom view'));
       },
     });

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewPopover.tsx
@@ -9,10 +9,12 @@ import stopEvent from '../../../../../utils/domEvent';
 import { CustomViewPopover_customView$key } from './__generated__/CustomViewPopover_customView.graphql';
 import CustomViewDeletionDialog from './CustomViewDeletionDialog';
 import useDeletion from '../../../../../utils/hooks/useDeletion';
+import useCustomViewEdit from './useCustomViewEdit';
 
 const customViewPopoverFragment = graphql`
   fragment CustomViewPopover_customView on CustomView {
     id
+    enabled
   }
 `;
 
@@ -24,7 +26,6 @@ interface CustomViewPopoverProps {
 const CustomViewPopover = ({ data, paginationOptions }: CustomViewPopoverProps) => {
   const { t_i18n } = useFormatter();
   const customView = useFragment(customViewPopoverFragment, data);
-  const { id } = customView;
 
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const handleOpen = (event: UIEvent) => {
@@ -43,6 +44,21 @@ const CustomViewPopover = ({ data, paginationOptions }: CustomViewPopoverProps) 
     setAnchorEl(null);
   };
 
+  const [commitCustomViewMutation] = useCustomViewEdit();
+  const handleToggleEnabled = (event: UIEvent) => {
+    stopEvent(event);
+    commitCustomViewMutation({
+      variables: {
+        id: customView.id,
+        input: [{
+          key: 'enabled',
+          value: [!customView.enabled],
+        }],
+      },
+    });
+    setAnchorEl(null);
+  };
+
   return (
     <div>
       <IconButton
@@ -55,10 +71,11 @@ const CustomViewPopover = ({ data, paginationOptions }: CustomViewPopoverProps) 
         <MoreVert />
       </IconButton>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose} aria-label="Custom view menu">
+        <MenuItem onClick={handleToggleEnabled}>{customView.enabled ? t_i18n('Disable') : t_i18n('Enable')}</MenuItem>
         <MenuItem onClick={handleOpenDelete}>{t_i18n('Delete')}</MenuItem>
       </Menu>
       <CustomViewDeletionDialog
-        id={id}
+        id={customView.id}
         deletion={deletion}
         paginationOptions={paginationOptions}
       />

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewsSettingsDataTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewsSettingsDataTable.tsx
@@ -3,6 +3,7 @@ import useQueryLoading from '../../../../../utils/hooks/useQueryLoading';
 import DataTable from '../../../../../components/dataGrid/DataTable';
 import { DataTableVariant } from '../../../../../components/dataGrid/dataTableTypes';
 import { useFormatter } from '../../../../../components/i18n';
+import ItemBoolean from '../../../../../components/ItemBoolean';
 import DrawOutlinedIcon from '@mui/icons-material/DrawOutlined';
 import { usePaginationLocalStorage } from '../../../../../utils/hooks/useLocalStorage';
 import type { CustomViewsSettingsDataTablePaginationQuery } from './__generated__/CustomViewsSettingsDataTablePaginationQuery.graphql';
@@ -19,6 +20,7 @@ const customViewFragment = graphql`
     id
     name
     description
+    enabled
     ...CustomViewPopover_customView
   }
 `;
@@ -74,8 +76,23 @@ const customViewsLinesFragment = graphql`
 `;
 
 const DATA_COLUMNS = {
-  name: { percentWidth: 40, isSortable: true },
-  description: { percentWidth: 60, isSortable: false },
+  name: { percentWidth: 35, isSortable: true },
+  customViewEnabled: {
+    id: 'enabled',
+    label: 'Status',
+    percentWidth: 15,
+    isSortable: true,
+    render: ({ enabled }: CustomViewsSettingsDataTable_node$data) => {
+      const { t_i18n } = useFormatter();
+      return (
+        <ItemBoolean
+          label={enabled ? t_i18n('View is active') : t_i18n('View is stopped')}
+          status={enabled}
+        />
+      );
+    },
+  },
+  description: { percentWidth: 50, isSortable: true },
 } as const;
 
 const DEFAULT_SORT_CONFIG = {
@@ -122,7 +139,10 @@ const CustomViewsSettingsDataTable = ({
 
   return (
     <DataTable
-      icon={() => <DrawOutlinedIcon color="secondary" />}
+      icon={
+        (customView: CustomViewsSettingsDataTable_node$data) =>
+          <DrawOutlinedIcon color={customView.enabled ? 'secondary' : 'disabled'} />
+      }
       initialValues={DEFAULT_SORT_CONFIG}
       dataColumns={DATA_COLUMNS}
       storageKey={storageKey}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewsSettingsDataTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewsSettingsDataTable.tsx
@@ -4,7 +4,6 @@ import DataTable from '../../../../../components/dataGrid/DataTable';
 import { DataTableVariant } from '../../../../../components/dataGrid/dataTableTypes';
 import { useFormatter } from '../../../../../components/i18n';
 import ItemBoolean from '../../../../../components/ItemBoolean';
-import DrawOutlinedIcon from '@mui/icons-material/DrawOutlined';
 import { usePaginationLocalStorage } from '../../../../../utils/hooks/useLocalStorage';
 import type { CustomViewsSettingsDataTablePaginationQuery } from './__generated__/CustomViewsSettingsDataTablePaginationQuery.graphql';
 import type { CustomViewsSettingsDataTable_data$data } from './__generated__/CustomViewsSettingsDataTable_data.graphql';
@@ -86,8 +85,9 @@ const DATA_COLUMNS = {
       const { t_i18n } = useFormatter();
       return (
         <ItemBoolean
-          label={enabled ? t_i18n('View is active') : t_i18n('View is stopped')}
+          label={enabled ? t_i18n('View is enabled') : t_i18n('View is disabled')}
           status={enabled}
+          labelTextTransform="none"
         />
       );
     },
@@ -139,10 +139,6 @@ const CustomViewsSettingsDataTable = ({
 
   return (
     <DataTable
-      icon={
-        (customView: CustomViewsSettingsDataTable_node$data) =>
-          <DrawOutlinedIcon color={customView.enabled ? 'secondary' : 'disabled'} />
-      }
       initialValues={DEFAULT_SORT_CONFIG}
       dataColumns={DATA_COLUMNS}
       storageKey={storageKey}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/useCustomViewEdit.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/useCustomViewEdit.ts
@@ -11,6 +11,7 @@ const customViewEditMutation = graphql`
       name
       description
       path
+      enabled
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9752,7 +9752,7 @@ type Query {
   Auth log history by provider id: internal_id for DB providers, or static id for singletons (Headers, Cert).
   """
   authLogHistoryById(id: String!): [AuthLogEntry!]!
-  customViews(entityType: String, first: Int, after: ID, orderBy: CustomViewsOrdering, search: String, orderMode: OrderingMode): CustomViewsConnection!
+  customViews(entityType: String, first: Int, after: ID, orderBy: CustomViewsOrdering, search: String, orderMode: OrderingMode, filters: FilterGroup): CustomViewsConnection!
   customViewsSettings(entityType: String!): CustomViewsSettings!
   customView(id: ID!): CustomView
   taxiiCollection(id: String!): TaxiiCollection
@@ -16136,6 +16136,7 @@ type CustomView implements InternalObject & BasicObject {
   manifest: String
   path: String!
   targetEntityType: String!
+  enabled: Boolean!
   toWidgetExport(widgetId: ID!): String!
 }
 
@@ -16151,6 +16152,7 @@ type CustomViewsConnection {
 
 enum CustomViewsOrdering {
   name
+  enabled
 }
 
 type CustomViewsSettings {
@@ -16163,6 +16165,7 @@ input CustomViewAddInput {
   description: String
   manifest: String
   targetEntityType: String!
+  enabled: Boolean
 }
 
 input CustomViewImportWidgetInput {
@@ -16176,6 +16179,7 @@ input CustomViewDuplicateInput {
   description: String
   manifest: String
   targetEntityType: String!
+  enabled: Boolean
 }
 
 type TaxiiCollection {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -6437,6 +6437,7 @@ export type CustomView = BasicObject & InternalObject & {
   __typename?: 'CustomView';
   created_at: Scalars['DateTime']['output'];
   description?: Maybe<Scalars['String']['output']>;
+  enabled: Scalars['Boolean']['output'];
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   manifest?: Maybe<Scalars['String']['output']>;
@@ -6458,6 +6459,7 @@ export type CustomViewToWidgetExportArgs = {
 
 export type CustomViewAddInput = {
   description?: InputMaybe<Scalars['String']['input']>;
+  enabled?: InputMaybe<Scalars['Boolean']['input']>;
   manifest?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
   targetEntityType: Scalars['String']['input'];
@@ -6465,6 +6467,7 @@ export type CustomViewAddInput = {
 
 export type CustomViewDuplicateInput = {
   description?: InputMaybe<Scalars['String']['input']>;
+  enabled?: InputMaybe<Scalars['Boolean']['input']>;
   manifest?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
   targetEntityType: Scalars['String']['input'];
@@ -6488,6 +6491,7 @@ export type CustomViewsEdge = {
 };
 
 export enum CustomViewsOrdering {
+  Enabled = 'enabled',
   Name = 'name'
 }
 
@@ -24950,6 +24954,7 @@ export type QueryCustomViewArgs = {
 export type QueryCustomViewsArgs = {
   after?: InputMaybe<Scalars['ID']['input']>;
   entityType?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<FilterGroup>;
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<CustomViewsOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
@@ -42989,6 +42994,7 @@ export type CsvMapperTestResultResolvers<ContextType = any, ParentType extends R
 export type CustomViewResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomView'] = ResolversParentTypes['CustomView']> = ResolversObject<{
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  enabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   manifest?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-converter.ts
@@ -12,6 +12,7 @@ const convertCustomViewToStix = (instance: StoreEntityCustomView): StixCustomVie
     description: instance.description,
     manifest: instance.manifest,
     target_entity_type: instance.target_entity_type,
+    enabled: Boolean(instance.enabled),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-converter.ts
@@ -2,6 +2,7 @@ import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
 import { buildStixObject } from '../../database/stix-2-1-converter';
 import type { StixCustomView, StoreEntityCustomView } from './customView-types';
 import { cleanObject } from '../../database/stix-converter-utils';
+import { computeCustomViewPath } from './customView-domain';
 
 const convertCustomViewToStix = (instance: StoreEntityCustomView): StixCustomView => {
   const stixObject = buildStixObject(instance);
@@ -13,6 +14,7 @@ const convertCustomViewToStix = (instance: StoreEntityCustomView): StixCustomVie
     manifest: instance.manifest,
     target_entity_type: instance.target_entity_type,
     enabled: Boolean(instance.enabled),
+    path: computeCustomViewPath(instance),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
@@ -1,7 +1,14 @@
 import { pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { ENTITY_TYPE_CUSTOM_VIEW, type BasicStoreEntityCustomView, type StoreEntityCustomView } from './customView-types';
-import { type QueryCustomViewsArgs, type CustomViewAddInput, type CustomViewDuplicateInput, type EditInput, type CustomViewImportWidgetInput } from '../../generated/graphql';
+import {
+  type QueryCustomViewsArgs,
+  type CustomViewAddInput,
+  type CustomViewDuplicateInput,
+  type EditInput,
+  type CustomViewImportWidgetInput,
+  FilterMode,
+} from '../../generated/graphql';
 import slugify from 'slug';
 import {
   ENTITY_TYPE_CONTAINER_NOTE,
@@ -85,17 +92,25 @@ export const findAllCustomViews = async (
   entityType: string | undefined | null,
   paginationOptions: Omit<QueryCustomViewsArgs, 'entityType'>,
 ) => {
+  const entityTypeFilterGroup = addFilter(
+    undefined,
+    'target_entity_type',
+    entityType ? [entityType] : getEntityTypesCandidateToCustomViews(),
+  );
   return pageEntitiesConnection<BasicStoreEntityCustomView>(
     context,
     user,
     [ENTITY_TYPE_CUSTOM_VIEW],
     {
       ...paginationOptions,
-      filters: addFilter(
-        undefined,
-        'target_entity_type',
-        entityType ? [entityType] : getEntityTypesCandidateToCustomViews(),
-      ),
+      filters: {
+        filterGroups: [
+          entityTypeFilterGroup,
+          ...paginationOptions.filters ? [paginationOptions.filters] : [],
+        ],
+        mode: FilterMode.And,
+        filters: [],
+      },
     },
   );
 };
@@ -121,6 +136,7 @@ export const addCustomView = async (
     name: input.name,
     target_entity_type: input.targetEntityType,
     slug: slugify(input.name),
+    enabled: input.enabled ?? false,
   };
   return createInternalObject<StoreEntityCustomView>(
     context,
@@ -224,6 +240,7 @@ export async function duplicateCustomView(
     name: input.name,
     target_entity_type: input.targetEntityType,
     slug: slugify(input.name),
+    enabled: input.enabled ?? false,
   };
   return createInternalObject<StoreEntityCustomView>(
     context,

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-resolver.ts
@@ -31,6 +31,9 @@ const customViewResolver: Resolvers = {
     targetEntityType: (customView) => {
       return customView.target_entity_type;
     },
+    enabled: (customView) => {
+      return Boolean(customView.enabled);
+    },
     toWidgetExport: (customView, { widgetId }, context) => {
       return exportCustomViewWidget(context, context.user, customView, widgetId);
     },

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-types.ts
@@ -29,6 +29,7 @@ export interface StixCustomView extends StixObject {
   name: string;
   description: string;
   slug: string;
+  path: string;
   manifest: string;
   target_entity_type: string;
   enabled: boolean;

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-types.ts
@@ -11,6 +11,7 @@ export interface BasicStoreEntityCustomView extends BasicStoreEntity {
   slug: string;
   manifest: string;
   target_entity_type: string;
+  enabled?: boolean;
 }
 
 export interface StoreEntityCustomView extends StoreEntity {
@@ -19,6 +20,7 @@ export interface StoreEntityCustomView extends StoreEntity {
   slug: string;
   manifest: string;
   target_entity_type: string;
+  enabled?: boolean;
 }
 // endregion
 
@@ -29,6 +31,7 @@ export interface StixCustomView extends StixObject {
   slug: string;
   manifest: string;
   target_entity_type: string;
+  enabled: boolean;
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
   };

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView.graphql
@@ -13,6 +13,7 @@ type CustomView implements InternalObject & BasicObject {
     manifest: String
     path: String! # Derived field, not stored in DB
     targetEntityType: String!
+    enabled: Boolean!
     toWidgetExport(widgetId: ID!): String! @auth(for: [SETTINGS_SETCUSTOMIZATION]) @ff(flags: ["CUSTOM_VIEW"])
 }
 
@@ -28,6 +29,7 @@ type CustomViewsConnection {
 
 enum CustomViewsOrdering {
     name
+    enabled
 }
 
 type CustomViewsSettings {
@@ -39,6 +41,7 @@ input CustomViewAddInput {
     description: String
     manifest: String
     targetEntityType: String!
+    enabled: Boolean # Defaults to False
 }
 
 input CustomViewImportWidgetInput {
@@ -51,6 +54,7 @@ input CustomViewDuplicateInput {
     description: String
     manifest: String
     targetEntityType: String!
+    enabled: Boolean # Defaults to False
 }
 
 type Query {
@@ -61,6 +65,7 @@ type Query {
         orderBy: CustomViewsOrdering
         search: String
         orderMode: OrderingMode
+        filters: FilterGroup
     ): CustomViewsConnection! @auth @ff(flags: ["CUSTOM_VIEW"])
     customViewsSettings(
         entityType: String!

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView.ts
@@ -29,6 +29,8 @@ export const CUSTOM_VIEW_DEFINITION: ModuleDefinition<StoreEntityCustomView, Sti
     { name: 'manifest', label: 'Manifest', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     /** The entity type for which this custom view applies **/
     { name: 'target_entity_type', label: 'Target entity type', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    /** Only enabled custom views are displayed to end users **/
+    { name: 'enabled', label: 'Enabled', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   relations: [],
   relationsRefs: [],

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/customView/customView-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/customView/customView-converter-test.ts
@@ -2,10 +2,24 @@ import { describe, expect, test } from 'vitest';
 import convertCustomViewToStix from '../../../../src/modules/customView/customView-converter';
 import { ENTITY_TYPE_CUSTOM_VIEW, type StoreEntityCustomView } from '../../../../src/modules/customView/customView-types';
 import { toB64 } from '../../../../src/utils/base64';
+import { computeCustomViewPath } from '../../../../src/modules/customView/customView-domain';
+
+type StoreEntityCustomViewForTest = Required<Pick<
+  StoreEntityCustomView,
+  | 'id'
+  | 'entity_type'
+  | 'name'
+  | 'description'
+  | 'slug'
+  | 'manifest'
+  | 'target_entity_type'
+  | 'enabled'
+>>;
 
 describe('customView module STIX converter', () => {
   test('converts module-specific properties', () => {
-    const customView = {
+    const customView: StoreEntityCustomViewForTest = {
+      id: '4716b259-5856-4d8a-888b-cb2f8bbe52a3',
       entity_type: ENTITY_TYPE_CUSTOM_VIEW,
       name: 'My Great Custom View',
       description: 'My great custom view description',
@@ -19,14 +33,18 @@ describe('customView module STIX converter', () => {
           },
         }],
       }) ?? '',
-      restricted_members: [],
-    } satisfies Partial<StoreEntityCustomView>;
+      target_entity_type: 'Intrusion-Set',
+      enabled: true,
+    };
     const stixCustomView = convertCustomViewToStix(customView as unknown as StoreEntityCustomView);
     expect(stixCustomView).toMatchObject({
       name: customView.name,
       description: customView.description,
       slug: 'great-custom-view',
       manifest: customView.manifest,
+      target_entity_type: customView.target_entity_type,
+      path: computeCustomViewPath(customView as StoreEntityCustomView),
+      enabled: true,
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-fixtures.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-fixtures.ts
@@ -8,6 +8,7 @@ type BasicStoreEntityCustomViewForTestsKeys = Extract<
   | 'slug'
   | 'manifest'
   | 'target_entity_type'
+  | 'enabled'
 >;
 
 type BasicStoreEntityCustomViewForTests = Record<
@@ -232,6 +233,7 @@ export const CUSTOM_VIEW_ENTITY_1: BasicStoreEntityCustomViewForTests = {
   slug: 'first-custom-view',
   manifest: DASHBOARD_MANIFEST,
   target_entity_type: 'Intrusion-Set',
+  enabled: true,
 };
 
 export const CUSTOM_VIEW_ENTITY_2: BasicStoreEntityCustomViewForTests = {
@@ -240,6 +242,7 @@ export const CUSTOM_VIEW_ENTITY_2: BasicStoreEntityCustomViewForTests = {
   slug: 'second-custom-view',
   manifest: DASHBOARD_MANIFEST,
   target_entity_type: 'Case-Rft',
+  enabled: false,
 };
 
 export const CUSTOM_VIEW_ENTITY_INVALID: BasicStoreEntityCustomViewForTests = {
@@ -248,4 +251,5 @@ export const CUSTOM_VIEW_ENTITY_INVALID: BasicStoreEntityCustomViewForTests = {
   slug: 'invalid-custom-view',
   manifest: DASHBOARD_MANIFEST,
   target_entity_type: 'Feedback', // Can't have custom views on Feedback entity_type
+  enabled: false,
 };

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
@@ -43,6 +43,7 @@ const READ_ALL_CUSTOM_VIEWS_QUERY = gql`
           created_at
           updated_at
           targetEntityType
+          enabled
         }
       }
     }
@@ -59,6 +60,7 @@ const CREATE_CUSTOM_VIEW_QUERY = gql`
       targetEntityType
       updated_at
       created_at
+      enabled
     }
   }
 `;
@@ -111,6 +113,7 @@ const DUPLICATE_CUSTOM_VIEW_QUERY = gql`
       targetEntityType
       created_at
       updated_at
+      enabled
     }
   }
 `;
@@ -183,6 +186,7 @@ describe('CustomView resolvers', () => {
           created_at: expect.any(Date),
           updated_at: expect.any(Date),
           targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+          enabled: true,
         });
         expect(nodes).toContainEqual({
           id: customView2?.id,
@@ -192,6 +196,7 @@ describe('CustomView resolvers', () => {
           created_at: expect.any(Date),
           updated_at: expect.any(Date),
           targetEntityType: CUSTOM_VIEW_ENTITY_2.target_entity_type,
+          enabled: false,
         });
         // Ordered by name ascending as defined by the query
         // Doesn't contain custom view not part of the whitelist
@@ -262,6 +267,8 @@ describe('CustomView resolvers', () => {
             targetEntityType,
             created_at: expect.any(Date),
             updated_at: expect.any(Date),
+            // Defaults to false when not provided
+            enabled: false,
           });
         });
 
@@ -390,6 +397,8 @@ describe('CustomView resolvers', () => {
             targetEntityType: customView2?.target_entity_type,
             created_at: expect.any(Date),
             updated_at: expect.any(Date),
+            // Defaults to false when not provided
+            enabled: false,
           };
           expect(result.data.customViewDuplicate).toMatchObject(expectedResult);
           expect(result.data.customViewDuplicate.id).not.toBe(customView2?.id);


### PR DESCRIPTION
### Proposed changes

Implements "Enable/disable custom view" chunk:

* Added a `enabled` field on the data model: boolean, not mandatory but the field is present (mandatory) on API and STIX output
* By default set to `false` on creation & duplication
* The settings datatable show the status in a dedicated column : "View is disabled" or "View is enabled"
* A quick action is available directly on the line
* On the CustomViewEdition page a icon button allows the same and the status is repeated
* The filtering is made server-side for the other query

### Related issues

* Partially fixes https://github.com/OpenCTI-Platform/opencti/issues/13389

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
