### PR TITLE
[frontend] Fix input searching in playbook component (#15963)

### DIFF
--- a/opencti-platform/opencti-front/src/components/fields/SwitchField.jsx
+++ b/opencti-platform/opencti-front/src/components/fields/SwitchField.jsx
@@ -45,6 +45,7 @@ const SwitchField = (props) => {
     <div style={props.containerstyle}>
       <FormGroup>
         <FormControlLabel
+          style={{ width: 'fit-content' }}
           control={(
             <MuiSwitch
               {...fieldToSwitch(props)}

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
@@ -53,6 +53,54 @@ const PlaybookFlowFieldActions = ({
     return a.op && a.attribute && a.value && a.value.length > 0;
   });
 
+  /**
+   * Returns the label for a given option.
+   * Handles both string values and FieldOption objects.
+   */
+  const getOptionLabel = (options: FieldOption[]) => (option: string | FieldOption): string => {
+    if (typeof option === 'string') {
+      return options.find((o) => o.value === option)?.label ?? option;
+    }
+    return option.label ?? '';
+  };
+
+  /**
+   * Reset the action when the operation changes.
+   * Clears attribute, value, and form display value.
+   */
+  const handleOperationChange = (index: number, val: FieldOption | null) => {
+    const newOp = val?.value ?? '';
+    setFieldValue(`actions.${index}`, { op: newOp });
+    if (formActionsValues[index] !== undefined) {
+      setFieldValue(`actionsFormValues.${index}`, null);
+    }
+  };
+
+  /**
+   * Reset the action value when the attribute changes.
+   * Keeps the current operation and sets the new attribute.
+   */
+  const handleAttributeChange = (index: number, currentOp: string | undefined, val: FieldOption | null) => {
+    const newAttribute = val?.value;
+    const newAction: PlaybookUpdateAction = { op: currentOp };
+    if (newAttribute) newAction.attribute = newAttribute;
+    setFieldValue(`actions.${index}`, newAction);
+    if (formActionsValues[index] !== undefined) {
+      const isMultiple = attributesMultiple.includes(newAttribute ?? '');
+      setFieldValue(`actionsFormValues.${index}`, isMultiple ? [] : null);
+    }
+  };
+
+  /**
+   * Remove an action and its associated form display value.
+   */
+  const handleDeleteAction = (index: number, remove: (index: number) => void) => {
+    remove(index);
+    const newFormValues = [...formActionsValues];
+    newFormValues.splice(index, 1);
+    setFieldValue('actionsFormValues', newFormValues);
+  };
+
   return (
     <FieldArray
       name="actions"
@@ -86,19 +134,8 @@ const PlaybookFlowFieldActions = ({
                         }}
                         options={operationOptions}
                         isOptionEqualToValue={(option: FieldOption, val: string | FieldOption) => option.value === (typeof val === 'string' ? val : val.value)}
-                        getOptionLabel={(option: string | FieldOption) => {
-                          if (typeof option === 'string') {
-                            return operationOptions.find((o) => o.value === option)?.label ?? option;
-                          }
-                          return option.label ?? '';
-                        }}
-                        onInternalChange={(_: string, val: FieldOption | null) => {
-                          const newOp = val?.value ?? '';
-                          setFieldValue(`actions.${i}`, { op: newOp });
-                          if (formActionsValues[i] !== undefined) {
-                            setFieldValue(`actionsFormValues.${i}`, null);
-                          }
-                        }}
+                        getOptionLabel={getOptionLabel(operationOptions)}
+                        onInternalChange={(_: string, val: FieldOption | null) => handleOperationChange(i, val)}
                       />
                     </Grid>
                     <Grid size={{ xs: 3 }}>
@@ -114,22 +151,8 @@ const PlaybookFlowFieldActions = ({
                         options={fieldOptions}
                         noOptionsText={t_i18n('None')}
                         isOptionEqualToValue={(option: FieldOption, val: string | FieldOption) => option.value === (typeof val === 'string' ? val : val.value)}
-                        getOptionLabel={(option: string | FieldOption) => {
-                          if (typeof option === 'string') {
-                            return fieldOptions.find((o) => o.value === option)?.label ?? option;
-                          }
-                          return option.label ?? '';
-                        }}
-                        onInternalChange={(_: string, val: FieldOption | null) => {
-                          const newAttribute = val?.value;
-                          const newAction: PlaybookUpdateAction = { op: action.op };
-                          if (newAttribute) newAction.attribute = newAttribute;
-                          setFieldValue(`actions.${i}`, newAction);
-                          if (formActionsValues[i] !== undefined) {
-                            const isMultiple = attributesMultiple.includes(newAttribute ?? '');
-                            setFieldValue(`actionsFormValues.${i}`, isMultiple ? [] : null);
-                          }
-                        }}
+                        getOptionLabel={getOptionLabel(fieldOptions)}
+                        onInternalChange={(_: string, val: FieldOption | null) => handleAttributeChange(i, action.op, val)}
                       />
                     </Grid>
                     <Grid size={{ xs: 5 }}>
@@ -150,12 +173,7 @@ const PlaybookFlowFieldActions = ({
                       <IconButton
                         aria-label="Delete"
                         disabled={actions.length === 1}
-                        onClick={() => {
-                          arrayHelpers.remove(i);
-                          const newFormvalues = [...formActionsValues];
-                          newFormvalues.splice(i, 1);
-                          setFieldValue('actionsFormValues', newFormvalues);
-                        }}
+                        onClick={() => handleDeleteAction(i, arrayHelpers.remove)}
                       >
                         <DeleteOutlined />
                       </IconButton>

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
@@ -15,15 +15,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import IconButton from '@common/button/IconButton';
 import { AddOutlined, DeleteOutlined } from '@mui/icons-material';
-import { Grid2 as Grid, MenuItem, Stack } from '@mui/material';
+import { Grid2 as Grid, Stack } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import { Field, FieldArray, useFormikContext } from 'formik';
 import type { Theme } from '../../../../../../../components/Theme';
+import AutocompleteField from '../../../../../../../components/AutocompleteField';
 import Button from '../../../../../../../components/common/button/Button';
-import SelectField from '../../../../../../../components/fields/SelectField';
 import { useFormatter } from '../../../../../../../components/i18n';
 import { capitalizeFirstLetter } from '../../../../../../../utils/String';
-import { fieldSpacingContainerStyle } from '../../../../../../../utils/field';
+import { FieldOption, fieldSpacingContainerStyle } from '../../../../../../../utils/field';
 import { isEmptyField } from '../../../../../../../utils/utils';
 import PlaybookActionValueField from './PlaybookActionValueField';
 import { attributesMultiple, PlaybookUpdateAction, PlaybookUpdateActionsForm } from './playbookAction-types';
@@ -38,6 +38,11 @@ const PlaybookFlowFieldActions = ({
 }: PlaybookFlowFieldActionsProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
+  const operationOptions: FieldOption[] = operations.map((op) => ({
+    label: t_i18n(capitalizeFirstLetter(op)),
+    value: op,
+  }));
+
   const getActionFieldOptions = useActionFieldOptions();
   const { values, setFieldValue } = useFormikContext<PlaybookUpdateActionsForm>();
   const actions = values.actions ?? [];
@@ -47,32 +52,6 @@ const PlaybookFlowFieldActions = ({
     if (a.attribute === 'x_opencti_detection') return true;
     return a.op && a.attribute && a.value && a.value.length > 0;
   });
-
-  /**
-   * When changing either the operation (op) or the attribute, we need to reset
-   * the field for the value of the action.
-   *
-   * @param index Index of the action in the array of actions in the form.
-   * @param attribute The new value of attribute concerned by the action (undefined = it's the 'op' that has changed).
-   */
-  const resetActionValue = (index: number, attribute?: string) => {
-    if (actions[index]) {
-      const newValue: PlaybookUpdateAction = {
-        // By default we only set in the new object the operation.
-        op: actions[index].op,
-      };
-      if (attribute) {
-        newValue.attribute = attribute;
-      }
-      setFieldValue(`actions.${index}`, newValue);
-    }
-    if (formActionsValues[index] !== undefined) {
-      // We also reset in the array containing form data, it's either null or empty array
-      // depending of the kind of attribute manipulated (multiple or not).
-      const isMultiple = attributesMultiple.includes(attribute ?? '');
-      setFieldValue(`actionsFormValues.${index}`, isMultiple ? [] : null);
-    }
-  };
 
   return (
     <FieldArray
@@ -95,42 +74,63 @@ const PlaybookFlowFieldActions = ({
                   display: 'flex',
                 }}
                 >
-                  <Grid container spacing={3} sx={{ width: '100%' }}>
+                  <Grid container spacing={3} sx={{ width: '100%', alignItems: 'flex-end' }}>
                     <Grid size={{ xs: 3 }}>
                       <Field
-                        component={SelectField}
-                        variant="standard"
+                        component={AutocompleteField}
                         name={`actions.${i}.op`}
-                        containerstyle={{ width: '100%' }}
-                        label={t_i18n('Action type')}
-                        onChange={() => resetActionValue(i)}
-                      >
-                        {operations.map((op) => (
-                          <MenuItem key={op} value={op}>
-                            {t_i18n(capitalizeFirstLetter(op))}
-                          </MenuItem>
-                        ))}
-                      </Field>
+                        multiple={false}
+                        textfieldprops={{
+                          variant: 'standard',
+                          label: t_i18n('Action type'),
+                        }}
+                        options={operationOptions}
+                        isOptionEqualToValue={(option: FieldOption, val: string | FieldOption) => option.value === (typeof val === 'string' ? val : val.value)}
+                        getOptionLabel={(option: string | FieldOption) => {
+                          if (typeof option === 'string') {
+                            return operationOptions.find((o) => o.value === option)?.label ?? option;
+                          }
+                          return option.label ?? '';
+                        }}
+                        onInternalChange={(_: string, val: FieldOption | null) => {
+                          const newOp = val?.value ?? '';
+                          setFieldValue(`actions.${i}`, { op: newOp });
+                          if (formActionsValues[i] !== undefined) {
+                            setFieldValue(`actionsFormValues.${i}`, null);
+                          }
+                        }}
+                      />
                     </Grid>
                     <Grid size={{ xs: 3 }}>
                       <Field
-                        component={SelectField}
-                        disabled={isEmptyField(action.op)}
-                        variant="standard"
+                        component={AutocompleteField}
                         name={`actions.${i}.attribute`}
-                        containerstyle={{ width: '100%' }}
-                        label={t_i18n('Field')}
-                        onChange={(_: string, val: string) => resetActionValue(i, val)}
-                      >
-                        {fieldOptions.length === 0
-                          ? <MenuItem value="none">{t_i18n('None')}</MenuItem>
-                          : fieldOptions.map((option) => (
-                              <MenuItem key={option.value} value={option.value}>
-                                {option.label}
-                              </MenuItem>
-                            ))
-                        }
-                      </Field>
+                        multiple={false}
+                        disabled={isEmptyField(action.op)}
+                        textfieldprops={{
+                          variant: 'standard',
+                          label: t_i18n('Field'),
+                        }}
+                        options={fieldOptions}
+                        noOptionsText={t_i18n('None')}
+                        isOptionEqualToValue={(option: FieldOption, val: string | FieldOption) => option.value === (typeof val === 'string' ? val : val.value)}
+                        getOptionLabel={(option: string | FieldOption) => {
+                          if (typeof option === 'string') {
+                            return fieldOptions.find((o) => o.value === option)?.label ?? option;
+                          }
+                          return option.label ?? '';
+                        }}
+                        onInternalChange={(_: string, val: FieldOption | null) => {
+                          const newAttribute = val?.value;
+                          const newAction: PlaybookUpdateAction = { op: action.op };
+                          if (newAttribute) newAction.attribute = newAttribute;
+                          setFieldValue(`actions.${i}`, newAction);
+                          if (formActionsValues[i] !== undefined) {
+                            const isMultiple = attributesMultiple.includes(newAttribute ?? '');
+                            setFieldValue(`actionsFormValues.${i}`, isMultiple ? [] : null);
+                          }
+                        }}
+                      />
                     </Grid>
                     <Grid size={{ xs: 5 }}>
                       <PlaybookActionValueField

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
@@ -193,6 +193,8 @@ const PlaybookFlowFieldActions = ({
               disabled={!actionsAreValid}
               onClick={() => {
                 arrayHelpers.push({});
+                const newFormvalues = [...formActionsValues, []];
+                setFieldValue('actionsFormValues', newFormvalues);
               }}
             >
               {t_i18n('Add action')}


### PR DESCRIPTION
### Proposed changes
In the 'Manipulate knowledge' component of playbook : 
- fix input searching (when entering an input in a search field, the keyword should be written)
- align the 'action', 'field' and 'value' inputs
- the 'manipulate all elements included in the bundle' should switch if we click on its label only (not on the entire line after the label)

<img width="1204" height="751" alt="image" src="https://github.com/user-attachments/assets/d79677f2-333c-4f7b-b542-5d6337e116d8" />


### Related issues
fixes #15963