### PR TITLE
[frontend] Easily remove a date in forms (#9389)

### DIFF
--- a/opencti-platform/opencti-front/src/components/DateTimePickerField.tsx
+++ b/opencti-platform/opencti-front/src/components/DateTimePickerField.tsx
@@ -52,6 +52,7 @@ const DateTimePickerField = (props: DateTimePickerFieldProps) => {
   const intl = useIntl();
   const [field, meta] = useField(name);
   const parsedValue = typeof value === 'string' ? new Date(value) : value; // Convert string to Date (MUI v6)
+  const defaultEmpty = null;
   const internalOnAccept = React.useCallback(
     (date: Date) => {
       setFieldTouched(name, true);
@@ -63,7 +64,6 @@ const DateTimePickerField = (props: DateTimePickerFieldProps) => {
   );
   const internalOnChange = React.useCallback(
     (date: Date | null) => {
-      const defaultEmpty = null;
       setFieldValue(name, date ?? defaultEmpty);
       if (typeof onChange === 'function') {
         onChange(name, date ?? defaultEmpty);
@@ -85,6 +85,13 @@ const DateTimePickerField = (props: DateTimePickerFieldProps) => {
 
   const showError = !isNil(meta.error) && (meta.touched || submitCount > 0);
 
+  const internalOnClear = React.useCallback(() => {
+    setFieldValue(name, defaultEmpty);
+    if (typeof onChange === 'function') {
+      onChange(name, defaultEmpty);
+    }
+  }, [setFieldValue, onChange, name]);
+
   if (withSeconds) {
     return (
       <DateTimePicker
@@ -103,6 +110,7 @@ const DateTimePickerField = (props: DateTimePickerFieldProps) => {
           dateTimeFormatsMapWithSeconds[intl.locale] || 'yyyy-MM-dd hh:mm:ss a'
         }
         slotProps={{
+          field: { clearable: true, onClear: internalOnClear },
           textField: {
             ...textFieldProps,
             onFocus: internalOnFocus,
@@ -129,6 +137,7 @@ const DateTimePickerField = (props: DateTimePickerFieldProps) => {
       views={['year', 'month', 'day', 'hours', 'minutes']}
       format={dateTimeFormatsMap[intl.locale] || 'yyyy-MM-dd hh:mm a'}
       slotProps={{
+        field: { clearable: true, onClear: internalOnClear },
         textField: {
           ...textFieldProps,
           onFocus: internalOnFocus,

--- a/opencti-platform/opencti-front/src/components/DateTimePickerField.tsx
+++ b/opencti-platform/opencti-front/src/components/DateTimePickerField.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { TextFieldProps } from '@mui/material/TextField';
 import { fieldToDateTimePicker } from 'formik-mui-lab';
-import { useField } from 'formik';
+import { FieldProps, useField } from 'formik';
 import { useIntl } from 'react-intl';
 import { isNil } from 'ramda';
 import { parse } from '../utils/Time';
 
-const dateTimeFormatsMap = {
+const dateTimeFormatsMap: Record<string, string> = {
   'de-de': 'dd.MM.yyyy HH:mm',
   'en-us': 'yyyy-MM-dd hh:mm a',
   'es-es': 'dd/MM/yyyy HH:mm',
@@ -17,7 +18,7 @@ const dateTimeFormatsMap = {
   'zh-cn': 'yyyy-MM-dd hh:mm a',
 };
 
-const dateTimeFormatsMapWithSeconds = {
+const dateTimeFormatsMapWithSeconds: Record<string, string> = {
   'de-de': 'dd.MM.yyyy HH:mm:ss',
   'en-us': 'yyyy-MM-dd hh:mm:ss a',
   'es-es': 'dd/MM/yyyy HH:mm:ss',
@@ -28,7 +29,16 @@ const dateTimeFormatsMapWithSeconds = {
   'zh-cn': 'yyyy-MM-dd hh:mm:ss a',
 };
 
-const DateTimePickerField = (props) => {
+type DateTimePickerFieldProps = FieldProps<string> & {
+  onFocus?: (name: string) => void;
+  onChange?: (name: string, value: Date | null) => void;
+  onSubmit?: (name: string, value: string | null) => void;
+  textFieldProps: TextFieldProps;
+  withSeconds?: boolean;
+  required?: boolean;
+};
+
+const DateTimePickerField = (props: DateTimePickerFieldProps) => {
   const {
     form: { setFieldValue, setFieldTouched, submitCount },
     field: { name, value },
@@ -43,7 +53,7 @@ const DateTimePickerField = (props) => {
   const [field, meta] = useField(name);
   const parsedValue = typeof value === 'string' ? new Date(value) : value; // Convert string to Date (MUI v6)
   const internalOnAccept = React.useCallback(
-    (date) => {
+    (date: Date) => {
       setFieldTouched(name, true);
       if (typeof onSubmit === 'function') {
         onSubmit(name, date.toISOString());
@@ -52,7 +62,7 @@ const DateTimePickerField = (props) => {
     [setFieldTouched, onSubmit, name],
   );
   const internalOnChange = React.useCallback(
-    (date) => {
+    (date: Date | null) => {
       const defaultEmpty = null;
       setFieldValue(name, date ?? defaultEmpty);
       if (typeof onChange === 'function') {


### PR DESCRIPTION
### Proposed changes
- Turn DateTimePickerField from jsx to tsx
- Add the possibility to easily remove a date from a date field by clicking on a cross button

Example when editing the 'first seen' of a relationship : 
<img width="1197" height="477" alt="image" src="https://github.com/user-attachments/assets/9bf9b1e4-a380-42e6-8a9e-152498370541" />




### Related issues
fixes #9389