### PR TITLE
[backend] New entity type SecurityCoverageResult (#14716)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "Suche",
   "Secondary motivation": "Sekundäre Motivation",
+  "Security coverage": "Sicherheitsabdeckung",
   "Security platform type": "Typ der Sicherheitsplattform",
   "Selected attribute date": "Ausgewähltes Attribut Datum",
   "Selected IDs": "Ausgewählte IDs",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "Search",
   "Secondary motivation": "Secondary motivation",
+  "Security coverage": "Security coverage",
   "Security platform type": "Security platform type",
   "Selected attribute date": "Selected attribute date",
   "Selected IDs": "Selected IDs",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "Búsqueda",
   "Secondary motivation": "Motivación secundaria",
+  "Security coverage": "Cobertura de seguridad",
   "Security platform type": "Tipo de plataforma de seguridad",
   "Selected attribute date": "Fecha del atributo seleccionado",
   "Selected IDs": "IDs seleccionados",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "Recherche",
   "Secondary motivation": "Motivation secondaire",
+  "Security coverage": "Couverture de sécurité",
   "Security platform type": "Type de plateforme de sécurité",
   "Selected attribute date": "Date de l'attribut sélectionné",
   "Selected IDs": "ID sélectionnées",

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "Cerca",
   "Secondary motivation": "Motivazione secondaria",
+  "Security coverage": "Copertura di sicurezza",
   "Security platform type": "Tipo di piattaforma di sicurezza",
   "Selected attribute date": "Data attributo selezionato",
   "Selected IDs": "ID selezionati",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "検索",
   "Secondary motivation": "郵便番号",
+  "Security coverage": "安全保障",
   "Security platform type": "セキュリティ・プラットフォーム・タイプ",
   "Selected attribute date": "選択された属性の日付",
   "Selected IDs": "選択されたID",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "검색",
   "Secondary motivation": "부차적 동기",
+  "Security coverage": "보안 범위",
   "Security platform type": "보안 플랫폼 유형",
   "Selected attribute date": "선택된 속성 날짜",
   "Selected IDs": "선택된 ID",

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "Поиск",
   "Secondary motivation": "Вторичная мотивация",
+  "Security coverage": "Защитное покрытие",
   "Security platform type": "Тип платформы безопасности",
   "Selected attribute date": "Дата выбранного атрибута",
   "Selected IDs": "Выбранные идентификаторы",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -862,6 +862,7 @@
   "SDHASH": "SDHASH",
   "Search": "搜索",
   "Secondary motivation": "次要动机",
+  "Security coverage": "安保范围",
   "Security platform type": "安全平台类型",
   "Selected attribute date": "选定属性日期",
   "Selected IDs": "选定的 ID",

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -196,6 +196,7 @@ import { pushAll, unshiftAll } from '../utils/arrayUtil';
 import { getRoleAssumerWithWebIdentity } from '../utils/awsSdk';
 import { elConvertHits, elConvertHitsToMap, INNER_HITS_WINDOWS_SIZE } from './engine-data-converter';
 import { isEsScriptFilterEnabled } from './engine-config';
+import { RELATION_RESULT_OF } from '../modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 
 const ELK_ENGINE = 'elk';
 const OPENSEARCH_ENGINE = 'opensearch';
@@ -1699,6 +1700,7 @@ const REL_DEFAULT_FETCH = [
   `${REL_INDEX_PREFIX}${RELATION_GRANTED_TO}${REL_DEFAULT_SUFFIX}`,
   // DEFAULT (LOW VOLUME)
   `${REL_INDEX_PREFIX}${RELATION_COVERED}${REL_DEFAULT_SUFFIX}`,
+  `${REL_INDEX_PREFIX}${RELATION_RESULT_OF}${REL_DEFAULT_SUFFIX}`,
   `${REL_INDEX_PREFIX}${RELATION_CREATED_BY}${REL_DEFAULT_SUFFIX}`,
   `${REL_INDEX_PREFIX}${RELATION_OBJECT_LABEL}${REL_DEFAULT_SUFFIX}`,
   `${REL_INDEX_PREFIX}${RELATION_OBJECT_PARTICIPANT}${REL_DEFAULT_SUFFIX}`,

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -78,6 +78,7 @@ import './securityPlatform/securityPlatform';
 import './emailTemplate/emailTemplate';
 import './form/form';
 import './securityCoverage/securityCoverage';
+import './securityCoverage/securityCoverageResult/securityCoverageResult';
 import './authenticationProvider/authenticationProvider';
 import './customView/customView';
 import './retentionRules/retentionRules';

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-converter.ts
@@ -2,7 +2,6 @@ import { INPUT_COVERED, type StixSecurityCoverage, type StoreEntitySecurityCover
 import { buildStixDomain } from '../../database/stix-2-1-converter';
 import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
 import { cleanObject } from '../../database/stix-converter-utils';
-import { isNotEmptyField } from '../../database/utils';
 
 const convertSecurityCoverageToStix = (instance: StoreEntitySecurityCoverage): StixSecurityCoverage => {
   const stixDomainObject = buildStixDomain(instance);
@@ -10,9 +9,6 @@ const convertSecurityCoverageToStix = (instance: StoreEntitySecurityCoverage): S
     ...stixDomainObject,
     name: instance.name,
     description: instance.description,
-    covered: isNotEmptyField(instance.coverage_information),
-    coverage: (instance.coverage_information ?? [])
-      .map((c) => ({ name: c.coverage_name, score: c.coverage_score })),
     periodicity: instance.periodicity,
     type_affinity: instance.type_affinity,
     platforms_affinity: instance.platforms_affinity,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
@@ -13,7 +13,6 @@ export interface BasicStoreEntitySecurityCoverage extends BasicStoreEntity {
   duration: string;
   type_affinity: string;
   platforms_affinity: string[];
-  coverage_information: { coverage_name: string; coverage_score: number }[];
 }
 
 export interface StoreEntitySecurityCoverage extends StoreEntity {
@@ -22,7 +21,6 @@ export interface StoreEntitySecurityCoverage extends StoreEntity {
   type_affinity: string;
   platforms_affinity: string[];
   [INPUT_COVERED]: BasicStoreEntity;
-  coverage_information: { coverage_name: string; coverage_score: number }[];
 }
 // endregion
 
@@ -35,8 +33,6 @@ export interface StixSecurityCoverage extends StixDomainObject {
   type_affinity: string;
   platforms_affinity: string[];
   covered_ref: string;
-  covered: boolean;
-  coverage: { name: string; score: number }[];
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
   };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.ts
@@ -1,7 +1,7 @@
 import { type ModuleDefinition, registerDefinition } from '../../schema/module';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import { normalizeName } from '../../schema/identifier';
-import { createdAt, creators, coverageInformation, updatedAt } from '../../schema/attribute-definition';
+import { createdAt, creators, updatedAt } from '../../schema/attribute-definition';
 import {
   ATTRIBUTE_COVERED,
   ENTITY_TYPE_SECURITY_COVERAGE,
@@ -12,14 +12,8 @@ import {
 } from './securityCoverage-types';
 import convertSecurityCoverageToStix from './securityCoverage-converter';
 import { createdBy, objectLabel, objectMarking, objectOrganization } from '../../schema/stixRefRelationship';
-import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_VULNERABILITY } from '../../schema/stixDomainObject';
 import { COVERED_ENTITIES_TYPE, securityCoverageStixBundle } from './securityCoverage-domain';
-import { RELATION_HAS_COVERED } from '../../schema/stixCoreRelationship';
-import { REL_NEW } from '../../database/stix';
-import { ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM } from '../securityPlatform/securityPlatform-types';
 import type { StoreEntity } from '../../types/store';
-import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../../schema/stixCyberObservable';
-import { ENTITY_TYPE_INDICATOR } from '../indicator/indicator-types';
 
 const SECURITY_COVERAGE_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverage, StixSecurityCoverage> = {
   type: {
@@ -48,29 +42,13 @@ const SECURITY_COVERAGE_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverage
     { name: 'duration', label: 'Duration', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'type_affinity', label: 'Type affinity', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'platforms_affinity', label: 'Platform(s) affinity', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
-    { name: 'external_uri', label: 'External URI', type: 'string', format: 'short', mandatoryType: 'no', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     // TODO Move this field to upper level. Stix Domain Object
     { name: 'auto_enrichment_disable', label: 'Auto enrichment disable', type: 'boolean', mandatoryType: 'internal', editDefault: false, multiple: false, upsert: false, isFilterable: false },
-    { name: 'coverage_last_result', label: 'Last coverage', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
-    { name: 'coverage_valid_from', label: 'Valid coverage from', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
-    { name: 'coverage_valid_to', label: 'Valid coverage to', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
-    coverageInformation,
     creators,
     createdAt,
     updatedAt,
   ],
-  relations: [
-    {
-      name: RELATION_HAS_COVERED,
-      targets: [
-        { name: ENTITY_TYPE_ATTACK_PATTERN, type: REL_NEW },
-        { name: ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM, type: REL_NEW },
-        { name: ENTITY_TYPE_VULNERABILITY, type: REL_NEW },
-        { name: ENTITY_HASHED_OBSERVABLE_ARTIFACT, type: REL_NEW },
-        { name: ENTITY_TYPE_INDICATOR, type: REL_NEW },
-      ],
-    },
-  ],
+  relations: [],
   relationsRefs: [
     {
       name: INPUT_COVERED,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter.ts
@@ -1,0 +1,29 @@
+import { buildStixDomain } from '../../../database/stix-2-1-converter';
+import { STIX_EXT_OCTI } from '../../../types/stix-2-1-extensions';
+import { cleanObject } from '../../../database/stix-converter-utils';
+import { ATTRIBUTE_RESULT_OF, INPUT_RESULT_OF, type StixSecurityCoverageResult, type StoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
+import { isNotEmptyField } from '../../../database/utils';
+
+const convertSecurityCoverageResultToStix = (instance: StoreEntitySecurityCoverageResult): StixSecurityCoverageResult => {
+  const stixDomainObject = buildStixDomain(instance);
+  return {
+    ...stixDomainObject,
+    name: instance.name,
+    external_uri: instance.external_uri,
+    coverage_last_result: instance.coverage_last_result,
+    coverage_valid_from: instance.coverage_valid_from,
+    coverage_valid_to: instance.coverage_valid_to,
+    covered: isNotEmptyField(instance.coverage_information),
+    coverage: (instance.coverage_information ?? [])
+      .map((c) => ({ name: c.coverage_name, score: c.coverage_score })),
+    [ATTRIBUTE_RESULT_OF]: instance[INPUT_RESULT_OF].standard_id,
+    extensions: {
+      [STIX_EXT_OCTI]: cleanObject({
+        ...stixDomainObject.extensions[STIX_EXT_OCTI],
+        extension_type: 'new-sdo',
+      }),
+    },
+  };
+};
+
+export default convertSecurityCoverageResultToStix;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types.ts
@@ -1,0 +1,42 @@
+import type { BasicStoreEntity, StoreEntity } from '../../../types/store';
+import type { StixDomainObject, StixOpenctiExtensionSDO } from '../../../types/stix-2-1-common';
+import { STIX_EXT_OCTI } from '../../../types/stix-2-1-extensions';
+import type { BasicStoreEntitySecurityCoverage } from '../securityCoverage-types';
+
+export const ENTITY_TYPE_SECURITY_COVERAGE_RESULT = 'Security-Coverage-Result';
+export const RELATION_RESULT_OF = 'result-of';
+export const ATTRIBUTE_RESULT_OF = 'result_of_ref';
+export const INPUT_RESULT_OF = 'resultOf';
+
+export interface BasicStoreEntitySecurityCoverageResult extends BasicStoreEntity {
+  name: string;
+  external_uri?: string;
+  coverage_last_result?: string;
+  coverage_valid_from?: string;
+  coverage_valid_to?: string;
+  coverage_information?: { coverage_name: string; coverage_score: number }[];
+}
+
+export interface StoreEntitySecurityCoverageResult extends StoreEntity {
+  name: string;
+  external_uri?: string;
+  coverage_last_result?: string;
+  coverage_valid_from?: string;
+  coverage_valid_to?: string;
+  coverage_information?: { coverage_name: string; coverage_score: number }[];
+  [INPUT_RESULT_OF]: BasicStoreEntitySecurityCoverage;
+}
+
+export interface StixSecurityCoverageResult extends StixDomainObject {
+  name: string;
+  external_uri?: string;
+  coverage_last_result?: string;
+  coverage_valid_from?: string;
+  coverage_valid_to?: string;
+  coverage: { name: string; score: number }[];
+  covered: boolean;
+  [ATTRIBUTE_RESULT_OF]: string;
+  extensions: {
+    [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
+  };
+}

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types.ts
@@ -8,13 +8,18 @@ export const RELATION_RESULT_OF = 'result-of';
 export const ATTRIBUTE_RESULT_OF = 'result_of_ref';
 export const INPUT_RESULT_OF = 'resultOf';
 
+interface CoverageInformation {
+  coverage_name: string;
+  coverage_score: number;
+}
+
 export interface BasicStoreEntitySecurityCoverageResult extends BasicStoreEntity {
   name: string;
   external_uri?: string;
   coverage_last_result?: string;
   coverage_valid_from?: string;
   coverage_valid_to?: string;
-  coverage_information?: { coverage_name: string; coverage_score: number }[];
+  coverage_information?: CoverageInformation[];
 }
 
 export interface StoreEntitySecurityCoverageResult extends StoreEntity {
@@ -23,7 +28,7 @@ export interface StoreEntitySecurityCoverageResult extends StoreEntity {
   coverage_last_result?: string;
   coverage_valid_from?: string;
   coverage_valid_to?: string;
-  coverage_information?: { coverage_name: string; coverage_score: number }[];
+  coverage_information?: CoverageInformation[];
   [INPUT_RESULT_OF]: BasicStoreEntitySecurityCoverage;
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.ts
@@ -1,0 +1,95 @@
+import { type ModuleDefinition, registerDefinition } from '../../../schema/module';
+import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../../schema/general';
+import { normalizeName } from '../../../schema/identifier';
+import { createdAt, creators, coverageInformation, updatedAt } from '../../../schema/attribute-definition';
+import { ENTITY_TYPE_SECURITY_COVERAGE } from '../securityCoverage-types';
+import { createdBy, objectLabel, objectMarking, objectOrganization } from '../../../schema/stixRefRelationship';
+import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_VULNERABILITY } from '../../../schema/stixDomainObject';
+import { RELATION_HAS_COVERED } from '../../../schema/stixCoreRelationship';
+import { REL_NEW } from '../../../database/stix';
+import type { StoreEntity } from '../../../types/store';
+import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../../../schema/stixCyberObservable';
+import { ENTITY_TYPE_INDICATOR } from '../../indicator/indicator-types';
+import { ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM } from '../../securityPlatform/securityPlatform-types';
+import {
+  ATTRIBUTE_RESULT_OF,
+  ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  INPUT_RESULT_OF,
+  RELATION_RESULT_OF,
+  type StixSecurityCoverageResult,
+  type StoreEntitySecurityCoverageResult,
+} from './securityCoverageResult-types';
+import convertSecurityCoverageResultToStix from './securityCoverageResult-converter';
+
+const SECURITY_COVERAGE_RESULT_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverageResult, StixSecurityCoverageResult> = {
+  type: {
+    id: 'security-coverage-result',
+    name: ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+    category: ABSTRACT_STIX_DOMAIN_OBJECT,
+    aliased: false,
+  },
+  identifier: {
+    definition: {
+      [ENTITY_TYPE_SECURITY_COVERAGE_RESULT]: [{ src: 'name' }, { src: 'external_uri' }, { src: INPUT_RESULT_OF }],
+    },
+    resolvers: {
+      name(data: object) {
+        return normalizeName(data);
+      },
+      resultOf(data: object) {
+        return (data as StoreEntity).standard_id;
+      },
+    },
+  },
+  attributes: [
+    { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'external_uri', label: 'External URI', type: 'string', format: 'short', mandatoryType: 'no', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { name: 'coverage_last_result', label: 'Last coverage', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'coverage_valid_from', label: 'Valid coverage from', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    { name: 'coverage_valid_to', label: 'Valid coverage to', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: false },
+    coverageInformation,
+    creators,
+    createdAt,
+    updatedAt,
+  ],
+  relations: [
+    {
+      name: RELATION_HAS_COVERED,
+      targets: [
+        { name: ENTITY_TYPE_ATTACK_PATTERN, type: REL_NEW },
+        { name: ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM, type: REL_NEW },
+        { name: ENTITY_TYPE_VULNERABILITY, type: REL_NEW },
+        { name: ENTITY_HASHED_OBSERVABLE_ARTIFACT, type: REL_NEW },
+        { name: ENTITY_TYPE_INDICATOR, type: REL_NEW },
+      ],
+    },
+  ],
+  relationsRefs: [
+    {
+      name: INPUT_RESULT_OF,
+      type: 'ref',
+      databaseName: RELATION_RESULT_OF,
+      stixName: ATTRIBUTE_RESULT_OF,
+      label: 'Security coverage',
+      mandatoryType: 'external',
+      editDefault: false,
+      multiple: false,
+      upsert: true,
+      isRefExistingForTypes(this, fromType, toType) {
+        return fromType === ENTITY_TYPE_SECURITY_COVERAGE_RESULT && this.toTypes.includes(toType);
+      },
+      isFilterable: true,
+      toTypes: [ENTITY_TYPE_SECURITY_COVERAGE],
+    },
+    objectLabel,
+    objectMarking,
+    createdBy,
+    { ...objectOrganization, isFilterable: false },
+  ],
+  representative: (stix: StixSecurityCoverageResult) => {
+    return stix.name;
+  },
+  converter_2_1: convertSecurityCoverageResultToStix,
+};
+
+registerDefinition(SECURITY_COVERAGE_RESULT_DEFINITION);

--- a/opencti-platform/opencti-graphql/src/schema/module.ts
+++ b/opencti-platform/opencti-graphql/src/schema/module.ts
@@ -35,6 +35,8 @@ import { pushAll } from '../utils/arrayUtil';
 
 export const modules = new Map();
 
+type IdentifierDefinition = { src: string; dependencies?: string[] };
+
 export interface ModuleDefinition<T extends StoreEntity, Z extends StixObject, Z0 extends S20.StixObject = S20.StixObject> {
   type: {
     id: string;
@@ -44,7 +46,7 @@ export interface ModuleDefinition<T extends StoreEntity, Z extends StixObject, Z
   };
   identifier: {
     definition: {
-      [k: string]: Array<{ src: string; dependencies?: string[] }> | string | (() => string);
+      [k: string]: Array<IdentifierDefinition | IdentifierDefinition[]> | string | (() => string);
     };
     resolvers?: {
       [f: string]: (value: any, data?: object) => string;

--- a/opencti-platform/opencti-graphql/src/schema/stixDomainObject.ts
+++ b/opencti-platform/opencti-graphql/src/schema/stixDomainObject.ts
@@ -26,6 +26,7 @@ import { ENTITY_TYPE_IDENTITY_SECURITY_PLATFORM } from '../modules/securityPlatf
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../modules/grouping/grouping-types';
 import { ENTITY_TYPE_CONTAINER_FEEDBACK } from '../modules/case/feedback/feedback-types';
 import { ENTITY_TYPE_SECURITY_COVERAGE } from '../modules/securityCoverage/securityCoverage-types';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT } from '../modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 
 export const ATTRIBUTE_NAME = 'name';
 export const ATTRIBUTE_ABSTRACT = 'attribute_abstract';
@@ -145,6 +146,7 @@ export const STIX_DOMAIN_OBJECTS: Array<string> = [
   ENTITY_TYPE_VULNERABILITY,
   ENTITY_TYPE_INCIDENT,
   ENTITY_TYPE_SECURITY_COVERAGE,
+  ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
 ];
 schemaTypesDefinition.register(ABSTRACT_STIX_DOMAIN_OBJECT, STIX_DOMAIN_OBJECTS);
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-converter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-converter-test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import convertSecurityCoverageResultToStix from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter';
+import {
+  ATTRIBUTE_RESULT_OF,
+  ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  INPUT_RESULT_OF,
+  type StoreEntitySecurityCoverageResult,
+} from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
+import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+
+const BASE_INSTANCE = {
+  _index: 'opencti_internal_objects-000001',
+  internal_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
+  standard_id: 'security-coverage-result--aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
+  x_opencti_stix_ids: [],
+  created_at: '2025-01-01T00:00:00.000Z',
+  updated_at: '2025-01-02T00:00:00.000Z',
+  base_type: 'ENTITY' as const,
+  entity_type: ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  parent_types: ['Basic-Object', 'Internal-Object'],
+};
+
+describe('SecurityCoverageResult converter', () => {
+  it('should return expected STIX result', () => {
+    const instance = {
+      ...BASE_INSTANCE,
+      name: 'security coverage result',
+      external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      coverage_last_result: '2025-02-01T00:00:00.000Z',
+      coverage_valid_from: '2025-03-01T00:00:00.000Z',
+      coverage_valid_to: '2025-04-01T00:00:00.000Z',
+      coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 40 }],
+      [INPUT_RESULT_OF]: { standard_id: 'security-coverage-aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa' },
+    } as unknown as StoreEntitySecurityCoverageResult;
+
+    const expectedExtensions = {
+      [STIX_EXT_OCTI]: {
+        extension_type: 'new-sdo',
+        id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa',
+        type: 'Security-Coverage-Result',
+        created_at: '2025-01-01T00:00:00.000Z',
+        updated_at: '2025-01-02T00:00:00.000Z',
+        is_inferred: false,
+      },
+    };
+
+    const result = convertSecurityCoverageResultToStix(instance);
+    expect(result.name).toEqual('security coverage result');
+    expect(result.external_uri).toEqual('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131');
+    expect(result.coverage_last_result).toEqual('2025-02-01T00:00:00.000Z');
+    expect(result.coverage_valid_from).toEqual('2025-03-01T00:00:00.000Z');
+    expect(result.coverage_valid_to).toEqual('2025-04-01T00:00:00.000Z');
+    expect(result.coverage).toEqual([{ name: 'vulnerability', score: 40 }]);
+    expect(result[ATTRIBUTE_RESULT_OF]).toEqual('security-coverage-aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa');
+    expect(result.extensions).toEqual(expectedExtensions);
+    expect(result.covered).toEqual(true);
+  });
+
+  it('should return expected STIX result when there is no coverage_information', () => {
+    const instance = {
+      ...BASE_INSTANCE,
+      name: 'security coverage result',
+      external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      coverage_last_result: '2025-02-01T00:00:00.000Z',
+      coverage_valid_from: '2025-03-01T00:00:00.000Z',
+      coverage_valid_to: '2025-04-01T00:00:00.000Z',
+      [INPUT_RESULT_OF]: { standard_id: 'security-coverage-aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa' },
+    } as unknown as StoreEntitySecurityCoverageResult;
+
+    const result = convertSecurityCoverageResultToStix(instance);
+
+    expect(result.coverage).toEqual([]);
+    expect(result.covered).toEqual(false);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
+import { generateStandardId } from '../../../../src/schema/identifier';
+
+describe('SecurityCoverageResult identifier', () => {
+  const generateId = (data: any) => generateStandardId(
+    ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+    {
+      resultOf: { standard_id: 'security-coverage-1232121a12e' },
+      ...data,
+    },
+  );
+
+  it('should throw an error if no data given', () => {});
+
+  describe('using same ref resultOf', () => {
+    it('should have same ID if given same name (no external_uri)', () => {
+      const standardId1 = generateId({
+        name: 'My security coverage',
+      });
+      const standardId2 = generateId({
+        name: 'My security coverage',
+      });
+      expect(standardId1).toEqual(standardId2);
+    });
+
+    it('should have different ID if given different name (no external_uri)', () => {
+      const standardId1 = generateId({
+        name: 'My security coverage',
+      });
+      const standardId2 = generateId({
+        name: 'My security coverage bis',
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+
+    it('should have same ID if given same external_uri (no name)', () => {
+      const standardId1 = generateId({
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      expect(standardId1).toEqual(standardId2);
+    });
+
+    it('should have different ID if given different external_uri (no name)', () => {
+      const standardId1 = generateId({
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd35294',
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+
+    it('should have same ID if given same couple (name/external_uri)', () => {
+      const standardId1 = generateId({
+        name: 'Super result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        name: 'Super result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      expect(standardId1).toEqual(standardId2);
+    });
+
+    it('should have different ID if given same name but different external_uri', () => {
+      const standardId1 = generateId({
+        name: 'Super result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        name: 'Super result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd39375',
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+
+    it('should have different ID if given same external_uri but different name', () => {
+      const standardId1 = generateId({
+        name: 'Super result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        name: 'Super coverage result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+
+    it('should have different ID if given different external_uri but different name', () => {
+      const standardId1 = generateId({
+        name: 'Super result',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        name: 'Super result bis',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd37351',
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+  });
+
+  describe('using different ref resultOf', () => {
+    it('should have different ID with same name but different ref', () => {
+      const standardId1 = generateId({
+        name: 'Super result',
+      });
+      const standardId2 = generateId({
+        name: 'Super result',
+        resultOf: { standard_id: 'security-coverage-1232121472165' },
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+
+    it('should have different ID with same external_uri but different ref', () => {
+      const standardId1 = generateId({
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      });
+      const standardId2 = generateId({
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd39375',
+        resultOf: { standard_id: 'security-coverage-1232121472165' },
+      });
+      expect(standardId1).not.toEqual(standardId2);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 import { generateStandardId } from '../../../../src/schema/identifier';
 
+import '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult';
+
 describe('SecurityCoverageResult identifier', () => {
   const generateId = (data: any) => generateStandardId(
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,

--- a/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/entityCountHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/02-dataInjection/01-dataCount/entityCountHelper.ts
@@ -10,7 +10,7 @@ export const entitiesCounter = {
   CourseOfAction: 1,
   Credential: 1,
   DecayRule: 4,
-  EntitySetting: 46,
+  EntitySetting: 47,
   ExternalReference: 7,
   Group: TESTING_GROUPS.length + 3,
   Incident: 1,


### PR DESCRIPTION
### Proposed changes

Chunk 1 of the feature

**Objective**: in backend side, the new entity `SecurityCoverageResult` is defined in OpenCTI structure. At this point, we cannot create any results through the API and fetching results is not ISO with old model.

* Create new partial module `SecurityCoverageResult`,
* Remove some attributes and ref `has-covered` of `SecurityCoverage`,
* Add unit tests for converter and identifier computation of `SecurityCoverageResult`.

The module does not contain any API yet, only entity definition.

Tests are failing in CI right now and it is expected. They will be green again in next chunk which is about make the required modifications to make the old API compliant with the new data model.

### Related issues

* #14716

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->