### PR TITLE
feat(backend): add cleanup that logs users who are passively logged out due to session expiring (#15676)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
+++ b/opencti-platform/opencti-graphql/src/database/sessionStore-redis.js
@@ -3,6 +3,7 @@ import { LRUCache } from 'lru-cache';
 import AsyncLock from 'async-lock';
 import { clearSessions, extendSession, getSession, getSessionKeys, getSessions, getSessionTtl, killSession, setSession } from './redis';
 import { logApp } from '../config/conf';
+import { publishUserAction } from '../listener/UserActionListener';
 
 const { Store } = session;
 
@@ -50,7 +51,8 @@ class RedisStore extends Store {
   touch(sid, sess, cb = noop) {
     const key = this.prefix + sid;
     const { touchCache } = this;
-    const sessionExtender = (done) => {
+    const sessionExtender = async (done) => {
+      await this._cleanUpSessions();
       const cachedTouch = touchCache.has(`touch-${key}`);
       if (cachedTouch) {
         return done(null, 'OK');
@@ -98,6 +100,22 @@ class RedisStore extends Store {
       return cb(null, keys);
     });
   }
+
+  _cleanUpSessions = async () => {
+    const sessions = await getSessions();
+    for (const session of sessions) {
+      if (session.redis_key_ttl <= 0) {
+        await this.destroy(session.redis_key_id);
+        await publishUserAction({
+          user: { ...session.user, origin: { socket: 'query', user_id: session.user.id } },
+          event_type: 'authentication',
+          event_access: 'administration',
+          event_scope: 'logout',
+          context_data: undefined,
+        });
+      }
+    }
+  };
 }
 
 export default RedisStore;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add method for recording users who are logged out passively. Example: closing the tab or browser and not reopening OpenCTI before the session cookie expiration 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Resolves #15676 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
