### PR TITLE
[backend] Add OAuth2 authentication support for SMTP (#12069)

### DIFF
--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -248,8 +248,20 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 | smtp:port                | SMTP__PORT                | 465           | SMTP Port (25 or 465 for TLS)             |
 | smtp:use_ssl             | SMTP__USE_SSL             | `false`       | SMTP over TLS                             |
 | smtp:reject_unauthorized | SMTP__REJECT_UNAUTHORIZED | `false`       | Enable TLS certificate check              |
-| smtp:username            | SMTP__USERNAME            |               | SMTP Username if authentication is needed |
-| smtp:password            | SMTP__PASSWORD            |               | SMTP Password if authentication is needed |
+| smtp:username            | SMTP__USERNAME            |               | SMTP Username if authentication is needed (Basic Auth) |
+| smtp:password            | SMTP__PASSWORD            |               | SMTP Password if authentication is needed (Basic Auth) |
+| smtp:auth_type           | SMTP__AUTH_TYPE           | `basic`       | Authentication type: `basic` or `oauth2`               |
+| smtp:oauth_user          | SMTP__OAUTH_USER          |               | OAuth2: email address of the SMTP user                 |
+| smtp:oauth_client_id     | SMTP__OAUTH_CLIENT_ID     |               | OAuth2: Azure AD application (client) ID               |
+| smtp:oauth_client_secret | SMTP__OAUTH_CLIENT_SECRET |               | OAuth2: Azure AD client secret                         |
+| smtp:oauth_access_token  | SMTP__OAUTH_ACCESS_TOKEN  |               | OAuth2: static access token                            |
+
+!!! note "OAuth2 authentication (Microsoft/Office 365)"
+
+    If your SMTP server requires OAuth2 (e.g. `smtp.office365.com` after Microsoft retired Basic Auth in April 2026),
+    set `smtp:auth_type` to `oauth2` and provide the four `oauth_*` fields.
+    All four fields are required when `oauth2` is selected.
+    Basic Auth (`smtp:auth_type: basic`) remains the default and is unaffected by this change.
 
 #### AI Service
 

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -24,7 +24,17 @@ const smtpOptions = {
   },
 };
 
