### PR TITLE
[frontend] Fix Specific Workflow for Request Access not shown in settings (#16017)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.test.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GlobalWorkflowSettingsCard from './GlobalWorkflowSettingsCard';
+import { useSubTypeOutletContext } from '../SubTypeOutletContext';
+
+vi.mock('@common/card/Card', () => ({
+  default: ({ title, children }: { title: string; children: ReactNode }) => (
+    <div>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../../../../../components/i18n', () => ({
+  useFormatter: () => ({
+    t_i18n: (value: string) => value,
+  }),
+}));
+
+vi.mock('../SubTypeOutletContext', () => ({
+  useSubTypeOutletContext: vi.fn(),
+}));
+
+vi.mock('./GlobalWorkflowSettings', () => ({
+  default: () => <div>global-workflow-settings</div>,
+}));
+
+vi.mock('./RequestAccessSettings', () => ({
+  default: () => <div>request-access-settings</div>,
+}));
+
+const makeSubType = (availableSettings: string[]) => ({
+  id: 'sub-type-id',
+  workflowEnabled: true,
+  settings: {
+    availableSettings,
+    requestAccessConfiguration: { id: 'request-access-configuration-id' },
+  },
+});
+
+describe('GlobalWorkflowSettingsCard', () => {
+  it('renders request access settings when request_access_workflow is available', () => {
+    vi.mocked(useSubTypeOutletContext).mockReturnValue({
+      subType: makeSubType(['workflow_configuration', 'request_access_workflow']),
+    } as never);
+
+    render(<GlobalWorkflowSettingsCard />);
+
+    expect(screen.getByText('global-workflow-settings')).toBeInTheDocument();
+    expect(screen.getByText('request-access-settings')).toBeInTheDocument();
+  });
+
+  it('does not render request access settings when request_access_workflow is not available', () => {
+    vi.mocked(useSubTypeOutletContext).mockReturnValue({
+      subType: makeSubType(['workflow_configuration', 'request_access_configuration']),
+    } as never);
+
+    render(<GlobalWorkflowSettingsCard />);
+
+    expect(screen.getByText('global-workflow-settings')).toBeInTheDocument();
+    expect(screen.queryByText('request-access-settings')).not.toBeInTheDocument();
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import GlobalWorkflowSettingsCard from './GlobalWorkflowSettingsCard';
 import { useSubTypeOutletContext } from '../SubTypeOutletContext';
+import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
 
 vi.mock('@common/card/Card', () => ({
   default: ({ title, children }: { title: string; children: ReactNode }) => (
@@ -21,6 +22,10 @@ vi.mock('../../../../../components/i18n', () => ({
 
 vi.mock('../SubTypeOutletContext', () => ({
   useSubTypeOutletContext: vi.fn(),
+}));
+
+vi.mock('../../../../../utils/hooks/useEnterpriseEdition', () => ({
+  default: vi.fn(),
 }));
 
 vi.mock('./GlobalWorkflowSettings', () => ({
@@ -42,6 +47,7 @@ const makeSubType = (availableSettings: string[]) => ({
 
 describe('GlobalWorkflowSettingsCard', () => {
   it('renders request access settings when request_access_workflow is available', () => {
+    vi.mocked(useEnterpriseEdition).mockReturnValue(true);
     vi.mocked(useSubTypeOutletContext).mockReturnValue({
       subType: makeSubType(['workflow_configuration', 'request_access_workflow']),
     } as never);
@@ -53,8 +59,21 @@ describe('GlobalWorkflowSettingsCard', () => {
   });
 
   it('does not render request access settings when request_access_workflow is not available', () => {
+    vi.mocked(useEnterpriseEdition).mockReturnValue(true);
     vi.mocked(useSubTypeOutletContext).mockReturnValue({
       subType: makeSubType(['workflow_configuration', 'request_access_configuration']),
+    } as never);
+
+    render(<GlobalWorkflowSettingsCard />);
+
+    expect(screen.getByText('global-workflow-settings')).toBeInTheDocument();
+    expect(screen.queryByText('request-access-settings')).not.toBeInTheDocument();
+  });
+
+  it('does not render request access settings in CE even when request_access_workflow is available', () => {
+    vi.mocked(useEnterpriseEdition).mockReturnValue(false);
+    vi.mocked(useSubTypeOutletContext).mockReturnValue({
+      subType: makeSubType(['workflow_configuration', 'request_access_workflow']),
     } as never);
 
     render(<GlobalWorkflowSettingsCard />);

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.tsx
@@ -4,14 +4,17 @@ import { useFormatter } from '../../../../../components/i18n';
 import { useSubTypeOutletContext } from '../SubTypeOutletContext';
 import GlobalWorkflowSettings from './GlobalWorkflowSettings';
 import RequestAccessSettings from './RequestAccessSettings';
+import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
 
 const GlobalWorkflowSettingsCard = () => {
   const { t_i18n } = useFormatter();
 
   const { subType } = useSubTypeOutletContext();
+  const isEnterpriseEdition = useEnterpriseEdition();
   const requestAccessConfiguration = subType.settings.requestAccessConfiguration;
 
-  const hasRequestAccessConfig = subType.settings.availableSettings.includes('request_access_workflow')
+  const hasRequestAccessConfig = isEnterpriseEdition
+    && subType.settings.availableSettings.includes('request_access_workflow')
     && !!requestAccessConfiguration;
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/GlobalWorkflowSettingsCard.tsx
@@ -11,7 +11,7 @@ const GlobalWorkflowSettingsCard = () => {
   const { subType } = useSubTypeOutletContext();
   const requestAccessConfiguration = subType.settings.requestAccessConfiguration;
 
-  const hasRequestAccessConfig = subType.settings.availableSettings.includes('request_access_configuration')
+  const hasRequestAccessConfig = subType.settings.availableSettings.includes('request_access_workflow')
     && !!requestAccessConfiguration;
 
   return (


### PR DESCRIPTION

### Proposed changes

* Fix `Specific Workflow for Request Access` section not shown in UI anymore after recent UI changes
Regression introduced by deletion of `opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeOverview.tsx` in https://github.com/OpenCTI-Platform/opencti/pull/15372/changes#diff-88bfdd68a0105b4a5465ef6d0c614a637442f41f7eaebf08df364cbcf584f670L60 .

### Related issues

* Fixes #16017

### Test instructions

- Go to Settings > Customization > Request for information
- The workflow tab should have a specific working "Specific Workflow for Request Access" section

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I considered (and tried) doing the EE check in the backend but it has a lot more implications as we are creating request-access-related entities during the init stage. Also correctly handling a CE -> EE transition at runtime without a restart of the platform would be involved. Before the regression the check was done in the UI too.