### PR TITLE
[backend] Connector manager was removing Redis keys too early when completing old jobs (#15886)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -480,8 +480,7 @@ export const lockResource = async (resources: Array<string>, opts: LockOptions =
 
 // region work handling
 export const redisDeleteWorks = async (internalIds: Array<string>) => {
-  const ids = Array.isArray(internalIds) ? internalIds : [internalIds];
-  return Promise.all(ids.map((id) => getClientBase().del(id)));
+  return Promise.all(internalIds.map((id) => getClientBase().del(id)));
 };
 export const redisGetWork = async (internalId: string) => {
   return getClientBase().hgetall(internalId);

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -286,12 +286,19 @@ export const reportExpectation = async (context, user, workId, errorData) => {
   await redisUpdateWorkFigures(workId);
   const { expected, total, isProcessed, isMultiPartWork } = await redisGetWorkCompletionState(workId);
   const isComplete = (!isMultiPartWork || isProcessed) && isWorkFinished(expected, total);
-  // Ensure that work hasn't been deleted in the meantime
+
+  // Important: isWorkAlive is intentionally checked *after* redisUpdateWorkFigures, not before.
+  // If we checked liveness upfront and the work closed between that check and the figures update,
+  // redisUpdateWorkFigures would recreate the Redis key, potentially leaving it orphaned indefinitely
+  // (i.e. if no subsequent reportExpectation/updateExpectationsNumber call would have permitted cleaning it up).
+  // By checking liveness after the update, we guarantee Redis stays consistent:
+  // any key recreated by redisUpdateWorkFigures is immediately removed if the work is no longer alive.
   const workAlive = await isWorkAlive(context, user, workId);
   if (!workAlive) {
-    await redisDeleteWorks(workId);
+    await redisDeleteWorks([workId]);
     return workId;
   }
+
   if (isComplete || errorData) {
     const params = { now: timestamp };
     let sourceScript = '';
@@ -333,21 +340,33 @@ export const reportExpectation = async (context, user, workId, errorData) => {
  * @returns {Promise<string>}
  */
 export const updateExpectationsNumber = async (context, user, workId, expectations) => {
+  await redisUpdateActionExpectation(user, workId, expectations);
+
+  // Important: isWorkAlive is intentionally checked *after* redisUpdateActionExpectation, not before.
+  // If we checked liveness upfront and the work closed between that check and the figures update,
+  // redisUpdateActionExpectation would recreate the Redis key, potentially leaving it orphaned indefinitely
+  // (i.e. if no subsequent reportExpectation/updateExpectationsNumber call would have permitted cleaning it up).
+  // By checking liveness after the update, we guarantee Redis stays consistent:
+  // any key recreated by redisUpdateActionExpectation is immediately removed if the work is no longer alive.
+  // Ensure that work hasn't been deleted in the meantime in case of race condition
+  const workAlive = await isWorkAlive(context, user, workId);
+  if (!workAlive) {
+    await redisDeleteWorks([workId]);
+    logApp.warn('The work cannot be found in database, expectation cannot be updated.', { workId, expectations });
+    return workId;
+  }
+
   const currentWork = await loadWorkById(context, user, workId);
   if (!currentWork) { // work is no longer exists
     logApp.warn('The work cannot be found in database, expectation cannot be updated.', { workId, expectations });
     return workId;
   }
-  await redisUpdateActionExpectation(user, workId, expectations);
+
   const params = { updated_at: now(), import_expected_number: expectations };
   let source = 'ctx._source.updated_at = params.updated_at;';
   source += 'ctx._source["import_expected_number"] = ctx._source["import_expected_number"] + params.import_expected_number;';
   await elUpdate(currentWork._index, workId, { script: { source, lang: 'painless', params } });
-  // Ensure that work hasn't been deleted in the meantime in case of race condition
-  const workAlive = await isWorkAlive(context, user, workId);
-  if (!workAlive) {
-    await redisDeleteWorks(workId);
-  }
+
   return workId;
 };
 

--- a/opencti-platform/opencti-graphql/src/manager/connectorManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/connectorManager.js
@@ -1,13 +1,14 @@
 import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async/fixed';
-import { redisDeleteWorks, redisGetConnectorStatus, redisGetWork } from '../database/redis';
+import { redisGetConnectorStatus, redisGetWork } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { connectors } from '../database/repository';
-import { elDeleteInstances, elList, elUpdate } from '../database/engine';
+import { elList, elUpdate } from '../database/engine';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { READ_INDEX_HISTORY } from '../database/utils';
-import { now, sinceNowInDays } from '../utils/format';
+import { now } from '../utils/format';
+import { deleteWorksRaw } from '../domain/work';
 
 // Manage work created by connectors
 // Update status to complete when needed
@@ -38,28 +39,21 @@ const closeOldWorks = async (context, connector) => {
       for (let i = 0; i < elements.length; i += 1) {
         const element = elements[i];
         try {
-          // If element is too old, just delete it
-          if (sinceNowInDays(element.timestamp) > CONNECTOR_WORK_RANGE) {
-            await elDeleteInstances([element]);
-          } else { // If not, update the status to complete + the number of processed elements
-            const currentWorkStatus = await redisGetWork(element.internal_id);
-            if (currentWorkStatus) {
-              const params = { completed_time: now(), completed_number: parseInt(currentWorkStatus.import_processed_number, 10) };
-              const sourceScript = `ctx._source['status'] = "complete";
-                  ctx._source['completed_time'] = params.completed_time;
-                  ctx._source['completed_number'] = params.completed_number;`;
-              await elUpdate(element._index, element.internal_id, {
-                script: {
-                  source: sourceScript,
-                  lang: 'painless',
-                  params,
-                },
-              });
-              logApp.info('Work completed by force due to age', { workId: element.internal_id });
-            }
+          const currentWorkStatus = await redisGetWork(element.internal_id);
+          if (currentWorkStatus) {
+            const params = { completed_time: now(), completed_number: parseInt(currentWorkStatus.import_processed_number, 10) };
+            const sourceScript = `ctx._source['status'] = "complete";
+                ctx._source['completed_time'] = params.completed_time;
+                ctx._source['completed_number'] = params.completed_number;`;
+            await elUpdate(element._index, element.internal_id, {
+              script: {
+                source: sourceScript,
+                lang: 'painless',
+                params,
+              },
+            });
+            logApp.info('Work completed by force due to age', { workId: element.internal_id });
           }
-          // Delete redis tracking key
-          await redisDeleteWorks(element.internal_id);
         } catch (e) {
           logApp.error('[OPENCTI-MODULE] Connector manager error processing work closing', { cause: e });
         }
@@ -91,9 +85,7 @@ export const deleteCompletedWorks = async (context, connector) => {
   const queryCallback = async (elements) => {
     const message = `[WORKS] Deleting ${elements.length} works for ${connector.name}`;
     logApp.info(message);
-    const ids = elements.map((w) => w.internal_id);
-    await redisDeleteWorks(ids);
-    await elDeleteInstances(elements);
+    await deleteWorksRaw(elements);
   };
   await elList(context, SYSTEM_USER, [READ_INDEX_HISTORY], {
     filters,


### PR DESCRIPTION
### Proposed changes

* Do not delete the Redis key as soon age the connector complete the old job, eg in case a new work already started while previous job works are still running
* Some cleanup

### Related issues
* Fix #15886

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
