### PR TITLE
[frontend] Apply CKEditor theme correctly on first render (#15964)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AppThemeProvider.tsx
+++ b/opencti-platform/opencti-front/src/components/AppThemeProvider.tsx
@@ -115,7 +115,12 @@ const AppThemeProvider: FunctionComponent<AppThemeProviderProps> = ({
     return createTheme(themeBuilder(appTheme) as ThemeOptions);
   }, [themeToUse]);
 
-  useDocumentThemeModifier(themeToUse?.name ?? defaultTheme.name);
+  // Compute the lowercase palette mode used by the body `data-theme`
+  // attribute. This must match `theme.palette.mode` so that CSS files
+  // targeting `body[data-theme="dark"]` / `body[data-theme="light"]`
+  // (e.g. CKEditor theming) apply on the very first render.
+  const themeMode = (themeToUse?.name ?? defaultTheme.name) === 'Light' ? 'light' : 'dark';
+  useDocumentThemeModifier(themeMode);
 
   return <ThemeProvider theme={muiTheme}>{children}</ThemeProvider>;
 };

--- a/opencti-platform/opencti-front/src/utils/hooks/useDocumentModifier.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDocumentModifier.ts
@@ -39,8 +39,11 @@ export const useDocumentFaviconModifier = (href?: string | null) => {
   });
 };
 
-export const useDocumentThemeModifier = (theme: string) => {
+export const useDocumentThemeModifier = (mode: string) => {
   useEffect(() => {
-    document.body.setAttribute('data-theme', theme);
-  }, []);
+    // CKEditor (and other components) rely on the lowercase mode
+    // (`dark` / `light`) to apply theme-specific CSS variables.
+    // The attribute must also stay in sync if the theme changes at runtime.
+    document.body.setAttribute('data-theme', mode);
+  }, [mode]);
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project!
-->

### Proposed changes

* Pass the lowercase MUI palette mode (`'dark'` / `'light'`) to `useDocumentThemeModifier` instead of the human-readable theme name (`'Dark'` / `'Light'`), so the `<body data-theme="…">` attribute matches the CSS selectors used by `CKEditorDark.css`, `CKEditorLight.css` and `TiptapEditor.css`.
* Fix `useDocumentThemeModifier` to react to mode changes (`useEffect(..., [mode])`) instead of using an empty dependency array, so the body attribute stays in sync whenever the theme is switched at runtime.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes #15964
* Regression introduced by #15653 (CKEditor v48 upgrade)

### Root cause (short)

`AppThemeProvider` was writing `data-theme="Dark"` (capitalized) while every CSS override targets `body[data-theme="dark"]` (lowercase). The fallback `useEffect` in `private/Index.tsx` did write the correct lowercase value, but because React fires effects bottom-up the parent's capitalized write happened *after* the child's correct write, leaving `<body data-theme="Dark">` as the final state — so the overrides never matched.

In CKEditor v43 the affected base CSS variables were scoped under `.ck` selectors, which masked the bug. CKEditor v48 moved them to `:root` (`--ck-color-toolbar-background: #fff`, `--ck-color-text: #333`, etc.), so any miss on the `body[data-theme="dark"]` selector now visibly leaks the light defaults — hence the white toolbar / dark text in Dark mode after a hard reload.

Toggling the theme worked because only `private/Index.tsx`'s effect re-runs on theme change (the hook with empty deps stays frozen), and it writes the correct lowercase value, restoring the rendering until the next full reload.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: This is a small, targeted UI-state fix. The behavior is hard to cover with a unit test (it requires asserting DOM mutations after concurrent React effects). Manual verification covered: hard reload in Dark, hard reload in Light, runtime toggle in both directions, and CKEditor content visible after reload._ -->

### Further comments

I evaluated whether the fix should live in the CSS layer instead (e.g. renaming variables to match CKEditor v48). After cross-referencing every variable overridden in `CKEditorDark.css` / `CKEditorLight.css` against the v48 `:root` block in `node_modules/ckeditor5/dist/ckeditor5.css`, all theming variables still exist in v48 — the override file is correct as-is. The actual bug is the body attribute value, so the change is intentionally minimal and only touches two files. The defensive duplicate in `private/Index.tsx` is left in place; both writers now produce the same lowercase value.
