### PR TITLE
[backend] Allow redis stream to be shutdown faster on stop (#15163)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis-stream.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis-stream.ts
@@ -126,10 +126,14 @@ const rawCreateStreamProcessor = <T extends BaseEvent> (
         await processStreamResult([], callback, opts.withInternal);
       }
       const bufferTime = opts.bufferTime ?? 50;
-      if (bufferTime > 0) {
+      if (bufferTime > 0 && streamListening) {
         await wait(bufferTime);
       }
     } catch (err) {
+      // During shutdown, connection errors are expected (client is disconnected to cancel blocking XREAD)
+      if (!streamListening) {
+        return false;
+      }
       logApp.error('Redis stream consume fail', { cause: err, provider });
       if (opts.autoReconnect) {
         await waitInSec(5);
@@ -172,10 +176,14 @@ const rawCreateStreamProcessor = <T extends BaseEvent> (
     shutdown: async () => {
       logApp.info('[STREAM] Shutdown stream processor', { provider });
       streamListening = false;
+      // Disconnect the Redis client to immediately cancel any blocking XREAD
+      if (client) {
+        client.disconnect();
+      }
       if (processingLoopPromise) {
         await processingLoopPromise;
       }
-      logApp.info('[STREAM] Stream processor current promise terminated');
+      logApp.info('[STREAM] Stream processor current promise terminated', { provider });
     },
   };
 };

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-stream-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-stream-test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { createStreamProcessor } from '../../../src/database/stream/stream-handler';
+import type { ActivityStreamEvent, SseEvent } from '../../../src/types/event';
+import { wait } from '../../../src/database/utils';
+import { type StreamProcessor } from '../../../src/database/stream/stream-utils';
+
+describe('Redis stream test coverage', () => {
+  it('Should stream processor works', async () => {
+    const startTime = Date.now();
+    let streamProcessor: StreamProcessor;
+    const streamTestStart = async () => {
+      console.time('Stream start');
+      const streamTestHandler = async (_streamEvents: Array<SseEvent<ActivityStreamEvent>>) => {
+        // Do nothing
+        await wait(100);
+      };
+      streamProcessor = createStreamProcessor('Activity manager', streamTestHandler);
+      await streamProcessor.start(undefined);
+      console.timeEnd('Stream start');
+    };
+
+    const streamTestStop = async () => {
+      console.time('500ms stop');
+      await wait(500);
+      await streamProcessor.shutdown();
+      console.timeEnd('500ms stop');
+    };
+
+    const allPromises = [];
+    allPromises.push(streamTestStart());
+    allPromises.push(streamTestStop());
+    await Promise.all(allPromises);
+
+    // Shudown action should stop stream handler right away
+    const totalTime = Date.now() - startTime;
+    expect(totalTime).toBeLessThan(2_000);
+    expect(totalTime).toBeGreaterThan(200);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-stream-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-stream-test.ts
@@ -26,10 +26,8 @@ describe('Redis stream test coverage', () => {
       console.timeEnd('500ms stop');
     };
 
-    const allPromises = [];
-    allPromises.push(streamTestStart());
-    allPromises.push(streamTestStop());
-    await Promise.all(allPromises);
+    await streamTestStart();
+    await streamTestStop();
 
     // Shudown action should stop stream handler right away
     const totalTime = Date.now() - startTime;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Part 2 of https://github.com/OpenCTI-Platform/opencti/pull/14901
* Close redis stream on stop

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15163 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
