### PR TITLE
feat(frontend/backend): custom fields POC (flat)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -150,7 +150,9 @@ const FilterIconButton: FunctionComponent<FilterIconButtonProps> = ({
     ? {
         ...filters,
         filters:
-          filters.filters.filter((currentFilter) => !availableFilterKeys || availableFilterKeys?.some((currentKey) => currentFilter.key === currentKey)),
+          filters.filters.filter((currentFilter) => !availableFilterKeys
+            || currentFilter.key.startsWith('x_opencti_cf_') // always show dynamic custom field chips
+            || availableFilterKeys?.some((currentKey) => currentFilter.key === currentKey)),
       }
     : undefined;
   if (displayedFilters && isFilterGroupNotEmpty(displayedFilters)) { // to avoid running the FiltersRepresentatives query if filters are empty

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetListCoreObjects.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetListCoreObjects.tsx
@@ -30,7 +30,29 @@ const WidgetListCoreObjects = ({
           if (!attribute) {
             return acc;
           }
-          acc[attribute] = { percentWidth, isSortable: false, ...(label ? { label } : {}) };
+          // Custom fields (x_opencti_cf_*) are dynamic and not in defaultColumnsMap,
+          // so we provide a simple text renderer to display their raw value.
+          if (attribute.startsWith('x_opencti_cf_')) {
+            acc[attribute] = {
+              percentWidth,
+              isSortable: false,
+              ...(label ? { label } : {}),
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              render: (rowData: any) => {
+                const val = rowData[attribute];
+                if (val === null || val === undefined || val === '') {
+                  return <span>-</span>;
+                }
+                return (
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {String(val)}
+                  </span>
+                );
+              },
+            };
+          } else {
+            acc[attribute] = { percentWidth, isSortable: false, ...(label ? { label } : {}) };
+          }
           return acc;
         },
         {},

--- a/opencti-platform/opencti-front/src/private/components/cases/CaseIncidents.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/CaseIncidents.tsx
@@ -20,6 +20,7 @@ import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocum
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNASKIMPORT } from '../../../utils/hooks/useGranted';
 import Security from '../../../utils/Security';
 
+
 interface CaseIncidentsProps {
   inputValue?: string;
 }

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentCreation.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography';
 import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import { FunctionComponent, useState } from 'react';
-import { graphql } from 'react-relay';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useNavigate } from 'react-router-dom';
 import { RecordSourceSelectorProxy } from 'relay-runtime';
 import { handleErrorInForm } from 'src/relay/environment';
@@ -40,6 +40,9 @@ import ObjectMarkingField from '../../common/form/ObjectMarkingField';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { CaseIncidentAddInput, CaseIncidentCreationCaseMutation } from './__generated__/CaseIncidentCreationCaseMutation.graphql';
+import MenuItem from '@mui/material/MenuItem';
+import MuiTextField from '@mui/material/TextField';
+import Divider from '@mui/material/Divider';
 
 const caseIncidentMutation = graphql`
   mutation CaseIncidentCreationCaseMutation($input: CaseIncidentAddInput!) {
@@ -58,6 +61,48 @@ const caseIncidentMutation = graphql`
     }
   }
 `;
+
+// Flat storage: custom fields are written via the generic fieldPatch with key x_opencti_cf_<name>
+const setCustomFieldValueMutation = graphql`
+  mutation CaseIncidentCreationSetCustomFieldMutation($id: ID!, $input: [EditInput]!) {
+    stixDomainObjectEdit(id: $id) {
+      fieldPatch(input: $input) {
+        id
+      }
+    }
+  }
+`;
+
+const customFieldDefinitionsQuery = graphql`
+  query CaseIncidentCreationCustomFieldDefinitionsQuery($filters: FilterGroup) {
+    customFieldDefinitions(filters: $filters) {
+      edges {
+        node {
+          id
+          name
+          label
+          field_type
+          mandatory
+          min_value
+          max_value
+          select_options
+        }
+      }
+    }
+  }
+`;
+
+// Shape of one custom field definition (from relay)
+interface CustomFieldDef {
+  id: string;
+  name: string;
+  label: string;
+  field_type: string;
+  mandatory: boolean;
+  min_value?: number | null;
+  max_value?: number | null;
+  select_options?: ReadonlyArray<string> | null;
+}
 
 interface FormikCaseIncidentAddInput {
   name: string;
@@ -84,6 +129,8 @@ interface FormikCaseIncidentAddInput {
       value: string;
       type: string;
     }[]; }[] | undefined;
+  // custom field values: keyed by definition id
+  customFields: Record<string, string>;
 }
 
 interface IncidentFormProps {
@@ -101,6 +148,52 @@ interface IncidentFormProps {
 
 const CASE_INCIDENT_TYPE = 'Case-Incident';
 
+// Renders the appropriate input for a custom field definition
+const CustomFieldInput: FunctionComponent<{
+  definition: CustomFieldDef;
+  value: string;
+  onChange: (val: string) => void;
+}> = ({ definition, value, onChange }) => {
+  const { t_i18n } = useFormatter();
+  const label = `${definition.label}${definition.mandatory ? ' *' : ''}`;
+
+  if (definition.field_type === 'select' && definition.select_options) {
+    return (
+      <MuiTextField
+        select
+        fullWidth
+        variant="standard"
+        label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={fieldSpacingContainerStyle}
+      >
+        <MenuItem value=""><em>{t_i18n('None')}</em></MenuItem>
+        {definition.select_options.map((opt) => (
+          <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+        ))}
+      </MuiTextField>
+    );
+  }
+
+  return (
+    <MuiTextField
+      fullWidth
+      variant="standard"
+      label={label}
+      value={value}
+      type={definition.field_type === 'integer' ? 'number' : 'text'}
+      inputProps={
+        definition.field_type === 'integer'
+          ? { min: definition.min_value ?? undefined, max: definition.max_value ?? undefined }
+          : undefined
+      }
+      onChange={(e) => onChange(e.target.value)}
+      style={fieldSpacingContainerStyle}
+    />
+  );
+};
+
 export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   updater,
   onClose,
@@ -114,25 +207,36 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
   const [mapAfter, setMapAfter] = useState<boolean>(false);
   const canEditAuthorizedMembers = useGranted([KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]);
   const isEnterpriseEdition = useEnterpriseEdition();
-  const { mandatoryAttributes } = useIsMandatoryAttribute(
-    CASE_INCIDENT_TYPE,
-  );
+  const { mandatoryAttributes } = useIsMandatoryAttribute(CASE_INCIDENT_TYPE);
+
+  // Fetch custom field definitions applicable to Case-Incident
+  const customFieldData = useLazyLoadQuery<any>(customFieldDefinitionsQuery, {
+    filters: {
+      mode: 'and',
+      filters: [{ key: 'entity_types', values: ['Case-Incident'], operator: 'eq' }],
+      filterGroups: [],
+    },
+  });
+  const customFieldDefs: CustomFieldDef[] = (customFieldData?.customFieldDefinitions?.edges ?? [])
+    .map((e: any) => e?.node)
+    .filter(Boolean);
+
   const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2),
     description: Yup.string().nullable(),
     content: Yup.string().nullable(),
     authorized_members: Yup.array().nullable(),
   }, mandatoryAttributes);
-  const validator = useDynamicSchemaCreationValidation(
-    mandatoryAttributes,
-    basicShape,
-  );
+  const validator = useDynamicSchemaCreationValidation(mandatoryAttributes, basicShape);
+
   const [commit] = useApiMutation<CaseIncidentCreationCaseMutation>(
     caseIncidentMutation,
     undefined,
     { successMessage: `${t_i18n('entity_Case-Incident')} ${t_i18n('successfully created')}` },
   );
+
   const { buildCreationFilesInput, registerMarkdownImagesController } = useMarkdownCreationFilesInput();
+  const [commitSetCustomField] = useApiMutation<any>(setCustomFieldValueMutation);
   const onSubmit: FormikConfig<FormikCaseIncidentAddInput>['onSubmit'] = (
     values,
     { setSubmitting, setErrors, resetForm },
@@ -163,9 +267,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       }),
     };
     commit({
-      variables: {
-        input,
-      },
+      variables: { input },
       updater: (store, response) => {
         if (updater && response) {
           updater(store, 'caseIncidentAdd', response.caseIncidentAdd);
@@ -176,16 +278,30 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
         setSubmitting(false);
       },
       onCompleted: (response) => {
-        setSubmitting(false);
-        resetForm();
-        if (onClose) {
-          onClose();
-        }
-        if (mapAfter) {
-          navigate(
-            `/dashboard/cases/incidents/${response.caseIncidentAdd?.id}/content/mapping`,
-          );
-        }
+        const createdId = response.caseIncidentAdd?.id;
+        // Set each non-empty custom field value after creation via flat fieldPatch
+        const customFieldEntries = Object.entries(values.customFields).filter(([, v]) => v !== '');
+        // Build a map from definition id → name for key construction
+        const defById = Object.fromEntries(customFieldDefs.map((d) => [d.id, d.name]));
+        const setAll = customFieldEntries.map(([fieldId, value]) => new Promise<void>((resolve) => {
+          const fieldName = defById[fieldId];
+          if (!fieldName) {
+            resolve(); return;
+          }
+          commitSetCustomField({
+            variables: { id: createdId, input: [{ key: `x_opencti_cf_${fieldName}`, value: [value] }] },
+            onCompleted: () => resolve(),
+            onError: () => resolve(), // best-effort for POC
+          });
+        }));
+        Promise.all(setAll).then(() => {
+          setSubmitting(false);
+          resetForm();
+          if (onClose) onClose();
+          if (mapAfter) {
+            navigate(`/dashboard/cases/incidents/${createdId}/content/mapping`);
+          }
+        });
       },
     });
   };
@@ -210,11 +326,13 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
       externalReferences: [],
       file: undefined,
       authorized_members: undefined,
+      customFields: {},
     },
   );
   if (!canEditAuthorizedMembers) {
     delete initialValues.authorized_members;
   }
+
   return (
     <Formik<FormikCaseIncidentAddInput>
       initialValues={initialValues}
@@ -308,6 +426,23 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
               height: 200,
             }}
           />
+          {/* Custom fields section */}
+          {customFieldDefs.length > 0 && (
+            <>
+              <Divider style={{ marginTop: 24, marginBottom: 8 }} />
+              <Typography variant="overline" color="text.secondary">
+                {t_i18n('Custom fields')}
+              </Typography>
+              {customFieldDefs.map((def) => (
+                <CustomFieldInput
+                  key={def.id}
+                  definition={def}
+                  value={values.customFields[def.id] ?? ''}
+                  onChange={(val) => setFieldValue(`customFields.${def.id}`, val)}
+                />
+              ))}
+            </>
+          )}
           <ObjectAssigneeField
             name="objectAssignee"
             required={(mandatoryAttributes.includes('objectAssignee'))}
@@ -346,9 +481,7 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
           />
           <CustomFileUploader setFieldValue={setFieldValue} />
           {isEnterpriseEdition && (
-            <Security
-              needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}
-            >
+            <Security needs={[KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS]}>
               <div style={fieldSpacingContainerStyle}>
                 <Accordion>
                   <AccordionSummary id="accordion-panel">
@@ -370,24 +503,16 @@ export const CaseIncidentCreationForm: FunctionComponent<IncidentFormProps> = ({
             </Security>
           )}
           <FormButtonContainer>
-            <Button
-              variant="secondary"
-              onClick={handleReset}
-              disabled={isSubmitting}
-            >
+            <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
               {t_i18n('Cancel')}
             </Button>
-            <Button
-              onClick={submitForm}
-              disabled={isSubmitting}
-            >
+            <Button onClick={submitForm} disabled={isSubmitting}>
               {t_i18n('Create')}
             </Button>
             {values.content.length > 0 && (
               <Button
                 onClick={() => {
-                  setMapAfter(true);
-                  submitForm();
+                  setMapAfter(true); submitForm();
                 }}
                 disabled={isSubmitting}
               >

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentDetails.tsx
@@ -25,6 +25,13 @@ const CaseIncidentDetailsFragment = graphql`
     modified
     created_at
     response_types
+    customFieldValues {
+      field_id
+      field_name
+      int_value
+      string_value
+      select_value
+    }
     objectLabel {
       id
       value
@@ -53,6 +60,24 @@ const CaseIncidentDetailsFragment = graphql`
   }
 `;
 
+// Returns the display value for a custom field regardless of its type
+const getCustomFieldDisplayValue = (cfv: {
+  int_value?: number | null | undefined;
+  string_value?: string | null | undefined;
+  select_value?: string | null | undefined;
+}): string => {
+  if (cfv.int_value !== null && cfv.int_value !== undefined) return String(cfv.int_value);
+  if (cfv.string_value) return cfv.string_value;
+  if (cfv.select_value) return cfv.select_value;
+  return '';
+};
+
+// Turns "x_opencti_risk_score" into "Risk score"
+const formatCustomFieldLabel = (fieldName: string): string => {
+  const withoutPrefix = fieldName.replace(/^x_opencti_/, '');
+  return withoutPrefix.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase());
+};
+
 interface CaseIncidentDetailsProps {
   caseIncidentData: CaseIncidentDetails_case$key;
 }
@@ -63,6 +88,7 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
   const { t_i18n } = useFormatter();
   const data = useFragment(CaseIncidentDetailsFragment, caseIncidentData);
   const responseTypes = data.response_types ?? [];
