### PR TITLE
[backend/frontend] Implement work cancellation functionality and skip bundle only for canceled works (#15886)

### DIFF
--- a/client-python/pycti/api/opencti_api_work.py
+++ b/client-python/pycti/api/opencti_api_work.py
@@ -140,7 +140,7 @@ class OpenCTIApiWork:
                 )
             except Exception:
                 error_msg = traceback.format_exc()
-                if "WORK_NOT_ALIVE" in error_msg:
+                if "WORK_CANCELLED" in error_msg or "WORK_NOT_ALIVE" in error_msg:
                     self.api.app_logger.info(
                         "Work no longer exists",
                         {"work_id": work_id},
@@ -273,6 +273,64 @@ class OpenCTIApiWork:
         )
         return work["data"]
 
+    def cancel(self, **kwargs):
+        """Explicitly cancel a work (UI-driven semantic).
+
+        Calls the server-side ``workEdit(id).cancel`` mutation. This sets a
+        sliding-TTL Redis cancellation tombstone on the work so any
+        in-flight worker bundle carrying this workId is rejected by the
+        server with WORK_CANCELLED, then performs the regular silent
+        delete.
+
+        Use this when you need to actively abort a work and stop downstream
+        ingestion. For a plain storage delete that lets ongoing processing
+        finish, use :meth:`delete`.
+
+        :param id: the work id
+        :type id: str
+        :return: the response data
+        :rtype: dict or None
+        """
+        work_id = kwargs.get("id", None)
+        if work_id is None:
+            self.api.admin_logger.error(
+                "[opencti_work] Cannot cancel work, missing parameter: id"
+            )
+            return None
+        query = """
+        mutation ConnectorWorkCancelMutation($workId: ID!) {
+            workEdit(id: $workId) {
+                cancel
+            }
+        }"""
+        work = self.api.query(
+            query,
+            {"workId": work_id},
+        )
+        return work["data"]
+
+    def cancel_works_for_connector(self, connector_id: str):
+        """Explicitly cancel every in-flight work of a connector.
+
+        Tombstones each work (rejecting any concurrent worker traffic with
+        WORK_CANCELLED) then deletes them. Used for the "clear all works"
+        action on a connector page.
+
+        For a plain bulk delete that does not reject in-flight processing,
+        use the connector-side cleanup instead.
+
+        :param connector_id: the connector id
+        :type connector_id: str
+        :return: the response data
+        :rtype: dict or None
+        """
+        query = """
+        mutation ConnectorWorksCancelForConnectorMutation($connectorId: String!) {
+            workCancelForConnector(connectorId: $connectorId)
+        }"""
+        result = self.api.query(query, {"connectorId": connector_id})
+        return result["data"]
+
     def wait_for_work_to_finish(self, work_id: str):
         """Wait for a work to finish.
 
@@ -343,6 +401,11 @@ class OpenCTIApiWork:
     def get_is_work_alive(self, work_id: str) -> bool:
         """Check if a work is alive.
 
+        .. deprecated::
+            Use :meth:`get_is_work_cancelled` instead. The server-side
+            ``isWorkAlive`` field is deprecated; closed/completed works are
+            considered alive too. Use the explicit cancellation check.
+
         :param work_id: the work id
         :type work_id: str
         :return: whether the work is alive
@@ -355,6 +418,27 @@ class OpenCTIApiWork:
         """
         result = self.api.query(query, {"id": work_id}, True)
         return result["data"]["isWorkAlive"]
+
+    def get_is_work_cancelled(self, work_id: str) -> bool:
+        """Check if a work has been explicitly cancelled (user-initiated delete).
+
+        Unlike :meth:`get_is_work_alive`, this does not return ``True`` for
+        works that have naturally completed/closed: only cancelled works are
+        reported as cancelled. Backed by a sliding-TTL Redis tombstone on
+        the server side.
+
+        :param work_id: the work id
+        :type work_id: str
+        :return: whether the work has been cancelled
+        :rtype: bool
+        """
+        query = """
+        query WorkCancelledQuery($id: ID!) {
+            isWorkCancelled(id: $id)
+        }
+        """
+        result = self.api.query(query, {"id": work_id}, True)
+        return bool(result["data"]["isWorkCancelled"])
 
     def get_connector_works(self, connector_id: str) -> List[Dict]:
         """Get all works for a connector.

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -53,6 +53,11 @@ ERROR_TYPE_LOCK = "LOCK_ERROR"
 ERROR_TYPE_MISSING_REFERENCE = "MISSING_REFERENCE_ERROR"
 ERROR_TYPE_BAD_GATEWAY = "Bad Gateway"
 ERROR_TYPE_DRAFT_LOCK = "DRAFT_LOCKED"
+ERROR_TYPE_WORK_CANCELLED = "WORK_CANCELLED"
+# Legacy alias of ERROR_TYPE_WORK_CANCELLED. Kept so this client can still
+# detect the rejection when running against an older OpenCTI server that
+# emits the previous WORK_NOT_ALIVE code. Remove once support for those
+# servers is dropped.
 ERROR_TYPE_WORK_NOT_ALIVE = "WORK_NOT_ALIVE"
 ERROR_TYPE_TIMEOUT = "Request timed out"
 
@@ -3572,10 +3577,13 @@ class OpenCTIStix2:
                             },
                         )
                     return None
-                # A work not alive error occurs
-                elif ERROR_TYPE_WORK_NOT_ALIVE in error_msg:
+                # A work cancelled error occurs
+                elif (
+                    ERROR_TYPE_WORK_CANCELLED in error_msg
+                    or ERROR_TYPE_WORK_NOT_ALIVE in error_msg
+                ):
                     worker_logger.info(
-                        "Message skipped because work is no longer alive",
+                        "Message skipped because work has been cancelled",
                     )
                     return None
                 # Platform does not know what to do and raises an error:

--- a/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEnrichmentLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/external_references/ExternalReferenceEnrichmentLines.jsx
@@ -33,10 +33,10 @@ export const externalReferenceEnrichmentLinesQuery = graphql`
   }
 `;
 
