### PR TITLE
[frontend] Fix public dashboard crashes when queries fail (#15812)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetContainer.tsx
@@ -4,6 +4,7 @@ import Card, { CardProps } from '../common/card/Card';
 import Label from '../common/label/Label';
 import ChartExportPopover from '../../private/components/common/charts/ChartExportPopover';
 import { ErrorBoundary } from '@components/Error';
+import WidgetNoData from './WidgetNoData';
 
 interface WidgetContainerProps {
   children: ReactNode;
@@ -38,7 +39,7 @@ const WidgetContainer: FunctionComponent<WidgetContainerProps> = ({
                 </div>
               )}
             >
-              <ErrorBoundary>
+              <ErrorBoundary resNotFoundDisplay={<WidgetNoData />}>
                 {children}
               </ErrorBoundary>
             </Card>
@@ -46,7 +47,7 @@ const WidgetContainer: FunctionComponent<WidgetContainerProps> = ({
         : (
             <>
               {title && <Label>{title}</Label>}
-              <ErrorBoundary>
+              <ErrorBoundary resNotFoundDisplay={<WidgetNoData />}>
                 {children}
               </ErrorBoundary>
             </>

--- a/opencti-platform/opencti-front/src/private/components/Error.jsx
+++ b/opencti-platform/opencti-front/src/private/components/Error.jsx
@@ -10,6 +10,9 @@ import { useFormatter } from '../../components/i18n';
 import { commitMutation } from '../../relay/environment';
 import withRouter from '../../utils/compat_router/withRouter';
 
+// --- Region UI errors components
+// -------------------------------
+
 // Highest level of error catching, do not rely on any tierce (intl, theme, ...) pure fallback
 export const HighLevelError = () => (
   <Alert severity="error">An unknown error occurred. Please contact your administrator or OpenCTI maintainers</Alert>
@@ -36,6 +39,7 @@ export const SimpleError = () => {
   );
 };
 
+// Custom warning message display
 export const DedicatedWarning = ({ title, description }) => (
   <Alert severity="warning">
     <AlertTitle>{title}</AlertTitle>
@@ -43,6 +47,13 @@ export const DedicatedWarning = ({ title, description }) => (
   </Alert>
 );
 
+// 404
+export const NoMatch = () => <ErrorNotFound />;
+
+// --- End region
+// --------------
+
+// Mutation to send the frontend error to the backend.
 const frontendErrorLogMutation = graphql`
   mutation ErrorFrontendLogMutation($message: String!, $codeStack: String, $componentStack: String) {
     frontendErrorLog(message: $message, codeStack: $codeStack, componentStack: $componentStack)
@@ -59,7 +70,7 @@ class ErrorBoundaryComponent extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     try {
-      const isNetworkError = this.state.error.res;
+      const isNetworkError = this.state.error?.res;
       if (!isNetworkError) {
         // If direct javascript error, sent the error for back logging
         commitMutation({
@@ -96,6 +107,9 @@ class ErrorBoundaryComponent extends React.Component {
       if (includes('FORBIDDEN_ACCESS', types)) {
         return <ErrorNotFound />;
       }
+      if (includes('RESOURCE_NOT_FOUND', types)) {
+        return this.props.resNotFoundDisplay || <ErrorNotFound />;
+      }
       if (includes('AUTH_REQUIRED', types)) {
         throw this.state.error;
       }
@@ -107,6 +121,7 @@ class ErrorBoundaryComponent extends React.Component {
 }
 
 ErrorBoundaryComponent.propTypes = {
+  resNotFoundDisplay: PropTypes.object,
   display: PropTypes.object,
   children: PropTypes.node,
 };
@@ -119,6 +134,3 @@ export const boundaryWrapper = (Component) => {
     </ErrorBoundary>
   );
 };
-
-// 404
-export const NoMatch = () => <ErrorNotFound />;


### PR DESCRIPTION
### Proposed changes

* Enhanced error management to be able to customize error UI when we get RESOURCE_NOT_FOUND error
* Display "No data" widget when the query fails

How to reproduce:
- create an entity (ie. Malware) with marking TLP:RED
- create a custom dashboard
- create a widget inside: Line > Entities > filter "In regards of" with created entity
- create a new associated public dashboard and select TLP:CLEAR as max marking
- access the public dashboard
- master: crashes // branch: "No data" displayed

### Related issues

* Closes #15812

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality