### PR TITLE
[backend] Use default secure CSP as base for CSP (#15087)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpUtils.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpUtils.ts
@@ -114,9 +114,9 @@ export const buildPublicHelmetParameters = () => {
     crossOriginOpenerPolicy: false,
     crossOriginResourcePolicy: false,
     contentSecurityPolicy: {
-      useDefaults: false,
+      useDefaults: true,
       directives: {
-        defaultSrc: ["'self'"],
+        defaultSrc: ["'none'"],
         scriptSrc: buildScriptSrc(),
         styleSrc: ["'self'", "'unsafe-inline'"],
         scriptSrcAttr: ["'none'"],
@@ -142,9 +142,9 @@ export const buildDefaultHelmetParameters = () => {
     crossOriginOpenerPolicy: false,
     crossOriginResourcePolicy: false,
     contentSecurityPolicy: {
-      useDefaults: false,
+      useDefaults: true,
       directives: {
-        defaultSrc: ["'self'"],
+        defaultSrc: ["'none'"],
         scriptSrc: buildScriptSrc(),
         styleSrc: ["'self'", "'unsafe-inline'"],
         scriptSrcAttr: ["'none'"],

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpUtils-test.ts
@@ -75,7 +75,7 @@ describe('buildHelmetParameters coverage', () => {
       contentSecurityPolicy: {
         directives: {
           connectSrc: ["'self'", 'wss://*', 'data:', 'https://*'],
-          defaultSrc: ["'self'"],
+          defaultSrc: ["'none'"],
           fontSrc: ["'self'", 'data:'],
           frameAncestors: "'none'",
           frameSrc: ["'self'"],
@@ -86,7 +86,7 @@ describe('buildHelmetParameters coverage', () => {
           scriptSrcAttr: ["'none'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
         },
-        useDefaults: false,
+        useDefaults: true,
       },
       crossOriginEmbedderPolicy: false,
       crossOriginOpenerPolicy: false,
@@ -102,7 +102,7 @@ describe('buildHelmetParameters coverage', () => {
       contentSecurityPolicy: {
         directives: {
           connectSrc: ["'self'", 'wss://*', 'data:', 'https://*'],
-          defaultSrc: ["'self'"],
+          defaultSrc: ["'none'"],
           fontSrc: ["'self'", 'data:'],
           frameAncestors: "'none'",
           imgSrc: ["'self'", 'data:', 'https://*'],
@@ -112,7 +112,7 @@ describe('buildHelmetParameters coverage', () => {
           scriptSrcAttr: ["'none'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
         },
-        useDefaults: false,
+        useDefaults: true,
       },
       crossOriginEmbedderPolicy: false,
       crossOriginOpenerPolicy: false,

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpUtils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpUtils-test.ts
@@ -134,7 +134,7 @@ describe('buildHelmetParameters coverage', () => {
       contentSecurityPolicy: {
         directives: {
           connectSrc: ["'self'", 'wss://*', 'data:', 'https://*', 'http://*', 'ws://*'],
-          defaultSrc: ["'self'"],
+          defaultSrc: ["'none'"],
           fontSrc: ["'self'", 'data:'],
           frameAncestors: 'https://myctidomain.com',
           frameSrc: ["'self'"],
@@ -145,7 +145,7 @@ describe('buildHelmetParameters coverage', () => {
           scriptSrcAttr: ["'none'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
         },
-        useDefaults: false,
+        useDefaults: true,
       },
       crossOriginEmbedderPolicy: false,
       crossOriginOpenerPolicy: false,
@@ -161,7 +161,7 @@ describe('buildHelmetParameters coverage', () => {
       contentSecurityPolicy: {
         directives: {
           connectSrc: ["'self'", 'wss://*', 'data:', 'https://*', 'http://*', 'ws://*'],
-          defaultSrc: ["'self'"],
+          defaultSrc: ["'none'"],
           fontSrc: ["'self'", 'data:'],
           frameAncestors: "'none'",
           imgSrc: ["'self'", 'data:', 'https://*', 'http://*'],
@@ -171,7 +171,7 @@ describe('buildHelmetParameters coverage', () => {
           scriptSrcAttr: ["'none'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
         },
-        useDefaults: false,
+        useDefaults: true,
       },
       crossOriginEmbedderPolicy: false,
       crossOriginOpenerPolicy: false,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Some directive where not present because the CSP was not starting from the default one.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15087 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
