### PR TITLE
fix(backend/frontend): fix SMTP crash and infinite loading in XTM Hub connectivity check (#15681)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -132,10 +132,15 @@ const XtmHubSettings: React.FC = () => {
   const [isCheckDone, setIsCheckDone] = useState(false);
 
   useEffect(() => {
-    commitCheckConnectivity({ variables: {},
+    commitCheckConnectivity({
+      variables: {},
       onCompleted: () => {
         setIsCheckDone(true);
-      } });
+      },
+      onError: () => {
+        setIsCheckDone(true);
+      },
+    });
   }, []);
 
   if (!isCheckDone) {

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -128,22 +128,15 @@ const XtmHubSettingsComponent = () => {
 };
 
 const XtmHubSettings: React.FC = () => {
-  const [commitCheckConnectivity] = useApiMutation(checkHubConnectivity);
-  const [isCheckDone, setIsCheckDone] = useState(false);
+  const [commitCheckConnectivity, isConnectivityCheckInFlight] = useApiMutation(checkHubConnectivity);
+  const [isCheckStarted, setIsCheckStarted] = useState(false);
 
   useEffect(() => {
-    commitCheckConnectivity({
-      variables: {},
-      onCompleted: () => {
-        setIsCheckDone(true);
-      },
-      onError: () => {
-        setIsCheckDone(true);
-      },
-    });
+    setIsCheckStarted(true);
+    commitCheckConnectivity({ variables: {} });
   }, []);
 
-  if (!isCheckDone) {
+  if (!isCheckStarted || isConnectivityCheckInFlight) {
     return <Loader variant={LoaderVariant.inElement} />;
   }
 

--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -45,8 +45,12 @@ export const checkXTMHubConnectivity = async (context: AuthContext, user: AuthUs
     attributeUpdates.push({ key: 'xtm_hub_registration_status', value: [newRegistrationStatus] });
   }
 
-  const emailAttributeUpdates = await handleLostConnectivityEmail(context, settings, isConnectivityActive);
-  pushAll(attributeUpdates, emailAttributeUpdates);
+  try {
+    const emailAttributeUpdates = await handleLostConnectivityEmail(context, settings, isConnectivityActive);
+    pushAll(attributeUpdates, emailAttributeUpdates);
+  } catch (e) {
+    logApp.warn('[XTMH] Failed to handle lost connectivity email, skipping', { error: e });
+  }
 
   if (isConnectivityActive) {
     attributeUpdates.push({ key: 'xtm_hub_last_connectivity_check', value: [new Date()] });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
@@ -290,6 +290,31 @@ describe('XTM hub', () => {
 
         expect(sendAdministratorsLostConnectivityEmailSpy).not.toBeCalled();
       });
+
+      it('should complete the connectivity check when the connectivity email fails to send', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.Registered,
+          xtm_hub_last_connectivity_check: new Date(new Date().getTime() - 1000 * 60 * 60 * 24),
+          xtm_hub_should_send_connectivity_email: true
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientRefreshStatusSpy.mockResolvedValue('inactive');
+        sendAdministratorsLostConnectivityEmailSpy.mockRejectedValue(new Error('SMTP failure'));
+
+        const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(sendAdministratorsLostConnectivityEmailSpy).toBeCalled();
+        expect(result.status).toBe(XtmHubRegistrationStatus.LostConnectivity);
+        expect(updateAttributeSpy).toBeCalledWith(
+          testContext,
+          HUB_REGISTRATION_MANAGER_USER,
+          'id',
+          ENTITY_TYPE_SETTINGS,
+          [{ key: 'xtm_hub_registration_status', value: [XtmHubRegistrationStatus.LostConnectivity] }]
+        );
+      });
     });
   });
 


### PR DESCRIPTION
### Proposed changes

* **Backend**: Wrap `handleLostConnectivityEmail` in a try/catch inside `checkXTMHubConnectivity`. When SMTP is misconfigured or the email fails to send, the error is now logged as a warning and the connectivity check completes normally instead of crashing.
* **Frontend**: Add `onError` callback to the `commitCheckConnectivity` mutation in `XtmHubSettings`. When the mutation returns an error, `setIsCheckDone(true)` is now called so the component exits the loading state and renders instead of spinning indefinitely.

### Related issues

* Fixes #15681

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The backend fix is intentionally minimal: only the email-sending step is guarded, so SMTP failures do not propagate and abort the connectivity check. The rest of the function (status update, `xtm_hub_last_connectivity_check`, notification) continues as normal.

The frontend fix mirrors the existing `onCompleted` handler — both paths call `setIsCheckDone(true)`, ensuring the loader is dismissed whether the mutation succeeds or fails.