### PR TITLE
[backend] handle opinions when lower cased (#10828)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/opinion.js
+++ b/opencti-platform/opencti-graphql/src/domain/opinion.js
@@ -125,6 +125,14 @@ export const updateOpinionsMetrics = async (context, user, opinionId) => {
   };
   const vocabs = await fullEntitiesOrRelationsList(context, user, [ENTITY_TYPE_VOCABULARY], { filters: filtersForVocabs, maxSize: ES_MAX_PAGINATION });
   const indexedVocab = R.indexBy(R.prop('name'), vocabs);
+  const lowerCasedVocab = R.indexBy((o) => o.name?.toLowerCase(), vocabs);
+  const findOpinionVocab = (opinionName) => {
+    const vocab = indexedVocab[opinionName] || lowerCasedVocab[opinionName.toLowerCase()];
+    if (!vocab) {
+      throw new Error(`The opinion ${opinionName} does not exist in the vocabulary`);
+    }
+    return vocab;
+  };
   const filtersForObjects = {
     mode: 'and',
     filters: [{ key: buildRefRelationKey(RELATION_OBJECT), values: [opinionId] }],
@@ -143,7 +151,7 @@ export const updateOpinionsMetrics = async (context, user, opinionId) => {
       filterGroups: [],
     };
     const opinions = await fullEntitiesOrRelationsList(context, user, [ENTITY_TYPE_CONTAINER_OPINION], { filters: filtersForOpinions, maxSize: ES_MAX_PAGINATION });
-    const opinionsWithVocabs = opinions.map((n) => ({ ...n, vocab: indexedVocab[n.opinion] }));
+    const opinionsWithVocabs = opinions.map((n) => ({ ...n, vocab: findOpinionVocab(n.opinion) }));
     const opinionsNumbers = opinionsWithVocabs.map((n) => n.vocab.order);
     const opinionsMetrics = {
       mean: parseFloat(R.mean(opinionsNumbers).toFixed(2)),

--- a/opencti-platform/opencti-graphql/src/domain/opinion.js
+++ b/opencti-platform/opencti-graphql/src/domain/opinion.js
@@ -127,11 +127,7 @@ export const updateOpinionsMetrics = async (context, user, opinionId) => {
   const indexedVocab = R.indexBy(R.prop('name'), vocabs);
   const lowerCasedVocab = R.indexBy((o) => o.name?.toLowerCase(), vocabs);
   const findOpinionVocab = (opinionName) => {
-    const vocab = indexedVocab[opinionName] || lowerCasedVocab[opinionName.toLowerCase()];
-    if (!vocab) {
-      throw new Error(`The opinion ${opinionName} does not exist in the vocabulary`);
-    }
-    return vocab;
+    return indexedVocab[opinionName] || lowerCasedVocab[opinionName.toLowerCase()];
   };
   const filtersForObjects = {
     mode: 'and',


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* frontend always sends opinions in lower case, even when vocab is modified to contain upper cases. Backend now handles lower cased opinions
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #10828
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
