### PR TITLE
[backend] check work aliveness only for background task works (#15886)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -51,8 +51,12 @@ export const findById = (context, user, workId) => {
 };
 
 export const isWorkAlive = async (_context, _user, workId) => {
-  const redisWork = await redisGetWork(workId);
-  return redisWork?.is_initialized === 'true';
+  // check work alive only for background-task. e.g. connectors works must not be discarded
+  if (workId.startsWith('background-task')) {
+    const redisWork = await redisGetWork(workId);
+    return redisWork?.is_initialized === 'true';
+  }
+  return true;
 };
 
 export const findWorkPaginated = (context, user, args = {}) => {


### PR DESCRIPTION
### Proposed changes

Non background task works should always be considered alive

eg for connectors, it handles the race condition that happen on https://github.com/OpenCTI-Platform/opencti/blob/60b1fe80b57d7bafe3f4e524f3d8c05bd93ee4fe/opencti-platform/opencti-graphql/src/manager/connectorManager.js#L62 that delete the work that could be still referenced in queued elements (eg late or requeued elements)

### Related issues
* Fix #15886 

### Checklist

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
