### PR TITLE
[backend] Ensure no events are lost if Playbook manager error at processing (#15672)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -56,21 +56,21 @@ const STREAM_SCHEDULE_TIME = 10000;
 const CRON_SCHEDULE_TIME = 60000; // 1 minute
 
 const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEvent>>) => {
-  try {
-    if (streamEvents.length === 0) {
-      return;
-    }
-    const context = executionContext(PLAYBOOK_MANAGER_NAME);
-    const isEE = await isEnterpriseEdition(context);
-    if (!isEE) {
-      return;
-    }
-    const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
-    for (let index = 0; index < streamEvents.length; index += 1) {
-      const streamEvent = streamEvents[index];
-      const { id: eventId, data: { data, type, origin, scope } } = streamEvent;
-      // For each event we need to check ifs
-      for (let playbookIndex = 0; playbookIndex < playbooks.length; playbookIndex += 1) {
+  if (streamEvents.length === 0) {
+    return;
+  }
+  const context = executionContext(PLAYBOOK_MANAGER_NAME);
+  const isEE = await isEnterpriseEdition(context);
+  if (!isEE) {
+    return;
+  }
+  const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
+  for (let index = 0; index < streamEvents.length; index += 1) {
+    const streamEvent = streamEvents[index];
+    const { id: eventId, data: { data, type, origin, scope } } = streamEvent;
+    // For each event we need to check ifs
+    for (let playbookIndex = 0; playbookIndex < playbooks.length; playbookIndex += 1) {
+      try { // try catch per playbook and per event to avoid losing events if an error is thrown on a playbook event
         const playbook = playbooks[playbookIndex];
         // Execute only of definition is available
         if (playbook.playbook_definition) {
@@ -123,11 +123,11 @@ const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEven
             }
           }
         }
+      } catch (e) {
+        logApp.error('[OPENCTI-MODULE] Playbook manager stream error', { cause: e, manager: 'PLAYBOOK_MANAGER' });
       }
-      await redisSetManagerEventState(PLAYBOOK_MANAGER_NAME, streamEvent.id);
     }
-  } catch (e) {
-    logApp.error('[OPENCTI-MODULE] Playbook manager stream error', { cause: e, manager: 'PLAYBOOK_MANAGER' });
+    await redisSetManagerEventState(PLAYBOOK_MANAGER_NAME, streamEvent.id);
   }
 };
 


### PR DESCRIPTION
### Proposed changes
In playbook manager, when the error 'Playbook manager stream error' is thrown, we lose the whole batch of events for consumption.
-> Change the general try/catch for a try/catch per playbook and event, to prevent losing events on other playbooks.

### Related issues
fixes #15672