### PR TITLE
fix(frontend): fix background task dialog: move selected element count to title area (#16066)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -21,7 +21,7 @@ import {
   TransformOutlined,
   UnpublishedOutlined,
 } from '@mui/icons-material';
-import { DialogContentText, FormControlLabel, Switch } from '@mui/material';
+import { FormControlLabel, Switch } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Autocomplete from '@mui/material/Autocomplete';
 import Avatar from '@mui/material/Avatar';
@@ -2606,11 +2606,15 @@ class DataTableToolBar extends Component {
                 open={this.state.displayTask}
                 onClose={this.handleCloseTask.bind(this)}
                 data-testid="background-task-popup"
-                title={t('Launch a background task')}
+                title={(
+                  <span style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
+                    <span>{t('Launch a background task')}</span>
+                    <span style={{ fontSize: '0.875rem' }}>
+                      {n(numberOfSelectedElements)} {t('selected element(s)')}
+                    </span>
+                  </span>
+                )}
               >
-                <DialogContentText>
-                  {`${n(numberOfSelectedElements)} ${t('selected element(s)')}`}
-                </DialogContentText>
                 {numberOfSelectedElements > 1000 && (
                   <Alert severity="warning">
                     {t(


### PR DESCRIPTION
## Description

The number of selected elements was displayed inside the `DialogContentText` (body) of the 'Launch a background task' dialog. According to the issue, the count should be displayed at the top right of the dialog.

## Changes

- Moved the selected element count from the dialog content body (`DialogContentText`) to the dialog title area, positioned at the top right
- Removed the now-unused `DialogContentText` import

## Before

The selected count appeared as body text below the dialog title.

## After

The selected count now appears at the top right of the dialog title bar, aligned with the title text on the left and the count on the right.

## Related issue

Closes #16066