### PR TITLE
[frontend] [backend] Custom views telemetry (#13389)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -747,6 +747,13 @@ export const redisGetTelemetry = async (gaugeName: string) => {
 export const redisClearTelemetry = async () => {
   return getClientBase().del(TELEMETRY_EVENT_KEY);
 };
+
+/**
+ * Delete specific gauge entry
+ */
+export const redisClearTelemetryGauge = async (gaugeName: string) => {
+  return getClientBase().hdel(TELEMETRY_EVENT_KEY, gaugeName);
+};
 // endregion - telemetry gauges
 
 // region - manager stream state

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -69,6 +69,7 @@ export const TELEMETRY_FORM_INTAKE_DELETED = 'formIntakeDeletedCount';
 export const TELEMETRY_FORM_INTAKE_SUBMITTED = 'formIntakeSubmittedCount';
 export const TELEMETRY_USER_LOGIN = 'userLoginCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED = 'customViewCreatedCount';
+export const TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED = 'customViewEnabledCount';
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -148,6 +149,11 @@ export const addUserLoginCount = () => {
 export const addCustomViewCreatedCount = () => {
   redisSetTelemetryAdd(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED, 1)
     .catch((reason) => logApp.warn('Error adding custom view created count to telemetry', { reason }));
+};
+
+export const addCustomViewEnabledCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED, 1)
+    .catch((reason) => logApp.warn('Error adding custom view enabled count to telemetry', { reason }));
 };
 
 // End Region user event counters
@@ -338,6 +344,8 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setFormIntakeSubmittedCount(formIntakeSubmittedCountInRedis);
     const customViewCreatedCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED);
     manager.setCustomViewCreatedCount(customViewCreatedCountInRedis);
+    const customViewEnabledCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
+    manager.setCustomViewEnabledCount(customViewEnabledCountInRedis);
     // end region Telemetry user events
 
     logApp.debug('[TELEMETRY] Fetching telemetry data successfully');

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -68,6 +68,7 @@ export const TELEMETRY_FORM_INTAKE_UPDATED = 'formIntakeUpdatedCount';
 export const TELEMETRY_FORM_INTAKE_DELETED = 'formIntakeDeletedCount';
 export const TELEMETRY_FORM_INTAKE_SUBMITTED = 'formIntakeSubmittedCount';
 export const TELEMETRY_USER_LOGIN = 'userLoginCount';
+export const TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED = 'customViewCreatedCount';
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -142,6 +143,11 @@ export const addConnectorDeployedCount = async () => {
 
 export const addUserLoginCount = () => {
   redisSetTelemetryAdd(TELEMETRY_USER_LOGIN, 1).catch((reason) => logApp.info('Error add user login in telemetry', { reason }));
+};
+
+export const addCustomViewCreatedCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED, 1)
+    .catch((reason) => logApp.warn('Error adding custom view created count to telemetry', { reason }));
 };
 
 // End Region user event counters
@@ -330,6 +336,8 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setFormIntakeDeletedCount(formIntakeDeletedCountInRedis);
     const formIntakeSubmittedCountInRedis = await redisGetTelemetry(TELEMETRY_FORM_INTAKE_SUBMITTED);
     manager.setFormIntakeSubmittedCount(formIntakeSubmittedCountInRedis);
