### PR TITLE
[backend/frontend] Fix public dashboard URI key not generated for non-Latin names (#16005)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/PublicDashboardCreationForm.tsx
@@ -22,6 +22,7 @@ import useAuth from '../../../../../utils/hooks/useAuth';
 import { ME_FILTER_VALUE } from '../../../../../utils/filters/filtersUtils';
 import { fromB64 } from '../../../../../utils/String';
 import FormButtonContainer from '../../../../../components/common/form/FormButtonContainer';
+import { generatePublicDashboardUriKey } from './public-dashboard-utils';
 
 const publicDashboardCreateMutation = graphql`
   mutation PublicDashboardCreationFormCreateMutation($input: PublicDashboardAddInput!) {
@@ -165,7 +166,7 @@ const PublicDashboardCreationFormComponent = ({
             label={t_i18n('Name')}
             style={fieldSpacingContainerStyle}
             onChange={(_: string, val: string) => {
-              setFieldValue('uri_key', val.replace(/[^a-zA-Z0-9\s-]+/g, '').replace(/\s+/g, '-').toLowerCase());
+              setFieldValue('uri_key', generatePublicDashboardUriKey(val));
             }}
           />
           <Field

--- a/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/public-dashboard-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/dashboards/public_dashboards/public-dashboard-utils.ts
@@ -1,5 +1,16 @@
+import { v4 as uuidv4 } from 'uuid';
 import { copyToClipboard } from '../../../../../utils/utils';
 import { APP_BASE_PATH } from '../../../../../relay/environment';
+
+/**
+ * Generates a URI key slug from a dashboard name.
+ * Strips non-ASCII characters and replaces spaces with hyphens.
+ * Falls back to a UUID v4 if the resulting slug is empty (e.g. fully non-Latin name).
+ */
+export const generatePublicDashboardUriKey = (name: string): string => {
+  const slug = name.replace(/[^a-zA-Z0-9\s-]+/g, '').replace(/\s+/g, '-').toLowerCase();
+  return slug || uuidv4();
+};
 
 export const copyPublicDashboardLinkUrl = (t: (text: string) => string, uriKey: string) => {
   copyToClipboard(

--- a/opencti-platform/opencti-front/src/utils/tests/PublicDashboardUtils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/tests/PublicDashboardUtils.test.ts
@@ -15,5 +15,3 @@ describe('generatePublicDashboardUriKey', () => {
     expect(result).toMatch(UUID_V4_REGEX);
   });
 });
-
-

--- a/opencti-platform/opencti-front/src/utils/tests/PublicDashboardUtils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/tests/PublicDashboardUtils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+
+import { generatePublicDashboardUriKey } from '@components/workspaces/dashboards/public_dashboards/public-dashboard-utils';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('generatePublicDashboardUriKey', () => {
+  it('should convert a Latin name to a lowercase hyphenated slug', () => {
+    expect(generatePublicDashboardUriKey('My Dashboard')).toBe('my-dashboard');
+  });
+
+  it('should fall back to a UUID v4 when the name contains only non-Latin characters', () => {
+    // Japanese name — all characters are stripped by the ASCII-only regex
+    const result = generatePublicDashboardUriKey('私のダッシュボード');
+    expect(result).toMatch(UUID_V4_REGEX);
+  });
+});
+
+

--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
@@ -31,7 +31,7 @@ import { findAllWorkspaces } from '../workspace/workspace-domain';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../schema/stixMetaObject';
 import { getEntitiesMapFromCache } from '../../database/cache';
 import type { BasicStoreRelation, NumberResult, BasicConnection, StoreEntity, StoreMarkingDefinition } from '../../types/store';
-import { checkUserIsAdminOnDashboard, getWidgetArguments } from './publicDashboard-utils';
+import { checkUserIsAdminOnDashboard, getWidgetArguments, sanitizePublicDashboardUriKey } from './publicDashboard-utils';
 import {
   findStixCoreObjectPaginated,
   stixCoreObjectsDistribution,
@@ -175,7 +175,7 @@ export const addPublicDashboard = async (
     await checkUserCanShareMarkings(context, user, markingLevels);
   }
 
-  const uriKey = input.uri_key.replace(/[^a-zA-Z0-9\s-]+/g, '').replace(/\s+/g, '-').toLowerCase();
+  const uriKey = sanitizePublicDashboardUriKey(input.uri_key);
   const existingDashboard = await getPublicDashboardByUriKey(context, uriKey);
   if (existingDashboard) {
     throw FunctionalError(`Cannot publish this dashboard, uri key ${uriKey} already used.`);

--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-utils.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { getEntitiesListFromCache, getEntitiesMapFromCache } from '../../database/cache';
 import { getUserAccessRight, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../../utils/access';
 import { ENTITY_TYPE_PUBLIC_DASHBOARD, type PublicDashboardCached, type PublicDashboardCachedWidget } from './publicDashboard-types';
@@ -10,6 +11,15 @@ import { ENTITY_TYPE_MARKING_DEFINITION } from '../../schema/stixMetaObject';
 import { elLoadById } from '../../database/engine';
 import { cleanMarkings } from '../../utils/markingDefinition-utils';
 import { findById as findWorkspace } from '../workspace/workspace-domain';
+
+/**
+ * Sanitizes a raw uri_key input to a valid [a-z0-9-] slug.
+ * Falls back to a UUID v4 if the resulting slug is empty (e.g. fully non-Latin input).
+ */
+export const sanitizePublicDashboardUriKey = (input: string): string => {
+  const slug = input.replace(/[^a-zA-Z0-9\s-]+/g, '').replace(/\s+/g, '-').toLowerCase();
+  return slug || uuidv4();
+};
 
 /**
  * Find which markings should be used when searching the data to populate in the widgets.

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/publicDashboard/publicDashboard-utils-unit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/publicDashboard/publicDashboard-utils-unit-test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizePublicDashboardUriKey } from '../../../../src/modules/publicDashboard/publicDashboard-utils';
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('sanitizePublicDashboardUriKey', () => {
+  it('should convert a Latin name to a lowercase hyphenated slug', () => {
+    expect(sanitizePublicDashboardUriKey('My Dashboard')).toBe('my-dashboard');
+  });
+
+  it('should fall back to a UUID v4 when the input contains only non-Latin characters', () => {
+    // Japanese name — all characters are stripped by the ASCII-only regex
+    const result = sanitizePublicDashboardUriKey('私のダッシュボード');
+    expect(result).toMatch(UUID_V4_REGEX);
+  });
+});


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* add a UUID fallback when the generated uri_key is empty.

After investigating the fix for the empty URI key issue with non-Latin dashboard names, I've chosen to keep the URI strictly restricted to [a-z0-9-] characters and add a UUID fallback when the generated slug is empty.
Allowing Unicode characters in URIs would introduce security risks.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: #16005


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
