### PR TITLE
[backend] await JWT authentication in user request and enhance error logging (#15833)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1948,7 +1948,7 @@ export const authenticateUserFromRequest = async (context, req) => {
     // If bearer is a JWT
     if (bearerToken.startsWith(JWT_TOKEN_PREFIX)) {
       try {
-        return authenticateUserByJWT(context, req, bearerToken);
+        return await authenticateUserByJWT(context, req, bearerToken);
       } catch (err) {
         logApp.warn('Error resolving user by JWT', { cause: err });
         return undefined;

--- a/opencti-platform/opencti-graphql/src/domain/xtm-auth.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-auth.ts
@@ -104,6 +104,11 @@ export const verifyXtmJwt = async (token: string) => {
     if (err?.name === 'AuthenticationFailure' || err?.attributes?.reason) {
       throw err;
     }
+    logApp.warn('[XTM_AUTH] JWT verification failed', {
+      code: err?.code,
+      message: err?.message,
+      name: err?.name,
+    });
     throw AuthenticationFailure('JWT signature verification failed');
   }
 };


### PR DESCRIPTION
### Proposed changes

* Improve XTM auth error visibility: Log the exact jose error (e.g. kid mismatch, JWKS fetch failure) in verifyXtmJwt before it gets masked by the generic AuthenticationFailure.

* Fix missing await: Add missing await to authenticateUserByJWT in authenticateUserFromRequest to properly catch and handle asynchronous validation errors.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15833 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
