### PR TITLE
[frontend] Add dates in dashboard exports (#15585)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -84,13 +84,13 @@ export class ExportButtons extends Component {
 
       const container = document.getElementById(domElementId);
 
-    // Hide buttons: dashboard-buttons wraps everything (including export-buttons) on dashboards
-    if (dashboardButtons) {
-      dashboardButtons.setAttribute('style', 'display: none');
-    } else {
-      exportButtons?.setAttribute('style', 'display: none');
-      viewButtons?.setAttribute('style', 'display: none');
-    }
+      // Hide buttons: dashboard-buttons wraps everything (including export-buttons) on dashboards
+      if (dashboardButtons) {
+        dashboardButtons.setAttribute('style', 'display: none');
+      } else {
+        exportButtons?.setAttribute('style', 'display: none');
+        viewButtons?.setAttribute('style', 'display: none');
+      }
 
       const { offsetWidth, offsetHeight } = container;
       if (this.adjust) {
@@ -148,12 +148,12 @@ export class ExportButtons extends Component {
 
       setExportTheme(themeNode);
 
-    // Hide buttons: dashboard-buttons wraps everything on dashboards
-    if (dashboardButtons) {
-      dashboardButtons.setAttribute('style', 'display: none');
-    } else {
-      exportButtons?.setAttribute('style', 'display: none');
-    }
+      // Hide buttons: dashboard-buttons wraps everything on dashboards
+      if (dashboardButtons) {
+        dashboardButtons.setAttribute('style', 'display: none');
+      } else {
+        exportButtons?.setAttribute('style', 'display: none');
+      }
 
       // add some delay to permit the ui to re-render with the selected theme
       await wait();
@@ -173,7 +173,6 @@ export class ExportButtons extends Component {
       if (dashboardButtons) {
         restoreStyle(dashboardButtons, DASHBOARD_BUTTONS_STYLE);
       } else {
-        const exportButtons = document.getElementById('export-buttons');
         if (exportButtons) restoreStyle(exportButtons, EXPORT_BUTTONS_STYLE);
       }
     }

--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -116,9 +116,7 @@ export class ExportButtons extends Component {
       if (dashboardButtons) {
         restoreStyle(dashboardButtons, DASHBOARD_BUTTONS_STYLE);
       } else {
-        const exportButtons = document.getElementById('export-buttons');
         if (exportButtons) restoreStyle(exportButtons, EXPORT_BUTTONS_STYLE);
-        const viewButtons = document.getElementById('container-view-buttons');
         viewButtons?.setAttribute('style', '');
       }
       setExportTheme(null);

--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -62,6 +62,8 @@ export class ExportButtons extends Component {
     const { pixelRatio = 1, t, setExportTheme } = this.props;
     const exportButtons = document.getElementById('export-buttons');
     const viewButtons = document.getElementById('container-view-buttons');
+    const dashboardButtons = document.getElementById('dashboard-buttons');
+
     try {
       this.setState({ exporting: true });
       this.handleCloseImage();
@@ -73,9 +75,13 @@ export class ExportButtons extends Component {
 
       const container = document.getElementById(domElementId);
 
+    // Hide buttons: dashboard-buttons wraps everything (including export-buttons) on dashboards
+    if (dashboardButtons) {
+      dashboardButtons.setAttribute('style', 'display: none');
+    } else {
       exportButtons?.setAttribute('style', 'display: none');
-
       viewButtons?.setAttribute('style', 'display: none');
+    }
 
       const { offsetWidth, offsetHeight } = container;
       if (this.adjust) {
@@ -98,9 +104,14 @@ export class ExportButtons extends Component {
     } catch {
       MESSAGING$.notifyError(t('Dashboard cannot be exported to image'));
     } finally {
-      exportButtons?.setAttribute('style', 'display: block');
-      viewButtons?.setAttribute('style', 'display: block, marginLeft: theme.spacing(2)');
-
+      if (dashboardButtons) {
+        dashboardButtons.setAttribute('style', 'display: flex; gap: 8px');
+      } else {
+        const exportButtons = document.getElementById('export-buttons');
+        exportButtons?.setAttribute('style', 'display: flex; gap: 8px');
+        const viewButtons = document.getElementById('container-view-buttons');
+        viewButtons?.setAttribute('style', '');
+      }
       setExportTheme(null);
 
       this.setState({ exporting: false });
@@ -117,7 +128,8 @@ export class ExportButtons extends Component {
 
   async exportPdf({ domElementId, name, themeNode, background }) {
     const { pixelRatio = 1, t, setExportTheme } = this.props;
-    const buttons = document.getElementById('export-buttons');
+    const exportButtons = document.getElementById('export-buttons');
+    const dashboardButtons = document.getElementById('dashboard-buttons');
     try {
       this.setState({ exporting: true });
       this.handleClosePdf();
@@ -127,7 +139,12 @@ export class ExportButtons extends Component {
 
       setExportTheme(themeNode);
 
-      buttons.setAttribute('style', 'display: none');
+    // Hide buttons: dashboard-buttons wraps everything on dashboards
+    if (dashboardButtons) {
+      dashboardButtons.setAttribute('style', 'display: none');
+    } else {
+      exportButtons?.setAttribute('style', 'display: none');
+    }
 
       // add some delay to permit the ui to re-render with the selected theme
       await wait();
@@ -143,9 +160,13 @@ export class ExportButtons extends Component {
       MESSAGING$.notifyError(t('Dashboard cannot be exported to pdf'));
     } finally {
       setExportTheme(null);
-
       this.setState({ exporting: false });
-      buttons.setAttribute('style', 'display: block');
+      if (dashboardButtons) {
+        dashboardButtons.setAttribute('style', 'display: flex; gap: 8px');
+      } else {
+        const exportButtons = document.getElementById('export-buttons');
+        exportButtons?.setAttribute('style', 'display: flex; gap: 8px');
+      }
     }
   }
 

--- a/opencti-platform/opencti-front/src/components/ExportButtons.jsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.jsx
@@ -19,6 +19,7 @@ import withRouter from '../utils/compat_router/withRouter';
 import { KNOWLEDGE_KNFRONTENDEXPORT } from '../utils/hooks/useGranted';
 import Security from '../utils/Security';
 import { useExportTheme } from '../utils/ExportThemeContext';
+import { DASHBOARD_BUTTONS_STYLE } from '../private/components/workspaces/workspaceHeader/WorkspaceHeader';
 
 const styles = () => ({
   exportButtons: {
@@ -30,6 +31,14 @@ const styles = () => ({
 });
 
 const DELAY = 1000;
+
+export const EXPORT_BUTTONS_STYLE = { display: 'flex', gap: '8px' };
+
+// Reset an element's inline style and re-apply the given style object
+const restoreStyle = (element, style) => {
+  element.removeAttribute('style');
+  Object.assign(element.style, style);
+};
 
 const wait = async (delay = DELAY) => {
   await new Promise((resolve) => {
@@ -105,10 +114,10 @@ export class ExportButtons extends Component {
       MESSAGING$.notifyError(t('Dashboard cannot be exported to image'));
     } finally {
       if (dashboardButtons) {
-        dashboardButtons.setAttribute('style', 'display: flex; gap: 8px');
+        restoreStyle(dashboardButtons, DASHBOARD_BUTTONS_STYLE);
       } else {
         const exportButtons = document.getElementById('export-buttons');
-        exportButtons?.setAttribute('style', 'display: flex; gap: 8px');
+        if (exportButtons) restoreStyle(exportButtons, EXPORT_BUTTONS_STYLE);
         const viewButtons = document.getElementById('container-view-buttons');
         viewButtons?.setAttribute('style', '');
       }
@@ -162,10 +171,10 @@ export class ExportButtons extends Component {
       setExportTheme(null);
       this.setState({ exporting: false });
       if (dashboardButtons) {
-        dashboardButtons.setAttribute('style', 'display: flex; gap: 8px');
+        restoreStyle(dashboardButtons, DASHBOARD_BUTTONS_STYLE);
       } else {
         const exportButtons = document.getElementById('export-buttons');
-        exportButtons?.setAttribute('style', 'display: flex; gap: 8px');
+        if (exportButtons) restoreStyle(exportButtons, EXPORT_BUTTONS_STYLE);
       }
     }
   }
@@ -196,7 +205,7 @@ export class ExportButtons extends Component {
             <div
               className={classes.exportButtons}
               id="export-buttons"
-              style={{ display: 'flex', gap: '8px' }}
+              style={EXPORT_BUTTONS_STYLE}
             >
               {exportToImage && (
                 <Security needs={[KNOWLEDGE_KNFRONTENDEXPORT]}>

--- a/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
@@ -7,6 +7,9 @@ import { ExportButtons } from './ExportButtons';
 vi.mock('../utils/Image', () => ({
   exportImage: vi.fn(),
   exportPdf: vi.fn(),
+  isDomNodeKeptAtExport: vi.fn(() => true),
+  EXPORT_KEEP_CLASS: 'export-keep',
+  EXPORT_REMOVE_CLASS: 'export-remove',
 }));
 
 // Mock MESSAGING$ so we can assert error notifications
@@ -197,6 +200,6 @@ describe('ExportButtons — exportPdf()', () => {
     await instance.exportPdf({ domElementId: 'test-container', name: 'test', themeNode: mockThemeNode, background: true });
 
     const buttons = document.getElementById('export-buttons');
-    expect(buttons?.getAttribute('style')).toContain('display: block');
+    expect(buttons?.style.display).toBe('flex');
   });
 });

--- a/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
@@ -13,8 +13,12 @@ vi.mock('../utils/Image', () => ({
 }));
 
 // Mock MESSAGING$ so we can assert error notifications
+// Use a Proxy for environment so any method call (retain, check, etc.) is auto-mocked
 vi.mock('../relay/environment', () => ({
   MESSAGING$: { notifyError: vi.fn() },
+  environment: new Proxy({}, {
+    get: () => vi.fn(() => ({ dispose: vi.fn() })),
+  }),
 }));
 
 // Minimal ExportThemeContext mock

--- a/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../utils/Image', () => ({
 // Mock MESSAGING$ so we can assert error notifications
 vi.mock('../relay/environment', () => ({
   MESSAGING$: { notifyError: vi.fn() },
+  environment: {},
 }));
 
 // Minimal ExportThemeContext mock

--- a/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
+++ b/opencti-platform/opencti-front/src/components/ExportButtons.test.tsx
@@ -15,7 +15,6 @@ vi.mock('../utils/Image', () => ({
 // Mock MESSAGING$ so we can assert error notifications
 vi.mock('../relay/environment', () => ({
   MESSAGING$: { notifyError: vi.fn() },
-  environment: {},
 }));
 
 // Minimal ExportThemeContext mock

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardContent.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardContent.tsx
@@ -34,7 +34,6 @@ const DashboardContent = ({
   return (
     <Box
       ref={containerRef}
-      id="container"
       sx={{
         marginBottom: '20px',
         ...(isEditable

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardTimeFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardTimeFilters.tsx
@@ -10,6 +10,7 @@ import { Stack } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import { Theme } from '../Theme';
 import { DashboardConfig } from './dashboard-types';
+import { EXPORT_KEEP_CLASS, EXPORT_REMOVE_CLASS } from '../../utils/Image';
 
 interface DashboardTimeFiltersProps {
   config?: DashboardConfig;
@@ -43,6 +44,7 @@ const DashboardTimeFilters: React.FC<DashboardTimeFiltersProps> = ({
         size="small"
         style={{ width: 194 }}
         variant="outlined"
+        className={config.relativeDate ? EXPORT_KEEP_CLASS : EXPORT_REMOVE_CLASS}
       >
         <InputLabel
           id="relative"
@@ -56,6 +58,7 @@ const DashboardTimeFilters: React.FC<DashboardTimeFiltersProps> = ({
           onChange={handleChangeRelativeDate}
           label={t_i18n('Relative time')}
           variant="outlined"
+          className={config.relativeDate ? EXPORT_KEEP_CLASS : undefined}
           sx={{
             '& fieldset': {
               border: config.relativeDate
@@ -78,6 +81,7 @@ const DashboardTimeFilters: React.FC<DashboardTimeFiltersProps> = ({
         label={t_i18n('Start date')}
         disableFuture
         disabled={!!config.relativeDate}
+        className={config.startDate ? EXPORT_KEEP_CLASS : EXPORT_REMOVE_CLASS}
         onChange={(value: Date | null, context) => !context.validationError && handleChangeDate('startDate', value)}
       />
       <DatePicker
@@ -85,6 +89,7 @@ const DashboardTimeFilters: React.FC<DashboardTimeFiltersProps> = ({
         label={t_i18n('End date')}
         disabled={!!config.relativeDate}
         disableFuture
+        className={config.endDate ? EXPORT_KEEP_CLASS : EXPORT_REMOVE_CLASS}
         onChange={(value: Date | null, context) => !context.validationError && handleChangeDate('endDate', value)}
       />
     </Stack>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/CustomDashboard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/CustomDashboard.tsx
@@ -161,16 +161,18 @@ const CustomDashboard = ({ data, noToolbar = false }: CustomDashboardProps) => {
         </Stack>
       )
       }
-      <div id="container" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div id="container">
         {!noToolbar && (
           <Security
             needs={[EXPLORE_EXUPDATE, INVESTIGATION_INUPDATE]}
             hasAccess={userCanEdit}
           >
-            <DashboardTimeFilters
-              config={config}
-              handleDateChange={handleDateChange}
-            />
+            <div style={{ marginBottom: 12 }}>
+              <DashboardTimeFilters
+                config={config}
+                handleDateChange={handleDateChange}
+              />
+            </div>
           </Security>
         )}
         <DashboardContent

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/CustomDashboard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/CustomDashboard.tsx
@@ -158,6 +158,11 @@ const CustomDashboard = ({ data, noToolbar = false }: CustomDashboardProps) => {
             data={workspace}
             variant="dashboard"
           />
+        </Stack>
+      )
+      }
+      <div id="container" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {!noToolbar && (
           <Security
             needs={[EXPLORE_EXUPDATE, INVESTIGATION_INUPDATE]}
             hasAccess={userCanEdit}
@@ -167,15 +172,14 @@ const CustomDashboard = ({ data, noToolbar = false }: CustomDashboardProps) => {
               handleDateChange={handleDateChange}
             />
           </Security>
-        </Stack>
-      )
-      }
-      <DashboardContent
-        helpers={helpers}
-        isEditable={userCanEdit}
-        entity={workspace}
-        host={WIDGET_WORKSPACE_HOST}
-      />
+        )}
+        <DashboardContent
+          helpers={helpers}
+          isEditable={userCanEdit}
+          entity={workspace}
+          host={WIDGET_WORKSPACE_HOST}
+        />
+      </div>
     </Stack>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeader.tsx
@@ -107,7 +107,10 @@ const WorkspaceHeader = ({
             canEdit={canEdit}
           />
         </div>
-        <div style={{ display: 'flex', gap: '8px' }}>
+        <div
+          id="dashboard-buttons"
+          style={{ display: 'flex', gap: '8px' }}
+        >
           <ExportButtons
             domElementId="container"
             name={workspace.name}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeader.tsx
@@ -21,6 +21,8 @@ import { useFormatter } from '../../../../components/i18n';
 import type { Widget } from 'src/utils/widget/widget';
 import { WIDGET_WORKSPACE_HOST } from '../dashboards/custom-dashboards-utils';
 
+export const DASHBOARD_BUTTONS_STYLE: React.CSSProperties = { display: 'flex', gap: '8px' };
+
 const workspaceHeaderFragment = graphql`
   fragment WorkspaceHeaderFragment on Workspace {
     id
@@ -109,7 +111,7 @@ const WorkspaceHeader = ({
         </div>
         <div
           id="dashboard-buttons"
-          style={{ display: 'flex', gap: '8px' }}
+          style={DASHBOARD_BUTTONS_STYLE}
         >
           <ExportButtons
             domElementId="container"

--- a/opencti-platform/opencti-front/src/utils/Image.js
+++ b/opencti-platform/opencti-front/src/utils/Image.js
@@ -13,17 +13,17 @@ const ignoredClasses = [
 export const EXPORT_KEEP_CLASS = 'export-keep';
 export const EXPORT_REMOVE_CLASS = 'export-remove';
 
-const isNodeKeptAtExport = (domNode) => {
-  return domNode.closest?.(`.${EXPORT_KEEP_CLASS}`);
-};
-
-const isNodeRemovedAtExport = (domNode) => {
-  return domNode.closest?.(`.${EXPORT_REMOVE_CLASS}`);
-};
-
-const isDomNodeKeptAtExport = (domNode) => {
-  if (isNodeKeptAtExport(domNode)) return true;
-  if (isNodeRemovedAtExport(domNode)) return false;
+/**
+ * Determines whether a DOM node should be included in the exported image/PDF.
+ *
+ * - If the node (or an ancestor) has the `export-keep` class → kept
+ * - If the node (or an ancestor) has the `export-remove` class → removed
+ * - If the node has one of the `ignoredClasses` → removed
+ * - Otherwise → kept
+ */
+export const isDomNodeKeptAtExport = (domNode) => {
+  if (domNode.closest?.(`.${EXPORT_KEEP_CLASS}`)) return true;
+  if (domNode.closest?.(`.${EXPORT_REMOVE_CLASS}`)) return false;
   if (domNode.className) {
     for (const ignoredClass of ignoredClasses) {
       if (domNode.className.toString().includes(ignoredClass)) {

--- a/opencti-platform/opencti-front/src/utils/Image.js
+++ b/opencti-platform/opencti-front/src/utils/Image.js
@@ -10,6 +10,30 @@ const ignoredClasses = [
   'MuiInputBase-root',
 ];
 
+export const EXPORT_KEEP_CLASS = 'export-keep';
+export const EXPORT_REMOVE_CLASS = 'export-remove';
+
+const isNodeKeptAtExport = (domNode) => {
+  return domNode.closest?.(`.${EXPORT_KEEP_CLASS}`);
+};
+
+const isNodeRemovedAtExport = (domNode) => {
+  return domNode.closest?.(`.${EXPORT_REMOVE_CLASS}`);
+};
+
+const isDomNodeKeptAtExport = (domNode) => {
+  if (isNodeKeptAtExport(domNode)) return true;
+  if (isNodeRemovedAtExport(domNode)) return false;
+  if (domNode.className) {
+    for (const ignoredClass of ignoredClasses) {
+      if (domNode.className.toString().includes(ignoredClass)) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
 export const exportImage = (
   domElementId,
   currentWidth,
@@ -27,16 +51,7 @@ export const exportImage = (
         pixelRatio,
         backgroundColor,
         style: { margin: '0' },
-        filter: (domNode) => {
-          if (domNode.className) {
-            for (const ignoredClass of ignoredClasses) {
-              if (domNode.className.toString().includes(ignoredClass)) {
-                return false;
-              }
-            }
-          }
-          return true;
-        },
+        filter: isDomNodeKeptAtExport,
         onImageErrorHandler: () => {
           // We do nothing, it's just to avoid crashing export in case of image error.
         },
@@ -76,16 +91,7 @@ export const exportPdf = (
         backgroundColor,
         style: { margin: '0' },
         imagePlaceholder: '', // ignore image fetch failure, and display empty area
-        filter: (domNode) => {
-          if (domNode.className) {
-            for (const ignoredClass of ignoredClasses) {
-              if (domNode.className.toString().includes(ignoredClass)) {
-                return false;
-              }
-            }
-          }
-          return true;
-        },
+        filter: isDomNodeKeptAtExport,
         onImageErrorHandler: () => {
           // We do nothing, it's just to avoid crashing export in case of image error.
         },

--- a/opencti-platform/opencti-front/src/utils/Image.test.ts
+++ b/opencti-platform/opencti-front/src/utils/Image.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { isDomNodeKeptAtExport, EXPORT_KEEP_CLASS, EXPORT_REMOVE_CLASS } from './Image';
+
+const createDomNode = (className: string, parentClassName?: string): HTMLElement => {
+  const node = document.createElement('div');
+  node.className = className;
+  if (parentClassName) {
+    const parent = document.createElement('div');
+    parent.className = parentClassName;
+    parent.appendChild(node);
+  }
+  return node;
+};
+
+describe('Image', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('isDomNodeKeptAtExport', () => {
+    it('should keep a node with no special class', () => {
+      const node = createDomNode('some-class');
+      expect(isDomNodeKeptAtExport(node)).toBe(true);
+    });
+
+    it('should keep a node with no class at all', () => {
+      const node = document.createElement('div');
+      expect(isDomNodeKeptAtExport(node)).toBe(true);
+    });
+
+    it('should filter out MuiDialog-root', () => {
+      const node = createDomNode('MuiDialog-root');
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should filter out MuiDrawer-docked', () => {
+      const node = createDomNode('MuiDrawer-docked');
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should filter out MuiIconButton-root', () => {
+      const node = createDomNode('MuiIconButton-root');
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should filter out MuiInputBase-root', () => {
+      const node = createDomNode('MuiInputBase-root MuiOutlinedInput-root');
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should keep a node with export-keep class', () => {
+      const node = createDomNode(`MuiInputBase-root ${EXPORT_KEEP_CLASS}`);
+      document.body.appendChild(node);
+      expect(isDomNodeKeptAtExport(node)).toBe(true);
+    });
+
+    it('should keep a node inside an export-keep ancestor', () => {
+      const parent = document.createElement('div');
+      parent.className = EXPORT_KEEP_CLASS;
+      const node = document.createElement('div');
+      node.className = 'MuiInputBase-root';
+      parent.appendChild(node);
+      document.body.appendChild(parent);
+      expect(isDomNodeKeptAtExport(node)).toBe(true);
+    });
+
+    it('should filter out a node with export-remove class', () => {
+      const node = createDomNode(EXPORT_REMOVE_CLASS);
+      document.body.appendChild(node);
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should filter out a node inside an export-remove ancestor', () => {
+      const parent = document.createElement('div');
+      parent.className = EXPORT_REMOVE_CLASS;
+      const node = document.createElement('div');
+      node.className = 'some-class';
+      parent.appendChild(node);
+      document.body.appendChild(parent);
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should filter out an ignored class node not inside export-keep', () => {
+      const parent = document.createElement('div');
+      parent.className = 'regular-parent';
+      const node = document.createElement('div');
+      node.className = 'MuiIconButton-root';
+      parent.appendChild(node);
+      document.body.appendChild(parent);
+      expect(isDomNodeKeptAtExport(node)).toBe(false);
+    });
+
+    it('should keep a regular node inside a regular parent', () => {
+      const parent = document.createElement('div');
+      parent.className = 'regular-parent';
+      const node = document.createElement('div');
+      node.className = 'regular-child';
+      parent.appendChild(node);
+      document.body.appendChild(parent);
+      expect(isDomNodeKeptAtExport(node)).toBe(true);
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/Image.ts
+++ b/opencti-platform/opencti-front/src/utils/Image.ts
@@ -4,6 +4,10 @@ import pdfMake from 'pdfmake';
 import isSvg from 'is-svg';
 import { TDocumentDefinitions } from 'pdfmake/interfaces';
 
+/**
+ * MUI class names that are excluded from image/PDF exports by default.
+ * Elements with these classes are filtered out unless explicitly marked with EXPORT_KEEP_CLASS.
+ */
 const ignoredClasses = [
   'MuiDialog-root',
   'MuiDrawer-docked',
@@ -11,7 +15,10 @@ const ignoredClasses = [
   'MuiInputBase-root',
 ];
 
+/** CSS class to force a DOM node (and its descendants) to be included in exports. */
 export const EXPORT_KEEP_CLASS = 'export-keep';
+
+/** CSS class to force a DOM node (and its descendants) to be excluded from exports. */
 export const EXPORT_REMOVE_CLASS = 'export-remove';
 
 /**
@@ -52,7 +59,7 @@ export const exportImage = async (
         skipFonts: true,
         pixelRatio,
         backgroundColor,
-        style: { margin: '0' },
+        style: { margin: '0', paddingTop: '12px', paddingLeft: '12px' },
         filter: isDomNodeKeptAtExport,
         onImageErrorHandler: () => {
           // We do nothing, it's just to avoid crashing export in case of image error.
@@ -94,7 +101,7 @@ export const exportPdf = async (
         skipFonts: true,
         pixelRatio,
         backgroundColor,
-        style: { margin: '0' },
+        style: { margin: '0', paddingTop: '12px', paddingLeft: '12px' },
         imagePlaceholder: '', // ignore image fetch failure, and display empty area
         filter: isDomNodeKeptAtExport,
         onImageErrorHandler: () => {

--- a/opencti-platform/opencti-front/src/utils/Image.ts
+++ b/opencti-platform/opencti-front/src/utils/Image.ts
@@ -2,6 +2,7 @@ import * as htmlToImage from 'html-to-image';
 import fileDownload from 'js-file-download';
 import pdfMake from 'pdfmake';
 import isSvg from 'is-svg';
+import { TDocumentDefinitions } from 'pdfmake/interfaces';
 
 const ignoredClasses = [
   'MuiDialog-root',
@@ -21,7 +22,7 @@ export const EXPORT_REMOVE_CLASS = 'export-remove';
  * - If the node has one of the `ignoredClasses` → removed
  * - Otherwise → kept
  */
-export const isDomNodeKeptAtExport = (domNode) => {
+export const isDomNodeKeptAtExport = (domNode: HTMLElement): boolean => {
   if (domNode.closest?.(`.${EXPORT_KEEP_CLASS}`)) return true;
   if (domNode.closest?.(`.${EXPORT_REMOVE_CLASS}`)) return false;
   if (domNode.className) {
@@ -34,16 +35,17 @@ export const isDomNodeKeptAtExport = (domNode) => {
   return true;
 };
 
-export const exportImage = (
-  domElementId,
-  currentWidth,
-  currentHeight,
-  name,
-  backgroundColor,
+export const exportImage = async (
+  domElementId: string,
+  currentWidth: number,
+  currentHeight: number,
+  name: string,
+  backgroundColor: string | undefined,
   pixelRatio = 1,
-  adjust = null,
-) => {
+  adjust: ((value: boolean) => void) | null = null,
+): Promise<void> => {
   const container = document.getElementById(domElementId);
+  if (!container) return Promise.reject(new Error(`Element #${domElementId} not found`));
   return new Promise((resolve, reject) => {
     htmlToImage
       .toBlob(container, {
@@ -57,7 +59,9 @@ export const exportImage = (
         },
       })
       .then((blob) => {
-        fileDownload(blob, `${name}.png`, 'image/png');
+        if (blob) {
+          fileDownload(blob, `${name}.png`, 'image/png');
+        }
         if (adjust) {
           container.setAttribute(
             'style',
@@ -72,14 +76,15 @@ export const exportImage = (
   });
 };
 
-export const exportPdf = (
-  domElementId,
-  name,
-  backgroundColor,
+export const exportPdf = async (
+  domElementId: string,
+  name: string,
+  backgroundColor: string | undefined,
   pixelRatio = 1,
-  adjust = null,
-) => {
+  adjust: ((value: boolean) => void) | null = null,
+): Promise<void> => {
   const container = document.getElementById(domElementId);
+  if (!container) return Promise.reject(new Error(`Element #${domElementId} not found`));
   const { offsetWidth, offsetHeight } = container;
   const imageWidth = offsetWidth * pixelRatio;
   const imageHeight = offsetHeight * pixelRatio;
@@ -97,7 +102,7 @@ export const exportPdf = (
         },
       })
       .then((image) => {
-        const docDefinition = {
+        const docDefinition: TDocumentDefinitions = {
           pageSize: {
             width: imageWidth,
             height: 'auto',
@@ -141,7 +146,7 @@ export const exportPdf = (
   });
 };
 
-export const getBase64ImageFromURL = (url) => {
+export const getBase64ImageFromURL = async (url: string): Promise<string> => {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.setAttribute('crossOrigin', 'anonymous');
@@ -167,7 +172,12 @@ export const getBase64ImageFromURL = (url) => {
   });
 };
 
-export const isImageFromUrlSvg = async (url) => {
+interface SvgCheckResult {
+  isSvg: boolean;
+  content: string;
+}
+
+export const isImageFromUrlSvg = async (url: string): Promise<SvgCheckResult> => {
   const response = await fetch(url);
   const blob = await response.blob();
   const content = await blob.text();

--- a/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
+++ b/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
@@ -27,9 +27,15 @@ import { dateFormat } from '../Time';
  *
  * @param pdfMakeObject Definition of the PDF to generate.
  * @param checkOrientation True if check content to determine PDF orientation.
+
+ * @param isTiptapEnabled True if TipTap editor is enabled.
  * @returns PDF ready to be downloaded.
  */
-const generatePdf = (pdfMakeObject: TDocumentDefinitions, checkOrientation = false, isTiptapEnabled = false) => {
+const generatePdf = (
+  pdfMakeObject: TDocumentDefinitions,
+  checkOrientation = false,
+  isTiptapEnabled = false,
+) => {
   const docDefinition = { ...pdfMakeObject };
   if (checkOrientation) {
     docDefinition.pageOrientation = determineOrientation(isTiptapEnabled);
@@ -44,9 +50,14 @@ const generatePdf = (pdfMakeObject: TDocumentDefinitions, checkOrientation = fal
  *
  * @param fileName name of the file to transform.
  * @param content The content of the file.
+ * @param isTiptapEnabled True if TipTap editor is enabled.
  * @returns PDF object ready to be downloaded.
  */
-export const htmlToPdf = (fileName: string, content: string, isTiptapEnabled = false) => {
+export const htmlToPdf = (
+  fileName: string,
+  content: string,
+  isTiptapEnabled = false,
+) => {
   let htmlData = removeUnnecessaryHtml(content);
   htmlData = setImagesWidth(htmlData, undefined, isTiptapEnabled);
 
@@ -138,6 +149,7 @@ export const resolvePdfMakeEmbeddedImages = async (
  * @param templateName Name of the template used for PDF generation.
  * @param markingNames Markings of the outcome report.
  * @param fintelDesign Design of the template
+ * @param isTiptapEnabled True if TipTap editor is enabled.
  * @returns PDF object ready to be downloaded.
  */
 export const htmlToPdfReport = async (
@@ -223,11 +235,9 @@ export const htmlToPdfReport = async (
     content: [
       {
         columns: [
-          {
-            image: !isLogoSvg ? logo : undefined,
-            svg: isLogoSvg ? logo : undefined,
-            width: 133,
-          },
+          isLogoSvg
+            ? { svg: logo, width: 133 }
+            : { image: logo, width: 133 },
           {
             text: dateFormat(new Date()) ?? '',
             alignment: 'right',
@@ -261,14 +271,11 @@ export const htmlToPdfReport = async (
           linearGradient: linearGradiant,
         }],
       },
-      {
-        image: !isLogoSvg ? logo : undefined,
-        svg: isLogoSvg ? logo : undefined,
-        width: 133,
-        alignment: 'center',
-        margin: [0, 380, 0, 0],
-      },
-    ],
+      ...(isLogoSvg
+        ? [{ svg: logo, width: 133, alignment: 'center', margin: [0, 380, 0, 0] }]
+        : [{ image: logo, width: 133, alignment: 'center', margin: [0, 380, 0, 0] }]
+      ),
+    ] as Content[],
     background: pdfBackground(linearGradiant),
     header: pdfHeader(linearGradiant),
     footer: pdfFooter(markingNames),


### PR DESCRIPTION
### Proposed changes
Improve dashboard export to pdf and image : 
- remove 'import widget', 'create widget' and 'update' buttons in the export
- add Relative date or (start date, end date) values in the export
- convert Image.js to ts
- add top margin in the final export, not to have everything stick at the top

### Before changes
<img width="1904" height="636" alt="image" src="https://github.com/user-attachments/assets/a2204c55-a12b-44d4-a307-1ede8e8c7b88" />

### After changes

<img width="1872" height="664" alt="image" src="https://github.com/user-attachments/assets/20c012ea-1ed5-465f-94af-bd8fed3a9d64" />



### Related issues
fixes #15585