### PR TITLE
[frontend] Trigger logout when clicking logout button on TimeoutLock modal (#15654)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -131,9 +131,14 @@ const TimeoutLock: React.FunctionComponent = () => {
    * Going to /logout disconnects the user from the platform (see backend middleware).
    * Referrer is kept so user will be redirected there on next login.
    */
-  const handleLogout = () => {
-    // better than using navigate because it makes a HTTP request to /logout on the backend
+
+  const logout = () => {
     window.location.assign(`${APP_BASE_PATH}/logout`);
+  };
+
+  const handleLogout = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    logout();
   };
 
   /**
@@ -219,7 +224,7 @@ const TimeoutLock: React.FunctionComponent = () => {
       secondsBetween >= state.sessionLimit
       || (state.idleCount !== undefined && state.idleCount <= 0 && dialogOpen)
     ) {
-      handleLogout();
+      logout();
     }
     // Lock the screen for the remaining session time
     if (state.idleLimit > 0 && secondsBetween >= state.idleLimit && secondsBetween < state.sessionLimit) {
@@ -255,7 +260,7 @@ const TimeoutLock: React.FunctionComponent = () => {
       </DialogContentText>
 
       <DialogActions>
-        <Button variant="secondary" onClick={() => handleLogout()}>
+        <Button variant="secondary" onClick={handleLogout}>
           {t_i18n('Logout')}
         </Button>
         <Button onClick={() => unlockScreen()}>


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Update logout handling to prevent propagation of click event 
*  Perform a hard navigation so it can trigger redis to terminate the session

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fixes #15654 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
