### PR TITLE
[backend] add endpoint to check playbook state & add log when playbook manager is late (#15661)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9664,6 +9664,7 @@ type Query {
   playbooks(first: Int, after: ID, orderBy: PlaybooksOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): PlaybookConnection
   playbookComponents: [PlaybookComponent]!
   playbooksForEntity(id: String!): [Playbook]
+  playbookManagerInfo: PlaybookManager
   ingestionRss(id: String!): IngestionRss
   ingestionRsss(first: Int, after: ID, orderBy: IngestionRssOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionRssConnection
   ingestionRssAddInputFromImport(file: Upload!): IngestionRssAddInputFromImport!
@@ -13458,6 +13459,12 @@ type PlaybookConnection {
 type PlaybookEdge {
   cursor: String!
   node: Playbook!
+}
+
+type PlaybookManager {
+  activated: Boolean!
+  lastEventId: String
+  lastEventDate: DateTime
 }
 
 input PlaybookAddInput {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -13463,9 +13463,11 @@ type PlaybookEdge {
 
 type PlaybookManager {
   activated: Boolean!
-  lastEventId: String
-  lastEventDate: DateTime
+  lastProcessedEventId: String
+  lastProcessedEventDate: DateTime
+  lastStreamEventId: String
   lastStreamEventDate: DateTime
+  firstStreamEventId: String
   firstStreamEventDate: DateTime
   managerInGoodHealth: Boolean
 }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -13465,6 +13465,9 @@ type PlaybookManager {
   activated: Boolean!
   lastEventId: String
   lastEventDate: DateTime
+  lastStreamEventDate: DateTime
+  firstStreamEventDate: DateTime
+  managerInGoodHealth: Boolean
 }
 
 input PlaybookAddInput {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23307,8 +23307,11 @@ export type PlaybookInsertResult = {
 export type PlaybookManager = {
   __typename?: 'PlaybookManager';
   activated: Scalars['Boolean']['output'];
+  firstStreamEventDate?: Maybe<Scalars['DateTime']['output']>;
   lastEventDate?: Maybe<Scalars['DateTime']['output']>;
   lastEventId?: Maybe<Scalars['String']['output']>;
+  lastStreamEventDate?: Maybe<Scalars['DateTime']['output']>;
+  managerInGoodHealth?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export enum PlaybooksOrdering {
@@ -48045,8 +48048,11 @@ export type PlaybookInsertResultResolvers<ContextType = any, ParentType extends 
 
 export type PlaybookManagerResolvers<ContextType = any, ParentType extends ResolversParentTypes['PlaybookManager'] = ResolversParentTypes['PlaybookManager']> = ResolversObject<{
   activated?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  firstStreamEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   lastEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   lastEventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lastStreamEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  managerInGoodHealth?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
 export type PositionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Position'] = ResolversParentTypes['Position']> = ResolversObject<{

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23308,9 +23308,11 @@ export type PlaybookManager = {
   __typename?: 'PlaybookManager';
   activated: Scalars['Boolean']['output'];
   firstStreamEventDate?: Maybe<Scalars['DateTime']['output']>;
-  lastEventDate?: Maybe<Scalars['DateTime']['output']>;
-  lastEventId?: Maybe<Scalars['String']['output']>;
+  firstStreamEventId?: Maybe<Scalars['String']['output']>;
+  lastProcessedEventDate?: Maybe<Scalars['DateTime']['output']>;
+  lastProcessedEventId?: Maybe<Scalars['String']['output']>;
   lastStreamEventDate?: Maybe<Scalars['DateTime']['output']>;
+  lastStreamEventId?: Maybe<Scalars['String']['output']>;
   managerInGoodHealth?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -48049,9 +48051,11 @@ export type PlaybookInsertResultResolvers<ContextType = any, ParentType extends 
 export type PlaybookManagerResolvers<ContextType = any, ParentType extends ResolversParentTypes['PlaybookManager'] = ResolversParentTypes['PlaybookManager']> = ResolversObject<{
   activated?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   firstStreamEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  lastEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  lastEventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  firstStreamEventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lastProcessedEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  lastProcessedEventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   lastStreamEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  lastStreamEventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   managerInGoodHealth?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23304,6 +23304,13 @@ export type PlaybookInsertResult = {
   nodeId: Scalars['String']['output'];
 };
 
+export type PlaybookManager = {
+  __typename?: 'PlaybookManager';
+  activated: Scalars['Boolean']['output'];
+  lastEventDate?: Maybe<Scalars['DateTime']['output']>;
+  lastEventId?: Maybe<Scalars['String']['output']>;
+};
+
 export enum PlaybooksOrdering {
   Score = '_score',
   CreatedAt = 'created_at',
@@ -24225,6 +24232,7 @@ export type Query = {
   pirs?: Maybe<PirConnection>;
   playbook?: Maybe<Playbook>;
   playbookComponents: Array<Maybe<PlaybookComponent>>;
+  playbookManagerInfo?: Maybe<PlaybookManager>;
   playbooks?: Maybe<PlaybookConnection>;
   playbooksForEntity?: Maybe<Array<Maybe<Playbook>>>;
   position?: Maybe<Position>;
@@ -39462,6 +39470,7 @@ export type ResolversTypes = ResolversObject<{
   PlaybookConnection: ResolverTypeWrapper<Omit<PlaybookConnection, 'edges'> & { edges: Array<ResolversTypes['PlaybookEdge']> }>;
   PlaybookEdge: ResolverTypeWrapper<Omit<PlaybookEdge, 'node'> & { node: ResolversTypes['Playbook'] }>;
   PlaybookInsertResult: ResolverTypeWrapper<PlaybookInsertResult>;
+  PlaybookManager: ResolverTypeWrapper<PlaybookManager>;
   PlaybooksOrdering: PlaybooksOrdering;
   Position: ResolverTypeWrapper<Omit<Position, 'avatar' | 'cases' | 'city' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversTypes['OpenCtiFile']>, cases?: Maybe<ResolversTypes['CaseConnection']>, city?: Maybe<ResolversTypes['City']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<ResolversTypes['FileConnection']>, fintelTemplates?: Maybe<Array<ResolversTypes['FintelTemplate']>>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, status?: Maybe<ResolversTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   PositionAddInput: PositionAddInput;
@@ -40469,6 +40478,7 @@ export type ResolversParentTypes = ResolversObject<{
   PlaybookConnection: Omit<PlaybookConnection, 'edges'> & { edges: Array<ResolversParentTypes['PlaybookEdge']> };
   PlaybookEdge: Omit<PlaybookEdge, 'node'> & { node: ResolversParentTypes['Playbook'] };
   PlaybookInsertResult: PlaybookInsertResult;
+  PlaybookManager: PlaybookManager;
   Position: Omit<Position, 'avatar' | 'cases' | 'city' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversParentTypes['OpenCtiFile']>, cases?: Maybe<ResolversParentTypes['CaseConnection']>, city?: Maybe<ResolversParentTypes['City']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<ResolversParentTypes['FileConnection']>, fintelTemplates?: Maybe<Array<ResolversParentTypes['FintelTemplate']>>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, status?: Maybe<ResolversParentTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
   PositionAddInput: PositionAddInput;
   PositionConnection: Omit<PositionConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['PositionEdge']>>> };
@@ -48033,6 +48043,12 @@ export type PlaybookInsertResultResolvers<ContextType = any, ParentType extends 
   nodeId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
+export type PlaybookManagerResolvers<ContextType = any, ParentType extends ResolversParentTypes['PlaybookManager'] = ResolversParentTypes['PlaybookManager']> = ResolversObject<{
+  activated?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  lastEventDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  lastEventId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
 export type PositionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Position'] = ResolversParentTypes['Position']> = ResolversObject<{
   avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<PositionCasesArgs>>;
@@ -48499,6 +48515,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   pirs?: Resolver<Maybe<ResolversTypes['PirConnection']>, ParentType, ContextType, Partial<QueryPirsArgs>>;
   playbook?: Resolver<Maybe<ResolversTypes['Playbook']>, ParentType, ContextType, RequireFields<QueryPlaybookArgs, 'id'>>;
   playbookComponents?: Resolver<Array<Maybe<ResolversTypes['PlaybookComponent']>>, ParentType, ContextType>;
+  playbookManagerInfo?: Resolver<Maybe<ResolversTypes['PlaybookManager']>, ParentType, ContextType>;
   playbooks?: Resolver<Maybe<ResolversTypes['PlaybookConnection']>, ParentType, ContextType, Partial<QueryPlaybooksArgs>>;
   playbooksForEntity?: Resolver<Maybe<Array<Maybe<ResolversTypes['Playbook']>>>, ParentType, ContextType, RequireFields<QueryPlaybooksForEntityArgs, 'id'>>;
   position?: Resolver<Maybe<ResolversTypes['Position']>, ParentType, ContextType, RequireFields<QueryPositionArgs, 'id'>>;
@@ -52564,6 +52581,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   PlaybookConnection?: PlaybookConnectionResolvers<ContextType>;
   PlaybookEdge?: PlaybookEdgeResolvers<ContextType>;
   PlaybookInsertResult?: PlaybookInsertResultResolvers<ContextType>;
+  PlaybookManager?: PlaybookManagerResolvers<ContextType>;
   Position?: PositionResolvers<ContextType>;
   PositionConnection?: PositionConnectionResolvers<ContextType>;
   PositionEdge?: PositionEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -47,6 +47,7 @@ import { listenPirEvents } from './listenPirEventsUtils';
 import { isValidEventType } from './playbookManagerUtils';
 import { playbookExecutor } from './playbookExecutor';
 import type { BasicConnection, BasicStoreBase } from '../../types/store';
+import { isModuleActivated } from '../../database/cluster-module';
 
 const PLAYBOOK_LIVE_KEY = conf.get('playbook_manager:lock_key');
 const PLAYBOOK_CRON_KEY = conf.get('playbook_manager:lock_cron_key');
@@ -54,6 +55,13 @@ const PLAYBOOK_CRON_MAX_SIZE = conf.get('playbook_manager:cron_max_size') || 500
 const PLAYBOOK_MANAGER_NAME = 'playbook_manager';
 const STREAM_SCHEDULE_TIME = 10000;
 const CRON_SCHEDULE_TIME = 60000; // 1 minute
+
+export const getManagerInfo = async () => {
+  const isPlaybookManagerActivated = await isModuleActivated('PLAYBOOK_MANAGER');
+  const lastEventState = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
+  const lastEventDate = lastEventState ? utcDate(Number(lastEventState.split('-')[0])).toISOString() : null;
+  return { activated: isPlaybookManagerActivated, lastEventId: lastEventState, lastEventDate };
+};
 
 const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEvent>>) => {
   try {
@@ -186,6 +194,19 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   return false;
 };
 
+const checkManagerDelay = async (streamProcessor: StreamProcessor) => {
+  const lastManagerEventState = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
+  const lastManagerEventId = lastManagerEventState ? Number(lastManagerEventState.split('-')[0]) : 0;
+  const streamProcessorInfo = await streamProcessor.info() as { firstEventId: string; lastEventId: string };
+  const lastStreamEventId = streamProcessorInfo.lastEventId;
+  const firstStreamEventId = streamProcessorInfo.firstEventId;
+  const middleStreamEventId = (Number(lastStreamEventId.split('-')[0]) + Number(firstStreamEventId.split('-')[0])) / 2;
+  const isManagerLate = lastManagerEventId < middleStreamEventId;
+  if (isManagerLate) {
+    logApp.warn('[OPENCTI-MODULE] Playbook manager is late to process events', { lastManagerEventId, firstStreamEventId, lastStreamEventId });
+  }
+};
+
 const initPlaybookManager = () => {
   const WAIT_TIME_ACTION = 2000;
   let streamScheduler: SetIntervalAsyncTimer<[]>;
@@ -208,9 +229,14 @@ const initPlaybookManager = () => {
       streamProcessor = createStreamProcessor('Playbook manager', playbookStreamHandler, { withInternal: true });
       const lastEventState = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
       await streamProcessor.start(lastEventState ?? 'live');
+      let delayCheckerCounter = 0;
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
         await wait(WAIT_TIME_ACTION);
+        if (++delayCheckerCounter >= 10) {
+          await checkManagerDelay(streamProcessor);
+          delayCheckerCounter = 0;
+        }
       }
       logApp.info('[OPENCTI-MODULE] End of playbook manager processing');
     } catch (e: any) {

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import { v4 as uuidv4 } from 'uuid';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import type { Moment } from 'moment/moment';
-import { createStreamProcessor } from '../../database/stream/stream-handler';
+import { createStreamProcessor, fetchStreamInfo } from '../../database/stream/stream-handler';
 import { type StreamProcessor } from '../../database/stream/stream-utils';
 import { redisGetManagerEventState, redisSetManagerEventState } from '../../database/redis';
 import { lockResources } from '../../lock/master-lock';
@@ -59,8 +59,17 @@ const CRON_SCHEDULE_TIME = 60000; // 1 minute
 export const getManagerInfo = async () => {
   const isPlaybookManagerActivated = await isModuleActivated('PLAYBOOK_MANAGER');
   const lastEventState = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
+  const lastManagerEventId = lastEventState ? Number(lastEventState.split('-')[0]) : 0;
   const lastEventDate = lastEventState ? utcDate(Number(lastEventState.split('-')[0])).toISOString() : null;
-  return { activated: isPlaybookManagerActivated, lastEventId: lastEventState, lastEventDate };
+
+  const streamProcessorInfo = await fetchStreamInfo();
+  const lastStreamEventId = streamProcessorInfo.lastEventId;
+  const lastStreamEventDate = lastStreamEventId ? utcDate(Number(lastStreamEventId.split('-')[0])).toISOString() : null;
+  const firstStreamEventId = streamProcessorInfo.firstEventId;
+  const firstStreamEventDate = firstStreamEventId ? utcDate(Number(firstStreamEventId.split('-')[0])).toISOString() : null;
+  const middleStreamEventId = (Number(lastStreamEventId.split('-')[0]) + Number(firstStreamEventId.split('-')[0])) / 2;
+  const isManagerLate = lastManagerEventId < middleStreamEventId;
+  return { activated: isPlaybookManagerActivated, lastEventId: lastEventState, lastEventDate, lastStreamEventDate, firstStreamEventDate, managerInGoodHealth: !isManagerLate };
 };
 
 const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEvent>>) => {

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -58,9 +58,9 @@ const CRON_SCHEDULE_TIME = 60000; // 1 minute
 
 export const getManagerInfo = async () => {
   const isPlaybookManagerActivated = await isModuleActivated('PLAYBOOK_MANAGER');
-  const lastEventState = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
-  const lastManagerEventId = lastEventState ? Number(lastEventState.split('-')[0]) : 0;
-  const lastEventDate = lastEventState ? utcDate(Number(lastEventState.split('-')[0])).toISOString() : null;
+  const lastProcessedEventId = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
+  const lastManagerEventId = lastProcessedEventId ? Number(lastProcessedEventId.split('-')[0]) : 0;
+  const lastProcessedEventDate = lastProcessedEventId ? utcDate(Number(lastProcessedEventId.split('-')[0])).toISOString() : null;
 
   const streamProcessorInfo = await fetchStreamInfo();
   const lastStreamEventId = streamProcessorInfo.lastEventId;
@@ -69,7 +69,16 @@ export const getManagerInfo = async () => {
   const firstStreamEventDate = firstStreamEventId ? utcDate(Number(firstStreamEventId.split('-')[0])).toISOString() : null;
   const middleStreamEventId = (Number(lastStreamEventId.split('-')[0]) + Number(firstStreamEventId.split('-')[0])) / 2;
   const isManagerLate = lastManagerEventId < middleStreamEventId;
-  return { activated: isPlaybookManagerActivated, lastEventId: lastEventState, lastEventDate, lastStreamEventDate, firstStreamEventDate, managerInGoodHealth: !isManagerLate };
+  return {
+    activated: isPlaybookManagerActivated,
+    lastProcessedEventId,
+    lastProcessedEventDate,
+    lastStreamEventId,
+    lastStreamEventDate,
+    firstStreamEventId,
+    firstStreamEventDate,
+    managerInGoodHealth: !isManagerLate,
+  };
 };
 
 const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEvent>>) => {
@@ -203,16 +212,10 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   return false;
 };
 
-const checkManagerDelay = async (streamProcessor: StreamProcessor) => {
-  const lastManagerEventState = await redisGetManagerEventState(PLAYBOOK_MANAGER_NAME);
-  const lastManagerEventId = lastManagerEventState ? Number(lastManagerEventState.split('-')[0]) : 0;
-  const streamProcessorInfo = await streamProcessor.info() as { firstEventId: string; lastEventId: string };
-  const lastStreamEventId = streamProcessorInfo.lastEventId;
-  const firstStreamEventId = streamProcessorInfo.firstEventId;
-  const middleStreamEventId = (Number(lastStreamEventId.split('-')[0]) + Number(firstStreamEventId.split('-')[0])) / 2;
-  const isManagerLate = lastManagerEventId < middleStreamEventId;
-  if (isManagerLate) {
-    logApp.warn('[OPENCTI-MODULE] Playbook manager is late to process events', { lastManagerEventId, firstStreamEventId, lastStreamEventId });
+const checkManagerDelay = async () => {
+  const { lastProcessedEventId, lastStreamEventId, firstStreamEventId, managerInGoodHealth } = await getManagerInfo();
+  if (!managerInGoodHealth) {
+    logApp.warn('[OPENCTI-MODULE] Playbook manager is late to process events', { lastProcessedEventId, firstStreamEventId, lastStreamEventId });
   }
 };
 
@@ -243,7 +246,7 @@ const initPlaybookManager = () => {
         lock.signal.throwIfAborted();
         await wait(WAIT_TIME_ACTION);
         if (++delayCheckerCounter >= 10) {
-          await checkManagerDelay(streamProcessor);
+          await checkManagerDelay();
           delayCheckerCounter = 0;
         }
       }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-resolvers.ts
@@ -34,7 +34,7 @@ import {
   playbookImport,
   playbookDuplicate,
 } from './playbook-domain';
-import { executePlaybookOnEntity, playbookStepExecution } from '../../manager/playbookManager/playbookManager';
+import { executePlaybookOnEntity, playbookStepExecution, getManagerInfo } from '../../manager/playbookManager/playbookManager';
 import { getLastPlaybookExecutions } from '../../database/redis';
 import { getConnectorQueueSize } from '../../database/rabbitmq';
 import { loadCreators } from '../../database/members';
@@ -47,6 +47,7 @@ const playbookResolvers: Resolvers = {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     playbookComponents: (_, __, context) => availableComponents(context),
+    playbookManagerInfo: (_, __, ___) => getManagerInfo(),
   },
   Playbook: {
     creators: async (current, _, context) => loadCreators(context, context.user, current),

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -77,6 +77,9 @@ type PlaybookManager {
     activated: Boolean!
     lastEventId: String
     lastEventDate: DateTime
+    lastStreamEventDate: DateTime
+    firstStreamEventDate: DateTime
+    managerInGoodHealth: Boolean
 }
 
 # Queries

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -73,6 +73,12 @@ type PlaybookEdge {
     node: Playbook!
 }
 
+type PlaybookManager {
+    activated: Boolean!
+    lastEventId: String
+    lastEventDate: DateTime
+}
+
 # Queries
 type Query {
     playbook(id: String!): Playbook @auth(for: [AUTOMATION])
@@ -86,6 +92,7 @@ type Query {
     ): PlaybookConnection @auth(for: [AUTOMATION])
     playbookComponents: [PlaybookComponent]! @auth(for: [AUTOMATION])
     playbooksForEntity(id: String!): [Playbook] @auth(for: [AUTOMATION])
+    playbookManagerInfo: PlaybookManager @auth(for: [AUTOMATION])
 }
 
 input PlaybookAddInput {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -75,9 +75,11 @@ type PlaybookEdge {
 
 type PlaybookManager {
     activated: Boolean!
-    lastEventId: String
-    lastEventDate: DateTime
+    lastProcessedEventId: String
+    lastProcessedEventDate: DateTime
+    lastStreamEventId: String
     lastStreamEventDate: DateTime
+    firstStreamEventId: String
     firstStreamEventDate: DateTime
     managerInGoodHealth: Boolean
 }

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
@@ -111,6 +111,14 @@ const DELETE_PLAYBOOK = gql`
     playbookDelete(id:$id)
   }
 `;
+const PLAYBOOK_MANAGER_INFO = gql`
+  query playbookManagerInfo {
+    playbookManagerInfo {
+      activated
+      lastEventDate
+    }
+  }
+`;
 
 const EMPTY_STRING_FILTERS = JSON.stringify({
   mode: 'and',
@@ -671,5 +679,15 @@ describe('Playbook resolver standard behavior', () => {
       });
       expect(queryResult.data?.playbookDelete).toEqual(playbookId);
     });
+  });
+});
+
+describe('Playbook manager info', () => {
+  it('should return playbook manager info', async () => {
+    const queryResult = await queryAsAdminWithSuccess({ query: PLAYBOOK_MANAGER_INFO });
+    const managerInfo = queryResult.data?.playbookManagerInfo;
+    expect(managerInfo).toBeDefined();
+    expect(managerInfo.activated).toBeDefined();
+    expect(typeof managerInfo.activated).toBe('boolean');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/playbook-test.ts
@@ -115,7 +115,7 @@ const PLAYBOOK_MANAGER_INFO = gql`
   query playbookManagerInfo {
     playbookManagerInfo {
       activated
-      lastEventDate
+      lastProcessedEventDate
     }
   }
 `;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  add endpoint to check playbook state & add log when playbook manager is late
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15661
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
