### PR TITLE
[frontend] add mainFields option for esbuild configuration in dev and prod builds (#15587)

### DIFF
--- a/opencti-platform/opencti-front/builder/dev/dev.js
+++ b/opencti-platform/opencti-front/builder/dev/dev.js
@@ -50,6 +50,7 @@ const middleware = (target, ws = false) => createProxyMiddleware({
       assetNames: "[dir]/[name]-[hash]",
       target: ["chrome58"],
       minify: true,
+      mainFields: ["browser", "module", "main"],
       keepNames: true,
       sourcemap: true,
       outdir: "builder/dev/build",

--- a/opencti-platform/opencti-front/builder/prod/prod.js
+++ b/opencti-platform/opencti-front/builder/prod/prod.js
@@ -27,6 +27,7 @@ const buildPath = "./builder/prod/build";
       entryNames: keep ? "static/[ext]/[name]" : "static/[ext]/[name]-[hash]",
       target: ["chrome58"],
       minify: true,
+      mainFields: ["browser", "module", "main"],
       keepNames: true,
       sourcemap: keep,
       outdir: "builder/prod/build",


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

### Proposed changes

* **Fixed React render crash in Notifier forms** (`Minified React error #130`) that occurred when selecting a connector.
* **Updated esbuild module resolution** in `builder/dev/dev.js` and `builder/prod/prod.js` to align with Vite's default behavior.
* Added `mainFields: ["browser", "module", "main"]` to prioritize resolving ES Modules (ESM) over CommonJS (CJS). 
* **Context**: After the `@rjsf` v6 migration, `esbuild` was defaulting to the CJS bundles of the library. This incorrectly wrapped the `JsonForm` UI components into plain objects instead of proper React functions/`forwardRef` components. By forcing `esbuild` to consume the ESM sources via the `mainFields` parameter, the library is now accurately bundled across all builds (both `yarn dev`, `yarn start`, and production).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15587
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
