### PR TITLE
[frontend] align export file markings with max shareable and entity markings (#10790)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/Root.tsx
@@ -54,6 +54,13 @@ const groupingQuery = graphql`
       entity_type
       name
       currentUserAccessRight
+      objectMarking {
+        id
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+      }
       securityCoverage {
         id
         coverage_information {

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -52,6 +52,13 @@ const reportQuery = graphql`
       entity_type
       name
       currentUserAccessRight
+      objectMarking {
+        id
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+      }
       securityCoverage {
           id
           coverage_information {

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/Root.tsx
@@ -53,6 +53,13 @@ const caseIncidentQuery = graphql`
       standard_id
       entity_type
       currentUserAccessRight
+      objectMarking {
+        id
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+      }
       creators {
         id
         name

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/Root.tsx
@@ -53,6 +53,13 @@ const caseRfiQuery = graphql`
       currentUserAccessRight
       name
       x_opencti_graph_data
+      objectMarking {
+        id
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+      }
       ...CaseUtils_case
       ...CaseRfi_caseRfi
       ...CaseRfiKnowledge_case

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/Root.tsx
@@ -52,6 +52,13 @@ const caseRftQuery = graphql`
       currentUserAccessRight
       name
       x_opencti_graph_data
+      objectMarking {
+        id
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+      }
       ...CaseUtils_case
       ...CaseRftKnowledge_case
       ...FileImportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/Root.tsx
@@ -48,6 +48,13 @@ const TaskQuery = graphql`
       name
       x_opencti_graph_data
       entity_type
+      objectMarking {
+        id
+        definition_type
+        definition
+        x_opencti_order
+        x_opencti_color
+      }
       ...Tasks_tasks
       ...FileImportViewer_entity
       ...FileExportViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileManager.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileManager.jsx
@@ -17,8 +17,8 @@ import inject18n, { useFormatter } from '../../../../components/i18n';
 import Loader from '../../../../components/Loader';
 import { commitMutation, handleErrorInForm, MESSAGING$, QueryRenderer } from '../../../../relay/environment';
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
+import { convertMarkings } from '../../../../utils/edition';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
-import { markingDefinitionsLinesSearchQuery } from '../../settings/MarkingDefinitionsQuery';
 import ObjectMarkingField from '../form/ObjectMarkingField';
 import { useInitCreateRelationshipContext } from '../stix_core_relationships/CreateRelationshipContextProvider';
 import DraftWorkspaceViewer from './draftWorkspace/DraftWorkspaceViewer';
@@ -27,6 +27,8 @@ import FileExternalReferencesViewer from './FileExternalReferencesViewer';
 import FileImportViewer from './FileImportViewer';
 import PictureManagementViewer from './PictureManagementViewer';
 import WorkbenchFileViewer from './workbench/WorkbenchFileViewer';
+import { Stack, Tooltip } from '@mui/material';
+import { InfoOutlined } from '@mui/icons-material';
 
 const styles = (theme) => ({
   container: {
@@ -127,6 +129,23 @@ export const fileManagerExportMutation = graphql`
   }
 `;
 
+const fileManagerExportDialogQuery = graphql`
+  query FileManagerExportDialogQuery($id: String!) {
+    stixCoreObject(id: $id) {
+      ... on StixCoreObject {
+        id
+        objectMarking {
+          id
+          definition_type
+          definition
+          x_opencti_order
+          x_opencti_color
+        }
+      }
+    }
+  }
+`;
+
 export const scopesConn = (exportConnectors) => {
   const scopes = uniq(flatten(map((c) => c.connector_scope, exportConnectors)));
   const connectors = map((s) => {
@@ -178,10 +197,19 @@ const FileManager = ({
   const [openExport, setOpenExport] = useState(false);
   const [selectedConnector, setSelectedConnector] = useState(null);
   const [selectedContentMaxMarkingsIds, setSelectedContentMaxMarkingsIds] = useState([]);
-  const handleSelectedContentMaxMarkingsChange = (values) => setSelectedContentMaxMarkingsIds(values.map(({ value }) => value));
+
+  const entityMarkings = convertMarkings(entity);
+
+  const handleSelectedContentMaxMarkingsChange = (values, setFieldValue, fallbackEntityMarkings) => {
+    const nextValues = values ?? [];
+    setSelectedContentMaxMarkingsIds(nextValues.map(({ value }) => value));
+    setFieldValue('fileMarkings', nextValues.length > 0 ? nextValues : fallbackEntityMarkings);
+  };
+
   const exportScopes = uniq(
     flatten(map((c) => c.connector_scope, connectorsExport)),
   );
+
   const exportConnsPerFormat = scopesConn(connectorsExport);
 
   const isExportActive = (format) => filter((x) => x.data.active, exportConnsPerFormat[format]).length > 0;
@@ -430,25 +458,41 @@ const FileManager = ({
             format: '',
             type: 'full',
             contentMaxMarkings: [],
-            fileMarkings: [],
+            fileMarkings: entityMarkings,
           }}
           validationSchema={exportValidation(t_i18n)}
           onSubmit={onSubmitExport}
           onReset={handleCloseExport}
         >
-          {({ submitForm, handleReset, isSubmitting, resetForm, setFieldValue }) => (
+          {({ submitForm, handleReset, isSubmitting, resetForm, setFieldValue, values }) => (
             <Form style={{ margin: '0 0 20px 0' }}>
               <Dialog
                 open={openExport}
                 onClose={resetForm}
                 data-testid="FileManagerExportDialog"
-                title={t('Generate an export')}
+                title={(
+                  <Stack direction="row" alignItems="center" gap={1}>
+                    {t_i18n('Generate an export')}
+                    <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
+                      <InfoOutlined fontSize="small" color="primary" />
+                    </Tooltip>
+                  </Stack>
+                )}
               >
                 <QueryRenderer
-                  query={markingDefinitionsLinesSearchQuery}
-                  variables={{ first: 200 }}
+                  query={fileManagerExportDialogQuery}
+                  variables={{ id }}
                   render={({ props }) => {
-                    if (props && props.markingDefinitions) {
+                    if (props) {
+                      const resolvedEntityMarkings = convertMarkings(props.stixCoreObject ?? entity);
+
+                      if (
+                        values.fileMarkings.length === 0
+                        && values.contentMaxMarkings.length === 0
+                        && resolvedEntityMarkings.length > 0
+                      ) {
+                        setFieldValue('fileMarkings', resolvedEntityMarkings);
+                      }
                       return (
                         <>
                           <Field
@@ -487,7 +531,11 @@ const FileManager = ({
                           <ObjectMarkingField
                             name="contentMaxMarkings"
                             label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
-                            onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values)}
+                            onChange={(_, updatedValues) => handleSelectedContentMaxMarkingsChange(
+                              updatedValues,
+                              setFieldValue,
+                              resolvedEntityMarkings,
+                            )}
                             style={fieldSpacingContainerStyle}
                             setFieldValue={setFieldValue}
                             limitToMaxSharing

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -64,6 +64,7 @@ export interface StixCoreObjectFileExportFormProps {
   connectors: ConnectorOption[];
   templates?: FieldOption[];
   fileOptions?: FileOption[];
+  defaultFileMarkings?: FieldOption[];
   defaultValues?: {
     connector: string;
     format: string;
@@ -107,6 +108,7 @@ const StixCoreObjectFileExportForm = ({
   connectors,
   templates,
   fileOptions,
+  defaultFileMarkings,
   defaultValues,
   scoName,
   handleOpenAskAi,
@@ -116,7 +118,18 @@ const StixCoreObjectFileExportForm = ({
   const isEnterpriseEdition = useEnterpriseEdition();
   const { fullyActive } = useAI();
   const [stepIndex, setStepIndex] = useState(defaultValues?.format ? 1 : 0);
+  const [selectedContentMaxMarkingsIds, setSelectedContentMaxMarkingsIds] = useState<string[]>([]);
   const isBuiltInConnector = (connector?: string) => [BUILT_IN_FROM_TEMPLATE.value, BUILT_IN_HTML_TO_PDF.value].includes(connector ?? '');
+
+  const handleSelectedContentMaxMarkingsChange = (
+    values: FieldOption[] | undefined,
+    setFieldValue: (field: string, value: unknown) => void,
+    fallbackFileMarkings: FieldOption[],
+  ) => {
+    const nextValues = values ?? [];
+    setSelectedContentMaxMarkingsIds(nextValues.map(({ value }) => value));
+    setFieldValue('fileMarkings', nextValues.length > 0 ? nextValues : fallbackFileMarkings);
+  };
 
   const validation = () => Yup.object().shape({
     connector: Yup.object().required(t_i18n('This field is required')),
@@ -160,7 +173,9 @@ const StixCoreObjectFileExportForm = ({
     exportFileName: null,
     contentMaxMarkings: [],
     fintelDesign: null,
-    fileMarkings: defaultFileToExport?.fileMarkings.map(({ id, name }) => ({ label: name, value: id })) ?? [],
+    fileMarkings: defaultFileToExport?.fileMarkings.map(({ id, name }) => ({ label: name, value: id }))
+      ?? defaultFileMarkings
+      ?? [],
   };
   const isConnectorValid = (option: ConnectorOption, selectedFormat: string) => {
     if (!selectedFormat) return true;
@@ -230,6 +245,11 @@ const StixCoreObjectFileExportForm = ({
             );
           }
         }, [values.fileToExport]);
+
+        useEffect(() => {
+          setSelectedContentMaxMarkingsIds((values.contentMaxMarkings ?? []).map(({ value }) => value));
+        }, [values.contentMaxMarkings]);
+
         return (
 
           <Dialog
@@ -441,6 +461,11 @@ const StixCoreObjectFileExportForm = ({
                         <ObjectMarkingField
                           name="contentMaxMarkings"
                           label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
+                          onChange={(_, updatedValues) => handleSelectedContentMaxMarkingsChange(
+                            updatedValues,
+                            setFieldValue,
+                            defaultFileMarkings ?? [],
+                          )}
                           style={fieldSpacingContainerStyle}
                           setFieldValue={setFieldValue}
                           limitToMaxSharing
@@ -450,6 +475,7 @@ const StixCoreObjectFileExportForm = ({
                       <ObjectMarkingField
                         name="fileMarkings"
                         label={t_i18n('File marking definition levels')}
+                        filterTargetIds={selectedContentMaxMarkingsIds}
                         style={fieldSpacingContainerStyle}
                         setFieldValue={setFieldValue}
                       />

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
@@ -414,6 +414,10 @@ const StixCoreObjectFileExportComponent = ({
           connectors={activeConnectors}
           fileOptions={fileOptions}
           templates={templateOptions}
+          defaultFileMarkings={(stixCoreObject?.objectMarking ?? []).map((o) => ({
+            value: o.id,
+            label: getMainRepresentative(o),
+          }))}
           isOpen={isOpen}
           onSubmit={onSubmitExport}
           onClose={close}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFilesAndHistory.jsx
@@ -9,8 +9,6 @@ import MenuItem from '@mui/material/MenuItem';
 import { createFragmentContainer, graphql } from 'react-relay';
 import { Field, Form, Formik } from 'formik';
 import Dialog from '@common/dialog/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import { InfoOutlined } from '@mui/icons-material';
@@ -29,6 +27,7 @@ import FileExternalReferencesViewer from '../files/FileExternalReferencesViewer'
 import WorkbenchFileViewer from '../files/workbench/WorkbenchFileViewer';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { resolveHasUserChoiceParsedCsvMapper } from '../../../../utils/csvMapperUtils';
+import { convertMarkings } from '../../../../utils/edition';
 import useDraftContext from '../../../../utils/hooks/useDraftContext';
 import useAuth from '../../../../utils/hooks/useAuth';
 import AuthorizedMembersField from '../form/AuthorizedMembersField';
@@ -40,6 +39,7 @@ import MarkdownField from '../../../../components/fields/markdownField/MarkdownF
 import ObjectAssigneeField from '@components/common/form/ObjectAssigneeField';
 import ObjectParticipantField from '@components/common/form/ObjectParticipantField';
 import CreatedByField from '@components/common/form/CreatedByField';
+import { Stack } from '@mui/material';
 
 const styles = (theme) => ({
   container: {
@@ -156,6 +156,9 @@ const StixCoreObjectFilesAndHistory = ({
   const [openExport, setOpenExport] = useState(false);
   const [selectedConnector, setSelectedConnector] = useState(null);
   const [selectedContentMaxMarkingsIds, setSelectedContentMaxMarkingsIds] = useState([]);
+
+  const entityMarkings = convertMarkings(entity);
+
   const exportScopes = uniq(
     flatten(map((c) => c.connector_scope, connectorsExport)),
   );
@@ -170,7 +173,13 @@ const StixCoreObjectFilesAndHistory = ({
   };
   const handleOpenExport = () => setOpenExport(true);
   const handleCloseExport = () => setOpenExport(false);
-  const handleSelectedContentMaxMarkingsChange = (values) => setSelectedContentMaxMarkingsIds(values.map(({ value }) => value));
+
+  const handleSelectedContentMaxMarkingsChange = (values, setFieldValue) => {
+    const nextValues = values ?? [];
+    setSelectedContentMaxMarkingsIds(nextValues.map(({ value }) => value));
+    setFieldValue('fileMarkings', nextValues.length > 0 ? nextValues : entityMarkings);
+  };
+
   const onSubmitImport = (values, { setSubmitting, resetForm }) => {
     const { connector_id, configuration, objectMarking, validation_mode, authorizedMembers } = values;
     let config = configuration;
@@ -496,7 +505,7 @@ const StixCoreObjectFilesAndHistory = ({
             format: '',
             type: 'full',
             contentMaxMarkings: [],
-            fileMarkings: [],
+            fileMarkings: entityMarkings,
           }}
           validationSchema={exportValidation(t_i18n)}
           onSubmit={onSubmitExport}
@@ -511,64 +520,64 @@ const StixCoreObjectFilesAndHistory = ({
                 onClose={handleCloseExport}
                 fullWidth={true}
                 data-testid="StixCoreObjectFilesAndHistoryExportDialog"
+                title={(
+                  <Stack direction="row" alignItems="center" gap={1}>
+                    {t_i18n('Generate an export')}
+                    <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
+                      <InfoOutlined fontSize="small" color="primary" />
+                    </Tooltip>
+                  </Stack>
+                )}
               >
-                <DialogTitle>
-                  {t_i18n('Generate an export')}
-                  <Tooltip title={t_i18n('Your max shareable markings will be applied to the content max markings')}>
-                    <InfoOutlined sx={{ paddingLeft: 1 }} fontSize="small" />
-                  </Tooltip>
-                </DialogTitle>
-                <DialogContent>
-                  <Field
-                    component={SelectField}
-                    variant="standard"
-                    name="format"
-                    label={t_i18n('Export format')}
-                    fullWidth={true}
-                    containerstyle={{ width: '100%' }}
-                  >
-                    {exportScopes.map((value, i) => (
-                      <MenuItem
-                        key={i}
-                        value={value}
-                        disabled={!isExportActive(value)}
-                      >
-                        {value}
-                      </MenuItem>
-                    ))}
-                  </Field>
-                  <Field
-                    component={SelectField}
-                    variant="standard"
-                    name="type"
-                    label={t_i18n('Export type')}
-                    fullWidth={true}
-                    containerstyle={fieldSpacingContainerStyle}
-                  >
-                    <MenuItem value="simple">
-                      {t_i18n('Simple export (just the entity)')}
+                <Field
+                  component={SelectField}
+                  variant="standard"
+                  name="format"
+                  label={t_i18n('Export format')}
+                  fullWidth={true}
+                  containerstyle={{ width: '100%' }}
+                >
+                  {exportScopes.map((value, i) => (
+                    <MenuItem
+                      key={i}
+                      value={value}
+                      disabled={!isExportActive(value)}
+                    >
+                      {value}
                     </MenuItem>
-                    <MenuItem value="full">
-                      {t_i18n('Full export (entity and first neighbours)')}
-                    </MenuItem>
-                  </Field>
-                  <ObjectMarkingField
-                    name="contentMaxMarkings"
-                    label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
-                    onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values)}
-                    style={fieldSpacingContainerStyle}
-                    setFieldValue={setFieldValue}
-                    limitToMaxSharing
-                    helpertext={t_i18n(CONTENT_MAX_MARKINGS_HELPERTEXT)}
-                  />
-                  <ObjectMarkingField
-                    name="fileMarkings"
-                    label={t_i18n('File marking definition levels')}
-                    filterTargetIds={selectedContentMaxMarkingsIds}
-                    style={fieldSpacingContainerStyle}
-                    setFieldValue={setFieldValue}
-                  />
-                </DialogContent>
+                  ))}
+                </Field>
+                <Field
+                  component={SelectField}
+                  variant="standard"
+                  name="type"
+                  label={t_i18n('Export type')}
+                  fullWidth={true}
+                  containerstyle={fieldSpacingContainerStyle}
+                >
+                  <MenuItem value="simple">
+                    {t_i18n('Simple export (just the entity)')}
+                  </MenuItem>
+                  <MenuItem value="full">
+                    {t_i18n('Full export (entity and first neighbours)')}
+                  </MenuItem>
+                </Field>
+                <ObjectMarkingField
+                  name="contentMaxMarkings"
+                  label={t_i18n(CONTENT_MAX_MARKINGS_TITLE)}
+                  onChange={(_, values) => handleSelectedContentMaxMarkingsChange(values, setFieldValue)}
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
+                  limitToMaxSharing
+                  helpertext={t_i18n(CONTENT_MAX_MARKINGS_HELPERTEXT)}
+                />
+                <ObjectMarkingField
+                  name="fileMarkings"
+                  label={t_i18n('File marking definition levels')}
+                  filterTargetIds={selectedContentMaxMarkingsIds}
+                  style={fieldSpacingContainerStyle}
+                  setFieldValue={setFieldValue}
+                />
                 <DialogActions>
                   <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
                     {t_i18n('Cancel')}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExportCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservablesExportCreation.jsx
@@ -181,10 +181,10 @@ class StixCyberObservablesExportCreationComponent extends Component {
                       }}
                       data-testid="StixCyberObservablesExportCreationDialog"
                       title={(
-                        <Stack direction="row" alignContent="center" gap={1}>
+                        <Stack direction="row" alignItems="center" gap={1}>
                           {t('Generate an export')}
                           <Tooltip title={t('Your max shareable markings will be applied to the content max markings')}>
-                            <InfoOutlined color="primary" />
+                            <InfoOutlined fontSize="small" color="primary" />
                           </Tooltip>
                         </Stack>
                       )}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Aligns export marking behavior to reduce user mistakes and improves dialog UX consistency.

https://github.com/user-attachments/assets/2c91eab9-512b-42a7-977e-757142b90371


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #10790


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
