### PR TITLE
[frontend] Custom views E2E tests (#13389)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewEditionHeader.tsx
@@ -92,7 +92,13 @@ const CustomViewEditionHeader = ({ data, onCreateWidget, onImportWidget, host }:
         />
         <Box sx={{ display: 'flex', alignItems: 'center', marginLeft: 'auto', gap: 1 }}>
           <Tooltip title={customView.enabled ? t_i18n('Disable') : t_i18n('Enable')}>
-            <IconButton variant="secondary" size="default" disabled={mutating} onClick={handleToggleEnabled}>
+            <IconButton
+              variant="secondary"
+              size="default"
+              disabled={mutating}
+              onClick={handleToggleEnabled}
+              aria-label={customView.enabled ? t_i18n('Disable') : t_i18n('Enable')}
+            >
               {customView.enabled ? <VisibilityOffIcon /> : <VisibilityIcon />}
             </IconButton>
           </Tooltip>

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewsSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewsSettings.tsx
@@ -32,6 +32,7 @@ const CustomViewsSettings = () => {
           <>
             <Tooltip title={t_i18n('Create a new custom view')}>
               <IconButton
+                aria-label={t_i18n('Create a new custom view')}
                 onClick={() => setDrawerOpen(true)}
                 size="small"
               >

--- a/opencti-platform/opencti-front/tests_e2e/customView/customView.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/customView/customView.spec.ts
@@ -1,0 +1,144 @@
+import { v4 as uuid } from 'uuid';
+import { expect, test } from '../fixtures/baseFixtures';
+import CustomViewsSettingsPage from '../model/customViewsSettings.pageModel';
+import CustomViewDetailsPage from '../model/customViewDetails.pageModel';
+import LeftBarPage from '../model/menu/leftBar.pageModel';
+import CampaignPage from '../model/campaign.pageModel';
+import SettingsCustomizationPage from 'tests_e2e/model/settingsCustomization.pageModel';
+
+/**
+ * Content of the test
+ * -------------------
+ * Golden path for Custom Views feature:
+ * 1. Navigate to Settings > Customization > Campaign > Custom Views.
+ * 2. Create a new Custom View targeting Campaign entities.
+ * 3. Validate form fields (required, min length).
+ * 4. Verify the view appears in the list.
+ * 5. Add a widget to the view.
+ * 6. Enable the view and verify it appears as a tab on a Campaign entity page.
+ * 7. Set the view as Default and verify it is the landing tab.
+ * 8. Duplicate the view.
+ * 9. Export then re-import the view.
+ * 10. Delete the view (and its duplicate and the imported view).
+ */
+test('Custom View CRUD - golden path', { tag: ['@ce'] }, async ({ page }) => {
+  const leftBarPage = new LeftBarPage(page);
+  const customViewsSettingsPage = new CustomViewsSettingsPage(page);
+  const customizationPage = new SettingsCustomizationPage(page);
+  const customViewDetailsPage = new CustomViewDetailsPage(page);
+  const campaignPage = new CampaignPage(page);
+
+  const viewName = `Custom View - ${uuid()}`;
+
+  // ─── Navigate ────────────────────────────────────────────────────────────────
+  await page.goto('/');
+  await customViewsSettingsPage.navigateFromMenu(customizationPage, 'Campaign');
+  await expect(page.getByRole('heading', { name: 'Campaign' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Custom Views' })).toBeVisible();
+
+  // ─── Open create form ────────────────────────────────────────────────────────
+  await customViewsSettingsPage.getAddButton().click();
+  await expect(page.getByRole('heading', { name: 'Create custom view' })).toBeVisible();
+
+  // ─── Validate required field ─────────────────────────────────────────────────
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.getByText('This field is required')).toBeVisible();
+
+  // ─── Validate min-length ─────────────────────────────────────────────────────
+  await page.getByRole('textbox', { name: 'Name' }).fill('a');
+  await expect(page.getByText('name must be at least 2 characters')).toBeVisible();
+
+  // ─── Fill form and create ─────────────────────────────────────────────────────
+  await page.getByRole('textbox', { name: 'Name' }).fill(viewName);
+  await page.getByTestId('text-area').fill('E2E test custom view');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  // ─── Verify we are in view detail / edit mode ────────────────────────────────────────────
+  await expect(customViewDetailsPage.getTitle(viewName)).toBeVisible();
+
+  // ─── Add a widget ─────────────────────────────────────────────────────────────
+  await customViewDetailsPage.widgets.openWidgetModal();
+  await customViewDetailsPage.widgets.selectWidget('List');
+  await customViewDetailsPage.widgets.selectPerspective('Entities');
+  await expect(page.getByText('In regards of')).toBeVisible();
+  await expect(page.getByText('CURRENT ENTITY', { exact: true })).toBeVisible();
+  await customViewDetailsPage.widgets.fillLabel('Malwares');
+  await customViewDetailsPage.widgets.validateFilters();
+  await customViewDetailsPage.widgets.titleField.fill('Related malwares');
+  await customViewDetailsPage.widgets.createWidget();
+  // Widget should now be visible in the view
+  await expect(page.getByText('Related malwares')).toBeVisible();
+
+  // ─── Enable the view ─────────────────────────────────────────────────────────
+  await expect(customViewDetailsPage.getViewIsDisabledTag()).toBeVisible();
+  await customViewDetailsPage.getEnableToggle().click();
+  await expect(customViewDetailsPage.getViewIsEnabledTag()).toBeVisible();
+
+  // ─── Verify view appears in list ─────────────────────────────────────────────
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  await expect(customViewsSettingsPage.getItemFromList(viewName)).toBeVisible();
+
+  // ─── Verify tab appears on a Campaign entity page ─────────────────────────────
+  await leftBarPage.clickOnMenu('Threats', 'Campaigns');
+  await campaignPage.getItemFromListWithUrl('menuPass').click();
+  // The custom view tab should be visible (single view → uses view name directly)
+  await expect(page.getByRole('tab', { name: viewName })).toBeVisible();
+
+  // ─── Set as Default ──────────────────────────────────────────────────────────
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  await customViewsSettingsPage.getItemFromList(viewName).click();
+  await customViewDetailsPage.getEditButton().click();
+  await customViewDetailsPage.getDefaultToggle().click();
+  await customViewDetailsPage.getCloseButton().click();
+
+  // Verify the default tab is first on a Campaign entity page
+  await leftBarPage.clickOnMenu('Threats', 'Campaigns');
+  await campaignPage.getItemFromListWithUrl('menuPass').click();
+  const tabs = page.getByRole('tab');
+  await expect(tabs.first()).toHaveText(viewName);
+
+  // ─── Duplicate ───────────────────────────────────────────────────────────────
+  const duplicateName = `${viewName} - copy`;
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  await customViewsSettingsPage.getItemFromList(viewName).click();
+  await customViewDetailsPage.getActionsPopover().click();
+  await customViewDetailsPage.getActionButton('Duplicate').click();
+  await customViewDetailsPage.getDuplicateButton().click();
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  await expect(customViewsSettingsPage.getItemFromList(duplicateName)).toBeVisible();
+
+  // ─── Export / Import ─────────────────────────────────────────────────────────
+  await customViewsSettingsPage.getItemFromList(viewName).click();
+  const downloadPromise = page.waitForEvent('download');
+  await customViewDetailsPage.getExportButton().click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBeDefined();
+  await download.saveAs(`./test-results/e2e-files/${download.suggestedFilename()}`);
+
+  // Import it back
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await customViewsSettingsPage.getImportButton().click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(`./test-results/e2e-files/${download.suggestedFilename()}`);
+  // Imported view should be visible (disabled by default)
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  const lines = customViewsSettingsPage.getItemFromList(viewName);
+  await expect.poll(async () => {
+    return await lines.filter({ visible: true }).count();
+  }, {
+    timeout: 5000,
+    intervals: [100, 200, 500],
+  }).toBe(2);
+
+  // ─── Cleanup: delete all created views ───────────────────────────────────────
+  await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
+  for (const name of [viewName, duplicateName, viewName]) {
+    const item = customViewsSettingsPage.getItemFromList(name).nth(0);
+    await item.waitFor({ state: 'visible', timeout: 5000 });
+    await customViewsSettingsPage.getQuickActionsButton(item).click();
+    await customViewsSettingsPage.getDeleteQuickActionButton().click();
+    await customViewsSettingsPage.getConfirmButton().click();
+  }
+  await expect(customViewsSettingsPage.getItemFromList(viewName)).toBeHidden();
+});

--- a/opencti-platform/opencti-front/tests_e2e/model/campaign.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/campaign.pageModel.ts
@@ -8,6 +8,10 @@ export default class CampaignPageModel {
     return this.page.getByText(name, { exact: true });
   }
 
+  getItemFromListWithUrl(name: string) {
+    return this.page.getByRole('link', { name });
+  }
+
   getPage() {
     return this.page.getByTestId('campaign-page');
   }

--- a/opencti-platform/opencti-front/tests_e2e/model/customViewDetails.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/customViewDetails.pageModel.ts
@@ -1,0 +1,66 @@
+import { Page } from '@playwright/test';
+import DashboardWidgetsPageModel from './DashboardWidgets.pageModel';
+
+export default class CustomViewDetailsPage {
+  widgets = new DashboardWidgetsPageModel(this.page);
+
+  constructor(private page: Page) {}
+
+  getTitle(name: string) {
+    return this.page.getByRole('heading', { name, exact: true });
+  }
+
+  getEditButton() {
+    return this.page.getByRole('button', { name: 'Update' });
+  }
+
+  getActionsPopover() {
+    return this.page.getByLabel('Popover of custom view actions');
+  }
+
+  getActionButton(name: string) {
+    return this.page.getByRole('menuitem', { name });
+  }
+
+  getConfirmButton() {
+    return this.page.getByRole('button', { name: 'Confirm' });
+  }
+
+  getDuplicateButton() {
+    return this.page.getByRole('button', { name: 'Duplicate' });
+  }
+
+  getExportButton() {
+    return this.page.getByRole('button', { name: 'Export' });
+  }
+
+  getEnableToggle() {
+    return this.page.getByRole('button', { name: 'Enable' });
+  }
+
+  getDisableToggle() {
+    return this.page.getByRole('button', { name: 'Disable' });
+  }
+
+  getDefaultToggle() {
+    return this.page.getByRole('checkbox', { name: 'Set as default custom view' });
+  }
+
+  getCloseButton() {
+    return this.page.getByRole('button', { name: 'Close' });
+  }
+
+  getViewIsEnabledTag() {
+    return this.page.getByText('View is enabled');
+  }
+
+  getViewIsDisabledTag() {
+    return this.page.getByText('View is disabled');
+  }
+
+  async delete() {
+    await this.getActionsPopover().click();
+    await this.getActionButton('Delete').click();
+    await this.getConfirmButton().click();
+  }
+}

--- a/opencti-platform/opencti-front/tests_e2e/model/customViewsSettings.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/customViewsSettings.pageModel.ts
@@ -1,0 +1,56 @@
+import { Locator, Page } from '@playwright/test';
+import SettingsCustomizationPage from './settingsCustomization.pageModel';
+
+export default class CustomViewsSettingsPage {
+  constructor(private page: Page) {}
+
+  async navigateFromMenu(customizationPage: SettingsCustomizationPage, entityTypeLabel: string) {
+    await customizationPage.navigateFromMenu();
+    await customizationPage.getItemFromList(entityTypeLabel).click();
+    await this.page.getByRole('tab', { name: 'Custom Views', exact: true }).click();
+  }
+
+  getPageUrl(entityType: string) {
+    return `/dashboard/settings/customization/entity_types/${entityType}/custom-views`;
+  }
+
+  getPageTitle() {
+    return this.page.getByTestId('custom-views-page');
+  }
+
+  getAddButton() {
+    return this.page.getByRole('button', { name: 'Create a new custom view' });
+  }
+
+  getItemFromList(name: string) {
+    return this.page.getByTestId(name);
+  }
+
+  getImportButton() {
+    return this.page.getByRole('button', { name: 'Import a custom view' });
+  }
+
+  getQuickActionsButton(itemLocator: Locator) {
+    return itemLocator.getByRole('button', { name: 'Custom view popover of actions' });
+  }
+
+  getDeleteQuickActionButton() {
+    return this.page.getByRole('menuitem', { name: 'Delete' });
+  }
+
+  getEnableQuickActionButton() {
+    return this.page.getByRole('menuitem', { name: 'Enable' });
+  }
+
+  getDisableQuickActionButton() {
+    return this.page.getByRole('menuitem', { name: 'Disable' });
+  }
+
+  getConfirmButton() {
+    return this.page.getByRole('button', { name: 'Confirm' });
+  }
+
+  getEmptyListMessage() {
+    return this.page.getByText('No entries yet');
+  }
+}


### PR DESCRIPTION
### Proposed changes

* Custom views E2E tests (GOLDEN PATH ONLY)

### Related issues

* Partially fixes https://github.com/OpenCTI-Platform/opencti/issues/13389

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
