### PR TITLE
fix(frontend): nested relationship node display after rel creation in knowledge graph (#11440)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
@@ -454,8 +454,8 @@ const useGraphInteractions = () => {
     }
     setGraphData((oldData) => {
       let newGraphData = oldData;
-      // If the from or the to of the link is a relationship and is not already in the graph nodes
-      // add it as a node so the link can be drawn properly.
+      // If the from or the to of the link to add is a relationship displayed as a link
+      // add it as a node so the link to add can be drawn properly.
       if (data.from?.relationship_type) {
         newGraphData = buildGraphDataAfterRelationshipLinkToNodeConversion(newGraphData, rawObjects, rawPositions, data.from);
       }

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
@@ -11,7 +11,7 @@ const useGraphInteractions = () => {
     buildLink,
     buildCorrelationData,
     buildGraphData,
-    buildNestedLinks,
+    buildGraphDataAfterRelationshipLinkToNodeConversion,
   } = useGraphParser();
 
   const {
@@ -413,8 +413,8 @@ const useGraphInteractions = () => {
     rebuildGraphData(newNodes);
   };
 
-  const addNode = (data: ObjectToParse, addAnyway = false) => {
-    if (!addAnyway && rawObjects.find((o) => o.id === data.id)) {
+  const addNode = (data: ObjectToParse) => {
+    if (rawObjects.find((o) => o.id === data.id)) {
       return;
     }
     setRawObjects((old) => ([...old, data]));
@@ -448,48 +448,27 @@ const useGraphInteractions = () => {
     });
   };
 
-  /**
-   * If a relationship is displayed as a link but needs to become a node
-   * (because it is the from or to of an other relationship), convert it:
-   * add it as a node,
-   * remove its existing link and create instead two links connecting its source and target to the new node.
-   */
-  const convertRelationshipLinkToNode = (relObj: NonNullable<ObjectToParse['from']>) => {
-    const nodeIds = graphData?.nodes.map((n) => n.id) ?? [];
-    if (!relObj.relationship_type) return;
-    if (nodeIds.includes(relObj.id)) return;
-    const relRaw = rawObjects.find((o) => o.id === relObj.id);
-    if (!relRaw) return;
-    // Add the relationship as a node in the graph
-    addNode(relRaw, true);
-    // Remove the single link that was representing this relationship
-    // and create two connector links (from→relNode, relNode→to)
-    removeLink(relRaw.id);
-    const [linkToRelNode, linkFromRelNode] = buildNestedLinks(relRaw);
-    // set the new graph data with the new node and links, but without the old link representing the relationship
-    setGraphData((oldData) => {
-      return {
-        nodes: oldData?.nodes ?? [],
-        links: [...(oldData?.links ?? []), linkToRelNode, linkFromRelNode],
-      };
-    });
-  };
-
   const addLink = (data: ObjectToParse) => {
     if (!rawObjects.find((o) => o.id === data.id)) {
       setRawObjects((old) => ([...old, data]));
     }
-    // If the from or the to of the link is a relationship and is not already in the graph nodes
-    // add it as a node so the link can be drawn properly.
-    if (data.from?.relationship_type) convertRelationshipLinkToNode(data.from);
-    if (data.to?.relationship_type) convertRelationshipLinkToNode(data.to);
-    const link = buildLink(data);
     setGraphData((oldData) => {
-      const withoutExisting = (oldData?.links ?? []).filter((l) => l.id !== link.id);
-      return {
-        links: [...withoutExisting, link],
-        nodes: oldData?.nodes ?? [],
-      };
+      let newGraphData = oldData;
+      // If the from or the to of the link is a relationship and is not already in the graph nodes
+      // add it as a node so the link can be drawn properly.
+      if (data.from?.relationship_type) {
+        newGraphData = buildGraphDataAfterRelationshipLinkToNodeConversion(newGraphData, rawObjects, rawPositions, data.from);
+      }
+      if (data.to?.relationship_type) {
+        newGraphData = buildGraphDataAfterRelationshipLinkToNodeConversion(newGraphData, rawObjects, rawPositions, data.to);
+      }
+      // link to add
+      const link = buildLink(data);
+      const withoutExisting = (newGraphData?.links ?? []).filter((l) => l.id !== link.id);
+      const newLinks = [...withoutExisting, link];
+      const newNodes = newGraphData?.nodes ?? [];
+      // set the new links and nodes
+      return { links: newLinks, nodes: newNodes };
     });
   };
 

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphInteractions.ts
@@ -11,6 +11,7 @@ const useGraphInteractions = () => {
     buildLink,
     buildCorrelationData,
     buildGraphData,
+    buildNestedLinks,
   } = useGraphParser();
 
   const {
@@ -412,8 +413,8 @@ const useGraphInteractions = () => {
     rebuildGraphData(newNodes);
   };
 
-  const addNode = (data: ObjectToParse) => {
-    if (rawObjects.find((o) => o.id === data.id)) {
+  const addNode = (data: ObjectToParse, addAnyway = false) => {
+    if (!addAnyway && rawObjects.find((o) => o.id === data.id)) {
       return;
     }
     setRawObjects((old) => ([...old, data]));
@@ -447,11 +448,42 @@ const useGraphInteractions = () => {
     });
   };
 
+  /**
+   * If a relationship is displayed as a link but needs to become a node
+   * (because it is the from or to of an other relationship), convert it:
+   * add it as a node,
+   * remove its existing link and create instead two links connecting its source and target to the new node.
+   */
+  const convertRelationshipLinkToNode = (relObj: NonNullable<ObjectToParse['from']>) => {
+    const nodeIds = graphData?.nodes.map((n) => n.id) ?? [];
+    if (!relObj.relationship_type) return;
+    if (nodeIds.includes(relObj.id)) return;
+    const relRaw = rawObjects.find((o) => o.id === relObj.id);
+    if (!relRaw) return;
+    // Add the relationship as a node in the graph
+    addNode(relRaw, true);
+    // Remove the single link that was representing this relationship
+    // and create two connector links (from→relNode, relNode→to)
+    removeLink(relRaw.id);
+    const [linkToRelNode, linkFromRelNode] = buildNestedLinks(relRaw);
+    // set the new graph data with the new node and links, but without the old link representing the relationship
+    setGraphData((oldData) => {
+      return {
+        nodes: oldData?.nodes ?? [],
+        links: [...(oldData?.links ?? []), linkToRelNode, linkFromRelNode],
+      };
+    });
+  };
+
   const addLink = (data: ObjectToParse) => {
     if (!rawObjects.find((o) => o.id === data.id)) {
       setRawObjects((old) => ([...old, data]));
     }
-    const link = buildLink(data); // TODO does it work with nested?
+    // If the from or the to of the link is a relationship and is not already in the graph nodes
+    // add it as a node so the link can be drawn properly.
+    if (data.from?.relationship_type) convertRelationshipLinkToNode(data.from);
+    if (data.to?.relationship_type) convertRelationshipLinkToNode(data.to);
+    const link = buildLink(data);
     setGraphData((oldData) => {
       const withoutExisting = (oldData?.links ?? []).filter((l) => l.id !== link.id);
       return {

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.test.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import useGraphParser, { ObjectToParse } from './useGraphParser';
@@ -36,17 +36,90 @@ const constructRelationship = (overrides: Partial<ObjectToParse> = {}): ObjectTo
 const emptyPositions: OctiGraphPositions = {};
 
 describe('useGraphParser', () => {
-  const getParser = () => {
+  let parser: ReturnType<typeof useGraphParser>;
+
+  beforeAll(() => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       React.createElement(IntlProvider, { locale: 'en', messages: {}, onError: () => {} }, children)
     );
     const { result } = renderHook(() => useGraphParser(), { wrapper });
-    return result.current;
-  };
+    parser = result.current;
+  });
+
+  describe('buildNode', () => {
+    it('should build a node with correct id and attributes', () => {
+      const entity = constructEntity({
+        id: 'node-1',
+        entity_type: 'Malware',
+        createdBy: { id: 'creator-1', name: 'Creator' },
+        objectMarking: [{ id: 'marking-1', definition: 'TLP:RED' }],
+      });
+
+      const node = parser.buildNode(entity, emptyPositions);
+
+      expect(node.id).toBe('node-1');
+      expect(node.entity_type).toBe('Malware');
+      expect(node.createdBy).toEqual({ id: 'creator-1', name: 'Creator' });
+      expect(node.markedBy).toEqual([{ id: 'marking-1', definition: 'TLP:RED' }]);
+      expect(node.isObservable).toBe(false);
+      expect(node.isNestedInferred).toBe(false);
+      expect(node.disabled).toBe(false);
+      expect(node.val).toBe(1);
+      expect(node.z).toBe(0); // default z to 0 when no position is provided
+    });
+
+    it('should use graph positions when provided', () => {
+      const entity = constructEntity({ id: 'node-1' });
+      const positions: OctiGraphPositions = {
+        'node-1': { id: 'node-1', x: 100, y: 200, z: 300 },
+      };
+
+      const node = parser.buildNode(entity, positions);
+
+      expect(node.x).toBe(100);
+      expect(node.y).toBe(200);
+      expect(node.z).toBe(300);
+      expect(node.fx).toBe(100);
+      expect(node.fy).toBe(200);
+      expect(node.fz).toBe(300);
+    });
+
+    it('should use custom color when x_opencti_color is set', () => {
+      const entity = constructEntity({ id: 'node-1', x_opencti_color: '#ff0000' });
+      const node = parser.buildNode(entity, emptyPositions);
+      expect(node.color).toBe('#ff0000');
+    });
+
+    it('should use provided numberOfConnectedElement over data value', () => {
+      const entity = constructEntity({ id: 'node-1', numberOfConnectedElement: 10 });
+
+      const node = parser.buildNode(entity, emptyPositions, 5);
+
+      expect(node.numberOfConnectedElement).toBe(5);
+    });
+
+    it('should fall back to data numberOfConnectedElement when not provided', () => {
+      const entity = constructEntity({ id: 'node-1', numberOfConnectedElement: 10 });
+
+      const node = parser.buildNode(entity, emptyPositions);
+
+      expect(node.numberOfConnectedElement).toBe(10);
+    });
+
+    it('should set fromId/toId for relationship entities', () => {
+      const rel = constructRelationship({ id: 'rel-1' });
+
+      const node = parser.buildNode(rel, emptyPositions);
+
+      expect(node.fromId).toBe('entity-A');
+      expect(node.fromType).toBe('Malware');
+      expect(node.toId).toBe('entity-B');
+      expect(node.toType).toBe('Attack-Pattern');
+    });
+  });
 
   describe('buildGraphDataAfterRelationshipLinkToNodeConversion', () => {
     it('should return previous graph data when relObj has no relationship_type', () => {
-      const parser = getParser();
       const previousGraphData = { nodes: [] as GraphNode[], links: [] as GraphLink[] };
 
       const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
@@ -60,7 +133,6 @@ describe('useGraphParser', () => {
     });
 
     it('should return previous graph data when relObj is already a node', () => {
-      const parser = getParser();
       const existingNode = parser.buildNode(constructEntity({ id: 'rel-1' }), emptyPositions);
       const previousGraphData = { nodes: [existingNode], links: [] as GraphLink[] };
 
@@ -75,8 +147,6 @@ describe('useGraphParser', () => {
     });
 
     it('should convert a relationship link to a node', () => {
-      const parser = getParser();
-
       const entityA = constructEntity({ id: 'entity-A', entity_type: 'Malware' });
       const entityB = constructEntity({ id: 'entity-B', entity_type: 'Attack-Pattern' });
       const rel = constructRelationship({ id: 'rel-1', relationship_type: 'related-to' });
@@ -116,8 +186,6 @@ describe('useGraphParser', () => {
     });
 
     it('should preserve existing nodes and other links', () => {
-      const parser = getParser();
-
       const entityA = constructEntity({ id: 'entity-A' });
       const entityB = constructEntity({ id: 'entity-B' });
       const entityC = constructEntity({ id: 'entity-C' });
@@ -160,8 +228,6 @@ describe('useGraphParser', () => {
     });
 
     it('should return previous graph data when previousGraphData is undefined', () => {
-      const parser = getParser();
-
       const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
         undefined,
         [],

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.test.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.test.ts
@@ -1,0 +1,175 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import useGraphParser, { ObjectToParse } from './useGraphParser';
+import type { GraphNode, GraphLink, OctiGraphPositions } from '../graph.types';
+
+/**
+ * Helper to build a minimal ObjectToParse for tests.
+ */
+const constructEntity = (overrides: Partial<ObjectToParse> = {}): ObjectToParse => ({
+  id: overrides.id ?? 'entity-1',
+  entity_type: overrides.entity_type ?? 'Malware',
+  relationship_type: overrides.relationship_type ?? '',
+  parent_types: overrides.parent_types ?? ['Stix-Domain-Object'],
+  is_inferred: false,
+  created: '2025-01-01T00:00:00.000Z',
+  start_time: '',
+  stop_time: '',
+  first_seen: '',
+  last_seen: '',
+  createdBy: { id: 'author-1', name: 'Author' },
+  objectMarking: [],
+  ...overrides,
+});
+
+const constructRelationship = (overrides: Partial<ObjectToParse> = {}): ObjectToParse => constructEntity({
+  entity_type: 'uses',
+  relationship_type: 'uses',
+  parent_types: ['basic-relationship', 'stix-core-relationship'],
+  from: { id: 'entity-A', entity_type: 'Malware' },
+  to: { id: 'entity-B', entity_type: 'Attack-Pattern' },
+  ...overrides,
+});
+
+const emptyPositions: OctiGraphPositions = {};
+
+describe('useGraphParser', () => {
+  const getParser = () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      React.createElement(IntlProvider, { locale: 'en', messages: {}, onError: () => {} }, children)
+    );
+    const { result } = renderHook(() => useGraphParser(), { wrapper });
+    return result.current;
+  };
+
+  describe('buildGraphDataAfterRelationshipLinkToNodeConversion', () => {
+    it('should return previous graph data when relObj has no relationship_type', () => {
+      const parser = getParser();
+      const previousGraphData = { nodes: [] as GraphNode[], links: [] as GraphLink[] };
+
+      const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
+        previousGraphData,
+        [],
+        emptyPositions,
+        { id: 'rel-1', entity_type: 'Malware' }, // no relationship_type
+      );
+
+      expect(result).toBe(previousGraphData);
+    });
+
+    it('should return previous graph data when relObj is already a node', () => {
+      const parser = getParser();
+      const existingNode = parser.buildNode(constructEntity({ id: 'rel-1' }), emptyPositions);
+      const previousGraphData = { nodes: [existingNode], links: [] as GraphLink[] };
+
+      const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
+        previousGraphData,
+        [],
+        emptyPositions,
+        { id: 'rel-1', relationship_type: 'uses', entity_type: 'uses' },
+      );
+
+      expect(result).toBe(previousGraphData);
+    });
+
+    it('should convert a relationship link to a node', () => {
+      const parser = getParser();
+
+      const entityA = constructEntity({ id: 'entity-A', entity_type: 'Malware' });
+      const entityB = constructEntity({ id: 'entity-B', entity_type: 'Attack-Pattern' });
+      const rel = constructRelationship({ id: 'rel-1', relationship_type: 'related-to' });
+
+      // Build initial graph: two entity nodes + one relationship link
+      const nodeA = parser.buildNode(entityA, emptyPositions);
+      const nodeB = parser.buildNode(entityB, emptyPositions);
+      const relLink = parser.buildLink(rel);
+
+      const previousGraphData = {
+        nodes: [nodeA, nodeB],
+        links: [relLink],
+      };
+
+      const rawObjects = [entityA, entityB, rel];
+
+      const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
+        previousGraphData,
+        rawObjects,
+        emptyPositions,
+        { id: 'rel-1', relationship_type: 'uses', entity_type: 'uses' },
+      );
+
+      // The relationship should now be a node
+      expect(result!.nodes).toHaveLength(3); // entityA + entityB + rel-1 as node
+      expect(result!.nodes.map((n) => n.id)).toContain('rel-1');
+
+      // The original link should be removed, replaced by two connector links
+      expect(result!.links).toHaveLength(2);
+      // One link should go to rel-1, the other from rel-1
+      const linkToRel = result!.links.find((l) => l.target_id === 'rel-1');
+      const linkFromRel = result!.links.find((l) => l.source_id === 'rel-1');
+      expect(linkToRel).toBeDefined();
+      expect(linkFromRel).toBeDefined();
+      expect(linkToRel!.source_id).toBe('entity-A');
+      expect(linkFromRel!.target_id).toBe('entity-B');
+    });
+
+    it('should preserve existing nodes and other links', () => {
+      const parser = getParser();
+
+      const entityA = constructEntity({ id: 'entity-A' });
+      const entityB = constructEntity({ id: 'entity-B' });
+      const entityC = constructEntity({ id: 'entity-C' });
+      const rel1 = constructRelationship({ id: 'rel-1', from: { id: 'entity-A' }, to: { id: 'entity-B' } });
+      const rel2 = constructRelationship({ id: 'rel-2', from: { id: 'entity-B' }, to: { id: 'entity-C' } });
+
+      const nodeA = parser.buildNode(entityA, emptyPositions);
+      const nodeB = parser.buildNode(entityB, emptyPositions);
+      const nodeC = parser.buildNode(entityC, emptyPositions);
+      const link1 = parser.buildLink(rel1);
+      const link2 = parser.buildLink(rel2);
+
+      const previousGraphData = {
+        nodes: [nodeA, nodeB, nodeC],
+        links: [link1, link2],
+      };
+
+      const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
+        previousGraphData,
+        [entityA, entityB, entityC, rel1, rel2],
+        emptyPositions,
+        { id: 'rel-1', relationship_type: 'uses', entity_type: 'uses' },
+      );
+
+      // rel-2 link should still be present
+      expect(result!.links.find((l) => l.id === 'rel-2')).toBeDefined();
+      // The original direct link for rel-1 (source=entity-A, target=entity-B) should be gone,
+      // replaced by two connector links going through the rel-1 node.
+      const directRel1Link = result!.links.find(
+        (l) => l.id === 'rel-1' && l.source_id === 'entity-A' && l.target_id === 'entity-B',
+      );
+      expect(directRel1Link).toBeUndefined();
+      // All original nodes should be preserved
+      expect(result!.nodes.find((n) => n.id === 'entity-A')).toBeDefined();
+      expect(result!.nodes.find((n) => n.id === 'entity-B')).toBeDefined();
+      expect(result!.nodes.find((n) => n.id === 'entity-C')).toBeDefined();
+      // Plus the new relationship node
+      expect(result!.nodes.find((n) => n.id === 'rel-1')).toBeDefined();
+      expect(result!.nodes).toHaveLength(4);
+    });
+
+    it('should return previous graph data when previousGraphData is undefined', () => {
+      const parser = getParser();
+
+      const result = parser.buildGraphDataAfterRelationshipLinkToNodeConversion(
+        undefined,
+        [],
+        emptyPositions,
+        { id: 'rel-1', relationship_type: 'uses', entity_type: 'uses' },
+      );
+
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 import { dateFormat, jsDate } from '../../../utils/Time';
 import { isNone, useFormatter } from '../../i18n';
 import { defaultDate, getMainRepresentative } from '../../../utils/defaultRepresentatives';
-import type { OctiGraphPositions, GraphLink, GraphNode } from '../graph.types';
+import { OctiGraphPositions, GraphLink, GraphNode, LibGraphProps } from '../graph.types';
 import { EMPTY_VALUE, truncate, sanitize } from '../../../utils/String';
 import GRAPH_IMAGES from './graphImages';
 import { itemColor } from '../../../utils/Colors';
@@ -323,7 +323,43 @@ const useGraphParser = () => {
     return { links, nodes };
   };
 
-  return { buildGraphData, buildCorrelationData, buildNode, buildLink, buildNestedLinks, isNestedRelationship };
+  /**
+   * Convert a relationship currently displayed as a link into a node in the graph.
+   * This is needed when a relationship becomes the source or target of another relationship
+   * (nested relationship): it can no longer be a simple link and must be represented as a node.
+   * The conversion is done by:
+   * - removing the existing direct link that represented this relationship,
+   * - adding the relationship as a new node,
+   * - creating two connector links: one from its source to the new node, and one from the new node to its target.
+   */
+  const buildGraphDataAfterRelationshipLinkToNodeConversion = (
+    previousGraphData: LibGraphProps['graphData'] | undefined,
+    rawObjects: ObjectToParse[],
+    rawPositions: OctiGraphPositions,
+    relObj: NonNullable<ObjectToParse['from']>,
+  ) => {
+    const nodeIds = previousGraphData?.nodes.map((n) => n.id) ?? [];
+    if (!relObj.relationship_type) return previousGraphData;
+    if (nodeIds.includes(relObj.id)) return previousGraphData;
+
+    const relRaw = rawObjects.find((o) => o.id === relObj.id);
+    if (!relRaw) return previousGraphData;
+
+    const nodeToAdd = buildNode(relRaw, rawPositions);
+    const [linkToRelNode, linkFromRelNode] = buildNestedLinks(relRaw);
+
+    // Defensive: should never filter anything since we already checked nodeIdSet above.
+    const previousNodes = (previousGraphData?.nodes ?? []).filter((n) => n.id !== nodeToAdd.id);
+    // Remove the single link that was representing this relationship
+    const previousLinks = (previousGraphData?.links ?? []).filter((link) => link.id !== relRaw.id);
+
+    return {
+      nodes: [...previousNodes, nodeToAdd],
+      links: [...previousLinks, linkToRelNode, linkFromRelNode],
+    };
+  };
+
+  return { buildGraphData, buildCorrelationData, buildNode, buildLink, buildNestedLinks, isNestedRelationship, buildGraphDataAfterRelationshipLinkToNodeConversion };
 };
 
 export default useGraphParser;

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
@@ -212,8 +212,8 @@ const useGraphParser = () => {
   /**
    * Check if a relationship is nested, i.e. its from or to is itself a relationship.
    */
-  const isNestedRelationship = (data: ObjectToParse) => {
-    return data.from && data.to && (data.from.relationship_type || data.to.relationship_type);
+  const isNestedRelationship = (data: ObjectToParse): boolean => {
+    return !!(data.from && data.to && (data.from.relationship_type || data.to.relationship_type));
   };
 
   /**

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
@@ -209,12 +209,30 @@ const useGraphParser = () => {
     };
   };
 
+  /**
+   * Check if a relationship is nested, i.e. its from or to is itself a relationship.
+   */
+  const isNestedRelationship = (data: ObjectToParse) => {
+    return data.from && data.to && (data.from.relationship_type || data.to.relationship_type);
+  };
+
+  /**
+   * Build the two connector links for a nested relationship displayed as a node:
+   * one from its source to the relationship node, one from the relationship node to its target.
+   */
+  const buildNestedLinks = (data: ObjectToParse): [GraphLink, GraphLink] => {
+    return [
+      buildLink(data, { name: '', label: '', target: data.id, target_id: data.id }),
+      buildLink(data, { name: '', label: '', source: data.id, source_id: data.id }),
+    ];
+  };
+
   const buildGraphData = (objects: ObjectToParse[], graphPositions: OctiGraphPositions) => {
     const uniqObjects = R.uniqBy(R.prop('id'), objects);
     const uniqIds = uniqObjects.map((o) => o.id);
     const relationshipsIdsInNestedRelationship = objects.flatMap((o) => {
-      if (o.from && o.to && (o.from.relationship_type || o.to.relationship_type)) {
-        return o.from?.relationship_type ? o.from.id : o.to.id;
+      if (isNestedRelationship(o)) {
+        return o.from?.relationship_type ? o.from.id : o.to!.id;
       }
       return [];
     });
@@ -230,10 +248,7 @@ const useGraphParser = () => {
         return buildLink(o);
       }
       if (relationshipsIdsInNestedRelationship.includes(o.id)) {
-        return [
-          buildLink(o, { name: '', label: '', target: o.id, target_id: o.id }),
-          buildLink(o, { name: '', label: '', source: o.id, source_id: o.id }),
-        ];
+        return buildNestedLinks(o);
       }
       return [];
     });
@@ -308,7 +323,7 @@ const useGraphParser = () => {
     return { links, nodes };
   };
 
-  return { buildGraphData, buildCorrelationData, buildNode, buildLink };
+  return { buildGraphData, buildCorrelationData, buildNode, buildLink, buildNestedLinks, isNestedRelationship };
 };
 
 export default useGraphParser;

--- a/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/useGraphParser.ts
@@ -339,7 +339,10 @@ const useGraphParser = () => {
     relObj: NonNullable<ObjectToParse['from']>,
   ) => {
     const nodeIds = previousGraphData?.nodes.map((n) => n.id) ?? [];
+
+    // nothing to do if the object to transform is not a relationship
     if (!relObj.relationship_type) return previousGraphData;
+    // nothing to do if the object to transform is already in the graph nodes (= if the relationship to transform is not displayed as a link but already as a node)
     if (nodeIds.includes(relObj.id)) return previousGraphData;
 
     const relRaw = rawObjects.find((o) => o.id === relObj.id);
@@ -349,17 +352,25 @@ const useGraphParser = () => {
     const [linkToRelNode, linkFromRelNode] = buildNestedLinks(relRaw);
 
     // Defensive: should never filter anything since we already checked nodeIdSet above.
-    const previousNodes = (previousGraphData?.nodes ?? []).filter((n) => n.id !== nodeToAdd.id);
+    const filteredNodes = (previousGraphData?.nodes ?? []).filter((n) => n.id !== nodeToAdd.id);
     // Remove the single link that was representing this relationship
-    const previousLinks = (previousGraphData?.links ?? []).filter((link) => link.id !== relRaw.id);
+    const filteredLinks = (previousGraphData?.links ?? []).filter((link) => link.id !== relRaw.id);
 
     return {
-      nodes: [...previousNodes, nodeToAdd],
-      links: [...previousLinks, linkToRelNode, linkFromRelNode],
+      nodes: [...filteredNodes, nodeToAdd],
+      links: [...filteredLinks, linkToRelNode, linkFromRelNode],
     };
   };
 
-  return { buildGraphData, buildCorrelationData, buildNode, buildLink, buildNestedLinks, isNestedRelationship, buildGraphDataAfterRelationshipLinkToNodeConversion };
+  return {
+    buildGraphData,
+    buildCorrelationData,
+    buildNode,
+    buildLink,
+    buildNestedLinks,
+    isNestedRelationship,
+    buildGraphDataAfterRelationshipLinkToNodeConversion,
+  };
 };
 
 export default useGraphParser;


### PR DESCRIPTION
### Proposed changes
In a knowledge graph, when creating a relationship between an entity and an other relationship, the created relationship should appear in the graph. For now, we needed to refresh to see the new created relationship.

### Example

Before creation
<img width="738" height="395" alt="image" src="https://github.com/user-attachments/assets/0540c196-3433-4df1-a2aa-bf2363158391" />



After creation of a related-to relationship between the 'Fedora related-to MenuPass' relationship and the attack pattern T1368

<img width="734" height="458" alt="image" src="https://github.com/user-attachments/assets/f44963df-07dc-4e1d-acd5-e6e6b00a73e6" />





### Related issues
fixes #11440