### PR TITLE
[backend] Start and stop managers in parallel (#15162)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -154,6 +154,7 @@ const initManager = (manager: ManagerDefinition) => {
       };
     },
     shutdown: async () => {
+      const startTime = new Date().getTime();
       logApp.info(`[OPENCTI-MODULE] Stopping ${manager.label}`);
       shutdown = true;
       if (scheduler) {
@@ -167,6 +168,7 @@ const initManager = (manager: ManagerDefinition) => {
       if (streamScheduler) {
         await clearIntervalAsync(streamScheduler);
       }
+      logApp.info(`[OPENCTI-MODULE] ${manager.label} stopped in ${new Date().getTime() - startTime} ms`);
       return true;
     },
   };
@@ -192,24 +194,34 @@ export const registerManager = (manager: ManagerDefinition) => {
   managersModule.add(managerModule);
 };
 
+export const getAllEnabledManagers = () => {
+  return managersModule.managers
+    .filter((managerModule) => managerModule.manager.enabledToStart());
+};
+
+export const getAllDisabledManagers = () => {
+  return managersModule.managers
+    .filter((managerModule) => !managerModule.manager.enabledToStart());
+};
+
 export const startAllManagers = async () => {
-  for (let i = 0; i < managersModule.managers.length; i += 1) {
-    const managerModule = managersModule.managers[i];
-    if (managerModule.manager.enabledToStart()) {
-      await managerModule.start();
-    } else {
-      logApp.info(`[OPENCTI-MODULE] ${managerModule.manager.label} not started (disabled by configuration)`);
-    }
+  const managersToStart = getAllEnabledManagers();
+  const disabledManagers = getAllDisabledManagers();
+
+  for (let i = 0; i < disabledManagers.length; i += 1) {
+    logApp.info(`[OPENCTI-MODULE] ${disabledManagers[i].manager.label} not started (disabled by configuration)`);
   }
+  await Promise.all(
+    managersToStart.map((managerModule) => managerModule.start()),
+  );
 };
 
 export const shutdownAllManagers = async () => {
-  for (let i = 0; i < managersModule.managers.length; i += 1) {
-    const managerModule = managersModule.managers[i];
-    if (managerModule.manager.enabledToStart()) {
-      await managerModule.shutdown();
-    }
-  }
+  const managersToShutdown = getAllEnabledManagers();
+
+  await Promise.all(
+    managersToShutdown.map((managerModule) => managerModule.shutdown()),
+  );
 };
 
 export const getAllManagersStatuses = (settings: BasicStoreSettings) => {

--- a/opencti-platform/opencti-graphql/src/managers.js
+++ b/opencti-platform/opencti-graphql/src/managers.js
@@ -38,6 +38,8 @@ import authenticationProviderListener from './modules/authenticationProvider/aut
 import supportPackageListener from './modules/support/supportPackage-listener';
 
 export const startModules = async () => {
+  const startingPromises = [];
+
   // region API initialization
   if (ENABLED_API) {
     await httpServer.start();
@@ -46,105 +48,117 @@ export const startModules = async () => {
     logApp.info('[OPENCTI] API not started (disabled by configuration)');
   }
   // endregion
+
   // region Expiration manager
   if (ENABLED_EXPIRED_MANAGER) {
-    await expiredManager.start();
+    startingPromises.push(expiredManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Expiration manager not started (disabled by configuration)');
   }
   // endregion
+
   // region connector manager
   if (ENABLED_CONNECTOR_MANAGER) {
-    await connectorManager.start();
+    startingPromises.push(connectorManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Connector manager not started (disabled by configuration)');
   }
   // endregion
+
   // region import csv built in connector
   if (ENABLED_IMPORT_CSV_BUILT_IN_CONNECTOR) {
-    await importCsvConnector.start();
+    startingPromises.push(importCsvConnector.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Connector built in manager not started (disabled by configuration)');
   }
   // endregion
-  // region draft validation built in connector
-  await draftValidationConnector.start();
 
+  // region draft validation built in connector
+  startingPromises.push(draftValidationConnector.start());
   // endregion
+
   // region Task manager
   if (ENABLED_TASK_SCHEDULER) {
-    await taskManager.start();
+    startingPromises.push(taskManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Task manager not started (disabled by configuration)');
   }
   // endregion
+
   // region Inference engine
   if (ENABLED_RULE_ENGINE) {
-    await ruleEngine.start();
+    startingPromises.push(ruleEngine.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Rule engine not started (disabled by configuration)');
   }
   // endregion
+
   // region Sync manager
   if (ENABLED_SYNC_MANAGER) {
-    await syncManager.start();
+    startingPromises.push(syncManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Sync manager not started (disabled by configuration)');
   }
   if (ENABLED_INGESTION_MANAGER) {
-    await ingestionManager.start();
+    startingPromises.push(ingestionManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Ingestion manager not started (disabled by configuration)');
   }
   // endregion
+
   // region History manager
   if (ENABLED_HISTORY_MANAGER) {
-    await historyManager.start();
+    startingPromises.push(historyManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] History manager not started (disabled by configuration)');
   }
   // endregion
+
   // region notification
   if (ENABLED_NOTIFICATION_MANAGER) {
-    await notificationManager.start();
+    startingPromises.push(notificationManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Notification manager not started (disabled by configuration)');
   }
   if (ENABLED_PUBLISHER_MANAGER) {
-    await publisherManager.start();
+    startingPromises.push(publisherManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Publisher manager not started (disabled by configuration)');
   }
   // endregion
+
   // region playbook manager
   if (ENABLED_PLAYBOOK_MANAGER) {
-    await playbookManager.start();
+    startingPromises.push(playbookManager.start());
   } else {
     logApp.info('[OPENCTI-MODULE] Playbook manager not started (disabled by configuration)');
   }
   if (ENABLED_FILE_INDEX_MANAGER && isAttachmentProcessorEnabled()) {
-    await fileIndexManager.start();
+    startingPromises.push(fileIndexManager.start());
   } else if (ENABLED_FILE_INDEX_MANAGER && !isAttachmentProcessorEnabled()) {
     logApp.info('[OPENCTI-MODULE] File index manager not started : attachment processor is not configured.');
   } else {
     logApp.info('[OPENCTI-MODULE] File index manager not started (disabled by configuration)');
   }
 
+  // endregion
+  // region Cluster manager
+  startingPromises.push(clusterManager.start());
+  // endregion
+
+  // region Audit
+  startingPromises.push(activityListener.start());
+  startingPromises.push(activityManager.start());
+  // endregion
+
+  startingPromises.push(supportPackageListener.start());
+  startingPromises.push(authenticationProviderListener.start());
+
+  await Promise.all(startingPromises);
+
   // refactoring in module in progress
   // all managers will be started only in this method
   await startAllManagers();
-
-  // endregion
-  // region Cluster manager
-  await clusterManager.start();
-  // endregion
-  // region Audit
-  await activityListener.start();
-  await activityManager.start();
-  // endregion
-
-  await supportPackageListener.start();
-  await authenticationProviderListener.start();
 };
 
 export const shutdownModules = async () => {
@@ -210,13 +224,9 @@ export const shutdownModules = async () => {
   // endregion
   // region file index manager
   if (ENABLED_FILE_INDEX_MANAGER && isAttachmentProcessorEnabled()) {
-    await fileIndexManager.shutdown();
+    stoppingPromises.push(fileIndexManager.shutdown());
   }
   // endregion
-
-  // refactoring in module in progress
-  // all managers will be started only in this method
-  await shutdownAllManagers();
 
   // endregion
   // region Cluster manager
@@ -229,5 +239,9 @@ export const shutdownModules = async () => {
   stoppingPromises.push(supportPackageListener.shutdown());
   stoppingPromises.push(authenticationProviderListener.shutdown());
   await Promise.all(stoppingPromises);
+
+  // refactoring in module in progress
+  // all managers will be shutdown only in this method
+  await shutdownAllManagers();
 };
 // endregion

--- a/opencti-platform/opencti-graphql/src/managers.js
+++ b/opencti-platform/opencti-graphql/src/managers.js
@@ -141,11 +141,6 @@ export const startModules = async () => {
     logApp.info('[OPENCTI-MODULE] File index manager not started (disabled by configuration)');
   }
 
-  // endregion
-  // region Cluster manager
-  startingPromises.push(clusterManager.start());
-  // endregion
-
   // region Audit
   startingPromises.push(activityListener.start());
   startingPromises.push(activityManager.start());
@@ -159,6 +154,9 @@ export const startModules = async () => {
   // refactoring in module in progress
   // all managers will be started only in this method
   await startAllManagers();
+
+  // cluster manager checks all manager statuses, so better at the end
+  await clusterManager.start();
 };
 
 export const shutdownModules = async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpUtils-test.ts
@@ -66,7 +66,7 @@ describe('buildHelmetParameters coverage', () => {
     vi.restoreAllMocks();
   });
 
-  it('should most secure option works file', () => {
+  it('should most secure option works fine', () => {
     vi.spyOn(httpConfig, 'isDevMode').mockReturnValue(false);
     vi.spyOn(httpConfig, 'isUnsecureHttpResourceAllowed').mockReturnValue(false);
     vi.spyOn(httpConfig, 'getPublicAuthorizedDomainsFromConfiguration').mockReturnValue('');

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getAllEnabledManagers, getAllManagersStatuses, registerManager, shutdownAllManagers, startAllManagers } from '../../../../src/manager/managerModule';
+import { getSettings } from '../../../../src/domain/settings';
+import { testContext } from '../../../utils/testQuery';
+import type { BasicStoreSettings } from '../../../../src/types/settings';
+
+// Enable testManager to run
+import './testManager';
+import { TEST_MANAGER_DEFINITION } from './testManager';
+
+describe('Manager module tests ', () => {
+  it('should startup and shutdown and startup be a noop', async () => {
+    registerManager(TEST_MANAGER_DEFINITION);
+    await startAllManagers();
+
+    const allManagers = getAllEnabledManagers();
+    const myTestManager = allManagers.find((manager) => manager.manager.id === 'TEST_MANAGER');
+
+    // We should be able to check the running state, but there is an issue with this boolean.
+    expect(myTestManager?.manager.enabledByConfig).toBeTruthy();
+
+    const settings = await getSettings(testContext) as unknown as BasicStoreSettings;
+    const managerStatus = getAllManagersStatuses(settings);
+    const testManagerStatus1 = managerStatus.find((manager) => manager.id === 'TEST_MANAGER');
+    expect(testManagerStatus1?.enable).toBeTruthy();
+
+    await shutdownAllManagers();
+
+    await startAllManagers();
+    const managerStatusAtTheEnd = getAllManagersStatuses(settings);
+    const testManagerStatusAtTheEnd = managerStatusAtTheEnd.find((manager) => manager.id === 'TEST_MANAGER');
+    expect(testManagerStatusAtTheEnd?.enable).toBeTruthy();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getAllEnabledManagers, getAllManagersStatuses, registerManager, shutdownAllManagers, startAllManagers } from '../../../../src/manager/managerModule';
+import { getAllEnabledManagers, getAllManagersStatuses, registerManager } from '../../../../src/manager/managerModule';
 import { getSettings } from '../../../../src/domain/settings';
 import { testContext } from '../../../utils/testQuery';
 import type { BasicStoreSettings } from '../../../../src/types/settings';
@@ -7,11 +7,11 @@ import type { BasicStoreSettings } from '../../../../src/types/settings';
 // Enable testManager to run
 import './testManager';
 import { TEST_MANAGER_DEFINITION } from './testManager';
+import { wait } from '../../../../src/database/utils';
 
 describe('Manager module tests ', () => {
-  it('should startup and shutdown and startup be a noop', async () => {
+  it('should manage be able to start and stop', async () => {
     registerManager(TEST_MANAGER_DEFINITION);
-    await startAllManagers();
 
     const allManagers = getAllEnabledManagers();
     const myTestManager = allManagers.find((manager) => manager.manager.id === 'TEST_MANAGER');
@@ -19,16 +19,19 @@ describe('Manager module tests ', () => {
     // We should be able to check the running state, but there is an issue with this boolean.
     expect(myTestManager?.manager.enabledByConfig).toBeTruthy();
 
+    await myTestManager?.start();
+    await wait(200);
+
     const settings = await getSettings(testContext) as unknown as BasicStoreSettings;
     const managerStatus = getAllManagersStatuses(settings);
     const testManagerStatus1 = managerStatus.find((manager) => manager.id === 'TEST_MANAGER');
     expect(testManagerStatus1?.enable).toBeTruthy();
 
-    await shutdownAllManagers();
+    await myTestManager?.shutdown();
+    await wait(100);
 
-    await startAllManagers();
-    const managerStatusAtTheEnd = getAllManagersStatuses(settings);
-    const testManagerStatusAtTheEnd = managerStatusAtTheEnd.find((manager) => manager.id === 'TEST_MANAGER');
-    expect(testManagerStatusAtTheEnd?.enable).toBeTruthy();
+    const managerStatus2 = getAllManagersStatuses(settings);
+    const testManagerStatus2 = managerStatus2.find((manager) => manager.id === 'TEST_MANAGER');
+    expect(testManagerStatus2?.running).toBeFalsy();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-test.ts
@@ -4,8 +4,6 @@ import { getSettings } from '../../../../src/domain/settings';
 import { testContext } from '../../../utils/testQuery';
 import type { BasicStoreSettings } from '../../../../src/types/settings';
 
-// Enable testManager to run
-import './testManager';
 import { TEST_MANAGER_DEFINITION } from './testManager';
 import { wait } from '../../../../src/database/utils';
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/testManager.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/testManager.ts
@@ -1,0 +1,27 @@
+import { logApp } from '../../../../src/config/conf';
+import { type ManagerDefinition } from '../../../../src/manager/managerModule';
+
+/**
+ * This is an empty manager to validate manager module
+ */
+export const cronTestManager = async () => {
+  logApp.info('[TEST] test manager is running');
+};
+
+export const TEST_MANAGER_DEFINITION: ManagerDefinition = {
+  id: 'TEST_MANAGER',
+  label: 'Test manager',
+  executionContext: 'test_manager',
+  cronSchedulerHandler: {
+    handler: cronTestManager,
+    interval: 1000,
+    lockKey: 'test_manager_lock',
+  },
+  enabledByConfig: true,
+  enabledToStart(): boolean {
+    return this.enabledByConfig;
+  },
+  enabled(): boolean {
+    return this.enabledByConfig;
+  },
+};

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/testManager.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/testManager.ts
@@ -14,7 +14,7 @@ export const TEST_MANAGER_DEFINITION: ManagerDefinition = {
   executionContext: 'test_manager',
   cronSchedulerHandler: {
     handler: cronTestManager,
-    interval: 1000,
+    interval: 100,
     lockKey: 'test_manager_lock',
   },
   enabledByConfig: true,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Part 4 of https://github.com/OpenCTI-Platform/opencti/pull/14901
* Start and stop manager in parallel instead of one after the other

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15162 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
