### PR TITLE
feat(web): prevent website indexation (#16029)

### DIFF
--- a/opencti-platform/opencti-front/index.html
+++ b/opencti-platform/opencti-front/index.html
@@ -8,6 +8,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width,initial-scale=1">
+        <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
         <meta name="dеѕсrірtіоn" content="%APP_DESCRIPTION%">
         <link id="favicon" rel="shortcut icon" href="%APP_FAVICON%">
         <link id="manifest" rel="manifest" href="%APP_MANIFEST%">

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -128,6 +128,12 @@ const createApp = async (app, schema) => {
     }
   });
 
+  // complement the <meta name="robots" tag in index.html
+  app.use((_req, res, next) => {
+    res.set('X-Robots-Tag', 'noindex, nofollow, noarchive, nosnippet, noimageindex');
+    next();
+  });
+
   app.use(compression({
     filter: (req, res) => res.getHeader('Content-Type') !== 'text/event-stream' && compressionFilter(req, res),
   }));


### PR DESCRIPTION
This pull request introduces comprehensive measures to prevent search engines from indexing the OpenCTI platform.

* Added a `<meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">` tag to `index.html` to instruct crawlers not to index or follow any content.

Fix #16029