### PR TITLE
[frontend] Fix entity selection in Fintel template preview (#15211)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
@@ -138,7 +138,7 @@ const EntitySelect = ({ types, ...otherProps }: EntitySelectProps) => {
   const [, startTransition] = useTransition();
   const [queryRef, loadQuery] = useQueryLoader<EntitySelectSearchQuery>(entitySelectSearchQuery);
 
-  const buildVariables = (search: string) => ({
+  const search = (search: string) => loadQuery({
     search,
     filters: {
       mode: 'and' as FilterMode,
@@ -152,16 +152,16 @@ const EntitySelect = ({ types, ...otherProps }: EntitySelectProps) => {
         },
       ],
     },
-  });
+  }, { fetchPolicy: 'store-and-network' });
 
   // Initial load
   useEffect(() => {
-    loadQuery(buildVariables(''), { fetchPolicy: 'store-and-network' });
+    search('');
   }, [types]);
 
   const handleSearchChange = (val: string) => {
     startTransition(() => {
-      loadQuery(buildVariables(val), { fetchPolicy: 'store-and-network' });
+      search(val);
     });
   };
 

--- a/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
@@ -1,8 +1,7 @@
 import { Autocomplete, Checkbox, Chip, TextField, TextFieldProps, TextFieldVariants } from '@mui/material';
-import React, { Suspense, useMemo, useState } from 'react';
-import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
+import React, { Suspense, useEffect, useTransition } from 'react';
+import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import { useTheme } from '@mui/styles';
-import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { EntitySelectSearchQuery, FilterMode, FilterOperator } from './__generated__/EntitySelectSearchQuery.graphql';
 import useDebounceCallback from '../../../../utils/hooks/useDebounceCallback';
 import Loader from '../../../../components/Loader';
@@ -136,9 +135,10 @@ type EntitySelectProps = Omit<EntitySelectComponentProps, 'onInputChange' | 'que
 };
 
 const EntitySelect = ({ types, ...otherProps }: EntitySelectProps) => {
-  const [search, setSearch] = useState('');
+  const [, startTransition] = useTransition();
+  const [queryRef, loadQuery] = useQueryLoader<EntitySelectSearchQuery>(entitySelectSearchQuery);
 
-  const variables = useMemo(() => ({
+  const buildVariables = (search: string) => ({
     search,
     filters: {
       mode: 'and' as FilterMode,
@@ -152,19 +152,25 @@ const EntitySelect = ({ types, ...otherProps }: EntitySelectProps) => {
         },
       ],
     },
-  }), [search, types]);
+  });
 
-  const queryRef = useQueryLoading<EntitySelectSearchQuery>(
-    entitySelectSearchQuery,
-    variables,
-  );
+  // Initial load
+  useEffect(() => {
+    loadQuery(buildVariables(''), { fetchPolicy: 'store-and-network' });
+  }, [types]);
+
+  const handleSearchChange = (val: string) => {
+    startTransition(() => {
+      loadQuery(buildVariables(val), { fetchPolicy: 'store-and-network' });
+    });
+  };
 
   return (
     <Suspense fallback={<Loader />}>
       {queryRef && (
         <EntitySelectComponent
           {...otherProps}
-          onInputChange={setSearch}
+          onInputChange={handleSearchChange}
           queryRef={queryRef}
         />
       )}

--- a/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/EntitySelect.tsx
@@ -157,7 +157,7 @@ const EntitySelect = ({ types, ...otherProps }: EntitySelectProps) => {
   // Initial load
   useEffect(() => {
     search('');
-  }, [types]);
+  }, []);
 
   const handleSearchChange = (val: string) => {
     startTransition(() => {

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
@@ -34,7 +34,7 @@ interface PlaybookFlowFieldActionsProps {
 }
 
 const PlaybookFlowFieldActions = ({
-  operations = ['add, replace, remove'],
+  operations = ['add', 'replace', 'remove'],
 }: PlaybookFlowFieldActionsProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreview.tsx
@@ -62,7 +62,7 @@ const FintelTemplatePreview = ({
   const { editorValue } = useFintelTemplateContext();
 
   const [pdf, setPdf] = useState<File>();
-  const [formValues, setFormValues] = useState<FintelTemplatePreviewFormInputs>();
+  const [formValues, setFormValues] = useState<FintelTemplatePreviewFormInputs | null>();
 
   const { fintel_template_widgets } = useFragment<FintelTemplatePreview_template$key>(
     previewFragment,
@@ -91,7 +91,11 @@ const FintelTemplatePreview = ({
   };
 
   useEffect(() => {
-    const { fileMarkings, entity, contentMaxMarkings, fintelDesign } = formValues ?? {};
+    if (!formValues) {
+      setPdf(undefined);
+      return;
+    }
+    const { fileMarkings, entity, contentMaxMarkings, fintelDesign } = formValues;
     if (!entity || !isTabActive) return;
     buildPreview(
       entity.value,
@@ -119,7 +123,7 @@ const FintelTemplatePreview = ({
 
       <div style={{ flex: 5, display: 'flex', flexDirection: 'column' }}>
         <Card title={t_i18n('Preview')}>
-          {pdf && formValues?.entity ? (
+          {pdf ? (
             <PdfViewer pdf={pdf} />
           ) : (
             <div style={{

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreview.tsx
@@ -119,7 +119,7 @@ const FintelTemplatePreview = ({
 
       <div style={{ flex: 5, display: 'flex', flexDirection: 'column' }}>
         <Card title={t_i18n('Preview')}>
-          {pdf ? (
+          {pdf && formValues?.entity ? (
             <PdfViewer pdf={pdf} />
           ) : (
             <div style={{

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreviewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreviewForm.tsx
@@ -20,7 +20,7 @@ export interface FintelTemplatePreviewFormInputs {
 }
 
 interface FintelTemplatePreviewFormProps {
-  onChange: (val: FintelTemplatePreviewFormInputs) => void;
+  onChange: (val: FintelTemplatePreviewFormInputs | null) => void;
 }
 
 const FintelTemplatePreviewForm = ({
@@ -32,7 +32,7 @@ const FintelTemplatePreviewForm = ({
   if (!subTypeId) return <ErrorNotFound />;
 
   const validation = () => Yup.object().shape({
-    entity: Yup.object().nullable(),
+    entity: Yup.object().required(),
   });
 
   const initialValues: FintelTemplatePreviewFormInputs = {
@@ -52,7 +52,11 @@ const FintelTemplatePreviewForm = ({
         useEffect(() => {
           const validate = async () => {
             const isValid = isEmptyObject(await validateForm(values));
-            if (isValid) onChange(values);
+            if (isValid) {
+              onChange(values);
+            } else {
+              onChange(null);
+            }
           };
           validate();
         }, [values]);

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreviewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreviewForm.tsx
@@ -32,7 +32,7 @@ const FintelTemplatePreviewForm = ({
   if (!subTypeId) return <ErrorNotFound />;
 
   const validation = () => Yup.object().shape({
-    entity: Yup.object().required(),
+    entity: Yup.object().nullable(),
   });
 
   const initialValues: FintelTemplatePreviewFormInputs = {


### PR DESCRIPTION
### Proposed changes

In fintel template preview form, the form should not re-render when we start entering a keyword in the entity select field.

<img width="1235" height="690" alt="image" src="https://github.com/user-attachments/assets/c95f2fa5-0fe1-433b-85ee-1aef6ad25c2d" />


<img width="1223" height="757" alt="image" src="https://github.com/user-attachments/assets/72a7db5a-ad21-4eff-ad69-091079bb54d6" />


### Related issues
fixes #15211