### PR TITLE
[backend] removed feature flag on security coverage result page (#13488)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -25,7 +25,6 @@ import { OaevLogo } from '../../../../static/images/logo_oaev';
 import ExternalLinkPopover from '../../../../components/ExternalLinkPopover';
 import { RootSecurityCoverageSubscription } from '@components/analyses/security_coverages/__generated__/RootSecurityCoverageSubscription.graphql';
 import SecurityCoverageResult from '@components/analyses/security_coverages/SecurityCoverageResult';
-import useHelper from '../../../../utils/hooks/useHelper';
 import { PATH_SECURITY_COVERAGE, PATH_SECURITY_COVERAGES } from '@components/common/routes/paths';
 
 const subscription = graphql`
@@ -75,9 +74,6 @@ type RootSecurityCoverageProps = {
 };
 
 const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCoverageProps) => {
-  const { isFeatureEnable } = useHelper();
-  const isOAEVResultFeatureEnabled = isFeatureEnable('OEAV_SECURITY_COVERAGE_RESULT_PAGE');
-
   const location = useLocation();
   const { t_i18n } = useFormatter();
   const {
@@ -132,7 +128,7 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
             pages={{
               overview:
                 <SecurityCoverage data={securityCoverage} />,
-              ...(isOAEVResultFeatureEnabled ? { result: <SecurityCoverageResult id={securityCoverage.id} /> } : {}),
+              result: <SecurityCoverageResult id={securityCoverage.id} />,
               content: (
                 <StixCoreObjectContentRoot
                   stixCoreObject={securityCoverage}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removed feature flag `'OEAV_SECURITY_COVERAGE_RESULT_PAGE'`

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #13488 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
