### PR TITLE
[backend/frontend] Fix Individual min-length and Software case-insensitive ID (#15632, #15633)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualCreation.tsx
@@ -90,7 +90,7 @@ export const IndividualCreationForm: FunctionComponent<IndividualFormProps> = ({
 
   const { mandatoryAttributes } = useIsMandatoryAttribute(INDIVIDUAL_TYPE);
   const basicShape = yupShapeConditionalRequired({
-    name: Yup.string().min(2),
+    name: Yup.string().min(1),
     description: Yup.string()
       .nullable(),
     confidence: Yup.number().nullable(),

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -4206,7 +4206,7 @@ input IndividualAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
 
-  "*Constraints:*\n* Minimal length: `2`\n* Must match format: `not-blank`\n"
+  "*Constraints:*\n* Minimal length: `1`\n* Must match format: `not-blank`\n"
   name: String!
   description: String
   contact_information: String

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -5176,7 +5176,7 @@ type Individual implements BasicObject & StixObject & StixCoreObject & StixDomai
 input IndividualAddInput {
   stix_id: StixId
   x_opencti_stix_ids: [StixId]
-  name: String! @constraint(minLength: 2, format: "not-blank")
+  name: String! @constraint(minLength: 1, format: "not-blank")
   description: String
   contact_information: String
   roles: [String]

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -1,0 +1,114 @@
+import * as R from 'ramda';
+import { Promise } from 'bluebird';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { generateStandardId } from '../schema/identifier';
+import { ENTITY_SOFTWARE } from '../schema/stixCyberObservable';
+import { READ_INDEX_STIX_CYBER_OBSERVABLES } from '../database/utils';
+import { fullEntitiesList } from '../database/middleware-loader';
+import { mergeEntities, patchAttribute } from '../database/middleware';
+import { BULK_TIMEOUT, elBulk, ES_MAX_CONCURRENCY, MAX_BULK_OPERATIONS } from '../database/engine';
+import { logApp, logMigration } from '../config/conf';
+
+const message = '[MIGRATION] Software standard_id case-insensitive rewrite';
+
+export const up = async (next) => {
+  const context = executionContext('migration');
+  const start = new Date().getTime();
+  logMigration.info(`${message} > started`);
+
+  // 1. Load every existing Software observable (minimal but sufficient field set to
+  // recompute a standard_id and to build the bulk update / merge operations).
+  const allSoftwares = await fullEntitiesList(
+    context,
+    SYSTEM_USER,
+    [ENTITY_SOFTWARE],
+    { indices: [READ_INDEX_STIX_CYBER_OBSERVABLES] },
+  );
+  if (allSoftwares.length === 0) {
+    logMigration.info(`${message} > no Software observable found, nothing to do`);
+    next();
+    return;
+  }
+  logMigration.info(`${message} > ${allSoftwares.length} Software observable(s) to evaluate`);
+
+  // 2. Compute the new standard_id (lowercased name) for each Software and group them.
+  // Entities sharing the same new id would collide after the code change and must be merged.
+  const softwaresWithNewId = allSoftwares.map((sw) => ({ sw, newId: generateStandardId(ENTITY_SOFTWARE, sw) }));
+  const groupedByNewId = R.groupBy((e) => e.newId, softwaresWithNewId);
+  const groups = Object.values(groupedByNewId);
+
+  // 3. Handle groups that collide: merge siblings into a single target entity.
+  // We pick the oldest entity (by created_at, falling back to internal_id) as the merge target
+  // to preserve provenance; all the other entities are merged into it so that their relations,
+  // markings, labels, stix ids... are kept. The merge target's standard_id is moved to the new
+  // value with patchAttribute so the middleware automatically archives the previous standard_id
+  // inside x_opencti_stix_ids.
+  const collisionGroups = groups.filter((g) => g.length > 1);
+  logMigration.info(`${message} > ${collisionGroups.length} collision group(s) to merge`);
+  let mergedEntities = 0;
+  for (let index = 0; index < collisionGroups.length; index += 1) {
+    const group = collisionGroups[index];
+    const { newId } = group[0];
+    const sorted = R.sortWith(
+      [
+        R.ascend((e) => e.sw.created_at || ''),
+        R.ascend((e) => e.sw.internal_id || ''),
+      ],
+      group,
+    );
+    const target = sorted[0].sw;
+    const sources = sorted.slice(1).map((e) => e.sw);
+    try {
+      if (target.standard_id !== newId) {
+        await patchAttribute(context, SYSTEM_USER, target.internal_id, target.entity_type, { standard_id: newId });
+      }
+      await mergeEntities(context, SYSTEM_USER, target.internal_id, sources.map((s) => s.internal_id));
+      mergedEntities += sources.length;
+      logApp.info(`${message} > merged ${sources.length} Software into ${target.internal_id} (${index + 1}/${collisionGroups.length})`);
+    } catch (err) {
+      // Do not abort the whole migration if one group fails: log and keep going,
+      // the remaining Software observables can still have their standard_id rewritten.
+      logApp.error(`${message} > failed to merge group for ${newId}`, { cause: err, targetId: target.internal_id, sourceIds: sources.map((s) => s.internal_id) });
+    }
+  }
+
+  // 4. Bulk-rewrite the standard_id of all remaining (non-colliding) Software observables
+  // whose id actually changed. The previous standard_id is archived in x_opencti_stix_ids
+  // so older STIX IDs keep resolving to the same entity.
+  const bulkOperations = [];
+  const singletonGroups = groups.filter((g) => g.length === 1);
+  for (let index = 0; index < singletonGroups.length; index += 1) {
+    const { sw, newId } = singletonGroups[index][0];
+    if (sw.standard_id === newId) continue;
+    const existingStixIds = sw.x_opencti_stix_ids ?? [];
+    const updatedStixIds = R.uniq([...existingStixIds, sw.standard_id]);
+    bulkOperations.push(
+      { update: { _index: sw._index, _id: sw._id } },
+      { doc: { standard_id: newId, x_opencti_stix_ids: updatedStixIds } },
+    );
+  }
+
+  if (bulkOperations.length > 0) {
+    let currentProcessing = 0;
+    const groupsOfOperations = R.splitEvery(MAX_BULK_OPERATIONS, bulkOperations);
+    const concurrentUpdate = async (bulk) => {
+      await elBulk({ refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+      currentProcessing += bulk.length;
+      logApp.info(`${message} > bulk rewrote Software standard ids: ${currentProcessing} / ${bulkOperations.length}`);
+    };
+    await Promise.map(groupsOfOperations, concurrentUpdate, { concurrency: ES_MAX_CONCURRENCY });
+  }
+
+  logMigration.info(
+    `${message} > done in ${new Date().getTime() - start} ms`
+    + ` (${bulkOperations.length / 2} standard_id rewritten, ${mergedEntities} duplicate(s) merged across ${collisionGroups.length} group(s))`,
+  );
+  next();
+};
+
+export const down = async (next) => {
+  // This migration is intentionally not reversible: the old standard_ids are preserved in
+  // x_opencti_stix_ids so data is not lost, but recomputing the previous case-sensitive ids
+  // would require the original pre-merge state which is no longer available after merges.
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/schema/identifier.js
+++ b/opencti-platform/opencti-graphql/src/schema/identifier.js
@@ -164,6 +164,14 @@ const stixBaseCyberObservableContribution = {
       if (hashes[SSDEEP]) return { [SSDEEP]: hashes[SSDEEP] };
       return undefined;
     },
+    name(value, data) {
+      // Software names are case-insensitive for ID generation only (indexing keeps original case).
+      // File names must stay case-sensitive (Linux file systems), Mutex stays as-is.
+      if (data?.[INNER_TYPE] === C.ENTITY_SOFTWARE) {
+        return R.is(String, value) ? value.toLowerCase() : value;
+      }
+      return value;
+    },
   },
 };
 
@@ -386,7 +394,9 @@ const filteredIdContributions = (contrib, way, data) => {
     const destKey = dest || src;
     const resolver = contrib.resolvers[src];
     if (resolver) {
-      objectData[destKey] = value ? resolver(value) : value;
+      // Pass the full data as a second argument so resolvers can discriminate on the entity type
+      // (available through the INNER_TYPE / opencti_type key injected in generateDataUUID).
+      objectData[destKey] = value ? resolver(value, data) : value;
     } else {
       objectData[destKey] = R.is(String, value) ? value.trim() : value;
     }

--- a/opencti-platform/opencti-graphql/src/schema/module.ts
+++ b/opencti-platform/opencti-graphql/src/schema/module.ts
@@ -44,7 +44,7 @@ export interface ModuleDefinition<T extends StoreEntity, Z extends StixObject> {
       [k: string]: Array<{ src: string; dependencies?: string[] }> | string | (() => string);
     };
     resolvers?: {
-      [f: string]: (data: object) => string;
+      [f: string]: (value: any, data?: object) => string;
     };
   };
   representative: RepresentativeFn<Z>;

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/identifier-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/identifier-test.js
@@ -28,6 +28,7 @@ import {
   ENTITY_TYPE_TOOL,
   ENTITY_TYPE_VULNERABILITY,
 } from '../../../src/schema/stixDomainObject';
+import { ENTITY_HASHED_OBSERVABLE_STIX_FILE, ENTITY_MUTEX, ENTITY_SOFTWARE } from '../../../src/schema/stixCyberObservable';
 import { ENTITY_TYPE_THREAT_ACTOR_INDIVIDUAL } from '../../../src/modules/threatActorIndividual/threatActorIndividual-types';
 import { ENTITY_TYPE_LOCATION_ADMINISTRATIVE_AREA } from '../../../src/modules/administrativeArea/administrativeArea-types';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../../../src/modules/case/case-incident/case-incident-types';
@@ -163,6 +164,29 @@ describe('identifier', () => {
     const aliasId = generateAliasesId(['SnowFlake'], { name: 'APT28', entity_type: ENTITY_TYPE_MALWARE }).at(0);
     expect(classicId).toEqual('malware--1bc77052-c136-5258-b95d-fc8117fba3fd');
     expect(classicId).toEqual(aliasId);
+  });
+
+  it('should software id be case-insensitive', () => {
+    // Software names must produce the same standard id regardless of their case
+    const lowerId = generateStandardId(ENTITY_SOFTWARE, { name: 'apache' });
+    const mixedId = generateStandardId(ENTITY_SOFTWARE, { name: 'Apache' });
+    const upperId = generateStandardId(ENTITY_SOFTWARE, { name: 'APACHE' });
+    expect(lowerId).toEqual(mixedId);
+    expect(lowerId).toEqual(upperId);
+    // Other discriminators (vendor, version, ...) must still be taken into account
+    const withVendor = generateStandardId(ENTITY_SOFTWARE, { name: 'Apache', vendor: 'Apache Foundation' });
+    expect(withVendor).not.toEqual(mixedId);
+  });
+
+  it('should file and mutex id remain case-sensitive', () => {
+    // File names must remain case-sensitive (e.g. Linux file systems are case-sensitive)
+    const fileLower = generateStandardId(ENTITY_HASHED_OBSERVABLE_STIX_FILE, { name: 'readme.md' });
+    const fileUpper = generateStandardId(ENTITY_HASHED_OBSERVABLE_STIX_FILE, { name: 'README.MD' });
+    expect(fileLower).not.toEqual(fileUpper);
+    // Mutex keeps its case too
+    const mutexLower = generateStandardId(ENTITY_MUTEX, { name: 'my-mutex' });
+    const mutexUpper = generateStandardId(ENTITY_MUTEX, { name: 'MY-MUTEX' });
+    expect(mutexLower).not.toEqual(mutexUpper);
   });
 
   it('should aliases filtered by rules', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
@@ -36,14 +36,17 @@ describe('JSON mapper testing', () => {
   it('should cisa correctly parsed', async () => {
     const objects = await jsonMappingExecution(testContext, ADMIN_USER, cisa_data, cisa_mapper);
     const { mapById, mapByType, mapByFromAndTo } = buildMaps(objects);
-    expect(objects.length).toBe(3556);
+    // Note: Software standard_id generation is now case-insensitive on name,
+    // so case-variant duplicates in the CISA fixture collapse into a single
+    // Software entity (hence -2 softwares and -2 relationships vs previous counts).
+    expect(objects.length).toBe(3552);
     expect(mapByType.get('marking-definition').length).toBe(1);
     expect(mapByType.get('identity').length).toBe(1);
-    expect(mapByType.get('software').length).toBe(528);
+    expect(mapByType.get('software').length).toBe(526);
     expect(mapByType.get('vulnerability').length).toBe(1249);
-    expect(mapByType.get('relationship').length).toBe(1777);
-    // Test software binding
-    const software = mapById.get('software--bd1130d6-ada7-594b-b54f-c0db8c814978');
+    expect(mapByType.get('relationship').length).toBe(1775);
+    // Test software binding (id depends on the lower-cased name).
+    const software = mapById.get('software--a71e777c-aa42-5279-ae89-785d9e414693');
     expect(software.name).toBe('Windows');
     expect(software.vendor).toBe('Microsoft');
     // Test vulnerability binding


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* **Software observable deduplication is now case-insensitive on `name`.** The `standard_id` of a Software Cyber Observable is now generated from the lower-cased `name`, so `Apache`, `apache` and `APACHE` all resolve to the same entity. The original casing is still preserved in storage and indexing; only the ID computation is normalized. `StixFile` and `Mutex` names remain case-sensitive to avoid regressions (Linux file systems are case-sensitive).
* **Data migration for existing Software observables.** A new migration (`1776859399668-software_case_insensitive_standard_id.js`) rewrites the `standard_id` of every existing Software observable using the new case-insensitive rules. Entities that collide on the new id (e.g. both `Apache` and `apache` exist today) are automatically merged using `mergeEntities`: the oldest entity is kept as the target, its `standard_id` is moved to the new value, and every other sibling is merged into it so relations, markings, labels and stix ids are preserved. Non-colliding Software entities get their `standard_id` rewritten in bulk with `elBulk`, and the previous `standard_id` is archived in `x_opencti_stix_ids` so older STIX IDs still resolve to the same entity. Without this migration, any new ingestion with different casing would have generated more duplicates, not fewer.
* **Individual entities can now be created with a single-character name.** The GraphQL constraint on `IndividualAddInput.name` is relaxed from `minLength: 2` to `minLength: 1`, and the frontend Yup validation in `IndividualCreation.tsx` is aligned (`.min(1)`). The `not-blank` format constraint is kept, so empty or whitespace-only names are still rejected.
* **Identifier resolver signature extended (backward-compatible).** Resolvers in `filteredIdContributions` now receive the full `data` object as an optional second argument, so they can discriminate on `opencti_type` when needed (used by the shared cyber observable `name` resolver to target only `Software`). All existing single-argument resolvers keep working unchanged.
* **Test coverage** added in `tests/01-unit/domain/identifier-test.js`:
  * new `should software id be case-insensitive` test proving `apache` / `Apache` / `APACHE` produce the same standard id, and that other discriminators (`vendor`, `version`, `cpe`, `swid`) are still honored;
  * new `should file and mutex id remain case-sensitive` test guarding the non-regression for `StixFile` and `Mutex`.

### Related issues

<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15632
* closes #15633

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The cyber observable `name` resolver is shared between `StixFile`, `Mutex` and `Software`, so a blanket `toLowerCase()` was not acceptable. The chosen approach is to let the resolver read the entity type from the `opencti_type` key that `generateDataUUID` already injects into the data object, and apply the case-insensitive transformation only for `Software`. This keeps the change surgical and fully backwards-compatible with existing identifiers for all other entity types (all 11 pre-existing identifier-test assertions continue to pass).

Regarding the migration, the collision merge step is intentionally serial (one group at a time) because `mergeEntities` acquires locks on every involved relation and parallelizing would risk contention on large platforms. The bulk rewrite of non-colliding entities runs with `ES_MAX_CONCURRENCY` in batches of `MAX_BULK_OPERATIONS` just like the existing `note_standard_id_abstract` migration. The migration is not reversible by design (once merges are applied the pre-merge state is lost), but no data is destroyed: every previous `standard_id` is archived in `x_opencti_stix_ids`.
