### PR TITLE
[backend] authorized_members in playbook should be an array (#15986)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/notifier-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/notifier-component.ts
@@ -17,7 +17,7 @@ import { extractEntityRepresentativeName } from '../../../database/entity-repres
 
 export interface NotifierConfiguration {
   notifiers: string[];
-  authorized_members: object;
+  authorized_members: { value: string }[];
 }
 
 const PLAYBOOK_NOTIFIER_COMPONENT_SCHEMA: JSONSchemaType<NotifierConfiguration> = {
@@ -30,7 +30,17 @@ const PLAYBOOK_NOTIFIER_COMPONENT_SCHEMA: JSONSchemaType<NotifierConfiguration> 
       $ref: 'Notifiers',
       items: { type: 'string', oneOf: [] },
     },
-    authorized_members: { type: 'object' },
+    authorized_members: {
+      type: 'array',
+      default: [],
+      items: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+        },
+        required: ['value'],
+      },
+    },
   },
   required: ['notifiers', 'authorized_members'],
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -627,7 +627,7 @@ const PLAYBOOK_RULE_COMPONENT: PlaybookComponent<RuleConfiguration> = {
 
 export interface NotifierConfiguration {
   notifiers: string[];
-  authorized_members: object;
+  authorized_members: { value: string }[];
 }
 const PLAYBOOK_NOTIFIER_COMPONENT_SCHEMA: JSONSchemaType<NotifierConfiguration> = {
   type: 'object',
@@ -639,7 +639,17 @@ const PLAYBOOK_NOTIFIER_COMPONENT_SCHEMA: JSONSchemaType<NotifierConfiguration> 
       $ref: 'Notifiers',
       items: { type: 'string', oneOf: [] },
     },
-    authorized_members: { type: 'object' },
+    authorized_members: {
+      type: 'array',
+      default: [],
+      items: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+        },
+        required: ['value'],
+      },
+    },
   },
   required: ['notifiers', 'authorized_members'],
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update authorized_members schema because frontend form expect an array instead of an object for the autocomplete
component

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #15986 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