-const externalReferenceEnrichmentLinesDeleteMutation = graphql`
-  mutation ExternalReferenceEnrichmentLinesDeleteMutation($workId: ID!) {
+const externalReferenceEnrichmentLinesCancelMutation = graphql`
+  mutation ExternalReferenceEnrichmentLinesCancelMutation($workId: ID!) {
     workEdit(id: $workId) {
-      delete
+      cancel
     }
   }
 `;
@@ -112,7 +112,7 @@ const ExternalReferenceEnrichment = (props) => {
   };
   const deleteWork = (workId) => {
     commitMutation({
-      mutation: externalReferenceEnrichmentLinesDeleteMutation,
+      mutation: externalReferenceEnrichmentLinesCancelMutation,
       variables: { workId },
       onCompleted: () => relay.refetch({ id, entityType: externalReference.entity_type }),
     });

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -71,10 +71,10 @@ export const FileLineDeleteMutation = graphql`
   }
 `;
 
-const FileLineAskDeleteMutation = graphql`
-  mutation FileLineAskDeleteMutation($workId: ID!) {
+const FileLineAskCancelMutation = graphql`
+  mutation FileLineAskCancelMutation($workId: ID!) {
     workEdit(id: $workId) {
-      delete
+      cancel
     }
   }
 `;
@@ -222,7 +222,7 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
 
   const handleRemoveJob = (id: string | undefined) => {
     if (id) {
-      executeRemove(FileLineAskDeleteMutation, { workId: id });
+      executeRemove(FileLineAskCancelMutation, { workId: id });
     }
   };
 

--- a/opencti-platform/opencti-front/src/private/components/common/files/FileWork.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileWork.jsx
@@ -45,10 +45,10 @@ const styles = (theme) => ({
   },
 });
 
