### PR TITLE
feat(frontend): add offset to startDateEpoch so frontend session expires when backend session is still valid (#15889)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -85,7 +85,7 @@ const TimeoutLock: React.FunctionComponent = () => {
     sessionLimit,
     idleCount: null,
     startDate: new Date(),
-    startDateEpoch: Date.now(),
+    startDateEpoch: Date.now() - 1000,
   });
   const [resetCounter, triggerReset] = useState(false);
   const interval = useRef<NodeJS.Timeout | null>(null);

--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -30,6 +30,13 @@ const timeoutLockRefreshQuery = graphql`
     }
   }
 `;
+const createTimeWithOffset = (): number => {
+  return Date.now() - ONE_SECOND;
+};
+
+const createOffsetTimeItem = (): { startDate: Date; startDateEpoch: number } => {
+  return { startDate: new Date(), startDateEpoch: createTimeWithOffset() };
+};
 
 /**
  * Handles various state changes for the timeout counting functionality.
@@ -37,7 +44,7 @@ const timeoutLockRefreshQuery = graphql`
 const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
   const { idleLimit, sessionLimit } = state;
   let { idleCount, startDate, startDateEpoch } = state;
-  const offsetTime = Date.now() - ONE_SECOND;
+  const offsetTimeItem = createOffsetTimeItem();
   if (idleCount === null) {
     idleCount = sessionLimit;
   }
@@ -49,8 +56,7 @@ const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
     idleCount = sessionLimit - (Date.now() - timeoutData.startDateEpoch) / ONE_SECOND;
   } else {
     // If timeout start not yet initialize, setup the local storage
-    const newTimeItem = { startDate: new Date(), startDateEpoch: offsetTime };
-    localStorage.setItem('lockoutTracker', JSON.stringify(newTimeItem));
+    localStorage.setItem('lockoutTracker', JSON.stringify(offsetTimeItem));
     idleCount -= 1;
   }
   // Handle actions
@@ -61,14 +67,13 @@ const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
     return state;
   }
   if (action.type === 'reset timeout') {
-    const newTimeItem = { startDate: new Date(), startDateEpoch: offsetTime };
-    localStorage.setItem('lockoutTracker', JSON.stringify(newTimeItem));
+    localStorage.setItem('lockoutTracker', JSON.stringify(offsetTimeItem));
     return {
       idleLimit,
       sessionLimit,
       idleCount: sessionLimit,
-      startDate: newTimeItem.startDate,
-      startDateEpoch: newTimeItem.startDateEpoch,
+      startDate: offsetTimeItem.startDate,
+      startDateEpoch: offsetTimeItem.startDateEpoch,
     };
   }
   return state;
@@ -86,7 +91,7 @@ const TimeoutLock: React.FunctionComponent = () => {
     sessionLimit,
     idleCount: null,
     startDate: new Date(),
-    startDateEpoch: Date.now() - ONE_SECOND,
+    startDateEpoch: createTimeWithOffset(),
   });
   const [resetCounter, triggerReset] = useState(false);
   const interval = useRef<NodeJS.Timeout | null>(null);

--- a/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
+++ b/opencti-platform/opencti-front/src/private/components/TimeoutLock.tsx
@@ -37,6 +37,7 @@ const timeoutLockRefreshQuery = graphql`
 const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
   const { idleLimit, sessionLimit } = state;
   let { idleCount, startDate, startDateEpoch } = state;
+  const offsetTime = Date.now() - ONE_SECOND;
   if (idleCount === null) {
     idleCount = sessionLimit;
   }
@@ -45,10 +46,10 @@ const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
     const timeoutData = JSON.parse(timeoutJSON);
     startDate = timeoutData.startDate;
     startDateEpoch = timeoutData.startDateEpoch;
-    idleCount = sessionLimit - (Date.now() - timeoutData.startDateEpoch) / 1000;
+    idleCount = sessionLimit - (Date.now() - timeoutData.startDateEpoch) / ONE_SECOND;
   } else {
     // If timeout start not yet initialize, setup the local storage
-    const newTimeItem = { startDate: new Date(), startDateEpoch: Date.now() };
+    const newTimeItem = { startDate: new Date(), startDateEpoch: offsetTime };
     localStorage.setItem('lockoutTracker', JSON.stringify(newTimeItem));
     idleCount -= 1;
   }
@@ -60,7 +61,7 @@ const timeoutReducer = (state: TimeoutState, action: Action): TimeoutState => {
     return state;
   }
   if (action.type === 'reset timeout') {
-    const newTimeItem = { startDate: new Date(), startDateEpoch: Date.now() };
+    const newTimeItem = { startDate: new Date(), startDateEpoch: offsetTime };
     localStorage.setItem('lockoutTracker', JSON.stringify(newTimeItem));
     return {
       idleLimit,
@@ -85,7 +86,7 @@ const TimeoutLock: React.FunctionComponent = () => {
     sessionLimit,
     idleCount: null,
     startDate: new Date(),
-    startDateEpoch: Date.now() - 1000,
+    startDateEpoch: Date.now() - ONE_SECOND,
   });
   const [resetCounter, triggerReset] = useState(false);
   const interval = useRef<NodeJS.Timeout | null>(null);


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add 1 second offset to startDateEpoch so frontend session expires when backend session is still valid

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fixes #15889,  #15644
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
