### PR TITLE
[backend] Update key mapping to use publicJWK instead of publicKey (#15840)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/platformCrypto.ts
+++ b/opencti-platform/opencti-graphql/src/utils/platformCrypto.ts
@@ -206,7 +206,7 @@ export const createCryptoKeyFactory = (seed: Buffer) => {
 
     return {
       publicKeys: {
-        [toHex(kid)]: publicKey,
+        [toHex(kid)]: publicJWK,
       },
       jwks: {
         keys: [


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fixed a bug where `publicKeys` exposed a raw Uint8Array instead of a jose-compatible KeyLike object (`publicJWK`).
This caused an AuthenticationFailure ("Key must be of type CryptoKey... Received Uint8Array") when OpenCTI attempted to verify its own locally-issued JWTs in environments without XTM One configured.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15840 


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
