### PR TITLE
[client-python]fix: Restrain requests version to >=2.32.0, <2.34.0 in setup.cfg (#15973)

### DIFF
--- a/client-python/setup.cfg
+++ b/client-python/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     python-magic-bin~=0.4.14; sys_platform == 'win32'
     python_json_logger~=4.0.0
     PyYAML~=6.0
-    requests>=2.32.0, <3
+    requests>=2.32.0, <2.34.0
     setuptools~=82.0.0
     cachetools~=7.0.1
     prometheus-client~=0.24.1


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Restrain requests version to >=2.32.0, <2.34.0 in setup.cfg
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15973
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
