### PR TITLE
[frontend] wrap long titles and increase layout spacing for playbooks (#15751)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/hooks/useLayout.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/hooks/useLayout.ts
@@ -6,7 +6,7 @@ import { commitMutation } from '../../../../../relay/environment';
 import { useManipulateComponentsPlaybookUpdatePositionsMutation } from './useManipulateComponents';
 
 const layout = tree<Node>()
-  .nodeSize([200, 150])
+  .nodeSize([200, 175])
   .separation(() => 1);
 
 const options = { duration: 300 };

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodeWorkflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodeWorkflow.tsx
@@ -1,65 +1,18 @@
 import React, { memo, useState } from 'react';
 import { Handle, Position, NodeProps, useReactFlow } from 'reactflow';
-import { makeStyles } from '@mui/styles';
+import { useTheme } from '@mui/material/styles';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import IconButton from '@common/button/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { MoreVert, LoginOutlined } from '@mui/icons-material';
 import ItemIcon from '../../../../../../components/ItemIcon';
-import type { Theme } from '../../../../../../components/Theme';
 import { useFormatter } from '../../../../../../components/i18n';
+import { truncate } from '../../../../../../utils/String';
 
 type node = {
   id: string;
 };
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  node: {
-    position: 'relative',
-    border:
-      theme.palette.mode === 'dark'
-        ? '1px solid rgba(255, 255, 255, 0.12)'
-        : '1px solid rgba(0, 0, 0, 0.12)',
-    borderRadius: 4,
-    backgroundColor: theme.palette.background.paper,
-    width: 160,
-    height: 50,
-    padding: '8px 5px 5px 5px',
-  },
-  name: {
-    maxWidth: 100,
-    fontSize: 10,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  component: {
-    maxWidth: 100,
-    color:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, 0.5)'
-        : 'rgba(0, 0, 0, 0.5)',
-    fontSize: 8,
-    whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-  handlesWrapper: {
-    position: 'absolute',
-    bottom: 0,
-    left: 0,
-    width: '100%',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  handle: {
-    position: 'absolute',
-  },
-}));
 
 const getHandlePositionStyle = (count: number, index: number, width = 160): React.CSSProperties | undefined => {
   // we distribute evenly the output ports at the bottom using CSS
@@ -70,19 +23,45 @@ const getHandlePositionStyle = (count: number, index: number, width = 160): Reac
 };
 
 const NodeWorkflow = ({ id, data }: NodeProps) => {
-  const classes = useStyles();
+  const theme = useTheme();
   const { t_i18n } = useFormatter();
   const [anchorEl, setAnchorEl] = useState<Element | null>(null);
   const { getNode } = useReactFlow();
+
   return (
-    <div className={classes.node}>
+    <div style={{
+      position: 'relative',
+      border: theme.palette.mode === 'dark'
+        ? '1px solid rgba(255, 255, 255, 0.12)'
+        : '1px solid rgba(0, 0, 0, 0.12)',
+      borderRadius: 4,
+      backgroundColor: theme.palette.background.paper,
+      width: 160,
+      minHeight: 50,
+      padding: '8px 5px 5px 5px',
+    }}
+    >
       <ItemIcon type={data.component.icon} variant="inline" />
       <div style={{ float: 'left' }}>
         <Tooltip title={t_i18n(data.name)}>
-          <div className={classes.name}>{t_i18n(data.name)}</div>
+          <div style={{ maxWidth: 100, fontSize: 10, wordBreak: 'break-word' }}>
+            {t_i18n(truncate(data.name, 100, false))}
+          </div>
         </Tooltip>
         <Tooltip title={t_i18n(data.component.description)}>
-          <div className={classes.component}>{t_i18n(data.component.description)}</div>
+          <div style={{
+            maxWidth: 100,
+            fontSize: 8,
+            color: theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, 0.5)'
+              : 'rgba(0, 0, 0, 0.5)',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          >
+            {t_i18n(data.component.description)}
+          </div>
         </Tooltip>
       </div>
       <div className="clearfix" />
@@ -146,7 +125,16 @@ const NodeWorkflow = ({ id, data }: NodeProps) => {
       {!data.component?.is_entry_point && (
         <Handle type="target" position={Position.Top} isConnectable={false} />
       )}
-      <div className={classes.handlesWrapper}>
+      <div style={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+      >
         {(data.component?.ports ?? []).map((n: node, index: number, array: node[]) => (
           <Handle
             key={n.id}
@@ -154,8 +142,7 @@ const NodeWorkflow = ({ id, data }: NodeProps) => {
             type="source"
             position={Position.Bottom}
             isConnectable={false}
-            className={classes.handle}
-            style={getHandlePositionStyle(array.length, index)}
+            style={{ ...getHandlePositionStyle(array.length, index), position: 'absolute' }}
           />
         ))}
       </div>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Node titles in the playbook graph were being silently clipped when they exceeded the node width, making it impossible to read the full name without extra context. This PR wraps long node titles across multiple lines and increases the vertical layout spacing between nodes to prevent overlap

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes  #15751 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->