### PR TITLE
[frontend] Fix flaky custom views E2E test (#16097)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/customView/customView.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/customView/customView.spec.ts
@@ -80,7 +80,7 @@ test('Custom View CRUD - golden path', { tag: ['@ce'] }, async ({ page }) => {
 
   // ─── Verify tab appears on a Campaign entity page ─────────────────────────────
   await leftBarPage.clickOnMenu('Threats', 'Campaigns');
-  await campaignPage.getItemFromListWithUrl('menuPass').click();
+  await campaignPage.getNthItemFromGrid(0).click();
   // The custom view tab should be visible (single view → uses view name directly)
   await expect(page.getByRole('tab', { name: viewName })).toBeVisible();
 
@@ -93,7 +93,7 @@ test('Custom View CRUD - golden path', { tag: ['@ce'] }, async ({ page }) => {
 
   // Verify the default tab is first on a Campaign entity page
   await leftBarPage.clickOnMenu('Threats', 'Campaigns');
-  await campaignPage.getItemFromListWithUrl('menuPass').click();
+  await campaignPage.getNthItemFromGrid(0).click();
   const tabs = page.getByRole('tab');
   await expect(tabs.first()).toHaveText(viewName);
 
@@ -104,6 +104,7 @@ test('Custom View CRUD - golden path', { tag: ['@ce'] }, async ({ page }) => {
   await customViewDetailsPage.getActionsPopover().click();
   await customViewDetailsPage.getActionButton('Duplicate').click();
   await customViewDetailsPage.getDuplicateButton().click();
+  await expect(page.getByText(/The custom view has been duplicated/i)).toBeVisible();
   await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
   await expect(customViewsSettingsPage.getItemFromList(duplicateName)).toBeVisible();
 
@@ -121,15 +122,10 @@ test('Custom View CRUD - golden path', { tag: ['@ce'] }, async ({ page }) => {
   await customViewsSettingsPage.getImportButton().click();
   const fileChooser = await fileChooserPromise;
   await fileChooser.setFiles(`./test-results/e2e-files/${download.suggestedFilename()}`);
+  await expect(page.getByText(/Custom view created/i)).toBeVisible();
   // Imported view should be visible (disabled by default)
   await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));
-  const lines = customViewsSettingsPage.getItemFromList(viewName);
-  await expect.poll(async () => {
-    return await lines.filter({ visible: true }).count();
-  }, {
-    timeout: 5000,
-    intervals: [100, 200, 500],
-  }).toBe(2);
+  await expect(customViewsSettingsPage.getItemFromList(viewName)).toHaveCount(2);
 
   // ─── Cleanup: delete all created views ───────────────────────────────────────
   await page.goto(customViewsSettingsPage.getPageUrl('Campaign'));

--- a/opencti-platform/opencti-front/tests_e2e/model/campaign.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/campaign.pageModel.ts
@@ -8,8 +8,8 @@ export default class CampaignPageModel {
     return this.page.getByText(name, { exact: true });
   }
 
-  getItemFromListWithUrl(name: string) {
-    return this.page.getByRole('link', { name });
+  getNthItemFromGrid(nth: number) {
+    return this.page.getByRole('gridcell').nth(nth);
   }
 
   getPage() {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Fixes flaky Custom Views E2E test by waiting for notification message displayed during duplication and import steps.
For future: avoid using a specific `Campaign` entity, uses first in the grid.
Also uses simpler `toHaveCount()` form.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->

* Fixes #16097

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
