### PR TITLE
feat(backend): add a dead letter queue manager (#15981)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -249,6 +249,7 @@
   "Data type": "Datentyp",
   "Date": "Datum",
   "Date of birth": "Geburtsdatum",
+  "Dead letter queue manager": "Warteschlangenmanager für tote Briefe",
   "Decay applied rule": "Verfall angewandte Regel",
   "Decay base score": "Zerfalls-Basiswert",
   "Decay base score date": "Datum der Zerfallsbasisbewertung",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -249,6 +249,7 @@
   "Data type": "Data type",
   "Date": "Date",
   "Date of birth": "Date of birth",
+  "Dead letter queue manager": "Dead letter queue manager",
   "Decay applied rule": "Decay applied rule",
   "Decay base score": "Decay base score",
   "Decay base score date": "Decay base score date",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -249,6 +249,7 @@
   "Data type": "Tipo de datos",
   "Date": "Fecha",
   "Date of birth": "Fecha de nacimiento",
+  "Dead letter queue manager": "Gestor de colas de letra muerta",
   "Decay applied rule": "Regla de decaimiento aplicada",
   "Decay base score": "Decaimiento base score",
   "Decay base score date": "Decay base score date",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -249,6 +249,7 @@
   "Data type": "Type de données",
   "Date": "Date",
   "Date of birth": "Date de naissance",
+  "Dead letter queue manager": "Gestionnaire de file d'attente pour les lettres mortes",
   "Decay applied rule": "Règle de désintégration appliquée",
   "Decay base score": "Score de base de la désintégration",
   "Decay base score date": "Date du score de base de la désintégration",

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -249,6 +249,7 @@
   "Data type": "Tipo di dati",
   "Date": "Data",
   "Date of birth": "Data di nascita",
+  "Dead letter queue manager": "Gestore della coda delle lettere morte",
   "Decay applied rule": "Regola di decadimento applicata",
   "Decay base score": "Punteggio base di decadimento",
   "Decay base score date": "Data del punteggio base di decadimento",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -249,6 +249,7 @@
   "Data type": "データ型",
   "Date": "日付",
   "Date of birth": "性別",
+  "Dead letter queue manager": "デッドレターキューマネージャー",
   "Decay applied rule": "マーキング",
   "Decay base score": "崩壊ベーススコア",
   "Decay base score date": "崩壊履歴",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -249,6 +249,7 @@
   "Data type": "데이터 유형",
   "Date": "날짜",
   "Date of birth": "생년월일",
+  "Dead letter queue manager": "사서함 대기열 관리자",
   "Decay applied rule": "적용된 감쇠 규칙",
   "Decay base score": "감쇠 기본 점수",
   "Decay base score date": "감쇠 기본 점수 날짜",

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -249,6 +249,7 @@
   "Data type": "Тип данных",
   "Date": "Дата",
   "Date of birth": "Дата рождения",
+  "Dead letter queue manager": "Менеджер очереди мертвых писем",
   "Decay applied rule": "Правило применения распада",
   "Decay base score": "Базовая оценка распада",
   "Decay base score date": "Дата оценки базы распада",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -249,6 +249,7 @@
   "Data type": "数据类型",
   "Date": "日期",
   "Date of birth": "出生日期",
+  "Dead letter queue manager": "死信队列管理器",
   "Decay applied rule": "衰减应用规则",
   "Decay base score": "衰变基础分数",
   "Decay base score date": "衰变基础分数日期",

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -290,6 +290,12 @@
     "lock_key": "hub_registration_manager_lock",
     "interval": 3600000
   },
