### PR TITLE
[backend] Add logs when work is initiated and completed (#15609)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -254,6 +254,12 @@ export const createWork = async (context, user, connector, friendlyName, sourceI
   if (createdWork) {
     await redisInitializeWork(createdWork.id, isMultiPartWork);
   }
+  logApp.info('Work initiated', {
+    workId,
+    connector_id: connector.internal_id,
+    connector_name: connector.connector_name,
+    connector_type: connector.connector_type,
+  });
   return createdWork;
 };
 
@@ -310,6 +316,7 @@ export const reportExpectation = async (context, user, workId, errorData) => {
       if (isComplete) {
         await updateWorkTaskToComplete(context, user, currentWork);
       }
+      logApp.info('Work completed via expectation reporting', { workId, hasError: !!errorData });
     } else {
       logApp.warn('The work cannot be found in database, report expectation cannot be updated.', { workId });
     }
@@ -414,6 +421,7 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
   // Remove redis work if needed
   if (isComplete) {
     await redisDeleteWorks([workId]);
+    logApp.info('Work completed', { workId, inError });
   }
   return workId;
 };

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -55,6 +55,7 @@ const closeOldWorks = async (context, connector) => {
                   params,
                 },
               });
+              logApp.info('Work completed by force due to age', { workId: element.internal_id });
             }
           }
           // Delete redis tracking key


### PR DESCRIPTION

### Proposed changes

* Adds info log when work is initiated and completed with connector info (name, id, type) to the log

### Related issues

* Fixes https://github.com/OpenCTI-Platform/opencti/issues/15609

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Haven't refactored the connector logic related to works but we should consider collocating everything work-related in one place (a module).