### PR TITLE
[backend] Added Indicator and Artifact in the security coverage has covered relationships (#14772)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -22,6 +22,8 @@ import {
 } from '../../schema/stixDomainObject';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-incident-types';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../grouping/grouping-types';
+import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../../schema/stixCyberObservable';
+import { ENTITY_TYPE_INDICATOR } from '../indicator/indicator-types';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -79,7 +81,7 @@ export const securityCoverageStixBundle = async (context: AuthContext, user: Aut
   };
   await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
     fromId: objectCovered.id,
-    toTypes: [ENTITY_TYPE_VULNERABILITY, ENTITY_TYPE_ATTACK_PATTERN],
+    toTypes: [ENTITY_TYPE_VULNERABILITY, ENTITY_TYPE_ATTACK_PATTERN, ENTITY_HASHED_OBSERVABLE_ARTIFACT, ENTITY_TYPE_INDICATOR],
     callback: relationsCallback,
   });
   if (targetIds.size > 0) {

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -22,8 +22,6 @@ import {
 } from '../../schema/stixDomainObject';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-incident-types';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../grouping/grouping-types';
-import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../../schema/stixCyberObservable';
-import { ENTITY_TYPE_INDICATOR } from '../indicator/indicator-types';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -81,7 +79,7 @@ export const securityCoverageStixBundle = async (context: AuthContext, user: Aut
   };
   await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
     fromId: objectCovered.id,
-    toTypes: [ENTITY_TYPE_VULNERABILITY, ENTITY_TYPE_ATTACK_PATTERN, ENTITY_HASHED_OBSERVABLE_ARTIFACT, ENTITY_TYPE_INDICATOR],
+    toTypes: [ENTITY_TYPE_VULNERABILITY, ENTITY_TYPE_ATTACK_PATTERN],
     callback: relationsCallback,
   });
   if (targetIds.size > 0) {

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.ts
@@ -18,6 +18,8 @@ import { RELATION_HAS_COVERED } from '../../schema/stixCoreRelationship';
 import { REL_NEW } from '../../database/stix';
 import { ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM } from '../securityPlatform/securityPlatform-types';
 import type { StoreEntity } from '../../types/store';
+import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../../schema/stixCyberObservable';
+import { ENTITY_TYPE_INDICATOR } from '../indicator/indicator-types';
 
 const SECURITY_COVERAGE_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverage, StixSecurityCoverage> = {
   type: {
@@ -64,6 +66,8 @@ const SECURITY_COVERAGE_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverage
         { name: ENTITY_TYPE_ATTACK_PATTERN, type: REL_NEW },
         { name: ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM, type: REL_NEW },
         { name: ENTITY_TYPE_VULNERABILITY, type: REL_NEW },
+        { name: ENTITY_HASHED_OBSERVABLE_ARTIFACT, type: REL_NEW },
+        { name: ENTITY_TYPE_INDICATOR, type: REL_NEW },
       ],
     },
   ],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added indicators and artifacts to relations.targets list (securityCoverage.ts) 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes #14772 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