+  const customFieldValues = data.customFieldValues ?? [];
 
   return (
     <div style={{ height: '100%' }}>
@@ -115,6 +141,26 @@ const CaseIncidentDetails: FunctionComponent<CaseIncidentDetailsProps> = ({
               </Stack>
             </FieldOrEmpty>
           </Grid>
+          {customFieldValues.length > 0 && (
+            <>
+              <Grid item xs={12}>
+                <Divider />
+              </Grid>
+              {customFieldValues.filter((cfv): cfv is NonNullable<typeof cfv> => cfv != null).map((cfv) => {
+                const displayValue = getCustomFieldDisplayValue(cfv);
+                return (
+                  <Grid item xs={6} key={cfv.field_id}>
+                    <Label>
+                      {formatCustomFieldLabel(cfv.field_name)}
+                    </Label>
+                    <FieldOrEmpty source={displayValue}>
+                      <Tag label={displayValue} />
+                    </FieldOrEmpty>
+                  </Grid>
+                );
+              })}
+            </>
+          )}
         </Grid>
         <Divider />
         <RelatedContainers

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/CaseIncidentEditionOverview.tsx
@@ -1,14 +1,16 @@
 import { Field, Form, Formik } from 'formik';
 import { FormikConfig } from 'formik/dist/types';
 import React, { FunctionComponent } from 'react';
-import { graphql, useFragment } from 'react-relay';
+import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 import * as Yup from 'yup';
+import MenuItem from '@mui/material/MenuItem';
 import { GenericContext } from '@components/common/model/GenericContextModel';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useFormatter } from '../../../../components/i18n';
 import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import TextField from '../../../../components/TextField';
+import SelectField from '../../../../components/fields/SelectField';
 import { convertAssignees, convertCreatedBy, convertMarkings, convertParticipants, convertStatus } from '../../../../utils/edition';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
@@ -25,8 +27,9 @@ import StatusField from '../../common/form/StatusField';
 import { CaseIncidentEditionOverview_case$key } from './__generated__/CaseIncidentEditionOverview_case.graphql';
 import ObjectParticipantField from '../../common/form/ObjectParticipantField';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import { CaseIncidentEditionOverviewCustomFieldDefinitionsQuery } from './__generated__/CaseIncidentEditionOverviewCustomFieldDefinitionsQuery.graphql';
 
-export const caseIncidentMutationFieldPatch = graphql`
+const caseIncidentMutationFieldPatch = graphql`
   mutation CaseIncidentEditionOverviewCaseFieldPatchMutation(
     $id: ID!
     $input: [EditInput]!
@@ -60,6 +63,24 @@ export const caseIncidentEditionOverviewFocus = graphql`
   }
 `;
 
+const caseIncidentCustomFieldDefinitionsQuery = graphql`
+  query CaseIncidentEditionOverviewCustomFieldDefinitionsQuery($filters: FilterGroup) {
+    customFieldDefinitions(first: 50, filters: $filters) {
+      edges {
+        node {
+          id
+          name
+          label
+          field_type
+          select_options
+          mandatory
+          description
+        }
+      }
+    }
+  }
+`;
+
 const caseIncidentEditionOverviewFragment = graphql`
   fragment CaseIncidentEditionOverview_case on CaseIncident {
     id
@@ -73,6 +94,13 @@ const caseIncidentEditionOverviewFragment = graphql`
     entity_type
     created
     response_types
+    customFieldValues {
+      field_id
+      field_name
+      int_value
+      string_value
+      select_value
+    }
     creators {
       id
       name
@@ -177,6 +205,12 @@ interface CaseIncidentEditionFormValues {
 
 const CASE_INCIDENT_TYPE = 'Case-Incident';
 
+const CUSTOM_FIELD_DEFINITIONS_FILTERS = {
+  mode: 'and',
+  filters: [{ key: 'entity_types', values: ['Case-Incident'], operator: 'eq', mode: 'or' }],
+  filterGroups: [],
+};
+
 const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverviewProps> = ({
   caseRef,
   context,
@@ -186,6 +220,15 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
   const { t_i18n } = useFormatter();
   const caseData = useFragment(caseIncidentEditionOverviewFragment, caseRef);
   const { mandatoryAttributes } = useIsMandatoryAttribute(CASE_INCIDENT_TYPE);
+
+  // Load custom field definitions for Case-Incident
+  const customFieldDefsData = useLazyLoadQuery<CaseIncidentEditionOverviewCustomFieldDefinitionsQuery>(
+    caseIncidentCustomFieldDefinitionsQuery,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    { filters: CUSTOM_FIELD_DEFINITIONS_FILTERS as any },
+  );
+  const customFieldDefs = customFieldDefsData?.customFieldDefinitions?.edges?.map((e) => e.node) ?? [];
+
   const basicShape = yupShapeConditionalRequired({
     name: Yup.string().trim().min(2),
     severity: Yup.string().nullable(),
@@ -239,6 +282,22 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
       if (['x_opencti_workflow_id'].includes(name)) {
         finalValue = (value as FieldOption).value;
       }
+      // For integer custom fields, coerce string → number so ES stores the right type
+      if (name.startsWith('x_opencti_cf_')) {
+        const numCandidate = Number(finalValue);
+        if (finalValue !== '' && finalValue !== null && !Number.isNaN(numCandidate)) {
+          finalValue = numCandidate;
+        }
+        // Bypass Yup validation: x_opencti_cf_* keys are not in the Yup schema,
+        // so validateAt() would throw and the silent .catch() would swallow the save.
+        editor.fieldPatch({
+          variables: {
+            id: caseData.id,
+            input: { key: name, value: finalValue ?? '' },
+          },
+        });
+        return;
+      }
       validator
         .validateAt(name, { [name]: value })
         .then(() => {
@@ -252,6 +311,23 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
         .catch(() => false);
     }
   };
+
+  // Build custom field initial values from customFieldValues resolver
+  const customFieldInitialValues: Record<string, string | number | null> = {};
+  customFieldDefs.forEach((def) => {
+    const flatKey = `x_opencti_cf_${def.name}`;
+    const cfValue = caseData.customFieldValues?.find(
+      (cv) => cv?.field_name === flatKey,
+    );
+    if (def.field_type === 'integer') {
+      // cfValue.int_value is a number, or null if not set
+      customFieldInitialValues[flatKey] = cfValue?.int_value ?? null;
+    } else {
+      // string or select — prefer select_value, then string_value
+      customFieldInitialValues[flatKey] = cfValue?.select_value ?? cfValue?.string_value ?? '';
+    }
+  });
+
   const initialValues = {
     name: caseData.name,
     description: caseData.description,
@@ -266,6 +342,7 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
     objectParticipant: convertParticipants(caseData),
     x_opencti_workflow_id: convertStatus(t_i18n, caseData) as FieldOption,
     references: [],
+    ...customFieldInitialValues,
   };
   return (
     <Formik
@@ -378,6 +455,45 @@ const CaseIncidentEditionOverview: FunctionComponent<CaseIncidentEditionOverview
               <SubscriptionFocus context={context} fieldName="description" />
             }
           />
+
+          {/* ── Custom fields ── */}
+          {customFieldDefs.map((def) => {
+            const flatKey = `x_opencti_cf_${def.name}`;
+            if (def.field_type === 'select' && def.select_options && def.select_options.length > 0) {
+              return (
+                <Field
+                  key={flatKey}
+                  component={SelectField}
+                  variant="standard"
+                  name={flatKey}
+                  label={t_i18n(def.label)}
+                  required={def.mandatory}
+                  containerstyle={{ ...fieldSpacingContainerStyle, width: '100%' }}
+                  onSubmit={handleSubmitField}
+                >
+                  <MenuItem value="">&nbsp;</MenuItem>
+                  {def.select_options.map((opt: string) => (
+                    <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+                  ))}
+                </Field>
+              );
+            }
+            return (
+              <Field
+                key={flatKey}
+                component={TextField}
+                variant="standard"
+                name={flatKey}
+                label={t_i18n(def.label)}
+                required={def.mandatory}
+                fullWidth={true}
+                type={def.field_type === 'integer' ? 'number' : 'text'}
+                style={fieldSpacingContainerStyle}
+                onFocus={editor.changeFocus}
+                onSubmit={handleSubmitField}
+              />
+            );
+          })}
 
           <ObjectAssigneeField
             name="objectAssignee"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.tsx
@@ -330,6 +330,12 @@ export const stixCoreObjectsListQuery = graphql`
             priority
             severity
             response_types
+            customFieldValues {
+              field_name
+              int_value
+              string_value
+              select_value
+            }
             objectAssignee {
               id
               name
@@ -436,7 +442,24 @@ const StixCoreObjectsListComponent = ({
   const data = usePreloadedQuery(stixCoreObjectsListQuery, queryRef);
   const selection = dataSelection[0];
   const columns = selection.columns ?? getDefaultWidgetColumns('entities');
-  const edges = data?.stixCoreObjects?.edges ?? [];
+  let edges = data?.stixCoreObjects?.edges ?? [];
+
+  // Flatten customFieldValues (x_opencti_cf_*) onto each node so
+  // dynamic custom field columns can access them by attribute key.
+  edges = edges.map(({ node, cursor }) => ({
+    cursor,
+    node: {
+      ...node,
+      ...((node.customFieldValues ?? []).reduce((acc, cv) => {
+        if (cv?.field_name) {
+          // int_value takes priority, then select_value, then string_value
+          acc[cv.field_name] = cv.int_value ?? cv.select_value ?? cv.string_value ?? null;
+        }
+        return acc;
+      }, {})),
+    },
+  }));
+
   return edges.length === 0 ? (
     <WidgetNoData />
   ) : (

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookActionValueField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookActionValueField.tsx
@@ -14,7 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import { Field, useFormikContext } from 'formik';
+import MenuItem from '@mui/material/MenuItem';
 import SwitchField from '../../../../../../../components/fields/SwitchField';
+import SelectField from '../../../../../../../components/fields/SelectField';
 import { FieldOption } from '../../../../../../../utils/field';
 import { isEmptyField } from '../../../../../../../utils/utils';
 import CreatedByField from '../../../../../common/form/CreatedByField';
@@ -26,6 +28,7 @@ import ObjectParticipantField from '../../../../../common/form/ObjectParticipant
 import OpenVocabField from '../../../../../common/form/OpenVocabField';
 import StatusField from '../../../../../common/form/StatusField';
 import { PlaybookUpdateAction, PlaybookUpdateActionsForm } from './playbookAction-types';
+import { CustomFieldOption } from './useActionFieldOptions';
 import TextField from '../../../../../../../components/TextField';
 import useAttributes from '../../../../../../../utils/hooks/useAttributes';
 import { useFormatter } from '../../../../../../../components/i18n';
@@ -33,11 +36,13 @@ import { useFormatter } from '../../../../../../../components/i18n';
 interface PlaybookActionValueFieldProps {
   action: PlaybookUpdateAction;
   index: number;
+  customFieldOptions?: CustomFieldOption[];
 }
 
 const PlaybookActionValueField = ({
   action,
   index,
+  customFieldOptions = [],
 }: PlaybookActionValueFieldProps) => {
   const { t_i18n } = useFormatter();
   const { numberAttributes } = useAttributes();
@@ -267,6 +272,43 @@ const PlaybookActionValueField = ({
         />
       );
     default:
+      // Dynamic custom fields: render the appropriate input based on field_type
+      if (action.attribute?.startsWith('x_opencti_cf_')) {
+        const cfDef = customFieldOptions.find((o) => o.value === action.attribute);
+        if (cfDef?.field_type === 'select' && cfDef.select_options && cfDef.select_options.length > 0) {
+          return (
+            <Field
+              component={SelectField}
+              variant="standard"
+              name={formValueName}
+              label={t_i18n('Value')}
+              disabled={disabled}
+              containerstyle={{ width: '100%' }}
+              onChange={(_: string, val: string) => {
+                setFieldValue(valueName, [{ label: val, value: val, patch_value: val }]);
+              }}
+            >
+              {cfDef.select_options.map((opt: string) => (
+                <MenuItem key={opt} value={opt}>{opt}</MenuItem>
+              ))}
+            </Field>
+          );
+        }
+        return (
+          <Field
+            component={TextField}
+            disabled={disabled}
+            type={cfDef?.field_type === 'integer' ? 'number' : 'text'}
+            variant="standard"
+            name={formValueName}
+            label={t_i18n('Value')}
+            fullWidth
+            onChange={(_: string, val: string) => {
+              setFieldValue(valueName, [{ label: val, value: val, patch_value: val }]);
+            }}
+          />
+        );
+      }
       return (
         <Field
           component={TextField}

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions.tsx
@@ -18,6 +18,7 @@ import { AddOutlined, DeleteOutlined } from '@mui/icons-material';
 import { Grid2 as Grid, Stack } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import { Field, FieldArray, useFormikContext } from 'formik';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import type { Theme } from '../../../../../../../components/Theme';
 import AutocompleteField from '../../../../../../../components/AutocompleteField';
 import Button from '../../../../../../../components/common/button/Button';
@@ -27,7 +28,24 @@ import { FieldOption, fieldSpacingContainerStyle } from '../../../../../../../ut
 import { isEmptyField } from '../../../../../../../utils/utils';
 import PlaybookActionValueField from './PlaybookActionValueField';
 import { attributesMultiple, PlaybookUpdateAction, PlaybookUpdateActionsForm } from './playbookAction-types';
-import useActionFieldOptions from './useActionFieldOptions';
+import useActionFieldOptions, { CustomFieldOption } from './useActionFieldOptions';
+import type { PlaybookFlowFieldActionsCustomFieldDefinitionsQuery } from './__generated__/PlaybookFlowFieldActionsCustomFieldDefinitionsQuery.graphql';
+
+const customFieldDefinitionsQuery = graphql`
+  query PlaybookFlowFieldActionsCustomFieldDefinitionsQuery {
+    customFieldDefinitions(first: 200) {
+      edges {
+        node {
+          id
+          name
+          label
+          field_type
+          select_options
+        }
+      }
+    }
+  }
+`;
 
 interface PlaybookFlowFieldActionsProps {
   operations?: string[];
@@ -43,7 +61,22 @@ const PlaybookFlowFieldActions = ({
     value: op,
   }));
 
-  const getActionFieldOptions = useActionFieldOptions();
+  // Load all custom field definitions to inject them into the Field dropdown
+  const customFieldData = useLazyLoadQuery<PlaybookFlowFieldActionsCustomFieldDefinitionsQuery>(
+    customFieldDefinitionsQuery,
+    {},
+    { fetchPolicy: 'store-or-network' },
+  );
+  const customFieldOptions: CustomFieldOption[] = (
+    customFieldData?.customFieldDefinitions?.edges ?? []
+  ).map(({ node }) => ({
+    label: node.label,
+    value: `x_opencti_cf_${node.name}`,
+    field_type: node.field_type as CustomFieldOption['field_type'],
+    select_options: (node.select_options ?? []) as string[],
+  }));
+
+  const getActionFieldOptions = useActionFieldOptions(customFieldOptions);
   const { values, setFieldValue } = useFormikContext<PlaybookUpdateActionsForm>();
   const actions = values.actions ?? [];
   const formActionsValues = values.actionsFormValues ?? [];
@@ -159,6 +192,7 @@ const PlaybookFlowFieldActions = ({
                       <PlaybookActionValueField
                         action={action}
                         index={i}
+                        customFieldOptions={customFieldOptions}
                       />
                     </Grid>
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/useActionFieldOptions.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/playbookFlowFieldsActions/useActionFieldOptions.ts
@@ -17,7 +17,12 @@ import { useFormatter } from '../../../../../../../components/i18n';
 import { FieldOption } from '../../../../../../../utils/field';
 import { PlaybookUpdateAction } from './playbookAction-types';
 
-const useActionFieldOptions = () => {
+export interface CustomFieldOption extends FieldOption {
+  field_type: 'string' | 'integer' | 'select';
+  select_options?: string[];
+}
+
+const useActionFieldOptions = (customFieldOptions: CustomFieldOption[] = []) => {
   const { t_i18n } = useFormatter();
 
   return (action: PlaybookUpdateAction) => {
@@ -48,6 +53,7 @@ const useActionFieldOptions = () => {
         { label: t_i18n('Platforms'), value: 'x_mitre_platforms' },
         { label: t_i18n('Detection'), value: 'x_opencti_detection' },
         { label: t_i18n('Status'), value: 'x_opencti_workflow_id' },
+        ...customFieldOptions,
       ];
     } else if (action.op === 'remove') {
       fieldOptions = [

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -13,9 +13,11 @@ import Tooltip from '@mui/material/Tooltip';
 import InputAdornment from '@mui/material/InputAdornment';
 import { InformationOutline } from 'mdi-material-ui';
 import React, { useState } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import { StixCyberObservablesLinesAttributesQuery$data } from '@components/observations/stix_cyber_observables/__generated__/StixCyberObservablesLinesAttributesQuery.graphql';
 import WidgetColumnsCustomizationInput from '@components/widgets/WidgetColumnsCustomizationInput';
 import { getDefaultWidgetColumns, getWidgetColumns } from '@components/widgets/WidgetListsDefaultColumns';
+import { WidgetCreationParametersCustomFieldDefinitionsQuery } from '@components/widgets/__generated__/WidgetCreationParametersCustomFieldDefinitionsQuery.graphql';
 import { useWidgetConfigContext } from '@components/widgets/WidgetConfigContext';
 import useWidgetConfigValidateForm from '@components/widgets/useWidgetConfigValidateForm';
 import WidgetAttributesInputContainer, { widgetAttributesInputInstanceQuery } from '@components/widgets/WidgetAttributesInputContainer';
@@ -36,8 +38,32 @@ import type { WidgetVisualizationTypes } from '../../../utils/widget/widgetUtils
 import Grid from '@mui/material/Grid2';
 import { Box, Typography } from '@mui/material';
 
+const widgetCreationParametersCustomFieldDefinitionsQuery = graphql`
+  query WidgetCreationParametersCustomFieldDefinitionsQuery {
+    customFieldDefinitions(first: 200) {
+      edges {
+        node {
+          id
+          name
+          label
+          field_type
+          entity_types
+        }
+      }
+    }
+  }
+`;
+
 const WidgetCreationParameters = () => {
   const { metricsDefinition } = useAttributes();
+
+  // Load all custom field definitions to inject them into the available widget columns
+  const customFieldDefsData = useLazyLoadQuery<WidgetCreationParametersCustomFieldDefinitionsQuery>(
+    widgetCreationParametersCustomFieldDefinitionsQuery,
+    {},
+    { fetchPolicy: 'store-or-network' },
+  );
+  const allCustomFieldDefs = customFieldDefsData?.customFieldDefinitions?.edges?.map((e) => e.node) ?? [];
 
   const { t_i18n } = useFormatter();
   const {
@@ -906,10 +932,23 @@ const WidgetCreationParameters = () => {
 
               const defaultWidgetColumnsByType = getDefaultWidgetColumns(perspective, host);
 
+              // Build custom field columns for this entity type
+              const customFieldColumns: WidgetColumn[] = entityType
+                ? allCustomFieldDefs
+                  .filter((def) => def.entity_types?.includes(entityType))
+                  .map((def) => ({
+                    attribute: `x_opencti_cf_${def.name}`,
+                    label: def.label,
+                  }))
+                : [];
+
               return (
                 <WidgetColumnsCustomizationInput
                   key={index}
-                  availableColumns={getWidgetColumns(perspective, entityType || undefined, metricsDefinition || undefined)}
+                  availableColumns={[
+                    ...getWidgetColumns(perspective, entityType || undefined, metricsDefinition || undefined),
+                    ...customFieldColumns,
+                  ]}
                   defaultColumns={defaultWidgetColumnsByType}
                   value={[...(columns ?? defaultWidgetColumnsByType)]}
                   onChange={(newColumns) => setColumns(index, newColumns)}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9803,6 +9803,8 @@ type Query {
   redisStreamInfo: RedisStreamInfo
   retentionRule(id: String!): RetentionRule
   retentionRules(first: Int, after: ID, search: String, orderBy: RetentionRuleOrdering, orderMode: OrderingMode): RetentionRuleConnection
+  customFieldDefinition(id: String!): CustomFieldDefinition
+  customFieldDefinitions(first: Int, after: ID, orderBy: CustomFieldDefinitionsOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): CustomFieldDefinitionConnection
 }
 
 type Subscription {
@@ -10769,6 +10771,11 @@ type Mutation {
   retentionRuleAdd(input: RetentionRuleAddInput!): RetentionRule!
   retentionRuleCheck(input: RetentionRuleAddInput): Int!
   retentionRuleEdit(id: ID!): RetentionRuleEditMutations
+  customFieldDefinitionAdd(input: CustomFieldDefinitionAddInput!): CustomFieldDefinition
+  customFieldDefinitionDelete(id: ID!): ID
+  customFieldDefinitionFieldPatch(id: ID!, input: [EditInput!]!): CustomFieldDefinition
+  customFieldDefinitionAddEntityType(id: ID!, entityType: String!): CustomFieldDefinition
+  customFieldDefinitionRemoveEntityType(id: ID!, entityType: String!): CustomFieldDefinition
 }
 
 enum WorkflowExecutionStatus {
@@ -12594,6 +12601,7 @@ type CaseIncident implements BasicObject & StixObject & StixCoreObject & StixDom
   response_types: [String!]
   severity: String
   priority: String
+  customFieldValues: [CustomFieldValue]
 }
 
 enum CaseIncidentsOrdering {
@@ -16760,4 +16768,67 @@ type RetentionRuleEdge {
 type RetentionRuleEditMutations {
   delete: ID
   fieldPatch(input: [EditInput]!): RetentionRule
+}
+
+type CustomFieldValue {
+  field_id: ID!
+  field_name: String!
+  int_value: Int
+  string_value: String
+  select_value: String
+}
+
+type CustomFieldDefinition implements InternalObject & BasicObject {
+  id: ID!
+  standard_id: String!
+  entity_type: String!
+  parent_types: [String!]!
+  metrics: [Metric]
+  created: DateTime
+  modified: DateTime
+  name: String!
+  label: String!
+  field_type: String!
+  entity_types: [String!]
+  mandatory: Boolean!
+  description: String
+  default_value: String
+  min_value: Int
+  max_value: Int
+  select_options: [String!]
+}
+
+enum CustomFieldDefinitionsOrdering {
+  name
+  label
+  field_type
+  created
+  _score
+}
+
+type CustomFieldDefinitionConnection {
+  pageInfo: PageInfo!
+  edges: [CustomFieldDefinitionEdge!]!
+}
+
+type CustomFieldDefinitionEdge {
+  cursor: String!
+  node: CustomFieldDefinition!
+}
+
+input CustomFieldDefinitionAddInput {
+  "*Constraints:*\n* Minimal length: `2`\n* Must match format: `not-blank`\n"
+  name: String!
+
+  "*Constraints:*\n* Minimal length: `2`\n* Must match format: `not-blank`\n"
+  label: String!
+  field_type: String!
+  entity_types: [String!]
+  mandatory: Boolean!
+  description: String
+  created: DateTime
+  default_value: String
+  min_value: Int
+  max_value: Int
+  select_options: [String!]
 }

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -453,6 +453,24 @@ export const filterValue = (
   if (filterKey === 'regardingOf' || filterKey === 'dynamicRegardingOf' || filterKey === 'dynamic' || filterKey === 'dynamicFrom' || filterKey === 'dynamicTo') {
     return JSON.stringify(value);
   }
+  if (filterKey === 'customFieldValue') {
+    // Encoded format: "x_opencti_cf_gravity|select_value|G1" → "gravity = G1"
+    if (value && typeof value === 'string' && value.includes('|')) {
+      const parts = (value as string).split('|');
+      const fieldDisplay = (parts[0] ?? '').replace(/^x_opencti_cf_/, '').replace(/^x_opencti_/, '');
+      const fieldValue = parts[2] ?? '';
+      return fieldValue ? `${fieldDisplay} = ${fieldValue}` : fieldDisplay;
+    }
+    // Legacy object format (backward compat)
+    if (value && typeof value === 'object' && 'key' in value && 'values' in value) {
+      const subFilter = value as { key: string; values: string[] };
+      if (subFilter.key === 'field_name') {
+        return (subFilter.values[0] ?? '').replace(/^x_opencti_/, '');
+      }
+      return subFilter.values[0] ?? '';
+    }
+    return String(value ?? '');
+  }
   if (
     value
     && (filterType === 'boolean' || filterType === 'enum')
@@ -842,6 +860,9 @@ export const useAvailableFilterKeysForEntityTypes = (
 };
 
 const isFilterKeyAvailable = (key: string, availableFilterKeys: string[]) => {
+  // Dynamic custom field keys are always valid — they are registered at runtime
+  // and may not be present in the filterKeysSchema cached at login time
+  if (key.startsWith('x_opencti_cf_')) return true;
   const completedAvailableFilterKeys = availableFilterKeys.concat(NOT_CLEANABLE_FILTER_KEYS);
   return completedAvailableFilterKeys.includes(key);
 };

--- a/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/useSearchEntities.tsx
@@ -44,6 +44,27 @@ import useGranted, { SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '..
 import { displayEntityTypeForTranslation } from '../String';
 import { useSearchEntitiesGroupsQuery$data } from './__generated__/useSearchEntitiesGroupsQuery.graphql';
 
+// ---------------------------------------------------------------------------
+// GraphQL query for custom field definitions (select-type options for filter dropdown)
+// ---------------------------------------------------------------------------
+const customFieldDefinitionsSearchQuery = graphql`
+  query useSearchEntitiesCustomFieldDefinitionsQuery {
+    customFieldDefinitions(first: 100) {
+      edges {
+        node {
+          id
+          name
+          label
+          field_type
+          select_options
+        }
+      }
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+
 const filtersStixCoreObjectsSearchQuery = graphql`
   query useSearchEntitiesStixCoreObjectsSearchQuery(
     $search: String
@@ -284,7 +305,7 @@ const useSearchEntities = ({
     value: { key: string; values: string[]; operator?: string }[],
   ) => void;
 }) => {
-  const [entities, setEntities] = useState<Record<string, EntityValue[]>>({});
+  const [entities, setEntities] = useState<Record<string, EntityValue>>({});
   const { t_i18n } = useFormatter();
   const { schema, me } = useAuth();
   const { stixCoreObjectTypes } = useAttributes();
@@ -341,6 +362,7 @@ const useSearchEntities = ({
         === index,
     ),
   }));
+
 
   const searchEntities = (
     filterKey: string,
@@ -651,10 +673,32 @@ const useSearchEntities = ({
       'connectedToId', // id of the listened entities in an instance trigger
       'sightedBy', // sighting relationship TODO remove because already in regardingOf, and migrate the key)
       'computed_reliability', // special key for the entity reliability, or the reliability of its author if no reliability is set
+      'customFieldValue', // nested filter for custom fields — options returned as encoded strings "fieldName|subKey|value"
     ].concat(entityTypesFilters)
       .concat(contextFilters);
     // case 1 : filter keys with specific behavior
-    if (keysWithSpecificSearch.includes(filterKey)) {
+    if (filterKey.startsWith('x_opencti_cf_')) {
+      // Dynamic custom field: fetch definitions to build options
+      const searchText: string = event?.target?.value ?? '';
+      fetchQuery(customFieldDefinitionsSearchQuery, {})
+        .toPromise()
+        .then((data: unknown) => {
+          const edges = (data as any)?.customFieldDefinitions?.edges ?? [];
+          const def = edges.map((e: any) => e?.node).find((d: any) => d && `x_opencti_cf_${d.name}` === filterKey);
+          if (!def) return;
+          const options: EntityValue[] = [];
+          if (def.field_type === 'select' && def.select_options?.length) {
+            def.select_options.forEach((opt: string) => {
+              if (!searchText || opt.toLowerCase().includes(searchText.toLowerCase())) {
+                options.push({ label: opt, value: opt, type: 'CustomFieldValue' });
+              }
+            });
+          } else if (searchText) {
+            options.push({ label: searchText, value: searchText, type: 'CustomFieldValue' });
+          }
+          unionSetEntities(filterKey, options);
+        });
+    } else if (keysWithSpecificSearch.includes(filterKey)) {
       switch (filterKey) {
         case 'objectAssignee':
           if (!cacheEntities[filterKey]) {
@@ -767,6 +811,54 @@ const useSearchEntities = ({
         case 'computed_reliability':
           buildOptionsFromVocabularySearchQuery(filterKey, ['reliability_ov']);
           break;
+        case 'customFieldValue': {
+          // Fetch all custom field definitions and build options:
+          // - select fields: one option per select_option value
+          // - integer/string fields: one option per field (user types the value in the search box)
+          const searchText: string = event?.target?.value ?? '';
+          fetchQuery(customFieldDefinitionsSearchQuery, {})
+            .toPromise()
+            .then((data: unknown) => {
+              const edges = (data as any)?.customFieldDefinitions?.edges ?? [];
+              const options: EntityValue[] = [];
+              edges.forEach((edge: any) => {
+                const def = edge?.node;
+                if (!def) return;
+                const fieldLabel: string = def.label ?? def.name;
+                const flatKey = `x_opencti_cf_${def.name}`;
+
+                if (def.field_type === 'select' && def.select_options?.length) {
+                  // Enumerate all select options
+                  def.select_options.forEach((opt: string) => {
+                    if (!searchText || opt.toLowerCase().includes(searchText.toLowerCase()) || fieldLabel.toLowerCase().includes(searchText.toLowerCase())) {
+                      options.push({
+                        label: `${fieldLabel} = ${opt}`,
+                        value: `${flatKey}|select_value|${opt}`,
+                        type: 'CustomFieldValue',
+                      });
+                    }
+                  });
+                } else if ((def.field_type === 'integer' || def.field_type === 'string') && searchText) {
+                  // Dynamic option built from what the user typed
+                  const subKey = def.field_type === 'integer' ? 'int_value' : 'string_value';
+                  options.push({
+                    label: `${fieldLabel} = ${searchText}`,
+                    value: `${flatKey}|${subKey}|${searchText}`,
+                    type: 'CustomFieldValue',
+                  });
+                } else if ((def.field_type === 'integer' || def.field_type === 'string') && !searchText) {
+                  // Show a placeholder so the field is visible — user needs to type a value
+                  options.push({
+                    label: `${fieldLabel} (type a value…)`,
+                    value: `${flatKey}|${def.field_type === 'integer' ? 'int_value' : 'string_value'}|`,
+                    type: 'CustomFieldValue',
+                  });
+                }
+              });
+              unionSetEntities(filterKey, options);
+            });
+          break;
+        }
         case 'contextObjectLabel':
           buildOptionsFromLabelsSearchQuery(filterKey);
           break;

--- a/opencti-platform/opencti-graphql/src/database/data-changes.ts
+++ b/opencti-platform/opencti-graphql/src/database/data-changes.ts
@@ -81,12 +81,39 @@ export const generateRestoreMessage = (instance: any) => {
   return generateCreateDeleteMessage('restore', instance);
 };
 
+/**
+ * Build a minimal synthetic AttributeDefinition for an unregistered x_opencti_cf_* key.
+ * Used as a fallback when the attribute has not been registered at runtime
+ * (e.g. after a server restart before registerDynamicAttribute is called).
+ */
+const syntheticCfAttrDef = (key: string): AttributeDefinition => {
+  // Try the runtime-registered definition first (has the proper human label).
+  const registered = (schemaAttributesDefinition as any).allAttributes?.get(key);
+  if (registered) return registered as AttributeDefinition;
+  // Fallback: derive a human-readable label from the key name.
+  const label = key.replace(/^x_opencti_cf_/, '').replace(/_/g, ' ');
+  return {
+    name: key,
+    label,
+    type: 'string',
+    format: 'short',
+    multiple: false,
+    mandatoryType: 'no',
+    upsert: true,
+    isFilterable: true,
+    editDefault: false,
+  } as any;
+};
+
 const resolveAttribute = (field: string) => {
   const fieldSplit = field.split('--');
   const key = fieldSplit[1];
   const entityType = fieldSplit[0];
   const attributeDefinition = schemaAttributesDefinition.getAttribute(entityType, key);
   const relationsRefDefinition = schemaRelationsRefDefinition.getRelationRef(entityType, key);
+  if (!attributeDefinition && !relationsRefDefinition && key?.startsWith('x_opencti_cf_')) {
+    return syntheticCfAttrDef(key);
+  }
   return attributeDefinition || relationsRefDefinition;
 };
 
@@ -168,7 +195,9 @@ export const generateMessageFromChanges = (resolvedMap: Record<string, string>,
     const entityType = fieldSplit[0];
     const attributeDefinition = schemaAttributesDefinition.getAttribute(entityType, key);
     const relationsRefDefinition = schemaRelationsRefDefinition.getRelationRef(entityType, key);
-    const attribute = attributeDefinition || relationsRefDefinition;
+    // Fall back to synthetic definition for unregistered custom fields
+    const attribute = attributeDefinition || relationsRefDefinition
+      || (key?.startsWith('x_opencti_cf_') ? syntheticCfAttrDef(key) : null);
     const convertChange = (vals?: string[], noValueToEmpty = false): string => {
       const isTooMuch = vals && vals.length > 3;
       const values = isTooMuch ? vals.slice(0, 3) : (vals ?? []);
@@ -300,6 +329,8 @@ export const buildChanges = async (context: AuthContext, user: AuthUser,
     const { key: field, previous: prevValues, value } = input;
     const ref = schemaRelationsRefDefinition.getRelationRef(entityType, field);
     if (ref) return []; // Ref are already available, no need to extra resolved them.
+    // Custom fields: scalar values, nothing to pre-resolve (no IDs).
+    if (field.startsWith('x_opencti_cf_')) return [];
     const attr = schemaAttributesDefinition.getAttribute(entityType, field);
     if (!attr) throw UnsupportedError('Cant resolve attribute', { entityType, field });
     const prev = Array.isArray(prevValues) ? prevValues : [prevValues];
@@ -317,6 +348,20 @@ export const buildChanges = async (context: AuthContext, user: AuthUser,
     if (!field) {
       continue;
     }
+    // ----- Custom fields (x_opencti_cf_*): generate history entry directly -----
+    if (field.startsWith('x_opencti_cf_')) {
+      const cfAttr = syntheticCfAttrDef(field);
+      const prevArr = Array.isArray(prevValues) ? prevValues : [prevValues];
+      const valArr = Array.isArray(value) ? value : [value];
+      const toChangeValue = (v: any): ChangeValue => ({ raw: v !== null && v !== undefined ? String(v) : '' });
+      changes.push({
+        field: entityType + '--' + field,
+        changes_removed: prevArr.filter((v) => v !== null && v !== undefined).map(toChangeValue),
+        changes_added: valArr.filter((v) => v !== null && v !== undefined).map(toChangeValue),
+      });
+      continue;
+    }
+    // ----- Standard attributes -----
     const attributeDefinition = schemaAttributesDefinition.getAttribute(entityType, field);
     const relationsRefDefinition = schemaRelationsRefDefinition.getRelationRef(entityType, field);
     const attribute = attributeDefinition || relationsRefDefinition;

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -1508,8 +1508,34 @@ const elCreateIndexTemplate = async (index: string, mappingProperties: Record<st
 };
 const sortMappingsKeys = (o: Record<string, any>): Record<string, any> => (Object(o) !== o || Array.isArray(o) ? o
   : Object.keys(o).sort().reduce((a, k) => ({ ...a, [k]: sortMappingsKeys(o[k]) }), {}));
+/**
+ * Dynamically adds a flat field mapping to all platform indices.
+ * Used when a CustomFieldDefinition is created to allow storing x_opencti_cf_<name> flat in ES
+ * without restarting the platform (ES dynamic: strict would reject unknown fields otherwise).
+ */
+export const elAddDynamicFieldMapping = async (fieldName: string, esType: 'keyword' | 'long' | 'text'): Promise<void> => {
+  const indices = await elPlatformIndices();
+  for (let i = 0; i < indices.length; i += 1) {
+    const { index } = indices[i];
+    const body = { properties: { [fieldName]: { type: esType } } };
+    const args = { index, body };
+    if (engine instanceof ElkClient) {
+      await engine.indices.putMapping(args).catch((e: any) => {
+        if (e?.meta?.body?.error?.type !== 'illegal_argument_exception') {
+          throw DatabaseError('Adding dynamic field mapping fail', { index, fieldName, cause: e });
+        }
+      });
+    } else {
+      await engine.indices.putMapping(args).catch((e: any) => {
+        if (e?.meta?.body?.error?.type !== 'illegal_argument_exception') {
+          throw DatabaseError('Adding dynamic field mapping fail', { index, fieldName, cause: e });
+        }
+      });
+    }
+  }
+};
+
 export const elUpdateIndicesMappings = async (): Promise<void> => {
-  // Update core settings
   await updateCoreSettings();
   // Reset the templates
   const mappingProperties = engineMappingGenerator();
@@ -2352,6 +2378,8 @@ export const elGenerateFieldTextSearchShould = (
   return shouldSearch;
 };
 const buildFieldForQuery = (field: string) => {
+  // Dynamic custom field attributes are mapped as plain `keyword` or `long` — no .keyword sub-field
+  if (field.startsWith('x_opencti_cf_')) return field;
   return isDateNumericOrBooleanAttribute(field) || field === '_id' || isObjectFlatAttribute(field)
     ? field
     : `${field}.keyword`;
@@ -2426,9 +2454,10 @@ export const buildLocalMustFilter = (validFilter: any) => {
                 },
               });
             } else if (RANGE_OPERATORS.includes(nestedOperator)) {
+              const rangeValue = nestedSearchValue;
               nestedShould.push({
                 range: {
-                  [nestedFieldKey]: { [nestedOperator]: nestedSearchValue },
+                  [nestedFieldKey]: { [nestedOperator]: rangeValue },
                 },
               });
             } else { // nestedOperator = 'eq'
@@ -2628,12 +2657,18 @@ export const buildLocalMustFilter = (validFilter: any) => {
             }
           } else if (operator === 'eq' || operator === 'not_eq') {
             const targets = operator === 'eq' ? valuesFiltering : noValuesFiltering;
-            targets.push({
-              multi_match: {
-                fields: arrayKeys.map((k) => buildFieldForQuery(k)),
-                query: values[i].toString(),
-              },
-            });
+            const fieldKeys = arrayKeys.map((k) => buildFieldForQuery(k));
+            // Dynamic custom fields are plain keyword/long fields — use term query for exact match
+            if (fieldKeys.length === 1 && fieldKeys[0].startsWith('x_opencti_cf_')) {
+              targets.push({ term: { [fieldKeys[0]]: values[i].toString() } });
+            } else {
+              targets.push({
+                multi_match: {
+                  fields: fieldKeys,
+                  query: values[i].toString(),
+                },
+              });
+            }
           } else if (operator === 'only_eq_to' || operator === 'not_only_eq_to') {
             const targets = operator === 'only_eq_to' ? valuesFiltering : noValuesFiltering;
             targets.push({

--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -1963,6 +1963,10 @@ const checkAttributeConsistency = (entityType: string, key: string) => {
   if (key.startsWith(RULE_PREFIX)) {
     return;
   }
+  // Dynamic custom field attributes bypass schema consistency check
+  if (key.startsWith('x_opencti_cf_')) {
+    return;
+  }
   // Always ok for creator_id, need a stronger schema definition
   // Waiting for merge of https://github.com/OpenCTI-Platform/opencti/issues/1850
   if (key === 'creator_id') {
@@ -1993,7 +1997,21 @@ const prepareAttributesForUpdate = async (
   const platformStatuses = await getEntitiesListFromCache<BasicWorkflowStatus>(context, user, ENTITY_TYPE_STATUS);
   return elements.map((input) => {
     // Dynamic cases, attributes not defined in the schema
-    if (input.key.startsWith(RULE_PREFIX) || input.key.startsWith(REL_INDEX_PREFIX)) {
+    if (input.key.startsWith(RULE_PREFIX) || input.key.startsWith(REL_INDEX_PREFIX) || input.key.startsWith('x_opencti_cf_')) {
+      // Coerce string values to number for numeric custom fields (x_opencti_cf_*)
+      // Values from upsert_operations arrive as strings ([String] GraphQL type) but ES expects a number.
+      // This avoids false-positive ES updates on each playbook run when the value is already set.
+      const dynamicDef = schemaAttributesDefinition.getAttributeByName(input.key);
+      if (dynamicDef?.type === 'numeric' && Array.isArray(input.value)) {
+        return {
+          ...input,
+          value: input.value.map((v) => {
+            if (v === null || v === undefined || v === '') return null;
+            const n = Number(v);
+            return Number.isNaN(n) ? v : n;
+          }),
+        };
+      }
       return input;
     }
     // Fixed cases in schema definition

--- a/opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts
@@ -59,7 +59,7 @@ import {
   isStixDomainObjectLocation,
   isStixDomainObjectThreatActor,
 } from '../schema/stixDomainObject';
-import { assertType, checkInstanceCompletion, cleanObject, convertObjectReferences, convertToStixDate, isValidStix } from './stix-converter-utils';
+import { assertType, checkInstanceCompletion, cleanObject, convertObjectReferences, convertToStixDate, extractCustomFields, isValidStix } from './stix-converter-utils';
 import { ENTITY_HASHED_OBSERVABLE_STIX_FILE } from '../schema/stixCyberObservable';
 import {
   ENTITY_AUTONOMOUS_SYSTEM,
@@ -193,10 +193,12 @@ const buildExternalReferences = (instance: StoreObject): Array<SMO.StixInternalE
 
 // Builders
 const buildStixObject = (instance: StoreObject): S.StixObject => {
+  const customFields = extractCustomFields(instance as unknown as Record<string, any>);
   return {
     id: buildStixId(instance.entity_type, instance.standard_id),
     type: convertTypeToStix2Type(instance.entity_type),
     spec_version: '2.0',
+    ...customFields,
     // extensions
     x_opencti_id: instance.id,
     x_opencti_type: instance.entity_type,

--- a/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
@@ -124,7 +124,7 @@ import { isRelationBuiltin, STIX_SPEC_VERSION } from './stix';
 import { isInternalRelationship, isStoreRelationPir, RELATION_IN_PIR } from '../schema/internalRelationship';
 import { isInternalObject } from '../schema/internalObject';
 import { isInternalId, isStixId } from '../schema/schemaUtils';
-import { assertType, cleanObject, convertObjectReferences, convertToStixDate, isValidStix } from './stix-converter-utils';
+import { assertType, cleanObject, convertObjectReferences, convertToStixDate, extractCustomFields, isValidStix } from './stix-converter-utils';
 import { type StoreRelationPir } from '../modules/pir/pir-types';
 import { pushAll } from '../utils/arrayUtil';
 
@@ -207,7 +207,7 @@ export const buildOCTIExtensions = (instance: StoreObject): S.StixOpenctiExtensi
     pir_information: instance.pir_information ?? [],
     metrics: instance.metrics ?? [],
   };
-  return cleanObject(octiExtensions);
+  return cleanObject({ ...octiExtensions, ...extractCustomFields(instance as unknown as Record<string, any>) } as S.StixOpenctiExtension);
 };
 export const buildMITREExtensions = (instance: StoreEntity): S.StixMitreExtension => {
   const mitreExtensions: S.StixMitreExtension = {

--- a/opencti-platform/opencti-graphql/src/database/stix-converter-utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-converter-utils.ts
@@ -63,3 +63,14 @@ export const checkInstanceCompletion = (instance: StoreRelation) => {
     throw UnsupportedError(`Cannot convert relation without a resolved to: ${instance.toId}`);
   }
 };
+
+export const extractCustomFields = (instance: Record<string, any>): Record<string, any> => {
+  const result: Record<string, any> = {};
+  for (const key of Object.keys(instance)) {
+    if (key.startsWith('x_opencti_cf_') && instance[key] !== null && instance[key] !== undefined) {
+      result[key] = instance[key];
+    }
+  }
+  return result;
+};
+

--- a/opencti-platform/opencti-graphql/src/domain/filterKeysSchema.ts
+++ b/opencti-platform/opencti-graphql/src/domain/filterKeysSchema.ts
@@ -13,6 +13,9 @@ import type {
 } from '../schema/attribute-definition';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { isStixCoreObject } from '../schema/stixCoreObject';
+import { fullEntitiesList } from '../database/middleware-loader';
+import type { BasicStoreEntityCustomFieldDefinition } from '../modules/customField/custom-field-types';
+import { ENTITY_TYPE_CUSTOM_FIELD_DEFINITION } from '../modules/customField/custom-field-types';
 import {
   ALIAS_FILTER,
   COMPUTED_RELIABILITY_FILTER,
@@ -23,6 +26,7 @@ import {
   CONTEXT_ENTITY_TYPE_FILTER,
   CONTEXT_OBJECT_LABEL_FILTER,
   CONTEXT_OBJECT_MARKING_FILTER,
+  CUSTOM_FIELD_VALUE_FILTER,
   INSTANCE_DYNAMIC_REGARDING_OF,
   INSTANCE_REGARDING_OF,
   IS_INFERRED_FILTER,
@@ -338,6 +342,17 @@ const completeFilterDefinitionMapWithSpecialKeys = (
       subEntityTypes,
       elementsForFilterValuesSearch: [],
     });
+    // custom field values filter — type 'id' restricts operators to eq/not_eq/nil/not_nil
+    // Text operators (starts_with, contains…) are not supported because values must be
+    // encoded strings in the format "x_opencti_cf_<name>|subKey|value"
+    filterDefinitionsMap.set(CUSTOM_FIELD_VALUE_FILTER, {
+      filterKey: CUSTOM_FIELD_VALUE_FILTER,
+      type: 'id',
+      label: 'Custom field value',
+      multiple: true,
+      subEntityTypes,
+      elementsForFilterValuesSearch: [],
+    });
   }
   if (type === ENTITY_TYPE_HISTORY || type === ENTITY_TYPE_ACTIVITY) {
     // add context filters
@@ -522,7 +537,50 @@ export const generateFilterKeysSchema = async () => {
     handleRemoveSpecialKeysFromFilterDefinitionsMap(filterDefinitionsMap, type, isNotEnterpriseEdition);
     filterKeysSchema.set(type, filterDefinitionsMap);
   });
-  // B. add special types
+  // B. Inject custom field definitions as direct filter keys for their applicable entity types
+  try {
+    const customFieldDefs = await fullEntitiesList<BasicStoreEntityCustomFieldDefinition>(
+      context,
+      SYSTEM_USER,
+      [ENTITY_TYPE_CUSTOM_FIELD_DEFINITION],
+    );
+    customFieldDefs.forEach((def) => {
+      const flatKey = `x_opencti_cf_${def.name}`;
+      const filterType = def.field_type === 'integer' ? 'integer' : def.field_type === 'select' ? 'enum' : 'string';
+      const filterDefinition: FilterDefinition = {
+        filterKey: flatKey,
+        type: filterType,
+        label: def.label ?? def.name,
+        multiple: false,
+        subEntityTypes: def.entity_types ?? [],
+        elementsForFilterValuesSearch: def.field_type === 'select' ? (def.select_options ?? []) : [],
+      };
+      // Add to every applicable entity type (and their parents)
+      const applicableTypes = def.entity_types ?? [];
+      applicableTypes.forEach((entityType) => {
+        const typeMap = filterKeysSchema.get(entityType);
+        if (typeMap) {
+          typeMap.set(flatKey, filterDefinition);
+        }
+        // Also add to parent abstract types so the filter appears for all subtypes
+        const parentTypes = ['Stix-Domain-Object', 'Stix-Core-Object', 'Basic-Object'];
+        parentTypes.forEach((parent) => {
+          const parentMap = filterKeysSchema.get(parent);
+          if (parentMap) {
+            const existing = parentMap.get(flatKey);
+            if (!existing) {
+              parentMap.set(flatKey, { ...filterDefinition, subEntityTypes: [entityType] });
+            } else {
+              parentMap.set(flatKey, { ...existing, subEntityTypes: uniq([...existing.subEntityTypes, entityType]) });
+            }
+          }
+        });
+      });
+    });
+  } catch {
+    // If custom field definitions are not available (e.g. cold boot), skip silently
+  }
+  // C. add special types
   // connectedToId special key (for instance triggers)
   filterKeysSchema.set('Instance', new Map([[CONNECTED_TO_INSTANCE_FILTER, {
     filterKey: CONNECTED_TO_INSTANCE_FILTER,

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -2814,6 +2814,7 @@ export type CaseIncident = BasicObject & Case & Container & StixCoreObject & Sti
   created_at: Scalars['DateTime']['output'];
   creators?: Maybe<Array<Creator>>;
   currentUserAccessRight?: Maybe<Scalars['String']['output']>;
+  customFieldValues?: Maybe<Array<Maybe<CustomFieldValue>>>;
   description?: Maybe<Scalars['String']['output']>;
   draftVersion?: Maybe<DraftVersion>;
   editContext?: Maybe<Array<EditUserContext>>;
@@ -6436,6 +6437,70 @@ export type CsvMapperTestResult = {
 export type CurrentConnectorStatusInput = {
   id: Scalars['ID']['input'];
   status: ConnectorCurrentStatus;
+};
+
+export type CustomFieldDefinition = BasicObject & InternalObject & {
+  __typename?: 'CustomFieldDefinition';
+  created?: Maybe<Scalars['DateTime']['output']>;
+  default_value?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  entity_type: Scalars['String']['output'];
+  entity_types?: Maybe<Array<Scalars['String']['output']>>;
+  field_type: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  label: Scalars['String']['output'];
+  mandatory: Scalars['Boolean']['output'];
+  max_value?: Maybe<Scalars['Int']['output']>;
+  metrics?: Maybe<Array<Maybe<Metric>>>;
+  min_value?: Maybe<Scalars['Int']['output']>;
+  modified?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  parent_types: Array<Scalars['String']['output']>;
+  select_options?: Maybe<Array<Scalars['String']['output']>>;
+  standard_id: Scalars['String']['output'];
+};
+
+export type CustomFieldDefinitionAddInput = {
+  created?: InputMaybe<Scalars['DateTime']['input']>;
+  default_value?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  entity_types?: InputMaybe<Array<Scalars['String']['input']>>;
+  field_type: Scalars['String']['input'];
+  label: Scalars['String']['input'];
+  mandatory: Scalars['Boolean']['input'];
+  max_value?: InputMaybe<Scalars['Int']['input']>;
+  min_value?: InputMaybe<Scalars['Int']['input']>;
+  name: Scalars['String']['input'];
+  select_options?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+export type CustomFieldDefinitionConnection = {
+  __typename?: 'CustomFieldDefinitionConnection';
+  edges: Array<CustomFieldDefinitionEdge>;
+  pageInfo: PageInfo;
+};
+
+export type CustomFieldDefinitionEdge = {
+  __typename?: 'CustomFieldDefinitionEdge';
+  cursor: Scalars['String']['output'];
+  node: CustomFieldDefinition;
+};
+
+export enum CustomFieldDefinitionsOrdering {
+  Score = '_score',
+  Created = 'created',
+  FieldType = 'field_type',
+  Label = 'label',
+  Name = 'name'
+}
+
+export type CustomFieldValue = {
+  __typename?: 'CustomFieldValue';
+  field_id: Scalars['ID']['output'];
+  field_name: Scalars['String']['output'];
+  int_value?: Maybe<Scalars['Int']['output']>;
+  select_value?: Maybe<Scalars['String']['output']>;
+  string_value?: Maybe<Scalars['String']['output']>;
 };
 
 export type CustomView = BasicObject & InternalObject & {
@@ -17031,6 +17096,11 @@ export type Mutation = {
   csvMapperDelete?: Maybe<Scalars['ID']['output']>;
   csvMapperFieldPatch?: Maybe<CsvMapper>;
   csvMapperTest?: Maybe<CsvMapperTestResult>;
+  customFieldDefinitionAdd?: Maybe<CustomFieldDefinition>;
+  customFieldDefinitionAddEntityType?: Maybe<CustomFieldDefinition>;
+  customFieldDefinitionDelete?: Maybe<Scalars['ID']['output']>;
+  customFieldDefinitionFieldPatch?: Maybe<CustomFieldDefinition>;
+  customFieldDefinitionRemoveEntityType?: Maybe<CustomFieldDefinition>;
   customViewAdd: CustomView;
   customViewConfigurationImport: CustomView;
   customViewDelete: Scalars['ID']['output'];
@@ -17860,6 +17930,34 @@ export type MutationCsvMapperFieldPatchArgs = {
 export type MutationCsvMapperTestArgs = {
   configuration: Scalars['String']['input'];
   file: Scalars['Upload']['input'];
+};
+
+
+export type MutationCustomFieldDefinitionAddArgs = {
+  input: CustomFieldDefinitionAddInput;
+};
+
+
+export type MutationCustomFieldDefinitionAddEntityTypeArgs = {
+  entityType: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationCustomFieldDefinitionDeleteArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationCustomFieldDefinitionFieldPatchArgs = {
+  id: Scalars['ID']['input'];
+  input: Array<EditInput>;
+};
+
+
+export type MutationCustomFieldDefinitionRemoveEntityTypeArgs = {
+  entityType: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
 };
 
 
@@ -24368,6 +24466,8 @@ export type Query = {
   /** @deprecated [>=6.4 & <6.7]. Use `csvMapperTest mutation`. */
   csvMapperTest?: Maybe<CsvMapperTestResult>;
   csvMappers?: Maybe<CsvMapperConnection>;
+  customFieldDefinition?: Maybe<CustomFieldDefinition>;
+  customFieldDefinitions?: Maybe<CustomFieldDefinitionConnection>;
   customView?: Maybe<CustomView>;
   customViews: CustomViewsConnection;
   customViewsSettings: CustomViewsSettings;
@@ -25173,6 +25273,21 @@ export type QueryCsvMappersArgs = {
   filters?: InputMaybe<FilterGroup>;
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<CsvMapperOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryCustomFieldDefinitionArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryCustomFieldDefinitionsArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<CustomFieldDefinitionsOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
   search?: InputMaybe<Scalars['String']['input']>;
 };
@@ -38836,6 +38951,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( Omit<CryptocurrencyWallet, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( Omit<CryptographicKey, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( BasicStoreEntityCsvMapper )
+    | ( CustomFieldDefinition )
     | ( BasicStoreEntityCustomView )
     | ( BasicStoreEntityDataComponent )
     | ( BasicStoreEntityDataSource )
@@ -38984,6 +39100,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( Omit<Connector, 'configurations' | 'connector_user' | 'works'> & { configurations?: Maybe<Array<_RefType['ConnectorConfiguration']>>, connector_user?: Maybe<_RefType['User']>, works?: Maybe<Array<Maybe<_RefType['Work']>>> } )
     | ( ConnectorManager )
     | ( BasicStoreEntityCsvMapper )
+    | ( CustomFieldDefinition )
     | ( BasicStoreEntityCustomView )
     | ( BasicStoreEntityDecayExclusionRule )
     | ( BasicStoreEntityDecayRule )
@@ -39520,6 +39637,12 @@ export type ResolversTypes = ResolversObject<{
   CsvMapperSchemaAttributes: ResolverTypeWrapper<CsvMapperSchemaAttributes>;
   CsvMapperTestResult: ResolverTypeWrapper<CsvMapperTestResult>;
   CurrentConnectorStatusInput: CurrentConnectorStatusInput;
+  CustomFieldDefinition: ResolverTypeWrapper<CustomFieldDefinition>;
+  CustomFieldDefinitionAddInput: CustomFieldDefinitionAddInput;
+  CustomFieldDefinitionConnection: ResolverTypeWrapper<CustomFieldDefinitionConnection>;
+  CustomFieldDefinitionEdge: ResolverTypeWrapper<CustomFieldDefinitionEdge>;
+  CustomFieldDefinitionsOrdering: CustomFieldDefinitionsOrdering;
+  CustomFieldValue: ResolverTypeWrapper<CustomFieldValue>;
   CustomView: ResolverTypeWrapper<BasicStoreEntityCustomView>;
   CustomViewAddInput: CustomViewAddInput;
   CustomViewDuplicateInput: CustomViewDuplicateInput;
@@ -40633,6 +40756,11 @@ export type ResolversParentTypes = ResolversObject<{
   CsvMapperSchemaAttributes: CsvMapperSchemaAttributes;
   CsvMapperTestResult: CsvMapperTestResult;
   CurrentConnectorStatusInput: CurrentConnectorStatusInput;
+  CustomFieldDefinition: CustomFieldDefinition;
+  CustomFieldDefinitionAddInput: CustomFieldDefinitionAddInput;
+  CustomFieldDefinitionConnection: CustomFieldDefinitionConnection;
+  CustomFieldDefinitionEdge: CustomFieldDefinitionEdge;
+  CustomFieldValue: CustomFieldValue;
   CustomView: BasicStoreEntityCustomView;
   CustomViewAddInput: CustomViewAddInput;
   CustomViewDuplicateInput: CustomViewDuplicateInput;
@@ -42143,7 +42271,7 @@ export type BankAccountResolvers<ContextType = any, ParentType extends Resolvers
 }>;
 
 export type BasicObjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['BasicObject'] = ResolversParentTypes['BasicObject']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AuthenticationProvider' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'Capability' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'CaseTemplate' | 'Catalog' | 'Channel' | 'City' | 'Connector' | 'ConnectorManager' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'CsvMapper' | 'CustomView' | 'DataComponent' | 'DataSource' | 'DecayExclusionRule' | 'DecayRule' | 'DeleteOperation' | 'Directory' | 'DisseminationList' | 'DomainName' | 'DraftWorkspace' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'EmailTemplate' | 'EntitySetting' | 'Event' | 'ExclusionList' | 'ExternalReference' | 'Feedback' | 'FintelDesign' | 'FintelTemplate' | 'Form' | 'Group' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IngestionCsv' | 'IngestionJson' | 'IngestionRss' | 'IngestionTaxii' | 'IngestionTaxiiCollection' | 'IntrusionSet' | 'JsonMapper' | 'KillChainPhase' | 'Label' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'ManagedConnector' | 'ManagerConfiguration' | 'MarkingDefinition' | 'MeUser' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'NewsFeedItem' | 'Note' | 'Notification' | 'Notifier' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Pir' | 'Playbook' | 'Position' | 'Process' | 'PublicDashboard' | 'Region' | 'Report' | 'Role' | 'SSHKey' | 'SavedFilter' | 'Sector' | 'SecurityCoverage' | 'SecurityPlatform' | 'Settings' | 'Software' | 'StixFile' | 'SupportPackage' | 'System' | 'Task' | 'TaskTemplate' | 'Text' | 'Theme' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Trigger' | 'Url' | 'User' | 'UserAccount' | 'UserAgent' | 'Vocabulary' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'Workspace' | 'X509Certificate', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AuthenticationProvider' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'Capability' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'CaseTemplate' | 'Catalog' | 'Channel' | 'City' | 'Connector' | 'ConnectorManager' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'CsvMapper' | 'CustomFieldDefinition' | 'CustomView' | 'DataComponent' | 'DataSource' | 'DecayExclusionRule' | 'DecayRule' | 'DeleteOperation' | 'Directory' | 'DisseminationList' | 'DomainName' | 'DraftWorkspace' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'EmailTemplate' | 'EntitySetting' | 'Event' | 'ExclusionList' | 'ExternalReference' | 'Feedback' | 'FintelDesign' | 'FintelTemplate' | 'Form' | 'Group' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IngestionCsv' | 'IngestionJson' | 'IngestionRss' | 'IngestionTaxii' | 'IngestionTaxiiCollection' | 'IntrusionSet' | 'JsonMapper' | 'KillChainPhase' | 'Label' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'ManagedConnector' | 'ManagerConfiguration' | 'MarkingDefinition' | 'MeUser' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'NewsFeedItem' | 'Note' | 'Notification' | 'Notifier' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Pir' | 'Playbook' | 'Position' | 'Process' | 'PublicDashboard' | 'Region' | 'Report' | 'Role' | 'SSHKey' | 'SavedFilter' | 'Sector' | 'SecurityCoverage' | 'SecurityPlatform' | 'Settings' | 'Software' | 'StixFile' | 'SupportPackage' | 'System' | 'Task' | 'TaskTemplate' | 'Text' | 'Theme' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Trigger' | 'Url' | 'User' | 'UserAccount' | 'UserAgent' | 'Vocabulary' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'Workspace' | 'X509Certificate', ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
@@ -42385,6 +42513,7 @@ export type CaseIncidentResolvers<ContextType = any, ParentType extends Resolver
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   creators?: Resolver<Maybe<Array<ResolversTypes['Creator']>>, ParentType, ContextType>;
   currentUserAccessRight?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  customFieldValues?: Resolver<Maybe<Array<Maybe<ResolversTypes['CustomFieldValue']>>>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   draftVersion?: Resolver<Maybe<ResolversTypes['DraftVersion']>, ParentType, ContextType>;
   editContext?: Resolver<Maybe<Array<ResolversTypes['EditUserContext']>>, ParentType, ContextType>;
@@ -43511,6 +43640,45 @@ export type CsvMapperTestResultResolvers<ContextType = any, ParentType extends R
   nbEntities?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   nbRelationships?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   objects?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type CustomFieldDefinitionResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomFieldDefinition'] = ResolversParentTypes['CustomFieldDefinition']> = ResolversObject<{
+  created?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  default_value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  entity_types?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  field_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  mandatory?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  max_value?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
+  min_value?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  parent_types?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  select_options?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type CustomFieldDefinitionConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomFieldDefinitionConnection'] = ResolversParentTypes['CustomFieldDefinitionConnection']> = ResolversObject<{
+  edges?: Resolver<Array<ResolversTypes['CustomFieldDefinitionEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+}>;
+
+export type CustomFieldDefinitionEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomFieldDefinitionEdge'] = ResolversParentTypes['CustomFieldDefinitionEdge']> = ResolversObject<{
+  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<ResolversTypes['CustomFieldDefinition'], ParentType, ContextType>;
+}>;
+
+export type CustomFieldValueResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomFieldValue'] = ResolversParentTypes['CustomFieldValue']> = ResolversObject<{
+  field_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  field_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  int_value?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  select_value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  string_value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type CustomViewResolvers<ContextType = any, ParentType extends ResolversParentTypes['CustomView'] = ResolversParentTypes['CustomView']> = ResolversObject<{
@@ -46049,7 +46217,7 @@ export type IngestionTaxiiEdgeResolvers<ContextType = any, ParentType extends Re
 }>;
 
 export type InternalObjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['InternalObject'] = ResolversParentTypes['InternalObject']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AuthenticationProvider' | 'Capability' | 'CaseTemplate' | 'Catalog' | 'Connector' | 'ConnectorManager' | 'CsvMapper' | 'CustomView' | 'DecayExclusionRule' | 'DecayRule' | 'DeleteOperation' | 'DisseminationList' | 'DraftWorkspace' | 'EmailTemplate' | 'EntitySetting' | 'ExclusionList' | 'FintelDesign' | 'FintelTemplate' | 'Form' | 'Group' | 'IngestionCsv' | 'IngestionJson' | 'IngestionRss' | 'IngestionTaxii' | 'IngestionTaxiiCollection' | 'JsonMapper' | 'ManagedConnector' | 'ManagerConfiguration' | 'MeUser' | 'NewsFeedItem' | 'Notification' | 'Notifier' | 'Pir' | 'Playbook' | 'PublicDashboard' | 'Role' | 'SavedFilter' | 'Settings' | 'SupportPackage' | 'TaskTemplate' | 'Theme' | 'Trigger' | 'User' | 'Workspace', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AuthenticationProvider' | 'Capability' | 'CaseTemplate' | 'Catalog' | 'Connector' | 'ConnectorManager' | 'CsvMapper' | 'CustomFieldDefinition' | 'CustomView' | 'DecayExclusionRule' | 'DecayRule' | 'DeleteOperation' | 'DisseminationList' | 'DraftWorkspace' | 'EmailTemplate' | 'EntitySetting' | 'ExclusionList' | 'FintelDesign' | 'FintelTemplate' | 'Form' | 'Group' | 'IngestionCsv' | 'IngestionJson' | 'IngestionRss' | 'IngestionTaxii' | 'IngestionTaxiiCollection' | 'JsonMapper' | 'ManagedConnector' | 'ManagerConfiguration' | 'MeUser' | 'NewsFeedItem' | 'Notification' | 'Notifier' | 'Pir' | 'Playbook' | 'PublicDashboard' | 'Role' | 'SavedFilter' | 'Settings' | 'SupportPackage' | 'TaskTemplate' | 'Theme' | 'Trigger' | 'User' | 'Workspace', ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
 }>;
@@ -47253,6 +47421,11 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   csvMapperDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationCsvMapperDeleteArgs, 'id'>>;
   csvMapperFieldPatch?: Resolver<Maybe<ResolversTypes['CsvMapper']>, ParentType, ContextType, RequireFields<MutationCsvMapperFieldPatchArgs, 'id' | 'input'>>;
   csvMapperTest?: Resolver<Maybe<ResolversTypes['CsvMapperTestResult']>, ParentType, ContextType, RequireFields<MutationCsvMapperTestArgs, 'configuration' | 'file'>>;
+  customFieldDefinitionAdd?: Resolver<Maybe<ResolversTypes['CustomFieldDefinition']>, ParentType, ContextType, RequireFields<MutationCustomFieldDefinitionAddArgs, 'input'>>;
+  customFieldDefinitionAddEntityType?: Resolver<Maybe<ResolversTypes['CustomFieldDefinition']>, ParentType, ContextType, RequireFields<MutationCustomFieldDefinitionAddEntityTypeArgs, 'entityType' | 'id'>>;
+  customFieldDefinitionDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationCustomFieldDefinitionDeleteArgs, 'id'>>;
+  customFieldDefinitionFieldPatch?: Resolver<Maybe<ResolversTypes['CustomFieldDefinition']>, ParentType, ContextType, RequireFields<MutationCustomFieldDefinitionFieldPatchArgs, 'id' | 'input'>>;
+  customFieldDefinitionRemoveEntityType?: Resolver<Maybe<ResolversTypes['CustomFieldDefinition']>, ParentType, ContextType, RequireFields<MutationCustomFieldDefinitionRemoveEntityTypeArgs, 'entityType' | 'id'>>;
   customViewAdd?: Resolver<ResolversTypes['CustomView'], ParentType, ContextType, RequireFields<MutationCustomViewAddArgs, 'input'>>;
   customViewConfigurationImport?: Resolver<ResolversTypes['CustomView'], ParentType, ContextType, RequireFields<MutationCustomViewConfigurationImportArgs, 'file' | 'targetEntityType'>>;
   customViewDelete?: Resolver<ResolversTypes['ID'], ParentType, ContextType, RequireFields<MutationCustomViewDeleteArgs, 'id'>>;
@@ -49124,6 +49297,8 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   csvMapperSchemaAttributes?: Resolver<Array<ResolversTypes['CsvMapperSchemaAttributes']>, ParentType, ContextType>;
   csvMapperTest?: Resolver<Maybe<ResolversTypes['CsvMapperTestResult']>, ParentType, ContextType, RequireFields<QueryCsvMapperTestArgs, 'configuration' | 'content'>>;
   csvMappers?: Resolver<Maybe<ResolversTypes['CsvMapperConnection']>, ParentType, ContextType, Partial<QueryCsvMappersArgs>>;
+  customFieldDefinition?: Resolver<Maybe<ResolversTypes['CustomFieldDefinition']>, ParentType, ContextType, RequireFields<QueryCustomFieldDefinitionArgs, 'id'>>;
+  customFieldDefinitions?: Resolver<Maybe<ResolversTypes['CustomFieldDefinitionConnection']>, ParentType, ContextType, Partial<QueryCustomFieldDefinitionsArgs>>;
   customView?: Resolver<Maybe<ResolversTypes['CustomView']>, ParentType, ContextType, RequireFields<QueryCustomViewArgs, 'id'>>;
   customViews?: Resolver<ResolversTypes['CustomViewsConnection'], ParentType, ContextType, Partial<QueryCustomViewsArgs>>;
   customViewsSettings?: Resolver<ResolversTypes['CustomViewsSettings'], ParentType, ContextType, RequireFields<QueryCustomViewsSettingsArgs, 'entityType'>>;
@@ -53165,6 +53340,10 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   CsvMapperSchemaAttribute?: CsvMapperSchemaAttributeResolvers<ContextType>;
   CsvMapperSchemaAttributes?: CsvMapperSchemaAttributesResolvers<ContextType>;
   CsvMapperTestResult?: CsvMapperTestResultResolvers<ContextType>;
+  CustomFieldDefinition?: CustomFieldDefinitionResolvers<ContextType>;
+  CustomFieldDefinitionConnection?: CustomFieldDefinitionConnectionResolvers<ContextType>;
+  CustomFieldDefinitionEdge?: CustomFieldDefinitionEdgeResolvers<ContextType>;
+  CustomFieldValue?: CustomFieldValueResolvers<ContextType>;
   CustomView?: CustomViewResolvers<ContextType>;
   CustomViewsConnection?: CustomViewsConnectionResolvers<ContextType>;
   CustomViewsEdge?: CustomViewsEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
@@ -352,3 +352,6 @@ const stixDomainObjectsAttributes: { [k: string]: Array<AttributeDefinition<any>
   ],
 };
 R.forEachObjIndexed((value, key) => schemaAttributesDefinition.registerAttributes(key as string, value), stixDomainObjectsAttributes);
+
+// Custom field values are stored flat (x_opencti_cf_<name>) — dynamic putMapping at field creation time.
+

--- a/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident-domain.ts
@@ -13,9 +13,9 @@ import type { BasicStoreEntityCaseIncident } from './case-incident-types';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from './case-incident-types';
 import type { DomainFindById } from '../../../domain/domainTypes';
 import type { CaseIncidentAddInput } from '../../../generated/graphql';
+import { FilterMode } from '../../../generated/graphql';
 import { isStixId } from '../../../schema/schemaUtils';
 import { RELATION_OBJECT } from '../../../schema/stixRefRelationship';
-import { FilterMode } from '../../../generated/graphql';
 
 export const findById: DomainFindById<BasicStoreEntityCaseIncident> = (context: AuthContext, user: AuthUser, caseIncidentId: string) => {
   return storeLoadById(context, user, caseIncidentId, ENTITY_TYPE_CONTAINER_CASE_INCIDENT);
@@ -55,3 +55,5 @@ export const caseIncidentContainsStixObjectOrStixRelationship = async (context: 
   const caseIncidentFound = await findCaseIncidentPaginated(context, user, args);
   return caseIncidentFound.edges.length > 0;
 };
+
+

--- a/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident-resolvers.ts
@@ -2,7 +2,12 @@ import type { Resolvers } from '../../../generated/graphql';
 import { buildRefRelationKey } from '../../../schema/general';
 import { RELATION_OBJECT_ASSIGNEE } from '../../../schema/stixRefRelationship';
 import { stixDomainObjectDelete } from '../../../domain/stixDomainObject';
-import { addCaseIncident, caseIncidentContainsStixObjectOrStixRelationship, findCaseIncidentPaginated, findById } from './case-incident-domain';
+import {
+  addCaseIncident,
+  caseIncidentContainsStixObjectOrStixRelationship,
+  findCaseIncidentPaginated,
+  findById,
+} from './case-incident-domain';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from './case-incident-types';
 import { findSecurityCoverageByCoveredId } from '../../securityCoverage/securityCoverage-domain';
 
@@ -16,6 +21,20 @@ const caseIncidentResolvers: Resolvers = {
   },
   CaseIncident: {
     securityCoverage: (caseIncident, _, context) => findSecurityCoverageByCoveredId(context, context.user, caseIncident.id),
+    // Flat storage: custom fields are stored as x_opencti_cf_<name> at root of the ES document
+    customFieldValues: (caseIncident: any) => Object.keys(caseIncident)
+      .filter((key) => key.startsWith('x_opencti_cf_'))
+      .map((key) => {
+        const rawVal = caseIncident[key];
+        const isNumeric = typeof rawVal === 'number';
+        return {
+          field_id: key,
+          field_name: key,
+          int_value: isNumeric ? rawVal : undefined,
+          string_value: !isNumeric ? String(rawVal) : undefined,
+          select_value: !isNumeric ? String(rawVal) : undefined,
+        };
+      }),
   },
   CaseIncidentsOrdering: {
     creator: 'creator_id',

--- a/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/case/case-incident/case-incident.graphql
@@ -172,6 +172,8 @@ type CaseIncident implements BasicObject & StixObject & StixCoreObject & StixDom
   response_types: [String!]
   severity: String
   priority: String
+  # Custom Field Values
+  customFieldValues: [CustomFieldValue]
 }
 
 # Ordering

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field-converter.ts
@@ -1,0 +1,28 @@
+import { buildStixDomain } from '../../database/stix-2-1-converter';
+import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
+import type { StixCustomFieldDefinition, StoreEntityCustomFieldDefinition } from './custom-field-types';
+import { cleanObject } from '../../database/stix-converter-utils';
+
+const convertCustomFieldDefinitionToStix = (instance: StoreEntityCustomFieldDefinition): StixCustomFieldDefinition => {
+  const customFieldDefinition = buildStixDomain(instance);
+  return {
+    ...customFieldDefinition,
+    name: instance.name,
+    description: instance.description,
+    label: instance.label,
+    field_type: instance.field_type,
+    entity_types: instance.entity_types,
+    mandatory: instance.mandatory,
+    default_value: instance.default_value,
+    min_value: instance.min_value,
+    max_value: instance.max_value,
+    extensions: {
+      [STIX_EXT_OCTI]: cleanObject({
+        ...customFieldDefinition.extensions[STIX_EXT_OCTI],
+        extension_type: 'new-sdo',
+      }),
+    },
+  };
+};
+
+export default convertCustomFieldDefinitionToStix;

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field-domain.ts
@@ -1,0 +1,116 @@
+import { type EntityOptions, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
+import { type BasicStoreEntityCustomFieldDefinition, ENTITY_TYPE_CUSTOM_FIELD_DEFINITION, type StoreEntityCustomFieldDefinition } from './custom-field-types';
+import type { EditInput } from '../../generated/graphql';
+import { EditOperation, FilterMode, FilterOperator } from '../../generated/graphql';
+import type { DomainFindById } from '../../domain/domainTypes';
+import type { AuthContext, AuthUser } from '../../types/user';
+import { createEntity, deleteElementById, updateAttribute } from '../../database/middleware';
+import { notify } from '../../database/redis';
+import { BUS_TOPICS } from '../../config/conf';
+import { ABSTRACT_INTERNAL_OBJECT, ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
+import { publishUserAction } from '../../listener/UserActionListener';
+import { elAddDynamicFieldMapping } from '../../database/engine';
+import { schemaAttributesDefinition } from '../../schema/schema-attributes';
+
+// Local type until GraphQL types are regenerated
+interface CustomFieldDefinitionAddInput {
+  name: string;
+  label: string;
+  field_type: string;
+  entity_types?: string[] | null;
+  mandatory: boolean;
+  description?: string | null;
+  created?: Date | null;
+  // Common optional
+  default_value?: string | null;
+  // Integer-specific
+  min_value?: number | null;
+  max_value?: number | null;
+  // Select-specific
+  select_options?: string[] | null;
+}
+
+export const findById: DomainFindById<BasicStoreEntityCustomFieldDefinition> = (context: AuthContext, user: AuthUser, customFieldDefinitionId: string) => {
+  return storeLoadById(context, user, customFieldDefinitionId, ENTITY_TYPE_CUSTOM_FIELD_DEFINITION);
+};
+
+export const findCustomFieldDefinitionsPaginated = (context: AuthContext, user: AuthUser, opts: EntityOptions<BasicStoreEntityCustomFieldDefinition>) => {
+  return pageEntitiesConnection<BasicStoreEntityCustomFieldDefinition>(context, user, [ENTITY_TYPE_CUSTOM_FIELD_DEFINITION], opts);
+};
+
+export const findCustomFieldDefinitionsForEntityType = (context: AuthContext, user: AuthUser, entityType: string) => {
+  const filters = {
+    mode: FilterMode.And,
+    filters: [{ key: ['entity_types'], values: [entityType], operator: FilterOperator.Eq }],
+    filterGroups: [],
+  };
+  return pageEntitiesConnection<BasicStoreEntityCustomFieldDefinition>(context, user, [ENTITY_TYPE_CUSTOM_FIELD_DEFINITION], { filters });
+};
+
+export const customFieldDefinitionAdd = async (context: AuthContext, user: AuthUser, input: CustomFieldDefinitionAddInput) => {
+  const created = await createEntity(context, user, input, ENTITY_TYPE_CUSTOM_FIELD_DEFINITION);
+
+  // Register the flat field in Elasticsearch (putMapping at hot — no restart needed)
+  const fieldMappingName = `x_opencti_cf_${input.name}`;
+  const esType = input.field_type === 'integer' ? 'long' : 'keyword';
+  await elAddDynamicFieldMapping(fieldMappingName, esType);
+
+  // Register the attribute in schema so the platform validator accepts it without restart
+  const schemaAttrType = input.field_type === 'integer' ? 'numeric' : 'string';
+  schemaAttributesDefinition.registerDynamicAttribute(ABSTRACT_STIX_DOMAIN_OBJECT, {
+    name: fieldMappingName,
+    label: input.label,
+    type: schemaAttrType as any,
+    ...(schemaAttrType === 'string' ? { format: 'short' } : { precision: 'integer' }),
+    mandatoryType: 'no',
+    editDefault: false,
+    multiple: false,
+    upsert: true,
+    isFilterable: true,
+  } as any);
+
+  await publishUserAction({
+    user,
+    event_type: 'mutation',
+    event_scope: 'create',
+    event_access: 'administration',
+    message: `creates custom field definition \`${input.name}\``,
+    context_data: { id: created.id, entity_type: ENTITY_TYPE_CUSTOM_FIELD_DEFINITION, input },
+  });
+  return notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].ADDED_TOPIC, created, user);
+};
+
+export const customFieldDefinitionDelete = async (context: AuthContext, user: AuthUser, customFieldDefinitionId: string) => {
+  const element = await deleteElementById<StoreEntityCustomFieldDefinition>(context, user, customFieldDefinitionId, ENTITY_TYPE_CUSTOM_FIELD_DEFINITION);
+  await notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].DELETE_TOPIC, element, user);
+  await publishUserAction({
+    user,
+    event_type: 'mutation',
+    event_scope: 'delete',
+    event_access: 'administration',
+    message: `deletes custom field definition \`${element.name}\``,
+    context_data: { id: customFieldDefinitionId, entity_type: ENTITY_TYPE_CUSTOM_FIELD_DEFINITION, input: element },
+  });
+  return customFieldDefinitionId;
+};
+
+export const customFieldDefinitionEdit = async (context: AuthContext, user: AuthUser, customFieldDefinitionId: string, input: EditInput[]) => {
+  const { element: updatedElem } = await updateAttribute<StoreEntityCustomFieldDefinition>(context, user, customFieldDefinitionId, ENTITY_TYPE_CUSTOM_FIELD_DEFINITION, input);
+  await publishUserAction({
+    user,
+    event_type: 'mutation',
+    event_scope: 'update',
+    event_access: 'administration',
+    message: `updates \`${input.map((i) => i.key).join(', ')}\` for custom field definition \`${updatedElem.name}\``,
+    context_data: { id: customFieldDefinitionId, entity_type: ENTITY_TYPE_CUSTOM_FIELD_DEFINITION, input },
+  });
+  return notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].EDIT_TOPIC, updatedElem, user);
+};
+
+export const customFieldDefinitionAddEntityType = (context: AuthContext, user: AuthUser, customFieldDefinitionId: string, entityType: string) => {
+  return customFieldDefinitionEdit(context, user, customFieldDefinitionId, [{ key: 'entity_types', value: [entityType], operation: EditOperation.Add }]);
+};
+
+export const customFieldDefinitionRemoveEntityType = (context: AuthContext, user: AuthUser, customFieldDefinitionId: string, entityType: string) => {
+  return customFieldDefinitionEdit(context, user, customFieldDefinitionId, [{ key: 'entity_types', value: [entityType], operation: EditOperation.Remove }]);
+};

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field-graphql.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field-graphql.ts
@@ -1,0 +1,9 @@
+import { registerGraphqlSchema } from '../../graphql/schema';
+import customFieldTypeDefs from './custom-field.graphql';
+import customFieldResolvers from './custom-field-resolvers';
+
+registerGraphqlSchema({
+  schema: customFieldTypeDefs,
+  resolver: customFieldResolvers,
+});
+

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field-resolvers.ts
@@ -1,0 +1,26 @@
+import type { Resolvers } from '../../generated/graphql';
+import {
+  customFieldDefinitionAdd,
+  customFieldDefinitionAddEntityType,
+  customFieldDefinitionDelete,
+  customFieldDefinitionEdit,
+  customFieldDefinitionRemoveEntityType,
+  findById,
+  findCustomFieldDefinitionsPaginated,
+} from './custom-field-domain';
+
+const customFieldResolvers: Resolvers = {
+  Query: {
+    customFieldDefinition: (_: unknown, { id }: { id: string }, context: any) => findById(context, context.user, id),
+    customFieldDefinitions: (_: unknown, args: any, context: any) => findCustomFieldDefinitionsPaginated(context, context.user, args),
+  },
+  Mutation: {
+    customFieldDefinitionAdd: (_: unknown, { input }: { input: any }, context: any) => customFieldDefinitionAdd(context, context.user, input),
+    customFieldDefinitionDelete: (_: unknown, { id }: { id: string }, context: any) => customFieldDefinitionDelete(context, context.user, id),
+    customFieldDefinitionFieldPatch: (_: unknown, { id, input }: { id: string; input: any }, context: any) => customFieldDefinitionEdit(context, context.user, id, input),
+    customFieldDefinitionAddEntityType: (_: unknown, { id, entityType }: { id: string; entityType: string }, context: any) => customFieldDefinitionAddEntityType(context, context.user, id, entityType),
+    customFieldDefinitionRemoveEntityType: (_: unknown, { id, entityType }: { id: string; entityType: string }, context: any) => customFieldDefinitionRemoveEntityType(context, context.user, id, entityType),
+  },
+};
+
+export default customFieldResolvers;

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field-types.ts
@@ -1,0 +1,52 @@
+import type { BasicStoreEntity, StoreEntity } from '../../types/store';
+import type { StixObject, StixOpenctiExtensionSDO } from '../../types/stix-2-1-common';
+import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
+
+export const ENTITY_TYPE_CUSTOM_FIELD_DEFINITION = 'CustomFieldDefinition';
+
+export interface BasicStoreEntityCustomFieldDefinition extends BasicStoreEntity {
+  name: string;
+  description: string;
+  label: string;
+  field_type: string; // 'integer' for now
+  entity_types?: string[]; // optional: not yet assigned to any entity
+  mandatory: boolean;
+  // Common optional
+  default_value?: string; // serialized as string, parsed according to field_type
+  // Integer-specific
+  min_value?: number;
+  max_value?: number;
+  // Select-specific
+  select_options?: string[];
+}
+
+export interface StoreEntityCustomFieldDefinition extends StoreEntity {
+  name: string;
+  description: string;
+  label: string;
+  field_type: string;
+  entity_types?: string[]; // optional: not yet assigned to any entity
+  mandatory: boolean;
+  default_value?: string;
+  min_value?: number;
+  max_value?: number;
+  // Select-specific
+  select_options?: string[];
+}
+
+export interface StixCustomFieldDefinition extends StixObject {
+  name: string;
+  description: string;
+  label: string;
+  field_type: string;
+  entity_types?: string[]; // optional: not yet assigned to any entity
+  mandatory: boolean;
+  default_value?: string;
+  min_value?: number;
+  max_value?: number;
+  // Select-specific
+  select_options?: string[];
+  extensions: {
+    [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
+  };
+}

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field.graphql
@@ -1,0 +1,90 @@
+# Value of a CustomFieldDefinition on a specific entity instance
+type CustomFieldValue {
+  field_id:     ID!      # id of the CustomFieldDefinition
+  field_name:   String!  # ex: "x_opencti_priority"
+  int_value:    Int      # value for field_type = integer
+  string_value: String   # value for field_type = string
+  select_value: String   # value for field_type = select
+}
+
+type CustomFieldDefinition implements InternalObject & BasicObject {
+  id: ID!
+  standard_id: String!
+  entity_type: String!
+  parent_types: [String!]!
+  metrics: [Metric]
+  created: DateTime
+  modified: DateTime
+  # CustomFieldDefinition - mandatory attributes
+  name: String!
+  label: String!
+  field_type: String!    # 'integer' | 'string' | 'select'
+  entity_types: [String!]
+  mandatory: Boolean!
+  # Common optional
+  description: String
+  default_value: String  # serialized as string, parsed according to field_type
+  # Integer-specific
+  min_value: Int
+  max_value: Int
+  # Select-specific
+  select_options: [String!]
+}
+
+# Ordering
+enum CustomFieldDefinitionsOrdering {
+  name
+  label
+  field_type
+  created
+  _score
+}
+
+# Relay connections
+type CustomFieldDefinitionConnection {
+  pageInfo: PageInfo!
+  edges: [CustomFieldDefinitionEdge!]!
+}
+type CustomFieldDefinitionEdge {
+  cursor: String!
+  node: CustomFieldDefinition!
+}
+
+# Queries
+type Query {
+  customFieldDefinition(id: String!): CustomFieldDefinition @auth
+  customFieldDefinitions(
+    first: Int
+    after: ID
+    orderBy: CustomFieldDefinitionsOrdering
+    orderMode: OrderingMode
+    search: String
+    filters: FilterGroup
+  ): CustomFieldDefinitionConnection @auth
+}
+
+# Mutations
+input CustomFieldDefinitionAddInput {
+  name: String! @constraint(minLength: 2, format: "not-blank")
+  label: String! @constraint(minLength: 2, format: "not-blank")
+  field_type: String!
+  entity_types: [String!]
+  mandatory: Boolean!
+  description: String
+  created: DateTime
+  # Common optional
+  default_value: String
+  # Integer-specific
+  min_value: Int
+  max_value: Int
+  # Select-specific
+  select_options: [String!]
+}
+
+type Mutation {
+  customFieldDefinitionAdd(input: CustomFieldDefinitionAddInput!): CustomFieldDefinition @auth(for: [SETTINGS_SETCUSTOMIZATION])
+  customFieldDefinitionDelete(id: ID!): ID @auth(for: [SETTINGS_SETCUSTOMIZATION])
+  customFieldDefinitionFieldPatch(id: ID!, input: [EditInput!]!): CustomFieldDefinition @auth(for: [SETTINGS_SETCUSTOMIZATION])
+  customFieldDefinitionAddEntityType(id: ID!, entityType: String!): CustomFieldDefinition @auth(for: [SETTINGS_SETCUSTOMIZATION])
+  customFieldDefinitionRemoveEntityType(id: ID!, entityType: String!): CustomFieldDefinition @auth(for: [SETTINGS_SETCUSTOMIZATION])
+}

--- a/opencti-platform/opencti-graphql/src/modules/customField/custom-field.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customField/custom-field.ts
@@ -1,0 +1,41 @@
+import { type ModuleDefinition, registerDefinition } from '../../schema/module';
+import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
+import type { StixCustomFieldDefinition, StoreEntityCustomFieldDefinition } from './custom-field-types';
+import { ENTITY_TYPE_CUSTOM_FIELD_DEFINITION } from './custom-field-types';
+import convertCustomFieldDefinitionToStix from './custom-field-converter';
+
+const CUSTOM_FIELD_DEFINITION_DEFINITION: ModuleDefinition<StoreEntityCustomFieldDefinition, StixCustomFieldDefinition> = {
+  type: {
+    id: 'custom-field-definition',
+    name: ENTITY_TYPE_CUSTOM_FIELD_DEFINITION,
+    category: ABSTRACT_INTERNAL_OBJECT,
+  },
+  identifier: {
+    definition: {
+      [ENTITY_TYPE_CUSTOM_FIELD_DEFINITION]: [{ src: 'name' }],
+    },
+    resolvers: {},
+  },
+  attributes: [
+    { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'label', label: 'Label', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'field_type', label: 'Field type', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'entity_types', label: 'Entity types', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
+    { name: 'mandatory', label: 'Mandatory', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    // Common optional
+    { name: 'default_value', label: 'Default value', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    // Integer-specific
+    { name: 'min_value', label: 'Min value', type: 'numeric', precision: 'integer', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'max_value', label: 'Max value', type: 'numeric', precision: 'integer', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    // Select-specific
+    { name: 'select_options', label: 'Select options', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: false },
+  ],
+  relations: [],
+  relationsRefs: [],
+  representative: (stix: StixCustomFieldDefinition) => {
+    return stix.label ?? stix.name;
+  },
+  converter_2_1: convertCustomFieldDefinitionToStix,
+};
+
+registerDefinition(CUSTOM_FIELD_DEFINITION_DEFINITION);

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -83,6 +83,7 @@ import './authenticationProvider/authenticationProvider';
 import './customView/customView';
 import './retentionRules/retentionRules';
 import './xtm/hub/news-feed/news-feed';
+import './customField/custom-field';
 
 // incomplete modules
 import './report/report';
@@ -166,4 +167,5 @@ import './dataSharing/feed-graphql';
 import './dataSharing/streamCollection-graphql';
 import './retentionRules/retentionRules-graphql';
 import './workflow/api/workflow-graphql';
+import './customField/custom-field-graphql';
 // endregion

--- a/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/csvMapper/csvMapper-domain.ts
@@ -17,6 +17,7 @@ import { schemaAttributesDefinition } from '../../../schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../../../schema/schema-relationsRef';
 import { INTERNAL_ATTRIBUTES, INTERNAL_REFS } from '../../../domain/attribute-utils';
 import { getAttributesConfiguration, getEntitySettingFromCache } from '../../entitySetting/entitySetting-utils';
+import { type BasicStoreEntityCustomFieldDefinition, ENTITY_TYPE_CUSTOM_FIELD_DEFINITION } from '../../customField/custom-field-types';
 import { isNotEmptyField } from '../../../database/utils';
 import { extractRepresentative } from '../../../database/entity-representative';
 import { isStixCoreRelationship } from '../../../schema/stixCoreRelationship';
@@ -269,6 +270,30 @@ export const csvMapperSchemaAttributes = async (context: AuthContext, user: Auth
           }
         }
       });
+    }
+  }
+
+  // Add custom field definitions from CustomFieldDefinition entities
+  const allCustomFieldDefs = await fullEntitiesList<BasicStoreEntityCustomFieldDefinition>(context, user, [ENTITY_TYPE_CUSTOM_FIELD_DEFINITION]);
+  for (const cfDef of allCustomFieldDefs) {
+    const cfEntityTypes = cfDef.entity_types ?? [];
+    for (const cfEntityType of cfEntityTypes) {
+      const schemaAttribute = schemaAttributes.find((a) => a.name === cfEntityType);
+      if (schemaAttribute) {
+        const cfAttrName = `x_opencti_cf_${cfDef.name}`;
+        // Avoid duplicates (field might already be registered dynamically in schema)
+        if (!schemaAttribute.attributes.some((a) => a.name === cfAttrName)) {
+          schemaAttribute.attributes.push({
+            name: cfAttrName,
+            label: cfDef.label,
+            type: cfDef.field_type === 'integer' ? 'numeric' : 'string',
+            mandatoryType: cfDef.mandatory ? 'external' : 'no',
+            mandatory: cfDef.mandatory,
+            editDefault: false,
+            multiple: false,
+          });
+        }
+      }
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -191,13 +191,35 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
     };
 
     const patchOperations: jsonpatch.Operation[] = [];
+    let customFieldsModified = false;
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const element = bundle.objects[index];
       const isMatchingScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters);
       if (isMatchingScope && isMatchingFilters) {
         const { type, id } = element.extensions[STIX_EXT_OCTI];
-        const elementOperations = actions
+
+        // --- Custom fields (x_opencti_cf_*): bypass STIX path resolution ---
+        // These are stored flat in ES and applied via opencti_upsert_operations.
+        // Values MUST be stored as strings: EditInput.value is [String] in GraphQL.
+        // The middleware handles type coercion when applying the attribute to ES.
+        const customFieldActions = actions.filter((a) => a.attribute.startsWith('x_opencti_cf_'));
+        if (customFieldActions.length > 0 && id) {
+          const cfPatchObject = customFieldActions.map((action) => {
+            const rawValue = String(R.head(action.value)?.patch_value ?? '');
+            return {
+              key: action.attribute,
+              value: [rawValue],
+              operation: action.op as 'add' | 'replace' | 'remove',
+            };
+          });
+          applyOperationFieldPatch(element, cfPatchObject);
+          customFieldsModified = true;
+        }
+
+        // --- Standard attributes: use STIX path resolution ---
+        const standardActions = actions.filter((a) => !a.attribute.startsWith('x_opencti_cf_'));
+        const elementOperations = standardActions
           .map((action) => {
             const attrPath = computeAttributePath(type, action.attribute);
             const multiple = isAttributeMultiple(type, action.attribute);
@@ -272,11 +294,18 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
     }
     // Apply operations if needed
     if (patchOperations.length > 0) {
+      // bundle may already contain opencti_upsert_operations added in-place above,
+      // so structuredClone captures them before applying standard JSON-patch operations.
       const patchedBundle = jsonpatch.applyPatch(structuredClone(bundle), patchOperations).newDocument;
       const diff = jsonpatch.compare(bundle, patchedBundle);
-      if (isNotEmptyField(diff)) {
+      if (isNotEmptyField(diff) || customFieldsModified) {
         return { output_port: 'out', bundle: patchedBundle };
       }
+    }
+    // Custom-field-only modifications: patchOperations is empty but bundle was mutated
+    // in-place (opencti_upsert_operations), so we must still send it for ingestion.
+    if (customFieldsModified) {
+      return { output_port: 'out', bundle };
     }
     return { output_port: 'unmodified', bundle };
   },

--- a/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-attributes.ts
@@ -185,6 +185,22 @@ export const schemaAttributesDefinition = {
     });
   },
 
+  /**
+   * Register a dynamic attribute (e.g. x_opencti_cf_<name>) bypassing the usageProtection lock.
+   * Used at runtime when a CustomFieldDefinition is created so the platform accepts the flat key.
+   */
+  registerDynamicAttribute(entityType: string, attribute: AttributeDefinition) {
+    const directAttributes = this.attributes[entityType] ?? new Map<string, AttributeDefinition>();
+    if (!directAttributes.has(attribute.name)) {
+      directAttributes.set(attribute.name, attribute);
+      this.allAttributes.set(attribute.name, attribute);
+      this.attributes[entityType] = directAttributes;
+      if (attribute.upsert) {
+        this.upsertByEntity.set(entityType, [...(this.upsertByEntity.get(entityType) ?? []), attribute.name]);
+      }
+    }
+  },
+
   selectEntityType(entityType: string) {
     usageProtection = true;
     if (this.attributes[entityType]) {

--- a/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
+++ b/opencti-platform/opencti-graphql/src/schema/schema-validator.ts
@@ -222,6 +222,9 @@ export const validateInputCreation = async (
 export const validateUpdatableAttribute = (instanceType: string, input: Record<string, unknown>) => {
   const invalidKeys: string[] = [];
   Object.entries(input).forEach(([key]) => {
+    // Dynamic custom field attributes (flat storage) bypass schema validation — their mapping
+    // is registered at runtime via elAddDynamicFieldMapping / registerDynamicAttribute.
+    if (key.startsWith('x_opencti_cf_')) return;
     const attribute = schemaAttributesDefinition.getAttribute(instanceType, key);
     const reference = schemaRelationsRefDefinition.getRelationRef(instanceType, key);
     const schemaAttribute = attribute || reference;

--- a/opencti-platform/opencti-graphql/src/types/stix-2-1-common.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/stix-2-1-common.d.ts
@@ -76,6 +76,7 @@ interface StixOpenctiExtension {
   opencti_operation?: string;
   opencti_field_patch?: EditInput[];
   opencti_upsert_operations?: EditInput[];
+  [key: string]: any; // Dynamic custom field values (x_opencti_cf_*)
 }
 
 interface StixOpenctiExtensionSDO extends StixOpenctiExtension {

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
@@ -5,6 +5,7 @@ import {
   BULK_SEARCH_KEYWORDS_FILTER,
   BULK_SEARCH_KEYWORDS_FILTER_KEYS,
   COMPUTED_RELIABILITY_FILTER,
+  CUSTOM_FIELD_VALUE_FILTER,
   ID_SUBFILTER,
   IDS_FILTER,
   INSTANCE_DYNAMIC_REGARDING_OF,
@@ -556,6 +557,44 @@ const adaptFilterToPirFilterKeys = async (context: AuthContext, user: AuthUser, 
   return { newFilter, newFilterGroup: undefined };
 };
 
+const adaptFilterToCustomFieldValueFilterKey = (filter: Filter) => {
+  const { values, operator, mode } = filter;
+  const op: string = operator ?? FilterOperator.Eq;
+
+  if (values.length === 0) {
+    throw FunctionalError('customFieldValue filter requires at least one value', { filter });
+  }
+
+  // Format: "fieldName|subKey|value"  e.g. "x_opencti_cf_gravity|select_value|G1"
+  // Flat storage: fieldName IS the ES key — subKey is used only to hint the value type (ignored for query)
+  const flatFilters = values.flatMap((encodedValue: any) => {
+    if (typeof encodedValue !== 'string') return [];
+    const parts = (encodedValue as string).split('|');
+    if (parts.length !== 3) return [];
+    const [fieldName, , subValue] = parts;
+    return [{
+      key: [fieldName],
+      values: [subValue],
+      operator: op,
+    }];
+  });
+
+  if (flatFilters.length === 0) {
+    throw FunctionalError('customFieldValue filter has no valid encoded values', { filter });
+  }
+  if (flatFilters.length === 1) {
+    return { newFilter: flatFilters[0] as Filter, newFilterGroup: undefined };
+  }
+  return {
+    newFilter: undefined,
+    newFilterGroup: {
+      mode: mode ?? FilterMode.Or,
+      filters: flatFilters as Filter[],
+      filterGroups: [],
+    } as FilterGroup,
+  };
+};
+
 const adaptFilterToServiceAccountFilterKey = (filter: Filter) => {
   const { operator, mode, values } = filter;
   let newFilter;
@@ -827,6 +866,15 @@ export const completeSpecialFilterKeys = async (
         const { newFilter } = await adaptFilterToPirFilterKeys(context, user, filterKey, filter);
         finalFilters.push(newFilter);
       }
+      if (filterKey === CUSTOM_FIELD_VALUE_FILTER) {
+        const { newFilter, newFilterGroup } = adaptFilterToCustomFieldValueFilterKey(filter);
+        if (newFilter) {
+          finalFilters.push(newFilter);
+        }
+        if (newFilterGroup) {
+          finalFilterGroups.push(newFilterGroup);
+        }
+      }
       if (filterKey === USER_SERVICE_ACCOUNT_FILTER) {
         const { newFilter, newFilterGroup } = adaptFilterToServiceAccountFilterKey(filter);
         if (newFilter) {
@@ -854,29 +902,17 @@ export const completeSpecialFilterKeys = async (
         throw UnsupportedError('A filter with these multiple keys is not supported', { keys: arrayKeys });
       }
       const definition = schemaAttributesDefinition.getAttributeByName(key[0]) as ComplexAttribute;
-      if (definition.format === 'standard') {
-        finalFilterGroups.push({
-          mode: filter.mode ?? FilterMode.And,
-          filters: filter.values.map((v) => {
-            const filterKeys = Array.isArray(v.key) ? v.key : [v.key];
-            return { ...v, key: filterKeys.map((k: any) => `${k}.${v.key}`) };
-          }),
-          filterGroups: [],
-        });
-      } else if (definition.format === 'nested') {
-        finalFilters.push({ key, operator: filter.operator, nested: filter.values, mode: filter.mode, values: [] });
+      if (definition?.multiple) {
+        // in case of array attribute, we need to build a nested query
+        const nested = [{ key: 'value', operator: filter.operator, values: filter.values }];
+        finalFilters.push({ key: [key[0]], nested, mode: filter.mode, values: [] });
       } else {
-        throw UnsupportedError('Object attribute format is not filterable', { format: definition.format });
+        // in case of single value attribute, nothing special to do
+        finalFilters.push(filter);
       }
     } else {
-      // not a special case, leave the filter unchanged
-      // Of special case but in a multi keys filter but is currently not supported
       finalFilters.push(filter);
     }
   }
-  return {
-    ...inputFilters,
-    filters: finalFilters,
-    filterGroups: finalFilterGroups,
-  };
+  return { mode: inputFilters.mode, filters: finalFilters, filterGroups: finalFilterGroups };
 };

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-constants.ts
@@ -108,6 +108,9 @@ export const PIR_SCORE_SUBFILTER = 'score';
 export const LAST_PIR_SCORE_DATE_SUBFILTER = 'date';
 export const PIR_IDS_SUBFILTER = 'pir_ids';
 
+// for Custom Fields (flat storage — x_opencti_cf_<name> per field)
+export const CUSTOM_FIELD_VALUE_FILTER = 'customFieldValue';
+
 // for users
 export const USER_SERVICE_ACCOUNT_FILTER = 'user_service_account';
 
@@ -146,6 +149,7 @@ const COMPLEX_CONVERSION_FILTER_KEYS = [
   BULK_SEARCH_KEYWORDS_FILTER, // set of keywords used in bulk search
   PIR_SCORE_FILTER, // should be associated to Pir Ids
   LAST_PIR_SCORE_DATE_FILTER, // should be associated to Pir Ids
+  CUSTOM_FIELD_VALUE_FILTER, // nested filter on custom_field_values array
 ];
 
 export const isComplexConversionFilterKey = (filterKey: string) => {

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-utils.ts
@@ -468,6 +468,7 @@ const checkFilterKeys = (filterGroup: FilterGroup) => {
     .map((k) => k.split('.')[0]) // keep only the first part of the key to handle composed keys
     .filter((k) => !(getAvailableKeys().has(k)
       || k.startsWith(RULE_PREFIX)
+      || k.startsWith('x_opencti_cf_') // dynamic custom field keys — registered at runtime
       || getMetricsAttributesNames().includes(k)
     ));
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customField/customFieldDefinition-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/customField/customFieldDefinition-test.ts
@@ -1,0 +1,281 @@
+/**
+ * Integration tests for the CustomFieldDefinition module.
+ *
+ * Tests cover the full CRUD lifecycle of CustomFieldDefinition:
+ *   - create (customFieldDefinitionAdd)
+ *   - read by id (customFieldDefinition)
+ *   - list/paginate (customFieldDefinitions)
+ *   - patch a field (customFieldDefinitionFieldPatch)
+ *   - add / remove entity type association
+ *   - delete (customFieldDefinitionDelete)
+ *
+ * Note: currently only the `integer` field_type is implemented.
+ * Additional field types (string, boolean, date…) should be added in dedicated
+ * describe blocks below without modifying the existing ones.
+ *
+ * Location: tests/03-integration/10-modules/customField/
+ * Run via:  yarn test:ci-integration-sync (or the test suite that includes 10-modules)
+ */
+
+import { afterAll, describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { queryAsAdmin } from '../../../utils/testQueryHelper';
+
+// ---------------------------------------------------------------------------
+// GraphQL documents
+// ---------------------------------------------------------------------------
+
+const CREATE_DEFINITION = gql`
+  mutation CustomFieldDefinitionAdd($input: CustomFieldDefinitionAddInput!) {
+    customFieldDefinitionAdd(input: $input) {
+      id
+      name
+      label
+      field_type
+      mandatory
+      min_value
+      max_value
+      entity_types
+      description
+    }
+  }
+`;
+
+const READ_DEFINITION = gql`
+  query CustomFieldDefinition($id: String!) {
+    customFieldDefinition(id: $id) {
+      id
+      name
+      label
+      field_type
+      mandatory
+      min_value
+      max_value
+      entity_types
+      description
+    }
+  }
+`;
+
+const LIST_DEFINITIONS = gql`
+  query CustomFieldDefinitions($first: Int, $filters: FilterGroup) {
+    customFieldDefinitions(first: $first, filters: $filters) {
+      edges {
+        node {
+          id
+          name
+          label
+          field_type
+        }
+      }
+      pageInfo {
+        globalCount
+      }
+    }
+  }
+`;
+
+const PATCH_DEFINITION = gql`
+  mutation CustomFieldDefinitionFieldPatch($id: ID!, $input: [EditInput!]!) {
+    customFieldDefinitionFieldPatch(id: $id, input: $input) {
+      id
+      label
+      description
+    }
+  }
+`;
+
+const ADD_ENTITY_TYPE = gql`
+  mutation CustomFieldDefinitionAddEntityType($id: ID!, $entityType: String!) {
+    customFieldDefinitionAddEntityType(id: $id, entityType: $entityType) {
+      id
+      entity_types
+    }
+  }
+`;
+
+const REMOVE_ENTITY_TYPE = gql`
+  mutation CustomFieldDefinitionRemoveEntityType($id: ID!, $entityType: String!) {
+    customFieldDefinitionRemoveEntityType(id: $id, entityType: $entityType) {
+      id
+      entity_types
+    }
+  }
+`;
+
+const DELETE_DEFINITION = gql`
+  mutation CustomFieldDefinitionDelete($id: ID!) {
+    customFieldDefinitionDelete(id: $id)
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createIntegerDefinition = async (name: string, overrides: Record<string, unknown> = {}) => {
+  const result = await queryAsAdmin({
+    query: CREATE_DEFINITION,
+    variables: {
+      input: {
+        name,
+        label: `Test label for ${name}`,
+        field_type: 'integer',
+        mandatory: false,
+        min_value: 1,
+        max_value: 10,
+        ...overrides,
+      },
+    },
+  });
+  expect(result.errors).toBeUndefined();
+  return result.data?.customFieldDefinitionAdd;
+};
+
+const deleteDefinition = async (id: string) => {
+  await queryAsAdmin({ query: DELETE_DEFINITION, variables: { id } });
+};
+
+// ---------------------------------------------------------------------------
+// Tests — integer field type (only type currently supported)
+// ---------------------------------------------------------------------------
+
+describe('CustomFieldDefinition — integer field_type', () => {
+  let definitionId: string;
+
+  afterAll(async () => {
+    if (definitionId) await deleteDefinition(definitionId);
+  });
+
+  // --- CREATE ---
+
+  it('should create a CustomFieldDefinition with field_type=integer', async () => {
+    const def = await createIntegerDefinition('test_priority', { description: 'POC priority field' });
+    expect(def).toBeDefined();
+    expect(def.id).toBeTruthy();
+    expect(def.name).toBe('test_priority');
+    expect(def.label).toBe('Test label for test_priority');
+    expect(def.field_type).toBe('integer');
+    expect(def.mandatory).toBe(false);
+    expect(def.min_value).toBe(1);
+    expect(def.max_value).toBe(10);
+    expect(def.description).toBe('POC priority field');
+    definitionId = def.id;
+  });
+
+  // --- READ ---
+
+  it('should load a CustomFieldDefinition by internal id', async () => {
+    const result = await queryAsAdmin({ query: READ_DEFINITION, variables: { id: definitionId } });
+    expect(result.errors).toBeUndefined();
+    const def = result.data?.customFieldDefinition;
+    expect(def).toBeDefined();
+    expect(def.id).toBe(definitionId);
+    expect(def.name).toBe('test_priority');
+    expect(def.field_type).toBe('integer');
+  });
+
+  it('should return null for a non-existent id', async () => {
+    const result = await queryAsAdmin({ query: READ_DEFINITION, variables: { id: 'non-existent-id' } });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customFieldDefinition).toBeNull();
+  });
+
+  // --- LIST ---
+
+  it('should list CustomFieldDefinitions and include the created one', async () => {
+    const result = await queryAsAdmin({ query: LIST_DEFINITIONS, variables: { first: 50 } });
+    expect(result.errors).toBeUndefined();
+    const ids = result.data?.customFieldDefinitions.edges.map((e: any) => e.node.id);
+    expect(ids).toContain(definitionId);
+  });
+
+  it('should filter CustomFieldDefinitions by name', async () => {
+    const result = await queryAsAdmin({
+      query: LIST_DEFINITIONS,
+      variables: {
+        first: 10,
+        filters: {
+          mode: 'and',
+          filters: [{ key: ['name'], values: ['test_priority'] }],
+          filterGroups: [],
+        },
+      },
+    });
+    expect(result.errors).toBeUndefined();
+    const edges = result.data?.customFieldDefinitions.edges;
+    expect(edges.length).toBeGreaterThanOrEqual(1);
+    expect(edges.some((e: any) => e.node.id === definitionId)).toBe(true);
+  });
+
+  // --- PATCH ---
+
+  it('should patch the label of a CustomFieldDefinition', async () => {
+    const result = await queryAsAdmin({
+      query: PATCH_DEFINITION,
+      variables: {
+        id: definitionId,
+        input: [{ key: 'label', value: ['Updated label'] }],
+      },
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customFieldDefinitionFieldPatch.label).toBe('Updated label');
+  });
+
+  // --- entity_types association ---
+
+  it('should associate a CustomFieldDefinition to Case-Incident', async () => {
+    const result = await queryAsAdmin({
+      query: ADD_ENTITY_TYPE,
+      variables: { id: definitionId, entityType: 'Case-Incident' },
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customFieldDefinitionAddEntityType.entity_types).toContain('Case-Incident');
+  });
+
+  it('should list definitions filtered by entity_types = Case-Incident', async () => {
+    const result = await queryAsAdmin({
+      query: LIST_DEFINITIONS,
+      variables: {
+        first: 50,
+        filters: {
+          mode: 'and',
+          filters: [{ key: ['entity_types'], values: ['Case-Incident'] }],
+          filterGroups: [],
+        },
+      },
+    });
+    expect(result.errors).toBeUndefined();
+    const ids = result.data?.customFieldDefinitions.edges.map((e: any) => e.node.id);
+    expect(ids).toContain(definitionId);
+  });
+
+  it('should dissociate a CustomFieldDefinition from Case-Incident', async () => {
+    const result = await queryAsAdmin({
+      query: REMOVE_ENTITY_TYPE,
+      variables: { id: definitionId, entityType: 'Case-Incident' },
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customFieldDefinitionRemoveEntityType.entity_types).not.toContain('Case-Incident');
+  });
+
+  // --- DELETE ---
+
+  it('should delete a CustomFieldDefinition', async () => {
+    const result = await queryAsAdmin({ query: DELETE_DEFINITION, variables: { id: definitionId } });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.customFieldDefinitionDelete).toBe(definitionId);
+    // Verify it is gone
+    const readResult = await queryAsAdmin({ query: READ_DEFINITION, variables: { id: definitionId } });
+    expect(readResult.data?.customFieldDefinition).toBeNull();
+    definitionId = ''; // already deleted, skip afterAll cleanup
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TODO: Additional field types (add here when implemented)
+// ---------------------------------------------------------------------------
+// describe('CustomFieldDefinition — string field_type', () => { ... });
+// describe('CustomFieldDefinition — boolean field_type', () => { ... });
+// describe('CustomFieldDefinition — date field_type', () => { ... });
+


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* POC: Add custom field for Case Incident
* SCOPE:
  - No UI for configuration (all with graphQL api only cc bottom of this page)
  - custom field value in Entity overview 
  - in creation and edition drawer (for the Entity)
  - filter with the field in list (for example filter on risk > 50 on Incident Response list)
  - can be used in dashboard (select columns)
  -  playbook can update this custom attribute 
  - CSV Mapper config
  - History on entity 
  - export stix ok => missing custom key because client python not updated for now

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* related : https://github.com/OpenCTI-Platform/opencti/issues/6177


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
* Query to crete custom fields
````
mutation CreateSelectCustomField {
  customFieldDefinitionAdd(input: {
    name: "priority"
    label: "Priority"
    field_type: "select"
    entity_types: ["Case-Incident"]
    mandatory: false
    description: "Prioriy level of the incident"
    select_options: ["P1", "P2", "P3", "P4"]
  }) {
    id
    name
    label
    field_type
    select_options
    entity_types
  }
}
````

* Query to add custom field to an Entity
````
mutation AddEntityTypeToCustomField {
  customFieldDefinitionAddEntityType(
    id: "<definition-id>"
    entityType: "Report"
  ) {
    id
    entity_types
  }
}
````

* Add custom field value to a sepcific Entity
````
mutation SetSelectCustomFieldValue {
  stixDomainObjectEdit(id: "<case-incident-id>") {
    fieldPatch(input: [
      { key: "x_opencti_cf_priority", value: ["P2"] }
    ]) {
      id
      customFieldValues {
        field_name
        select_value
      }
    }
  }
}
````

* Filter Entities on custom field value
````
query FilterBySelectCustomField {
  caseIncidents(
    filters: {
      mode: and
      filters: [{
        key: "x_opencti_cf_priority"
        values: ["P2"]
        operator: eq
      }]
      filterGroups: []
    }
  ) {
    edges {
      node {
        id
        name
        customFieldValues {
          field_name
          select_value
        }
      }
    }
  }
}
````