### PR TITLE
[backend] fix unsharing component (#15586)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/unsharing-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/unsharing-component.ts
@@ -55,15 +55,17 @@ export const PLAYBOOK_UNSHARING_COMPONENT: PlaybookComponent<UnsharingConfigurat
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const element = bundle.objects[index];
       if (all || element.id === dataInstanceId) {
+        const currentElementGrantedRefs = element.extensions[STIX_EXT_OCTI].granted_refs ?? [];
+        const newGrantedRefs = currentElementGrantedRefs.filter((o) => !organizationIds.includes(o));
         const patchValue = {
-          op: EditOperation.Remove,
+          op: EditOperation.Replace,
           path: `/objects/${index}/extensions/${STIX_EXT_OCTI}/granted_refs`,
-          value: organizationIds,
+          value: newGrantedRefs,
         };
         const patchOperation = {
-          operation: patchValue.op,
+          operation: EditOperation.Remove,
           key: INPUT_GRANTED_REFS,
-          value: patchValue.value,
+          value: organizationIds,
         };
         applyOperationFieldPatch(element, [patchOperation]);
         patchOperations.push(patchValue);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/unsharing-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/unsharing-component.ts
@@ -57,18 +57,20 @@ export const PLAYBOOK_UNSHARING_COMPONENT: PlaybookComponent<UnsharingConfigurat
       if (all || element.id === dataInstanceId) {
         const currentElementGrantedRefs = element.extensions[STIX_EXT_OCTI].granted_refs ?? [];
         const newGrantedRefs = currentElementGrantedRefs.filter((o) => !organizationIds.includes(o));
-        const patchValue = {
-          op: EditOperation.Replace,
-          path: `/objects/${index}/extensions/${STIX_EXT_OCTI}/granted_refs`,
-          value: newGrantedRefs,
-        };
-        const patchOperation = {
-          operation: EditOperation.Remove,
-          key: INPUT_GRANTED_REFS,
-          value: organizationIds,
-        };
-        applyOperationFieldPatch(element, [patchOperation]);
-        patchOperations.push(patchValue);
+        if (currentElementGrantedRefs.length !== newGrantedRefs.length) {
+          const patchValue = {
+            op: EditOperation.Replace,
+            path: `/objects/${index}/extensions/${STIX_EXT_OCTI}/granted_refs`,
+            value: newGrantedRefs,
+          };
+          const patchOperation = {
+            operation: EditOperation.Remove,
+            key: INPUT_GRANTED_REFS,
+            value: organizationIds,
+          };
+          applyOperationFieldPatch(element, [patchOperation]);
+          patchOperations.push(patchValue);
+        }
       }
     }
     if (patchOperations.length > 0) {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/unsharing-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/unsharing-component-test.ts
@@ -169,7 +169,7 @@ describe('PLAYBOOK_UNSHARING_COMPONENT', () => {
       const ext = result.bundle.objects[0].extensions[STIX_EXT_OCTI];
 
       // granted_refs should be removed
-      expect(ext.granted_refs).toBe([]);
+      expect(ext.granted_refs).toStrictEqual([]);
 
       // upsert operation should be added
       if (!ext.opencti_upsert_operations || !ext.opencti_upsert_operations[0]) {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/unsharing-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/unsharing-component-test.ts
@@ -169,7 +169,7 @@ describe('PLAYBOOK_UNSHARING_COMPONENT', () => {
       const ext = result.bundle.objects[0].extensions[STIX_EXT_OCTI];
 
       // granted_refs should be removed
-      expect(ext.granted_refs).toBeUndefined();
+      expect(ext.granted_refs).toBe([]);
 
       // upsert operation should be added
       if (!ext.opencti_upsert_operations || !ext.opencti_upsert_operations[0]) {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/unsharing-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbookComponents/unsharing-component-test.ts
@@ -232,7 +232,7 @@ describe('PLAYBOOK_UNSHARING_COMPONENT', () => {
 
       const ext = result.bundle.objects[0].extensions[STIX_EXT_OCTI];
 
-      expect(ext.granted_refs).toBeUndefined();
+      expect(ext.granted_refs).toStrictEqual([]);
 
       if (!ext.opencti_upsert_operations || !ext.opencti_upsert_operations[0]) {
         assert.fail('Upsert operation missing');


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request updates the logic for unsharing playbook components to ensure that only the specified organizations are removed from the `granted_refs` field, rather than attempting to remove the entire field or replace it with the full list. This change makes the unsharing process more precise and prevents unintended removal of access for other organizations.

Improvements to unsharing logic:

* In `opencti-graphql/src/modules/playbook/components/unsharing-component.ts`, the code now filters out only the specified organization IDs from the `granted_refs` array, and replaces the field with the updated list, improving the accuracy of the unsharing operation

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15586 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
