### PR TITLE
[frontend/backend] on session timeout, user is logout (#15252)

### DIFF
--- a/opencti-platform/opencti-front/src/private/Index.tsx
+++ b/opencti-platform/opencti-front/src/private/Index.tsx
@@ -94,7 +94,7 @@ const Index = ({ settings }: IndexProps) => {
       <SystemBanners settings={settings} />
       <LicenseBanner />
       <StartTrialBanner />
-      {(settings.platform_session_idle_timeout ?? 0) > 0 && <TimeoutLock />}
+      {((settings.platform_session_idle_timeout ?? 0) > 0 || (settings.platform_session_timeout ?? 0) > 0) && <TimeoutLock />}
       <SettingsMessagesBanner />
       <PlatformCriticalAlertDialog alerts={settings.platform_critical_alerts} />
       <Box

--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -3,9 +3,9 @@ import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
 import React, { useEffect, useReducer, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { graphql } from 'react-relay';
 import { useFormatter } from '../../components/i18n';
-import { APP_BASE_PATH } from '../../relay/environment';
+import { APP_BASE_PATH, fetchQuery } from '../../relay/environment';
 import { formatSeconds, ONE_SECOND, secondsBetweenDates } from '../../utils/Time';
 import useAuth from '../../utils/hooks/useAuth';
 
@@ -21,6 +21,14 @@ interface TimeoutState {
 }
 
 type Action = { type: 'count down' } | { type: 'reset timeout' };
+
+const timeoutLockRefreshQuery = graphql`
+  query TimeoutLockRefreshQuery {
+    me {
+      id
+    }
+  }
+`;
 
 /**
  * Handles various state changes for the timeout counting functionality.
@@ -80,8 +88,6 @@ const TimeoutLock: React.FunctionComponent = () => {
   const [resetCounter, triggerReset] = useState(false);
   const interval = useRef<NodeJS.Timeout | null>(null);
 
-  const navigate = useNavigate();
-
   /**
    * Decrements the idle timeout counter by one until it is zero.
    */
@@ -126,7 +132,8 @@ const TimeoutLock: React.FunctionComponent = () => {
    * Referrer is kept so user will be redirected there on next login.
    */
   const handleLogout = () => {
-    navigate(`${APP_BASE_PATH}/logout`);
+    // better than using navigate because it makes a HTTP request to /logout on the backend
+    window.location.assign(`${APP_BASE_PATH}/logout`);
   };
 
   /**
@@ -139,8 +146,12 @@ const TimeoutLock: React.FunctionComponent = () => {
    */
   const unlockScreen = () => {
     setDialogOpen(false);
-    const newTimeItem = { startDate: new Date(), startDateEpoch: Date.now() };
-    localStorage.setItem('lockoutTracker', JSON.stringify(newTimeItem));
+    dispatch({ type: 'reset timeout' });
+    // make a simple call to the backend to refresh the session
+    // and prevent immediate lockout after unlocking
+    fetchQuery(timeoutLockRefreshQuery, {})
+      .toPromise()
+      .catch(() => undefined);
   };
 
   /**
@@ -211,7 +222,7 @@ const TimeoutLock: React.FunctionComponent = () => {
       handleLogout();
     }
     // Lock the screen for the remaining session time
-    if (secondsBetween >= state.idleLimit && secondsBetween < state.sessionLimit) {
+    if (state.idleLimit > 0 && secondsBetween >= state.idleLimit && secondsBetween < state.sessionLimit) {
       lockScreen();
     } else { // To handle close on different tab
       setDialogOpen(false);

--- a/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
+++ b/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
@@ -16,7 +16,7 @@ class RedisStore extends Store {
     this.scanCount = Number(options.scanCount) || 100;
     this.serializer = options.serializer || JSON;
     // ttl < 2mins, divide by 10 to have a more frequent touch, otherwise touch every 2 mins
-    this.touchCache = new LRUCache({ ttl: Math.min(options.ttl / 10, 120000), max: 1000 });
+    this.touchCache = new LRUCache({ ttl: options.ttl < 120000 ? options.ttl / 10 : 120000, max: 1000 });
     this.locker = new AsyncLock();
   }
 

--- a/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
+++ b/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
@@ -1,4 +1,3 @@
-/* eslint-disable class-methods-use-this */
 import session from 'express-session';
 import { LRUCache } from 'lru-cache';
 import AsyncLock from 'async-lock';
@@ -16,7 +15,8 @@ class RedisStore extends Store {
     this.prefix = options.prefix == null ? 'sess:' : options.prefix;
     this.scanCount = Number(options.scanCount) || 100;
     this.serializer = options.serializer || JSON;
-    this.touchCache = new LRUCache({ ttl: 120000, max: 1000 }); // Touch the session every 2 minutes
+    // ttl < 2mins, divide by 10 to have a more frequent touch, otherwise touch every 2 mins
+    this.touchCache = new LRUCache({ ttl: Math.min(options.ttl / 10, 120000), max: 1000 });
     this.locker = new AsyncLock();
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* screen recorded with session_timeout = 8000 and session_idle_timeout = 4000
https://github.com/user-attachments/assets/7829dc82-e163-4302-a4f3-ac5736706a3d

* without settings session_idle_timeout in the config, it is 0 by default, the user is logout directly
https://github.com/user-attachments/assets/679b0454-fa53-4851-9c47-0af6f6734e3c

* for session_timeout set under 2 mins, reduce the ttl toucheCache, otherwise, cap to 2 mins



### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fixes #15252 , #15644 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