+  "dead_letter_queue_manager": {
+    "enabled": true,
+    "lock_key": "dead_letter_queue_manager_lock",
+    "interval": 6000000,
+    "batch_size": 100
+  },
   "indicator_decay_manager": {
     "enabled": true,
     "lock_key": "indicator_decay_manager_lock",

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -522,7 +522,7 @@ export const pushRouting = (connectorId) => `${RABBIT_QUEUE_PREFIX}push_routing_
 // - This constant is used here to build the dead_letter_routing value in connectorConfig.
 // - The full CONNECTOR_QUEUE_BUNDLES_TOO_LARGE queue configuration object is defined later
 //   in this file near the rest of the queue declarations.
-const CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID = 'too-large-bundle';
+export const CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID = 'too-large-bundle';
 
 /**
  * Build the complete connector configuration that includes:
@@ -745,6 +745,77 @@ export const consumeQueue = async (context, connectorId, connectionSetterCallbac
             }
           });
         }
+      });
+    } catch (globalError) {
+      reject(globalError);
+    }
+  });
+};
+
+/**
+ * Pull-based queue consumption with manual ack/nack support.
+ * Uses channel.get() to fetch messages one at a time.
+ * The callback receives the message content and must return true to ack or false to nack+requeue.
+ * Processes at most the number of messages present in the queue at the start, to avoid infinite loops
+ * when messages are nacked and requeued.
+ */
+export const consumeQueueWithAck = async (connectorId, callback) => {
+  const cfg = connectorConfig(connectorId);
+  const listenQueue = cfg.listen;
+  const connOptions = getConnectionOptions();
+  return new Promise((resolve, reject) => {
+    try {
+      amqp.connect(amqpUri(), connOptions, (err, conn) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        conn.on('error', (onConnectError) => {
+          reject(onConnectError);
+        });
+        conn.createChannel((channelError, channel) => {
+          if (channelError) {
+            conn.close();
+            reject(channelError);
+            return;
+          }
+          channel.on('error', (onChannelError) => {
+            reject(onChannelError);
+          });
+          const checkQueue = util.promisify(channel.checkQueue).bind(channel);
+          const getMsg = util.promisify(channel.get).bind(channel);
+          const processMessages = async () => {
+            // Get initial message count to cap processing and avoid infinite loops
+            const queueInfo = await checkQueue(listenQueue);
+            const maxMessages = queueInfo.messageCount;
+            let processed = 0;
+            while (processed < maxMessages) {
+              const msg = await getMsg(listenQueue, { noAck: false });
+              if (!msg) {
+                break; // Queue is empty
+              }
+              processed += 1;
+              try {
+                const success = await callback(msg.content.toString());
+                if (success) {
+                  channel.ack(msg);
+                } else {
+                  channel.nack(msg, false, true); // nack and requeue
+                }
+              } catch (_callbackError) {
+                channel.nack(msg, false, true); // nack and requeue on error
+              }
+            }
+            channel.close(() => conn.close(() => resolve()));
+          };
+          processMessages().catch((e) => {
+            try {
+              channel.close(() => conn.close(() => reject(e)));
+            } catch (_) {
+              reject(e);
+            }
+          });
+        });
       });
     } catch (globalError) {
       reject(globalError);

--- a/opencti-platform/opencti-graphql/src/manager/deadLetterQueueManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/deadLetterQueueManager.ts
@@ -1,0 +1,91 @@
+import { type ManagerDefinition, registerManager } from './managerModule';
+import conf, { booleanConf, logApp } from '../config/conf';
+import { CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID, consumeQueueWithAck, pushToWorkerForConnector } from '../database/rabbitmq';
+
+const DEAD_LETTER_QUEUE_MANAGER_ENABLED = booleanConf('dead_letter_queue_manager:enabled', true);
+const DEAD_LETTER_QUEUE_MANAGER_KEY = conf.get('dead_letter_queue_manager:lock_key') || 'dead_letter_queue_manager_lock';
+const SCHEDULE_TIME = conf.get('dead_letter_queue_manager:interval') || 6000000; // 100 minutes default
+
+/**
+ * Consumes messages from the dead letter queue (too-large-bundle) one by one,
+ * and re-publishes them to the original connector's worker queue.
+ *
+ * Each message contains a `rejection_info.original_connector_id` field
+ * that identifies which connector originally produced the bundle.
+ *
+ * Messages are only acked if successfully re-routed.
+ * If re-routing fails, the message is nacked and requeued.
+ */
+export const deadLetterQueueHandler = async () => {
+  let successCount = 0;
+  let errorCount = 0;
+
+  try {
+    await consumeQueueWithAck(CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID, async (rawMessage: string) => {
+      let data: any;
+      try {
+        data = JSON.parse(rawMessage);
+      } catch (e: any) {
+        logApp.error('[OPENCTI-MODULE] Dead letter queue manager - failed to parse message, nacking', {
+          cause: e,
+          manager: 'DEAD_LETTER_QUEUE_MANAGER',
+        });
+        errorCount += 1;
+        return false; // nack and requeue
+      }
+
+      const originalConnectorId = data?.rejection_info?.original_connector_id;
+      if (!originalConnectorId) {
+        logApp.warn('[OPENCTI-MODULE] Dead letter queue message missing original_connector_id, nacking', {
+          manager: 'DEAD_LETTER_QUEUE_MANAGER',
+        });
+        errorCount += 1;
+        return false; // nack and requeue
+      }
+
+      try {
+        // Remove rejection_info before re-sending to avoid infinite loops
+        delete data.rejection_info;
+
+        // Push the message back to the original connector's worker queue
+        await pushToWorkerForConnector(originalConnectorId, data);
+        successCount += 1;
+        return true; // ack
+      } catch (e: any) {
+        logApp.error('[OPENCTI-MODULE] Dead letter queue manager - failed to reprocess message, nacking', {
+          cause: e,
+          manager: 'DEAD_LETTER_QUEUE_MANAGER',
+          originalConnectorId,
+        });
+        errorCount += 1;
+        return false; // nack and requeue
+      }
+    });
+  } catch (e: any) {
+    logApp.error('[OPENCTI-MODULE] Dead letter queue manager handling error', { cause: e, manager: 'DEAD_LETTER_QUEUE_MANAGER' });
+  }
+
+  if (successCount > 0 || errorCount > 0) {
+    logApp.info(`[OPENCTI-MODULE] Dead letter queue manager completed: ${successCount} requeued, ${errorCount} errors`);
+  }
+};
+
+const DEAD_LETTER_QUEUE_MANAGER_DEFINITION: ManagerDefinition = {
+  id: 'DEAD_LETTER_QUEUE_MANAGER',
+  label: 'Dead letter queue manager',
+  executionContext: 'dead_letter_queue_manager',
+  cronSchedulerHandler: {
+    handler: deadLetterQueueHandler,
+    interval: SCHEDULE_TIME,
+    lockKey: DEAD_LETTER_QUEUE_MANAGER_KEY,
+  },
+  enabledByConfig: DEAD_LETTER_QUEUE_MANAGER_ENABLED,
+  enabledToStart(): boolean {
+    return this.enabledByConfig;
+  },
+  enabled(): boolean {
+    return this.enabledByConfig;
+  },
+};
+
+registerManager(DEAD_LETTER_QUEUE_MANAGER_DEFINITION);

--- a/opencti-platform/opencti-graphql/src/manager/index.ts
+++ b/opencti-platform/opencti-graphql/src/manager/index.ts
@@ -7,3 +7,4 @@ import './retentionManager';
 import './exclusionListCacheBuildManager';
 import './exclusionListCacheSyncManager';
 import './pirManager';
+import './deadLetterQueueManager';


### PR DESCRIPTION
This pull request introduces a new "dead letter queue manager" feature to improve reliability in handling failed message bundles in the OpenCTI platform. The main changes add a manager that periodically processes messages from the dead letter queue, attempts to re-route them to the appropriate connector, and provides robust error handling and logging. Additionally, a new utility for manual queue consumption with acknowledgment control is added, and related configuration and exports are updated.

**Dead Letter Queue Management:**

* Added a new `deadLetterQueueManager` configuration section in `default.json` to control enabling, locking, interval, and batch size for the manager.
* Implemented `deadLetterQueueManager.ts`, which defines a scheduled manager that consumes messages from the "too-large-bundle" dead letter queue, attempts to re-publish them to the original connector's worker queue, and provides detailed logging and error handling.
* Registered the new manager in the `manager/index.ts` entrypoint to ensure it is started with other managers.

**RabbitMQ Utilities:**

* Added `consumeQueueWithAck` to `rabbitmq.js`, allowing manual, pull-based queue consumption with per-message ack/nack and requeue logic, used by the dead letter queue manager.
* Exported `CONNECTOR_QUEUE_BUNDLES_TOO_LARGE_ID` from `rabbitmq.js` to make it accessible for dead letter queue management.
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fix #15981
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
