### PR TITLE
[backend] check work aliveness in Elastic if key has not been found in Redis (#15886)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -50,9 +50,15 @@ export const findById = (context, user, workId) => {
   return loadWorkById(context, user, workId);
 };
 
-export const isWorkAlive = async (_context, _user, workId) => {
+export const isWorkAlive = async (context, user, workId) => {
+  // if work exists in Redis not need to check elastic
   const redisWork = await redisGetWork(workId);
-  return redisWork?.is_initialized === 'true';
+  if (redisWork?.is_initialized === 'true') {
+    return true;
+  }
+
+  // if work has been deleted from Redis, check in Elastic to be able to process late messages that arrives when works is already completed
+  return Boolean(await findById(context, user, workId));
 };
 
 export const findWorkPaginated = (context, user, args = {}) => {


### PR DESCRIPTION
### Proposed changes

* Check work aliveness in Elastic if key has not been found in Redis

### Related issues
* Fix #15886

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