-const fileWorkDeleteMutation = graphql`
-  mutation FileWorkDeleteMutation($workId: ID!) {
+const fileWorkCancelMutation = graphql`
+  mutation FileWorkCancelMutation($workId: ID!) {
     workEdit(id: $workId) {
-      delete
+      cancel
     }
   }
 `;
@@ -78,7 +78,7 @@ const FileWorkComponent = (props) => {
 
   const deleteWork = () => {
     commitMutation({
-      mutation: fileWorkDeleteMutation,
+      mutation: fileWorkCancelMutation,
       variables: { workId },
       optimisticUpdater: (store) => {
         const fileStore = store.get(workId);

--- a/opencti-platform/opencti-front/src/private/components/common/files/ImportWorksDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/ImportWorksDrawer.tsx
@@ -126,10 +126,10 @@ export const fileWorksQuery = graphql`
   }
 `;
 
-const importWorkDeleteMutation = graphql`
-  mutation ImportWorksDrawerDeleteMutation($workId: ID!) {
+const importWorkCancelMutation = graphql`
+  mutation ImportWorksDrawerCancelMutation($workId: ID!) {
     workEdit(id: $workId) {
-      delete
+      cancel
     }
   }
 `;
@@ -164,7 +164,7 @@ const FileWorksComponent = ({
   const deleteWork = (workId: string) => {
     commitMutation({
       ...defaultCommitMutation,
-      mutation: importWorkDeleteMutation,
+      mutation: importWorkCancelMutation,
       variables: { workId },
       onCompleted: () => {
         setDeleting(false);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrichmentLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectEnrichmentLines.jsx
@@ -33,10 +33,10 @@ export const stixCoreObjectEnrichmentLinesQuery = graphql`
   }
 `;
 
-const stixCoreObjectEnrichmentLinesDeleteMutation = graphql`
-  mutation StixCoreObjectEnrichmentLinesDeleteMutation($workId: ID!) {
+const stixCoreObjectEnrichmentLinesCancelMutation = graphql`
+  mutation StixCoreObjectEnrichmentLinesCancelMutation($workId: ID!) {
     workEdit(id: $workId) {
-      delete
+      cancel
     }
   }
 `;
@@ -109,7 +109,7 @@ const StixCoreObjectEnrichment = ({
   };
   const deleteWork = (workId) => {
     commitMutation({
-      mutation: stixCoreObjectEnrichmentLinesDeleteMutation,
+      mutation: stixCoreObjectEnrichmentLinesCancelMutation,
       variables: { workId },
       onCompleted: () => relay.refetch({ id, entityType: stixCoreObject.entity_type }),
     });

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/Connector.tsx
@@ -81,9 +81,9 @@ export const connectorDeletionMutation = graphql`
   }
 `;
 
-export const connectorWorkDeleteMutation = graphql`
-  mutation ConnectorWorkDeleteMutation($connectorId: String!) {
-    workDelete(connectorId: $connectorId)
+export const connectorWorkCancelMutation = graphql`
+  mutation ConnectorWorkCancelMutation($connectorId: String!) {
+    workCancelForConnector(connectorId: $connectorId)
   }
 `;
 

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorPopover.tsx
@@ -2,7 +2,7 @@ import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DangerZoneBlock from '@components/common/danger_zone/DangerZoneBlock';
 import DangerZoneChip from '@components/common/danger_zone/DangerZoneChip';
-import { connectorDeletionMutation, connectorResetStateMutation, connectorWorkDeleteMutation } from '@components/data/connectors/Connector';
+import { connectorDeletionMutation, connectorResetStateMutation, connectorWorkCancelMutation } from '@components/data/connectors/Connector';
 import ManagedConnectorEdition from '@components/data/connectors/ManagedConnectorEdition';
 import { Connector_connector$data } from '@components/data/connectors/__generated__/Connector_connector.graphql';
 import MoreVert from '@mui/icons-material/MoreVert';
@@ -46,7 +46,7 @@ const ConnectorPopover = ({ connector, onRefreshData }: ConnectorPopoverProps) =
   const { isSensitive } = useSensitiveModifications('connector_reset');
 
   const [commitDeleteConnector] = useApiMutation(connectorDeletionMutation);
-  const [commitClearWorks] = useApiMutation(connectorWorkDeleteMutation);
+  const [commitClearWorks] = useApiMutation(connectorWorkCancelMutation);
   const [commitResetState] = useApiMutation(connectorResetStateMutation);
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
@@ -19,7 +19,7 @@ import ConnectorWorksErrorLine from '@components/data/connectors/ConnectorWorksE
 import Drawer from '@components/common/drawer/Drawer';
 import { ConnectorWorks_data$data, State } from '@components/data/connectors/__generated__/ConnectorWorks_data.graphql';
 import parseWorkErrors, { ParsedWorkMessage } from '@components/data/connectors/parseWorkErrors';
-import { connectorWorksWorkDeletionMutation } from '@components/data/connectors/ConnectorWorks';
+import { connectorWorksWorkCancelMutation } from '@components/data/connectors/ConnectorWorks';
 import { MODULES_MODMANAGE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import TaskStatus from '../../../../components/TaskStatus';
@@ -46,7 +46,7 @@ const ConnectorWorkLine: FunctionComponent<
 > = ({ workId, workName, workStatus, workReceivedTime, workEndTime, workExpectedNumber, workProcessedNumber, workErrors, readOnly }) => {
   const { t_i18n, nsdt } = useFormatter();
 
-  const [commit] = useApiMutation(connectorWorksWorkDeletionMutation);
+  const [commit] = useApiMutation(connectorWorksWorkCancelMutation);
   const [openDrawerErrors, setOpenDrawerErrors] = useState<boolean>(false);
   const [errors, setErrors] = useState<ParsedWorkMessage[]>([]);
   const [criticals, setCriticals] = useState<ParsedWorkMessage[]>([]);

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorks.tsx
@@ -13,10 +13,10 @@ import { ConnectorWorks_data$data } from './__generated__/ConnectorWorks_data.gr
 
 const interval$ = interval(FIVE_SECONDS);
 
-export const connectorWorksWorkDeletionMutation = graphql`
-  mutation ConnectorWorksWorkDeletionMutation($id: ID!) {
+export const connectorWorksWorkCancelMutation = graphql`
+  mutation ConnectorWorksWorkCancelMutation($id: ID!) {
     workEdit(id: $id) {
-      delete
+      cancel
     }
   }
 `;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9425,7 +9425,8 @@ type Query {
   connectorsForNotification: [Connector]
   connectorMigrationAssessment(connectorId: ID!, containerImage: String!, configuration: [ContractConfigInput!]): MigrationAssessment!
   work(id: ID!): Work
-  isWorkAlive(id: ID!): Boolean
+  isWorkAlive(id: ID!): Boolean @deprecated(reason: "Use isWorkCancelled (inverted semantics): closed/completed works are alive too.")
+  isWorkCancelled(id: ID!): Boolean
   works(first: Int, after: ID, orderBy: WorksOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): WorkConnection
   runtimeAttributes(first: Int, search: String, orderMode: OrderingMode, attributeName: String!): AttributeConnection
   schemaAttributeNames(elementType: [String]!): AttributeConnection
@@ -9796,6 +9797,7 @@ type Subscription {
 }
 
 type WorkEditMutations {
+  cancel: ID!
   delete: ID!
   ping: ID!
   reportExpectation(error: WorkErrorInput): ID!
@@ -10271,6 +10273,7 @@ type Mutation {
   synchronizerTest(input: SynchronizerAddInput): String
   workAdd(connectorId: String!, friendlyName: String, isMultiPartWork: Boolean = false): Work!
   workEdit(id: ID!): WorkEditMutations
+  workCancelForConnector(connectorId: String!): Boolean
   workDelete(connectorId: String!): Boolean
   deleteBackgroundTask(id: ID!): ID!
   listTaskAdd(input: ListTaskAddInput!): BackgroundTask!

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -365,7 +365,8 @@
     "ca": [],
     "port": 6379,
     "host_ip_family": 4,
-    "trimming": 2000000
+    "trimming": 2000000,
+    "work_cancel_ttl": 3600
   },
   "elasticsearch": {
     "index_prefix": "opencti",

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -14844,7 +14844,8 @@ type Query {
   connectorsForNotification: [Connector] @auth(for: [SETTINGS_SETACCESSES, SETTINGS_SETCUSTOMIZATION])
   connectorMigrationAssessment(connectorId: ID!, containerImage: String!, configuration: [ContractConfigInput!]): MigrationAssessment! @auth(for: [MODULES_MODMANAGE])
   work(id: ID!): Work @auth(for: [MODULES])
-  isWorkAlive(id: ID!): Boolean @auth(for: [MODULES])
+  isWorkAlive(id: ID!): Boolean @auth(for: [MODULES]) @deprecated(reason: "Use isWorkCancelled (inverted semantics): closed/completed works are alive too.")
+  isWorkCancelled(id: ID!): Boolean @auth(for: [MODULES])
   works(
     first: Int
     after: ID
@@ -15941,6 +15942,7 @@ type Subscription {
 ###### INTERNAL
 
 type WorkEditMutations {
+  cancel: ID!
   delete: ID!
   ping: ID!
   reportExpectation(error: WorkErrorInput): ID!
@@ -16415,6 +16417,7 @@ type Mutation {
   ### WORK
   workAdd(connectorId: String!, friendlyName: String, isMultiPartWork: Boolean = false): Work! @auth(for: [CONNECTORAPI, MODULES_MODMANAGE, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNGETEXPORT_KNASKEXPORT])
   workEdit(id: ID!): WorkEditMutations @auth(for: [CONNECTORAPI, MODULES_MODMANAGE])
+  workCancelForConnector(connectorId: String!): Boolean @auth(for: [CONNECTORAPI, MODULES_MODMANAGE])
   workDelete(connectorId: String!): Boolean @auth(for: [CONNECTORAPI, MODULES_MODMANAGE])
 
   ### TASK

--- a/opencti-platform/opencti-graphql/src/config/errors.js
+++ b/opencti-platform/opencti-graphql/src/config/errors.js
@@ -192,8 +192,8 @@ export const DraftLockedError = (data) => error(DRAFT_LOCKED_ERROR, 'Draft is in
   ...data,
 });
 
-export const WORK_NOT_ALIVE_ERROR = 'WORK_NOT_ALIVE';
-export const WorkNotALiveError = () => error(WORK_NOT_ALIVE_ERROR, 'Work is no longer alive, no request can be done within the context of this work', {
+export const WORK_CANCELLED_ERROR = 'WORK_CANCELLED';
+export const WorkCancelledError = () => error(WORK_CANCELLED_ERROR, 'Work has been cancelled, no request can be done within the context of this work', {
   http_status: 400,
   genre: CATEGORY_BUSINESS,
 });

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -479,9 +479,32 @@ export const lockResource = async (resources: Array<string>, opts: LockOptions =
 // endregion
 
 // region work handling
+// Sliding TTL (in seconds) for the per-work cancellation tombstone.
+// Refreshed atomically on every read via GETEX. Default: 1 hour.
+const WORK_CANCEL_TTL = conf.get('redis:work_cancel_ttl') ?? 3600;
+const workCancelKey = (workId: string) => `work:cancel:${workId}`;
+
 export const redisDeleteWorks = async (internalIds: Array<string>) => {
   const ids = Array.isArray(internalIds) ? internalIds : [internalIds];
   return Promise.all(ids.map((id) => getClientBase().del(id)));
+};
+/**
+ * Mark a work as cancelled by writing a short-lived tombstone in Redis.
+ * The tombstone TTL is sliding: each read via redisIsWorkCancelled refreshes it.
+ * This is used to reject incoming requests targeting a cancelled work, while
+ * still allowing late worker traffic for naturally completed/closed works.
+ */
+export const redisMarkWorkAsCancelled = async (workId: string) => {
+  await getClientBase().set(workCancelKey(workId), '1', 'EX', WORK_CANCEL_TTL);
+};
+/**
+ * Atomically check whether a work has been cancelled and, if so, refresh
+ * its tombstone TTL (sliding window). Single Redis round-trip via GETEX.
+ * Requires Redis >= 6.2.
+ */
+export const redisIsWorkCancelled = async (workId: string): Promise<boolean> => {
+  const value = await getClientBase().getex(workCancelKey(workId), 'EX', WORK_CANCEL_TTL);
+  return value !== null;
 };
 export const redisGetWork = async (internalId: string) => {
   return getClientBase().hgetall(internalId);

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -8,6 +8,8 @@ import {
   redisGetWork,
   redisGetWorkCompletionState,
   redisInitializeWork,
+  redisIsWorkCancelled,
+  redisMarkWorkAsCancelled,
   redisMarkWorkAsProcessed,
   redisUpdateActionExpectation,
   redisUpdateWorkFigures,
@@ -53,6 +55,10 @@ export const findById = (context, user, workId) => {
 export const isWorkAlive = async (_context, _user, workId) => {
   const redisWork = await redisGetWork(workId);
   return redisWork?.is_initialized === 'true';
+};
+
+export const isWorkCancelled = async (_context, _user, workId) => {
+  return redisIsWorkCancelled(workId);
 };
 
 export const findWorkPaginated = (context, user, args = {}) => {
@@ -208,6 +214,68 @@ export const deleteWorkForSource = async (sourceId) => {
     throw DatabaseError('[SEARCH] Error deleting all works ', { sourceId, cause: err });
   });
 };
+
+export const cancelWork = async (context, user, workId) => {
+  const work = await loadWorkById(context, user, workId);
+  if (!work) {
+    return workId;
+  }
+  await redisMarkWorkAsCancelled(workId);
+  logApp.info('Work cancelled marker set', { workId });
+  await publishUserAction({
+    user,
+    event_type: 'mutation',
+    event_scope: 'cancel',
+    event_access: 'administration',
+    message: `cancels Connector Work \`${work.name}\``,
+    context_data: { id: workId, entity_type: ENTITY_TYPE_WORK, input: work },
+  });
+  await deleteWorksRaw([work]);
+  return workId;
+};
+
+/**
+ * Cancel every in-flight Work belonging to a connector (UI explicit only,
+ * "clear all works" button on a connector page).
+ * Wired to: workCancelForConnector(connectorId)
+ *
+ * Tombstones each work, publishes a single `cancel` user action, then
+ * delegates to `deleteWorkForConnector` for storage cleanup. Connector
+ * deletion does NOT use this path (it uses `deleteWorkForConnector`
+ * directly to preserve the original silent-cleanup behavior).
+ */
+export const cancelWorksForConnector = async (context, user, connectorId) => {
+  let connector;
+  if (connectorId === IMPORT_CSV_CONNECTOR_ID) {
+    connector = IMPORT_CSV_CONNECTOR;
+  } else if (connectorId === DRAFT_VALIDATION_CONNECTOR_ID) {
+    connector = DRAFT_VALIDATION_CONNECTOR;
+  } else {
+    connector = await elLoadById(context, user, connectorId, { type: ENTITY_TYPE_CONNECTOR });
+  }
+  if (!connector) {
+    throw AlreadyDeletedError({ connectorId });
+  }
+  // Tombstone every existing in-flight work for the connector before any
+  // storage mutation so concurrent worker traffic is rejected immediately.
+  let toMark = await worksForConnector(context, user, connectorId, { first: 500 });
+  while (toMark.length > 0) {
+    await Promise.all(toMark.map((w) => redisMarkWorkAsCancelled(w.internal_id)));
+    toMark.forEach((w) => logApp.info('Work cancelled marker set', { workId: w.internal_id, connectorId }));
+    await deleteWorksRaw(toMark);
+    toMark = await worksForConnector(context, user, connectorId, { first: 500 });
+  }
+  await publishUserAction({
+    user,
+    event_type: 'mutation',
+    event_scope: 'cancel',
+    event_access: 'administration',
+    message: `cancels \`all works\` for connector \`${connector.name}\``,
+    context_data: { id: connectorId, entity_type: ENTITY_TYPE_CONNECTOR, input: { id: connectorId } },
+  });
+  return true;
+};
+// endregion
 
 export const createWork = async (context, user, connector, friendlyName, sourceId, args = {}) => {
   // Create the new work

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17281,6 +17281,7 @@ export type Mutation = {
   vulnerabilityAdd?: Maybe<Vulnerability>;
   vulnerabilityEdit?: Maybe<VulnerabilityEditMutations>;
   workAdd: Work;
+  workCancelForConnector?: Maybe<Scalars['Boolean']['output']>;
   workDelete?: Maybe<Scalars['Boolean']['output']>;
   workEdit?: Maybe<WorkEditMutations>;
   workspaceAdd?: Maybe<Workspace>;
@@ -19869,6 +19870,11 @@ export type MutationWorkAddArgs = {
   connectorId: Scalars['String']['input'];
   friendlyName?: InputMaybe<Scalars['String']['input']>;
   isMultiPartWork?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type MutationWorkCancelForConnectorArgs = {
+  connectorId: Scalars['String']['input'];
 };
 
 
@@ -24177,7 +24183,9 @@ export type Query = {
   ingestionTaxiis?: Maybe<IngestionTaxiiConnection>;
   intrusionSet?: Maybe<IntrusionSet>;
   intrusionSets?: Maybe<IntrusionSetConnection>;
+  /** @deprecated Use isWorkCancelled (inverted semantics): closed/completed works are alive too. */
   isWorkAlive?: Maybe<Scalars['Boolean']['output']>;
+  isWorkCancelled?: Maybe<Scalars['Boolean']['output']>;
   jsonMapper?: Maybe<JsonMapper>;
   jsonMappers?: Maybe<JsonMapperConnection>;
   killChainPhase?: Maybe<KillChainPhase>;
@@ -25534,6 +25542,11 @@ export type QueryIntrusionSetsArgs = {
 
 
 export type QueryIsWorkAliveArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryIsWorkCancelledArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -37483,6 +37496,7 @@ export type WorkEditMutations = {
   __typename?: 'WorkEditMutations';
   addDraftContext: Scalars['ID']['output'];
   addExpectations: Scalars['ID']['output'];
+  cancel: Scalars['ID']['output'];
   delete: Scalars['ID']['output'];
   ping: Scalars['ID']['output'];
   reportExpectation: Scalars['ID']['output'];
@@ -46954,6 +46968,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   vulnerabilityAdd?: Resolver<Maybe<ResolversTypes['Vulnerability']>, ParentType, ContextType, RequireFields<MutationVulnerabilityAddArgs, 'input'>>;
   vulnerabilityEdit?: Resolver<Maybe<ResolversTypes['VulnerabilityEditMutations']>, ParentType, ContextType, RequireFields<MutationVulnerabilityEditArgs, 'id'>>;
   workAdd?: Resolver<ResolversTypes['Work'], ParentType, ContextType, RequireFields<MutationWorkAddArgs, 'connectorId' | 'isMultiPartWork'>>;
+  workCancelForConnector?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationWorkCancelForConnectorArgs, 'connectorId'>>;
   workDelete?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationWorkDeleteArgs, 'connectorId'>>;
   workEdit?: Resolver<Maybe<ResolversTypes['WorkEditMutations']>, ParentType, ContextType, RequireFields<MutationWorkEditArgs, 'id'>>;
   workspaceAdd?: Resolver<Maybe<ResolversTypes['Workspace']>, ParentType, ContextType, RequireFields<MutationWorkspaceAddArgs, 'input'>>;
@@ -48479,6 +48494,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   intrusionSet?: Resolver<Maybe<ResolversTypes['IntrusionSet']>, ParentType, ContextType, Partial<QueryIntrusionSetArgs>>;
   intrusionSets?: Resolver<Maybe<ResolversTypes['IntrusionSetConnection']>, ParentType, ContextType, Partial<QueryIntrusionSetsArgs>>;
   isWorkAlive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryIsWorkAliveArgs, 'id'>>;
+  isWorkCancelled?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryIsWorkCancelledArgs, 'id'>>;
   jsonMapper?: Resolver<Maybe<ResolversTypes['JsonMapper']>, ParentType, ContextType, RequireFields<QueryJsonMapperArgs, 'id'>>;
   jsonMappers?: Resolver<Maybe<ResolversTypes['JsonMapperConnection']>, ParentType, ContextType, Partial<QueryJsonMappersArgs>>;
   killChainPhase?: Resolver<Maybe<ResolversTypes['KillChainPhase']>, ParentType, ContextType, RequireFields<QueryKillChainPhaseArgs, 'id'>>;
@@ -52012,6 +52028,7 @@ export type WorkEdgeResolvers<ContextType = any, ParentType extends ResolversPar
 export type WorkEditMutationsResolvers<ContextType = any, ParentType extends ResolversParentTypes['WorkEditMutations'] = ResolversParentTypes['WorkEditMutations']> = ResolversObject<{
   addDraftContext?: Resolver<ResolversTypes['ID'], ParentType, ContextType, Partial<WorkEditMutationsAddDraftContextArgs>>;
   addExpectations?: Resolver<ResolversTypes['ID'], ParentType, ContextType, Partial<WorkEditMutationsAddExpectationsArgs>>;
+  cancel?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   delete?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   ping?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   reportExpectation?: Resolver<ResolversTypes['ID'], ParentType, ContextType, Partial<WorkEditMutationsReportExpectationArgs>>;

--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -18,14 +18,14 @@ import createApolloServer from '../graphql/graphql';
 import { applicationSession } from '../database/session';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { userEditField } from '../domain/user';
-import { DraftLockedError, ForbiddenAccess, WorkNotALiveError } from '../config/errors';
+import { DraftLockedError, ForbiddenAccess, WorkCancelledError } from '../config/errors';
 import { getEntitiesMapFromCache } from '../database/cache';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
 import { DRAFT_STATUS_OPEN } from '../modules/draftWorkspace/draftStatuses';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { createAuthenticatedContext } from './httpAuthenticatedContext';
 import { getSettings } from '../domain/settings';
-import { isWorkAlive } from '../domain/work';
+import { isWorkCancelled } from '../domain/work';
 import { buildRateLimiterOptions } from './httpUtils';
 
 const MIN_20 = 20 * 60 * 1000;
@@ -145,11 +145,13 @@ const createHttpServer = async () => {
       path: `${basePath}/graphql`,
       context: async ({ req, res }) => {
         const executeContext = await createAuthenticatedContext(req, res, 'api');
-        // When context is related to a work, we need to check work status
+        // When context is related to a work, reject only if it has been
+        // explicitly cancelled (user-initiated delete). Closed/completed works
+        // must keep accepting late worker traffic.
         if (executeContext.workId) {
-          const workStillAlive = await isWorkAlive(executeContext, executeContext.user, executeContext.workId);
-          if (!workStillAlive) {
-            throw WorkNotALiveError();
+          const workCancelled = await isWorkCancelled(executeContext, executeContext.user, executeContext.workId);
+          if (workCancelled) {
+            throw WorkCancelledError();
           }
         }
         // When context is in draft, we need to check draft status: if draft is not in an open status, it means that it is no longer possible to execute requests in this draft

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -9,19 +9,36 @@ import { executionContext, SYSTEM_USER } from '../utils/access';
 import { READ_INDEX_HISTORY } from '../database/utils';
 import { now, sinceNowInDays } from '../utils/format';
 
-// Manage work created by connectors
-// Update status to complete when needed
-// Cleanup "batch_size" work in Elastic and Redis when complete "after works_day_range" days
+// Manage work created by connectors.
+// Two engine-driven lifecycles run periodically (engine-only, never a cancel):
+//   - completeAbandonedWorks: finalize Works left in wait/progress that the
+//     connector never closed. Force the `complete` status transition (or a
+//     pure delete if older than the retention window).
+//   - deleteCompletedWorks: storage cleanup of Works already in `complete`
+//     status, older than the retention window.
 const SCHEDULE_TIME = conf.get('connector_manager:interval') || 60000;
 const CONNECTOR_MANAGER_KEY = conf.get('connector_manager:lock_key') || 'connector_manager_lock';
 const CONNECTOR_WORK_RANGE = conf.get('connector_manager:works_day_range') || 7;
 const BATCH_SIZE = conf.get('connector_manager:batch_size') || 10000;
 let running = false;
 
-const closeOldWorks = async (context, connector) => {
+/**
+ * Engine-driven lifecycle finalization for Works abandoned by their
+ * connector. Renamed from `closeOldWorks` for clarity (it actually
+ * completes the Work). Behavior is unchanged from the original `closeOldWorks`:
+ *   - if older than CONNECTOR_WORK_RANGE days: delete from ES;
+ *   - otherwise: flip status to `complete` and record processed count;
+ *   - either way: drop the redis tracking key.
+ *
+ * This is NEVER a cancellation: no tombstone is set. Late worker traffic
+ * for these works falls through the http middleware (no tombstone) and is
+ * silently absorbed by the existing race-condition checks in
+ * `reportExpectation` / `updateExpectationsNumber` (work missing => return).
+ */
+const completeAbandonedWorks = async (context, connector) => {
   // Get current status from Redis
   const status = await redisGetConnectorStatus(connector.internal_id);
-  // If status is here we can try to close all old open works
+  // If status is here we can try to complete all old open works
   if (status) {
     const [,, timestamp] = status.split('_');
     // Get all works created before the current one and put a complete status on it.
@@ -61,7 +78,7 @@ const closeOldWorks = async (context, connector) => {
           // Delete redis tracking key
           await redisDeleteWorks(element.internal_id);
         } catch (e) {
-          logApp.error('[OPENCTI-MODULE] Connector manager error processing work closing', { cause: e });
+          logApp.error('[OPENCTI-MODULE] Connector manager error completing abandoned work', { cause: e });
         }
       }
     };
@@ -119,9 +136,9 @@ const connectorHandler = async () => {
     for (let index = 0; index < platformConnectors.length; index += 1) {
       lock.signal.throwIfAborted();
       const platformConnector = platformConnectors[index];
-      // Force close all needed works
-      await closeOldWorks(context, platformConnector);
-      // Cleanup too old complete works
+      // Lifecycle: force-complete works abandoned by the connector
+      await completeAbandonedWorks(context, platformConnector);
+      // Janitorial: cleanup too old complete works
       await deleteCompletedWorks(context, platformConnector);
     }
   } catch (e) {

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -35,12 +35,15 @@ import {
 } from '../domain/connector';
 import {
   addDraftContext,
+  cancelWork,
+  cancelWorksForConnector,
   createWork,
   deleteWork,
   deleteWorkForConnector,
   findById,
   findWorkPaginated,
   isWorkAlive,
+  isWorkCancelled,
   pingWork,
   reportExpectation,
   updateExpectationsNumber,
@@ -89,6 +92,7 @@ const connectorResolvers = {
     works: (_, args, context) => findWorkPaginated(context, context.user, args),
     work: (_, { id }, context) => findById(context, context.user, id),
     isWorkAlive: (_, { id }, context) => isWorkAlive(context, context.user, id),
+    isWorkCancelled: (_, { id }, context) => isWorkCancelled(context, context.user, id),
     synchronizer: (_, { id }, context) => findSyncById(context, context.user, id, true),
     synchronizerAddInputFromImport: (_, { file }) => syncAddInputFromImport(file),
     synchronizers: (_, args, context) => findSyncPaginated(context, context.user, args),
@@ -186,6 +190,7 @@ const connectorResolvers = {
       });
     },
     workEdit: (_, { id }, context) => ({
+      cancel: () => cancelWork(context, context.user, id),
       delete: () => deleteWork(context, context.user, id),
       ping: () => pingWork(context, context.user, id),
       reportExpectation: ({ error }) => reportExpectation(context, context.user, id, error),
@@ -194,6 +199,7 @@ const connectorResolvers = {
       toReceived: ({ message }) => updateReceivedTime(context, context.user, id, message),
       toProcessed: ({ message, inError }) => updateProcessedTime(context, context.user, id, message, inError),
     }),
+    workCancelForConnector: (_, { connectorId }, context) => cancelWorksForConnector(context, context.user, connectorId),
     workDelete: (_, { connectorId }, context) => deleteWorkForConnector(context, context.user, connectorId),
     // Sync part
     synchronizerAdd: (_, { input }, context) => registerSync(context, context.user, input),

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/backgroundTask-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/backgroundTask-test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import gql from 'graphql-tag';
 import { queryUnauthenticatedIsExpectedForbidden } from '../../utils/testQueryHelper';
-import { deleteWork } from '../../../src/domain/work';
+import { cancelWork } from '../../../src/domain/work';
 import { ADMIN_USER, queryInitPlatformAsAdmin, testContext } from '../../utils/testQuery';
 import { getBestBackgroundConnectorId } from '../../../src/database/rabbitmq';
 import { createWorkForBackgroundTask } from '../../../src/domain/backgroundTask-common';
@@ -19,11 +19,11 @@ describe('Background task graphQL API permission checks', () => {
     });
   });
 });
-describe('Verify deleted works', () => {
-  it('should request on deleted work be rejected with reason WORK_NOT_ALIVE.', async () => {
+describe('Verify cancelled works', () => {
+  it('should request on cancelled work be rejected with reason WORK_CANCELLED.', async () => {
     const backgroundTaskConnectorId = await getBestBackgroundConnectorId(testContext, ADMIN_USER);
     const work = await createWorkForBackgroundTask(testContext, 'fake_id', backgroundTaskConnectorId);
-    await deleteWork(testContext, ADMIN_USER, work?.id);
+    await cancelWork(testContext, ADMIN_USER, work?.id);
 
     let error: any;
     try {
@@ -31,6 +31,6 @@ describe('Verify deleted works', () => {
     } catch (err) {
       error = err;
     }
-    expect(error?.response.data.errors[0].name).toEqual('WORK_NOT_ALIVE');
+    expect(error?.response.data.errors[0].name).toEqual('WORK_CANCELLED');
   });
 });


### PR DESCRIPTION
Fix #15886 

This pull request introduces a new explicit "work cancellation" flow across the OpenCTI platform, replacing and deprecating the older "work delete" and "work not alive" semantics. The changes add support for actively cancelling in-progress work items, update both backend and frontend APIs to use this new model, and ensure clearer error handling and messaging around cancelled work.

Key changes include:

**API and Backend Enhancements:**

* Added new `cancel` and `cancel_works_for_connector` methods to the Python client (`opencti_api_work.py`), allowing explicit cancellation of individual works or all works for a connector. These methods interact with new GraphQL mutations and set a Redis-based cancellation tombstone to reject in-flight work with a `WORK_CANCELLED` error.
* Introduced `get_is_work_cancelled` API and marked `get_is_work_alive` as deprecated, aligning with new server-side semantics for work cancellation. [[1]](diffhunk://#diff-046d4c9d5fcb76d2670b1c8da0f2680778a389bcbba7566f87427abfd45979bbR404-R408) [[2]](diffhunk://#diff-046d4c9d5fcb76d2670b1c8da0f2680778a389bcbba7566f87427abfd45979bbR422-R442)
* Updated error handling and constants to use `WORK_CANCELLED` instead of `WORK_NOT_ALIVE`, with legacy support for older servers. [[1]](diffhunk://#diff-7d7a6ec46e89176497346256e04416a162b13c36d4ac4389d1bf2d17a4e2701aR56-R60) [[2]](diffhunk://#diff-7d7a6ec46e89176497346256e04416a162b13c36d4ac4389d1bf2d17a4e2701aL3575-R3583)
* Updated GraphQL schema to add `isWorkCancelled` query, `cancel` mutation for `workEdit`, and `workCancelForConnector` mutation. Deprecated `isWorkAlive` field. [[1]](diffhunk://#diff-b34cf62a4fe93fb172ed0cabf59e0d2b4330a0a5b537cf7a5a83fa7573257c52L14847-R14848) [[2]](diffhunk://#diff-b34cf62a4fe93fb172ed0cabf59e0d2b4330a0a5b537cf7a5a83fa7573257c52R15945) [[3]](diffhunk://#diff-b34cf62a4fe93fb172ed0cabf59e0d2b4330a0a5b537cf7a5a83fa7573257c52R16420)
* Added `work_cancel_ttl` configuration option for Redis cancellation tombstones.
* Changed backend error type from `WORK_NOT_ALIVE` to `WORK_CANCELLED` for cancelled works.

**Frontend and UI Updates:**

* Refactored all relevant mutations and UI components to use `cancel` instead of `delete` for work cancellation actions (e.g., enrichment lines, file work, import works, connector works). This affects multiple files and components, ensuring UI actions now explicitly cancel work. [[1]](diffhunk://#diff-e0bc947bf62e4ff2b4dd32004f58343a7bda6f46501729fe3b38f1ad5d85c8ffL36-R39) [[2]](diffhunk://#diff-e0bc947bf62e4ff2b4dd32004f58343a7bda6f46501729fe3b38f1ad5d85c8ffL115-R115) [[3]](diffhunk://#diff-8f182d84c69c1fa6eafd20a35dae7d50e4515bba07ba8231ea53aba03cf6384aL74-R77) [[4]](diffhunk://#diff-8f182d84c69c1fa6eafd20a35dae7d50e4515bba07ba8231ea53aba03cf6384aL225-R225) [[5]](diffhunk://#diff-9e29c46d36f345485a02e9d928a4a9e654249d5794d515c9928206361c3319acL48-R51) [[6]](diffhunk://#diff-9e29c46d36f345485a02e9d928a4a9e654249d5794d515c9928206361c3319acL81-R81) [[7]](diffhunk://#diff-325468edd69c1bd25085814596647f40aab0c406318b860c6b0d1cc7318788e1L129-R132) [[8]](diffhunk://#diff-325468edd69c1bd25085814596647f40aab0c406318b860c6b0d1cc7318788e1L167-R167) [[9]](diffhunk://#diff-fa4d63de98852f147bc19607eaa3e18246db6b256a839fd44fe2eb4f3d5e2a27L36-R39) [[10]](diffhunk://#diff-fa4d63de98852f147bc19607eaa3e18246db6b256a839fd44fe2eb4f3d5e2a27L112-R112) [[11]](diffhunk://#diff-3be0dc7456a0c0e2a8e9e5aee0ec9f5ab9971e4ae22291c4530d964900c3dc6aL84-R86) [[12]](diffhunk://#diff-161b312e5734113995bf4ae8b52a24aef5b628b3194b586d7a32155af256cb6fL5-R5) [[13]](diffhunk://#diff-161b312e5734113995bf4ae8b52a24aef5b628b3194b586d7a32155af256cb6fL49-R49) [[14]](diffhunk://#diff-81ab749a7e8e3d647412f4a76acb0d733b072a0acb0fa765f892cbf2f4835c78L22-R22) [[15]](diffhunk://#diff-81ab749a7e8e3d647412f4a76acb0d733b072a0acb0fa765f892cbf2f4835c78L49-R49) [[16]](diffhunk://#diff-1ab279ad9c47251ec76a8f022ae488e0355bfbdabf451b80859fbafe5947396fL16-R19)
* Updated connector and connector work management UIs to use the new cancellation flow, including bulk cancellation for connectors. [[1]](diffhunk://#diff-3be0dc7456a0c0e2a8e9e5aee0ec9f5ab9971e4ae22291c4530d964900c3dc6aL84-R86) [[2]](diffhunk://#diff-161b312e5734113995bf4ae8b52a24aef5b628b3194b586d7a32155af256cb6fL5-R5) [[3]](diffhunk://#diff-161b312e5734113995bf4ae8b52a24aef5b628b3194b586d7a32155af256cb6fL49-R49) [[4]](diffhunk://#diff-81ab749a7e8e3d647412f4a76acb0d733b072a0acb0fa765f892cbf2f4835c78L22-R22) [[5]](diffhunk://#diff-81ab749a7e8e3d647412f4a76acb0d733b072a0acb0fa765f892cbf2f4835c78L49-R49) [[6]](diffhunk://#diff-1ab279ad9c47251ec76a8f022ae488e0355bfbdabf451b80859fbafe5947396fL16-R19)

**Deprecations and Compatibility:**

* Deprecated the old "work alive" check and error, providing backward compatibility for older servers but guiding clients to use the new cancellation approach. [[1]](diffhunk://#diff-046d4c9d5fcb76d2670b1c8da0f2680778a389bcbba7566f87427abfd45979bbR404-R408) [[2]](diffhunk://#diff-7d7a6ec46e89176497346256e04416a162b13c36d4ac4389d1bf2d17a4e2701aR56-R60)

These changes collectively provide a more robust and semantically clear way to abort and manage long-running or stuck work items, improving both user experience and system reliability.

---

**API and Backend Enhancements**
- Added explicit `cancel` and `cancel_works_for_connector` methods in the Python client, with corresponding GraphQL mutations, to actively abort work and reject in-flight processing using Redis tombstones.
- Introduced `get_is_work_cancelled` API and deprecated `get_is_work_alive`, aligning with new server semantics for work cancellation. [[1]](diffhunk://#diff-046d4c9d5fcb76d2670b1c8da0f2680778a389bcbba7566f87427abfd45979bbR404-R408) [[2]](diffhunk://#diff-046d4c9d5fcb76d2670b1c8da0f2680778a389bcbba7566f87427abfd45979bbR422-R442)
- Updated error handling to use `WORK_CANCELLED` instead of `WORK_NOT_ALIVE`, with legacy support for backward compatibility. [[1]](diffhunk://#diff-7d7a6ec46e89176497346256e04416a162b13c36d4ac4389d1bf2d17a4e2701aR56-R60) [[2]](diffhunk://#diff-7d7a6ec46e89176497346256e04416a162b13c36d4ac4389d1bf2d17a4e2701aL3575-R3583) [[3]](diffhunk://#diff-3e312aced984302e1ddea27da8819d2f71048dbfee9df7db45ba87155dacc892L195-R196)
- Extended GraphQL schema with `isWorkCancelled`, `cancel` mutation for `workEdit`, and `workCancelForConnector` mutation; deprecated `isWorkAlive`. [[1]](diffhunk://#diff-b34cf62a4fe93fb172ed0cabf59e0d2b4330a0a5b537cf7a5a83fa7573257c52L14847-R14848) [[2]](diffhunk://#diff-b34cf62a4fe93fb172ed0cabf59e0d2b4330a0a5b537cf7a5a83fa7573257c52R15945) [[3]](diffhunk://#diff-b34cf62a4fe93fb172ed0cabf59e0d2b4330a0a5b537cf7a5a83fa7573257c52R16420)
- Added `work_cancel_ttl` Redis configuration for cancellation tombstones.

**Frontend and UI Updates**
- Refactored all work-related UI mutations and components to use `cancel` instead of `delete`, ensuring users now explicitly cancel work (affecting enrichment, file, import, and connector work components). [[1]](diffhunk://#diff-e0bc947bf62e4ff2b4dd32004f58343a7bda6f46501729fe3b38f1ad5d85c8ffL36-R39) [[2]](diffhunk://#diff-e0bc947bf62e4ff2b4dd32004f58343a7bda6f46501729fe3b38f1ad5d85c8ffL115-R115) [[3]](diffhunk://#diff-8f182d84c69c1fa6eafd20a35dae7d50e4515bba07ba8231ea53aba03cf6384aL74-R77) [[4]](diffhunk://#diff-8f182d84c69c1fa6eafd20a35dae7d50e4515bba07ba8231ea53aba03cf6384aL225-R225) [[5]](diffhunk://#diff-9e29c46d36f345485a02e9d928a4a9e654249d5794d515c9928206361c3319acL48-R51) [[6]](diffhunk://#diff-9e29c46d36f345485a02e9d928a4a9e654249d5794d515c9928206361c3319acL81-R81) [[7]](diffhunk://#diff-325468edd69c1bd25085814596647f40aab0c406318b860c6b0d1cc7318788e1L129-R132) [[8]](diffhunk://#diff-325468edd69c1bd25085814596647f40aab0c406318b860c6b0d1cc7318788e1L167-R167) [[9]](diffhunk://#diff-fa4d63de98852f147bc19607eaa3e18246db6b256a839fd44fe2eb4f3d5e2a27L36-R39) [[10]](diffhunk://#diff-fa4d63de98852f147bc19607eaa3e18246db6b256a839fd44fe2eb4f3d5e2a27L112-R112) [[11]](diffhunk://#diff-3be0dc7456a0c0e2a8e9e5aee0ec9f5ab9971e4ae22291c4530d964900c3dc6aL84-R86) [[12]](diffhunk://#diff-161b312e5734113995bf4ae8b52a24aef5b628b3194b586d7a32155af256cb6fL5-R5) [[13]](diffhunk://#diff-161b312e5734113995bf4ae8b52a24aef5b628b3194b586d7a32155af256cb6fL49-R49) [[14]](diffhunk://#diff-81ab749a7e8e3d647412f4a76acb0d733b072a0acb0fa765f892cbf2f4835c78L22-R22) [[15]](diffhunk://#diff-81ab749a7e8e3d647412f4a76acb0d733b072a0acb0fa765f892cbf2f4835c78L49-R49) [[16]](diffhunk://#diff-1ab279ad9c47251ec76a8f022ae488e0355bfbdabf451b80859fbafe5947396fL16-R19)

**Deprecations and Compatibility**
- Deprecated `get_is_work_alive` and `WORK_NOT_ALIVE` error, providing backward compatibility for legacy servers but moving clients to the new cancellation model. [[1]](diffhunk://#diff-046d4c9d5fcb76d2670b1c8da0f2680778a389bcbba7566f87427abfd45979bbR404-R408) [[2]](diffhunk://#diff-7d7a6ec46e89176497346256e04416a162b13c36d4ac4389d1bf2d17a4e2701aR56-R60)