### PR TITLE
[frontend/backend] hide create draft button without create/update knowledge capability (#15768)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -145,7 +145,7 @@ interface DraftsProps {
 
 const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenCreate, emptyStateMessage }) => {
   const { isFeatureEnable } = useHelper();
-  const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]);
+  const isKnowledgeUpdater = useGranted([], false, { capabilitiesInDraft: [KNOWLEDGE_KNUPDATE] });
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const draftColor = getDraftModeColor(theme);

--- a/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/Drafts.tsx
@@ -25,6 +25,7 @@ import { DraftsLines_data$data } from './__generated__/DraftsLines_data.graphql'
 import { DraftsLinesPaginationQuery, DraftsLinesPaginationQuery$variables } from './__generated__/DraftsLinesPaginationQuery.graphql';
 import DraftPopover from './DraftPopover';
 import useHelper from '../../../utils/hooks/useHelper';
+import useGranted, { KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 
 const DraftLineFragment = graphql`
     fragment Drafts_node on DraftWorkspace {
@@ -144,6 +145,7 @@ interface DraftsProps {
 
 const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenCreate, emptyStateMessage }) => {
   const { isFeatureEnable } = useHelper();
+  const isKnowledgeUpdater = useGranted([KNOWLEDGE_KNUPDATE]);
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const draftColor = getDraftModeColor(theme);
@@ -321,7 +323,7 @@ const Drafts: FunctionComponent<DraftsProps> = ({ entityId, openCreate, setOpenC
             hideHeaders={!!entityId}
             disableLineSelection={!!entityId}
             emptyStateMessage={emptyStateMessage}
-            createButton={!draftContext && <DraftCreation paginationOptions={queryPaginationOptions} />}
+            createButton={!draftContext && isKnowledgeUpdater && <DraftCreation paginationOptions={queryPaginationOptions} />}
             actions={(row) => (
               <DraftPopover
                 draftId={row.id}

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -125,7 +125,7 @@ type DraftWorkspaceEdit {
 }
 
 type Mutation {
-    draftWorkspaceAdd(input: DraftWorkspaceAddInput!): DraftWorkspace @auth(for: [KNOWLEDGE])
+    draftWorkspaceAdd(input: DraftWorkspaceAddInput!): DraftWorkspace @auth(for: [KNOWLEDGE_KNUPDATE])
     draftWorkspaceEdit(id: ID!): DraftWorkspaceEdit @auth(for: [KNOWLEDGE_KNUPDATE])
     draftWorkspaceFieldPatch(id: ID!, input: [EditInput!]!): DraftWorkspace @auth(for: [KNOWLEDGE_KNUPDATE])
     draftWorkspaceValidate(id: ID!): Work @auth(for: [KNOWLEDGE_KNUPDATE_KNDELETE])

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace.graphql
@@ -125,7 +125,7 @@ type DraftWorkspaceEdit {
 }
 
 type Mutation {
-    draftWorkspaceAdd(input: DraftWorkspaceAddInput!): DraftWorkspace @auth(for: [KNOWLEDGE_KNUPDATE])
+    draftWorkspaceAdd(input: DraftWorkspaceAddInput!): DraftWorkspace @auth(for: [KNOWLEDGE_KNUPDATE], forDraft: [KNOWLEDGE_KNUPDATE])
     draftWorkspaceEdit(id: ID!): DraftWorkspaceEdit @auth(for: [KNOWLEDGE_KNUPDATE])
     draftWorkspaceFieldPatch(id: ID!, input: [EditInput!]!): DraftWorkspace @auth(for: [KNOWLEDGE_KNUPDATE])
     draftWorkspaceValidate(id: ID!): Work @auth(for: [KNOWLEDGE_KNUPDATE_KNDELETE])


### PR DESCRIPTION
### Proposed changes

* hide create draft button without create/update knowledge capability in draft

### Related issues

* close #15768 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality