### PR TITLE
[docs] add missing target for installing with Nx (#15694)

### DIFF
--- a/docs/project.json
+++ b/docs/project.json
@@ -1,0 +1,18 @@
+{
+  "name": "docs",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "docs",
+  "projectType": "application",
+  "targets": {
+    "install": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "docs",
+        "command": "pip install -r requirements.txt"
+      },
+      "metadata": {
+        "description": "Install the OpenCTI Documentation dependencies"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add install target to be able to install the documentation dependencies with Nx.

Closes #15694 