### PR TITLE
[frontend] Fix creators display in Home dashboard last report widget (#15704)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableUtils.tsx
@@ -211,6 +211,13 @@ const defaultColumns: DataTableProps['dataColumns'] = {
       return <Tag label={context} />;
     },
   },
+  coverage_last_result: {
+    id: 'coverage_last_result',
+    label: 'Last result',
+    percentWidth: 12,
+    isSortable: true,
+    render: ({ coverage_last_result }, { fndt }) => fndt(coverage_last_result),
+  },
   created: {
     id: 'created',
     label: 'Original creation date',
@@ -225,13 +232,6 @@ const defaultColumns: DataTableProps['dataColumns'] = {
     isSortable: true,
     render: ({ created_at }, helpers) => defaultRender(helpers.fd(created_at)),
   },
-  coverage_last_result: {
-    id: 'coverage_last_result',
-    label: 'Last result',
-    percentWidth: 12,
-    isSortable: true,
-    render: ({ coverage_last_result }, { fndt }) => fndt(coverage_last_result),
-  },
   createdBy: {
     id: 'createdBy',
     label: 'Author',
@@ -240,6 +240,15 @@ const defaultColumns: DataTableProps['dataColumns'] = {
   },
   creator: {
     id: 'creator',
+    label: 'Creators',
+    percentWidth: 12,
+    render: ({ creators }) => {
+      const value = creators?.map((c: { name: string }) => c.name);
+      return defaultRender(value);
+    },
+  },
+  creators: {
+    id: 'creators',
     label: 'Creators',
     percentWidth: 12,
     render: ({ creators }) => {


### PR DESCRIPTION
### Proposed changes
Fix regression introduced in https://github.com/OpenCTI-Platform/opencti/pull/15489

In Home dashboard, display the creators of the last report widget : 

<img width="1095" height="182" alt="image" src="https://github.com/user-attachments/assets/d8ff17d9-bc0e-4fdb-a14e-12de0804c3b6" />


### Related issues
fixes #15704