### PR TITLE
[frontend][backend] Mark a Custom view as default to use it as the index on the entity page (#13389)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -257,6 +257,7 @@
   "Decay history": "Zerfallsgeschichte",
   "Decay next reaction date": "Abklingende nächste Reaktion Datum",
   "Decryption key": "Entschlüsselungsschlüssel",
+  "Default": "Standard",
   "Default assignation": "Standardzuweisung",
   "Default dashboard": "Standard-Dashboard",
   "Default Group used for integration user creation": "Standardgruppe, die für die Erstellung von Integrationsbenutzern verwendet wird",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -257,6 +257,7 @@
   "Decay history": "Decay history",
   "Decay next reaction date": "Decay next reaction date",
   "Decryption key": "Decryption key",
+  "Default": "Default",
   "Default assignation": "Default assignation",
   "Default dashboard": "Default dashboard",
   "Default Group used for integration user creation": "Default Group used for integration user creation",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -257,6 +257,7 @@
   "Decay history": "Historial de descomposición",
   "Decay next reaction date": "Fecha de la próxima reacción",
   "Decryption key": "Clave de descifrado",
+  "Default": "Por defecto",
   "Default assignation": "Asignación por defecto",
   "Default dashboard": "Cuadro de mandos por defecto",
   "Default Group used for integration user creation": "Grupo por defecto utilizado para la creación de usuarios de integración",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -257,6 +257,7 @@
   "Decay history": "Historique de la désintégration",
   "Decay next reaction date": "Date de la prochaine réaction de désintégration",
   "Decryption key": "Clé de décryptage",
+  "Default": "Défaut",
   "Default assignation": "Affectation par défaut",
   "Default dashboard": "Tableau de bord par défaut",
   "Default Group used for integration user creation": "Groupe par défaut utilisé pour la création d'utilisateurs d'intégration",

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -257,6 +257,7 @@
   "Decay history": "Cronologia del decadimento",
   "Decay next reaction date": "Data della prossima reazione al decadimento",
   "Decryption key": "Chiave di decrittazione",
+  "Default": "Predefinito",
   "Default assignation": "Assegnazione predefinita",
   "Default dashboard": "Dashboard predefinita",
   "Default Group used for integration user creation": "Gruppo predefinito usato per la creazione dell'utente dell'integrazione",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -257,6 +257,7 @@
   "Decay history": "ディケイ適用ルール",
   "Decay next reaction date": "崩壊ベーススコア",
   "Decryption key": "復号キー",
+  "Default": "デフォルト",
   "Default assignation": "デフォルトの割り当て",
   "Default dashboard": "デフォルトダッシュボード",
   "Default Group used for integration user creation": "統合ユーザーの作成に使用されるデフォルトグループ",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -257,6 +257,7 @@
   "Decay history": "감쇠 기록",
   "Decay next reaction date": "다음 감쇠 반응 날짜",
   "Decryption key": "복호화 키",
+  "Default": "기본값",
   "Default assignation": "기본 할당",
   "Default dashboard": "기본 대시보드",
   "Default Group used for integration user creation": "통합 사용자 생성에 사용되는 기본 그룹",

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -257,6 +257,7 @@
   "Decay history": "История распада",
   "Decay next reaction date": "Дата следующей реакции Decay",
   "Decryption key": "Ключ дешифрования",
+  "Default": "По умолчанию",
   "Default assignation": "Назначение по умолчанию",
   "Default dashboard": "Приборная панель по умолчанию",
   "Default Group used for integration user creation": "Группа по умолчанию, используемая для создания пользователей интеграции",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -257,6 +257,7 @@
   "Decay history": "衰减历史",
   "Decay next reaction date": "衰变下一次反应日期",
   "Decryption key": "解密密钥",
+  "Default": "默认值",
   "Default assignation": "默认分配",
   "Default dashboard": "默认仪表板",
   "Default Group used for integration user creation": "创建集成用户时使用的默认组",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3828,6 +3828,7 @@
   "Sessions": "Sitzungen",
   "Sessions | Security | Settings": "Sessions | Security | Settings (Sitzungen | Sicherheit | Einstellungen)",
   "Set a new secret": "Ein neues Geheimnis festlegen",
+  "Set as default custom view": "Als benutzerdefinierte Standardansicht festlegen",
   "SETTINGS": "EINSTELLUNGEN",
   "Settings": "Einstellungen",
   "Settings default values": "Standardwert aus den Entitätseinstellungen: {value}",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3828,6 +3828,7 @@
   "Sessions": "Sessions",
   "Sessions | Security | Settings": "Sessions | Security | Settings",
   "Set a new secret": "Set a new secret",
+  "Set as default custom view": "Set as default custom view",
   "SETTINGS": "SETTINGS",
   "Settings": "Settings",
   "Settings default values": "Default value from entity settings: {value}",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3828,6 +3828,7 @@
   "Sessions": "Sesiones",
   "Sessions | Security | Settings": "Sesiones | Seguridad | Configuración",
   "Set a new secret": "Establecer un nuevo secreto",
+  "Set as default custom view": "Establecer como vista personalizada por defecto",
   "SETTINGS": "PARÁMETROS",
   "Settings": "Parámetros",
   "Settings default values": "Valor por defecto de la configuración de la entidad: {value}",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3828,6 +3828,7 @@
   "Sessions": "Sessions",
   "Sessions | Security | Settings": "Sessions | Sécurité | Paramètres",
   "Set a new secret": "Définir un nouveau secret",
+  "Set as default custom view": "Définir la vue personnalisée par défaut",
   "SETTINGS": "PARAMÈTRES",
   "Settings": "Paramètres",
   "Settings default values": "Valeur par défaut des paramètres de l'entité : {value}",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3828,6 +3828,7 @@
   "Sessions": "Sessioni",
   "Sessions | Security | Settings": "Sessioni | Sicurezza | Impostazioni",
   "Set a new secret": "Impostare un nuovo segreto",
+  "Set as default custom view": "Imposta come vista personalizzata predefinita",
   "SETTINGS": "IMPOSTAZIONI",
   "Settings": "Impostazioni",
   "Settings default values": "Valore predefinito dalle impostazioni dell'entità: {value}",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3828,6 +3828,7 @@
   "Sessions": "セッション",
   "Sessions | Security | Settings": "セッション｜セキュリティ｜設定",
   "Set a new secret": "新しい秘密を設定する",
+  "Set as default custom view": "カスタムビューのデフォルト設定",
   "SETTINGS": "設定",
   "Settings": "設定",
   "Settings default values": "エンティティ設定のデフォルト値{value}",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3828,6 +3828,7 @@
   "Sessions": "세션",
   "Sessions | Security | Settings": "세션 | 보안 | 설정",
   "Set a new secret": "새 비밀 설정",
+  "Set as default custom view": "기본 사용자 지정 보기로 설정",
   "SETTINGS": "설정",
   "Settings": "설정",
   "Settings default values": "기본 값: {value}",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3828,6 +3828,7 @@
   "Sessions": "Сессии",
   "Sessions | Security | Settings": "Сеансы | Безопасность | Настройки",
   "Set a new secret": "Установите новый секрет",
+  "Set as default custom view": "Установить пользовательское представление по умолчанию",
   "SETTINGS": "НАСТРОЙКИ",
   "Settings": "Настройки",
   "Settings default values": "Значения параметров по умолчанию",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3828,6 +3828,7 @@
   "Sessions": "会话",
   "Sessions | Security | Settings": "会话 | 安全性 | 设置",
   "Set a new secret": "设置新密码",
+  "Set as default custom view": "设置为默认自定义视图",
   "SETTINGS": "设置",
   "Settings": "设置",
   "Settings default values": "实体设置中的默认值：{value}",

--- a/opencti-platform/opencti-front/src/components/TabWithDropDownMenu.tsx
+++ b/opencti-platform/opencti-front/src/components/TabWithDropDownMenu.tsx
@@ -17,7 +17,11 @@ export const useDropDownMenuState = () => {
     setAnchorEl(null);
   };
 
-  return { anchorEl, onOpen, onClose, isOpen: Boolean(anchorEl) };
+  const close = () => {
+    setAnchorEl(null);
+  };
+
+  return { anchorEl, onOpen, onClose, isOpen: Boolean(anchorEl), close };
 };
 
 type TabWithDropDownMenuProps = Omit<TabProps<'div'>, 'onClick'> & {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.test.tsx
@@ -23,7 +23,7 @@ describe('StixDomainObjectMain', () => {
     const { user } = testRender(
       <StixDomainObjectMain
         entityType="Intrusion-Set"
-        pages={{ [tab]: <span>{pageContent}</span> }}
+        pages={{ overview: 'overview', [tab]: <span>{pageContent}</span> }}
         basePath=""
       />,
       {
@@ -40,7 +40,7 @@ describe('StixDomainObjectMain', () => {
     testRender(
       <StixDomainObjectMain
         entityType="Intrusion-Set"
-        pages={{}}
+        pages={{ overview: 'overview' }}
         basePath=""
         extraRoutes={<Route path={extraRoute} element={pageContent} />}
       />,
@@ -56,7 +56,7 @@ describe('StixDomainObjectMain', () => {
     testRender(
       <StixDomainObjectMain
         entityType="Intrusion-Set"
-        pages={{}}
+        pages={{ overview: 'overview' }}
         basePath=""
       />,
       {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectMain.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, ReactNode } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import StixDomainObjectTabsBox, { type StixDomainObjectTabsBoxTab } from './StixDomainObjectTabsBox';
 import ErrorNotFound from '../../../../components/ErrorNotFound';
 import CustomViewRedirector from '@components/custom_views/CustomViewRedirector';
@@ -8,7 +8,8 @@ import useHelper from '../../../../utils/hooks/useHelper';
 interface StixDomainObjectMainProps {
   entityType: string;
   basePath: string;
-  pages: Partial<Record<StixDomainObjectTabsBoxTab, ReactNode>>;
+  /** The overview page is mandatory **/
+  pages: { overview: ReactNode } & Partial<Omit<Record<StixDomainObjectTabsBoxTab, ReactNode>, 'overview'>>;
   extraActions?: ReactNode;
   extraRoutes?: ReactElement<typeof Route> | ReactElement<typeof Route>[];
 }
@@ -32,9 +33,7 @@ const StixDomainObjectMain = ({
         extraActions={extraActions}
       />
       <Routes>
-        {tabs.includes('overview') && (
-          <Route path="/" element={pages.overview} />
-        )}
+        <Route path="/overview" element={pages.overview} />
         {tabs.includes('result') && (
           <Route path="/result" element={pages.result} />
         )}
@@ -70,6 +69,7 @@ const StixDomainObjectMain = ({
                 <CustomViewRedirector
                   entityType={entityType}
                   Fallback={<ErrorNotFound />}
+                  indexFallback={<Navigate to="overview" replace />}
                 />
               )
             : <ErrorNotFound />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
@@ -8,9 +8,9 @@ import { getCurrentTab } from '../../../../utils/utils';
 import { useFormatter } from '../../../../components/i18n';
 import useHelper from '../../../../utils/hooks/useHelper';
 import useCustomViewTabs from '@components/custom_views/useCustomViewTabs';
-import CustomViewTab from '@components/custom_views/CustomViewTab';
+import { OtherCustomViewsTab, DefaultCustomViewTab } from '@components/custom_views/CustomViewTab';
 import CustomViewTabDropDownMenu from '@components/custom_views/CustomViewTabDropDownMenu';
-import { CUSTOM_VIEW_TAB_VALUE } from '@components/custom_views/useCustomViews';
+import { CUSTOM_VIEW_TAB_VALUE, DEFAULT_CUSTOM_VIEW_TAB_VALUE } from '@components/custom_views/useCustomViews';
 
 export type StixDomainObjectTabsBoxTab
   = | 'overview'
@@ -44,7 +44,7 @@ interface TabInfo {
 // Order is important, will be reflected in the UI.
 const TABS_INFO: readonly TabInfo[] = [{
   tab: 'overview',
-  path: '',
+  path: 'overview',
   label: 'Overview',
 }, {
   tab: 'result',
@@ -97,7 +97,8 @@ const TabsWithCustomViews = ({
   currentTab,
 }: TabsWithCustomViewsProps) => {
   const {
-    customViews,
+    defaultCustomView,
+    otherCustomViews,
     displayMode,
     dropDownMenuState,
     currentCustomViewTab,
@@ -106,18 +107,25 @@ const TabsWithCustomViews = ({
 
   return (
     <>
-      <Tabs value={currentCustomViewTab ?? currentTab}>
+      <Tabs value={(currentCustomViewTab ?? currentTab) || false}>
+        {defaultCustomView ? (
+          <DefaultCustomViewTab
+            value={DEFAULT_CUSTOM_VIEW_TAB_VALUE}
+            displayMode={displayMode}
+            defaultCustomView={defaultCustomView}
+          />
+        ) : null}
         {children}
-        <CustomViewTab
+        <OtherCustomViewsTab
           value={CUSTOM_VIEW_TAB_VALUE}
           displayMode={displayMode}
-          customViews={customViews}
+          otherCustomViews={otherCustomViews}
           dropDownMenuState={dropDownMenuState}
         />
       </Tabs>
       <CustomViewTabDropDownMenu
         currentCustomViewMenuItem={currentCustomViewMenuItem}
-        customViews={customViews}
+        otherCustomViews={otherCustomViews}
         displayMode={displayMode}
         dropDownMenuState={dropDownMenuState}
       />
@@ -166,7 +174,7 @@ const StixDomainObjectTabsBox = (props: StixDomainObjectTabsBoxProps) => {
           {staticTabs}
         </TabsWithCustomViews>
       ) : (
-        <Tabs value={currentTab}>
+        <Tabs value={currentTab || false}>
           {staticTabs}
         </Tabs>
       )}

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomView.tsx
@@ -36,7 +36,7 @@ const CustomViewComponent = ({ queryRef }: CustomViewComponentProps) => {
   return <DashboardContent helpers={helpers} isEditable={false} entity={customView} />;
 };
 
-interface CustomViewProps {
+export interface CustomViewProps {
   customViewId: string;
 }
 

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.test.tsx
@@ -4,11 +4,12 @@ import testRender from '../../../utils/tests/test-render';
 import CustomViewRedirector from './CustomViewRedirector';
 import { Route, Routes } from 'react-router-dom';
 import { useCustomViewsData } from './useCustomViewsData';
+import type { CustomViewProps } from './CustomView';
 
-const CUSTOM_VIEW_MOCK_CONTENT = 'A great custom view page';
+const getCustomViewMockContent = (id: string) => `A great custom view page (${id})`;
 
 vi.mock('./CustomView', () => ({
-  default: () => <span>{CUSTOM_VIEW_MOCK_CONTENT}</span>,
+  default: ({ customViewId }: CustomViewProps) => <span>{getCustomViewMockContent(customViewId)}</span>,
   __esModule: true,
 }));
 
@@ -30,17 +31,18 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
     const customViewPath = 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3';
+    const id = '1504f07b-ee3f-4c09-ae66-b9550eb3abe3';
     testRender(
       <Routes>
         <Route
           path="*"
           element={
-            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" />
+            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
           }
         />
       </Routes>,
@@ -48,7 +50,7 @@ describe('CustomViewRedirector', () => {
         route: customViewPath,
       },
     );
-    expect(screen.getByText(CUSTOM_VIEW_MOCK_CONTENT)).toBeInTheDocument();
+    expect(screen.getByText(getCustomViewMockContent(id))).toBeInTheDocument();
   });
 
   it('renders fallback when no match', () => {
@@ -58,7 +60,7 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -67,7 +69,7 @@ describe('CustomViewRedirector', () => {
         <Route
           path="*"
           element={
-            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" />
+            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
           }
         />
       </Routes>,
@@ -85,7 +87,7 @@ describe('CustomViewRedirector', () => {
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -94,7 +96,7 @@ describe('CustomViewRedirector', () => {
         <Route
           path="*"
           element={
-            <CustomViewRedirector entityType="Case-Rft" Fallback="Not matched" />
+            <CustomViewRedirector entityType="Case-Rft" Fallback="Not matched" indexFallback="Index fallback" />
           }
         />
       </Routes>,
@@ -106,13 +108,14 @@ describe('CustomViewRedirector', () => {
   });
 
   it('renders custom view when the id in the path matches but not the slug', () => {
+    const id = '1504f07b-ee3f-4c09-ae66-b9550eb3abe3';
     vi.mocked(useCustomViewsData).mockImplementation(() => ({
       allCustomViews: [{
-        id: '1504f07b-ee3f-4c09-ae66-b9550eb3abe3',
+        id,
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
-        enabled: true,
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -121,7 +124,7 @@ describe('CustomViewRedirector', () => {
         <Route
           path="*"
           element={
-            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" />
+            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
           }
         />
       </Routes>,
@@ -129,6 +132,67 @@ describe('CustomViewRedirector', () => {
         route: 'old-slug-1504f07bee3f4c09ae66b9550eb3abe3',
       },
     );
-    expect(screen.getByText(CUSTOM_VIEW_MOCK_CONTENT)).toBeInTheDocument();
+    expect(screen.getByText(getCustomViewMockContent(id))).toBeInTheDocument();
+  });
+
+  it('renders default custom view when on index and there is a default view', () => {
+    const defaultCustomViewId = '1504f07b-ee3f-4c09-ae66-b9550eb3abe3';
+    vi.mocked(useCustomViewsData).mockImplementation(() => ({
+      allCustomViews: [{
+        id: 'c1ed490c-bb1b-44c5-9e38-46574ed87bd0',
+        name: 'My other custom view',
+        path: 'my-other-custom-view-c1ed490cbb1b44c59e3846574ed87bd0',
+        targetEntityType: 'Intrusion-Set',
+        default: false,
+      }, {
+        id: defaultCustomViewId,
+        name: 'My custom view',
+        path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
+        targetEntityType: 'Intrusion-Set',
+        default: true,
+      }],
+      refetchCustomViews: () => ({ dispose: () => {} }),
+    }));
+    testRender(
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
+          }
+        />
+      </Routes>,
+      {
+        route: '/',
+      },
+    );
+    expect(screen.getByText(getCustomViewMockContent(defaultCustomViewId))).toBeInTheDocument();
+  });
+
+  it('renders indexFallback when on index and there is no default view', () => {
+    vi.mocked(useCustomViewsData).mockImplementation(() => ({
+      allCustomViews: [{
+        id: 'c1ed490c-bb1b-44c5-9e38-46574ed87bd0',
+        name: 'My other custom view',
+        path: 'my-other-custom-view-c1ed490cbb1b44c59e3846574ed87bd0',
+        targetEntityType: 'Intrusion-Set',
+        default: false,
+      }],
+      refetchCustomViews: () => ({ dispose: () => {} }),
+    }));
+    testRender(
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <CustomViewRedirector entityType="Intrusion-Set" Fallback="Not matched" indexFallback="Index fallback" />
+          }
+        />
+      </Routes>,
+      {
+        route: '/',
+      },
+    );
+    expect(screen.getByText(/Index fallback/i)).toBeInTheDocument();
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewRedirector.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useMemo } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
 import CustomView from './CustomView';
 import { useCustomViews } from './useCustomViews';
 import type { CustomView as CustomViewType } from './CustomViews-types';
@@ -7,12 +8,13 @@ import SlugRedirectHandler, { type SlugRedirectHandlerPageInfo } from '../../../
 interface CustomViewRedirectorProps {
   entityType: string;
   Fallback: ReactNode;
+  indexFallback: ReactNode;
 }
 
 const renderMatch = (info: SlugRedirectHandlerPageInfo) =>
   <CustomView customViewId={(info as CustomViewType).id} />;
 
-const CustomViewRedirector = ({ entityType, Fallback }: CustomViewRedirectorProps) => {
+const CustomViewRedirector = ({ entityType, Fallback, indexFallback }: CustomViewRedirectorProps) => {
   const { customViews } = useCustomViews(entityType);
   const pagesInfo = useMemo(() => customViews.reduce(
     (acc, customViewInfo) => ({
@@ -20,6 +22,14 @@ const CustomViewRedirector = ({ entityType, Fallback }: CustomViewRedirectorProp
       [customViewInfo.id.replaceAll('-', '')]: customViewInfo,
     }), {} as Record<string, CustomViewType>,
   ), [customViews]);
+  const { '*': splat } = useParams();
+  if (splat === '') {
+    const defaultCustomView = customViews.find((customView) => customView.default);
+    if (defaultCustomView) {
+      return <Navigate to={defaultCustomView.path} replace />;
+    }
+    return indexFallback;
+  }
   return (
     <SlugRedirectHandler
       renderMatch={renderMatch}

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTab.tsx
@@ -5,16 +5,16 @@ import { useCustomViews } from './useCustomViews';
 import { TabWithDropDownMenu, useDropDownMenuState } from '../../../components/TabWithDropDownMenu';
 import { useFormatter } from '../../../components/i18n';
 
-type CustomViewTabProps = {
+type OtherCustomViewsTabProps = {
   displayMode: CustomViewDisplayMode;
-  customViews: ReturnType<typeof useCustomViews>['customViews'];
+  otherCustomViews: ReturnType<typeof useCustomViews>['customViews'];
   dropDownMenuState: ReturnType<typeof useDropDownMenuState>;
   value: string;
 } & TabProps<'a'> & TabProps<'div'>;
 
-const CustomViewTab = ({ customViews, displayMode, dropDownMenuState, value, ...tabProps }: CustomViewTabProps) => {
+export const OtherCustomViewsTab = ({ otherCustomViews: customViews, displayMode, dropDownMenuState, value, ...tabProps }: OtherCustomViewsTabProps) => {
   const { t_i18n } = useFormatter();
-  if (displayMode === 'single') {
+  if (displayMode.others === 'single') {
     return (
       <Tab
         {...tabProps}
@@ -35,7 +35,7 @@ const CustomViewTab = ({ customViews, displayMode, dropDownMenuState, value, ...
     );
   }
 
-  if (displayMode === 'dropdown') {
+  if (displayMode.others === 'dropdown') {
     return (
       <TabWithDropDownMenu
         {...tabProps}
@@ -50,4 +50,36 @@ const CustomViewTab = ({ customViews, displayMode, dropDownMenuState, value, ...
   return null;
 };
 
-export default CustomViewTab;
+type DefaultCustomViewTabProps = {
+  value: string;
+  displayMode: CustomViewDisplayMode;
+  defaultCustomView: ReturnType<typeof useCustomViews>['customViews'][number] | undefined;
+} & TabProps<'a'> & TabProps<'div'>;
+
+export const DefaultCustomViewTab = ({ value, displayMode, defaultCustomView, ...tabProps }: DefaultCustomViewTabProps) => {
+  if (!displayMode.default) {
+    return null;
+  }
+  if (!defaultCustomView) {
+    return null;
+  }
+  return (
+    <Tab
+      {...tabProps}
+      key="default-custom-view"
+      component={Link}
+      to={defaultCustomView.path}
+      value={value}
+      label={defaultCustomView.name}
+      sx={{
+      // Override the theme/global rule set to have all
+      // tabs in first-letter-capitalized case, to display
+      // exactly what customers want.
+        textTransform: 'none',
+        '&::first-letter': {
+          textTransform: 'none',
+        },
+      }}
+    />
+  );
+};

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabDropDownMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabDropDownMenu.tsx
@@ -6,14 +6,14 @@ import { type CustomViewDisplayMode } from './useCustomViewTabs';
 
 interface CustomViewTabDropDownMenuProps {
   displayMode: CustomViewDisplayMode;
-  customViews: ReturnType<typeof useCustomViews>['customViews'];
+  otherCustomViews: ReturnType<typeof useCustomViews>['customViews'];
   dropDownMenuState: ReturnType<typeof useDropDownMenuState>;
   currentCustomViewMenuItem?: string;
 }
 
-const CustomViewTabDropDownMenu = ({ displayMode, customViews, dropDownMenuState, currentCustomViewMenuItem }: CustomViewTabDropDownMenuProps) => {
-  const { anchorEl, isOpen, onClose } = dropDownMenuState;
-  if (displayMode !== 'dropdown') {
+const CustomViewTabDropDownMenu = ({ displayMode, otherCustomViews: customViews, dropDownMenuState, currentCustomViewMenuItem }: CustomViewTabDropDownMenuProps) => {
+  const { anchorEl, isOpen, onClose, close } = dropDownMenuState;
+  if (displayMode.others !== 'dropdown') {
     return null;
   }
   return (
@@ -30,6 +30,7 @@ const CustomViewTabDropDownMenu = ({ displayMode, customViews, dropDownMenuState
             role="link"
             component={Link}
             to={path}
+            onClick={close}
             sx={{
               '&.Mui-selected': {
                 boxShadow: 'none',

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
@@ -259,7 +259,7 @@ describe('useCustomViewTabs', () => {
     );
     const defaultTabElem = screen.getByRole('tab', { name: /My default custom view/i });
     expect(defaultTabElem).toBeInTheDocument();
-    const othersTabElem = screen.getByRole('tab', { name: /Custom view/i });
+    const othersTabElem = screen.getByRole('tab', { name: /^Custom view$/i });
     expect(othersTabElem).toBeInTheDocument();
     await user.click(othersTabElem);
     const firstLinkElem = screen.getByRole('link', { name: /My first custom view/i });

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
@@ -6,7 +6,7 @@ import Tab from '@mui/material/Tab';
 import { screen } from '@testing-library/react';
 import testRender, { createMockUserContext } from '../../../utils/tests/test-render';
 import useCustomViewTabs from './useCustomViewTabs';
-import { CUSTOM_VIEW_TAB_VALUE } from './useCustomViews';
+import { CUSTOM_VIEW_TAB_VALUE, DEFAULT_CUSTOM_VIEW_TAB_VALUE } from './useCustomViews';
 import { DropDownMenu, TabWithDropDownMenu } from '../../../components/TabWithDropDownMenu';
 import { useCustomViewsData } from './useCustomViewsData';
 
@@ -24,7 +24,8 @@ interface TestWrapperProps {
 
 const TestWrapper = ({ entityType, basePath }: TestWrapperProps) => {
   const {
-    customViews,
+    defaultCustomView,
+    otherCustomViews,
     displayMode,
     dropDownMenuState,
     currentCustomViewTab,
@@ -32,7 +33,7 @@ const TestWrapper = ({ entityType, basePath }: TestWrapperProps) => {
 
   const { anchorEl, onOpen, onClose, isOpen } = dropDownMenuState;
 
-  const renderMenuItems = () => customViews.map(({ id, name, path }) => (
+  const renderMenuItems = () => otherCustomViews.map(({ id, name, path }) => (
     <MenuItem
       key={id}
       role="link"
@@ -44,19 +45,34 @@ const TestWrapper = ({ entityType, basePath }: TestWrapperProps) => {
     </MenuItem>
   ));
 
-  const renderCustomViewTab = () => {
-    if (displayMode === 'single') {
+  const renderDefaultCustomViewTab = () => {
+    if (defaultCustomView) {
       return (
         <Tab
           component={Link}
-          to={customViews[0].path}
-          value={CUSTOM_VIEW_TAB_VALUE}
-          label={customViews[0].name}
+          to={defaultCustomView.path}
+          value={DEFAULT_CUSTOM_VIEW_TAB_VALUE}
+          label={defaultCustomView.name}
         />
       );
     }
 
-    if (displayMode === 'dropdown') {
+    return null;
+  };
+
+  const renderOtherCustomViewsTab = () => {
+    if (displayMode.others === 'single') {
+      return (
+        <Tab
+          component={Link}
+          to={otherCustomViews[0].path}
+          value={CUSTOM_VIEW_TAB_VALUE}
+          label={otherCustomViews[0].name}
+        />
+      );
+    }
+
+    if (displayMode.others === 'dropdown') {
       return (
         <TabWithDropDownMenu
           value={CUSTOM_VIEW_TAB_VALUE}
@@ -73,9 +89,10 @@ const TestWrapper = ({ entityType, basePath }: TestWrapperProps) => {
   return (
     <>
       <Tabs value={currentCustomViewTab || false}>
-        {renderCustomViewTab()}
+        {renderDefaultCustomViewTab()}
+        {renderOtherCustomViewsTab()}
       </Tabs>
-      {displayMode === 'dropdown' && (
+      {displayMode.others === 'dropdown' && (
         <DropDownMenu
           anchorEl={anchorEl}
           isOpen={isOpen}
@@ -98,6 +115,7 @@ describe('useCustomViewTabs', () => {
         name: customViewDisplayName,
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -131,11 +149,13 @@ describe('useCustomViewTabs', () => {
         name: 'My first custom view',
         path: 'some-path',
         targetEntityType: 'Intrusion-Set',
+        default: false,
       }, {
         id: '90ebf22f-2c36-4836-b21a-e114ed4ca2ab',
         name: 'My second custom view',
         path: 'some-other-path',
         targetEntityType: 'Intrusion-Set',
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -167,7 +187,7 @@ describe('useCustomViewTabs', () => {
     );
   });
 
-  it('does not renders another tab when custom view available but for other entity type', () => {
+  it('does not render another tab when custom view available but for other entity type', () => {
     const customViewDisplayName = 'My custom view';
     const customViewPath = 'some-path';
     vi.mocked(useCustomViewsData).mockImplementation(() => ({
@@ -176,6 +196,7 @@ describe('useCustomViewTabs', () => {
         name: customViewDisplayName,
         path: customViewPath,
         targetEntityType: 'Intrusion-Set',
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));
@@ -198,5 +219,58 @@ describe('useCustomViewTabs', () => {
     expect(screen.queryByRole('tab', {
       name: /Custom view/i,
     })).not.toBeInTheDocument();
+  });
+
+  it('renders a default and a "Custom view" tab with other values when multiple custom views available and one is default', async () => {
+    vi.mocked(useCustomViewsData).mockImplementation(() => ({
+      allCustomViews: [{
+        id: '1504f07b-ee3f-4c09-ae66-b9550eb3abe3',
+        name: 'My first custom view',
+        path: 'some-path',
+        targetEntityType: 'Intrusion-Set',
+        default: false,
+      }, {
+        id: '90ebf22f-2c36-4836-b21a-e114ed4ca2ab',
+        name: 'My second custom view',
+        path: 'some-other-path',
+        targetEntityType: 'Intrusion-Set',
+        default: false,
+      }, {
+        id: '808605b9-7bb3-4578-9175-e1ca74600e34',
+        name: 'My default custom view',
+        path: 'default-path',
+        targetEntityType: 'Intrusion-Set',
+        default: true,
+      }],
+      refetchCustomViews: () => ({ dispose: () => {} }),
+    }));
+    const { user } = testRender(
+      <TestWrapper entityType="Intrusion-Set" basePath="" />,
+      {
+        userContext: createMockUserContext({
+          settings: {
+            platform_feature_flags: [{
+              id: 'CUSTOM_VIEW',
+              enable: true,
+            }],
+          },
+        }),
+      },
+    );
+    const defaultTabElem = screen.getByRole('tab', { name: /My default custom view/i });
+    expect(defaultTabElem).toBeInTheDocument();
+    const othersTabElem = screen.getByRole('tab', { name: /Custom view/i });
+    expect(othersTabElem).toBeInTheDocument();
+    await user.click(othersTabElem);
+    const firstLinkElem = screen.getByRole('link', { name: /My first custom view/i });
+    expect(firstLinkElem).toHaveAttribute(
+      'href',
+      expect.stringMatching(/some-path$/),
+    );
+    const secondLinkElem = screen.getByRole('link', { name: /My second custom view/i });
+    expect(secondLinkElem).toHaveAttribute(
+      'href',
+      expect.stringMatching(/some-other-path$/),
+    );
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomViewTabs.test.tsx
@@ -46,18 +46,14 @@ const TestWrapper = ({ entityType, basePath }: TestWrapperProps) => {
   ));
 
   const renderDefaultCustomViewTab = () => {
-    if (defaultCustomView) {
-      return (
-        <Tab
-          component={Link}
-          to={defaultCustomView.path}
-          value={DEFAULT_CUSTOM_VIEW_TAB_VALUE}
-          label={defaultCustomView.name}
-        />
-      );
-    }
-
-    return null;
+    return defaultCustomView ? (
+      <Tab
+        component={Link}
+        to={defaultCustomView.path}
+        value={DEFAULT_CUSTOM_VIEW_TAB_VALUE}
+        label={defaultCustomView.name}
+      />
+    ) : null;
   };
 
   const renderOtherCustomViewsTab = () => {

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViewTabs.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViewTabs.ts
@@ -10,10 +10,14 @@ interface UseCustomViewTabsParams {
   basePath: string;
 }
 
-export type CustomViewDisplayMode = 'none' | 'single' | 'dropdown';
+export interface CustomViewDisplayMode {
+  default: boolean;
+  others: 'none' | 'single' | 'dropdown';
+}
 
 interface UseCustomViewTabsResult {
-  customViews: ReturnType<typeof useCustomViews>['customViews'];
+  defaultCustomView: ReturnType<typeof useCustomViews>['customViews'][number] | undefined;
+  otherCustomViews: ReturnType<typeof useCustomViews>['customViews'];
   displayMode: CustomViewDisplayMode;
   dropDownMenuState: ReturnType<typeof useDropDownMenuState>;
   currentCustomViewTab: string | undefined;
@@ -27,12 +31,25 @@ const useCustomViewTabs = ({ basePath, entityType }: UseCustomViewTabsParams): U
   const currentCustomViewMenuItem = getCurrentTab(location.pathname, basePath);
   const dropDownMenuState = useDropDownMenuState();
 
-  let displayMode: CustomViewDisplayMode = 'none';
-  if (customViews.length === 1) displayMode = 'single';
-  else if (customViews.length > 1) displayMode = 'dropdown';
+  const defaultCustomView = customViews.find(({ default: def }) => def);
+  const hasDefault = !!defaultCustomView;
+
+  let othersDisplayMode: CustomViewDisplayMode['others'] = 'none';
+  const minCountForOthers = hasDefault ? 2 : 1;
+  if (customViews.length === minCountForOthers) {
+    othersDisplayMode = 'single';
+  } else if (customViews.length > minCountForOthers) {
+    othersDisplayMode = 'dropdown';
+  }
+  const displayMode: CustomViewDisplayMode = {
+    default: hasDefault,
+    others: othersDisplayMode,
+  };
+  const otherCustomViews = hasDefault ? customViews.filter((c) => !c.default) : customViews;
 
   return {
-    customViews,
+    defaultCustomView,
+    otherCustomViews,
     displayMode,
     dropDownMenuState,
     currentCustomViewTab,

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.test.ts
@@ -21,16 +21,19 @@ describe('useCustomViews', () => {
         name: 'Basic view',
         path: 'basic-view-e8170a92344d4b17815b7eb2ec26430c',
         targetEntityType: 'Intrusion-Set',
+        default: false,
       }, {
         id: '1504f07b-ee3f-4c09-ae66-b9550eb3abe3',
         name: 'My custom view',
         path: 'my-custom-view-1504f07bee3f4c09ae66b9550eb3abe3',
         targetEntityType: 'Intrusion-Set',
+        default: true,
       }, {
         id: '0f65d13d-fef7-4ed7-8f40-5d53183fb983',
         name: 'Other view',
         path: 'other-view-0f65d13d-fef7-4ed7-8f40-5d53183fb983',
         targetEntityType: 'Malware',
+        default: false,
       }],
       refetchCustomViews: () => ({ dispose: () => {} }),
     }));

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.ts
@@ -3,6 +3,8 @@ import { getCurrentTab } from '../../../utils/utils';
 import type { CustomView } from './CustomViews-types';
 import { useCustomViewsData } from './useCustomViewsData';
 
+export const DEFAULT_CUSTOM_VIEW_TAB_VALUE = 'default-custom-view';
+
 export const CUSTOM_VIEW_TAB_VALUE = 'custom-view';
 
 export const customViewsFragment = graphql`
@@ -26,6 +28,7 @@ export const customViewsFragment = graphql`
           name
           path
           targetEntityType
+          default
         }
       }
     }
@@ -35,8 +38,11 @@ export const customViewsFragment = graphql`
 function matchPath(customViews: CustomView[]) {
   return (fullPath: string, basePath: string) => {
     const current = getCurrentTab(fullPath, basePath);
-    if (customViews.find(({ path }) => path === current)) {
-      return CUSTOM_VIEW_TAB_VALUE;
+    const currentCustomView = customViews.find(({ path }) => path === current);
+    if (currentCustomView) {
+      return currentCustomView.default
+        ? DEFAULT_CUSTOM_VIEW_TAB_VALUE
+        : CUSTOM_VIEW_TAB_VALUE;
     }
     return undefined;
   };

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
@@ -27,6 +27,7 @@ const headerFragment = graphql`
     description
     targetEntityType
     enabled
+    default
     ...CustomViewMenu_customView
   }
 `;

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
@@ -7,10 +7,12 @@ import MarkdownField from '../../../../../components/fields/markdownField/Markdo
 import { useFormatter } from '../../../../../components/i18n';
 import { fieldSpacingContainerStyle } from '../../../../../utils/field';
 import { Stack } from '@mui/material';
+import SwitchField from '../../../../../components/fields/SwitchField';
 
 export interface CustomViewFormInputs {
   name: string;
   description?: string | null;
+  default?: boolean | null;
 }
 
 export type CustomViewFormInputKeys = keyof CustomViewFormInputs;
@@ -18,6 +20,7 @@ export type CustomViewFormInputKeys = keyof CustomViewFormInputs;
 const DEFAULT_VALUES: CustomViewFormInputs = {
   name: '',
   description: null,
+  default: false,
 };
 
 interface CustomViewFormProps {
@@ -44,6 +47,7 @@ const CustomViewForm = ({
   const validators = {
     name: Yup.string().trim().min(2).required(t_i18n('This field is required')),
     description: Yup.string().nullable(),
+    default: Yup.boolean().nullable(),
   };
 
   const validation = Yup.object().shape(validators);
@@ -84,6 +88,13 @@ const CustomViewForm = ({
                 multiline={true}
                 rows="4"
                 onSubmit={handleFieldSubmit(setSubmitting)}
+              />
+              <Field
+                component={SwitchField}
+                type="checkbox"
+                name="default"
+                label={t_i18n('Set as default custom view')}
+                onChange={handleFieldSubmit(setSubmitting)}
               />
               {!isEdition && (
                 <FormButtonContainer>

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/useCustomViewEdit.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/useCustomViewEdit.ts
@@ -12,6 +12,7 @@ const customViewEditMutation = graphql`
       description
       path
       enabled
+      default
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -16137,6 +16137,7 @@ type CustomView implements InternalObject & BasicObject {
   path: String!
   targetEntityType: String!
   enabled: Boolean!
+  default: Boolean!
   toWidgetExport(widgetId: ID!): String!
 }
 
@@ -16166,6 +16167,7 @@ input CustomViewAddInput {
   manifest: String
   targetEntityType: String!
   enabled: Boolean
+  default: Boolean
 }
 
 input CustomViewImportWidgetInput {
@@ -16180,6 +16182,7 @@ input CustomViewDuplicateInput {
   manifest: String
   targetEntityType: String!
   enabled: Boolean
+  default: Boolean
 }
 
 type TaxiiCollection {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -6436,6 +6436,7 @@ export type CurrentConnectorStatusInput = {
 export type CustomView = BasicObject & InternalObject & {
   __typename?: 'CustomView';
   created_at: Scalars['DateTime']['output'];
+  default: Scalars['Boolean']['output'];
   description?: Maybe<Scalars['String']['output']>;
   enabled: Scalars['Boolean']['output'];
   entity_type: Scalars['String']['output'];
@@ -6458,6 +6459,7 @@ export type CustomViewToWidgetExportArgs = {
 };
 
 export type CustomViewAddInput = {
+  default?: InputMaybe<Scalars['Boolean']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   enabled?: InputMaybe<Scalars['Boolean']['input']>;
   manifest?: InputMaybe<Scalars['String']['input']>;
@@ -6466,6 +6468,7 @@ export type CustomViewAddInput = {
 };
 
 export type CustomViewDuplicateInput = {
+  default?: InputMaybe<Scalars['Boolean']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   enabled?: InputMaybe<Scalars['Boolean']['input']>;
   manifest?: InputMaybe<Scalars['String']['input']>;
@@ -42993,6 +42996,7 @@ export type CsvMapperTestResultResolvers<ContextType = any, ParentType extends R
 
 export type CustomViewResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomView'] = ResolversParentTypes['CustomView']> = ResolversObject<{
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  default?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   enabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-converter.ts
@@ -15,6 +15,7 @@ const convertCustomViewToStix = (instance: StoreEntityCustomView): StixCustomVie
     target_entity_type: instance.target_entity_type,
     enabled: Boolean(instance.enabled),
     path: computeCustomViewPath(instance),
+    default: Boolean(instance.default),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
@@ -1,4 +1,4 @@
-import { pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
+import { fullEntitiesList, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { ENTITY_TYPE_CUSTOM_VIEW, type BasicStoreEntityCustomView, type StoreEntityCustomView } from './customView-types';
 import {
@@ -8,6 +8,7 @@ import {
   type EditInput,
   type CustomViewImportWidgetInput,
   FilterMode,
+  FilterOperator,
 } from '../../generated/graphql';
 import slugify from 'slug';
 import {
@@ -28,6 +29,7 @@ import { addFilter } from '../../utils/filtering/filtering-utils';
 import { FunctionalError } from '../../config/errors';
 import { exportDashboardWidget, importDashboardWidgetConfiguration } from '../dashboard/dashboard-utils';
 import { createInternalObject, deleteInternalObject, editInternalObject } from '../../domain/internalObject';
+import { updateAttribute } from '../../database/middleware';
 
 /**
  * Exclusion list: entity types not capable of
@@ -67,6 +69,55 @@ const getEntityTypesCandidateToCustomViews = () => {
 
 const isCustomViewsAvailableForEntityType = (entityType: string) => {
   return getEntityTypesCandidateToCustomViews().includes(entityType);
+};
+
+const applyUniqueDefaultCustomViewConstraint = async (
+  context: AuthContext,
+  user: AuthUser,
+  targetEntityType: string,
+  newDefaultCustomViewId: string,
+) => {
+  const previousDefaultCustomViews = await fullEntitiesList<BasicStoreEntityCustomView>(
+    context,
+    user,
+    [ENTITY_TYPE_CUSTOM_VIEW],
+    {
+      baseData: true,
+      filters: {
+        filters: [{
+          key: ['target_entity_type'],
+          values: [targetEntityType],
+        }, {
+          key: ['default'],
+          values: [true],
+        }, {
+          key: ['id'],
+          values: [newDefaultCustomViewId],
+          operator: FilterOperator.NotEq,
+        }],
+        filterGroups: [],
+        mode: FilterMode.And,
+      },
+    },
+  );
+  if (previousDefaultCustomViews.length === 0) {
+    return;
+  }
+  // There should be only one but we never know as the constraint is not
+  // enforced at the DB level.
+  const promises = previousDefaultCustomViews.map((entity) => {
+    return updateAttribute<StoreEntityCustomView>(
+      context,
+      user,
+      entity.id,
+      ENTITY_TYPE_CUSTOM_VIEW,
+      [{
+        key: 'default',
+        value: [false],
+      }],
+    );
+  });
+  await Promise.all(promises);
 };
 
 export const computeCustomViewPath = ({ slug, id }: BasicStoreEntityCustomView) => {
@@ -137,8 +188,9 @@ export const addCustomView = async (
     target_entity_type: input.targetEntityType,
     slug: slugify(input.name),
     enabled: input.enabled ?? false,
+    default: input.default ?? false,
   };
-  return createInternalObject<StoreEntityCustomView>(
+  const element = await createInternalObject<StoreEntityCustomView>(
     context,
     user,
     customViewToCreate,
@@ -151,6 +203,17 @@ export const addCustomView = async (
       }),
     },
   );
+  if (element.default) {
+    // Unset the `default` fields for other CustomViews of the same
+    // target_entity_type to enforce uniqueness constraint
+    await applyUniqueDefaultCustomViewConstraint(
+      context,
+      user,
+      element.target_entity_type,
+      element.id,
+    );
+  }
+  return element;
 };
 
 export const editCustomView = async (
@@ -160,7 +223,8 @@ export const editCustomView = async (
   input: EditInput[],
 ) => {
   const nameInput = input.find((i) => i.key === 'name');
-  return editInternalObject<StoreEntityCustomView>(
+  const defaultFieldValue = input.find((i) => i.key === 'default')?.value?.[0];
+  const element = await editInternalObject<StoreEntityCustomView>(
     context,
     user,
     customViewId,
@@ -180,6 +244,17 @@ export const editCustomView = async (
       })),
     },
   );
+  if (defaultFieldValue) {
+    // Unset the `default` fields for other CustomViews of the same
+    // target_entity_type to enforce uniqueness constraint
+    await applyUniqueDefaultCustomViewConstraint(
+      context,
+      user,
+      element.target_entity_type,
+      element.id,
+    );
+  }
+  return element;
 };
 
 export const customViewImportWidgetConfiguration = async (
@@ -241,8 +316,9 @@ export async function duplicateCustomView(
     target_entity_type: input.targetEntityType,
     slug: slugify(input.name),
     enabled: input.enabled ?? false,
+    default: input.default ?? false,
   };
-  return createInternalObject<StoreEntityCustomView>(
+  const duplicate = await createInternalObject<StoreEntityCustomView>(
     context,
     user,
     customViewToCreate,
@@ -255,6 +331,17 @@ export async function duplicateCustomView(
       }),
     },
   );
+  if (duplicate.default) {
+    // Unset the `default` fields for other CustomViews of the same
+    // target_entity_type to enforce uniqueness constraint
+    await applyUniqueDefaultCustomViewConstraint(
+      context,
+      user,
+      duplicate.target_entity_type,
+      duplicate.id,
+    );
+  }
+  return duplicate;
 };
 
 export const deleteCustomView = async (

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-resolver.ts
@@ -37,6 +37,9 @@ const customViewResolver: Resolvers = {
     toWidgetExport: (customView, { widgetId }, context) => {
       return exportCustomViewWidget(context, context.user, customView, widgetId);
     },
+    default: (customView) => {
+      return Boolean(customView.default);
+    },
   },
   Mutation: {
     customViewAdd: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-types.ts
@@ -12,6 +12,7 @@ export interface BasicStoreEntityCustomView extends BasicStoreEntity {
   manifest: string;
   target_entity_type: string;
   enabled?: boolean;
+  default?: boolean;
 }
 
 export interface StoreEntityCustomView extends StoreEntity {
@@ -21,6 +22,7 @@ export interface StoreEntityCustomView extends StoreEntity {
   manifest: string;
   target_entity_type: string;
   enabled?: boolean;
+  default?: boolean;
 }
 // endregion
 
@@ -33,6 +35,7 @@ export interface StixCustomView extends StixObject {
   manifest: string;
   target_entity_type: string;
   enabled: boolean;
+  default: boolean;
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
   };

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView.graphql
@@ -14,6 +14,7 @@ type CustomView implements InternalObject & BasicObject {
     path: String! # Derived field, not stored in DB
     targetEntityType: String!
     enabled: Boolean!
+    default: Boolean!
     toWidgetExport(widgetId: ID!): String! @auth(for: [SETTINGS_SETCUSTOMIZATION]) @ff(flags: ["CUSTOM_VIEW"])
 }
 
@@ -42,6 +43,7 @@ input CustomViewAddInput {
     manifest: String
     targetEntityType: String!
     enabled: Boolean # Defaults to False
+    default: Boolean # Defaults to False
 }
 
 input CustomViewImportWidgetInput {
@@ -55,6 +57,7 @@ input CustomViewDuplicateInput {
     manifest: String
     targetEntityType: String!
     enabled: Boolean # Defaults to False
+    default: Boolean # Defaults to False
 }
 
 type Query {

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView.ts
@@ -31,6 +31,8 @@ export const CUSTOM_VIEW_DEFINITION: ModuleDefinition<StoreEntityCustomView, Sti
     { name: 'target_entity_type', label: 'Target entity type', type: 'string', format: 'short', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     /** Only enabled custom views are displayed to end users **/
     { name: 'enabled', label: 'Enabled', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    /** One custom view per target_entity_type can be marked as default **/
+    { name: 'default', label: 'Default', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
   ],
   relations: [],
   relationsRefs: [],

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/customView/customView-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/customView/customView-converter-test.ts
@@ -14,6 +14,7 @@ type StoreEntityCustomViewForTest = Required<Pick<
   | 'manifest'
   | 'target_entity_type'
   | 'enabled'
+  | 'default'
 >>;
 
 describe('customView module STIX converter', () => {
@@ -35,6 +36,7 @@ describe('customView module STIX converter', () => {
       }) ?? '',
       target_entity_type: 'Intrusion-Set',
       enabled: true,
+      default: true,
     };
     const stixCustomView = convertCustomViewToStix(customView as unknown as StoreEntityCustomView);
     expect(stixCustomView).toMatchObject({
@@ -45,6 +47,7 @@ describe('customView module STIX converter', () => {
       target_entity_type: customView.target_entity_type,
       path: computeCustomViewPath(customView as StoreEntityCustomView),
       enabled: true,
+      default: true,
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-fixtures.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-fixtures.ts
@@ -9,6 +9,7 @@ type BasicStoreEntityCustomViewForTestsKeys = Extract<
   | 'manifest'
   | 'target_entity_type'
   | 'enabled'
+  | 'default'
 >;
 
 type BasicStoreEntityCustomViewForTests = Record<
@@ -234,6 +235,7 @@ export const CUSTOM_VIEW_ENTITY_1: BasicStoreEntityCustomViewForTests = {
   manifest: DASHBOARD_MANIFEST,
   target_entity_type: 'Intrusion-Set',
   enabled: true,
+  default: true,
 };
 
 export const CUSTOM_VIEW_ENTITY_2: BasicStoreEntityCustomViewForTests = {
@@ -243,6 +245,7 @@ export const CUSTOM_VIEW_ENTITY_2: BasicStoreEntityCustomViewForTests = {
   manifest: DASHBOARD_MANIFEST,
   target_entity_type: 'Case-Rft',
   enabled: false,
+  default: false,
 };
 
 export const CUSTOM_VIEW_ENTITY_INVALID: BasicStoreEntityCustomViewForTests = {
@@ -252,4 +255,5 @@ export const CUSTOM_VIEW_ENTITY_INVALID: BasicStoreEntityCustomViewForTests = {
   manifest: DASHBOARD_MANIFEST,
   target_entity_type: 'Feedback', // Can't have custom views on Feedback entity_type
   enabled: false,
+  default: false,
 };

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
@@ -44,6 +44,29 @@ const READ_ALL_CUSTOM_VIEWS_QUERY = gql`
           updated_at
           targetEntityType
           enabled
+          default
+        }
+      }
+    }
+  }
+`;
+
+const READ_DEFAULT_CUSTOM_VIEWS_QUERY = gql`
+  query DefaultCustomViewsTest($entityType: String) {
+    customViews(
+      entityType: $entityType
+      filters: {
+        mode: and
+        filters: [{
+          key: ["default"]
+          values: [true]
+        }]
+        filterGroups: []
+      }
+    ) {
+      edges {
+        node {
+          id
         }
       }
     }
@@ -61,6 +84,7 @@ const CREATE_CUSTOM_VIEW_QUERY = gql`
       updated_at
       created_at
       enabled
+      default
     }
   }
 `;
@@ -77,6 +101,7 @@ const EDIT_CUSTOM_VIEW_QUERY = gql`
       path
       manifest
       updated_at
+      default
     }
   }
 `;
@@ -114,6 +139,7 @@ const DUPLICATE_CUSTOM_VIEW_QUERY = gql`
       created_at
       updated_at
       enabled
+      default
     }
   }
 `;
@@ -187,6 +213,7 @@ describe('CustomView resolvers', () => {
           updated_at: expect.any(Date),
           targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
           enabled: true,
+          default: true,
         });
         expect(nodes).toContainEqual({
           id: customView2?.id,
@@ -197,6 +224,7 @@ describe('CustomView resolvers', () => {
           updated_at: expect.any(Date),
           targetEntityType: CUSTOM_VIEW_ENTITY_2.target_entity_type,
           enabled: false,
+          default: false,
         });
         // Ordered by name ascending as defined by the query
         // Doesn't contain custom view not part of the whitelist
@@ -269,6 +297,8 @@ describe('CustomView resolvers', () => {
             updated_at: expect.any(Date),
             // Defaults to false when not provided
             enabled: false,
+            // Defaults to false when not provided
+            default: false,
           });
         });
 
@@ -399,6 +429,8 @@ describe('CustomView resolvers', () => {
             updated_at: expect.any(Date),
             // Defaults to false when not provided
             enabled: false,
+            // Defaults to false when not provided
+            default: false,
           };
           expect(result.data.customViewDuplicate).toMatchObject(expectedResult);
           expect(result.data.customViewDuplicate.id).not.toBe(customView2?.id);
@@ -423,9 +455,83 @@ describe('CustomView resolvers', () => {
           // Not returned in list query
           const listResult = await queryAsAdminWithSuccess({
             query: READ_ALL_CUSTOM_VIEWS_QUERY,
+            variables: {
+              entityType: result.data.targetEntityType,
+            },
           });
           const nodeIds = listResult.data.customViews.edges.map((e: any) => e.node).map((node: any) => node.id);
           expect(nodeIds).not.toContain(customView2?.id);
+        });
+
+        it('should guarantee unique default custom view', async () => {
+          // 1. Guarantee unique default custom view upon creation
+          let result = await queryAsAdminWithSuccess({
+            query: CREATE_CUSTOM_VIEW_QUERY,
+            variables: {
+              input: {
+                name: 'The new default',
+                targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+                default: true,
+              },
+            },
+          });
+          const firstElementId = result.data.customViewAdd.id;
+          expect(result.data.customViewAdd.default).toBe(true);
+
+          let listResult = await queryAsAdminWithSuccess({
+            query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
+            variables: {
+              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+            },
+          });
+          let nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+          expect(nodes.length).toBe(1);
+          expect(nodes[0].id).toBe(result.data.customViewAdd.id);
+
+          // 2. Guarantee unique default custom view upon duplication
+          result = await queryAsAdminWithSuccess({
+            query: DUPLICATE_CUSTOM_VIEW_QUERY,
+            variables: {
+              input: {
+                name: 'The newer default',
+                targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+                default: true,
+              },
+            },
+          });
+          expect(result.data.customViewDuplicate.default).toBe(true);
+
+          listResult = await queryAsAdminWithSuccess({
+            query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
+            variables: {
+              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+            },
+          });
+          nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+          expect(nodes.length).toBe(1);
+          expect(nodes[0].id).toBe(result.data.customViewDuplicate.id);
+
+          result = await queryAsAdminWithSuccess({
+            query: EDIT_CUSTOM_VIEW_QUERY,
+            variables: {
+              id: firstElementId,
+              input: [{
+                key: 'default',
+                value: [true],
+              }],
+            },
+          });
+          expect(result.data.customViewEdit.default).toBe(true);
+
+          listResult = await queryAsAdminWithSuccess({
+            query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
+            variables: {
+              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+            },
+          });
+          nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+          expect(nodes.length).toBe(1);
+          expect(nodes[0].id).toBe(firstElementId);
         });
       });
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
@@ -186,414 +186,408 @@ describe('CustomView resolvers', () => {
     );
   });
   describe('display use cases', () => {
-    describe('customView', () => {
-      it('should retrieve serialized dashboard manifest', async () => {
-        const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
-          query: READ_CUSTOM_VIEW_QUERY,
-          variables: {
-            id: customView1?.id,
-          },
-        });
-        expect(result.data.customView.manifest).toBe(CUSTOM_VIEW_ENTITY_1.manifest);
+    it('should retrieve serialized dashboard manifest', async () => {
+      const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
+        query: READ_CUSTOM_VIEW_QUERY,
+        variables: {
+          id: customView1?.id,
+        },
       });
+      expect(result.data.customView.manifest).toBe(CUSTOM_VIEW_ENTITY_1.manifest);
     });
 
-    describe('customViews', () => {
-      it('should retrieve all custom views', async () => {
-        const result = await queryAsAdminWithSuccess({
-          query: READ_ALL_CUSTOM_VIEWS_QUERY,
-        });
-        const nodes = result.data.customViews.edges.map((e: any) => e.node);
-        expect(nodes).toContainEqual({
-          id: customView1?.id,
-          name: CUSTOM_VIEW_ENTITY_1.name,
-          description: CUSTOM_VIEW_ENTITY_1.description,
-          path: `${CUSTOM_VIEW_ENTITY_1.slug}-${customView1?.id.replaceAll('-', '')}`,
-          created_at: expect.any(Date),
-          updated_at: expect.any(Date),
-          targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-          enabled: true,
-          default: true,
-        });
-        expect(nodes).toContainEqual({
-          id: customView2?.id,
-          name: CUSTOM_VIEW_ENTITY_2.name,
-          description: CUSTOM_VIEW_ENTITY_2.description,
-          path: `${CUSTOM_VIEW_ENTITY_2.slug}-${customView2?.id.replaceAll('-', '')}`,
-          created_at: expect.any(Date),
-          updated_at: expect.any(Date),
-          targetEntityType: CUSTOM_VIEW_ENTITY_2.target_entity_type,
-          enabled: false,
-          default: false,
-        });
-        // Ordered by name ascending as defined by the query
-        // Doesn't contain custom view not part of the whitelist
-        expect(nodes.map(({ name }: { name: string }) => name)).toStrictEqual([
-          CUSTOM_VIEW_ENTITY_2.name,
-          CUSTOM_VIEW_ENTITY_1.name,
-        ]);
+    it('should retrieve all custom views', async () => {
+      const result = await queryAsAdminWithSuccess({
+        query: READ_ALL_CUSTOM_VIEWS_QUERY,
       });
+      const nodes = result.data.customViews.edges.map((e: any) => e.node);
+      expect(nodes).toContainEqual({
+        id: customView1?.id,
+        name: CUSTOM_VIEW_ENTITY_1.name,
+        description: CUSTOM_VIEW_ENTITY_1.description,
+        path: `${CUSTOM_VIEW_ENTITY_1.slug}-${customView1?.id.replaceAll('-', '')}`,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+        targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+        enabled: true,
+        default: true,
+      });
+      expect(nodes).toContainEqual({
+        id: customView2?.id,
+        name: CUSTOM_VIEW_ENTITY_2.name,
+        description: CUSTOM_VIEW_ENTITY_2.description,
+        path: `${CUSTOM_VIEW_ENTITY_2.slug}-${customView2?.id.replaceAll('-', '')}`,
+        created_at: expect.any(Date),
+        updated_at: expect.any(Date),
+        targetEntityType: CUSTOM_VIEW_ENTITY_2.target_entity_type,
+        enabled: false,
+        default: false,
+      });
+      // Ordered by name ascending as defined by the query
+      // Doesn't contain custom view not part of the whitelist
+      expect(nodes.map(({ name }: { name: string }) => name)).toStrictEqual([
+        CUSTOM_VIEW_ENTITY_2.name,
+        CUSTOM_VIEW_ENTITY_1.name,
+      ]);
+    });
 
-      it('should retrieve all custom views of given type', async () => {
-        const result = await queryAsAdminWithSuccess({
-          query: READ_ALL_CUSTOM_VIEWS_QUERY,
-          variables: {
-            entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-          },
-        });
-        const targetEntityTypes = result.data.customViews.edges.map((e: any) => e.node)
-          .map((n: any) => n.targetEntityType);
-        expect(targetEntityTypes).toStrictEqual([CUSTOM_VIEW_ENTITY_1.target_entity_type]);
+    it('should retrieve all custom views of given type', async () => {
+      const result = await queryAsAdminWithSuccess({
+        query: READ_ALL_CUSTOM_VIEWS_QUERY,
+        variables: {
+          entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+        },
       });
+      const targetEntityTypes = result.data.customViews.edges.map((e: any) => e.node)
+        .map((n: any) => n.targetEntityType);
+      expect(targetEntityTypes).toStrictEqual([CUSTOM_VIEW_ENTITY_1.target_entity_type]);
     });
   });
 
   describe('settings use cases', () => {
-    describe('customViewsSettings', () => {
-      describe('when user is admin', () => {
-        it('should retrieve canEntityTypeHaveCustomViews=true for allowed entity type', async () => {
-          const result = await queryAsAdminWithSuccess({
-            query: READ_SETTINGS_QUERY,
-            variables: {
-              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-            },
-          });
-          expect(result.data.customViewsSettings.canEntityTypeHaveCustomViews).toBe(true);
+    describe('when user is admin', () => {
+      it('should retrieve canEntityTypeHaveCustomViews=true for allowed entity type', async () => {
+        const result = await queryAsAdminWithSuccess({
+          query: READ_SETTINGS_QUERY,
+          variables: {
+            entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+          },
         });
+        expect(result.data.customViewsSettings.canEntityTypeHaveCustomViews).toBe(true);
+      });
 
-        it('should retrieve canEntityTypeHaveCustomViews=false for other entity type', async () => {
-          const result = await queryAsAdminWithSuccess({
-            query: READ_SETTINGS_QUERY,
-            variables: {
-              entityType: CUSTOM_VIEW_ENTITY_INVALID.target_entity_type,
-            },
-          });
-          expect(result.data.customViewsSettings.canEntityTypeHaveCustomViews).toBe(false);
+      it('should retrieve canEntityTypeHaveCustomViews=false for other entity type', async () => {
+        const result = await queryAsAdminWithSuccess({
+          query: READ_SETTINGS_QUERY,
+          variables: {
+            entityType: CUSTOM_VIEW_ENTITY_INVALID.target_entity_type,
+          },
         });
+        expect(result.data.customViewsSettings.canEntityTypeHaveCustomViews).toBe(false);
+      });
 
-        it('should allow creating a custom view', async () => {
-          const description = 'Some great description';
-          const manifest = DASHBOARD_MANIFEST;
-          const name = 'Custom view name';
-          const targetEntityType = 'Intrusion-Set';
-          const result = await queryAsAdminWithSuccess({
-            query: CREATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                description,
-                manifest,
-                name,
-                targetEntityType,
-              },
-            },
-          });
-          expect(result.data.customViewAdd).toMatchObject({
-            id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
-            name,
-            description,
-            path: `custom-view-name-${result.data.customViewAdd.id.replaceAll('-', '')}`,
-            targetEntityType,
-            created_at: expect.any(Date),
-            updated_at: expect.any(Date),
-            // Defaults to false when not provided
-            enabled: false,
-            // Defaults to false when not provided
-            default: false,
-          });
-        });
-
-        it('should return a client error when trying to create a custom view for a non-supported entity type', async () => {
-          const description = 'Some great description';
-          const manifest = DASHBOARD_MANIFEST;
-          const name = 'Custom view name';
-          const targetEntityType = ENTITY_TYPE_CONTAINER_FEEDBACK;
-          await queryAsAdminWithError({
-            query: CREATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                description,
-                manifest,
-                name,
-                targetEntityType,
-              },
+      it('should allow creating a custom view', async () => {
+        const description = 'Some great description';
+        const manifest = DASHBOARD_MANIFEST;
+        const name = 'Custom view name';
+        const targetEntityType = 'Intrusion-Set';
+        const result = await queryAsAdminWithSuccess({
+          query: CREATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              description,
+              manifest,
+              name,
+              targetEntityType,
             },
           },
-          'Custom views cannot be created for given entity type',
-          'FUNCTIONAL_ERROR',
-          );
         });
-
-        it('should allow editing a custom view', async () => {
-          const updatedDescription = 'Updated description';
-          const updatedAtBefore = customView1?.updated_at;
-          const updatedManifest = toB64({
-            widgets: {},
-            config: {
-              relativeDate: 'months-3',
-              startDate: null,
-              endDate: null,
-            },
-          })!;
-          const result = await queryAsAdminWithSuccess({
-            query: EDIT_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView1?.id,
-              input: [{
-                key: 'description',
-                value: [updatedDescription],
-              }, {
-                key: 'manifest',
-                value: [updatedManifest],
-              }],
-            },
-          });
-          expect(result.data.customViewEdit.description).toBe(updatedDescription);
-          expect(result.data.customViewEdit.manifest).toBe(updatedManifest);
-          expect(result.data.customViewEdit.updated_at).not.toBe(updatedAtBefore);
-          // TODO: Check activity logs using the audits query
-        });
-
-        it('should update the slug and thus the path when the name is edited', async () => {
-          const updatedName = 'Updated name';
-          const result = await queryAsAdminWithSuccess({
-            query: EDIT_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView1?.id,
-              input: [{
-                key: 'name',
-                value: [updatedName],
-              }],
-            },
-          });
-          expect(result.data.customViewEdit.name).toBe(updatedName);
-          expect(result.data.customViewEdit.path).toBe(`updated-name-${customView1?.id.replaceAll('-', '')}`);
-        });
-
-        it('should allow exporting a widget', async () => {
-          const widgetId = Object.keys(DASHBOARD_MANIFEST_OBJECT.widgets)[0];
-          const result = await queryAsAdminWithSuccess({
-            query: EXPORT_WIDGET_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView2?.id,
-              widgetId,
-            },
-          });
-          expect(result.data.customView.toWidgetExport).toBeDefined();
-          expect(typeof result.data.customView.toWidgetExport).toBe('string');
-          const parsedWidget = JSON.parse(result.data.customView.toWidgetExport);
-          expect(parsedWidget.openCTI_version).toBeDefined();
-          expect(parsedWidget.configuration).toBeDefined();
-          expect(parsedWidget.type).toBe('widget');
-        });
-
-        it('should allow importing a widget', async () => {
-          const file = createUploadFile(
-            './tests/03-integration/10-modules/customView/data/',
-            'custom-view-widget.json',
-          );
-          const manifestBefore = customView2?.manifest;
-          const result = await queryAsAdminWithSuccess({
-            query: IMPORT_WIDGET_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView2?.id,
-              input: {
-                file,
-                manifest: customView2?.manifest,
-              },
-            },
-          });
-          expect(fromB64(result.data?.customViewWidgetConfigurationImport?.manifest)).toBeDefined();
-          expect(fromB64(result.data?.customViewWidgetConfigurationImport?.manifest)).not.toBe(manifestBefore);
-        });
-
-        it('should duplicate a custom view', async () => {
-          const duplicateName = 'Duplicated custom view 2';
-          const result = await queryAsAdminWithSuccess({
-            query: DUPLICATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                name: duplicateName,
-                description: customView2?.description,
-                manifest: customView2?.manifest,
-                targetEntityType: customView2?.target_entity_type,
-              },
-            },
-          });
-          const expectedResult = {
-            id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
-            name: duplicateName,
-            description: customView2?.description,
-            path: `duplicated-custom-view-2-${result.data.customViewDuplicate.id.replaceAll('-', '')}`,
-            targetEntityType: customView2?.target_entity_type,
-            created_at: expect.any(Date),
-            updated_at: expect.any(Date),
-            // Defaults to false when not provided
-            enabled: false,
-            // Defaults to false when not provided
-            default: false,
-          };
-          expect(result.data.customViewDuplicate).toMatchObject(expectedResult);
-          expect(result.data.customViewDuplicate.id).not.toBe(customView2?.id);
-
-          // Find new custom view in list query
-          const listResult = await queryAsAdminWithSuccess({
-            query: READ_ALL_CUSTOM_VIEWS_QUERY,
-          });
-          const nodes = listResult.data.customViews.edges.map((e: any) => e.node);
-          expect(nodes).toContainEqual(expectedResult);
-        });
-
-        it('should delete a custom view', async () => {
-          const result = await queryAsAdminWithSuccess({
-            query: DELETE_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView2?.id,
-            },
-          });
-          expect(result.data.customViewDelete).toBe(customView2?.id);
-
-          // Not returned in list query
-          const listResult = await queryAsAdminWithSuccess({
-            query: READ_ALL_CUSTOM_VIEWS_QUERY,
-            variables: {
-              entityType: result.data.targetEntityType,
-            },
-          });
-          const nodeIds = listResult.data.customViews.edges.map((e: any) => e.node).map((node: any) => node.id);
-          expect(nodeIds).not.toContain(customView2?.id);
-        });
-
-        it('should guarantee unique default custom view', async () => {
-          // 1. Guarantee unique default custom view upon creation
-          let result = await queryAsAdminWithSuccess({
-            query: CREATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                name: 'The new default',
-                targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-                default: true,
-              },
-            },
-          });
-          const firstElementId = result.data.customViewAdd.id;
-          expect(result.data.customViewAdd.default).toBe(true);
-
-          let listResult = await queryAsAdminWithSuccess({
-            query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
-            variables: {
-              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-            },
-          });
-          let nodes = listResult.data.customViews.edges.map((e: any) => e.node);
-          expect(nodes.length).toBe(1);
-          expect(nodes[0].id).toBe(result.data.customViewAdd.id);
-
-          // 2. Guarantee unique default custom view upon duplication
-          result = await queryAsAdminWithSuccess({
-            query: DUPLICATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                name: 'The newer default',
-                targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-                default: true,
-              },
-            },
-          });
-          expect(result.data.customViewDuplicate.default).toBe(true);
-
-          listResult = await queryAsAdminWithSuccess({
-            query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
-            variables: {
-              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-            },
-          });
-          nodes = listResult.data.customViews.edges.map((e: any) => e.node);
-          expect(nodes.length).toBe(1);
-          expect(nodes[0].id).toBe(result.data.customViewDuplicate.id);
-
-          result = await queryAsAdminWithSuccess({
-            query: EDIT_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: firstElementId,
-              input: [{
-                key: 'default',
-                value: [true],
-              }],
-            },
-          });
-          expect(result.data.customViewEdit.default).toBe(true);
-
-          listResult = await queryAsAdminWithSuccess({
-            query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
-            variables: {
-              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
-            },
-          });
-          nodes = listResult.data.customViews.edges.map((e: any) => e.node);
-          expect(nodes.length).toBe(1);
-          expect(nodes[0].id).toBe(firstElementId);
+        expect(result.data.customViewAdd).toMatchObject({
+          id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
+          name,
+          description,
+          path: `custom-view-name-${result.data.customViewAdd.id.replaceAll('-', '')}`,
+          targetEntityType,
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+          // Defaults to false when not provided
+          enabled: false,
+          // Defaults to false when not provided
+          default: false,
         });
       });
 
-      describe('when user is a simple participant', () => {
-        it('should fail retrieving custom view settings with ForbiddenAccess 403 error', async () => {
-          await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
-            query: READ_SETTINGS_QUERY,
-            variables: {
-              entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+      it('should return a client error when trying to create a custom view for a non-supported entity type', async () => {
+        const description = 'Some great description';
+        const manifest = DASHBOARD_MANIFEST;
+        const name = 'Custom view name';
+        const targetEntityType = ENTITY_TYPE_CONTAINER_FEEDBACK;
+        await queryAsAdminWithError({
+          query: CREATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              description,
+              manifest,
+              name,
+              targetEntityType,
             },
-          });
-        });
+          },
+        },
+        'Custom views cannot be created for given entity type',
+        'FUNCTIONAL_ERROR',
+        );
+      });
 
-        it('should fail creating a custom view with ForbiddenAccess 403 error', async () => {
-          await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
-            query: CREATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                description: 'Some great description',
-                manifest: DASHBOARD_MANIFEST,
-                name: 'Custom view name',
-                targetEntityType: ENTITY_TYPE_INTRUSION_SET,
-              },
-            },
-          });
+      it('should allow editing a custom view', async () => {
+        const updatedDescription = 'Updated description';
+        const updatedAtBefore = customView1?.updated_at;
+        const updatedManifest = toB64({
+          widgets: {},
+          config: {
+            relativeDate: 'months-3',
+            startDate: null,
+            endDate: null,
+          },
+        })!;
+        const result = await queryAsAdminWithSuccess({
+          query: EDIT_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView1?.id,
+            input: [{
+              key: 'description',
+              value: [updatedDescription],
+            }, {
+              key: 'manifest',
+              value: [updatedManifest],
+            }],
+          },
         });
+        expect(result.data.customViewEdit.description).toBe(updatedDescription);
+        expect(result.data.customViewEdit.manifest).toBe(updatedManifest);
+        expect(result.data.customViewEdit.updated_at).not.toBe(updatedAtBefore);
+        // TODO: Check activity logs using the audits query
+      });
 
-        it('should fail trying to edit a custom view', async () => {
-          const updatedDescription = 'Updated description';
-          await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
-            query: EDIT_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView1?.id,
-              input: [{
-                key: 'description',
-                value: [updatedDescription],
-              }],
-            },
-          });
+      it('should update the slug and thus the path when the name is edited', async () => {
+        const updatedName = 'Updated name';
+        const result = await queryAsAdminWithSuccess({
+          query: EDIT_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView1?.id,
+            input: [{
+              key: 'name',
+              value: [updatedName],
+            }],
+          },
         });
+        expect(result.data.customViewEdit.name).toBe(updatedName);
+        expect(result.data.customViewEdit.path).toBe(`updated-name-${customView1?.id.replaceAll('-', '')}`);
+      });
 
-        it('should fail trying to delete a custom view', async () => {
-          await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
-            query: DELETE_CUSTOM_VIEW_QUERY,
-            variables: {
-              id: customView1?.id,
-            },
-          });
+      it('should allow exporting a widget', async () => {
+        const widgetId = Object.keys(DASHBOARD_MANIFEST_OBJECT.widgets)[0];
+        const result = await queryAsAdminWithSuccess({
+          query: EXPORT_WIDGET_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView2?.id,
+            widgetId,
+          },
         });
+        expect(result.data.customView.toWidgetExport).toBeDefined();
+        expect(typeof result.data.customView.toWidgetExport).toBe('string');
+        const parsedWidget = JSON.parse(result.data.customView.toWidgetExport);
+        expect(parsedWidget.openCTI_version).toBeDefined();
+        expect(parsedWidget.configuration).toBeDefined();
+        expect(parsedWidget.type).toBe('widget');
+      });
 
-        it('should fail trying to duplicate a custom view', async () => {
-          await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
-            query: DUPLICATE_CUSTOM_VIEW_QUERY,
-            variables: {
-              input: {
-                name: 'Never gonna be created',
-                description: customView1?.description,
-                manifest: customView1?.manifest,
-                targetEntityType: customView1?.target_entity_type,
-              },
+      it('should allow importing a widget', async () => {
+        const file = createUploadFile(
+          './tests/03-integration/10-modules/customView/data/',
+          'custom-view-widget.json',
+        );
+        const manifestBefore = customView2?.manifest;
+        const result = await queryAsAdminWithSuccess({
+          query: IMPORT_WIDGET_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView2?.id,
+            input: {
+              file,
+              manifest: customView2?.manifest,
             },
-          });
+          },
+        });
+        expect(fromB64(result.data?.customViewWidgetConfigurationImport?.manifest)).toBeDefined();
+        expect(fromB64(result.data?.customViewWidgetConfigurationImport?.manifest)).not.toBe(manifestBefore);
+      });
+
+      it('should duplicate a custom view', async () => {
+        const duplicateName = 'Duplicated custom view 2';
+        const result = await queryAsAdminWithSuccess({
+          query: DUPLICATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              name: duplicateName,
+              description: customView2?.description,
+              manifest: customView2?.manifest,
+              targetEntityType: customView2?.target_entity_type,
+            },
+          },
+        });
+        const expectedResult = {
+          id: expect.stringMatching(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i),
+          name: duplicateName,
+          description: customView2?.description,
+          path: `duplicated-custom-view-2-${result.data.customViewDuplicate.id.replaceAll('-', '')}`,
+          targetEntityType: customView2?.target_entity_type,
+          created_at: expect.any(Date),
+          updated_at: expect.any(Date),
+          // Defaults to false when not provided
+          enabled: false,
+          // Defaults to false when not provided
+          default: false,
+        };
+        expect(result.data.customViewDuplicate).toMatchObject(expectedResult);
+        expect(result.data.customViewDuplicate.id).not.toBe(customView2?.id);
+
+        // Find new custom view in list query
+        const listResult = await queryAsAdminWithSuccess({
+          query: READ_ALL_CUSTOM_VIEWS_QUERY,
+        });
+        const nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+        expect(nodes).toContainEqual(expectedResult);
+      });
+
+      it('should delete a custom view', async () => {
+        const result = await queryAsAdminWithSuccess({
+          query: DELETE_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView2?.id,
+          },
+        });
+        expect(result.data.customViewDelete).toBe(customView2?.id);
+
+        // Not returned in list query
+        const listResult = await queryAsAdminWithSuccess({
+          query: READ_ALL_CUSTOM_VIEWS_QUERY,
+          variables: {
+            entityType: result.data.targetEntityType,
+          },
+        });
+        const nodeIds = listResult.data.customViews.edges.map((e: any) => e.node).map((node: any) => node.id);
+        expect(nodeIds).not.toContain(customView2?.id);
+      });
+
+      it('should guarantee unique default custom view', async () => {
+        // 1. Guarantee unique default custom view upon creation
+        let result = await queryAsAdminWithSuccess({
+          query: CREATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              name: 'The new default',
+              targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+              default: true,
+            },
+          },
+        });
+        const firstElementId = result.data.customViewAdd.id;
+        expect(result.data.customViewAdd.default).toBe(true);
+
+        let listResult = await queryAsAdminWithSuccess({
+          query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
+          variables: {
+            entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+          },
+        });
+        let nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+        expect(nodes.length).toBe(1);
+        expect(nodes[0].id).toBe(result.data.customViewAdd.id);
+
+        // 2. Guarantee unique default custom view upon duplication
+        result = await queryAsAdminWithSuccess({
+          query: DUPLICATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              name: 'The newer default',
+              targetEntityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+              default: true,
+            },
+          },
+        });
+        expect(result.data.customViewDuplicate.default).toBe(true);
+
+        listResult = await queryAsAdminWithSuccess({
+          query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
+          variables: {
+            entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+          },
+        });
+        nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+        expect(nodes.length).toBe(1);
+        expect(nodes[0].id).toBe(result.data.customViewDuplicate.id);
+
+        result = await queryAsAdminWithSuccess({
+          query: EDIT_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: firstElementId,
+            input: [{
+              key: 'default',
+              value: [true],
+            }],
+          },
+        });
+        expect(result.data.customViewEdit.default).toBe(true);
+
+        listResult = await queryAsAdminWithSuccess({
+          query: READ_DEFAULT_CUSTOM_VIEWS_QUERY,
+          variables: {
+            entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+          },
+        });
+        nodes = listResult.data.customViews.edges.map((e: any) => e.node);
+        expect(nodes.length).toBe(1);
+        expect(nodes[0].id).toBe(firstElementId);
+      });
+    });
+
+    describe('when user is a simple participant', () => {
+      it('should fail retrieving custom view settings with ForbiddenAccess 403 error', async () => {
+        await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+          query: READ_SETTINGS_QUERY,
+          variables: {
+            entityType: CUSTOM_VIEW_ENTITY_1.target_entity_type,
+          },
+        });
+      });
+
+      it('should fail creating a custom view with ForbiddenAccess 403 error', async () => {
+        await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+          query: CREATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              description: 'Some great description',
+              manifest: DASHBOARD_MANIFEST,
+              name: 'Custom view name',
+              targetEntityType: ENTITY_TYPE_INTRUSION_SET,
+            },
+          },
+        });
+      });
+
+      it('should fail trying to edit a custom view', async () => {
+        const updatedDescription = 'Updated description';
+        await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+          query: EDIT_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView1?.id,
+            input: [{
+              key: 'description',
+              value: [updatedDescription],
+            }],
+          },
+        });
+      });
+
+      it('should fail trying to delete a custom view', async () => {
+        await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+          query: DELETE_CUSTOM_VIEW_QUERY,
+          variables: {
+            id: customView1?.id,
+          },
+        });
+      });
+
+      it('should fail trying to duplicate a custom view', async () => {
+        await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+          query: DUPLICATE_CUSTOM_VIEW_QUERY,
+          variables: {
+            input: {
+              name: 'Never gonna be created',
+              description: customView1?.description,
+              manifest: customView1?.manifest,
+              targetEntityType: customView1?.target_entity_type,
+            },
+          },
         });
       });
     });


### PR DESCRIPTION
### Proposed changes

Implements second half of the dedicated chunk that sets a Custom View as `default`:

* Added a `default` boolean field in the data model. Like `enabled` it's optional but mandatory in ougoing types (API & STIX), defaults to `false`.
* Adds a `SwitchField` in the update drawer
* Behavior for end-users: the default custom view is displayed as a first Tab in the SDO page. Other custom views remain at the right
* There's always one default custom view at any time. This constraint is guaranteed at the backend domain level (not possible at the DB level). Supported the eddition/creation/duplication cases.
* Added integration test case

### Related issues

* Partially fixes https://github.com/OpenCTI-Platform/opencti/issues/13389

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
