### PR TITLE
[backend] Fix playbook filtering cache management (#14285)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -100,10 +100,9 @@ export const extractResolvedFiltersFromInstance = (instance: BasicStoreCommon) =
     const configurations = definition.nodes.map((n) => JSON.parse(n.configuration));
     // IDs from filters in playbook components.
     const playbookFilterIds = configurations
-      .map((config) => config.filters)
+      .flatMap((config) => [config.filters, config.applyWithFilters])
       .filter((f) => isNotEmptyField(f))
-      .map((f) => extractFilterGroupValuesToResolveForCache(JSON.parse(f)))
-      .flat();
+      .flatMap((f) => extractFilterGroupValuesToResolveForCache(JSON.parse(f)));
     // IDs from list of PIRs to listen.
     const playbookInPirFilterIds = configurations
       .map((config) => config.inPirFilters)

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/container-wrapper-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/container-wrapper-component-test.ts
@@ -5,6 +5,7 @@ import { testBundleObject, testExecutor } from './playbook-components-test-utils
 import type { StixRelation } from '../../../../src/types/stix-2-1-sro';
 import { playbookBundleElementsToApply } from '../../../../src/modules/playbook/playbook-types';
 import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+import type { StixDomainObject } from '../../../../src/types/stix-2-1-common';
 
 const componentConfig = (config: Partial<ContainerWrapperConfiguration>) => {
   return {
@@ -21,11 +22,13 @@ describe('PLAYBOOK_CONTAINER_WRAPPER_COMPONENT', () => {
   const MALWARE_ID = 'malware--09bd862a-f030-55f2-920a-900c4913d9ff';
   const CAMPAIGN_ID = 'campaign--6bcf59ca-70c8-55ae-ac7d-a6f9b107a35b';
   const REL_ID = 'relationship--08e64f51-e890-5bec-be34-3344746f1b0c';
+  const LABEL_ID = '98d475ca-0f72-4878-8d64-de2e094f007e';
 
   const BUNDLE_OBJECTS = () => [
-    testBundleObject({
+    testBundleObject<StixDomainObject>({
       id: MALWARE_ID,
       type: 'Malware',
+      labels: [LABEL_ID],
     }),
     testBundleObject({
       id: CAMPAIGN_ID,
@@ -122,6 +125,7 @@ describe('PLAYBOOK_CONTAINER_WRAPPER_COMPONENT', () => {
     const filterCampaign = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Campaign"],"mode":"or"}],"filterGroups":[]}';
     const filterMalware = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Malware"],"mode":"or"}],"filterGroups":[]}';
     const filterMalwareCampaign = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Malware","Campaign"],"mode":"or"}],"filterGroups":[]}';
+    const filterLabel = JSON.stringify({ mode: 'or', filters: [{ key: ['objectLabel'], operator: 'eq', values: [LABEL_ID], mode: 'or' }], filterGroups: [] });
 
     it('should add nothing if no match (only-main)', async () => {
       const result = await PLAYBOOK_CONTAINER_WRAPPER_COMPONENT.executor(testExecutor({
@@ -166,6 +170,21 @@ describe('PLAYBOOK_CONTAINER_WRAPPER_COMPONENT', () => {
       const reportResult = result.bundle.objects
         .find((element) => element.type === 'report') as StixContainer;
       expect(reportResult.object_refs).toEqual([]);
+    });
+
+    it('should add only the matching label element with label filter (all-elements)', async () => {
+      const result = await PLAYBOOK_CONTAINER_WRAPPER_COMPONENT.executor(testExecutor({
+        mainId: MALWARE_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allElements.value,
+          applyWithFilters: filterLabel,
+        }),
+      }));
+
+      const reportResult = result.bundle.objects
+        .find((element) => element.type === 'report') as StixContainer;
+      expect(reportResult.object_refs).toEqual([MALWARE_ID]);
     });
 
     it('should add only campaign if partial match (all-elements)', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/create-indicator-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/create-indicator-component-test.ts
@@ -6,7 +6,7 @@ import type { StixIndicator } from '../../../../src/modules/indicator/indicator-
 import type { StixRelation } from '../../../../src/types/stix-2-1-sro';
 import { RELATION_BASED_ON, RELATION_INDICATES } from '../../../../src/schema/stixCoreRelationship';
 import type { StixId } from '../../../../src/types/stix-2-0-common';
-import type { StixCyberObject } from '../../../../src/types/stix-2-1-common';
+import type { CyberObjectExtension, StixCyberObject } from '../../../../src/types/stix-2-1-common';
 import { playbookBundleElementsToApply } from '../../../../src/modules/playbook/playbook-types';
 import type { StixInternalExternalReference } from '../../../../src/types/stix-2-1-smo';
 
@@ -17,16 +17,16 @@ const LABEL_ID = '98d475ca-0f72-4878-8d64-de2e094f007e';
 
 const FAKE_PATTERN = "[domain-name:value = 'malicious.example.com']";
 
-const domainObservable = (id: StixId = OBSERVABLE_ID, withLabel?: boolean) =>
-  testBundleObject<StixCyberObject & { value: string; labels: string[] }>({
-    id,
+const domainObservable = (objectProperties?: { id: StixId; scoExtension?: Partial<CyberObjectExtension> }) =>
+  testBundleObject<StixCyberObject & { value: string }>({
+    id: OBSERVABLE_ID, // default, is replaced by objectProperties.id if existing
     type: 'domain-name',
     value: 'malicious.example.com',
-    ...(withLabel ? { labels: [LABEL_ID] } : {}),
     octiExtension: {
       type: 'Domain-Name',
       id: '',
     },
+    ...objectProperties,
   });
 
 const reportObject = () =>
@@ -134,7 +134,7 @@ describe('Create indicator component', () => {
     const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
       testExecutor({
         mainId: OBSERVABLE_ID,
-        bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+        bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
         configuration: { applyToElements: playbookBundleElementsToApply.allElements.value, wrap_in_container: false, types: [] },
       }),
     );
@@ -160,7 +160,7 @@ describe('Create indicator component', () => {
     const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
       testExecutor({
         mainId: OBSERVABLE_ID,
-        bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+        bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
         configuration: { applyToElements: playbookBundleElementsToApply.allExceptMain.value, wrap_in_container: false, types: [] },
       }),
     );
@@ -187,7 +187,7 @@ describe('Create indicator component', () => {
     const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
       testExecutor({
         mainId: OBSERVABLE_ID,
-        bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+        bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
         configuration: { applyToElements: playbookBundleElementsToApply.onlyMain.value, wrap_in_container: false, types: [] },
       }),
     );
@@ -288,7 +288,7 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.allElements.value,
             applyWithFilters: filterDomainNames,
@@ -317,7 +317,12 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID, true), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable(
+            {
+              id: OBSERVABLE_ID,
+              scoExtension: {
+                labels: [LABEL_ID],
+              } }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.allElements.value,
             applyWithFilters: filterLabel,
@@ -346,7 +351,7 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.allElements.value,
             applyWithFilters: filterNotMatching,
@@ -369,7 +374,7 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.onlyMain.value,
             applyWithFilters: filterDomainNames,
@@ -398,7 +403,7 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.onlyMain.value,
             applyWithFilters: filterNotMatching,
@@ -421,7 +426,7 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.allExceptMain.value,
             applyWithFilters: filterDomainNames,
@@ -450,7 +455,7 @@ describe('Create indicator component', () => {
       const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
         testExecutor({
           mainId: OBSERVABLE_ID,
-          bundleObjects: [domainObservable(OBSERVABLE_ID), domainObservable(OBSERVABLE_ID_2)],
+          bundleObjects: [domainObservable({ id: OBSERVABLE_ID }), domainObservable({ id: OBSERVABLE_ID_2 })],
           configuration: {
             applyToElements: playbookBundleElementsToApply.allExceptMain.value,
             applyWithFilters: filterNotMatching,
@@ -474,8 +479,8 @@ describe('Create indicator component', () => {
         testExecutor({
           mainId: OBSERVABLE_ID,
           bundleObjects: [
-            domainObservable(OBSERVABLE_ID),
-            domainObservable(OBSERVABLE_ID_2),
+            domainObservable({ id: OBSERVABLE_ID }),
+            domainObservable({ id: OBSERVABLE_ID_2 }),
             testBundleObject({
               id: INTRUSION_SET_ID_2,
               type: 'intrusion-set',
@@ -515,8 +520,8 @@ describe('Create indicator component', () => {
         testExecutor({
           mainId: OBSERVABLE_ID,
           bundleObjects: [
-            domainObservable(OBSERVABLE_ID),
-            domainObservable(OBSERVABLE_ID_2),
+            domainObservable({ id: OBSERVABLE_ID }),
+            domainObservable({ id: OBSERVABLE_ID_2 }),
             testBundleObject({
               id: INTRUSION_SET_ID_2,
               type: 'intrusion-set',

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/create-indicator-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/create-indicator-component-test.ts
@@ -13,14 +13,16 @@ import type { StixInternalExternalReference } from '../../../../src/types/stix-2
 const OBSERVABLE_ID = 'domain-name--a1b2c3d4-0000-0000-0000-000000000001' as const;
 const INTRUSION_SET_ID = 'intrusion-set--1ad04810-ab05-5873-96f5-a89d19607e1c' as const;
 const REPORT_ID = 'report--b4754e7d-88b4-51d9-aac4-86edaad66c4d' as const;
+const LABEL_ID = '98d475ca-0f72-4878-8d64-de2e094f007e';
 
 const FAKE_PATTERN = "[domain-name:value = 'malicious.example.com']";
 
-const domainObservable = (id: StixId = OBSERVABLE_ID) =>
-  testBundleObject<StixCyberObject & { value: string }>({
+const domainObservable = (id: StixId = OBSERVABLE_ID, withLabel?: boolean) =>
+  testBundleObject<StixCyberObject & { value: string; labels: string[] }>({
     id,
     type: 'domain-name',
     value: 'malicious.example.com',
+    ...(withLabel ? { labels: [LABEL_ID] } : {}),
     octiExtension: {
       type: 'Domain-Name',
       id: '',
@@ -278,6 +280,7 @@ describe('Create indicator component', () => {
 
     const filterDomainNames = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Domain-Name"],"mode":"or"}],"filterGroups":[]}';
     const filterNotMatching = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["IPv4-Addr"],"mode":"or"}],"filterGroups":[]}';
+    const filterLabel = JSON.stringify({ mode: 'or', filters: [{ key: ['objectLabel'], operator: 'eq', values: [LABEL_ID], mode: 'or' }], filterGroups: [] });
 
     // -- all-elements + filter matching all observables
 
@@ -306,6 +309,35 @@ describe('Create indicator component', () => {
       expect(basedOnRels).toHaveLength(2);
       expect(basedOnRels.map((r) => r.target_ref)).toContain(OBSERVABLE_ID);
       expect(basedOnRels.map((r) => r.target_ref)).toContain(OBSERVABLE_ID_2);
+    });
+
+    // -- all-elements + filter matching label
+
+    it('should create indicators for the observable with matching label when applyToElements = "all-elements" and filter matches a label', async () => {
+      const result = await PLAYBOOK_CREATE_INDICATOR_COMPONENT.executor(
+        testExecutor({
+          mainId: OBSERVABLE_ID,
+          bundleObjects: [domainObservable(OBSERVABLE_ID, true), domainObservable(OBSERVABLE_ID_2)],
+          configuration: {
+            applyToElements: playbookBundleElementsToApply.allElements.value,
+            applyWithFilters: filterLabel,
+            wrap_in_container: false,
+            types: [],
+          },
+        }),
+      );
+
+      expect(result.output_port).toBe('out');
+
+      const indicators = result.bundle.objects.filter((o) => o.type === 'indicator') as StixIndicator[];
+      expect(indicators).toHaveLength(1);
+
+      const basedOnRels = result.bundle.objects.filter(
+        (o) => o.type === 'relationship' && (o as StixRelation).relationship_type === RELATION_BASED_ON,
+      ) as StixRelation[];
+      expect(basedOnRels).toHaveLength(1);
+      expect(basedOnRels.map((r) => r.target_ref)).toContain(OBSERVABLE_ID);
+      expect(basedOnRels.map((r) => r.target_ref)).not.toContain(OBSERVABLE_ID_2);
     });
 
     // -- all-elements + filter not matching any observable

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/manipulate-knowledge-component-test.ts
@@ -4,9 +4,41 @@ import type { StixThreatActor } from '../../../../src/types/stix-2-1-sdo';
 import { ENTITY_TYPE_THREAT_ACTOR } from '../../../../src/schema/general';
 import { PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT, type ManipulateConfiguration } from '../../../../src/modules/playbook/components/manipulate-knowledge-component';
 import { testBundleObject, testExecutor } from './playbook-components-test-utils';
+import type { StixDomainObject } from '../../../../src/types/stix-2-1-common';
 
 describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
   const THREAT_ACTOR_ID = 'threat--09bd862a-f030-55f2-920a-900c4913d9fd';
+  const MALWARE_ID = 'malware--09bd862a-f030-55f2-920a-900c4913d9ff';
+  const CAMPAIGN_ID = 'campaign--6bcf59ca-70c8-55ae-ac7d-a6f9b107a35b';
+  const LABEL_ID = '98d475ca-0f72-4878-8d64-de2e094f007e';
+
+  const BUNDLE_OBJECTS = () => [
+    testBundleObject<StixDomainObject>({
+      id: MALWARE_ID,
+      type: 'Malware',
+      labels: [LABEL_ID],
+    }),
+    testBundleObject({
+      id: CAMPAIGN_ID,
+      type: 'Campaign',
+    }),
+  ];
+
+  const componentConfig = (config?: Partial<ManipulateConfiguration>) => {
+    return {
+      applyToElements: 'only-main' as const,
+      actions: [{
+        op: 'add' as const,
+        attribute: 'objectLabel',
+        value: [{
+          label: 'Duck',
+          value: 'duck-id',
+          patch_value: 'duck',
+        }],
+      }],
+      ...config,
+    };
+  };
 
   it('should replace labels by field patch', async () => {
     const bundleObjects = [testBundleObject<StixThreatActor>({
@@ -165,36 +197,6 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect(updatedActor.object_marking_refs).toEqual(['pap-green-id']);
   });
 
-  const MALWARE_ID = 'malware--09bd862a-f030-55f2-920a-900c4913d9ff';
-  const CAMPAIGN_ID = 'campaign--6bcf59ca-70c8-55ae-ac7d-a6f9b107a35b';
-
-  const BUNDLE_OBJECTS = () => [
-    testBundleObject({
-      id: MALWARE_ID,
-      type: 'Malware',
-    }),
-    testBundleObject({
-      id: CAMPAIGN_ID,
-      type: 'Campaign',
-    }),
-  ];
-
-  const componentConfig = (config?: Partial<ManipulateConfiguration>) => {
-    return {
-      applyToElements: 'only-main' as const,
-      actions: [{
-        op: 'add' as const,
-        attribute: 'objectLabel',
-        value: [{
-          label: 'Duck',
-          value: 'duck-id',
-          patch_value: 'duck',
-        }],
-      }],
-      ...config,
-    };
-  };
-
   describe('Bundle scope', () => {
     it('should add label only on main element', async () => {
       const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
@@ -247,6 +249,7 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     const filterCampaign = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Campaign"],"mode":"or"}],"filterGroups":[]}';
     const filterMalware = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Malware"],"mode":"or"}],"filterGroups":[]}';
     const filterMalwareCampaign = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Malware","Campaign"],"mode":"or"}],"filterGroups":[]}';
+    const filterLabel = JSON.stringify({ mode: 'or', filters: [{ key: ['objectLabel'], operator: 'eq', values: [LABEL_ID], mode: 'or' }], filterGroups: [] });
 
     it('should manipulate nothing if no match (only-main)', async () => {
       const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
@@ -312,6 +315,24 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
       const campaignExtensions = campaignResult?.extensions[STIX_EXT_OCTI];
       expect(malwareExtensions?.opencti_upsert_operations).toBeUndefined();
       expect(campaignExtensions?.opencti_upsert_operations?.length).toEqual(1);
+    });
+
+    it('should manipulate only matching label element if partial match (all-elements)', async () => {
+      const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
+        mainId: MALWARE_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: 'all-elements',
+          applyWithFilters: filterLabel,
+        }),
+      }));
+
+      const malwareResult = result.bundle.objects.find((o) => o.id === MALWARE_ID);
+      const malwareExtensions = malwareResult?.extensions[STIX_EXT_OCTI];
+      const campaignResult = result.bundle.objects.find((o) => o.id === CAMPAIGN_ID);
+      const campaignExtensions = campaignResult?.extensions[STIX_EXT_OCTI];
+      expect(malwareExtensions?.opencti_upsert_operations?.length).toEqual(1);
+      expect(campaignExtensions?.opencti_upsert_operations).toBeUndefined();
     });
 
     it('should manipulate all elements if full match (all-elements)', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/playbook-components-test-utils.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/playbook-components-test-utils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
-import type { StixBundle, StixObject, StixOpenctiExtension } from '../../../../src/types/stix-2-1-common';
-import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+import type { CyberObjectExtension, StixBundle, StixObject, StixOpenctiExtension } from '../../../../src/types/stix-2-1-common';
+import { STIX_EXT_OCTI, STIX_EXT_OCTI_SCO } from '../../../../src/types/stix-2-1-extensions';
 import type { StixId } from '../../../../src/types/stix-2-0-common';
 import type { ExecutorParameters } from '../../../../src/modules/playbook/playbook-types';
 
@@ -8,12 +8,14 @@ type TestBundleObjectArgs<T extends StixObject> = {
   id?: StixId;
   type: string;
   octiExtension?: Partial<StixOpenctiExtension>;
+  scoExtension?: Partial<CyberObjectExtension>;
 } & Partial<Omit<T, 'extensions' | 'id' | 'type'>>;
 
 export const testBundleObject = <T extends StixObject>({
   id,
   type,
   octiExtension,
+  scoExtension,
   ...args
 }: TestBundleObjectArgs<T>): T => {
   return {
@@ -28,6 +30,14 @@ export const testBundleObject = <T extends StixObject>({
         type,
         ...octiExtension,
       },
+      ...(scoExtension
+        ? {
+            [STIX_EXT_OCTI_SCO]: {
+              extension_type: 'property-extension',
+              ...scoExtension,
+            },
+          } : {}
+      ),
     },
   } as T;
 };

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/security-coverage-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/security-coverage-component-test.ts
@@ -3,15 +3,18 @@ import { PLAYBOOK_SECURITY_COVERAGE_COMPONENT, type SecurityCoverageConfiguratio
 import { testBundleObject, testExecutor } from './playbook-components-test-utils';
 import type { StixSecurityCoverage } from '../../../../src/modules/securityCoverage/securityCoverage-types';
 import { playbookBundleElementsToApply } from '../../../../src/modules/playbook/playbook-types';
+import type { StixDomainObject } from '../../../../src/types/stix-2-1-common';
 
 const REPORT_ID = 'report--b4754e7d-88b4-51d9-aac4-86edaad66c4d';
 const INTRUSION_SET_ID = 'intrusion-set--1ad04810-ab05-5873-96f5-a89d19607e1c';
 const CAMPAIGN_ID = 'campaign--c85bcdd3-1042-5f74-ab5d-05fddf30bdb8';
+const LABEL_ID = '98d475ca-0f72-4878-8d64-de2e094f007e';
 
 const BUNDLE_OBJECTS = () => [
-  testBundleObject({
+  testBundleObject<StixDomainObject>({
     id: REPORT_ID,
     type: 'report',
+    labels: [LABEL_ID],
     octiExtension: { type: 'Report' },
     object_refs: [
       INTRUSION_SET_ID,
@@ -113,6 +116,7 @@ describe('Security coverage component', () => {
     const filterReport = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Report"],"mode":"or"}],"filterGroups":[]}';
     const filterReportCampaign = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Report", "Campaign"],"mode":"or"}],"filterGroups":[]}';
     const filterAll = '{"mode":"and","filters":[{"key":["entity_type"],"operator":"eq","values":["Report", "Campaign", "Intrusion-Set"],"mode":"or"}],"filterGroups":[]}';
+    const filterLabel = JSON.stringify({ mode: 'or', filters: [{ key: ['objectLabel'], operator: 'eq', values: [LABEL_ID], mode: 'or' }], filterGroups: [] });
 
     it('should create nothing if no match (only-main)', async () => {
       const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
@@ -175,6 +179,22 @@ describe('Security coverage component', () => {
       expect(securityCoverages).toHaveLength(2);
       expect(securityCoverages[0].covered_ref).toEqual(REPORT_ID);
       expect(securityCoverages[1].covered_ref).toEqual(CAMPAIGN_ID);
+    });
+
+    it('should create only for element with matching label if partial match (all-elements)', async () => {
+      const result = await PLAYBOOK_SECURITY_COVERAGE_COMPONENT.executor(testExecutor({
+        mainId: REPORT_ID,
+        bundleObjects: BUNDLE_OBJECTS(),
+        configuration: componentConfig({
+          applyToElements: playbookBundleElementsToApply.allElements.value,
+          applyWithFilters: filterLabel,
+        }),
+      }));
+
+      const securityCoverages = result.bundle.objects
+        .filter((o) => o.type === 'security-coverage') as StixSecurityCoverage[];
+      expect(securityCoverages).toHaveLength(1);
+      expect(securityCoverages[0].covered_ref).toEqual(REPORT_ID);
     });
 
     it('should create for all elements if full match (all-elements)', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added the applyWithFilters config to the playbook cache filters + added some tests to cover the filtering with every entities such as labels, author, markings...

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* #14285 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
