### PR TITLE
[backend] allow managers to be interrupted on stop (#15160)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/activityManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityManager.ts
@@ -37,6 +37,7 @@ import { ENTITY_TYPE_MARKING_DEFINITION } from '../schema/stixMetaObject';
 import { lockResources } from '../lock/master-lock';
 import { ACTIVITY_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const ACTIVITY_ENGINE_KEY = conf.get('activity_manager:lock_key');
 const SCHEDULE_TIME = 10000;
@@ -147,11 +148,7 @@ const initActivityManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+  const waitTimer = new InterruptibleTimer();
   const activityHandler = async (lastEventId: string) => {
     let lock;
     try {
@@ -164,7 +161,7 @@ const initActivityManager = () => {
       await streamProcessor.start(lastEventId);
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of Activity manager processing');
     } catch (e: any) {
@@ -215,11 +212,14 @@ const initActivityManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping activity manager');
       shutdown = true;
+      waitTimer.interrupt();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Activity manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/activityManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/activityManager.ts
@@ -212,7 +212,7 @@ const initActivityManager = () => {
       };
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping activity manager');
       shutdown = true;
       waitTimer.interrupt();

--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -383,6 +383,7 @@ const initCacheManager = () => {
       logApp.info('[OPENCTI-MODULE] Cache manager pub sub listener initialized');
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping cache manager');
       try {
         subscribeAdd.unsubscribe();
@@ -393,6 +394,7 @@ const initCacheManager = () => {
       try {
         subscribeDelete.unsubscribe();
       } catch { /* dont care */ }
+      logApp.info(`[OPENCTI-MODULE] Cache manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -383,7 +383,7 @@ const initCacheManager = () => {
       logApp.info('[OPENCTI-MODULE] Cache manager pub sub listener initialized');
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping cache manager');
       try {
         subscribeAdd.unsubscribe();

--- a/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
@@ -54,10 +54,12 @@ const initClusterManager = () => {
       }, SCHEDULE_TIME);
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping cluster manager');
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Cluster manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/clusterManager.ts
@@ -54,7 +54,7 @@ const initClusterManager = () => {
       }, SCHEDULE_TIME);
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping cluster manager');
       if (scheduler) {
         await clearIntervalAsync(scheduler);

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -145,10 +145,12 @@ const initConnectorManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping connector manager');
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Connector manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/expiredManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/expiredManager.js
@@ -113,10 +113,12 @@ const initExpiredManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping expiration manager');
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Expiration manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -39,6 +39,7 @@ import { allFilesForPaths, getIndexFromDate } from '../modules/internal/document
 import { buildOptionsFromFileManager } from '../domain/file';
 import { internalLoadById } from '../database/middleware-loader';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const FILE_INDEX_MANAGER_KEY = conf.get('file_index_manager:lock_key');
 const SCHEDULE_TIME = conf.get('file_index_manager:interval') || 60000; // 1 minute
@@ -143,11 +144,7 @@ const initFileIndexManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+  const waitTimer = new InterruptibleTimer();
   const fileIndexHandler = async () => {
     const context = executionContext(FILE_INDEX_MANAGER_NAME);
     const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
@@ -194,7 +191,7 @@ const initFileIndexManager = () => {
         await streamProcessor.start(lastEventState ?? 'live');
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
-          await wait(WAIT_TIME_ACTION);
+          await waitTimer.start(WAIT_TIME_ACTION);
         }
         logApp.info('[OPENCTI-MODULE] End of file index manager stream handler');
       } catch (e: any) {
@@ -232,6 +229,7 @@ const initFileIndexManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping file index manager');
       shutdown = true;
+      waitTimer.interrupt();
       if (scheduler) await clearIntervalAsync(scheduler);
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;

--- a/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/fileIndexManager.ts
@@ -227,11 +227,13 @@ const initFileIndexManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping file index manager');
       shutdown = true;
       waitTimer.interrupt();
       if (scheduler) await clearIntervalAsync(scheduler);
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
+      logApp.info(`[OPENCTI-MODULE] File index manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -28,6 +28,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organ
 import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
 import { RELATION_IN_PIR } from '../schema/internalRelationship';
 import { pushAll } from '../utils/arrayUtil';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const HISTORY_ENGINE_KEY = conf.get('history_manager:lock_key');
 const HISTORY_WITH_INFERENCES = booleanConf('history_manager:include_inferences', false);
@@ -283,11 +284,7 @@ const initHistoryManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+  const waitTimer = new InterruptibleTimer();
   const historyHandler = async (lastEventId: string) => {
     let lock;
     try {
@@ -299,7 +296,7 @@ const initHistoryManager = () => {
       await streamProcessor.start(lastEventId);
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of history manager processing');
     } catch (e: any) {
@@ -351,6 +348,7 @@ const initHistoryManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping history manager');
       shutdown = true;
+      waitTimer.interrupt();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/historyManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/historyManager.ts
@@ -346,12 +346,14 @@ const initHistoryManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping history manager');
       shutdown = true;
       waitTimer.interrupt();
       if (scheduler) {
         await clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] History manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -715,10 +715,12 @@ const initIngestionManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] INGESTION - Stopping ingestion manager');
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Ingestion manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/interruptible-timer.ts
+++ b/opencti-platform/opencti-graphql/src/manager/interruptible-timer.ts
@@ -1,0 +1,39 @@
+/**
+ * A timer that can be interrupted, resolving the promise immediately.
+ * Used in manager loops to allow clean shutdown without waiting for the full delay.
+ *
+ * Usage:
+ *   const timer = new InterruptibleTimer();
+ *   await timer.start(5_000); // waits up to 5 seconds
+ *   timer.interrupt(); // resolves immediately from another context
+ */
+export class InterruptibleTimer {
+  private timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  private resolve: (() => void) | null = null;
+
+  interrupt() {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+    this.resolve?.();
+    this.resolve = null;
+  }
+
+  async start(timeMs: number): Promise<void> {
+    // Clean up any previous timer before starting a new one
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+    return new Promise<void>((resolve) => {
+      this.resolve = resolve;
+      this.timeoutId = setTimeout(() => {
+        this.resolve?.();
+        this.resolve = null;
+        this.timeoutId = null;
+      }, timeMs);
+    });
+  }
+}

--- a/opencti-platform/opencti-graphql/src/manager/interruptible-timer.ts
+++ b/opencti-platform/opencti-graphql/src/manager/interruptible-timer.ts
@@ -13,7 +13,7 @@ export class InterruptibleTimer {
   private resolve: (() => void) | null = null;
 
   interrupt() {
-    if (this.timeoutId) {
+    if (this.timeoutId !== null) {
       clearTimeout(this.timeoutId);
       this.timeoutId = null;
     }

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -157,7 +157,7 @@ const initManager = (manager: ManagerDefinition) => {
       };
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
+      const startTime = Date.now();
       logApp.info(`[OPENCTI-MODULE] Stopping ${manager.label}`);
       shutdown = true;
       cronTimer.interrupt();

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -8,9 +8,9 @@ import type { BasicStoreSettings } from '../types/settings';
 import { logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { utcDate } from '../utils/format';
-import { wait } from '../database/utils';
 import type { DataEvent, SseEvent } from '../types/event';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { InterruptibleTimer } from './interruptible-timer';
 
 export interface HandlerInput {
   shutdown?: () => Promise<void>;
@@ -56,6 +56,9 @@ const initManager = (manager: ManagerDefinition) => {
   let running = false;
   let shutdown = false;
 
+  const cronTimer = new InterruptibleTimer();
+  const streamTimer = new InterruptibleTimer();
+
   const cronHandler = async (cronInputFn?: () => Promise<HandlerInput>) => {
     if (manager.cronSchedulerHandler) {
       let lock;
@@ -71,7 +74,7 @@ const initManager = (manager: ManagerDefinition) => {
           logApp.info(`[OPENCTI-MODULE] Running ${manager.label} infinite cron handler`);
           while (!shutdown) {
             await manager.cronSchedulerHandler.handler(cronInput);
-            await wait(manager.cronSchedulerHandler.infiniteInterval);
+            await cronTimer.start(manager.cronSchedulerHandler.infiniteInterval);
           }
         } else if (manager.cronSchedulerHandler.lockInHandlerParams) {
           await manager.cronSchedulerHandler.handler(lock);
@@ -109,7 +112,7 @@ const initManager = (manager: ManagerDefinition) => {
         await streamProcessor.start(startFrom);
         while (!shutdown && streamProcessor.running()) {
           lock.signal.throwIfAborted();
-          await wait(WAIT_TIME_ACTION);
+          await streamTimer.start(WAIT_TIME_ACTION);
         }
         logApp.info(`[OPENCTI-MODULE] End of ${manager.label} stream handler`);
       } catch (e: any) {
@@ -157,6 +160,8 @@ const initManager = (manager: ManagerDefinition) => {
       const startTime = new Date().getTime();
       logApp.info(`[OPENCTI-MODULE] Stopping ${manager.label}`);
       shutdown = true;
+      cronTimer.interrupt();
+      streamTimer.interrupt();
       if (scheduler) {
         if (manager.cronSchedulerHandler?.shutdown) {
           manager.cronSchedulerHandler?.shutdown();

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -36,6 +36,7 @@ import type { Representative } from '../types/store';
 import type { BasicStoreSettings } from '../types/settings';
 import { type BasicStoreEntityNotifier, ENTITY_TYPE_NOTIFIER } from '../modules/notifier/notifier-types';
 import { NOTIFIER_CONNECTOR_WEBHOOK } from '../modules/notifier/notifier-statics';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const NOTIFICATION_LIVE_KEY = conf.get('notification_manager:lock_live_key');
 const NOTIFICATION_DIGEST_KEY = conf.get('notification_manager:lock_digest_key');
@@ -650,11 +651,9 @@ const initNotificationManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+  const liveTimer = new InterruptibleTimer();
+  const cronTimer = new InterruptibleTimer();
+
   const notificationLiveHandler = async () => {
     let lock;
     try {
@@ -667,7 +666,7 @@ const initNotificationManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await liveTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of notification manager processing (live)');
     } catch (e: any) {
@@ -692,7 +691,7 @@ const initNotificationManager = () => {
       while (!shutdown) {
         lock.signal.throwIfAborted();
         await handleDigestNotifications(context);
-        await wait(CRON_SCHEDULE_TIME);
+        await cronTimer.start(CRON_SCHEDULE_TIME);
       }
       logApp.info('[OPENCTI-MODULE] End of notification manager processing (digest)');
     } catch (e: any) {
@@ -722,10 +721,14 @@ const initNotificationManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping notification manager');
       shutdown = true;
+      liveTimer.interrupt();
+      cronTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
+      logApp.info(`[OPENCTI-MODULE] Notification manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -721,7 +721,7 @@ const initNotificationManager = () => {
       };
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping notification manager');
       shutdown = true;
       liveTimer.interrupt();

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -47,6 +47,7 @@ import { listenPirEvents } from './listenPirEventsUtils';
 import { isDebugPlaybook, isValidEventType } from './playbookManagerUtils';
 import { playbookExecutor } from './playbookExecutor';
 import type { BasicConnection, BasicStoreBase } from '../../types/store';
+import { InterruptibleTimer } from '../interruptible-timer';
 import { isModuleActivated } from '../../database/cluster-module';
 
 const PLAYBOOK_LIVE_KEY = conf.get('playbook_manager:lock_key');
@@ -219,6 +220,9 @@ export const executePlaybookOnEntity = async (context: AuthContext, id: string, 
   return false;
 };
 
+const cronTimer = new InterruptibleTimer();
+const streamTimer = new InterruptibleTimer();
+
 const checkManagerDelay = async () => {
   const { lastProcessedEventId, lastStreamEventId, firstStreamEventId, managerInGoodHealth } = await getManagerInfo();
   if (!managerInGoodHealth) {
@@ -233,11 +237,7 @@ const initPlaybookManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+
   const playbookHandler = async () => {
     let lock;
     try {
@@ -251,13 +251,13 @@ const initPlaybookManager = () => {
       let delayCheckerCounter = 0;
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await streamTimer.start(WAIT_TIME_ACTION);
         if (++delayCheckerCounter >= 10) {
           await checkManagerDelay();
           delayCheckerCounter = 0;
         }
       }
-      logApp.info('[OPENCTI-MODULE] End of playbook manager processing');
+      logApp.info('[OPENCTI-MODULE] End of playbook manager processing (live)');
     } catch (e: any) {
       if (e.name === TYPE_LOCK_ERROR) {
         logApp.debug('[OPENCTI-MODULE] Playbook manager already started by another API');
@@ -416,7 +416,7 @@ const initPlaybookManager = () => {
       while (!shutdown) {
         lock.signal.throwIfAborted();
         await handlePlaybookCrons(context);
-        await wait(CRON_SCHEDULE_TIME);
+        await cronTimer.start(CRON_SCHEDULE_TIME);
       }
       logApp.info('[OPENCTI-MODULE] End of playbook manager processing (cron)');
     } catch (e: any) {
@@ -446,10 +446,14 @@ const initPlaybookManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping playbook manager');
       shutdown = true;
+      streamTimer.interrupt();
+      cronTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       if (cronScheduler) await clearIntervalAsync(cronScheduler);
+      logApp.info(`[OPENCTI-MODULE] Playbook manager stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -446,7 +446,7 @@ const initPlaybookManager = () => {
       };
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping playbook manager');
       shutdown = true;
       streamTimer.interrupt();

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -42,6 +42,7 @@ import { EVENT_TYPE_UPDATE } from '../database/utils';
 import { sanitizeNotificationData } from '../utils/templateContextSanitizer';
 import { safeRender } from '../utils/safeEjs.client';
 import { NOTIFICATION_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const DOC_URI = 'https://docs.opencti.io';
 const PUBLISHER_ENGINE_KEY = conf.get('publisher_manager:lock_key');
@@ -515,11 +516,7 @@ const initPublisherManager = () => {
   let running = false;
   let shutdown = false;
   let isSmtpActive = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+  const waitTimer = new InterruptibleTimer();
   const notificationHandler = async () => {
     let lock;
     try {
@@ -536,7 +533,7 @@ const initPublisherManager = () => {
         if (PUBLISHER_ENABLE_BUFFERING) {
           await handleEntityNotificationBuffer();
         }
-        await wait(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of publisher manager processing');
     } catch (e: any) {
@@ -571,6 +568,7 @@ const initPublisherManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping publisher manager');
       shutdown = true;
+      waitTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
       return true;
     },

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -566,10 +566,12 @@ const initPublisherManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping publisher manager');
       shutdown = true;
       waitTimer.interrupt();
       if (streamScheduler) await clearIntervalAsync(streamScheduler);
+      logApp.info(`[OPENCTI-MODULE] Publisher manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -43,6 +43,7 @@ import jsonCanonicalize from 'canonicalize';
 import { v5 as uuidv5 } from 'uuid';
 
 import { pushAll } from '../utils/arrayUtil';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const MIN_LIVE_STREAM_EVENT_VERSION = 4;
 
@@ -296,11 +297,7 @@ const initRuleManager = () => {
   let streamProcessor: StreamProcessor;
   let running = false;
   let shutdown = false;
-  const wait = (ms: number) => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
+  const waitTimer = new InterruptibleTimer();
   const ruleHandler = async () => {
     let lock;
     try {
@@ -323,7 +320,7 @@ const initRuleManager = () => {
       await streamProcessor.start(lastEventState ?? 'live');
       while (!shutdown && streamProcessor.running()) {
         lock.signal.throwIfAborted();
-        await wait(WAIT_TIME_ACTION);
+        await waitTimer.start(WAIT_TIME_ACTION);
       }
       logApp.info('[OPENCTI-MODULE] End of rule manager processing');
     } catch (e: any) {
@@ -340,6 +337,7 @@ const initRuleManager = () => {
   };
   return {
     start: async () => {
+      logApp.info('[OPENCTI-MODULE] Starting rule engine');
       scheduler = setIntervalAsync(async () => {
         await ruleHandler();
       }, SCHEDULE_TIME);
@@ -354,6 +352,7 @@ const initRuleManager = () => {
     shutdown: async () => {
       logApp.info('[OPENCTI-MODULE] Stopping rule engine');
       shutdown = true;
+      waitTimer.interrupt();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }

--- a/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ruleManager.ts
@@ -350,12 +350,14 @@ const initRuleManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping rule engine');
       shutdown = true;
       waitTimer.interrupt();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Rule engine stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -16,10 +16,13 @@ import { createSyncHttpUri, httpBase } from '../domain/connector-utils';
 import { EVENT_CURRENT_VERSION } from '../database/stream/stream-utils';
 import { storeSyncConsumerMetrics, clearSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
 import { createParser } from 'eventsource-parser';
+import { InterruptibleTimer } from './interruptible-timer';
 
 const SYNC_MANAGER_KEY = conf.get('sync_manager:lock_key') || 'sync_manager_lock';
 const SCHEDULE_TIME = conf.get('sync_manager:interval') || 10000;
 const WAIT_TIME_ACTION = 2000;
+
+const waitLoopTimer = new InterruptibleTimer();
 
 const syncManagerInstance = (syncId) => {
   // Variables
@@ -30,6 +33,7 @@ const syncManagerInstance = (syncId) => {
   let lastEventDate; // Track the last saved event date (ISO string) for reconnection
   let running = false;
   let abortController = null;
+
   // Async generator that yields SSE events from a raw HTTP stream.
   // Backpressure is natural: when the consumer is busy processing an event,
   // the generator is suspended, bytes are not read from the socket,
@@ -89,10 +93,13 @@ const syncManagerInstance = (syncId) => {
   return {
     id: syncId,
     stop: () => {
+      const startTime = new Date().getTime();
       logApp.info(`[OPENCTI] Sync ${syncId}: stopping manager`);
       running = false;
+      waitLoopTimer.interrupt();
       if (abortController) abortController.abort();
       clearSyncConsumerMetrics(syncId).catch(() => {});
+      logApp.info(`[OPENCTI] Sync ${syncId}: manager stopped in ${new Date().getTime() - startTime} ms`);
     },
     start: async (context) => {
       running = true;
@@ -190,6 +197,7 @@ const initSyncManager = () => {
   let scheduler;
   let syncListening = true;
   let managerRunning = false;
+
   const syncManagers = new Map();
   const processStep = async () => {
     // Get syncs definition
@@ -230,7 +238,7 @@ const initSyncManager = () => {
     while (syncListening) {
       lock.signal.throwIfAborted();
       await processStep();
-      await wait(WAIT_TIME_ACTION);
+      await waitLoopTimer.start(WAIT_TIME_ACTION);
     }
     // Stopping
     for (const syncManager of syncManagers.values()) {
@@ -272,11 +280,13 @@ const initSyncManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping Sync manager');
       syncListening = false;
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Stopping Sync manager ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -33,7 +33,6 @@ const syncManagerInstance = (syncId) => {
   let lastEventDate; // Track the last saved event date (ISO string) for reconnection
   let running = false;
   let abortController = null;
-
   // Async generator that yields SSE events from a raw HTTP stream.
   // Backpressure is natural: when the consumer is busy processing an event,
   // the generator is suspended, bytes are not read from the socket,
@@ -93,13 +92,10 @@ const syncManagerInstance = (syncId) => {
   return {
     id: syncId,
     stop: () => {
-      const startTime = new Date().getTime();
       logApp.info(`[OPENCTI] Sync ${syncId}: stopping manager`);
       running = false;
-      waitLoopTimer.interrupt();
       if (abortController) abortController.abort();
       clearSyncConsumerMetrics(syncId).catch(() => {});
-      logApp.info(`[OPENCTI] Sync ${syncId}: manager stopped in ${new Date().getTime() - startTime} ms`);
     },
     start: async (context) => {
       running = true;
@@ -197,7 +193,6 @@ const initSyncManager = () => {
   let scheduler;
   let syncListening = true;
   let managerRunning = false;
-
   const syncManagers = new Map();
   const processStep = async () => {
     // Get syncs definition
@@ -280,13 +275,12 @@ const initSyncManager = () => {
       };
     },
     shutdown: async () => {
-      const startTime = new Date().getTime();
       logApp.info('[OPENCTI-MODULE] Stopping Sync manager');
       syncListening = false;
+      waitLoopTimer.interrupt();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
-      logApp.info(`[OPENCTI-MODULE] Stopping Sync manager ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -275,12 +275,14 @@ const initSyncManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE] Stopping Sync manager');
       syncListening = false;
       waitLoopTimer.interrupt();
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] Sync manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -686,10 +686,12 @@ const initTaskManager = () => {
       };
     },
     shutdown: async () => {
+      const startTime = Date.now();
       logApp.info('[OPENCTI-MODULE][TASK-MANAGER] Stopping task manager');
       if (scheduler) {
         return clearIntervalAsync(scheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] task manager stopped in ${Date.now() - startTime} ms`);
       return true;
     },
   };

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -147,6 +147,7 @@ export const addUserLoginCount = () => {
 // End Region user event counters
 
 const telemetryInitializer = async (): Promise<HandlerInput> => {
+  const startTime = new Date().getTime();
   const context = executionContext('telemetry_manager');
   const filigranMetricReaders = [];
   const collectorCallback = async () => {
@@ -214,10 +215,12 @@ const telemetryInitializer = async (): Promise<HandlerInput> => {
   const filigranMeterProvider = new MeterProvider(({ resource, readers: filigranMetricReaders }));
   const filigranTelemetryMeterManager = new TelemetryMeterManager(filigranMeterProvider);
   filigranTelemetryMeterManager.registerFiligranTelemetry();
+  logApp.info(`[TELEMETRY] Initialized in ${new Date().getTime() - startTime} ms`);
   return filigranTelemetryMeterManager;
 };
 
 export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
+  const startTime = new Date().getTime();
   try {
     const context = executionContext('telemetry_manager');
     // region Settings information
@@ -332,7 +335,7 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setFormIntakeSubmittedCount(formIntakeSubmittedCountInRedis);
     // end region Telemetry user events
 
-    logApp.debug('[TELEMETRY] Fetching telemetry data successfully');
+    logApp.debug(`[TELEMETRY] Fetching telemetry data successfully in ${new Date().getTime() - startTime} ms`);
   } catch (e) {
     logApp.error('[TELEMETRY] Error fetching platform information', { cause: e });
   }

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -147,7 +147,7 @@ export const addUserLoginCount = () => {
 // End Region user event counters
 
 const telemetryInitializer = async (): Promise<HandlerInput> => {
-  const startTime = new Date().getTime();
+  const startTime = Date.now();
   const context = executionContext('telemetry_manager');
   const filigranMetricReaders = [];
   const collectorCallback = async () => {
@@ -220,7 +220,7 @@ const telemetryInitializer = async (): Promise<HandlerInput> => {
 };
 
 export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
-  const startTime = new Date().getTime();
+  const startTime = Date.now();
   try {
     const context = executionContext('telemetry_manager');
     // region Settings information

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/interruptible-timer-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/interruptible-timer-test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InterruptibleTimer } from '../../../src/manager/interruptible-timer';
+
+describe('interruptible time test coverage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should start resolve after the specified duration', async () => {
+    const timer = new InterruptibleTimer();
+
+    let resolved = false;
+    const promise = timer.start(60_000).then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await promise;
+
+    expect(resolved).toBe(true);
+  });
+
+  it('should interruption before the end of timer works', async () => {
+    const timer = new InterruptibleTimer();
+
+    let resolved = false;
+    const promise = timer.start(60_000).then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+
+    // Advance only 500ms then interrupt — should resolve without waiting the full 60s
+    await vi.advanceTimersByTimeAsync(500);
+    timer.interrupt();
+    await promise;
+
+    expect(resolved).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Part 1 of https://github.com/OpenCTI-Platform/opencti/pull/14901
* Add an interuptible scheduler and use it in managers sheduler to avoid waiting on stop
* Add log and time
 
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15160

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