+    const customViewCreatedCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED);
+    manager.setCustomViewCreatedCount(customViewCreatedCountInRedis);
     // end region Telemetry user events
 
     logApp.debug('[TELEMETRY] Fetching telemetry data successfully');

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
@@ -33,7 +33,7 @@ import { convertDashboardManifestIds, exportDashboardWidget, importDashboardWidg
 import { createInternalObject, deleteInternalObject, editInternalObject } from '../../domain/internalObject';
 import { updateAttribute } from '../../database/middleware';
 import { extractContentFrom } from '../../utils/fileToContent';
-import { addCustomViewCreatedCount } from '../../manager/telemetryManager';
+import { addCustomViewCreatedCount, addCustomViewEnabledCount } from '../../manager/telemetryManager';
 
 /**
  * Exclusion list: entity types not capable of
@@ -126,6 +126,7 @@ const applyUniqueDefaultCustomViewConstraint = async (
 
 const TELEMETRY = {
   customViewCreated: addCustomViewCreatedCount,
+  customViewEnabled: addCustomViewEnabledCount,
 };
 
 export const computeCustomViewPath = ({ slug, id }: BasicStoreEntityCustomView) => {
@@ -212,6 +213,9 @@ export const addCustomView = async (
     },
   );
   TELEMETRY.customViewCreated();
+  if (element.enabled) {
+    TELEMETRY.customViewEnabled();
+  }
   if (element.default) {
     // Unset the `default` fields for other CustomViews of the same
     // target_entity_type to enforce uniqueness constraint
@@ -233,6 +237,7 @@ export const editCustomView = async (
 ) => {
   const nameInput = input.find((i) => i.key === 'name');
   const defaultFieldValue = input.find((i) => i.key === 'default')?.value?.[0];
+  const enabledFieldValue = input.find((i) => i.key === 'enabled')?.value?.[0];
   const element = await editInternalObject<StoreEntityCustomView>(
     context,
     user,
@@ -253,6 +258,9 @@ export const editCustomView = async (
       })),
     },
   );
+  if (enabledFieldValue) {
+    TELEMETRY.customViewEnabled();
+  }
   if (defaultFieldValue) {
     // Unset the `default` fields for other CustomViews of the same
     // target_entity_type to enforce uniqueness constraint
@@ -341,6 +349,9 @@ export async function duplicateCustomView(
     },
   );
   TELEMETRY.customViewCreated();
+  if (duplicate.enabled) {
+    TELEMETRY.customViewEnabled();
+  }
   if (duplicate.default) {
     // Unset the `default` fields for other CustomViews of the same
     // target_entity_type to enforce uniqueness constraint

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
@@ -33,6 +33,7 @@ import { convertDashboardManifestIds, exportDashboardWidget, importDashboardWidg
 import { createInternalObject, deleteInternalObject, editInternalObject } from '../../domain/internalObject';
 import { updateAttribute } from '../../database/middleware';
 import { extractContentFrom } from '../../utils/fileToContent';
+import { addCustomViewCreatedCount } from '../../manager/telemetryManager';
 
 /**
  * Exclusion list: entity types not capable of
@@ -123,6 +124,10 @@ const applyUniqueDefaultCustomViewConstraint = async (
   await Promise.all(promises);
 };
 
+const TELEMETRY = {
+  customViewCreated: addCustomViewCreatedCount,
+};
+
 export const computeCustomViewPath = ({ slug, id }: BasicStoreEntityCustomView) => {
   return `${slug}-${id.replaceAll('-', '')}`;
 };
@@ -206,6 +211,7 @@ export const addCustomView = async (
       }),
     },
   );
+  TELEMETRY.customViewCreated();
   if (element.default) {
     // Unset the `default` fields for other CustomViews of the same
     // target_entity_type to enforce uniqueness constraint
@@ -334,6 +340,7 @@ export async function duplicateCustomView(
       }),
     },
   );
+  TELEMETRY.customViewCreated();
   if (duplicate.default) {
     // Unset the `default` fields for other CustomViews of the same
     // target_entity_type to enforce uniqueness constraint
@@ -408,7 +415,7 @@ export const importCustomViewConfiguration = async (
     default: false,
     enabled: false,
   };
-  return createInternalObject<StoreEntityCustomView>(
+  const imported = await createInternalObject<StoreEntityCustomView>(
     context,
     user,
     customViewToCreate,
@@ -421,4 +428,6 @@ export const importCustomViewConfiguration = async (
       }),
     },
   );
+  TELEMETRY.customViewCreated();
+  return imported;
 };

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -114,6 +114,8 @@ export class TelemetryMeterManager {
 
   ssoGithubStrategyEnabled = 0;
 
+  customViewCreatedCount = 0;
+
   // endregion providers usage
 
   constructor(meterProvider: MeterProvider) {
@@ -288,6 +290,10 @@ export class TelemetryMeterManager {
     this.securityCoveragesCount = n;
   }
 
+  setCustomViewCreatedCount(n: number) {
+    this.customViewCreatedCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: {
     unit?: string;
     valueType?: ValueType;
@@ -346,5 +352,6 @@ export class TelemetryMeterManager {
     this.registerGauge('is_sso_facebook_strategy_enabled', 'FacebookStrategy is configured and enabled', 'ssoFacebookStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('is_sso_google_strategy_enabled', 'GoogleStrategy is configured and enabled', 'ssoGoogleStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('is_sso_github_strategy_enabled', 'GithubStrategy is configured and enabled', 'ssoGithubStrategyEnabled', { unit: 'boolean' });
+    this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
   }
 }

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -116,6 +116,8 @@ export class TelemetryMeterManager {
 
   customViewCreatedCount = 0;
 
+  customViewEnabledCount = 0;
+
   // endregion providers usage
 
   constructor(meterProvider: MeterProvider) {
@@ -294,6 +296,10 @@ export class TelemetryMeterManager {
     this.customViewCreatedCount = n;
   }
 
+  setCustomViewEnabledCount(n: number) {
+    this.customViewEnabledCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: {
     unit?: string;
     valueType?: ValueType;
@@ -353,5 +359,6 @@ export class TelemetryMeterManager {
     this.registerGauge('is_sso_google_strategy_enabled', 'GoogleStrategy is configured and enabled', 'ssoGoogleStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('is_sso_github_strategy_enabled', 'GithubStrategy is configured and enabled', 'ssoGithubStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
+    this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
   }
 }

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customView/customView-resolvers-test.ts
@@ -1,15 +1,17 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
 import Upload from 'graphql-upload/Upload.mjs';
-import { createEntity } from '../../../../src/database/middleware';
+import { createEntity, deleteElementById } from '../../../../src/database/middleware';
 import { ADMIN_USER, testContext, USER_PARTICIPATE } from '../../../utils/testQuery';
 import { queryAsUserWithSuccess, queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden, queryAsAdminWithError } from '../../../utils/testQueryHelper';
-import { CUSTOM_VIEW_ENTITY_1, CUSTOM_VIEW_ENTITY_2, CUSTOM_VIEW_ENTITY_INVALID, DASHBOARD_MANIFEST, DASHBOARD_MANIFEST_OBJECT } from './customView-fixtures';
 import { ENTITY_TYPE_CONTAINER_FEEDBACK } from '../../../../src/modules/case/feedback/feedback-types';
 import { ENTITY_TYPE_INTRUSION_SET } from '../../../../src/schema/stixDomainObject';
-import type { StoreEntityCustomView } from '../../../../src/modules/customView/customView-types';
+import { ENTITY_TYPE_CUSTOM_VIEW, type StoreEntityCustomView } from '../../../../src/modules/customView/customView-types';
 import { fromB64, toB64 } from '../../../../src/utils/base64';
 import { fileToReadStream } from '../../../../src/database/file-storage';
+import { redisClearTelemetryGauge, redisGetTelemetry } from '../../../../src/database/redis';
+import { TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED, TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED } from '../../../../src/manager/telemetryManager';
+import { CUSTOM_VIEW_ENTITY_1, CUSTOM_VIEW_ENTITY_2, CUSTOM_VIEW_ENTITY_INVALID, DASHBOARD_MANIFEST, DASHBOARD_MANIFEST_OBJECT } from './customView-fixtures';
 
 const READ_CUSTOM_VIEW_QUERY = gql`
   query CustomViewTest($id: ID!) {
@@ -104,6 +106,7 @@ const EDIT_CUSTOM_VIEW_QUERY = gql`
       manifest
       updated_at
       default
+      enabled
     }
   }
 `;
@@ -182,7 +185,6 @@ const createUploadFile = (filePath: string, fileName: string) => {
     executor(fileUpload);
   });
   upload.file = fileUpload;
-
   return upload;
 };
 
@@ -209,6 +211,23 @@ describe('CustomView resolvers', () => {
       'CustomView',
     );
   });
+  afterAll(async () => {
+    await redisClearTelemetryGauge(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED);
+    await redisClearTelemetryGauge(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
+    const result = await queryAsAdminWithSuccess({
+      query: READ_ALL_CUSTOM_VIEWS_QUERY,
+    });
+    const nodes = result.data.customViews.edges.map((e: any) => e.node);
+    await Promise.all(nodes.map(({ id }: { id: string }) =>
+      deleteElementById(
+        testContext,
+        ADMIN_USER,
+        id,
+        ENTITY_TYPE_CUSTOM_VIEW,
+      ),
+    ));
+  });
+
   describe('display use cases', () => {
     it('should retrieve serialized dashboard manifest', async () => {
       const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
@@ -363,12 +382,16 @@ describe('CustomView resolvers', () => {
             }, {
               key: 'manifest',
               value: [updatedManifest],
+            }, {
+              key: 'enabled',
+              value: [true],
             }],
           },
         });
         expect(result.data.customViewEdit.description).toBe(updatedDescription);
         expect(result.data.customViewEdit.manifest).toBe(updatedManifest);
         expect(result.data.customViewEdit.updated_at).not.toBe(updatedAtBefore);
+        expect(result.data.customViewEdit.enabled).toBe(true);
         // TODO: Check activity logs using the audits query
       });
 
@@ -660,6 +683,13 @@ describe('CustomView resolvers', () => {
             },
           },
         });
+      });
+    });
+
+    describe('telemetry', () => {
+      it('gauges are updated', async () => {
+        expect(await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED)).toBe(5);
+        expect(await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED)).toBe(1);
       });
     });
   });


### PR DESCRIPTION
### Proposed changes

See specs here: https://www.notion.so/filigran/New-TAB-with-a-custom-knowledge-view-2b18fce17f2a80f09a34db26a15ff8d1?source=copy_link#2b18fce17f2a8108838bde12d9125adb.

Implements the following metrics in the backend:

* `custom_view_created_count`
* `custom_view_enabled_count`

### Related issues

* Partially fixes https://github.com/OpenCTI-Platform/opencti/issues/13389

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
