### PR TITLE
[backend/frontend] feat(news-feed): mark items as read on list page load (#15934)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/profile/NewsFeed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/NewsFeed.tsx
@@ -3,8 +3,8 @@ import { NewsFeedLines_data$data } from '@components/profile/__generated__/NewsF
 import { NewsFeedLinesPaginationQuery, NewsFeedLinesPaginationQuery$variables } from '@components/profile/__generated__/NewsFeedLinesPaginationQuery.graphql';
 import { Alert, IconButton, Stack, Tooltip } from '@mui/material';
 import { InsertChartOutlined, OpenInNewOutlined } from '@mui/icons-material';
-import React, { FunctionComponent, Suspense, useCallback, useMemo } from 'react';
-import { graphql, PreloadedQuery, useSubscription } from 'react-relay';
+import React, { FunctionComponent, Suspense, useCallback, useEffect, useMemo } from 'react';
+import { graphql, PreloadedQuery, useMutation, useSubscription } from 'react-relay';
 import { Link } from 'react-router-dom';
 import Tag from '../../../components/common/tag/Tag';
 import DataTable from '../../../components/dataGrid/DataTable';
@@ -114,6 +114,12 @@ const newsFeedItemSubscription = graphql`
   }
 `;
 
+const markAllNewsFeedItemsAsReadMutation = graphql`
+  mutation NewsFeedMarkAllAsReadMutation {
+    markAllNewsFeedItemsAsRead
+  }
+`;
+
 const TagsCell: FunctionComponent<{ tags: readonly (string | null | undefined)[] }> = ({ tags }) => {
   const tagValues = tags.filter(Boolean) as string[];
   const { containerRef, chipRefs, visibleCount, shouldTruncate } = useChipOverflow(tagValues);
@@ -187,6 +193,12 @@ interface NewsFeedComponentProps {
 
 const NewsFeedComponent: FunctionComponent<NewsFeedComponentProps> = ({ queryRef, helpers, contextFilters, onNewItem }) => {
   const { t_i18n } = useFormatter();
+
+  const [commitMarkAllAsRead] = useMutation(markAllNewsFeedItemsAsReadMutation);
+
+  useEffect(() => {
+    commitMarkAllAsRead({ variables: {} });
+  }, [commitMarkAllAsRead]);
 
   const subConfig = useMemo(() => ({
     subscription: newsFeedItemSubscription,

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10706,6 +10706,7 @@ type Mutation {
   checkXTMHubConnectivity: CheckXTMHubConnectivityResponse!
   autoRegisterOpenCTI(input: AutoRegisterInput!): Success!
   contactUsXtmHub(message: String!): Success!
+  markAllNewsFeedItemsAsRead: Boolean
   metricPatch(id: ID!, input: PatchMetricInput!): BasicObject
   oidcProviderAdd(input: OidcInput!): AuthenticationProvider
   oidcProviderEdit(id: ID!, input: OidcInput!): AuthenticationProvider

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17128,6 +17128,7 @@ export type Mutation = {
   managedConnectorAdd?: Maybe<ManagedConnector>;
   managedConnectorEdit?: Maybe<ManagedConnector>;
   managerConfigurationFieldPatch?: Maybe<ManagerConfiguration>;
+  markAllNewsFeedItemsAsRead?: Maybe<Scalars['Boolean']['output']>;
   markingDefinitionAdd?: Maybe<MarkingDefinition>;
   markingDefinitionEdit?: Maybe<MarkingDefinitionEditMutations>;
   meEdit?: Maybe<MeUser>;
@@ -46980,6 +46981,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   managedConnectorAdd?: Resolver<Maybe<ResolversTypes['ManagedConnector']>, ParentType, ContextType, Partial<MutationManagedConnectorAddArgs>>;
   managedConnectorEdit?: Resolver<Maybe<ResolversTypes['ManagedConnector']>, ParentType, ContextType, Partial<MutationManagedConnectorEditArgs>>;
   managerConfigurationFieldPatch?: Resolver<Maybe<ResolversTypes['ManagerConfiguration']>, ParentType, ContextType, RequireFields<MutationManagerConfigurationFieldPatchArgs, 'id' | 'input'>>;
+  markAllNewsFeedItemsAsRead?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   markingDefinitionAdd?: Resolver<Maybe<ResolversTypes['MarkingDefinition']>, ParentType, ContextType, RequireFields<MutationMarkingDefinitionAddArgs, 'input'>>;
   markingDefinitionEdit?: Resolver<Maybe<ResolversTypes['MarkingDefinitionEditMutations']>, ParentType, ContextType, RequireFields<MutationMarkingDefinitionEditArgs, 'id'>>;
   meEdit?: Resolver<Maybe<ResolversTypes['MeUser']>, ParentType, ContextType, RequireFields<MutationMeEditArgs, 'input'>>;

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/news-feed/news-feed-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/news-feed/news-feed-domain.ts
@@ -3,16 +3,19 @@ import { ENTITY_TYPE_NEWS_FEED_ITEM, NEWS_FEED_NUMBER, type BasicStoreEntityNews
 import type { NewsFeedAddInput } from './news-feed-types';
 import { createInternalObject } from '../../../../domain/internalObject';
 import { addFilter } from '../../../../utils/filtering/filtering-utils';
-import { pageEntitiesConnection } from '../../../../database/middleware-loader';
+import { fullEntitiesList, pageEntitiesConnection } from '../../../../database/middleware-loader';
 import { elCount } from '../../../../database/engine';
 import { READ_INDEX_INTERNAL_OBJECTS } from '../../../../database/utils';
 import type { QueryMyNewsFeedsArgs } from '../../../../generated/graphql';
+import { FilterMode } from '../../../../generated/graphql';
 import { notify } from '../../../../database/redis';
 import { BUS_TOPICS } from '../../../../config/conf';
+import { patchAttribute } from '../../../../database/middleware';
+import { promiseMap } from '../../../../utils/promiseUtils';
 
 export const myUnreadNewsFeedsCount = (context: AuthContext, user: AuthUser, userId?: string | null) => {
   const queryFilters = {
-    mode: 'and',
+    mode: FilterMode.And,
     filters: [
       { key: 'user_id', values: [userId ?? user.id] },
       { key: 'is_read', values: [false] },
@@ -39,4 +42,20 @@ export const addNewsFeed = async (context: AuthContext, user: AuthUser, input: N
   const unreadNewsFeedsCount = await myUnreadNewsFeedsCount(context, user, created.user_id);
   await notify(BUS_TOPICS[NEWS_FEED_NUMBER].EDIT_TOPIC, { count: unreadNewsFeedsCount, user_id: created.user_id }, user);
   return created;
+};
+
+export const markAllNewsFeedItemsAsRead = async (context: AuthContext, user: AuthUser): Promise<boolean> => {
+  const queryFilters = {
+    mode: FilterMode.And,
+    filters: [
+      { key: ['user_id'], values: [user.id] },
+      { key: ['is_read'], values: [false] },
+    ],
+    filterGroups: [],
+  };
+  const unreadItems = await fullEntitiesList<BasicStoreEntityNewsFeedItem>(context, user, [ENTITY_TYPE_NEWS_FEED_ITEM], { filters: queryFilters });
+  await promiseMap(unreadItems, (item) => patchAttribute(context, user, item.id, ENTITY_TYPE_NEWS_FEED_ITEM, { is_read: true }), 5);
+  const remainingUnreadCount = await myUnreadNewsFeedsCount(context, user);
+  await notify(BUS_TOPICS[NEWS_FEED_NUMBER].EDIT_TOPIC, { count: remainingUnreadCount, user_id: user.id }, user);
+  return true;
 };

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/news-feed/news-feed-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/news-feed/news-feed-resolver.ts
@@ -1,6 +1,6 @@
 import type { QueryMyNewsFeedsArgs, Resolvers } from '../../../../generated/graphql';
 import type { AuthContext } from '../../../../types/user';
-import { myNewsFeedsFind, myUnreadNewsFeedsCount } from './news-feed-domain';
+import { markAllNewsFeedItemsAsRead, myNewsFeedsFind, myUnreadNewsFeedsCount } from './news-feed-domain';
 import { BUS_TOPICS } from '../../../../config/conf';
 import { ENTITY_TYPE_NEWS_FEED_ITEM, NEWS_FEED_NUMBER } from './news-feed-types';
 import { subscribeToUserEvents } from '../../../../graphql/subscriptionWrapper';
@@ -9,6 +9,9 @@ const newsFeedResolvers = {
   Query: {
     myNewsFeeds: (_: unknown, args: QueryMyNewsFeedsArgs, context: AuthContext) => myNewsFeedsFind(context, context.user!, args),
     myUnreadNewsFeedsCount: (_: unknown, __: unknown, context: AuthContext) => myUnreadNewsFeedsCount(context, context.user!),
+  },
+  Mutation: {
+    markAllNewsFeedItemsAsRead: (_: unknown, __: unknown, context: AuthContext) => markAllNewsFeedItemsAsRead(context, context.user!),
   },
   Subscription: {
     newsFeedItem: {

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/news-feed/news-feed.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/news-feed/news-feed.graphql
@@ -52,6 +52,10 @@ type Query {
   myUnreadNewsFeedsCount: Int @auth
 }
 
+type Mutation {
+  markAllNewsFeedItemsAsRead: Boolean @auth
+}
+
 type Subscription {
   newsFeedItem: NewsFeedItem @auth
   newsFeedsNumber: NewsFeedCount @auth

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/newsFeed-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/newsFeed-test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { addNewsFeed, myNewsFeedsFind, myUnreadNewsFeedsCount } from '../../../src/modules/xtm/hub/news-feed/news-feed-domain';
+import { addNewsFeed, markAllNewsFeedItemsAsRead, myNewsFeedsFind, myUnreadNewsFeedsCount } from '../../../src/modules/xtm/hub/news-feed/news-feed-domain';
 import { NewsFeedItemType } from '../../../src/modules/xtm/hub/news-feed/news-feed-types';
 import type { NewsFeedAddInput } from '../../../src/modules/xtm/hub/news-feed/news-feed-types';
 
@@ -274,6 +274,102 @@ describe('News feed', () => {
       const result = await myUnreadNewsFeedsCount(mockContext, mockUser, 'other-user-42');
 
       expect(result).toBe(7);
+    });
+  });
+
+  describe('markAllNewsFeedItemsAsRead', () => {
+    beforeEach(() => {
+      mockFullEntitiesList.mockReset();
+      mockPatchAttribute.mockReset();
+      mockElCount.mockReset();
+      mockNotify.mockReset();
+
+      mockPatchAttribute.mockResolvedValue({});
+      mockElCount.mockResolvedValue(0);
+      mockNotify.mockResolvedValue(undefined);
+    });
+
+    it('should query unread items for the current user', async () => {
+      mockFullEntitiesList.mockResolvedValue([]);
+
+      const result = await markAllNewsFeedItemsAsRead(mockContext, mockUser);
+
+      expect(mockFullEntitiesList).toHaveBeenCalledWith(
+        mockContext,
+        mockUser,
+        ['NewsFeedItem'],
+        expect.objectContaining({
+          filters: expect.objectContaining({
+            filters: expect.arrayContaining([
+              expect.objectContaining({ key: ['user_id'], values: [mockUser.id] }),
+              expect.objectContaining({ key: ['is_read'], values: [false] }),
+            ]),
+          }),
+        }),
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should patch each unread item with is_read=true', async () => {
+      const unreadItems = [
+        { id: 'item-1', is_read: false },
+        { id: 'item-2', is_read: false },
+        { id: 'item-3', is_read: false },
+      ];
+      mockFullEntitiesList.mockResolvedValue(unreadItems);
+
+      await markAllNewsFeedItemsAsRead(mockContext, mockUser);
+
+      expect(mockPatchAttribute).toHaveBeenCalledTimes(3);
+      for (const item of unreadItems) {
+        expect(mockPatchAttribute).toHaveBeenCalledWith(
+          mockContext,
+          mockUser,
+          item.id,
+          'NewsFeedItem',
+          { is_read: true },
+        );
+      }
+    });
+
+    it('should not call patchAttribute when there are no unread items', async () => {
+      mockFullEntitiesList.mockResolvedValue([]);
+
+      await markAllNewsFeedItemsAsRead(mockContext, mockUser);
+
+      expect(mockPatchAttribute).not.toHaveBeenCalled();
+    });
+
+    it('should notify with the recomputed unread count after marking all as read', async () => {
+      mockFullEntitiesList.mockResolvedValue([{ id: 'item-1', is_read: false }]);
+      mockElCount.mockResolvedValue(0);
+
+      await markAllNewsFeedItemsAsRead(mockContext, mockUser);
+
+      expect(mockElCount).toHaveBeenCalledOnce();
+      expect(mockNotify).toHaveBeenCalledOnce();
+      expect(mockNotify).toHaveBeenCalledWith(
+        'ENTITY_TYPE_NEWS_FEED_NUMBER_EDIT_TOPIC',
+        { count: 0, user_id: mockUser.id },
+        mockUser,
+      );
+    });
+
+    it('should notify with a non-zero count if new unread items appeared concurrently', async () => {
+      mockFullEntitiesList.mockResolvedValue([{ id: 'item-1', is_read: false }]);
+      // Simulate a concurrent new unread item arriving after the patches
+      mockElCount.mockResolvedValue(1);
+
+      await markAllNewsFeedItemsAsRead(mockContext, mockUser);
+
+      expect(mockElCount).toHaveBeenCalledOnce();
+      expect(mockNotify).toHaveBeenCalledOnce();
+      expect(mockNotify).toHaveBeenCalledWith(
+        'ENTITY_TYPE_NEWS_FEED_NUMBER_EDIT_TOPIC',
+        { count: 1, user_id: mockUser.id },
+        mockUser,
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR adds a “mark all as read” capability for XTM Hub news feed items, wiring a new GraphQL mutation from the backend domain layer through to the frontend so items are marked read when the news feed list page loads.

- Add `markAllNewsFeedItemsAsRead` GraphQL mutation and resolver in the backend.
- Implement domain logic to fetch unread `NewsFeedItem` entities for the current user and patch them as read, then notify the unread-count topic.
- Call the new mutation on `NewsFeed` page load in the frontend and extend schemas/generated types accordingly; add unit tests for the new domain behavior.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15934 
* Related to https://github.com/FiligranHQ/xtm-hub/issues/2140

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
