### PR TITLE
fix(backend): mark work as complete on ES in updateProcessedTime (#15813)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -395,12 +395,20 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
     logApp.warn('The work cannot be found in database, processed time cannot be updated.', { workId });
     return workId;
   }
-  const { isMultiPartWork } = await redisGetWorkCompletionState(workId);
-  if (isMultiPartWork) {
+  const { expected, total, isMultiPartWork } = await redisGetWorkCompletionState(workId);
+  const isComplete = isWorkFinished(expected, total);
+  if (isMultiPartWork && !isComplete) {
     await redisMarkWorkAsProcessed(workId);
   }
   const params = { processed_time: now(), message };
   let source = 'ctx._source["processed_time"] = params.processed_time;';
+  if (isComplete) {
+    params.completed_number = total && !Number.isNaN(total) ? total : 1;
+    source += `ctx._source['status'] = "complete";
+               ctx._source['import_expected_number'] = params.completed_number;
+               ctx._source['completed_number'] = params.completed_number;
+               ctx._source['completed_time'] = params.processed_time;`;
+  }
   if (isNotEmptyField(message)) {
     if (inError) {
       source += 'ctx._source.errors.add(["timestamp": params.processed_time, "message": params.message]); ';

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-test.ts
@@ -242,7 +242,7 @@ describe('Connector resolver standard behaviour', () => {
     // Read work and verify status
     queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
     expect(queryResult).not.toBeNull();
-    expect(queryResult.data.work.status).toEqual('progress');
+    expect(queryResult.data.work.status).toEqual('complete');
   });
   it('should delete work', async () => {
     // Delete the work
@@ -378,7 +378,7 @@ describe.todo('Connector sending multiple bundles during the same multi-part wor
 
       // Status should have changed to `complete`
       queryResult = await queryAsUserWithSuccess(USER_CONNECTOR, { query: READ_WORK_QUERY, variables: { id: workId } });
-      expect(queryResult.data.work.status).toEqual('progress');
+      expect(queryResult.data.work.status).toEqual('complete');
       expect(queryResult.data.work.completed_number).toEqual(5);
     });
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* mark work as complete on ES in updateProcessedTime. This reverts in part changes done in https://github.com/OpenCTI-Platform/opencti/pull/15725
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15813 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
