### PR TITLE
[graphql] Add draft workspace review queries and mutations (#8707)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9727,7 +9727,7 @@ type Query {
   draftWorkspace(id: String!): DraftWorkspace
   draftWorkspaces(first: Int, after: ID, orderBy: DraftWorkspacesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): DraftWorkspaceConnection
   draftWorkspacesRestricted(first: Int, after: ID, orderBy: DraftWorkspacesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): DraftWorkspaceConnection
-  draftWorkspaceEntities(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, draftOperation: String): StixCoreObjectConnection
+  draftWorkspaceEntities(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, draftOperation: DraftOperation): StixCoreObjectConnection
   draftWorkspaceContainerObjects(draftId: String!, containerId: String!): [DraftContainerObjectChange!]!
   draftWorkspaceRelationships(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixRelationshipsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixRelationshipConnection
   draftWorkspaceSightingRelationships(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixSightingRelationshipsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixSightingRelationshipConnection
@@ -14980,11 +14980,18 @@ enum DraftStatus {
   validated
 }
 
+enum DraftChangeType {
+  create
+  delete
+  add
+  remove
+}
+
 type DraftContainerObjectChange {
   entity_id: String!
   entity_type: String!
   representative_main: String
-  draft_operation: String!
+  draft_operation: DraftChangeType!
 }
 
 type DraftWorkspace implements InternalObject & BasicObject {
@@ -15052,14 +15059,14 @@ type DraftEntityRelation {
   to_id: String!
   to_type: String!
   to_name: String!
-  draft_operation: String!
+  draft_operation: DraftChangeType!
 }
 
 type DraftEntityContainerRef {
   container_id: String!
   container_type: String!
   container_name: String!
-  draft_operation: String!
+  draft_operation: DraftChangeType!
 }
 
 type DraftResolvedId {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -2394,6 +2394,7 @@ enum DraftOperation {
 type DraftVersion {
   draft_id: String!
   draft_operation: DraftOperation!
+  draft_updates_patch: String
 }
 
 interface StixObject {
@@ -9726,9 +9727,14 @@ type Query {
   draftWorkspace(id: String!): DraftWorkspace
   draftWorkspaces(first: Int, after: ID, orderBy: DraftWorkspacesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): DraftWorkspaceConnection
   draftWorkspacesRestricted(first: Int, after: ID, orderBy: DraftWorkspacesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): DraftWorkspaceConnection
-  draftWorkspaceEntities(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixCoreObjectConnection
+  draftWorkspaceEntities(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixCoreObjectsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, draftOperation: String): StixCoreObjectConnection
+  draftWorkspaceContainerObjects(draftId: String!, containerId: String!): [DraftContainerObjectChange!]!
   draftWorkspaceRelationships(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixRelationshipsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixRelationshipConnection
   draftWorkspaceSightingRelationships(draftId: String!, types: [String], first: Int, after: ID, orderBy: StixSightingRelationshipsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): StixSightingRelationshipConnection
+  draftWorkspaceResolveIds(draftId: String!, ids: [String!]!): [DraftResolvedId!]!
+  draftWorkspaceEntityFields(draftId: String!, entityId: String!): [DraftEntityField!]!
+  draftWorkspaceEntityRelations(draftId: String!, entityId: String!): [DraftEntityRelation!]!
+  draftWorkspaceEntityContainerRefs(draftId: String!, entityId: String!): [DraftEntityContainerRef!]!
   fintelTemplate(id: ID!): FintelTemplate
   disseminationList(id: ID!): DisseminationList
   disseminationLists(first: Int, after: ID, orderBy: DisseminationListOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): DisseminationListConnection
@@ -14974,6 +14980,13 @@ enum DraftStatus {
   validated
 }
 
+type DraftContainerObjectChange {
+  entity_id: String!
+  entity_type: String!
+  representative_main: String
+  draft_operation: String!
+}
+
 type DraftWorkspace implements InternalObject & BasicObject {
   id: ID!
   entity_type: String!
@@ -15004,6 +15017,7 @@ type DraftObjectsCount {
   relationshipsCount: Int!
   sightingsCount: Int!
   containersCount: Int!
+  reviewsCount: Int!
 }
 
 enum DraftWorkspacesOrdering {
@@ -15022,6 +15036,35 @@ type DraftWorkspaceConnection {
 type DraftWorkspaceEdge {
   cursor: String!
   node: DraftWorkspace!
+}
+
+type DraftEntityField {
+  field: String!
+  values: [String!]!
+}
+
+type DraftEntityRelation {
+  relation_id: String!
+  relationship_type: String!
+  from_id: String!
+  from_type: String!
+  from_name: String!
+  to_id: String!
+  to_type: String!
+  to_name: String!
+  draft_operation: String!
+}
+
+type DraftEntityContainerRef {
+  container_id: String!
+  container_type: String!
+  container_name: String!
+  draft_operation: String!
+}
+
+type DraftResolvedId {
+  id: String!
+  representative_main: String
 }
 
 input DraftWorkspaceAddInput {

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -2320,6 +2320,7 @@ enum DraftOperation {
 type DraftVersion {
   draft_id: String!
   draft_operation: DraftOperation!
+  draft_updates_patch: String
 }
 
 interface StixObject {

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -129,6 +129,7 @@ export interface RelationOptions<T extends BasicStoreCommon> extends RelationFil
   indices?: Array<string>;
   baseData?: boolean;
   withInferences?: boolean;
+  includeDeletedInDraft?: boolean | null;
 }
 
 export const buildAggregationFilter = <T extends BasicStoreCommon>(args: RelationFilters<T>) => {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7795,6 +7795,13 @@ export type DomainNameAddInput = {
   value: Scalars['String']['input'];
 };
 
+export enum DraftChangeType {
+  Add = 'add',
+  Create = 'create',
+  Delete = 'delete',
+  Remove = 'remove'
+}
+
 export type DraftContainerObjectChange = {
   __typename?: 'DraftContainerObjectChange';
   draft_operation: DraftChangeType;
@@ -7840,13 +7847,6 @@ export type DraftObjectsCount = {
   sightingsCount: Scalars['Int']['output'];
   totalCount: Scalars['Int']['output'];
 };
-
-export enum DraftChangeType {
-  Add = 'add',
-  Create = 'create',
-  Delete = 'delete',
-  Remove = 'remove',
-}
 
 export enum DraftOperation {
   Create = 'create',

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7797,7 +7797,7 @@ export type DomainNameAddInput = {
 
 export type DraftContainerObjectChange = {
   __typename?: 'DraftContainerObjectChange';
-  draft_operation: Scalars['String']['output'];
+  draft_operation: DraftChangeType;
   entity_id: Scalars['String']['output'];
   entity_type: Scalars['String']['output'];
   representative_main?: Maybe<Scalars['String']['output']>;
@@ -7808,7 +7808,7 @@ export type DraftEntityContainerRef = {
   container_id: Scalars['String']['output'];
   container_name: Scalars['String']['output'];
   container_type: Scalars['String']['output'];
-  draft_operation: Scalars['String']['output'];
+  draft_operation: DraftChangeType;
 };
 
 export type DraftEntityField = {
@@ -7819,7 +7819,7 @@ export type DraftEntityField = {
 
 export type DraftEntityRelation = {
   __typename?: 'DraftEntityRelation';
-  draft_operation: Scalars['String']['output'];
+  draft_operation: DraftChangeType;
   from_id: Scalars['String']['output'];
   from_name: Scalars['String']['output'];
   from_type: Scalars['String']['output'];
@@ -7840,6 +7840,13 @@ export type DraftObjectsCount = {
   sightingsCount: Scalars['Int']['output'];
   totalCount: Scalars['Int']['output'];
 };
+
+export enum DraftChangeType {
+  Add = 'add',
+  Create = 'create',
+  Delete = 'delete',
+  Remove = 'remove',
+}
 
 export enum DraftOperation {
   Create = 'create',
@@ -25191,7 +25198,7 @@ export type QueryDraftWorkspaceContainerObjectsArgs = {
 export type QueryDraftWorkspaceEntitiesArgs = {
   after?: InputMaybe<Scalars['ID']['input']>;
   draftId: Scalars['String']['input'];
-  draftOperation?: InputMaybe<Scalars['String']['input']>;
+  draftOperation?: InputMaybe<DraftOperation>;
   filters?: InputMaybe<FilterGroup>;
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<StixCoreObjectsOrdering>;
@@ -39291,6 +39298,7 @@ export type ResolversTypes = ResolversObject<{
   DocsMetrics: ResolverTypeWrapper<DocsMetrics>;
   DomainName: ResolverTypeWrapper<Omit<DomainName, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<ResolversTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, indicators?: Maybe<ResolversTypes['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   DomainNameAddInput: DomainNameAddInput;
+  DraftChangeType: DraftChangeType;
   DraftContainerObjectChange: ResolverTypeWrapper<DraftContainerObjectChange>;
   DraftEntityContainerRef: ResolverTypeWrapper<DraftEntityContainerRef>;
   DraftEntityField: ResolverTypeWrapper<DraftEntityField>;
@@ -43681,7 +43689,7 @@ export type DomainNameResolvers<ContextType = any, ParentType extends ResolversP
 }>;
 
 export type DraftContainerObjectChangeResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftContainerObjectChange'] = ResolversParentTypes['DraftContainerObjectChange']> = ResolversObject<{
-  draft_operation?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  draft_operation?: Resolver<ResolversTypes['DraftChangeType'], ParentType, ContextType>;
   entity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   representative_main?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -43691,7 +43699,7 @@ export type DraftEntityContainerRefResolvers<ContextType = any, ParentType exten
   container_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   container_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   container_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  draft_operation?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  draft_operation?: Resolver<ResolversTypes['DraftChangeType'], ParentType, ContextType>;
 }>;
 
 export type DraftEntityFieldResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftEntityField'] = ResolversParentTypes['DraftEntityField']> = ResolversObject<{
@@ -43700,7 +43708,7 @@ export type DraftEntityFieldResolvers<ContextType = any, ParentType extends Reso
 }>;
 
 export type DraftEntityRelationResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftEntityRelation'] = ResolversParentTypes['DraftEntityRelation']> = ResolversObject<{
-  draft_operation?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  draft_operation?: Resolver<ResolversTypes['DraftChangeType'], ParentType, ContextType>;
   from_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   from_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   from_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7795,12 +7795,48 @@ export type DomainNameAddInput = {
   value: Scalars['String']['input'];
 };
 
+export type DraftContainerObjectChange = {
+  __typename?: 'DraftContainerObjectChange';
+  draft_operation: Scalars['String']['output'];
+  entity_id: Scalars['String']['output'];
+  entity_type: Scalars['String']['output'];
+  representative_main?: Maybe<Scalars['String']['output']>;
+};
+
+export type DraftEntityContainerRef = {
+  __typename?: 'DraftEntityContainerRef';
+  container_id: Scalars['String']['output'];
+  container_name: Scalars['String']['output'];
+  container_type: Scalars['String']['output'];
+  draft_operation: Scalars['String']['output'];
+};
+
+export type DraftEntityField = {
+  __typename?: 'DraftEntityField';
+  field: Scalars['String']['output'];
+  values: Array<Scalars['String']['output']>;
+};
+
+export type DraftEntityRelation = {
+  __typename?: 'DraftEntityRelation';
+  draft_operation: Scalars['String']['output'];
+  from_id: Scalars['String']['output'];
+  from_name: Scalars['String']['output'];
+  from_type: Scalars['String']['output'];
+  relation_id: Scalars['String']['output'];
+  relationship_type: Scalars['String']['output'];
+  to_id: Scalars['String']['output'];
+  to_name: Scalars['String']['output'];
+  to_type: Scalars['String']['output'];
+};
+
 export type DraftObjectsCount = {
   __typename?: 'DraftObjectsCount';
   containersCount: Scalars['Int']['output'];
   entitiesCount: Scalars['Int']['output'];
   observablesCount: Scalars['Int']['output'];
   relationshipsCount: Scalars['Int']['output'];
+  reviewsCount: Scalars['Int']['output'];
   sightingsCount: Scalars['Int']['output'];
   totalCount: Scalars['Int']['output'];
 };
@@ -7813,6 +7849,12 @@ export enum DraftOperation {
   UpdateLinked = 'update_linked'
 }
 
+export type DraftResolvedId = {
+  __typename?: 'DraftResolvedId';
+  id: Scalars['String']['output'];
+  representative_main?: Maybe<Scalars['String']['output']>;
+};
+
 export enum DraftStatus {
   Open = 'open',
   Validated = 'validated'
@@ -7822,6 +7864,7 @@ export type DraftVersion = {
   __typename?: 'DraftVersion';
   draft_id: Scalars['String']['output'];
   draft_operation: DraftOperation;
+  draft_updates_patch?: Maybe<Scalars['String']['output']>;
 };
 
 export type DraftWorkspace = BasicObject & InternalObject & {
@@ -24241,8 +24284,13 @@ export type Query = {
   disseminationList?: Maybe<DisseminationList>;
   disseminationLists?: Maybe<DisseminationListConnection>;
   draftWorkspace?: Maybe<DraftWorkspace>;
+  draftWorkspaceContainerObjects: Array<DraftContainerObjectChange>;
   draftWorkspaceEntities?: Maybe<StixCoreObjectConnection>;
+  draftWorkspaceEntityContainerRefs: Array<DraftEntityContainerRef>;
+  draftWorkspaceEntityFields: Array<DraftEntityField>;
+  draftWorkspaceEntityRelations: Array<DraftEntityRelation>;
   draftWorkspaceRelationships?: Maybe<StixRelationshipConnection>;
+  draftWorkspaceResolveIds: Array<DraftResolvedId>;
   draftWorkspaceSightingRelationships?: Maybe<StixSightingRelationshipConnection>;
   draftWorkspaces?: Maybe<DraftWorkspaceConnection>;
   draftWorkspacesRestricted?: Maybe<DraftWorkspaceConnection>;
@@ -25134,15 +25182,40 @@ export type QueryDraftWorkspaceArgs = {
 };
 
 
+export type QueryDraftWorkspaceContainerObjectsArgs = {
+  containerId: Scalars['String']['input'];
+  draftId: Scalars['String']['input'];
+};
+
+
 export type QueryDraftWorkspaceEntitiesArgs = {
   after?: InputMaybe<Scalars['ID']['input']>;
   draftId: Scalars['String']['input'];
+  draftOperation?: InputMaybe<Scalars['String']['input']>;
   filters?: InputMaybe<FilterGroup>;
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<StixCoreObjectsOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
   search?: InputMaybe<Scalars['String']['input']>;
   types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDraftWorkspaceEntityContainerRefsArgs = {
+  draftId: Scalars['String']['input'];
+  entityId: Scalars['String']['input'];
+};
+
+
+export type QueryDraftWorkspaceEntityFieldsArgs = {
+  draftId: Scalars['String']['input'];
+  entityId: Scalars['String']['input'];
+};
+
+
+export type QueryDraftWorkspaceEntityRelationsArgs = {
+  draftId: Scalars['String']['input'];
+  entityId: Scalars['String']['input'];
 };
 
 
@@ -25155,6 +25228,12 @@ export type QueryDraftWorkspaceRelationshipsArgs = {
   orderMode?: InputMaybe<OrderingMode>;
   search?: InputMaybe<Scalars['String']['input']>;
   types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type QueryDraftWorkspaceResolveIdsArgs = {
+  draftId: Scalars['String']['input'];
+  ids: Array<Scalars['String']['input']>;
 };
 
 
@@ -39212,8 +39291,13 @@ export type ResolversTypes = ResolversObject<{
   DocsMetrics: ResolverTypeWrapper<DocsMetrics>;
   DomainName: ResolverTypeWrapper<Omit<DomainName, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<ResolversTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, indicators?: Maybe<ResolversTypes['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   DomainNameAddInput: DomainNameAddInput;
+  DraftContainerObjectChange: ResolverTypeWrapper<DraftContainerObjectChange>;
+  DraftEntityContainerRef: ResolverTypeWrapper<DraftEntityContainerRef>;
+  DraftEntityField: ResolverTypeWrapper<DraftEntityField>;
+  DraftEntityRelation: ResolverTypeWrapper<DraftEntityRelation>;
   DraftObjectsCount: ResolverTypeWrapper<DraftObjectsCount>;
   DraftOperation: DraftOperation;
+  DraftResolvedId: ResolverTypeWrapper<DraftResolvedId>;
   DraftStatus: DraftStatus;
   DraftVersion: ResolverTypeWrapper<DraftVersion>;
   DraftWorkspace: ResolverTypeWrapper<BasicStoreEntityDraftWorkspace>;
@@ -40294,7 +40378,12 @@ export type ResolversParentTypes = ResolversObject<{
   DocsMetrics: DocsMetrics;
   DomainName: Omit<DomainName, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<ResolversParentTypes['CaseConnection']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, indicators?: Maybe<ResolversParentTypes['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
   DomainNameAddInput: DomainNameAddInput;
+  DraftContainerObjectChange: DraftContainerObjectChange;
+  DraftEntityContainerRef: DraftEntityContainerRef;
+  DraftEntityField: DraftEntityField;
+  DraftEntityRelation: DraftEntityRelation;
   DraftObjectsCount: DraftObjectsCount;
+  DraftResolvedId: DraftResolvedId;
   DraftVersion: DraftVersion;
   DraftWorkspace: BasicStoreEntityDraftWorkspace;
   DraftWorkspaceAddInput: DraftWorkspaceAddInput;
@@ -43591,18 +43680,56 @@ export type DomainNameResolvers<ContextType = any, ParentType extends ResolversP
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type DraftContainerObjectChangeResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftContainerObjectChange'] = ResolversParentTypes['DraftContainerObjectChange']> = ResolversObject<{
+  draft_operation?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  entity_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  representative_main?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type DraftEntityContainerRefResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftEntityContainerRef'] = ResolversParentTypes['DraftEntityContainerRef']> = ResolversObject<{
+  container_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  container_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  container_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  draft_operation?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type DraftEntityFieldResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftEntityField'] = ResolversParentTypes['DraftEntityField']> = ResolversObject<{
+  field?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  values?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type DraftEntityRelationResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftEntityRelation'] = ResolversParentTypes['DraftEntityRelation']> = ResolversObject<{
+  draft_operation?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  from_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  from_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  from_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  relation_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  relationship_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  to_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  to_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  to_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type DraftObjectsCountResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftObjectsCount'] = ResolversParentTypes['DraftObjectsCount']> = ResolversObject<{
   containersCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   entitiesCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   observablesCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   relationshipsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  reviewsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sightingsCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   totalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type DraftResolvedIdResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftResolvedId'] = ResolversParentTypes['DraftResolvedId']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  representative_main?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type DraftVersionResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftVersion'] = ResolversParentTypes['DraftVersion']> = ResolversObject<{
   draft_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   draft_operation?: Resolver<ResolversTypes['DraftOperation'], ParentType, ContextType>;
+  draft_updates_patch?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type DraftWorkspaceResolvers<ContextType = any, ParentType extends ResolversParentTypes['DraftWorkspace'] = ResolversParentTypes['DraftWorkspace']> = ResolversObject<{
@@ -48659,8 +48786,13 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   disseminationList?: Resolver<Maybe<ResolversTypes['DisseminationList']>, ParentType, ContextType, RequireFields<QueryDisseminationListArgs, 'id'>>;
   disseminationLists?: Resolver<Maybe<ResolversTypes['DisseminationListConnection']>, ParentType, ContextType, Partial<QueryDisseminationListsArgs>>;
   draftWorkspace?: Resolver<Maybe<ResolversTypes['DraftWorkspace']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceArgs, 'id'>>;
+  draftWorkspaceContainerObjects?: Resolver<Array<ResolversTypes['DraftContainerObjectChange']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceContainerObjectsArgs, 'containerId' | 'draftId'>>;
   draftWorkspaceEntities?: Resolver<Maybe<ResolversTypes['StixCoreObjectConnection']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceEntitiesArgs, 'draftId'>>;
+  draftWorkspaceEntityContainerRefs?: Resolver<Array<ResolversTypes['DraftEntityContainerRef']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceEntityContainerRefsArgs, 'draftId' | 'entityId'>>;
+  draftWorkspaceEntityFields?: Resolver<Array<ResolversTypes['DraftEntityField']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceEntityFieldsArgs, 'draftId' | 'entityId'>>;
+  draftWorkspaceEntityRelations?: Resolver<Array<ResolversTypes['DraftEntityRelation']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceEntityRelationsArgs, 'draftId' | 'entityId'>>;
   draftWorkspaceRelationships?: Resolver<Maybe<ResolversTypes['StixRelationshipConnection']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceRelationshipsArgs, 'draftId'>>;
+  draftWorkspaceResolveIds?: Resolver<Array<ResolversTypes['DraftResolvedId']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceResolveIdsArgs, 'draftId' | 'ids'>>;
   draftWorkspaceSightingRelationships?: Resolver<Maybe<ResolversTypes['StixSightingRelationshipConnection']>, ParentType, ContextType, RequireFields<QueryDraftWorkspaceSightingRelationshipsArgs, 'draftId'>>;
   draftWorkspaces?: Resolver<Maybe<ResolversTypes['DraftWorkspaceConnection']>, ParentType, ContextType, Partial<QueryDraftWorkspacesArgs>>;
   draftWorkspacesRestricted?: Resolver<Maybe<ResolversTypes['DraftWorkspaceConnection']>, ParentType, ContextType, Partial<QueryDraftWorkspacesRestrictedArgs>>;
@@ -52585,7 +52717,12 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   Distribution?: DistributionResolvers<ContextType>;
   DocsMetrics?: DocsMetricsResolvers<ContextType>;
   DomainName?: DomainNameResolvers<ContextType>;
+  DraftContainerObjectChange?: DraftContainerObjectChangeResolvers<ContextType>;
+  DraftEntityContainerRef?: DraftEntityContainerRefResolvers<ContextType>;
+  DraftEntityField?: DraftEntityFieldResolvers<ContextType>;
+  DraftEntityRelation?: DraftEntityRelationResolvers<ContextType>;
   DraftObjectsCount?: DraftObjectsCountResolvers<ContextType>;
+  DraftResolvedId?: DraftResolvedIdResolvers<ContextType>;
   DraftVersion?: DraftVersionResolvers<ContextType>;
   DraftWorkspace?: DraftWorkspaceResolvers<ContextType>;
   DraftWorkspaceConnection?: DraftWorkspaceConnectionResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -11,6 +11,7 @@ import { buildStixBundle } from '../../database/stix-2-1-converter';
 import { computeSumOfList, isDraftIndex, READ_INDEX_DRAFT_OBJECTS, READ_INDEX_HISTORY, READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
 import { createWork, updateExpectationsNumber } from '../../domain/work';
 import {
+  DraftChangeType,
   type DraftWorkspaceAddInput,
   type EditContext,
   type EditInput,
@@ -513,7 +514,7 @@ export const listDraftContainerObjects = async (context: AuthContext, user: Auth
       entity_id: rel.toId,
       entity_type: entity.entity_type,
       representative_main: extractEntityRepresentativeName(entity as any),
-      draft_operation: op === DRAFT_OPERATION_CREATE ? 'add' : 'remove',
+      draft_operation: op === DRAFT_OPERATION_CREATE ? DraftChangeType.Add : DraftChangeType.Remove,
     });
   }
   return result;
@@ -557,7 +558,7 @@ type DraftEntityRelationResult = {
   relation_id: string; relationship_type: string;
   from_id: string; from_type: string; from_name: string;
   to_id: string; to_type: string; to_name: string;
-  draft_operation: string;
+  draft_operation: DraftChangeType;
 };
 
 export const getEntityRelations = async (
@@ -617,7 +618,7 @@ export const getEntityRelations = async (
     to_id: rel.toId,
     to_type: rel.toType,
     to_name: rel.toName,
-    draft_operation: rel.draft_change!.draft_operation === DRAFT_OPERATION_CREATE ? 'create' : 'delete',
+    draft_operation: rel.draft_change!.draft_operation === DRAFT_OPERATION_CREATE ? DraftChangeType.Create : DraftChangeType.Delete,
   }));
   const containerResults = containerRelations.map(({ rel, refOp }) => ({
     relation_id: rel.internal_id,
@@ -629,7 +630,7 @@ export const getEntityRelations = async (
     to_type: rel.toType,
     to_name: rel.toName,
     // The ref changed (added/removed from this container), not the relation itself
-    draft_operation: refOp === DRAFT_OPERATION_CREATE ? 'add' : 'remove',
+    draft_operation: refOp === DRAFT_OPERATION_CREATE ? DraftChangeType.Add : DraftChangeType.Remove,
   }));
   return [...directResults, ...containerResults];
 };
@@ -638,7 +639,7 @@ type DraftEntityContainerRefResult = {
   container_id: string;
   container_type: string;
   container_name: string;
-  draft_operation: string;
+  draft_operation: DraftChangeType;
 };
 
 export const getEntityContainerRefs = async (
@@ -678,7 +679,7 @@ export const getEntityContainerRefs = async (
       container_id: ref.fromId,
       container_type: container.entity_type,
       container_name: extractEntityRepresentativeName(container as any),
-      draft_operation: op === DRAFT_OPERATION_CREATE ? 'add' : 'remove',
+      draft_operation: op === DRAFT_OPERATION_CREATE ? DraftChangeType.Add : DraftChangeType.Remove,
     });
   }
   return results;

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -44,7 +44,7 @@ import { editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { getDraftContext } from '../../utils/draftContext';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { now } from '../../utils/format';
-import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_UPDATE } from './draftOperations';
+import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_UPDATE, getDraftOperations } from './draftOperations';
 import { DRAFT_STATUS_OPEN, DRAFT_STATUS_VALIDATED } from './draftStatuses';
 import { DRAFT_VALIDATION_CONNECTOR } from './draftWorkspace-connector';
 import { type BasicStoreEntityDraftWorkspace, ENTITY_TYPE_DRAFT_WORKSPACE, type StoreEntityDraftWorkspace } from './draftWorkspace-types';
@@ -194,6 +194,9 @@ export const listDraftObjects = async (context: AuthContext, user: AuthUser, arg
   }
   if (types.length === 0) {
     types.push(ABSTRACT_STIX_CORE_OBJECT);
+  }
+  if (draftOperation && !getDraftOperations().includes(draftOperation)) {
+    throw FunctionalError('Invalid draft operation', { draftOperation });
   }
   const draftContext = { ...context, draft_context: draftId };
   const draftOperationFilter = draftOperation
@@ -537,6 +540,10 @@ export const resolveIdRepresentatives = async (
 ): Promise<{ id: string; representative_main: string | null }[]> => {
   const { draftId, ids } = args;
   if (ids.length === 0) return [];
+  const MAX_RESOLVE_IDS = 100;
+  if (ids.length > MAX_RESOLVE_IDS) {
+    throw FunctionalError(`Too many IDs to resolve (max ${MAX_RESOLVE_IDS})`, { count: ids.length });
+  }
   await checkAndReturnDraft(context, user, draftId);
   const draftContext = { ...context, draft_context: draftId };
   const entities = await elFindByIds<BasicStoreCommon>(draftContext, user, ids) as BasicStoreCommon[];

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -44,7 +44,7 @@ import { editAuthorizedMembers } from '../../utils/authorizedMembers';
 import { getDraftContext } from '../../utils/draftContext';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { now } from '../../utils/format';
-import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_UPDATE, getDraftOperations } from './draftOperations';
+import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_UPDATE } from './draftOperations';
 import { DRAFT_STATUS_OPEN, DRAFT_STATUS_VALIDATED } from './draftStatuses';
 import { DRAFT_VALIDATION_CONNECTOR } from './draftWorkspace-connector';
 import { type BasicStoreEntityDraftWorkspace, ENTITY_TYPE_DRAFT_WORKSPACE, type StoreEntityDraftWorkspace } from './draftWorkspace-types';
@@ -194,9 +194,6 @@ export const listDraftObjects = async (context: AuthContext, user: AuthUser, arg
   }
   if (types.length === 0) {
     types.push(ABSTRACT_STIX_CORE_OBJECT);
-  }
-  if (draftOperation && !getDraftOperations().includes(draftOperation)) {
-    throw FunctionalError('Invalid draft operation', { draftOperation });
   }
   const draftContext = { ...context, draft_context: draftId };
   const draftOperationFilter = draftOperation

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -2,9 +2,9 @@ import { BUS_TOPICS, logApp } from '../../config/conf';
 import { FunctionalError, UnsupportedError } from '../../config/errors';
 import { elDeleteDraftContextFromUsers, elDeleteDraftContextFromWorks, elDeleteDraftElements, resolveDraftUpdateFiles } from '../../database/draft-engine';
 import { buildUpdateFieldPatch } from '../../database/draft-utils';
-import { elAggregationCount, elCount, elList, elLoadById, loadDraftElement } from '../../database/engine';
+import { elAggregationCount, elCount, elFindByIds, elList, elLoadById, loadDraftElement } from '../../database/engine';
 import { createEntity, createRelation, deleteElementById, deleteRelationsByFromAndTo, stixLoadByIds, updateAttribute } from '../../database/middleware';
-import { type EntityOptions, fullEntitiesList, pageEntitiesConnection, pageRelationsConnection, storeLoadById } from '../../database/middleware-loader';
+import { type EntityOptions, fullEntitiesList, fullRelationsList, pageEntitiesConnection, pageRelationsConnection, storeLoadById } from '../../database/middleware-loader';
 import { pushToWorkerForConnector } from '../../database/rabbitmq';
 import { notify, setEditContext } from '../../database/redis';
 import { buildStixBundle } from '../../database/stix-2-1-converter';
@@ -29,7 +29,7 @@ import { authorizedMembers } from '../../schema/attribute-definition';
 import { ABSTRACT_INTERNAL_RELATIONSHIP, ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_CORE_RELATIONSHIP } from '../../schema/general';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_INTERNAL_FILE, ENTITY_TYPE_USER, ENTITY_TYPE_WORK } from '../../schema/internalObject';
 import { isStixCoreObject } from '../../schema/stixCoreObject';
-import { isStixRefRelationship } from '../../schema/stixRefRelationship';
+import { isStixRefRelationship, RELATION_OBJECT } from '../../schema/stixRefRelationship';
 import { isStixSightingRelationship, STIX_SIGHTING_RELATIONSHIP } from '../../schema/stixSightingRelationship';
 import { isStixRelationshipExceptRef } from '../../schema/stixRelationship';
 import { isStixDomainObject, isStixDomainObjectContainer } from '../../schema/stixDomainObject';
@@ -95,6 +95,7 @@ export const getObjectsCount = async (context: AuthContext, user: AuthUser, draf
   };
   const draftContext = { ...context, draft_context: draft.id };
   const distributionResult = await elAggregationCount(draftContext, user, READ_INDEX_DRAFT_OBJECTS, opts);
+
   // TODO fix total to include only stix domain objects & SCO & stix core relationships & sightings & stix domain objects
   const totalCount = computeSumOfList(distributionResult.map((r: { label: string; count: number }) => r.count));
   const entitiesCount = computeSumOfList(
@@ -112,6 +113,8 @@ export const getObjectsCount = async (context: AuthContext, user: AuthUser, draf
   const containersCount = computeSumOfList(
     distributionResult.filter((r: { label: string }) => isStixDomainObjectContainer(r.label)).map((r: { count: number }) => r.count),
   );
+  // reviewsCount = all stix core objects (entities + observables + containers), matching what the Review list displays
+  const reviewsCount = entitiesCount + observablesCount + containersCount;
   return {
     totalCount,
     entitiesCount,
@@ -119,6 +122,7 @@ export const getObjectsCount = async (context: AuthContext, user: AuthUser, draf
     relationshipsCount,
     sightingsCount,
     containersCount,
+    reviewsCount,
   };
 };
 
@@ -182,7 +186,7 @@ export const getCurrentUserAccessRight = async (
 
 export const listDraftObjects = async (context: AuthContext, user: AuthUser, args: QueryDraftWorkspaceEntitiesArgs) => {
   let types: string[] = [];
-  const { draftId, ...listArgs } = args;
+  const { draftId, draftOperation, ...listArgs } = args as QueryDraftWorkspaceEntitiesArgs & { draftOperation?: string };
   await checkAndReturnDraft(context, user, draftId);
 
   if (args.types) {
@@ -191,8 +195,18 @@ export const listDraftObjects = async (context: AuthContext, user: AuthUser, arg
   if (types.length === 0) {
     types.push(ABSTRACT_STIX_CORE_OBJECT);
   }
-  const newArgs: EntityOptions<BasicStoreEntity> = { ...listArgs, types, indices: [READ_INDEX_DRAFT_OBJECTS], includeDeletedInDraft: true };
   const draftContext = { ...context, draft_context: draftId };
+  const draftOperationFilter = draftOperation
+    ? addFilter(listArgs.filters, 'draft_change.draft_operation', draftOperation)
+    : listArgs.filters;
+  const newArgs: EntityOptions<BasicStoreEntity> = {
+    ...listArgs,
+    types,
+    indices: [READ_INDEX_DRAFT_OBJECTS],
+    includeDeletedInDraft: true,
+    filters: draftOperationFilter,
+    noFiltersChecking: draftOperation ? true : undefined,
+  };
   return pageEntitiesConnection<BasicStoreEntity>(draftContext, user, types, newArgs);
 };
 
@@ -394,7 +408,11 @@ export const buildDraftVersion = (object: BasicStoreCommon) => {
     return null;
   }
 
-  return { draft_id: object.draft_ids[0], draft_operation: object.draft_change?.draft_operation };
+  return {
+    draft_id: object.draft_ids[0],
+    draft_operation: object.draft_change?.draft_operation,
+    draft_updates_patch: object.draft_change?.draft_updates_patch ?? null,
+  };
 };
 
 export const buildDraftValidationBundle = async (context: AuthContext, user: AuthUser, draft_id: string) => {
@@ -463,6 +481,44 @@ export const validateDraftWorkspace = async (context: AuthContext, user: AuthUse
   return work;
 };
 
+export const listDraftContainerObjects = async (context: AuthContext, user: AuthUser, args: { draftId: string; containerId: string }) => {
+  const { draftId, containerId } = args;
+  await checkAndReturnDraft(context, user, draftId);
+  const draftContext = { ...context, draft_context: draftId };
+
+  const relations = await fullRelationsList(draftContext, user, RELATION_OBJECT, {
+    fromId: containerId,
+    indices: [READ_INDEX_DRAFT_OBJECTS],
+    includeDeletedInDraft: true,
+  });
+
+  const relevantRels = relations.filter((rel) => {
+    const op = rel.draft_change?.draft_operation;
+    return op === DRAFT_OPERATION_CREATE || op === DRAFT_OPERATION_DELETE;
+  });
+  if (relevantRels.length === 0) return [];
+
+  const entityIds = relevantRels.map((rel) => rel.toId);
+  const entitiesMap = await elFindByIds<BasicStoreCommon>(draftContext, user, entityIds, {
+    includeDeletedInDraft: true,
+    toMap: true,
+  }) as Record<string, BasicStoreCommon>;
+
+  const result = [];
+  for (const rel of relevantRels) {
+    const entity = entitiesMap[rel.toId];
+    if (!entity) continue;
+    const op = rel.draft_change!.draft_operation;
+    result.push({
+      entity_id: rel.toId,
+      entity_type: entity.entity_type,
+      representative_main: extractEntityRepresentativeName(entity as any),
+      draft_operation: op === DRAFT_OPERATION_CREATE ? 'add' : 'remove',
+    });
+  }
+  return result;
+};
+
 export const draftWorkspaceEditContext = async (context: AuthContext, user: AuthUser, draftId: string, input?: EditContext) => {
   await checkEnterpriseEdition(context);
   await checkAndReturnDraft(context, user, draftId);
@@ -472,4 +528,190 @@ export const draftWorkspaceEditContext = async (context: AuthContext, user: Auth
   return storeLoadById(context, user, draftId, ENTITY_TYPE_DRAFT_WORKSPACE).then((draft) => {
     return notify(BUS_TOPICS[ENTITY_TYPE_DRAFT_WORKSPACE].CONTEXT_TOPIC, draft, user);
   });
+};
+
+export const resolveIdRepresentatives = async (
+  context: AuthContext,
+  user: AuthUser,
+  args: { draftId: string; ids: string[] },
+): Promise<{ id: string; representative_main: string | null }[]> => {
+  const { draftId, ids } = args;
+  if (ids.length === 0) return [];
+  await checkAndReturnDraft(context, user, draftId);
+  const draftContext = { ...context, draft_context: draftId };
+  const entities = await elFindByIds<BasicStoreCommon>(draftContext, user, ids) as BasicStoreCommon[];
+  return ids.map((id) => {
+    const entity = entities.find((e) => e.standard_id === id || e.internal_id === id);
+    return {
+      id,
+      representative_main: entity ? extractEntityRepresentativeName(entity as any) : null,
+    };
+  });
+};
+
+type DraftEntityRelationResult = {
+  relation_id: string; relationship_type: string;
+  from_id: string; from_type: string; from_name: string;
+  to_id: string; to_type: string; to_name: string;
+  draft_operation: string;
+};
+
+export const getEntityRelations = async (
+  context: AuthContext,
+  user: AuthUser,
+  args: { draftId: string; entityId: string },
+): Promise<DraftEntityRelationResult[]> => {
+  const { draftId, entityId } = args;
+  await checkAndReturnDraft(context, user, draftId);
+  const draftContext = { ...context, draft_context: draftId };
+
+  // Part 1: direct relations where the entity is from or to
+  const directRelations = await fullRelationsList<BasicStoreRelation>(draftContext, user, [ABSTRACT_STIX_CORE_RELATIONSHIP, STIX_SIGHTING_RELATIONSHIP], {
+    fromOrToId: entityId,
+    indices: [READ_INDEX_DRAFT_OBJECTS],
+    includeDeletedInDraft: true,
+  });
+  const filteredDirect = directRelations.filter((rel) => {
+    const op = rel.draft_change?.draft_operation;
+    return op === DRAFT_OPERATION_CREATE || op === DRAFT_OPERATION_DELETE;
+  });
+
+  // Part 2: for containers (e.g. Report), find core/sighting relations that are objects of this entity
+  // via RELATION_OBJECT refs (report → uses), which are not direct endpoints of the relation
+  const objectRefs = await fullRelationsList<BasicStoreRelation>(draftContext, user, RELATION_OBJECT, {
+    fromId: entityId,
+    indices: [READ_INDEX_DRAFT_OBJECTS],
+    includeDeletedInDraft: true,
+  });
+  const directRelationIds = new Set(filteredDirect.map((r) => r.internal_id));
+  const containerRelations: { rel: BasicStoreRelation; refOp: string }[] = [];
+  const relevantRefs = objectRefs.filter((ref) => {
+    const refOp = ref.draft_change?.draft_operation;
+    return refOp === DRAFT_OPERATION_CREATE || refOp === DRAFT_OPERATION_DELETE;
+  });
+  if (relevantRefs.length > 0) {
+    const targetIds = relevantRefs.map((ref) => ref.toId);
+    const targetsMap = await elFindByIds<BasicStoreRelation>(draftContext, user, targetIds, {
+      includeDeletedInDraft: true,
+      toMap: true,
+    }) as Record<string, BasicStoreRelation>;
+    for (const ref of relevantRefs) {
+      const target = targetsMap[ref.toId];
+      if (!target) continue;
+      if (!isStixCoreRelationship(target.entity_type) && !isStixSightingRelationship(target.entity_type)) continue;
+      if (directRelationIds.has(target.internal_id)) continue;
+      containerRelations.push({ rel: target, refOp: ref.draft_change!.draft_operation });
+    }
+  }
+
+  const directResults = filteredDirect.map((rel) => ({
+    relation_id: rel.internal_id,
+    relationship_type: rel.relationship_type,
+    from_id: rel.fromId,
+    from_type: rel.fromType,
+    from_name: rel.fromName,
+    to_id: rel.toId,
+    to_type: rel.toType,
+    to_name: rel.toName,
+    draft_operation: rel.draft_change!.draft_operation === DRAFT_OPERATION_CREATE ? 'create' : 'delete',
+  }));
+  const containerResults = containerRelations.map(({ rel, refOp }) => ({
+    relation_id: rel.internal_id,
+    relationship_type: rel.relationship_type,
+    from_id: rel.fromId,
+    from_type: rel.fromType,
+    from_name: rel.fromName,
+    to_id: rel.toId,
+    to_type: rel.toType,
+    to_name: rel.toName,
+    // The ref changed (added/removed from this container), not the relation itself
+    draft_operation: refOp === DRAFT_OPERATION_CREATE ? 'add' : 'remove',
+  }));
+  return [...directResults, ...containerResults];
+};
+
+type DraftEntityContainerRefResult = {
+  container_id: string;
+  container_type: string;
+  container_name: string;
+  draft_operation: string;
+};
+
+export const getEntityContainerRefs = async (
+  context: AuthContext,
+  user: AuthUser,
+  args: { draftId: string; entityId: string },
+): Promise<DraftEntityContainerRefResult[]> => {
+  const { draftId, entityId } = args;
+  await checkAndReturnDraft(context, user, draftId);
+  const draftContext = { ...context, draft_context: draftId };
+
+  // Find RELATION_OBJECT refs pointing TO this entity (container → entityId)
+  const objectRefs = await fullRelationsList<BasicStoreRelation>(draftContext, user, RELATION_OBJECT, {
+    toId: entityId,
+    indices: [READ_INDEX_DRAFT_OBJECTS],
+    includeDeletedInDraft: true,
+  });
+
+  const relevantRefs = objectRefs.filter((ref) => {
+    const op = ref.draft_change?.draft_operation;
+    return op === DRAFT_OPERATION_CREATE || op === DRAFT_OPERATION_DELETE;
+  });
+  if (relevantRefs.length === 0) return [];
+
+  const containerIds = relevantRefs.map((ref) => ref.fromId);
+  const containersMap = await elFindByIds<BasicStoreCommon>(draftContext, user, containerIds, {
+    includeDeletedInDraft: true,
+    toMap: true,
+  }) as Record<string, BasicStoreCommon>;
+
+  const results: DraftEntityContainerRefResult[] = [];
+  for (const ref of relevantRefs) {
+    const container = containersMap[ref.fromId];
+    if (!container) continue;
+    const op = ref.draft_change!.draft_operation;
+    results.push({
+      container_id: ref.fromId,
+      container_type: container.entity_type,
+      container_name: extractEntityRepresentativeName(container as any),
+      draft_operation: op === DRAFT_OPERATION_CREATE ? 'add' : 'remove',
+    });
+  }
+  return results;
+};
+
+const EXCLUDED_ENTITY_FIELDS = new Set([
+  '_index', '_score', 'internal_id', 'standard_id', 'id',
+  'parent_types', 'base_type', 'entity_type', 'i_aliases_ids',
+  'i_attributes_computed', 'sort', 'draft_ids', 'draft_change', 'draft_context',
+  'hashes', 'created_at', 'updated_at', 'spec_version',
+  'x_opencti_stix_ids', 'creator_id', 'x_opencti_id', 'x_opencti_workflow_id', 'x_opencti_organization_id', 'x_opencti_tags_ids',
+]);
+
+export const getEntityFields = async (
+  context: AuthContext,
+  user: AuthUser,
+  args: { draftId: string; entityId: string },
+): Promise<{ field: string; values: string[] }[]> => {
+  const { draftId, entityId } = args;
+  await checkAndReturnDraft(context, user, draftId);
+  const draftContext = { ...context, draft_context: draftId };
+  const entities = await elFindByIds<BasicStoreCommon>(draftContext, user, [entityId], { includeDeletedInDraft: true }) as BasicStoreCommon[];
+  const entity = entities[0];
+  if (!entity) return [];
+
+  return Object.entries(entity)
+    .filter(([key, value]) => {
+      if (EXCLUDED_ENTITY_FIELDS.has(key)) return false;
+      if (key.startsWith('_') || key.startsWith('i_')) return false;
+      if (key.startsWith('rel_')) return false;
+      if (value === null || value === undefined) return false;
+      if (Array.isArray(value) && value.length === 0) return false;
+      if (typeof value === 'object' && !Array.isArray(value)) return false;
+      return true;
+    })
+    .map(([field, value]) => ({
+      field,
+      values: Array.isArray(value) ? value.map(String) : [String(value)],
+    }));
 };

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-resolvers.ts
@@ -11,11 +11,16 @@ import {
   findDraftWorkspacePaginated,
   findDraftWorkspaceRestrictedPaginated,
   getCurrentUserAccessRight,
+  getEntityContainerRefs,
+  getEntityFields,
+  getEntityRelations,
   getObjectsCount,
   getProcessingCount,
   listDraftObjects,
   listDraftRelations,
   listDraftSightingRelations,
+  listDraftContainerObjects,
+  resolveIdRepresentatives,
   validateDraftWorkspace,
 } from './draftWorkspace-domain';
 import { findById as findWorkById, worksForDraft } from '../../domain/work';
@@ -38,6 +43,11 @@ const draftWorkspaceResolvers: Resolvers = {
       context.changeDraftContext(args.draftId);
       return listDraftSightingRelations(context, context.user, args);
     },
+    draftWorkspaceContainerObjects: (_, args, context) => listDraftContainerObjects(context, context.user, args),
+    draftWorkspaceResolveIds: (_, args, context) => resolveIdRepresentatives(context, context.user, args),
+    draftWorkspaceEntityFields: (_, args, context) => getEntityFields(context, context.user, args),
+    draftWorkspaceEntityRelations: (_, args, context) => getEntityRelations(context, context.user, args),
+    draftWorkspaceEntityContainerRefs: (_, args, context) => getEntityContainerRefs(context, context.user, args),
   },
   DraftWorkspace: {
     creators: async (draft, _, context) => loadCreators(context, context.user, draft),

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -4,6 +4,13 @@ enum DraftStatus {
     validated
 }
 
+type DraftContainerObjectChange {
+    entity_id: String!
+    entity_type: String!
+    representative_main: String
+    draft_operation: String!
+}
+
 type DraftWorkspace implements InternalObject & BasicObject {
     id: ID!
     entity_type: String!
@@ -35,6 +42,7 @@ type DraftObjectsCount {
     relationshipsCount: Int!
     sightingsCount: Int!
     containersCount: Int!
+    reviewsCount: Int!
 }
 
 # Ordering
@@ -85,7 +93,12 @@ type Query {
         orderMode: OrderingMode
         filters: FilterGroup
         search: String
+        draftOperation: String
     ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
+    draftWorkspaceContainerObjects(
+        draftId: String!
+        containerId: String!
+    ): [DraftContainerObjectChange!]! @auth(for: [KNOWLEDGE])
     draftWorkspaceRelationships(
         draftId: String!,
         types: [String]
@@ -106,6 +119,39 @@ type Query {
         filters: FilterGroup
         search: String
     ): StixSightingRelationshipConnection @auth(for: [KNOWLEDGE])
+    draftWorkspaceResolveIds(draftId: String!, ids: [String!]!): [DraftResolvedId!]! @auth(for: [KNOWLEDGE])
+    draftWorkspaceEntityFields(draftId: String!, entityId: String!): [DraftEntityField!]! @auth(for: [KNOWLEDGE])
+    draftWorkspaceEntityRelations(draftId: String!, entityId: String!): [DraftEntityRelation!]! @auth(for: [KNOWLEDGE])
+    draftWorkspaceEntityContainerRefs(draftId: String!, entityId: String!): [DraftEntityContainerRef!]! @auth(for: [KNOWLEDGE])
+}
+
+type DraftEntityField {
+    field: String!
+    values: [String!]!
+}
+
+type DraftEntityRelation {
+    relation_id: String!
+    relationship_type: String!
+    from_id: String!
+    from_type: String!
+    from_name: String!
+    to_id: String!
+    to_type: String!
+    to_name: String!
+    draft_operation: String!
+}
+
+type DraftEntityContainerRef {
+    container_id: String!
+    container_type: String!
+    container_name: String!
+    draft_operation: String!
+}
+
+type DraftResolvedId {
+    id: String!
+    representative_main: String
 }
 
 input DraftWorkspaceAddInput {

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -4,11 +4,18 @@ enum DraftStatus {
     validated
 }
 
+enum DraftChangeType {
+    create
+    delete
+    add
+    remove
+}
+
 type DraftContainerObjectChange {
     entity_id: String!
     entity_type: String!
     representative_main: String
-    draft_operation: String!
+    draft_operation: DraftChangeType!
 }
 
 type DraftWorkspace implements InternalObject & BasicObject {
@@ -93,7 +100,7 @@ type Query {
         orderMode: OrderingMode
         filters: FilterGroup
         search: String
-        draftOperation: String
+        draftOperation: DraftOperation
     ): StixCoreObjectConnection @auth(for: [KNOWLEDGE])
     draftWorkspaceContainerObjects(
         draftId: String!
@@ -139,14 +146,14 @@ type DraftEntityRelation {
     to_id: String!
     to_type: String!
     to_name: String!
-    draft_operation: String!
+    draft_operation: DraftChangeType!
 }
 
 type DraftEntityContainerRef {
     container_id: String!
     container_type: String!
     container_name: String!
-    draft_operation: String!
+    draft_operation: DraftChangeType!
 }
 
 type DraftResolvedId {

--- a/opencti-platform/opencti-graphql/src/resolvers/stixObjectOrStixRelationship.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stixObjectOrStixRelationship.js
@@ -24,7 +24,7 @@ const stixObjectOrStixRelationshipResolvers = {
     x_opencti_stix_ids: (object) => onlyStableStixIds(object.x_opencti_stix_ids || []),
   },
   StixObjectOrStixRelationship: {
-    // eslint-disable-next-line
+
     __resolveType(obj) {
       if (STIX_REF_RELATIONSHIP_TYPES.some((type) => obj.parent_types.includes(type))) {
         return 'StixRefRelationship';

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/draftWorkspace-review-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/draftWorkspace-review-domain-test.ts
@@ -1,0 +1,358 @@
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { ADMIN_USER, getAuthUser, testContext, USER_EDITOR } from '../../utils/testQuery';
+import {
+  addDraftWorkspace,
+  buildDraftVersion,
+  getEntityContainerRefs,
+  getEntityFields,
+  getEntityRelations,
+  getObjectsCount,
+  listDraftContainerObjects,
+  listDraftObjects,
+  resolveIdRepresentatives,
+} from '../../../src/modules/draftWorkspace/draftWorkspace-domain';
+import type { AuthContext, AuthUser } from '../../../src/types/user';
+import type { BasicStoreEntity, BasicStoreRelation, BasicStoreCommon } from '../../../src/types/store';
+import type { DraftWorkspaceAddInput, CityAddInput, AdministrativeAreaAddInput, StixCoreRelationshipAddInput } from '../../../src/generated/graphql';
+import { addCity } from '../../../src/domain/city';
+import { addAdministrativeArea } from '../../../src/modules/administrativeArea/administrativeArea-domain';
+import { addStixCoreRelationship } from '../../../src/domain/stixCoreRelationship';
+import { addReport } from '../../../src/domain/report';
+import { deleteElementById, updateAttribute } from '../../../src/database/middleware';
+import { storeLoadById } from '../../../src/database/middleware-loader';
+import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../../../src/modules/draftWorkspace/draftWorkspace-types';
+import { ENTITY_TYPE_LOCATION_CITY } from '../../../src/schema/stixDomainObject';
+import { ENTITY_TYPE_LOCATION_ADMINISTRATIVE_AREA } from '../../../src/modules/administrativeArea/administrativeArea-types';
+import { executionContext } from '../../../src/utils/access';
+import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_UPDATE } from '../../../src/modules/draftWorkspace/draftOperations';
+
+describe('Draft workspace review domain — new queries from PR #15637', () => {
+  let testDraftId: string;
+  let editorAuthUser: AuthUser;
+  let testDraftContext: AuthContext;
+
+  // Entities created inside the draft
+  let city: BasicStoreEntity;
+  let area: BasicStoreEntity;
+  let report: BasicStoreEntity;
+  let _relation: BasicStoreRelation;
+
+  // A live entity modified inside the draft
+  let liveCity: BasicStoreEntity;
+
+  beforeAll(async () => {
+    editorAuthUser = await getAuthUser(USER_EDITOR.id);
+
+    const draftInput: DraftWorkspaceAddInput = {
+      name: 'Draft review domain test',
+      authorized_members: [{ id: editorAuthUser.internal_id, access_right: 'admin' }],
+    };
+    const draft = await addDraftWorkspace(testContext, editorAuthUser, draftInput);
+    testDraftId = draft.id;
+
+    testDraftContext = {
+      ...executionContext('testing', editorAuthUser),
+      draft_context: testDraftId,
+    };
+
+    // Create entities inside the draft
+    city = await addCity(testDraftContext, editorAuthUser, { name: 'ReviewCity' } as CityAddInput);
+    area = await addAdministrativeArea(testDraftContext, editorAuthUser, { name: 'ReviewArea' } as AdministrativeAreaAddInput);
+
+    // Create a core relation between city → area (located-at)
+    const relInput: StixCoreRelationshipAddInput = {
+      relationship_type: 'located-at',
+      fromId: city.id,
+      toId: area.id,
+      confidence: 100,
+    };
+    _relation = await addStixCoreRelationship(testDraftContext, editorAuthUser, relInput);
+
+    // Create a Report container and add city as an object ref
+    report = await addReport(testDraftContext, editorAuthUser, {
+      name: 'ReviewReport',
+      published: '2024-01-01T00:00:00Z',
+      objects: [city.id],
+    });
+
+    // Load an existing live city from test fixtures (to avoid polluting stream event counts)
+    liveCity = await storeLoadById(testContext, editorAuthUser, 'location--c3794ffd-0e71-4670-aa4d-978b4cbdc72c', ENTITY_TYPE_LOCATION_CITY) as BasicStoreEntity;
+    // Modify it inside the draft to generate a draft_updates_patch
+    await updateAttribute(testDraftContext, editorAuthUser, liveCity.id, ENTITY_TYPE_LOCATION_CITY, [
+      { key: 'description', value: ['patched in draft'] },
+    ]);
+  });
+
+  afterAll(async () => {
+    if (testDraftId) {
+      await deleteElementById(testContext, ADMIN_USER, testDraftId, ENTITY_TYPE_DRAFT_WORKSPACE);
+    }
+    // liveCity is a test fixture, no cleanup needed
+  });
+
+  // -----------------------------------------------------------------------
+  // listDraftObjects — draftOperation filter
+  // -----------------------------------------------------------------------
+
+  describe('listDraftObjects with draftOperation filter', () => {
+    it('should return all draft objects when no draftOperation is given', async () => {
+      const result = await listDraftObjects(testContext, editorAuthUser, { draftId: testDraftId });
+      expect(result.edges.length).toBeGreaterThanOrEqual(3); // city, area, report
+    });
+
+    it('should filter by draftOperation=create and return created objects', async () => {
+      const result = await listDraftObjects(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        draftOperation: DRAFT_OPERATION_CREATE,
+      } as any);
+      const types = result.edges.map((e) => e.node.entity_type);
+      expect(types).toContain(ENTITY_TYPE_LOCATION_CITY);
+      expect(types).toContain(ENTITY_TYPE_LOCATION_ADMINISTRATIVE_AREA);
+    });
+
+    it('should filter by draftOperation=update and return only updated objects', async () => {
+      const result = await listDraftObjects(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        draftOperation: DRAFT_OPERATION_UPDATE,
+      } as any);
+      // Only the live city that was modified should appear
+      const ids = result.edges.map((e) => e.node.id);
+      expect(ids).toContain(liveCity.id);
+      // Entities created in draft should NOT appear under 'update'
+      const cityNode = result.edges.find((e) => e.node.id === city.id);
+      expect(cityNode).toBeUndefined();
+    });
+
+    it('should respect pagination (first: 1)', async () => {
+      const result = await listDraftObjects(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        first: 1,
+      } as any);
+      expect(result.edges.length).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getObjectsCount — reviewsCount
+  // -----------------------------------------------------------------------
+
+  describe('getObjectsCount — reviewsCount', () => {
+    it('should return reviewsCount = entitiesCount + observablesCount + containersCount', async () => {
+      const draft = await addDraftWorkspace(testContext, editorAuthUser, {
+        name: 'Draft count test',
+        authorized_members: [{ id: editorAuthUser.internal_id, access_right: 'admin' }],
+      } as DraftWorkspaceAddInput);
+      const countDraftContext = { ...executionContext('testing', editorAuthUser), draft_context: draft.id };
+      await addCity(countDraftContext, editorAuthUser, { name: 'CountCity' } as CityAddInput);
+      await addReport(countDraftContext, editorAuthUser, { name: 'CountReport', published: '2024-01-01T00:00:00Z' });
+
+      const counts = await getObjectsCount(testContext, editorAuthUser, draft as any);
+
+      expect(counts.reviewsCount).toBe(counts.entitiesCount + counts.observablesCount + counts.containersCount);
+      expect(counts.reviewsCount).toBeGreaterThanOrEqual(2); // at least city + report
+
+      await deleteElementById(testContext, ADMIN_USER, draft.id, ENTITY_TYPE_DRAFT_WORKSPACE);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // listDraftContainerObjects
+  // -----------------------------------------------------------------------
+
+  describe('listDraftContainerObjects', () => {
+    it('should return objects added to the container in the draft', async () => {
+      const result = await listDraftContainerObjects(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        containerId: report.id,
+      });
+      expect(result.length).toBeGreaterThan(0);
+      const cityEntry = result.find((r) => r.entity_id === city.id);
+      expect(cityEntry).toBeDefined();
+      // The city was added to the report via object ref in draft → operation should be 'add'
+      expect(cityEntry!.draft_operation).toBe('add');
+      expect(cityEntry!.entity_type).toBe(ENTITY_TYPE_LOCATION_CITY);
+      expect(cityEntry!.representative_main).toBe('ReviewCity');
+    });
+
+    it('should return empty for a container with no draft changes', async () => {
+      // Create a report with no objects
+      const emptyReport = await addReport(testDraftContext, editorAuthUser, {
+        name: 'EmptyReport',
+        published: '2024-01-01T00:00:00Z',
+      });
+      const result = await listDraftContainerObjects(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        containerId: emptyReport.id,
+      });
+      // No RELATION_OBJECT with create/delete in draft for this container
+      expect(result.length).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveIdRepresentatives
+  // -----------------------------------------------------------------------
+
+  describe('resolveIdRepresentatives', () => {
+    it('should resolve standard_ids to their representative names', async () => {
+      const draftCtx = { ...testContext, draft_context: testDraftId };
+      const result = await resolveIdRepresentatives(draftCtx, editorAuthUser, {
+        draftId: testDraftId,
+        ids: [city.standard_id, area.standard_id],
+      });
+      expect(result.length).toBe(2);
+      const cityRes = result.find((r) => r.id === city.standard_id);
+      expect(cityRes?.representative_main).toBe('ReviewCity');
+      const areaRes = result.find((r) => r.id === area.standard_id);
+      expect(areaRes?.representative_main).toBe('ReviewArea');
+    });
+
+    it('should return null representative_main for unknown ids', async () => {
+      const result = await resolveIdRepresentatives(
+        { ...testContext, draft_context: testDraftId },
+        editorAuthUser,
+        { draftId: testDraftId, ids: ['non-existent-id'] },
+      );
+      expect(result.length).toBe(1);
+      expect(result[0].representative_main).toBeNull();
+    });
+
+    it('should return empty for empty ids array', async () => {
+      const result = await resolveIdRepresentatives(
+        { ...testContext, draft_context: testDraftId },
+        editorAuthUser,
+        { draftId: testDraftId, ids: [] },
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEntityFields
+  // -----------------------------------------------------------------------
+
+  describe('getEntityFields', () => {
+    it('should return scalar fields of a draft entity', async () => {
+      const result = await getEntityFields(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: city.id,
+      });
+      expect(result.length).toBeGreaterThan(0);
+      const nameField = result.find((f) => f.field === 'name');
+      expect(nameField).toBeDefined();
+      expect(nameField!.values).toContain('ReviewCity');
+    });
+
+    it('should not include internal/excluded fields', async () => {
+      const result = await getEntityFields(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: city.id,
+      });
+      const fieldNames = result.map((f) => f.field);
+      expect(fieldNames).not.toContain('internal_id');
+      expect(fieldNames).not.toContain('draft_ids');
+      expect(fieldNames).not.toContain('draft_change');
+      expect(fieldNames).not.toContain('parent_types');
+    });
+
+    it('should return empty for a non-existent entity', async () => {
+      const result = await getEntityFields(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: 'non-existent-id',
+      });
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEntityRelations
+  // -----------------------------------------------------------------------
+
+  describe('getEntityRelations', () => {
+    it('should return direct relations created in draft for the entity', async () => {
+      const result = await getEntityRelations(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: city.id,
+      });
+      expect(result.length).toBeGreaterThan(0);
+      const locatedAt = result.find((r) => r.relationship_type === 'located-at');
+      expect(locatedAt).toBeDefined();
+      expect(locatedAt!.from_id).toBe(city.id);
+      expect(locatedAt!.to_id).toBe(area.id);
+      expect(locatedAt!.draft_operation).toBe('create');
+    });
+
+    it('should include relation id and type information', async () => {
+      const result = await getEntityRelations(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: city.id,
+      });
+      const locatedAt = result.find((r) => r.relationship_type === 'located-at')!;
+      expect(locatedAt.relation_id).toBeDefined();
+      expect(locatedAt.from_type).toBe(ENTITY_TYPE_LOCATION_CITY);
+      expect(locatedAt.to_type).toBe(ENTITY_TYPE_LOCATION_ADMINISTRATIVE_AREA);
+    });
+
+    it('should return empty for an entity with no draft relations', async () => {
+      const isolatedCity = await addCity(testDraftContext, editorAuthUser, { name: 'IsolatedCity' } as CityAddInput);
+      const result = await getEntityRelations(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: isolatedCity.id,
+      });
+      // No relations for this entity
+      expect(result.every((r) => r.from_id !== isolatedCity.id && r.to_id !== isolatedCity.id)).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getEntityContainerRefs
+  // -----------------------------------------------------------------------
+
+  describe('getEntityContainerRefs', () => {
+    it('should return containers that reference the entity in the draft', async () => {
+      const result = await getEntityContainerRefs(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: city.id,
+      });
+      expect(result.length).toBeGreaterThan(0);
+      const reportRef = result.find((r) => r.container_id === report.id);
+      expect(reportRef).toBeDefined();
+      expect(reportRef!.draft_operation).toBe('add');
+      expect(reportRef!.container_name).toBe('ReviewReport');
+    });
+
+    it('should return empty for an entity not referenced by any container', async () => {
+      const result = await getEntityContainerRefs(testContext, editorAuthUser, {
+        draftId: testDraftId,
+        entityId: area.id,
+      });
+      // area was not added to any container
+      expect(result.find((r) => r.container_id === report.id)).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildDraftVersion
+  // -----------------------------------------------------------------------
+
+  describe('buildDraftVersion', () => {
+    it('should include draft_updates_patch for an updated live entity', async () => {
+      const draftCtx = { ...testContext, draft_context: testDraftId };
+      const { elFindByIds } = await import('../../../src/database/engine');
+      const results = await elFindByIds(draftCtx, editorAuthUser, [liveCity.id], { includeDeletedInDraft: true }) as BasicStoreCommon[];
+      const draftLiveCity = results[0];
+      expect(draftLiveCity).toBeDefined();
+
+      const version = buildDraftVersion(draftLiveCity);
+      expect(version).not.toBeNull();
+      expect(version!.draft_id).toBe(testDraftId);
+      expect(version!.draft_operation).toBe(DRAFT_OPERATION_UPDATE);
+    });
+
+    it('should return null for an entity without draft_ids', async () => {
+      // Any live entity not in a draft has no draft_ids
+      const version = buildDraftVersion({ draft_ids: [] } as any);
+      expect(version).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### Proposed changes

Extend the `draftWorkspace` GraphQL API with queries needed for the review diff panel:

- Add `draftOperation` filter to `draftWorkspaceEntities` to list only created/updated/deleted objects.
- Add `draftWorkspaceContainerObjects(draftId, containerId)` — returns objects added or removed from a container inside a draft.
- Add `draftWorkspaceResolveIds(draftId, ids)` — resolves a list of ids to their representative names within a draft context.
- Add `draftWorkspaceEntityFields(draftId, entityId)` — returns the scalar fields of a draft entity.
- Add `draftWorkspaceEntityRelations(draftId, entityId)` — returns core/sighting relations created or deleted in a draft for a given entity.
- Add `draftWorkspaceEntityContainerRefs(draftId, entityId)` — returns containers that reference the entity via an `object` ref changed in a draft.
- Add `reviewsCount` to `DraftObjectsCount` (entities + observables + containers).
- Add `draft_updates_patch` to `DraftVersion` to expose the JSON diff of an updated entity.
- Add `includeDeletedInDraft` option to `RelationOptions` in `middleware-loader` to allow querying deleted-in-draft relations.
- Wire all domain helpers in `draftWorkspace-resolvers.ts`.

### Related issues

* Fixes https://github.com/OpenCTI-Platform/opencti/issues/8707 (part 2/3, depends on #15636).
