### PR TITLE
[backend] Fix it test flake on sharing and on e2e (#15955)

### DIFF
--- a/.github/workflows/ci-test-frontend.yml
+++ b/.github/workflows/ci-test-frontend.yml
@@ -99,6 +99,7 @@ jobs:
           -e APP__CHILD_LOCKING_PROCESS__ENABLED=true \
           -e APP__ADMIN__TOKEN=bfa014e0-e02e-4aa6-a42b-603b19dcf159 \
           -e APP__APP_LOG__EXTENDED_ERROR_MESSAGE=true \
+          -e APP__SESSION_TIMEOUT=3600000 \
           -e APP__HEALTH_ACCESS_KEY=cihealthkey \
           -e REDIS__HOSTNAME=redis \
           -e REDIS__NAMESPACE=e2e-start \

--- a/.github/workflows/ci-test-frontend.yml
+++ b/.github/workflows/ci-test-frontend.yml
@@ -162,6 +162,7 @@ jobs:
           -e BACK_END_URL=http://opencti-e2e-start:4100 \
           -e E2E_TEST=true \
           -e TEAMS_WEBHOOK="teams-webhook-url" \
+          -e NODE_OPTIONS=--max_old_space_size=8192 \
           node:22.21.0 \
           sh -c 'set -ex;
               echo "$(ls /root/.yarn/berry/cache/ 2> /dev/null | wc -l || echo 0) packages in Yarn global cache"

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -90,7 +90,8 @@
     "bulk_creation_size": 5
   },
   "task_scheduler": {
-    "enabled": true
+    "enabled": true,
+    "interval": 1000
   },
   "expiration_scheduler": {
     "enabled": true


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Default is 10s and in the test it loop until 10s max so on some case it's not enough at 1s. Instead of waiting more I think it's possible to increase task manager frequency for tests.

- default session timeout is 20min, I think in some case (with some retries) it's not enough for the e2e tests.

https://github.com/OpenCTI-Platform/opencti/blob/71b54d97ac4d31f5494eec20380bfb939aff9793/opencti-platform/opencti-graphql/config/default.json#L260-L263

And

https://github.com/OpenCTI-Platform/opencti/blob/71b54d97ac4d31f5494eec20380bfb939aff9793/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/organization-sharing-test.ts#L128

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #15955 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
