### PR TITLE
feat(backend): add engine health monitor (#15860) (#37)

### DIFF
--- a/opencti-platform/opencti-graphql/src/boot.js
+++ b/opencti-platform/opencti-graphql/src/boot.js
@@ -6,7 +6,7 @@ import { shutdownModules, startModules } from './managers';
 import { initLockFork } from './lock/master-lock';
 import { checkSystemDependencies } from './boot-utils';
 import { startLivenessServer, stopLivenessServer } from './http/httpLiveness';
-import { startEngineHealthMonitor, stopEngineHealthMonitor } from './database/engine';
+import { startEngineHealthMonitor, stopEngineHealthMonitor } from './database/engine-monitoring';
 
 // region platform start and stop
 export const platformStart = async () => {

--- a/opencti-platform/opencti-graphql/src/boot.js
+++ b/opencti-platform/opencti-graphql/src/boot.js
@@ -6,6 +6,7 @@ import { shutdownModules, startModules } from './managers';
 import { initLockFork } from './lock/master-lock';
 import { checkSystemDependencies } from './boot-utils';
 import { startLivenessServer, stopLivenessServer } from './http/httpLiveness';
+import { startEngineHealthMonitor, stopEngineHealthMonitor } from './database/engine';
 
 // region platform start and stop
 export const platformStart = async () => {
@@ -55,6 +56,8 @@ export const platformStart = async () => {
       logApp.error('[OPENCTI] Modules startup failed', { cause: modulesError });
       throw modulesError;
     }
+    // Start the engine health monitoring CRON
+    startEngineHealthMonitor();
     logApp.info(`[OPENCTI] Platform started ${Date.now() - startTime} ms`);
   } catch (_mainError) {
     process.exit(1);
@@ -65,6 +68,8 @@ export const platformStop = async () => {
   const stopTime = new Date().getTime();
   // Shutdown the liveness probe
   await stopLivenessServer();
+  // Stop the engine health monitoring CRON
+  stopEngineHealthMonitor();
   // Shutdown the cache manager
   await cacheManager.shutdown();
   // Destroy the modules

--- a/opencti-platform/opencti-graphql/src/database/engine-monitoring.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine-monitoring.ts
@@ -1,0 +1,100 @@
+// region Engine health monitoring CRON
+import { Client as ElkClient } from '@elastic/elasticsearch';
+import { isFeatureEnabled, logApp } from '../config/conf';
+import { engine, oebp } from './engine';
+
+const HEALTH_MONITOR_INTERVAL_MS = 60_000; // 1 minute
+let healthMonitorInterval: NodeJS.Timeout | null = null;
+
+const elGetClusterHealth = async () => {
+  try {
+    // 1. Cluster health
+    const healthResult = engine instanceof ElkClient
+      ? await engine.cluster.health()
+      : await engine.cluster.health();
+    const health = oebp(healthResult);
+    logApp.info('[SEARCH] Cluster health', {
+      status: health.status,
+      numberOfNodes: health.number_of_nodes,
+      numberOfDataNodes: health.number_of_data_nodes,
+      activePrimaryShards: health.active_primary_shards,
+      activeShards: health.active_shards,
+      relocatingShards: health.relocating_shards,
+      initializingShards: health.initializing_shards,
+      unassignedShards: health.unassigned_shards,
+      activeShardsPercentAsNumber: health.active_shards_percent_as_number,
+    });
+
+    // 2. Node stats (JVM heap, CPU, OS memory)
+    const nodesStatsResult = engine instanceof ElkClient
+      ? await engine.nodes.stats({ metric: ['jvm', 'os', 'process'] as any })
+      : await engine.nodes.stats({ metric: 'jvm,os,process' } as any);
+    const nodesStats = oebp(nodesStatsResult);
+    const nodeEntries = Object.entries(nodesStats.nodes ?? {}) as [string, any][];
+    for (const [nodeId, node] of nodeEntries) {
+      const jvmHeapUsedBytes = node.jvm?.mem?.heap_used_in_bytes ?? 0;
+      const jvmHeapMaxBytes = node.jvm?.mem?.heap_max_in_bytes ?? 1;
+      const jvmHeapUsedPercent = Math.round((jvmHeapUsedBytes / jvmHeapMaxBytes) * 100);
+      logApp.info('[SEARCH] Node stats', {
+        nodeId,
+        nodeName: node.name,
+        cpuPercent: node.os?.cpu?.percent,
+        osMemTotalBytes: node.os?.mem?.total_in_bytes,
+        osMemFreeBytes: node.os?.mem?.free_in_bytes,
+        osMemUsedPercent: node.os?.mem?.used_percent,
+        jvmHeapUsedBytes,
+        jvmHeapMaxBytes,
+        jvmHeapUsedPercent,
+        jvmGcYoungCollectionCount: node.jvm?.gc?.collectors?.young?.collection_count,
+        jvmGcYoungCollectionTimeMs: node.jvm?.gc?.collectors?.young?.collection_time_in_millis,
+        jvmGcOldCollectionCount: node.jvm?.gc?.collectors?.old?.collection_count,
+        jvmGcOldCollectionTimeMs: node.jvm?.gc?.collectors?.old?.collection_time_in_millis,
+        openFileDescriptors: node.process?.open_file_descriptors,
+      });
+    }
+
+    // 3. Thread pool stats (queue sizes, rejections)
+    const threadPoolResult = engine instanceof ElkClient
+      ? await engine.cat.threadPool({ format: 'json', h: 'node_name,name,active,queue,rejected,completed' as any })
+      : await engine.cat.threadPool({ format: 'json', h: ['node_name', 'name', 'active', 'queue', 'rejected', 'completed'] } as any);
+    const threadPools = oebp(threadPoolResult) as any[];
+    const monitoredPools = ['search', 'write', 'bulk', 'get', 'analyze', 'management'];
+    const relevantPools = (threadPools ?? []).filter(
+      (tp: any) => monitoredPools.includes(tp.name) && (Number(tp.active) > 0 || Number(tp.queue) > 0 || Number(tp.rejected) > 0),
+    );
+    if (relevantPools.length > 0) {
+      for (const tp of relevantPools) {
+        logApp.info('[SEARCH] Thread pool stats', {
+          nodeName: tp.node_name,
+          pool: tp.name,
+          active: Number(tp.active),
+          queue: Number(tp.queue),
+          rejected: Number(tp.rejected),
+          completed: Number(tp.completed),
+        });
+      }
+    } else {
+      logApp.info('[SEARCH] Thread pool stats: all monitored pools idle (no active, queued, or rejected tasks)');
+    }
+  } catch (e) {
+    logApp.error('[SEARCH] Error fetching cluster health', { cause: e });
+  }
+};
+
+export const startEngineHealthMonitor = () => {
+  const engineMonitorActivated = isFeatureEnabled('ENGINE_MONITORING');
+  if (!engineMonitorActivated || healthMonitorInterval) {
+    return; // Already running
+  }
+  logApp.info('[SEARCH] Starting engine health monitoring CRON (every 1 minute)');
+  healthMonitorInterval = setInterval(elGetClusterHealth, HEALTH_MONITOR_INTERVAL_MS);
+};
+
+export const stopEngineHealthMonitor = () => {
+  if (healthMonitorInterval) {
+    clearInterval(healthMonitorInterval);
+    healthMonitorInterval = null;
+    logApp.info('[SEARCH] Engine health monitoring CRON stopped');
+  }
+};
+// endregion

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -280,7 +280,7 @@ export const isImpactedRole = (type: string, fromType: string, toType: string, r
   return !UNIMPACTED_ENTITIES_ROLE.includes(role);
 };
 
-let engine: ElkClient | OpenClient;
+export let engine: ElkClient | OpenClient;
 let isRuntimeSortingEnable = false;
 let attachmentProcessorEnabled = false;
 
@@ -291,7 +291,7 @@ export const isAttachmentProcessorEnabled = () => {
 // The OpenSearch/ELK Body Parser (oebp)
 // Starting ELK8+, response are no longer inside a body envelop
 // Query wrapping is still accepted in ELK8
-const oebp = (queryResult: any): any => {
+export const oebp = (queryResult: any): any => {
   if (engine instanceof ElkClient) {
     return queryResult;
   }
@@ -5043,99 +5043,3 @@ export const isEngineAlive = async () => {
     throw DatabaseError('Invalid database content, missing migration schema');
   }
 };
-
-// region Engine health monitoring CRON
-const HEALTH_MONITOR_INTERVAL_MS = 60_000; // 1 minute
-let healthMonitorInterval: NodeJS.Timeout | null = null;
-
-const elGetClusterHealth = async () => {
-  try {
-    // 1. Cluster health
-    const healthResult = engine instanceof ElkClient
-      ? await engine.cluster.health()
-      : await engine.cluster.health();
-    const health = oebp(healthResult);
-    logApp.info('[SEARCH] Cluster health', {
-      status: health.status,
-      numberOfNodes: health.number_of_nodes,
-      numberOfDataNodes: health.number_of_data_nodes,
-      activePrimaryShards: health.active_primary_shards,
-      activeShards: health.active_shards,
-      relocatingShards: health.relocating_shards,
-      initializingShards: health.initializing_shards,
-      unassignedShards: health.unassigned_shards,
-      activeShardsPercentAsNumber: health.active_shards_percent_as_number,
-    });
-
-    // 2. Node stats (JVM heap, CPU, OS memory)
-    const nodesStatsResult = engine instanceof ElkClient
-      ? await engine.nodes.stats({ metric: ['jvm', 'os', 'process'] as any })
-      : await engine.nodes.stats({ metric: 'jvm,os,process' } as any);
-    const nodesStats = oebp(nodesStatsResult);
-    const nodeEntries = Object.entries(nodesStats.nodes ?? {}) as [string, any][];
-    for (const [nodeId, node] of nodeEntries) {
-      const jvmHeapUsedBytes = node.jvm?.mem?.heap_used_in_bytes ?? 0;
-      const jvmHeapMaxBytes = node.jvm?.mem?.heap_max_in_bytes ?? 1;
-      const jvmHeapUsedPercent = Math.round((jvmHeapUsedBytes / jvmHeapMaxBytes) * 100);
-      logApp.info('[SEARCH] Node stats', {
-        nodeId,
-        nodeName: node.name,
-        cpuPercent: node.os?.cpu?.percent,
-        osMemTotalBytes: node.os?.mem?.total_in_bytes,
-        osMemFreeBytes: node.os?.mem?.free_in_bytes,
-        osMemUsedPercent: node.os?.mem?.used_percent,
-        jvmHeapUsedBytes,
-        jvmHeapMaxBytes,
-        jvmHeapUsedPercent,
-        jvmGcYoungCollectionCount: node.jvm?.gc?.collectors?.young?.collection_count,
-        jvmGcYoungCollectionTimeMs: node.jvm?.gc?.collectors?.young?.collection_time_in_millis,
-        jvmGcOldCollectionCount: node.jvm?.gc?.collectors?.old?.collection_count,
-        jvmGcOldCollectionTimeMs: node.jvm?.gc?.collectors?.old?.collection_time_in_millis,
-        openFileDescriptors: node.process?.open_file_descriptors,
-      });
-    }
-
-    // 3. Thread pool stats (queue sizes, rejections)
-    const threadPoolResult = engine instanceof ElkClient
-      ? await engine.cat.threadPool({ format: 'json', h: 'node_name,name,active,queue,rejected,completed' as any })
-      : await engine.cat.threadPool({ format: 'json', h: ['node_name', 'name', 'active', 'queue', 'rejected', 'completed'] } as any);
-    const threadPools = oebp(threadPoolResult) as any[];
-    const monitoredPools = ['search', 'write', 'bulk', 'get', 'analyze', 'management'];
-    const relevantPools = (threadPools ?? []).filter(
-      (tp: any) => monitoredPools.includes(tp.name) && (Number(tp.active) > 0 || Number(tp.queue) > 0 || Number(tp.rejected) > 0),
-    );
-    if (relevantPools.length > 0) {
-      for (const tp of relevantPools) {
-        logApp.info('[SEARCH] Thread pool stats', {
-          nodeName: tp.node_name,
-          pool: tp.name,
-          active: Number(tp.active),
-          queue: Number(tp.queue),
-          rejected: Number(tp.rejected),
-          completed: Number(tp.completed),
-        });
-      }
-    } else {
-      logApp.info('[SEARCH] Thread pool stats: all monitored pools idle (no active, queued, or rejected tasks)');
-    }
-  } catch (e) {
-    logApp.error('[SEARCH] Error fetching cluster health', { cause: e });
-  }
-};
-
-export const startEngineHealthMonitor = () => {
-  if (healthMonitorInterval) {
-    return; // Already running
-  }
-  logApp.info('[SEARCH] Starting engine health monitoring CRON (every 1 minute)');
-  healthMonitorInterval = setInterval(elGetClusterHealth, HEALTH_MONITOR_INTERVAL_MS);
-};
-
-export const stopEngineHealthMonitor = () => {
-  if (healthMonitorInterval) {
-    clearInterval(healthMonitorInterval);
-    healthMonitorInterval = null;
-    logApp.info('[SEARCH] Engine health monitoring CRON stopped');
-  }
-};
-// endregion

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -5043,3 +5043,99 @@ export const isEngineAlive = async () => {
     throw DatabaseError('Invalid database content, missing migration schema');
   }
 };
+
+// region Engine health monitoring CRON
+const HEALTH_MONITOR_INTERVAL_MS = 60_000; // 1 minute
+let healthMonitorInterval: NodeJS.Timeout | null = null;
+
+const elGetClusterHealth = async () => {
+  try {
+    // 1. Cluster health
+    const healthResult = engine instanceof ElkClient
+      ? await engine.cluster.health()
+      : await engine.cluster.health();
+    const health = oebp(healthResult);
+    logApp.info('[SEARCH] Cluster health', {
+      status: health.status,
+      numberOfNodes: health.number_of_nodes,
+      numberOfDataNodes: health.number_of_data_nodes,
+      activePrimaryShards: health.active_primary_shards,
+      activeShards: health.active_shards,
+      relocatingShards: health.relocating_shards,
+      initializingShards: health.initializing_shards,
+      unassignedShards: health.unassigned_shards,
+      activeShardsPercentAsNumber: health.active_shards_percent_as_number,
+    });
+
+    // 2. Node stats (JVM heap, CPU, OS memory)
+    const nodesStatsResult = engine instanceof ElkClient
+      ? await engine.nodes.stats({ metric: ['jvm', 'os', 'process'] as any })
+      : await engine.nodes.stats({ metric: 'jvm,os,process' } as any);
+    const nodesStats = oebp(nodesStatsResult);
+    const nodeEntries = Object.entries(nodesStats.nodes ?? {}) as [string, any][];
+    for (const [nodeId, node] of nodeEntries) {
+      const jvmHeapUsedBytes = node.jvm?.mem?.heap_used_in_bytes ?? 0;
+      const jvmHeapMaxBytes = node.jvm?.mem?.heap_max_in_bytes ?? 1;
+      const jvmHeapUsedPercent = Math.round((jvmHeapUsedBytes / jvmHeapMaxBytes) * 100);
+      logApp.info('[SEARCH] Node stats', {
+        nodeId,
+        nodeName: node.name,
+        cpuPercent: node.os?.cpu?.percent,
+        osMemTotalBytes: node.os?.mem?.total_in_bytes,
+        osMemFreeBytes: node.os?.mem?.free_in_bytes,
+        osMemUsedPercent: node.os?.mem?.used_percent,
+        jvmHeapUsedBytes,
+        jvmHeapMaxBytes,
+        jvmHeapUsedPercent,
+        jvmGcYoungCollectionCount: node.jvm?.gc?.collectors?.young?.collection_count,
+        jvmGcYoungCollectionTimeMs: node.jvm?.gc?.collectors?.young?.collection_time_in_millis,
+        jvmGcOldCollectionCount: node.jvm?.gc?.collectors?.old?.collection_count,
+        jvmGcOldCollectionTimeMs: node.jvm?.gc?.collectors?.old?.collection_time_in_millis,
+        openFileDescriptors: node.process?.open_file_descriptors,
+      });
+    }
+
+    // 3. Thread pool stats (queue sizes, rejections)
+    const threadPoolResult = engine instanceof ElkClient
+      ? await engine.cat.threadPool({ format: 'json', h: 'node_name,name,active,queue,rejected,completed' as any })
+      : await engine.cat.threadPool({ format: 'json', h: ['node_name', 'name', 'active', 'queue', 'rejected', 'completed'] } as any);
+    const threadPools = oebp(threadPoolResult) as any[];
+    const monitoredPools = ['search', 'write', 'bulk', 'get', 'analyze', 'management'];
+    const relevantPools = (threadPools ?? []).filter(
+      (tp: any) => monitoredPools.includes(tp.name) && (Number(tp.active) > 0 || Number(tp.queue) > 0 || Number(tp.rejected) > 0),
+    );
+    if (relevantPools.length > 0) {
+      for (const tp of relevantPools) {
+        logApp.info('[SEARCH] Thread pool stats', {
+          nodeName: tp.node_name,
+          pool: tp.name,
+          active: Number(tp.active),
+          queue: Number(tp.queue),
+          rejected: Number(tp.rejected),
+          completed: Number(tp.completed),
+        });
+      }
+    } else {
+      logApp.info('[SEARCH] Thread pool stats: all monitored pools idle (no active, queued, or rejected tasks)');
+    }
+  } catch (e) {
+    logApp.error('[SEARCH] Error fetching cluster health', { cause: e });
+  }
+};
+
+export const startEngineHealthMonitor = () => {
+  if (healthMonitorInterval) {
+    return; // Already running
+  }
+  logApp.info('[SEARCH] Starting engine health monitoring CRON (every 1 minute)');
+  healthMonitorInterval = setInterval(elGetClusterHealth, HEALTH_MONITOR_INTERVAL_MS);
+};
+
+export const stopEngineHealthMonitor = () => {
+  if (healthMonitorInterval) {
+    clearInterval(healthMonitorInterval);
+    healthMonitorInterval = null;
+    logApp.info('[SEARCH] Engine health monitoring CRON stopped');
+  }
+};
+// endregion


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request introduces a new engine health monitoring feature to the platform. It adds a recurring background process that periodically checks and logs the health and resource usage of the search engine cluster, including cluster status, node statistics, and thread pool activity. The monitor starts automatically with the platform and stops gracefully during shutdown.

**Engine Health Monitoring**

* Added a health monitoring CRON job that runs every minute to gather and log cluster health, node statistics (JVM heap, CPU, OS memory), and thread pool stats for the search engine (`opencti-platform/opencti-graphql/src/database/engine.ts`).
* Exposed `startEngineHealthMonitor` and `stopEngineHealthMonitor` functions for controlling the health monitor lifecycle (`opencti-platform/opencti-graphql/src/database/engine.ts`).

**Platform Lifecycle Integration**

* Integrated the health monitor into the platform's startup and shutdown routines so it starts with `platformStart` and stops with `platformStop` (`opencti-platform/opencti-graphql/src/boot.js`). 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15860 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
