### PR TITLE
[backend/client-python] skip live stream recovery when origin filters are set (#15936)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1701,7 +1701,22 @@ class ListenStream(threading.Thread):
                         q.put(msg.event, block=False)
                     except queue.Full:
                         pass
-                    if (
+                    if msg.event == "no-recover":
+                        # Server signaled that recovery from history is disabled for this stream
+                        # (typically because origin_filters is set on the live stream collection).
+                        # Acknowledge once and persist `recover_until = False` so subsequent
+                        # restarts don't bother sending the recover query parameter.
+                        self.helper.connector_logger.warning(
+                            "Live stream recovery skipped by the platform; switching to live-only mode",
+                            {"data": msg.data},
+                        )
+                        state = self.helper.get_state()
+                        if state is None:
+                            self.exit_event.set()
+                        else:
+                            state["recover_until"] = False
+                            self.helper.set_state(state)
+                    elif (
                         msg.event == "heartbeat"
                         or msg.event == "consumer_metrics"
                         or msg.event == "connected"

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -38,7 +38,7 @@ import { stixRefsExtractor } from '../schema/stixEmbeddedRelationship';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_OBJECT, buildRefRelationKey, ENTITY_TYPE_CONTAINER, STIX_TYPE_RELATION, STIX_TYPE_SIGHTING } from '../schema/general';
 import { UnsupportedError } from '../config/errors';
 import { MARKING_FILTER } from '../utils/filtering/filtering-constants';
-import { findFiltersFromKey } from '../utils/filtering/filtering-utils';
+import { findFiltersFromKey, isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import { convertFiltersToQueryOptions } from '../utils/filtering/filtering-resolution';
 import { getParentTypes } from '../schema/schemaUtils';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
@@ -751,7 +751,23 @@ const createSseMiddleware = () => {
         logApp.info(`[STREAM] Listening stream ${id} from ${startMessage}${recoveringMessage}`);
         // Start recovery if needed
         const isRecoveryMode = isNotEmptyField(recoverIsoDate) && utcDate(recoverIsoDate).isAfter(startIsoDate);
-        if (isRecoveryMode) {
+        // Origin filters can only match against the live event envelope; Elasticsearch does not
+        // store the original origin so a recovery would either flood the consumer with un-filtered
+        // historical data (security/contract violation) or drop everything (useless work).
+        // We bypass the recovery entirely and let the consumer know via an explicit SSE event.
+        const isOriginFilteredStream = isFilterGroupNotEmpty(originFilters);
+        const skipRecoveryForOriginFilters = isRecoveryMode && isOriginFilteredStream;
+        if (skipRecoveryForOriginFilters) {
+          logApp.warn('[STREAM] Skipping Elasticsearch recovery because origin_filters is set on this stream', { streamCollectionId: id });
+          if (channel.connected()) {
+            await channel.sendEvent(streamEventId(utcDate().toDate()), 'no-recover', {
+              stream: id,
+              message: 'Recovery from history is disabled on streams configured with origin filters; resuming from live events only.',
+              resume_from: recoverStreamId,
+            });
+          }
+        }
+        if (isRecoveryMode && !skipRecoveryForOriginFilters) {
           // noinspection UnnecessaryLocalVariableJS
           const queryCallback = async (elements) => {
             const workingElementsIds = elements.filter((e) => !cache.has(e.standard_id)).map((e) => e.internal_id);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* **Backend (`opencti-graphql`)** - `liveStreamHandler` now bypasses the Elasticsearch recovery loop when the live stream collection has a non-empty `origin_filters` (introduced in #15874). Recovery would otherwise either flood the consumer with un-filtered historical events (each carrying `origin: { referer: 'init-create' }`) or, with the gate applied, drop them all - both useless. The live processor still resumes from `recoverStreamId` (the consumer's "now" cutoff), so the consumer transitions straight into properly filtered live events. A clear warning is logged server-side and an explicit SSE event with the new topic `no-recover` is emitted to inform the client (payload includes the resume Redis stream id).

* **Python helper (`client-python`)** - `ListenStream` now treats `no-recover` as a meta event: it is **not** forwarded to the user callback, a `warning` is logged for the operator, and the connector state is updated with `recover_until = False` so subsequent restarts don't even bother sending the `recover` query parameter to the platform. The existing `recover_iso_date` opt-out check (`if recover_until is not False ...`) was already in place, so the new state value flows through naturally.

#### Why bypass instead of "filter during recovery"?

`origin.user_id` / `group_ids` / `organization_ids` are not persisted on the Elasticsearch indices, only on the live Redis events. Applying the origin filter to recovery events would therefore either (a) match nothing - because synthetic recovery origins fall back to `<unknown>` in the testers - or (b) leak through unfiltered, defeating the whole point of `origin_filters`. Skipping the recovery phase is the only way to honour the filter contract without losing the live behaviour.

#### Connector restart semantics (also asked offline)

After the **first** run, the connector helper persists `recover_until = <first-run date>` and `start_from = <last Redis event id>`, both updated continuously. On every subsequent restart the server condition `isRecoveryMode = recoverIsoDate.isAfter(startIsoDate)` evaluates to `false`, and the live processor resumes from Redis. So the recovery skip only takes effect on the very first run (which is exactly when the bug bites today). With this PR, that first run also goes straight to live mode whenever `origin_filters` is set on the stream.

### Related issues

* Fixes #15936
* Builds on #15874

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Behaviour matrix after this PR (assuming a stream collection with `origin_filters` set on, say, `members_user = alice`):

| Consumer request | Before this PR | After this PR |
|---|---|---|
| `from=0-0&recover=today` (typical first run) | elList walks the entire knowledge base matching the STIX filter, sends synthetic-origin events ungated, then live | One `no-recover` SSE event, then live from Redis tail with origin filter applied |
| `from=<recent>&recover=<old>` (typical restart) | `isRecoveryMode = false` -> live only (already correct) | Unchanged |
| `from=<recent>` (no recover) | live only (already correct) | Unchanged |
| Stream without `origin_filters` | unchanged | unchanged (skip path is gated by `isFilterGroupNotEmpty(originFilters)`) |

Backwards compatibility:

* Older python connector helpers (pre-this PR) that still send `?recover=...` will get the `no-recover` event. They have no special case for the topic, so it falls into the generic SSE callback - which on the python side simply means it will be passed to the user's `message_callback`. That is harmless because the message body is a small JSON `{stream, message, resume_from}` (not a STIX object), and the live processor still resumes correctly afterward. The connector will still benefit from the recovery skip even without the helper update.
* Streams without `origin_filters` are unaffected.
