### PR TITLE
[frontend/backend] add origin filtering on live streams (#15874)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3254,7 +3254,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         ):
             recover_iso_date = self.connect_live_stream_recover_iso_date
         # Generate the stream URL
-        url = url + "/stream"
+        url = url.rstrip("/") + "/stream"
         if live_stream_id is not None:
             url = url + "/" + live_stream_id
         self.listen_stream = ListenStream(

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -676,6 +676,7 @@
   "Organization type": "Organization type",
   "Organizations": "Organizations",
   "Organizations management": "Organizations management",
+  "Origin filters": "Origin filters",
   "Origin of the case": "Origin of the case",
   "Original creation date": "Original creation date",
   "Other entities": "Other entities",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3099,6 +3099,7 @@
   "Organizations restriction": "Organizations restriction",
   "Organizations sharing": "Organizations sharing",
   "Organizations splitter": "Organizations splitter",
+  "Origin filters only apply to live events. Recovery mode (when starting from a past date) and dependency events will ignore them.": "Origin filters only apply to live events. Recovery mode (when starting from a past date) and dependency events will ignore them.",
   "Origin of the case": "Origin of the case",
   "Original creation date": "Original creation date",
   "Originates from": "Originates from",

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionCreation.tsx
@@ -7,10 +7,13 @@ import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
 import { FormikConfig } from 'formik/dist/types';
 import Button from '@common/button/Button';
 import Drawer, { DrawerControlledDialProps } from '@components/common/drawer/Drawer';
 import FormButtonContainer from '@common/form/FormButtonContainer';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import { useFormatter } from '../../../../components/i18n';
 import TextField from '../../../../components/TextField';
 import ObjectMembersField from '../../common/form/ObjectMembersField';
@@ -18,7 +21,7 @@ import Filters from '../../common/lists/Filters';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { fieldSpacingContainerStyle, FieldOption } from '../../../../utils/field';
 import CreatorField from '../../common/form/CreatorField';
-import { emptyFilterGroup, serializeFilterGroupForBackend, stixFilters } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, isFilterGroupNotEmpty, serializeFilterGroupForBackend, stixFilters, streamOriginFilters } from '../../../../utils/filters/filtersUtils';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
 import { insertNode } from '../../../../utils/store';
@@ -46,6 +49,8 @@ interface StreamCollectionFormProps {
   onCompleted?: () => void;
   filters: FilterGroup;
   helpers: ReturnType<typeof useFiltersState>[1];
+  originFilters: FilterGroup;
+  originHelpers: ReturnType<typeof useFiltersState>[1];
 }
 
 export interface StreamCollectionCreationFormValues {
@@ -62,6 +67,8 @@ const StreamCollectionCreationForm = ({
   onCompleted,
   filters,
   helpers,
+  originFilters,
+  originHelpers,
 }: StreamCollectionFormProps) => {
   const { t_i18n } = useFormatter();
   const isGrantedToSetAccesses = useGranted([SETTINGS_SETACCESSES]);
@@ -73,6 +80,9 @@ const StreamCollectionCreationForm = ({
     { setSubmitting, setErrors, resetForm },
   ) => {
     const jsonFilters = serializeFilterGroupForBackend(filters);
+    const jsonOriginFilters = isFilterGroupNotEmpty(originFilters)
+      ? serializeFilterGroupForBackend(originFilters)
+      : null;
     const authorized_members = values.authorized_members.map(({ value }) => ({
       id: value,
       access_right: 'view',
@@ -87,6 +97,7 @@ const StreamCollectionCreationForm = ({
           stream_public_user_id: (values.stream_public_user_id as FieldOption)?.value ?? null,
           authorized_members,
           filters: jsonFilters,
+          origin_filters: jsonOriginFilters,
         },
       },
       updater: (store) => {
@@ -204,6 +215,38 @@ const StreamCollectionCreationForm = ({
               redirection
               searchContext={{ entityTypes: ['Stix-Core-Object', 'stix-core-relationship'] }}
             />
+            <Accordion>
+              <AccordionSummary id="accordion-panel-advanced-options">
+                <Typography>{t_i18n('Advanced options')}</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+                  <Alert
+                    icon={false}
+                    severity="warning"
+                    variant="outlined"
+                    style={{ position: 'relative', width: '100%', overflow: 'hidden' }}
+                  >
+                    <div>
+                      {t_i18n('Origin filters only apply to live events. Recovery mode (when starting from a past date) and dependency events will ignore them.')}
+                    </div>
+                  </Alert>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Filters
+                      availableFilterKeys={streamOriginFilters}
+                      helpers={originHelpers}
+                      searchContext={{ entityTypes: ['History'] }}
+                    />
+                  </Box>
+                  <FilterIconButton
+                    filters={originFilters}
+                    helpers={originHelpers}
+                    redirection
+                    searchContext={{ entityTypes: ['History'] }}
+                  />
+                </div>
+              </AccordionDetails>
+            </Accordion>
           </div>
           <FormButtonContainer>
             <Button
@@ -229,6 +272,7 @@ const StreamCollectionCreationForm = ({
 const StreamCollectionCreation = ({ paginationOptions }: { paginationOptions: StreamLinesPaginationQuery$variables }) => {
   const { t_i18n } = useFormatter();
   const [filters, helpers] = useFiltersState(emptyFilterGroup);
+  const [originFilters, originHelpers] = useFiltersState(emptyFilterGroup);
 
   const updater = (store: RecordSourceSelectorProxy) => insertNode(
     store,
@@ -241,11 +285,16 @@ const StreamCollectionCreation = ({ paginationOptions }: { paginationOptions: St
     <CreateEntityControlledDial entityType="StreamCollection" {...props} />
   );
 
+  const handleClose = () => {
+    helpers.handleClearAllFilters();
+    originHelpers.handleClearAllFilters();
+  };
+
   return (
     <Drawer
       title={t_i18n('Create a stream')}
       controlledDial={CreateStreamControlledDial}
-      onClose={helpers.handleClearAllFilters}
+      onClose={handleClose}
     >
       {({ onClose }) => (
         <StreamCollectionCreationForm
@@ -254,6 +303,8 @@ const StreamCollectionCreation = ({ paginationOptions }: { paginationOptions: St
           onReset={onClose}
           filters={filters}
           helpers={helpers}
+          originFilters={originFilters}
+          originHelpers={originHelpers}
         />
       )}
     </Drawer>

--- a/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/stream/StreamCollectionEdition.tsx
@@ -7,14 +7,17 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import AlertTitle from '@mui/material/AlertTitle';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Typography from '@mui/material/Typography';
 import { StreamCollectionEdition_streamCollection$data } from '@components/data/stream/__generated__/StreamCollectionEdition_streamCollection.graphql';
 import { FormikConfig } from 'formik/dist/types';
+import { Accordion, AccordionSummary } from '../../../../components/Accordion';
 import ObjectMembersField from '../../common/form/ObjectMembersField';
 import { useFormatter } from '../../../../components/i18n';
 import { commitMutation } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
 import Filters from '../../common/lists/Filters';
-import { deserializeFilterGroupForFrontend, serializeFilterGroupForBackend, stixFilters } from '../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, isFilterGroupNotEmpty, serializeFilterGroupForBackend, stixFilters, streamOriginFilters } from '../../../../utils/filters/filtersUtils';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import CreatorField from '../../common/form/CreatorField';
@@ -61,6 +64,7 @@ const StreamCollectionEditionContainer: FunctionComponent<{ streamCollection: St
     stream_public_user_id: convertUser(streamCollection, 'stream_public_user'),
   };
   const [filters, helpers] = useFiltersState(deserializeFilterGroupForFrontend(streamCollection.filters) ?? undefined);
+  const [originFilters, originHelpers] = useFiltersState(deserializeFilterGroupForFrontend(streamCollection.origin_filters) ?? undefined);
   const handleSubmitField = (name: string, value: FieldOption[] | string) => {
     streamCollectionValidation(t_i18n('This field is required'))
       .validateAt(name, { [name]: value })
@@ -117,6 +121,25 @@ const StreamCollectionEditionContainer: FunctionComponent<{ streamCollection: St
       updater: undefined,
     });
   }, [filters]);
+  useEffect(() => {
+    const jsonOriginFilters = isFilterGroupNotEmpty(originFilters)
+      ? serializeFilterGroupForBackend(originFilters)
+      : '';
+    const variables = {
+      id: streamCollection.id,
+      input: { key: 'origin_filters', value: jsonOriginFilters },
+    };
+    commitMutation({
+      mutation: streamCollectionMutationFieldPatch,
+      variables,
+      setSubmitting: undefined,
+      onCompleted: undefined,
+      onError: undefined,
+      optimisticResponse: undefined,
+      optimisticUpdater: undefined,
+      updater: undefined,
+    });
+  }, [originFilters]);
   const onSubmit: FormikConfig<StreamCollectionCreationForm>['onSubmit'] = () => {};
 
   return (
@@ -236,6 +259,39 @@ const StreamCollectionEditionContainer: FunctionComponent<{ streamCollection: St
             searchContext={{ entityTypes: ['Stix-Core-Object', 'stix-core-relationship'] }}
             entityTypes={['Stix-Core-Object', 'stix-core-relationship', 'Stix-Filtering']}
           />
+          <Accordion style={{ marginTop: theme.spacing(2) }}>
+            <AccordionSummary id="accordion-panel-advanced-options">
+              <Typography>{t_i18n('Advanced options')}</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+                <Alert
+                  icon={false}
+                  severity="warning"
+                  variant="outlined"
+                  style={{ position: 'relative', width: '100%', overflow: 'hidden' }}
+                >
+                  <div>
+                    {t_i18n('Origin filters only apply to live events. Recovery mode (when starting from a past date) and dependency events will ignore them.')}
+                  </div>
+                </Alert>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Filters
+                    availableFilterKeys={streamOriginFilters}
+                    helpers={originHelpers}
+                    searchContext={{ entityTypes: ['History'] }}
+                  />
+                </Box>
+                <FilterIconButton
+                  filters={originFilters}
+                  helpers={originHelpers}
+                  redirection={true}
+                  searchContext={{ entityTypes: ['History'] }}
+                  entityTypes={['History']}
+                />
+              </div>
+            </AccordionDetails>
+          </Accordion>
         </Form>
       )}
     </Formik>
@@ -251,6 +307,7 @@ const StreamCollectionEditionFragment = createFragmentContainer(
                 name
                 description
                 filters
+                origin_filters
                 stream_live
                 stream_public
                 stream_public_user {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -16302,6 +16302,7 @@ type StreamCollection {
   name: String
   description: String
   filters: String
+  origin_filters: String
   stream_live: Boolean
   stream_public: Boolean
   stream_public_user_id: String
@@ -16325,6 +16326,7 @@ input StreamCollectionAddInput {
   name: String!
   description: String
   filters: String
+  origin_filters: String
   stream_live: Boolean
   stream_public: Boolean
   stream_public_user_id: String

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -111,6 +111,13 @@ export const contextFilters = [
   'contextObjectMarking',
 ];
 
+// filters available on the live stream event envelope (origin) - kept narrow on purpose
+export const streamOriginFilters = [
+  'members_user',
+  'members_group',
+  'members_organization',
+];
+
 // filters available in stix filtering (streams, playbooks, triggers)
 export const stixFilters = [
   'entity_type',

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -568,16 +568,19 @@ const useSearchEntities = ({
           if (entityTypes.includes('User') && searchContext.elementType !== 'Playbook-Stix-Component') {
             unionSetEntities(key, [meEntity]);
           }
-          const membersSystems = (
-            (data as ObjectAssigneeFieldMembersSearchQuery$data)?.systemMembers
-              ?.edges ?? []
-          ).map((n) => ({
-            label: n?.node.name,
-            value: n?.node.id,
-            type: n?.node.entity_type,
-            group: n?.node.entity_type,
-          }));
-          unionSetEntities(key, membersSystems);
+          // system members are always users; only add them when the filter targets users
+          if (entityTypes.includes('User')) {
+            const membersSystems = (
+              (data as ObjectAssigneeFieldMembersSearchQuery$data)?.systemMembers
+                ?.edges ?? []
+            ).map((n) => ({
+              label: n?.node.name,
+              value: n?.node.id,
+              type: n?.node.entity_type,
+              group: n?.node.entity_type,
+            }));
+            unionSetEntities(key, membersSystems);
+          }
         });
     };
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -32474,6 +32474,7 @@ export type StreamCollection = {
   filters?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name?: Maybe<Scalars['String']['output']>;
+  origin_filters?: Maybe<Scalars['String']['output']>;
   stream_live?: Maybe<Scalars['Boolean']['output']>;
   stream_public?: Maybe<Scalars['Boolean']['output']>;
   stream_public_user?: Maybe<Creator>;
@@ -32485,6 +32486,7 @@ export type StreamCollectionAddInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   filters?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
+  origin_filters?: InputMaybe<Scalars['String']['input']>;
   stream_live?: InputMaybe<Scalars['Boolean']['input']>;
   stream_public?: InputMaybe<Scalars['Boolean']['input']>;
   stream_public_user_id?: InputMaybe<Scalars['String']['input']>;
@@ -50403,6 +50405,7 @@ export type StreamCollectionResolvers<ContextType = any, ParentType extends Reso
   filters?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  origin_filters?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stream_live?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   stream_public?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   stream_public_user?: Resolver<Maybe<ResolversTypes['Creator']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -51,6 +51,7 @@ import { isStixDomainObjectContainer } from '../schema/stixDomainObject';
 import { STIX_SIGHTING_RELATIONSHIP } from '../schema/stixSightingRelationship';
 import { generateCreateMessage } from '../database/data-changes';
 import { isStixMatchFilterGroup } from '../utils/filtering/filtering-stix/stix-filtering';
+import { isOriginMatchFilterGroup } from '../utils/filtering/filtering-stream-origin/stream-origin-filtering';
 import { STIX_CORE_RELATIONSHIPS } from '../schema/stixCoreRelationship';
 import { resolvePublicUser } from '../modules/dataSharing/dataSharing-utils';
 import { createAuthenticatedContext } from '../http/httpAuthenticatedContext';
@@ -120,7 +121,7 @@ const computeUserAndCollection = async (req, res, { context, user, id }) => {
       sendErrorStatus(req, res, 401);
       return { error: res.statusMessage };
     }
-    return { streamFilters: null, collection: null };
+    return { streamFilters: null, originFilters: null, collection: null };
   }
   const collections = await getEntitiesListFromCache(context, user, ENTITY_TYPE_STREAM_COLLECTION);
   const collection = collections.find((c) => c.id === id);
@@ -138,9 +139,10 @@ const computeUserAndCollection = async (req, res, { context, user, id }) => {
     return { error: 'This live stream is stopped' };
   }
   const streamFilters = JSON.parse(collection.filters);
+  const originFilters = collection.origin_filters ? JSON.parse(collection.origin_filters) : null;
   // If bypass or public stream
   if (collection.stream_public) {
-    return { streamFilters, collection };
+    return { streamFilters, originFilters, collection };
   }
   // Access is restricted, user must be authenticated
   if (!user || !isUserHasCapability(user, TAXIIAPI)) {
@@ -172,13 +174,13 @@ const computeUserAndCollection = async (req, res, { context, user, id }) => {
       return { error: res.statusMessage };
     }
   }
-  return { streamFilters, collection };
+  return { streamFilters, originFilters, collection };
 };
 
 export const authenticateForPublic = async (req, res, next) => {
   const context = await createAuthenticatedContext(req, res, 'stream_authenticate');
   req.expirationTime = utcDate().add(1, 'days').toDate();
-  const { error, collection, streamFilters } = await computeUserAndCollection(req, res, {
+  const { error, collection, streamFilters, originFilters } = await computeUserAndCollection(req, res, {
     context,
     user: context.user ?? SYSTEM_USER,
     id: req.params.id,
@@ -207,6 +209,7 @@ export const authenticateForPublic = async (req, res, next) => {
     req.context = context;
     req.collection = collection;
     req.streamFilters = streamFilters;
+    req.originFilters = originFilters;
     next();
   }
 };
@@ -618,7 +621,7 @@ const createSseMiddleware = () => {
         streamQueryIndices.push(READ_INDEX_INFERRED_ENTITIES, READ_INDEX_INFERRED_RELATIONSHIPS);
       }
 
-      let { streamFilters, collection } = req;
+      let { streamFilters, originFilters, collection } = req;
 
       // Create channel.
       const { channel, client } = createSseChannel(req, res, startStreamId);
@@ -655,23 +658,32 @@ const createSseMiddleware = () => {
                 const elementType = stix.extensions[STIX_EXT_OCTI].type;
                 if (!isInferredData || (isInferredData && withInferences)) {
                   const isCurrentlyVisible = await isStixMatchFilterGroup(context, user, stix, streamFilters);
+                  // Only main-event publications are gated by origin. Dependency/container fallbacks
+                  // are intentionally left ungated (they target related data lacking real origin).
+                  const isOriginVisible = isOriginMatchFilterGroup(eventData, originFilters);
                   if (type === EVENT_TYPE_UPDATE) {
                     const { newDocument: previous } = jsonpatch.applyPatch(structuredClone(stix), evenContext.reverse_patch);
                     const isPreviouslyVisible = await isStixMatchFilterGroup(context, user, previous, streamFilters);
                     if (isPreviouslyVisible && !isCurrentlyVisible && publishDeletion) { // No longer visible
-                      await client.sendEvent(eventId, EVENT_TYPE_DELETE, eventData);
-                      cache.set(stix.id, 'hit');
-                    } else if (!isPreviouslyVisible && isCurrentlyVisible) { // Newly visible
-                      const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
-                      if (isValidResolution) {
-                        await client.sendEvent(eventId, EVENT_TYPE_CREATE, eventData);
+                      if (isOriginVisible) {
+                        await client.sendEvent(eventId, EVENT_TYPE_DELETE, eventData);
                         cache.set(stix.id, 'hit');
                       }
+                    } else if (!isPreviouslyVisible && isCurrentlyVisible) { // Newly visible
+                      if (isOriginVisible) {
+                        const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
+                        if (isValidResolution) {
+                          await client.sendEvent(eventId, EVENT_TYPE_CREATE, eventData);
+                          cache.set(stix.id, 'hit');
+                        }
+                      }
                     } else if (isCurrentlyVisible) { // Just an update
-                      const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
-                      if (isValidResolution) {
-                        await client.sendEvent(eventId, event, eventData);
-                        cache.set(stix.id, 'hit');
+                      if (isOriginVisible) {
+                        const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
+                        if (isValidResolution) {
+                          await client.sendEvent(eventId, event, eventData);
+                          cache.set(stix.id, 'hit');
+                        }
                       }
                     } else if (isRelation && publishDependencies) { // Update but not visible - relation type
                       // In case of relationship publication, from or to can be related to something that
@@ -700,16 +712,18 @@ const createSseMiddleware = () => {
                       }
                     }
                   } else if (isCurrentlyVisible) {
-                    if (type === EVENT_TYPE_DELETE) {
-                      if (publishDeletion) {
-                        await client.sendEvent(eventId, event, eventData);
-                        cache.set(stix.id, 'hit');
-                      }
-                    } else { // Create and merge
-                      const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
-                      if (isValidResolution) {
-                        await client.sendEvent(eventId, event, eventData);
-                        cache.set(stix.id, 'hit');
+                    if (isOriginVisible) {
+                      if (type === EVENT_TYPE_DELETE) {
+                        if (publishDeletion) {
+                          await client.sendEvent(eventId, event, eventData);
+                          cache.set(stix.id, 'hit');
+                        }
+                      } else { // Create and merge
+                        const isValidResolution = await resolveAndPublishDependencies(context, noDependencies, cache, channel, req, eventId, stix);
+                        if (isValidResolution) {
+                          await client.sendEvent(eventId, event, eventData);
+                          cache.set(stix.id, 'hit');
+                        }
                       }
                     }
                   } else if (isRelation && publishDependencies) { // Not an update and not visible
@@ -726,6 +740,7 @@ const createSseMiddleware = () => {
           channel.setLastEventId(lastEventId);
           const newComputed = await computeUserAndCollection(req, res, { id, user, context });
           streamFilters = newComputed.streamFilters;
+          originFilters = newComputed.originFilters;
           collection = newComputed.collection;
           error = newComputed.error;
         }, opts);

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-domain.ts
@@ -8,6 +8,7 @@ import { isUserHasCapability, MEMBER_ACCESS_RIGHT_VIEW, SETTINGS_SET_ACCESSES, S
 import { publishUserAction } from '../../listener/UserActionListener';
 import { addFilter } from '../../utils/filtering/filtering-utils';
 import { validateFilterGroupForStixMatch } from '../../utils/filtering/filtering-stix/stix-filtering';
+import { validateFilterGroupForStreamOriginMatch } from '../../utils/filtering/filtering-stream-origin/stream-origin-filtering';
 import { authorizedMembers } from '../../schema/attribute-definition';
 import { TAXIIAPI } from '../../domain/user';
 import { validatePublicUserId } from './dataSharing-utils';
@@ -23,6 +24,10 @@ export const createStreamCollection = async (context: AuthContext, user: AuthUse
   // our stix matching is currently limited, we need to validate the input filters
   if (input.filters) {
     validateFilterGroupForStixMatch(JSON.parse(input.filters));
+  }
+  // origin filters can only target the stream event envelope (members_user/group/organization)
+  if (input.origin_filters) {
+    validateFilterGroupForStreamOriginMatch(JSON.parse(input.origin_filters));
   }
   if (input.stream_public && !isUserHasCapability(user, SETTINGS_SET_ACCESSES)) {
     throw FunctionalError('You must have the SETTINGS_SETACCESSES capability to create a public stream collection');
@@ -72,6 +77,11 @@ export const streamCollectionEditField = async (context: AuthContext, user: Auth
   if (filtersItem?.value) {
     // our stix matching is currently limited, we need to validate the input filters
     validateFilterGroupForStixMatch(JSON.parse(filtersItem.value[0]));
+  }
+  const originFiltersItem = input.find((item) => item.key === 'origin_filters');
+  if (originFiltersItem?.value?.[0]) {
+    // origin filters can only target the stream event envelope (members_user/group/organization)
+    validateFilterGroupForStreamOriginMatch(JSON.parse(originFiltersItem.value[0]));
   }
   const publicFields = ['stream_public', 'stream_public_user_id'];
   if (input.some((item) => publicFields.includes(item.key)) && !isUserHasCapability(user, SETTINGS_SET_ACCESSES)) {

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection-types.ts
@@ -9,6 +9,7 @@ export interface BasicStoreEntityStreamCollection extends BasicStoreEntity {
   name: string;
   description: string;
   filters: string;
+  origin_filters?: string | null;
   stream_public: boolean;
   stream_public_user_id?: string | null;
   stream_live: boolean;
@@ -19,6 +20,7 @@ export interface StoreEntityStreamCollection extends StoreEntity {
   name: string;
   description: string;
   filters: string;
+  origin_filters?: string | null;
   stream_public: boolean;
   stream_public_user_id?: string | null;
   stream_live: boolean;
@@ -28,6 +30,7 @@ export interface StixStreamCollection extends StixObject {
   name: string;
   description: string;
   filters: string;
+  origin_filters?: string | null;
   stream_public: boolean;
   stream_public_user_id?: string | null;
   stream_live: boolean;

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection.graphql
@@ -23,6 +23,7 @@ type StreamCollection {
   name: String
   description: String
   filters: String
+  origin_filters: String
   stream_live: Boolean
   stream_public: Boolean
   stream_public_user_id: String @auth(for: [TAXIIAPI])
@@ -42,6 +43,7 @@ input StreamCollectionAddInput {
   name: String! @constraint(minLength: 2, format: "not-blank")
   description: String
   filters: String
+  origin_filters: String
   stream_live: Boolean
   stream_public: Boolean
   stream_public_user_id: String

--- a/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSharing/streamCollection.ts
@@ -22,6 +22,7 @@ const STREAM_COLLECTION_DEFINITION: ModuleDefinition<StoreEntityStreamCollection
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'filters', label: 'Filters', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
+    { name: 'origin_filters', label: 'Origin filters', type: 'string', format: 'text', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
     { name: 'stream_public', label: 'Public stream', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'stream_public_user_id', label: 'Public stream user id', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_USER], mandatoryType: 'no', editDefault: true, multiple: false, upsert: false, isFilterable: false },
     { name: 'stream_live', label: 'Is live', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stream-origin/stream-origin-filtering.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stream-origin/stream-origin-filtering.ts
@@ -1,0 +1,46 @@
+import type { Filter, FilterGroup } from '../../../generated/graphql';
+import { testFilterGroup, type TesterFunction } from '../boolean-logic-engine';
+import { UnsupportedError } from '../../../config/errors';
+import { testMembersGroup, testMembersOrganization, testMembersUser } from '../filtering-activity-event/activity-event-testers';
+import { MEMBERS_GROUP_FILTER, MEMBERS_ORGANIZATION_FILTER, MEMBERS_USER_FILTER } from '../filtering-constants';
+import { isFilterGroupNotEmpty } from '../filtering-utils';
+
+// Reuses the existing activity-event member testers; they read `event.origin.{user_id, group_ids, organization_ids}`,
+// which matches the SSE event envelope shape.
+const STREAM_ORIGIN_TESTERS_MAP: Record<string, TesterFunction> = {
+  [MEMBERS_USER_FILTER]: testMembersUser,
+  [MEMBERS_GROUP_FILTER]: testMembersGroup,
+  [MEMBERS_ORGANIZATION_FILTER]: testMembersOrganization,
+};
+
+const validateFilterForStreamOriginMatch = (filter: Filter) => {
+  if (!Array.isArray(filter.key) || filter.key.length !== 1) {
+    throw UnsupportedError('Stream origin filtering can only be executed on a unique filter key', { key: JSON.stringify(filter.key) });
+  }
+  if (STREAM_ORIGIN_TESTERS_MAP[filter.key[0]] === undefined) {
+    const availableFilters = JSON.stringify(Object.keys(STREAM_ORIGIN_TESTERS_MAP));
+    throw UnsupportedError('Stream origin filtering is not compatible with the provided filter key', { key: JSON.stringify(filter.key), availableFilters });
+  }
+};
+
+export const validateFilterGroupForStreamOriginMatch = (filterGroup: FilterGroup) => {
+  if (!filterGroup?.filterGroups || !filterGroup?.filters) {
+    throw UnsupportedError('Unrecognized filter format; expecting FilterGroup');
+  }
+  filterGroup.filters.forEach(validateFilterForStreamOriginMatch);
+  filterGroup.filterGroups.forEach(validateFilterGroupForStreamOriginMatch);
+};
+
+/**
+ * Tells whether a stream event matches the given origin filter group.
+ * Empty / undefined filter group is considered as matching anything.
+ */
+export const isOriginMatchFilterGroup = (
+  eventData: { origin?: { user_id?: string; group_ids?: string[]; organization_ids?: string[] } } | undefined,
+  filterGroup?: FilterGroup,
+): boolean => {
+  if (!filterGroup || !isFilterGroupNotEmpty(filterGroup)) return true;
+  // ensure origin is at least an empty object so testers can safely read its fields
+  const target = { ...eventData, origin: eventData?.origin ?? {} };
+  return testFilterGroup(target, filterGroup, STREAM_ORIGIN_TESTERS_MAP);
+};

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/stream-origin-filtering-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/stream-origin-filtering-test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { isOriginMatchFilterGroup, validateFilterGroupForStreamOriginMatch } from '../../../src/utils/filtering/filtering-stream-origin/stream-origin-filtering';
+import type { FilterGroup } from '../../../src/generated/graphql';
+
+const buildEvent = (origin?: { user_id?: string; group_ids?: string[]; organization_ids?: string[] }) => ({
+  type: 'create',
+  scope: 'external',
+  origin,
+  data: { id: 'report--abc', type: 'report' },
+});
+
+const emptyFilterGroup = { mode: 'and', filters: [], filterGroups: [] } as unknown as FilterGroup;
+
+describe('Stream origin filtering', () => {
+  describe('isOriginMatchFilterGroup', () => {
+    it('returns true when filter group is undefined', () => {
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-1' }))).toEqual(true);
+    });
+
+    it('returns true when filter group is empty', () => {
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-1' }), emptyFilterGroup)).toEqual(true);
+    });
+
+    it('returns true when origin user_id matches a single-value members_user filter', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['members_user'], mode: 'or', operator: 'eq', values: ['user-1'] }],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-1' }), filterGroup)).toEqual(true);
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-2' }), filterGroup)).toEqual(false);
+    });
+
+    it('returns true when at least one origin group_id matches a members_group filter', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['members_group'], mode: 'or', operator: 'eq', values: ['group-a', 'group-b'] }],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(isOriginMatchFilterGroup(buildEvent({ group_ids: ['group-a'] }), filterGroup)).toEqual(true);
+      expect(isOriginMatchFilterGroup(buildEvent({ group_ids: ['group-z'] }), filterGroup)).toEqual(false);
+      expect(isOriginMatchFilterGroup(buildEvent({ group_ids: [] }), filterGroup)).toEqual(false);
+      expect(isOriginMatchFilterGroup(buildEvent(undefined), filterGroup)).toEqual(false);
+    });
+
+    it('returns true when at least one origin organization_id matches a members_organization filter', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['members_organization'], mode: 'or', operator: 'eq', values: ['org-1'] }],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(isOriginMatchFilterGroup(buildEvent({ organization_ids: ['org-1', 'org-2'] }), filterGroup)).toEqual(true);
+      expect(isOriginMatchFilterGroup(buildEvent({ organization_ids: ['org-9'] }), filterGroup)).toEqual(false);
+    });
+
+    it('combines several origin filters with AND', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [
+          { key: ['members_user'], mode: 'or', operator: 'eq', values: ['user-1'] },
+          { key: ['members_group'], mode: 'or', operator: 'eq', values: ['group-a'] },
+        ],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-1', group_ids: ['group-a'] }), filterGroup)).toEqual(true);
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-1', group_ids: ['group-b'] }), filterGroup)).toEqual(false);
+      expect(isOriginMatchFilterGroup(buildEvent({ user_id: 'user-2', group_ids: ['group-a'] }), filterGroup)).toEqual(false);
+    });
+
+    it('falls back to <unknown> on missing user_id (so equality with a user filter fails)', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['members_user'], mode: 'or', operator: 'eq', values: ['user-1'] }],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(isOriginMatchFilterGroup(buildEvent({}), filterGroup)).toEqual(false);
+      expect(isOriginMatchFilterGroup(buildEvent(undefined), filterGroup)).toEqual(false);
+    });
+  });
+
+  describe('validateFilterGroupForStreamOriginMatch', () => {
+    it('accepts a filter group containing only allowed origin keys', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [
+          { key: ['members_user'], mode: 'or', operator: 'eq', values: ['user-1'] },
+          { key: ['members_group'], mode: 'or', operator: 'eq', values: ['group-a'] },
+          { key: ['members_organization'], mode: 'or', operator: 'eq', values: ['org-1'] },
+        ],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(() => validateFilterGroupForStreamOriginMatch(filterGroup)).not.toThrow();
+    });
+
+    it('throws when a filter key is not allowed for origin filtering', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['entity_type'], mode: 'or', operator: 'eq', values: ['Report'] }],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(() => validateFilterGroupForStreamOriginMatch(filterGroup)).toThrow(/origin filtering is not compatible/);
+    });
+
+    it('throws when a filter has more than one key', () => {
+      const filterGroup = {
+        mode: 'and',
+        filters: [{ key: ['members_user', 'members_group'], mode: 'or', operator: 'eq', values: ['x'] }],
+        filterGroups: [],
+      } as unknown as FilterGroup;
+      expect(() => validateFilterGroupForStreamOriginMatch(filterGroup)).toThrow(/unique filter key/);
+    });
+
+    it('recursively validates nested filter groups', () => {
+      const filterGroup = {
+        mode: 'or',
+        filters: [],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [{ key: ['contextEntityId'], mode: 'or', operator: 'eq', values: ['x'] }],
+            filterGroups: [],
+          },
+        ],
+      } as unknown as FilterGroup;
+      expect(() => validateFilterGroupForStreamOriginMatch(filterGroup)).toThrow(/origin filtering is not compatible/);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* **Backend** - new optional `origin_filters` JSON field on `StreamCollection` (and on `StreamCollectionAddInput`), with strict server-side validation. The SSE live handler runs the origin filter as a second gate after `isStixMatchFilterGroup`, only around main-event publications. Recovery, container-fallback and dependency-publication branches are intentionally **not** gated (they carry synthetic origins).
* **Frontend** - new "Advanced options" accordion on the stream creation and edition forms (same custom `Accordion` / `AccordionSummary` styled components used by the synchronizer form), containing a dedicated `Filters` widget restricted to the three origin keys, plus a clear warning that origin filtering does not apply during recovery or for dependency events.
* **Side bug fix** - `useSearchEntities` was always merging `systemMembers` (system users) into `members_*` value pickers regardless of the requested `entityTypes`, so opening the Group or Organization filter showed system users. `systemMembers` are now only added when the filter targets `User`. This also fixes the same leak in the activity-events filter UI and any other consumer of the same code path.

#### Reuse maximised

* Re-uses `testMembersUser` / `testMembersGroup` / `testMembersOrganization` from `filtering-activity-event/activity-event-testers` (already read `event.origin.{user_id, group_ids, organization_ids}`).
* Re-uses `MEMBERS_USER_FILTER` / `MEMBERS_GROUP_FILTER` / `MEMBERS_ORGANIZATION_FILTER` constants and the `isFilterGroupNotEmpty` / `testFilterGroup` helpers.
* Re-uses the existing `filterKeysSchema` registration for `History` (`searchContext={{ entityTypes: ['History'] }}`) so the value pickers work without any new FE registry entry.
* Re-uses the existing custom `Accordion` / `AccordionSummary` (same as `SyncCreation`) for the styled "Advanced options" outline + chevron, and the existing `Filters` + `FilterIconButton` + `useFiltersState` trio (identical pattern to the existing main filter section).
* New BE module is a single ~46 line file (`filtering-stream-origin/stream-origin-filtering.ts`) containing the testers map + strict validator + matcher.

#### Known limitation (documented in the UI warning)

In recovery mode the synthetic events come from Elasticsearch with `origin: { referer: EVENT_TYPE_INIT }`, so origin filtering cannot apply there. Same for dependency events (`EVENT_TYPE_DEPENDENCIES`). The Advanced options panel shows an explicit warning about this trade-off.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15874

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Design rationale for storing `origin_filters` as a separate JSON field rather than mixing the new keys into the existing `filters` field:

1. The existing `validateFilterGroupForStixMatch` registry is intentionally restricted to STIX-only keys; adding origin keys would have required loosening that contract everywhere `isStixMatchFilterGroup` is used (playbooks, triggers, etc.).
2. The two filters have different applicability windows: STIX filters apply in both live and recovery, origin filters only in live.
3. Two distinct UI sections clearly communicate the trade-off to the user.

The SSE gate is implemented by AND-ing the origin check inside each main-event `sendEvent` branch (rather than AND-ing into the outer `if/else if` chain conditions) so that an origin mismatch on the main event does **not** accidentally trigger the relation-fallback or container-fallback branches that would otherwise re-publish the event with its original `eventData` and defeat the filter.

Verification:
- 11/11 unit tests passing in `tests/01-unit/database/stream-origin-filtering-test.ts`
- `yarn check-ts` clean on both `opencti-graphql` and `opencti-front`
- `yarn lint` clean on both projects
- GraphQL types regenerated (`yarn build:types` + `yarn relay`)
