### PR TITLE
[frontend] Content mapping view should have no padding right (#15761)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/utils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getCurrentTab } from './utils';
+import { getCurrentTab, getPaddingRight } from './utils';
 
 describe('getCurrentTab', () => {
   it('returns next segment after the basepath', () => {
@@ -24,5 +24,33 @@ describe('getCurrentTab', () => {
       '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
     );
     expect(value).toBe('knowledge');
+  });
+});
+
+describe('getPaddingRight', () => {
+  const basePath = '/dashboard/threats/threat_actors_group/a079e1e7-ce97-4528-92f1-64df365d540b';
+
+  it('returns 200 for knowledge path when applyKnowledgePadding is true', () => {
+    expect(getPaddingRight(`${basePath}/knowledge`, basePath)).toBe(200);
+  });
+
+  it('returns 0 for knowledge path when applyKnowledgePadding is false', () => {
+    expect(getPaddingRight(`${basePath}/knowledge`, basePath, false)).toBe(0);
+  });
+
+  it('returns 350 for content path (non-mapping)', () => {
+    expect(getPaddingRight(`${basePath}/content/editor`, basePath)).toBe(350);
+  });
+
+  it('returns 0 for content/mapping path', () => {
+    expect(getPaddingRight(`${basePath}/content/mapping`, basePath)).toBe(0);
+  });
+
+  it('returns 0 for paths that are neither knowledge nor content', () => {
+    expect(getPaddingRight(`${basePath}/overview`, basePath)).toBe(0);
+  });
+
+  it('returns 200 for knowledge sub-paths', () => {
+    expect(getPaddingRight(`${basePath}/knowledge/overview?orderAsc=false`, basePath)).toBe(200);
   });
 });

--- a/opencti-platform/opencti-front/src/utils/utils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/utils.test.ts
@@ -28,7 +28,7 @@ describe('getCurrentTab', () => {
 });
 
 describe('getPaddingRight', () => {
-  const basePath = '/dashboard/threats/threat_actors_group/a079e1e7-ce97-4528-92f1-64df365d540b';
+  const basePath = '/dashboard/analyses/reports/a079e1e7-ce97-4528-92f1-64df365d540b';
 
   it('returns 200 for knowledge path when applyKnowledgePadding is true', () => {
     expect(getPaddingRight(`${basePath}/knowledge`, basePath)).toBe(200);
@@ -47,7 +47,8 @@ describe('getPaddingRight', () => {
   });
 
   it('returns 0 for paths that are neither knowledge nor content', () => {
-    expect(getPaddingRight(`${basePath}/overview`, basePath)).toBe(0);
+    expect(getPaddingRight(basePath, basePath)).toBe(0);
+    expect(getPaddingRight(`${basePath}/entities`, basePath)).toBe(0);
   });
 
   it('returns 200 for knowledge sub-paths', () => {

--- a/opencti-platform/opencti-front/src/utils/utils.ts
+++ b/opencti-platform/opencti-front/src/utils/utils.ts
@@ -72,17 +72,29 @@ export const getCurrentTab = (fullpath: string, basePath: string) => {
   return nextSlashPos >= 0 ? subpath.substring(0, nextSlashPos) : subpath;
 };
 
+/**
+ * Compute the right padding to apply on an entity page based on the current route.
+ * - Knowledge pages get extra padding (200) for the timeline/graph side panel.
+ * - Content pages get padding (350) for the files side panel, except the mapping view which needs full width.
+ *
+ * @param locationPath - The current location pathname.
+ * @param entityBasePath - The base path of the entity being viewed.
+ * @param applyKnowledgePadding - Whether to apply padding on knowledge routes (default: true).
+ * @returns The right padding value
+ */
 export const getPaddingRight = (locationPath: string, entityBasePath: string, applyKnowledgePadding = true) => {
   let paddingRight = 0;
   if (
-    applyKnowledgePadding && locationPath.includes(
-      `${entityBasePath}/knowledge`,
-    )
+    applyKnowledgePadding && locationPath.includes(`${entityBasePath}/knowledge`)
   ) {
     paddingRight = 200;
   }
   if (locationPath.includes(`${entityBasePath}/content`)) {
-    paddingRight = 350;
+    if (locationPath.includes(`${entityBasePath}/content/mapping`)) {
+      paddingRight = 0;
+    } else {
+      paddingRight = 350;
+    }
   }
   return paddingRight;
 };


### PR DESCRIPTION
### Proposed changes
In an entity Content tab, in the Mapping view, we should have no padding Right (padding right for content tab is only for files display for the editor and overview views)

Add tests for getPaddingRight utils



### Related issues
fixes #15761