### PR TITLE
feat(investigation): add select nodes by edge count to graph toolbar

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
@@ -677,6 +677,7 @@ const GraphToolbarExpandTools = ({
           onReset={() => setIsExpandOpen(false)}
         />
       </Dialog>
+
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarSelectTools.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarSelectTools.tsx
@@ -1,11 +1,13 @@
 import { SelectAll, SelectGroup, SelectionDrag } from 'mdi-material-ui';
-import { GestureOutlined, SwipeDown, SwipeUp, SwipeVertical, TouchApp } from '@mui/icons-material';
+import { DeviceHubOutlined, GestureOutlined, SwipeDown, SwipeUp, SwipeVertical, TouchApp } from '@mui/icons-material';
 import React, { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
 import GraphToolbarOptionsList from './GraphToolbarOptionsList';
 import GraphToolbarItem from './GraphToolbarItem';
 import { useFormatter } from '../../i18n';
 import { useGraphContext } from '../GraphContext';
 import useGraphInteractions from '../utils/useGraphInteractions';
+import InvestigationSelectByEdgeForm, { SelectByEdgeFormData } from '@components/workspaces/investigations/InvestigationSelectByEdgeForm';
 
 const GraphToolbarSelectTools = () => {
   const { t_i18n } = useFormatter();
@@ -13,6 +15,7 @@ const GraphToolbarSelectTools = () => {
 
   const {
     stixCoreObjectTypes,
+    graphData,
     graphState: {
       mode3D,
       selectFreeRectangle,
@@ -28,7 +31,31 @@ const GraphToolbarSelectTools = () => {
     switchSelectRelationshipMode,
     selectByEntityType,
     selectAllNodes,
+    setSelectedNodes,
+    clearSelection,
   } = useGraphInteractions();
+
+  const [isSelectByEdgeOpen, setIsSelectByEdgeOpen] = useState(false);
+
+  const onSelectByEdge = ({ edge_count, entity_types }: SelectByEdgeFormData) => {
+    if (entity_types.length === 0) return;
+
+    const links = graphData?.links ?? [];
+    const nodes = graphData?.nodes ?? [];
+    const entityTypeFilter = entity_types.map((o) => o.value);
+    const targetCount = Number(edge_count);
+
+    const matchingNodes = nodes.filter((node) => {
+      const edgeCount = links.filter(
+        (link) => link.source_id === node.id || link.target_id === node.id,
+      ).length;
+      return edgeCount === targetCount && entityTypeFilter.includes(node.entity_type);
+    });
+
+    clearSelection();
+    setSelectedNodes(matchingNodes);
+    setIsSelectByEdgeOpen(false);
+  };
 
   const titleSelectRelationshipMode = () => {
     if (selectRelationshipMode === 'children') return t_i18n('Select Child Relationships of Selected Nodes (From)');
@@ -94,6 +121,29 @@ const GraphToolbarSelectTools = () => {
         onClick={() => switchSelectRelationshipMode()}
         title={titleSelectRelationshipMode()}
       />
+
+      <GraphToolbarItem
+        Icon={<DeviceHubOutlined />}
+        color="primary"
+        onClick={() => setIsSelectByEdgeOpen(true)}
+        title={t_i18n('Select nodes by edge count')}
+        disabled={(graphData?.nodes ?? []).length === 0}
+      />
+
+      <Dialog
+        fullWidth
+        maxWidth={false}
+        open={isSelectByEdgeOpen}
+        sx={{ '& .MuiDialog-paper': { width: 640 } }}
+        onClose={() => setIsSelectByEdgeOpen(false)}
+      >
+        <InvestigationSelectByEdgeForm
+          nodes={graphData?.nodes ?? []}
+          links={graphData?.links ?? []}
+          onSubmit={onSelectByEdge}
+          onReset={() => setIsSelectByEdgeOpen(false)}
+        />
+      </Dialog>
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationSelectByEdgeForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationSelectByEdgeForm.tsx
@@ -1,0 +1,93 @@
+import Button from '@common/button/Button';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Stack from '@mui/material/Stack';
+import { Field, Form, Formik } from 'formik';
+import { FormikHelpers } from 'formik/dist/types';
+import { useMemo } from 'react';
+import * as Yup from 'yup';
+import CheckboxesField from '../../../../components/CheckboxesField';
+import { GraphLink, GraphNode } from '../../../../components/graph/graph.types';
+import { useFormatter } from '../../../../components/i18n';
+import { FieldOption } from '../../../../utils/field';
+
+export type SelectByEdgeFormData = {
+  edge_count: number;
+  entity_types: FieldOption[];
+};
+
+export type InvestigationSelectByEdgeFormProps = {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  onSubmit: (data: SelectByEdgeFormData, helpers: FormikHelpers<SelectByEdgeFormData>) => void;
+  onReset: () => void;
+};
+
+const InvestigationSelectByEdgeForm = ({
+  nodes,
+  links: _links,
+  onSubmit,
+  onReset,
+}: InvestigationSelectByEdgeFormProps) => {
+  const { t_i18n } = useFormatter();
+
+  const entityTypeOptions = useMemo<FieldOption[]>(() => {
+    const types = new Set(nodes.map((n) => n.entity_type).filter(Boolean));
+    return Array.from(types)
+      .sort()
+      .map((type) => ({ label: t_i18n(`entity_${type}`), value: type }));
+  }, [nodes, t_i18n]);
+
+  const validationSchema = Yup.object({
+    edge_count: Yup.number()
+      .min(0, t_i18n('Must be 0 or greater'))
+      .integer(t_i18n('Must be a whole number'))
+      .required(t_i18n('Required')),
+  });
+
+  return (
+    <Formik<SelectByEdgeFormData>
+      enableReinitialize={true}
+      initialValues={{ edge_count: 0, entity_types: [] }}
+      validationSchema={validationSchema}
+      onSubmit={onSubmit}
+      onReset={onReset}
+    >
+      {({ submitForm, handleReset, isSubmitting, values, handleChange, errors, touched }) => (
+        <Form>
+          <Stack spacing={3} sx={{ p: 3 }}>
+            <TextField
+              name="edge_count"
+              label={t_i18n('Number of edges')}
+              type="number"
+              value={values.edge_count}
+              onChange={handleChange}
+              error={touched.edge_count && Boolean(errors.edge_count)}
+              helperText={touched.edge_count && errors.edge_count}
+              inputProps={{ min: 0 }}
+              fullWidth
+            />
+
+            <Field
+              name="entity_types"
+              component={CheckboxesField}
+              label={t_i18n('All types of node')}
+              items={entityTypeOptions}
+            />
+
+            <DialogActions>
+              <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
+                {t_i18n('Cancel')}
+              </Button>
+              <Button onClick={submitForm} disabled={isSubmitting}>
+                {t_i18n('Select')}
+              </Button>
+            </DialogActions>
+          </Stack>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default InvestigationSelectByEdgeForm;


### PR DESCRIPTION
Closes #16927

## Description

Adds a **Select nodes by edge count** button to the investigation graph toolbar, positioned to the right of the existing *Select Relationships of Selected Nodes* button.

Clicking the button opens a modal (consistent with the existing Expand modal) where the user can:
- Enter a target **edge count** (number of visible edges in the current graph)
- Optionally filter by **entity type** using the same All/None checkbox pattern as the Expand modal

On submit, all nodes in the current graph that match both criteria are selected and the modal closes.

## Changes

- **`InvestigationSelectByEdgeForm.tsx`** (new) — Formik form with a number input for edge count and a `CheckboxesField` for entity types populated from the current graph nodes
- **`GraphToolbarSelectTools.tsx`** (modified) — adds the toolbar button, dialog, and selection handler; edge counting uses `source_id`/`target_id` from graph links; HTML input value is coerced to `Number` before comparison; empty entity type selection is a no-op (consistent with Expand modal behaviour)
- **`GraphToolbarExpandTools.tsx`** (modified) — removes the button/dialog/handler that was briefly placed here during development

## Behaviour details

- If no entity types are selected when **Select** is clicked, nothing happens (mirrors the Expand modal guard)
- Selecting **All** then submitting selects every node whose visible edge count equals the specified number
- The selection replaces any existing node/link selection

## Testing

1. Open an investigation with multiple nodes and relationships
2. Click the **Select nodes by edge count** button (hub icon) in the toolbar
3. Enter an edge count and optionally filter by entity type
4. Click **Select** — only nodes matching both criteria should be highlighted