### PR TITLE
[frontend] feature(xtmhub): import from hub redirects to the filtered resource in hub integrations library (#15852)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCsv.tsx
@@ -35,7 +35,7 @@ const IngestionCsv = () => {
   const classes = useStyles();
   const { settings, isXTMHubAccessible } = useContext(UserContext);
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}&integrationType=csv_feed`
     : '';
 
   const { t_i18n } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionRss.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionRss.tsx
@@ -39,7 +39,7 @@ const IngestionRss = () => {
   setTitle(t_i18n('RSS Feeds | Ingestion | Data'));
   const { platformModuleHelpers } = useAuth();
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}&integrationType=rss_feed`
     : '';
   const {
     viewStorage,

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionTaxiis.tsx
@@ -40,7 +40,7 @@ const IngestionTaxii = () => {
   const { platformModuleHelpers } = useAuth();
 
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}&integrationType=taxii_feed`
     : '';
 
   const {

--- a/opencti-platform/opencti-front/src/private/components/data/Sync.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Sync.tsx
@@ -29,7 +29,7 @@ const Sync = () => {
   const { settings, isXTMHubAccessible } = useContext(UserContext);
 
   const importFromHubUrl = isNotEmptyField(settings?.platform_xtmhub_url)
-    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}`
+    ? `${settings.platform_xtmhub_url}/redirect/opencti_integrations?platform_id=${settings.id}&integrationType=stream`
     : '';
 
   setTitle(t_i18n('Remote OCTI Streams | Ingestion | Data'));


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Import from hub redirects to the filtered resource on xtmhub side
*
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Resolves #15852 
* related to https://github.com/FiligranHQ/xtm-hub/pull/2284
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
