### PR TITLE
[frontend] description at first row in all entities and fullwidth (#15613)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceOverview.tsx
@@ -21,20 +21,20 @@ const ExternalReferenceOverviewComponent: FunctionComponent<
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Overview')}>
         <Grid container={true} spacing={3}>
-          <Grid item xs={6}>
+          <Grid item xs={12}>
             <Label>
-              {t_i18n('Source name')}
-            </Label>
-            {truncate(externalReference.source_name, 40)}
-            <Label
-              sx={{ marginTop: 2 }}
-            >
               {t_i18n('Description')}
             </Label>
             <ExpandableMarkdown
               source={externalReference.description}
               limit={400}
             />
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Source name')}
+            </Label>
+            {truncate(externalReference.source_name, 40)}
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -51,12 +51,14 @@ const GroupingDetailsComponent = (props) => {
     <div style={{ height: '100%' }}>
       <Card title={t('Entity details')}>
         <Grid container={true} spacing={3}>
-          <Grid item xs={6} ref={ref}>
+          <Grid item xs={12}>
             <Label>
               {t('Description')}
             </Label>
             <ExpandableMarkdown source={grouping.description} limit={400} />
-            <Label sx={{ marginTop: 2 }}>
+          </Grid>
+          <Grid item xs={6} ref={ref}>
+            <Label>
               {t('Context')}
             </Label>
             <Tag label={grouping.context} />

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -71,10 +71,12 @@ const ReportDetails = ({ report }) => {
     <div style={{ height: '100%' }} data-testid="report-overview">
       <Card title={t_i18n('Entity details')}>
         <Grid container={true} spacing={3}>
-          <Grid item xs={6} ref={ref}>
+          <Grid item xs={12}>
             <Label>{t_i18n('Description')}</Label>
             <ExpandableMarkdown source={reportData.description} limit={400} />
-            <Label sx={{ mt: 2 }}>{t_i18n('Report types')}</Label>
+          </Grid>
+          <Grid item xs={6} ref={ref}>
+            <Label>{t_i18n('Report types')}</Label>
             <FieldOrEmpty source={reportData.report_types}>
               <Stack direction="row" flexWrap="wrap" gap={1}>
                 {reportData.report_types?.map((reportType) => (

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageDetails.tsx
@@ -55,15 +55,15 @@ const SecurityCoverageDetails: FunctionComponent<SecurityCoverageDetailsProps> =
         <Grid container={true} spacing={2}>
           <Grid item xs={12}>
             <Label>
-              {t_i18n('Name')}
-            </Label>
-            {data.name || EMPTY_VALUE}
-          </Grid>
-          <Grid item xs={12}>
-            <Label>
               {t_i18n('Description')}
             </Label>
             <ExpandableMarkdown source={data.description} limit={300} />
+          </Grid>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Name')}
+            </Label>
+            {data.name || EMPTY_VALUE}
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelDetails.jsx
@@ -25,7 +25,7 @@ export const ChannelDetails = ({
   return (
     <Card title={t_i18n('Details')}>
       <Grid container={true} spacing={2}>
-        <Grid item xs={6}>
+        <Grid item xs={12}>
           <Label>
             {t_i18n('Description')}
           </Label>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareDetails.jsx
@@ -23,6 +23,12 @@ class MalwareDetailsComponent extends Component {
     return (
       <Card title={t('Details')}>
         <Grid container={true} spacing={3} style={{ marginBottom: 10 }}>
+          <Grid item xs={12}>
+            <Label>
+              {t('Description')}
+            </Label>
+            <ExpandableMarkdown source={malware.description} limit={400} />
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t('Is family')}
@@ -31,12 +37,6 @@ class MalwareDetailsComponent extends Component {
               status={malware.is_family}
               label={malware.is_family ? t('Yes') : t('No')}
             />
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t('Description')}
-            </Label>
-            <ExpandableMarkdown source={malware.description} limit={400} />
             <Label
               sx={{ marginTop: 2 }}
             >

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolDetails.tsx
@@ -42,14 +42,14 @@ const ToolDetails: FunctionComponent<ToolDetailsProps> = ({ tools }) => {
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={3}>
-          <Grid item xs={6}>
+          <Grid item xs={12}>
             <Label>
               {t_i18n('Description')}
             </Label>
             <ExpandableMarkdown source={tool.description} limit={400} />
-            <Label
-              sx={{ marginTop: 2 }}
-            >
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
               {t_i18n('Tool version')}
             </Label>
             <FieldOrEmpty source={tool.tool_version}>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -68,6 +68,14 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={2} sx={{ marginBottom: 2 }}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <FieldOrEmpty source={data.description}>
+              <ExpandableMarkdown source={data.description} limit={300} />
+            </FieldOrEmpty>
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Priority')}
@@ -105,14 +113,6 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
                   />
                 ))}
               </Stack>
-            </FieldOrEmpty>
-          </Grid>
-          <Grid item xs={12}>
-            <Label>
-              {t_i18n('Description')}
-            </Label>
-            <FieldOrEmpty source={data.description}>
-              <ExpandableMarkdown source={data.description} limit={300} />
             </FieldOrEmpty>
           </Grid>
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiDetails.tsx
@@ -68,6 +68,14 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
     <div style={{ height: '100%' }} data-testid="case-rfi-details-page">
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={2} sx={{ marginBottom: 2 }}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <FieldOrEmpty source={data.description}>
+              <ExpandableMarkdown source={data.description} limit={300} />
+            </FieldOrEmpty>
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Request for information types')}
@@ -106,14 +114,6 @@ const CaseRfiDetails: FunctionComponent<CaseRfiDetailsProps> = ({
               value={data.severity}
               displayMode="chip"
             />
-          </Grid>
-          <Grid item xs={12}>
-            <Label>
-              {t_i18n('Description')}
-            </Label>
-            <FieldOrEmpty source={data.description}>
-              <ExpandableMarkdown source={data.description} limit={300} />
-            </FieldOrEmpty>
           </Grid>
         </Grid>
         <Divider />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftDetails.tsx
@@ -68,6 +68,14 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
     <div style={{ height: '100%' }} data-testid="case-rft-details-page">
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={2} sx={{ marginBottom: 2 }}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <FieldOrEmpty source={data.description}>
+              <ExpandableMarkdown source={data.description} limit={300} />
+            </FieldOrEmpty>
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Request for takedown types')}
@@ -106,14 +114,6 @@ const CaseRftDetails: FunctionComponent<CaseRftDetailsProps> = ({
               value={data.severity}
               displayMode="chip"
             />
-          </Grid>
-          <Grid item xs={12}>
-            <Label>
-              {t_i18n('Description')}
-            </Label>
-            <FieldOrEmpty source={data.description}>
-              <ExpandableMarkdown source={data.description} limit={300} />
-            </FieldOrEmpty>
           </Grid>
         </Grid>
         <Divider />

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/FeedbackDetails.tsx
@@ -52,12 +52,6 @@ const FeedbackDetails: FunctionComponent<FeedbackDetailsProps> = ({
     <div style={{ height: '100%' }} data-testid="feedback-details-page">
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={3}>
-          <Grid item xs={6}>
-            <Label>
-              {t_i18n('Rating')}
-            </Label>
-            <RatingField rating={data.rating} size="small" readOnly={true} />
-          </Grid>
           <Grid item xs={12}>
             <Label>
               {t_i18n('Description')}
@@ -65,6 +59,12 @@ const FeedbackDetails: FunctionComponent<FeedbackDetailsProps> = ({
             {data.description && (
               <ExpandableMarkdown source={data.description} limit={300} />
             )}
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Rating')}
+            </Label>
+            <RatingField rating={data.rating} size="small" readOnly={true} />
           </Grid>
         </Grid>
       </Card>

--- a/opencti-platform/opencti-front/src/private/components/common/containers/related_containers/RelatedContainersDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/related_containers/RelatedContainersDetails.tsx
@@ -120,6 +120,13 @@ const RelatedContainersDetails: React.FC<RelatedContainersDetailsProps> = ({ con
 
   return (
     <Grid container rowSpacing={3}>
+      <Grid item xs={12}>
+        <Typography variant="h3" gutterBottom>
+          {t_i18n('Description')}
+        </Typography>
+        <ExpandableMarkdown source={relatedContainer.description} limit={300} />
+      </Grid>
+
       <Grid container item xs={12} columnSpacing={3}>
         <Grid item xs={6}>
           <Typography variant="h3" gutterBottom>
@@ -138,12 +145,6 @@ const RelatedContainersDetails: React.FC<RelatedContainersDetailsProps> = ({ con
       </Grid>
 
       <Grid container item xs={12} columnSpacing={3}>
-        <Grid item xs={6}>
-          <Typography variant="h3" gutterBottom>
-            {t_i18n('Description')}
-          </Typography>
-          <ExpandableMarkdown source={relatedContainer.description} limit={300} />
-        </Grid>
         <Grid item xs={6}>
           <Typography variant="h3" gutterBottom>
             {t_i18n('Processing status')}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
@@ -2,7 +2,7 @@ import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import Dialog from '@common/dialog/Dialog';
 import { ArrowRightAlt, EditOutlined, ExpandLessOutlined, ExpandMoreOutlined } from '@mui/icons-material';
-import { Tooltip, Typography } from '@mui/material';
+import { Stack, Tooltip, Typography } from '@mui/material';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
 import Divider from '@mui/material/Divider';
@@ -24,7 +24,6 @@ import ItemCreators from '../../../../components/ItemCreators';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemStatus from '../../../../components/ItemStatus';
-import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { commitMutation } from '../../../../relay/environment';
 import { itemColor } from '../../../../utils/Colors';
 import withRouter from '../../../../utils/compat_router/withRouter';
@@ -45,6 +44,7 @@ import StixCoreRelationshipObjectLabelsView from './StixCoreRelationshipLabelsVi
 import StixCoreRelationshipLatestHistory from './StixCoreRelationshipLatestHistory';
 import StixCoreRelationshipSharing from './StixCoreRelationshipSharing';
 import StixCoreRelationshipStixCoreRelationships from './StixCoreRelationshipStixCoreRelationships';
+import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 
 const styles = (theme) => ({
   container: {
@@ -377,8 +377,21 @@ class StixCoreRelationshipContainer extends Component {
                   </div>
                 </div>
               </Link>
-              <Divider style={{ marginTop: 30 }} />
-              <div style={{ padding: 15 }}>
+              <Divider style={{ marginTop: 30, marginBottom: 15 }} />
+              <Stack gap={2}>
+                <div>
+                  <Label>
+                    {t('Description')}
+                  </Label>
+                  <ExpandableMarkdown
+                    source={stixCoreRelationship.x_opencti_inferences !== null
+                      ? t('Inferred knowledge')
+                      : stixCoreRelationship.description
+                    }
+                    limit={400}
+                  />
+                </div>
+
                 <Grid container={true} spacing={2}>
                   <Grid item xs={6}>
                     <Label>
@@ -400,26 +413,13 @@ class StixCoreRelationshipContainer extends Component {
                     <StixCoreRelationshipSharing
                       elementId={stixCoreRelationship.id}
                     />
-                    <Label
-                      sx={{ marginTop: 2 }}
-                    >
-                      {t('Description')}
-                    </Label>
-                    <MarkdownDisplay
-                      content={stixCoreRelationship.x_opencti_inferences !== null
-                        ? t('Inferred knowledge')
-                        : stixCoreRelationship.description
-                      }
-                      remarkGfmPlugin={true}
-                      commonmark={true}
-                    />
                     <StixCoreObjectKillChainPhasesView
                       killChainPhases={stixCoreRelationship.killChainPhases}
                       displayIcon
                     />
                   </Grid>
                 </Grid>
-              </div>
+              </Stack>
             </Card>
           </Grid>
           <Grid item xs={6}>

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftDetails.tsx
@@ -18,20 +18,20 @@ const DraftDetails: FunctionComponent<DraftDetailsProps> = ({ draft }) => {
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={3}>
-          <Grid item xs={6}>
+          <Grid item xs={12}>
             <Label>
-              {t_i18n('Name')}
-            </Label>
-            {truncate(draft.name, 40)}
-            <Label
-              sx={{ marginTop: 2 }}
-            >
               {t_i18n('Description')}
             </Label>
             <ExpandableMarkdown
               source={draft.description}
               limit={400}
             />
+          </Grid>
+          <Grid item xs={6}>
+            <Label>
+              {t_i18n('Name')}
+            </Label>
+            {truncate(draft.name, 40)}
           </Grid>
         </Grid>
       </Card>

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftOverview.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { DraftRootFragment$data } from '@components/drafts/__generated__/DraftRootFragment.graphql';
-import { Grid } from '@mui/material';
+import { Grid, Stack } from '@mui/material';
 import useOverviewLayoutCustomization from '../../../utils/hooks/useOverviewLayoutCustomization';
 import DraftBasicInformation from './DraftBasicInformation';
 import DraftDetails from '@components/drafts/DraftDetails';
@@ -19,6 +19,11 @@ const DraftOverview: FunctionComponent<DraftOverviewProps> = ({ draft }) => {
 
   return (
     <>
+      {canEdit && (
+        <Stack direction="row" justifyContent="flex-end">
+          <DraftEdition draftId={draft.id} overviewData={draft} />
+        </Stack>
+      )}
       <div style={{ display: 'flex', gap: 20 }}>
         <Grid
           container={true}
@@ -46,9 +51,6 @@ const DraftOverview: FunctionComponent<DraftOverviewProps> = ({ draft }) => {
             })
           }
         </Grid>
-        {canEdit && (
-          <DraftEdition draftId={draft.id} overviewData={draft} />
-        )}
       </div>
     </>
   );

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventDetails.jsx
@@ -18,14 +18,14 @@ class EventDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={2}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>
               <ExpandableMarkdown source={event.description} limit={400} />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
+            </Grid>
+            <Grid item xs={6}>
+              <Label>
                 {t('Event types')}
               </Label>
               <FieldOrEmpty source={event.event_types}>

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualDetails.jsx
@@ -18,7 +18,7 @@ class IndividualDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={3}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationDetails.tsx
@@ -38,6 +38,15 @@ const OrganizationDetails: FunctionComponent<OrganizationDetailsComponentProps> 
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown
+              source={organization.description}
+              limit={400}
+            />
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Organization type')}
@@ -47,15 +56,6 @@ const OrganizationDetails: FunctionComponent<OrganizationDetailsComponentProps> 
                 label={organization.x_opencti_organization_type}
               />
             </FieldOrEmpty>
-            <Label
-              sx={{ mt: 2 }}
-            >
-              {t_i18n('Description')}
-            </Label>
-            <ExpandableMarkdown
-              source={organization.description}
-              limit={400}
-            />
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorDetails.jsx
@@ -17,7 +17,7 @@ class SectorDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={3}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformDetails.tsx
@@ -19,6 +19,15 @@ const SecurityPlatformDetailsComponent: FunctionComponent<SecurityPlatformDetail
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown
+              source={securityPlatform.description}
+              limit={400}
+            />
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Security platform type')}
@@ -28,15 +37,6 @@ const SecurityPlatformDetailsComponent: FunctionComponent<SecurityPlatformDetail
                 label={securityPlatform.security_platform_type}
               />
             </FieldOrEmpty>
-            <Label
-              sx={{ mt: 2 }}
-            >
-              {t_i18n('Description')}
-            </Label>
-            <ExpandableMarkdown
-              source={securityPlatform.description}
-              limit={400}
-            />
           </Grid>
         </Grid>
       </Card>

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemDetails.jsx
@@ -17,7 +17,7 @@ class SystemDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={3}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentDetails.tsx
@@ -95,6 +95,12 @@ const IncidentDetails: FunctionComponent<IncidentDetailsProps> = ({
     <div style={{ height: '100%' }} data-testid="incident-details-page">
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={2}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={incident.description} limit={400} />
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Incident type')}
@@ -110,12 +116,6 @@ const IncidentDetails: FunctionComponent<IncidentDetailsProps> = ({
               {t_i18n('First seen')}
             </Label>
             {fldt(incident.first_seen)}
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t_i18n('Description')}
-            </Label>
-            <ExpandableMarkdown source={incident.description} limit={400} />
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipOverview.jsx
@@ -2,7 +2,7 @@ import Button from '@common/button/Button';
 import Card from '@common/card/Card';
 import Dialog from '@common/dialog/Dialog';
 import { ArrowRightAlt } from '@mui/icons-material';
-import { alpha } from '@mui/material';
+import { alpha, Stack } from '@mui/material';
 import Chip from '@mui/material/Chip';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -24,7 +24,6 @@ import ItemCreators from '../../../../components/ItemCreators';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemStatus from '../../../../components/ItemStatus';
-import MarkdownDisplay from '../../../../components/MarkdownDisplay';
 import { commitMutation } from '../../../../relay/environment';
 import { itemColor } from '../../../../utils/Colors';
 import withRouter from '../../../../utils/compat_router/withRouter';
@@ -39,6 +38,7 @@ import { stixSightingRelationshipEditionFocus } from './StixSightingRelationship
 import StixSightingRelationshipLabelsView from './StixSightingRelationshipLabelsView';
 import StixSightingRelationshipLatestHistory from './StixSightingRelationshipLatestHistory';
 import StixSightingRelationshipSharing from './StixSightingRelationshipSharing';
+import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 
 const styles = (theme) => ({
   container: {
@@ -354,7 +354,20 @@ class StixSightingRelationshipContainer extends Component {
                 </div>
               </Link>
               <Divider sx={{ my: 2 }} />
-              <div>
+              <Stack gap={2}>
+                <div>
+                  <Label>
+                    {t('Description')}
+                  </Label>
+                  <ExpandableMarkdown
+                    source={stixSightingRelationship.x_opencti_inferences !== null
+                      ? t('Inferred knowledge')
+                      : stixSightingRelationship.description
+                    }
+                    limit={400}
+                  />
+                </div>
+
                 <Grid container={true} spacing={2}>
                   <Grid item xs={6}>
                     <Label>
@@ -404,23 +417,11 @@ class StixSightingRelationshipContainer extends Component {
                         {t('Count')}
                       </Label>
                       {n(stixSightingRelationship.attribute_count)}
-                      <Label
-                        sx={{ marginTop: 2 }}
-                      >
-                        {t('Description')}
-                      </Label>
-                      <MarkdownDisplay
-                        content={stixSightingRelationship.x_opencti_inferences !== null
-                          ? t('Inferred knowledge')
-                          : stixSightingRelationship.description
-                        }
-                        remarkGfmPlugin={true}
-                        commonmark={true}
-                      />
+
                     </div>
                   </Grid>
                 </Grid>
-              </div>
+              </Stack>
             </Card>
           </Grid>
           <Grid item xs={6}>

--- a/opencti-platform/opencti-front/src/private/components/locations/LocationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/LocationDetails.tsx
@@ -28,7 +28,7 @@ const LocationDetails: FunctionComponent<LocationDetailsProps> = ({ locationData
           <Label>
             {t_i18n('Description')}
           </Label>
-          <ExpandableMarkdown source={location.description} limit={300} />
+          <ExpandableMarkdown source={location.description} limit={1400} />
         </div>
       </Card>
     </div>

--- a/opencti-platform/opencti-front/src/private/components/locations/LocationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/LocationDetails.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from 'react';
-import Grid from '@mui/material/Grid';
 import { LocationDetails_location$key } from '@components/locations/__generated__/LocationDetails_location.graphql';
 import { graphql, useFragment } from 'react-relay';
 import ExpandableMarkdown from '../../../components/ExpandableMarkdown';
@@ -25,14 +24,12 @@ const LocationDetails: FunctionComponent<LocationDetailsProps> = ({ locationData
   return (
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
-        <Grid container={true} spacing={2}>
-          <Grid item xs={12}>
-            <Label>
-              {t_i18n('Description')}
-            </Label>
-            <ExpandableMarkdown source={location.description} limit={300} />
-          </Grid>
-        </Grid>
+        <div>
+          <Label>
+            {t_i18n('Description')}
+          </Label>
+          <ExpandableMarkdown source={location.description} limit={300} />
+        </div>
       </Card>
     </div>
   );

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorDetails.tsx
@@ -41,13 +41,27 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
 
   return (
     <Box sx={{ height: '100%' }} className="break">
-      <Card title={t_i18n('Details')}>
-        <Label>
-          {t_i18n('Indicator pattern')}
-        </Label>
-        <FieldOrEmpty source={indicator.pattern}>
-          <ExpandablePre source={indicator.pattern} limit={300} />
-        </FieldOrEmpty>
+      <Card title={t_i18n('Details')} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <div>
+          <Label>
+            {t_i18n('Description')}
+          </Label>
+          <ExpandableMarkdown
+            source={indicator.description}
+            limit={400}
+            removeLinks
+          />
+        </div>
+        <div>
+
+          <Label>
+            {t_i18n('Indicator pattern')}
+          </Label>
+          <FieldOrEmpty source={indicator.pattern}>
+            <ExpandablePre source={indicator.pattern} limit={300} />
+          </FieldOrEmpty>
+        </div>
+
         <Grid container={true} spacing={2} sx={{ mt: 0 }}>
           <Grid item xs={6}>
             <Label>
@@ -98,16 +112,6 @@ const IndicatorDetailsComponent: FunctionComponent<IndicatorDetailsComponentProp
                 </>
               )}
             </Stack>
-            <Label
-              sx={{ marginTop: 2 }}
-            >
-              {t_i18n('Description')}
-            </Label>
-            <ExpandableMarkdown
-              source={indicator.description}
-              limit={400}
-              removeLinks
-            />
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureDetails.tsx
@@ -77,6 +77,12 @@ const InfrastructureDetails: FunctionComponent<InfrastructureDetailsProps> = ({
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={3}>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown source={data.description} limit={400} />
+          </Grid>
           <Grid item xs={6}>
             <Label>
               {t_i18n('Infrastructure types')}
@@ -93,12 +99,6 @@ const InfrastructureDetails: FunctionComponent<InfrastructureDetailsProps> = ({
                   )}
               </Stack>
             </FieldOrEmpty>
-          </Grid>
-          <Grid item xs={6}>
-            <Label>
-              {t_i18n('Description')}
-            </Label>
-            <ExpandableMarkdown source={data.description} limit={400} />
           </Grid>
           <Grid item xs={6}>
             <Label>

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableDetails.tsx
@@ -435,13 +435,7 @@ const StixCyberObservableDetails = ({ data }: StixCyberObservableDetailsProps) =
     <div style={{ height: '100%' }} className="break">
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={2} sx={{ marginBottom: 2 }}>
-          {file && (
-            <Grid size={6}>
-              <DownloadFileButtonMenu fileSize={file.size} encodedFilePath={encodedFilePath} />
-            </Grid>
-          )}
-
-          <Grid size={6}>
+          <Grid size={12}>
             <>
               <Label>
                 {t_i18n('Description')}
@@ -452,6 +446,11 @@ const StixCyberObservableDetails = ({ data }: StixCyberObservableDetailsProps) =
               />
             </>
           </Grid>
+          {file && (
+            <Grid size={6}>
+              <DownloadFileButtonMenu fileSize={file.size} encodedFilePath={encodedFilePath} />
+            </Grid>
+          )}
 
           {orderedObservableAttributes.map((observableAttribute) => {
             const { key, value } = observableAttribute;

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationDetails.tsx
@@ -23,6 +23,12 @@ const SettingsOrganizationDetails: FunctionComponent<
       <Grid container={true} spacing={2}>
         <Grid item xs={12}>
           <Label>
+            {t_i18n('Description')}
+          </Label>
+          <ExpandableMarkdown source={organization.description} limit={400} />
+        </Grid>
+        <Grid item xs={12}>
+          <Label>
             {t_i18n('Organization type')}
           </Label>
           <FieldOrEmpty source={organization.x_opencti_organization_type}>
@@ -30,12 +36,6 @@ const SettingsOrganizationDetails: FunctionComponent<
               label={organization.x_opencti_organization_type}
             />
           </FieldOrEmpty>
-          <Label
-            sx={{ marginTop: 2 }}
-          >
-            {t_i18n('Description')}
-          </Label>
-          <ExpandableMarkdown source={organization.description} limit={400} />
           <Label
             sx={{ marginTop: 2 }}
           >

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternDetails.jsx
@@ -24,6 +24,15 @@ class AttackPatternDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={2}>
+            <Grid item xs={12}>
+              <Label>
+                {t('Description')}
+              </Label>
+              <ExpandableMarkdown
+                source={attackPattern.description}
+                limit={300}
+              />
+            </Grid>
             <Grid item xs={6}>
               {attackPattern.isSubAttackPattern && (
                 <AttackPatternParentAttackPatterns
@@ -40,15 +49,6 @@ class AttackPatternDetailsComponent extends Component {
                   label={attackPattern.x_mitre_id}
                 />
               </FieldOrEmpty>
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t('Description')}
-              </Label>
-              <ExpandableMarkdown
-                source={attackPattern.description}
-                limit={300}
-              />
               <div>
                 <Label
                   sx={{ marginTop: 2 }}

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionDetails.jsx
@@ -23,7 +23,7 @@ class CourseOfActionDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={2}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>
@@ -31,9 +31,9 @@ class CourseOfActionDetailsComponent extends Component {
                 source={courseOfAction.description}
                 limit={300}
               />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
+            </Grid>
+            <Grid item xs={6}>
+              <Label>
                 {t('Log sources')}
               </Label>
               <FieldOrEmpty source={courseOfAction.x_opencti_log_sources}>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceDetails.tsx
@@ -44,7 +44,7 @@ const DataSourceDetailsComponent: FunctionComponent<DataSourceDetailsProps> = ({
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container={true} spacing={2}>
-          <Grid item xs={6}>
+          <Grid item xs={12}>
             <Label>
               {t_i18n('Description')}
             </Label>

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeDetails.jsx
@@ -17,7 +17,7 @@ class NarrativeDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={3}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignDetails.jsx
@@ -16,14 +16,14 @@ class CampaignDetailsComponent extends Component {
       <div style={{ height: '100%' }}>
         <Card title={t('Details')}>
           <Grid container={true} spacing={3}>
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <Label>
                 {t('Description')}
               </Label>
               <ExpandableMarkdown source={campaign.description} limit={400} />
-              <Label
-                sx={{ marginTop: 2 }}
-              >
+            </Grid>
+            <Grid item xs={6}>
+              <Label>
                 {t('Objective')}
               </Label>
               <MarkdownDisplay

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetDetails.tsx
@@ -33,25 +33,21 @@ const IntrusionSetDetailsComponent = ({ intrusionSet }: IntrusionSetDetailsProps
     <div style={{ height: '100%' }}>
       <Card title={t_i18n('Details')}>
         <Grid container spacing={2}>
-          <Grid item xs={hasImages ? 7 : 6}>
-            <Grid container spacing={2}>
-              {hasImages && (
-                <Grid item xs={4}>
-                  <ImageCarousel data={imagesCarousel} />
-                </Grid>
-              )}
-              <Grid item xs={hasImages ? 8 : 12}>
-                <Label>
-                  {t_i18n('Description')}
-                </Label>
-                <ExpandableMarkdown
-                  source={intrusionSet.description}
-                  limit={hasImages ? 400 : 600}
-                />
-              </Grid>
-            </Grid>
+          <Grid item xs={12}>
+            <Label>
+              {t_i18n('Description')}
+            </Label>
+            <ExpandableMarkdown
+              source={intrusionSet.description}
+              limit={hasImages ? 400 : 600}
+            />
           </Grid>
-          <Grid item xs={hasImages ? 5 : 6}>
+          {hasImages && (
+            <Grid item xs={4}>
+              <ImageCarousel data={imagesCarousel} />
+            </Grid>
+          )}
+          <Grid item xs={hasImages ? 8 : 12}>
             <IntrusionSetLocations intrusionSet={intrusionSet} />
             <Label
               sx={{ marginTop: 2 }}

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupDetails.jsx
@@ -25,6 +25,15 @@ class ThreatActorGroupDetailsComponent extends Component {
     return (
       <Card title={t('Details')}>
         <Grid container={true} spacing={2}>
+          <Grid item xs={12}>
+            <Label>
+              {t('Description')}
+            </Label>
+            <ExpandableMarkdown
+              source={threatActorGroup.description}
+              limit={hasImages ? 400 : 600}
+            />
+          </Grid>
           <Grid item xs={hasImages ? 7 : 6}>
             <Grid container={true} spacing={2}>
               {hasImages && (
@@ -49,15 +58,6 @@ class ThreatActorGroupDetailsComponent extends Component {
                       )}
                   </Stack>
                 </FieldOrEmpty>
-                <Label
-                  sx={{ marginTop: 2 }}
-                >
-                  {t('Description')}
-                </Label>
-                <ExpandableMarkdown
-                  source={threatActorGroup.description}
-                  limit={hasImages ? 400 : 600}
-                />
               </Grid>
             </Grid>
           </Grid>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualDetails.tsx
@@ -93,6 +93,15 @@ const ThreatActorIndividualDetails: FunctionComponent<
   return (
     <Card title={t_i18n('Details')}>
       <Grid container={true} spacing={2}>
+        <Grid item xs={12}>
+          <Label>
+            {t_i18n('Description')}
+          </Label>
+          <ExpandableMarkdown
+            source={data.description}
+            limit={hasImages ? 400 : 600}
+          />
+        </Grid>
         <Grid item xs={hasImages ? 7 : 6}>
           <Grid container={true} spacing={2}>
             {hasImages && (
@@ -114,15 +123,6 @@ const ThreatActorIndividualDetails: FunctionComponent<
                   ))}
                 </Stack>
               </FieldOrEmpty>
-              <Label
-                sx={{ marginTop: 2 }}
-              >
-                {t_i18n('Description')}
-              </Label>
-              <ExpandableMarkdown
-                source={data.description}
-                limit={hasImages ? 400 : 600}
-              />
             </Grid>
           </Grid>
         </Grid>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The description field now takes full width of the container and is always on first row

https://github.com/user-attachments/assets/8c501bd2-d88f-4148-aa91-7d653d6463cc




### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Resolves #15613 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