-if (conf.get('smtp:username') && conf.get('smtp:username').length > 0) {
+const authType = conf.get('smtp:smtp_auth_type') || 'basic';
+
+if (authType === 'oauth2') {
+  smtpOptions.auth = {
+    type: 'OAuth2',
+    user: conf.get('smtp:oauth_user'),
+    clientId: conf.get('smtp:oauth_client_id'),
+    clientSecret: conf.get('smtp:oauth_client_secret'),
+    accessToken: conf.get('smtp:oauth_access_token'),
+  };
+} else if (conf.get('smtp:username')?.length > 0) {
   smtpOptions.auth = {
     user: conf.get('smtp:username'),
     pass: conf.get('smtp:password') || '',

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -24,21 +24,36 @@ const smtpOptions = {
   },
 };
 
-const authType = conf.get('smtp:smtp_auth_type') || 'basic';
+export const buildSmtpAuth = (authType, { username, password, oauthUser, oauthClientId, oauthClientSecret, oauthAccessToken }) => {
+  if (authType === 'oauth2') {
+    return {
+      type: 'OAuth2',
+      user: oauthUser,
+      clientId: oauthClientId,
+      clientSecret: oauthClientSecret,
+      accessToken: oauthAccessToken,
+    };
+  }
+  if (username?.length > 0) {
+    return {
+      user: username,
+      pass: password || '',
+    };
+  }
+  return undefined;
+};
 
-if (authType === 'oauth2') {
-  smtpOptions.auth = {
-    type: 'OAuth2',
-    user: conf.get('smtp:oauth_user'),
-    clientId: conf.get('smtp:oauth_client_id'),
-    clientSecret: conf.get('smtp:oauth_client_secret'),
-    accessToken: conf.get('smtp:oauth_access_token'),
-  };
-} else if (conf.get('smtp:username')?.length > 0) {
-  smtpOptions.auth = {
-    user: conf.get('smtp:username'),
-    pass: conf.get('smtp:password') || '',
-  };
+const authType = conf.get('smtp:smtp_auth_type') || 'basic';
+const smtpAuth = buildSmtpAuth(authType, {
+  username: conf.get('smtp:username'),
+  password: conf.get('smtp:password'),
+  oauthUser: conf.get('smtp:oauth_user'),
+  oauthClientId: conf.get('smtp:oauth_client_id'),
+  oauthClientSecret: conf.get('smtp:oauth_client_secret'),
+  oauthAccessToken: conf.get('smtp:oauth_access_token'),
+});
+if (smtpAuth) {
+  smtpOptions.auth = smtpAuth;
 }
 
 export const transporter = nodemailer.createTransport(smtpOptions);

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -26,6 +26,9 @@ const smtpOptions = {
 
 export const buildSmtpAuth = (authType, { username, password, oauthUser, oauthClientId, oauthClientSecret, oauthAccessToken }) => {
   if (authType === 'oauth2') {
+    if (!oauthUser || !oauthClientId || !oauthClientSecret || !oauthAccessToken) {
+      throw new Error('SMTP OAuth2 configuration is incomplete: oauth_user, oauth_client_id, oauth_client_secret and oauth_access_token are all required.');
+    }
     return {
       type: 'OAuth2',
       user: oauthUser,
@@ -43,7 +46,7 @@ export const buildSmtpAuth = (authType, { username, password, oauthUser, oauthCl
   return undefined;
 };
 
-const authType = conf.get('smtp:smtp_auth_type') || 'basic';
+const authType = conf.get('smtp:auth_type') || 'basic';
 const smtpAuth = buildSmtpAuth(authType, {
   username: conf.get('smtp:username'),
   password: conf.get('smtp:password'),

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import { buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
 
 type SmtpCredentials = {
@@ -50,15 +50,16 @@ describe('buildSmtpAuth — OAuth2', () => {
     expect(result).not.toHaveProperty('pass');
   });
 
-  it('should return an OAuth2 object even when oauth_* fields are undefined', () => {
-    const result = buildSmtpAuth('oauth2', {});
-    expect(result).toStrictEqual({
-      type: 'OAuth2',
-      user: undefined,
-      clientId: undefined,
-      clientSecret: undefined,
-      accessToken: undefined,
-    });
+  it('should throw an error when oauth_* required fields are missing', () => {
+    expect(() => buildSmtpAuth('oauth2', {})).toThrow(
+      'SMTP OAuth2 configuration is incomplete: oauth_user, oauth_client_id, oauth_client_secret and oauth_access_token are all required.',
+    );
+  });
+
+  it('should throw an error when only some oauth_* fields are provided', () => {
+    expect(() => buildSmtpAuth('oauth2', { oauthUser: 'user@example.com' })).toThrow(
+      'SMTP OAuth2 configuration is incomplete',
+    );
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -1,0 +1,110 @@
+﻿import { describe, expect, it } from 'vitest';
+import { buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
+
+type SmtpCredentials = {
+  username?: string;
+  password?: string;
+  oauthUser?: string;
+  oauthClientId?: string;
+  oauthClientSecret?: string;
+  oauthAccessToken?: string;
+};
+
+// The JS source infers all destructured params as required; cast to the intended optional API.
+const buildSmtpAuth = buildSmtpAuthImpl as (
+  authType: string | undefined,
+  credentials: SmtpCredentials,
+) => ReturnType<typeof buildSmtpAuthImpl>;
+
+// ==========================================================================
+// buildSmtpAuth — OAuth2
+// ==========================================================================
+
+describe('buildSmtpAuth — OAuth2', () => {
+  const oauth2Config = {
+    oauthUser: 'user@example.com',
+    oauthClientId: 'my-client-id',
+    oauthClientSecret: 'my-client-secret',
+    oauthAccessToken: 'my-access-token',
+  };
+
+  it('should return an OAuth2 auth object when authType is "oauth2"', () => {
+    const result = buildSmtpAuth('oauth2', oauth2Config);
+    expect(result).toStrictEqual({
+      type: 'OAuth2',
+      user: 'user@example.com',
+      clientId: 'my-client-id',
+      clientSecret: 'my-client-secret',
+      accessToken: 'my-access-token',
+    });
+  });
+
+  it('should use oauthUser and not username even when both are provided', () => {
+    const result = buildSmtpAuth('oauth2', {
+      ...oauth2Config,
+      username: 'legacy@example.com',
+      password: 'legacy-pass',
+    });
+    expect(result).toHaveProperty('type', 'OAuth2');
+    expect(result).toHaveProperty('user', 'user@example.com');
+    expect(result).not.toHaveProperty('pass');
+  });
+
+  it('should return an OAuth2 object even when oauth_* fields are undefined', () => {
+    const result = buildSmtpAuth('oauth2', {});
+    expect(result).toStrictEqual({
+      type: 'OAuth2',
+      user: undefined,
+      clientId: undefined,
+      clientSecret: undefined,
+      accessToken: undefined,
+    });
+  });
+});
+
+// ==========================================================================
+// buildSmtpAuth — Basic Auth
+// ==========================================================================
+
+describe('buildSmtpAuth — Basic Auth', () => {
+  it('should return a Basic Auth object when authType is "basic" and username is set', () => {
+    const result = buildSmtpAuth('basic', { username: 'user@example.com', password: 'mypassword' });
+    expect(result).toStrictEqual({ user: 'user@example.com', pass: 'mypassword' });
+  });
+
+  it('should return a Basic Auth object when authType is not set (defaults to basic)', () => {
+    const result = buildSmtpAuth(undefined, { username: 'user@example.com', password: 'mypassword' });
+    expect(result).toStrictEqual({ user: 'user@example.com', pass: 'mypassword' });
+  });
+
+  it('should set pass to empty string when password is absent', () => {
+    const result = buildSmtpAuth('basic', { username: 'user@example.com' });
+    expect(result).toStrictEqual({ user: 'user@example.com', pass: '' });
+  });
+
+  it('should return undefined when username is absent', () => {
+    const result = buildSmtpAuth('basic', {});
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when username is an empty string', () => {
+    const result = buildSmtpAuth('basic', { username: '', password: 'mypassword' });
+    expect(result).toBeUndefined();
+  });
+});
+
+// ==========================================================================
+// buildSmtpAuth — Security
+// ==========================================================================
+
+describe('buildSmtpAuth — security', () => {
+  it('should only expose the expected keys in the returned OAuth2 object', () => {
+    const result = buildSmtpAuth('oauth2', {
+      oauthUser: 'user@example.com',
+      oauthClientId: 'client-id',
+      oauthClientSecret: 'super-secret',
+      oauthAccessToken: 'super-token',
+    });
+    expect(Object.keys(result ?? {})).toStrictEqual(['type', 'user', 'clientId', 'clientSecret', 'accessToken']);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
 
 type SmtpCredentials = {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add SMTP OAuth2 (SASL XOAUTH2) authentication support via nodemailer,
while maintaining full backward compatibility with existing Basic Auth
configurations.

- Read smtp_auth_type config field (defaults to 'basic')
- If oauth2: configure nodemailer with OAuth2 type and flat oauth_*
  fields (oauth_user, oauth_client_id, oauth_client_secret,
  oauth_access_token)
- If basic (or unset): preserve existing username/password logic
  unchanged


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: #12069 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
