### PR TITLE
[frontend] AI Insights button display in entities overview (#16116)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/Root.tsx
@@ -22,6 +22,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { useIsEnforceReference } from '../../../../utils/hooks/useEntitySettings';
 import useGranted, { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE, KNOWLEDGE_KNUPDATE_KNBYPASSREFERENCE } from '../../../../utils/hooks/useGranted';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import ReportEdition from './ReportEdition';
 import ReportDeletion from './ReportDeletion';
 import { useGetCurrentUserAccessRight } from '../../../../utils/authorizedMembers';
@@ -110,7 +111,7 @@ const RootReport = () => {
           if (props) {
             if (props.report) {
               const { report } = props;
-              const isOverview = location.pathname === basePath;
+              const isOverview = isPathOverview(location.pathname, basePath);
               const paddingRight = getPaddingRight(location.pathname, basePath, false);
               const isKnowledgeOrContent = location.pathname.includes('knowledge') || location.pathname.includes('content');
               const currentAccessRight = useGetCurrentUserAccessRight(report.currentUserAccessRight);

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/Root.tsx
@@ -21,6 +21,7 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import { RootMalwareQuery } from './__generated__/RootMalwareQuery.graphql';
 import { RootMalwareSubscription } from './__generated__/RootMalwareSubscription.graphql';
 import Security from '../../../../utils/Security';
@@ -101,7 +102,7 @@ const RootMalware = ({ queryRef, malwareId }: RootMalwareProps) => {
   } = usePreloadedQuery<RootMalwareQuery>(malwareQuery, queryRef);
   const { forceUpdate } = useForceUpdate();
   const basePath = PATH_MALWARE(malwareId);
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   const link = `${basePath}/knowledge`;
   return (

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectTabsBox.tsx
@@ -4,7 +4,7 @@ import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Stack from '@mui/material/Stack';
-import { getCurrentTab } from '../../../../utils/utils';
+import { getCurrentTab } from '../../../../utils/tabUtils';
 import { useFormatter } from '../../../../components/i18n';
 import useCustomViewTabs from '@components/custom_views/useCustomViewTabs';
 import { OtherCustomViewsTab, DefaultCustomViewTab } from '@components/custom_views/CustomViewTab';

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViewTabs.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViewTabs.ts
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { useDropDownMenuState } from '../../../components/TabWithDropDownMenu';
-import { getCurrentTab } from '../../../utils/utils';
+import { getCurrentTab } from '../../../utils/tabUtils';
 import { useCustomViews } from './useCustomViews';
 
 interface UseCustomViewTabsParams {

--- a/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.ts
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/useCustomViews.ts
@@ -1,5 +1,5 @@
 import { graphql } from 'relay-runtime';
-import { getCurrentTab } from '../../../utils/utils';
+import { getCurrentTab } from '../../../utils/tabUtils';
 import type { CustomView } from './CustomViews-types';
 import { useCustomViewsData } from './useCustomViewsData';
 

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
@@ -15,7 +15,7 @@ import ImportFilesContent from '@components/data/import/ImportFilesContent';
 import useDraftContext from '../../../utils/hooks/useDraftContext';
 import Loader, { LoaderVariant } from '../../../components/Loader';
 import ErrorNotFound from '../../../components/ErrorNotFound';
-import { getCurrentTab } from '../../../utils/utils';
+import { getCurrentTab } from '../../../utils/tabUtils';
 import { useFormatter } from '../../../components/i18n';
 import { MESSAGING$ } from '../../../relay/environment';
 import { RelayError } from '../../../relay/relayTypes';

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/Root.tsx
@@ -24,6 +24,7 @@ import EntityStixSightingRelationships from '../../events/stix_sighting_relation
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import SectorEdition from './SectorEdition';
@@ -102,7 +103,7 @@ const RootSector = ({ sectorId, queryRef }: RootSectorProps) => {
   const { forceUpdate } = useForceUpdate();
 
   const basePath = PATH_SECTOR(sectorId);
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   const link = `${basePath}/knowledge`;
   return (

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/Root.tsx
@@ -31,6 +31,7 @@ import Breadcrumbs from '../../../../components/Breadcrumbs';
 import IncidentEdition from './IncidentEdition';
 import IncidentDeletion from './IncidentDeletion';
 import { PATH_INCIDENT, PATH_INCIDENTS } from '@components/common/routes/paths';
+import { isPathOverview } from '../../../../utils/tabUtils';
 
 const subscription = graphql`
   subscription RootIncidentSubscription($id: ID!) {
@@ -105,7 +106,7 @@ const RootIncidentComponent = ({ queryRef }) => {
   const { incident, connectorsForImport, connectorsForExport } = data;
   const basePath = PATH_INCIDENT(incidentId);
   const link = `${basePath}/knowledge`;
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRightValue = () => {
     if (location.pathname.includes(`${basePath}/knowledge`)) return 200;
     if (location.pathname.includes(`${basePath}/content`)) return 350;

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -1,5 +1,5 @@
-é;// TODO Remove this when V6
-
+// TODO Remove this when V6
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React, { useMemo } from 'react';
 import { Route, Routes, useParams, useLocation } from 'react-router-dom';

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -1,5 +1,5 @@
-// TODO Remove this when V6
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+é;// TODO Remove this when V6
+
 // @ts-nocheck
 import React, { useMemo } from 'react';
 import { Route, Routes, useParams, useLocation } from 'react-router-dom';
@@ -27,6 +27,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import CountryEdition from './CountryEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -97,7 +98,7 @@ const RootCountryComponent = ({ queryRef, countryId }) => {
   const { country, connectorsForImport, connectorsForExport } = data;
   const basePath = PATH_COUNTRY(countryId);
   const link = `${basePath}/knowledge`;
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   return (
     <CreateRelationshipContextProvider>

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -27,6 +27,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import RegionEdition from './RegionEdition';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -97,7 +98,7 @@ const RootRegionComponent = ({ queryRef, regionId }) => {
   const { region, connectorsForImport, connectorsForExport } = data;
   const basePath = PATH_REGION(regionId);
   const link = `${basePath}/knowledge`;
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   return (
     <CreateRelationshipContextProvider>

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeMenu.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeMenu.tsx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from '@mui/material';
 import { Link, useLocation } from 'react-router-dom';
 import { useFormatter } from '../../../../components/i18n';
 import type { SubTypeTabs } from './SubTypeOutletContext';
-import { getCurrentTab } from '../../../../utils/utils';
+import { getCurrentTab } from '../../../../utils/tabUtils';
 
 interface SubTypeMenuProps {
   entityType: string;

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/Root.tsx
@@ -21,6 +21,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import { RootCampaignQuery } from './__generated__/RootCampaignQuery.graphql';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
@@ -107,7 +108,7 @@ const RootCampaign = ({ campaignId, queryRef }: RootCampaignProps) => {
   const { forceUpdate } = useForceUpdate();
   const basePath = PATH_CAMPAIGN(campaignId);
   const link = `${basePath}/knowledge`;
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   return (
     <CreateRelationshipContextProvider>

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/Root.tsx
@@ -20,6 +20,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import { RootIntrusionSetQuery } from './__generated__/RootIntrusionSetQuery.graphql';
 import { RootIntrusionSetSubscription } from './__generated__/RootIntrusionSetSubscription.graphql';
 import Security from '../../../../utils/Security';
@@ -111,7 +112,7 @@ const RootIntrusionSet = ({ intrusionSetId, queryRef }: RootIntrusionSetProps) =
   } = usePreloadedQuery<RootIntrusionSetQuery>(intrusionSetQuery, queryRef);
   const { forceUpdate } = useForceUpdate();
   const basePath = PATH_INTRUSION_SET(intrusionSetId);
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   const link = `${basePath}/knowledge`;
   return (

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/Root.tsx
@@ -21,6 +21,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import ThreatActorGroupEdition from './ThreatActorGroupEdition';
@@ -102,7 +103,7 @@ const RootThreatActorGroup = ({ queryRef, threatActorGroupId }: RootThreatActorG
   } = usePreloadedQuery<RootThreatActorGroupQuery>(ThreatActorGroupQuery, queryRef);
   const { forceUpdate } = useForceUpdate();
   const basePath = PATH_THREAT_ACTORS_GROUP(threatActorGroupId);
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   const link = `${basePath}/knowledge`;
   return (

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/Root.tsx
@@ -21,6 +21,7 @@ import StixCoreObjectKnowledgeBar from '../../common/stix_core_objects/StixCoreO
 import { useFormatter } from '../../../../components/i18n';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { getPaddingRight } from '../../../../utils/utils';
+import { isPathOverview } from '../../../../utils/tabUtils';
 import Security from '../../../../utils/Security';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
 import ThreatActorIndividualEdition from './ThreatActorIndividualEdition';
@@ -113,7 +114,7 @@ const RootThreatActorIndividualComponent = ({
   );
   const { forceUpdate } = useForceUpdate();
   const basePath = PATH_THREAT_ACTORS_INDIVIDUAL(threatActorIndividualId);
-  const isOverview = location.pathname === basePath;
+  const isOverview = isPathOverview(location.pathname, basePath);
   const paddingRight = getPaddingRight(location.pathname, basePath);
   const link = `${basePath}/knowledge`;
   return (

--- a/opencti-platform/opencti-front/src/utils/tabUtils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/tabUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getCurrentTab, isPathOverview } from './tabUtils';
+
+describe('getCurrentTab', () => {
+  it('returns next segment after the basepath', () => {
+    const value = getCurrentTab(
+      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c/knowledge',
+      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
+    );
+    expect(value).toBe('knowledge');
+  });
+
+  it('returns an empty string when fullpath equals basepath', () => {
+    const value = getCurrentTab(
+      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
+      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
+    );
+    expect(value).toBe('');
+  });
+
+  it('returns next segment after the basepath even when there are more', () => {
+    const value = getCurrentTab(
+      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c/knowledge/or/something/else',
+      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
+    );
+    expect(value).toBe('knowledge');
+  });
+});
+
+describe('isPathOverview', () => {
+  const basePath = '/dashboard/threats/threat_actors_group/abc-123';
+
+  it('returns true when path equals basePath', () => {
+    expect(isPathOverview(basePath, basePath)).toBe(true);
+  });
+
+  it('returns true when path equals basePath/overview', () => {
+    expect(isPathOverview(`${basePath}/overview`, basePath)).toBe(true);
+  });
+
+  it('returns false for other sub-paths', () => {
+    expect(isPathOverview(`${basePath}/knowledge`, basePath)).toBe(false);
+    expect(isPathOverview(`${basePath}/content`, basePath)).toBe(false);
+    expect(isPathOverview(`${basePath}/files`, basePath)).toBe(false);
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/tabUtils.ts
+++ b/opencti-platform/opencti-front/src/utils/tabUtils.ts
@@ -1,0 +1,38 @@
+/**
+ * Compute the current state value of a <Tabs> component by comparing the
+ * location.pathname (`fullpath`) with the `basePath` of the component
+ * and extracting the next URL segment in the sequence.
+ *
+ * @param fullpath - The current full pathname as returned by useLocation().pathname.
+ * Should contain no query params nor hash param.
+ * @param basePath - The closest path to root where the <Tabs> component is rendered.
+ * @returns The current tab value.
+ *
+ * @example
+ * ```
+ * getCurrentTab(
+ *   '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c/knowledge/or/something/else',
+ *   '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
+ * ); // returns 'knowledge'
+ * ```
+ */
+export const getCurrentTab = (fullpath: string, basePath: string) => {
+  let subpath = fullpath.substring(basePath.length);
+  if (subpath.startsWith('/')) {
+    subpath = subpath.substring(1);
+  }
+  const nextSlashPos = subpath.indexOf('/');
+  return nextSlashPos >= 0 ? subpath.substring(0, nextSlashPos) : subpath;
+};
+
+/**
+ * Determines whether the current location corresponds to the overview page.
+ * The overview page can be either at the base path (before redirect) or at basePath/overview.
+ *
+ * @param locationPath The current location pathname.
+ * @param basePath The entity base path.
+ * @returns True if the current path is the overview page.
+ */
+export const isPathOverview = (locationPath: string, basePath: string): boolean => {
+  return locationPath === basePath || locationPath === `${basePath}/overview`;
+};

--- a/opencti-platform/opencti-front/src/utils/utils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/utils.test.ts
@@ -1,31 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { getCurrentTab, getPaddingRight } from './utils';
+import { getPaddingRight } from './utils';
 
-describe('getCurrentTab', () => {
-  it('returns next segment after the basepath', () => {
-    const value = getCurrentTab(
-      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c/knowledge',
-      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
-    );
-    expect(value).toBe('knowledge');
-  });
-
-  it('returns an empty string when fullpath equals basepath', () => {
-    const value = getCurrentTab(
-      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
-      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
-    );
-    expect(value).toBe('');
-  });
-
-  it('returns next segment after the basepath even when there are more', () => {
-    const value = getCurrentTab(
-      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c/knowledge/or/something/else',
-      '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
-    );
-    expect(value).toBe('knowledge');
-  });
-});
 
 describe('getPaddingRight', () => {
   const basePath = '/dashboard/analyses/reports/a079e1e7-ce97-4528-92f1-64df365d540b';

--- a/opencti-platform/opencti-front/src/utils/utils.test.ts
+++ b/opencti-platform/opencti-front/src/utils/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getPaddingRight } from './utils';
 
-
 describe('getPaddingRight', () => {
   const basePath = '/dashboard/analyses/reports/a079e1e7-ce97-4528-92f1-64df365d540b';
 

--- a/opencti-platform/opencti-front/src/utils/utils.ts
+++ b/opencti-platform/opencti-front/src/utils/utils.ts
@@ -46,33 +46,6 @@ export const getFileUri = (id: string) => {
 export const uniqueArray = <T>(items: IterableIterator<T> | Array<T>) => Array.from(new Set(items));
 
 /**
- * Compute the current state value of a <Tabs> component by comparing the
- * location.pathname (`fullpath`) with the `basePath` of the component
- * and extracting the next URL segment in the sequence.
- *
- * @param fullpath - The current full pathname as returned by useLocation().pathname.
- * Should contain no query params nor hash param.
- * @param basePath - The closest path to root where the <Tabs> component is rendered.
- * @returns The current tab value.
- *
- * @example
- * ```
- * getCurrentTab(
- *   '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c/knowledge/or/something/else',
- *   '/dashboard/techniques/attack_patterns/965f2989-6acb-4223-a163-89a99411c15c',
- * ); // returns 'knowledge'
- * ```
- */
-export const getCurrentTab = (fullpath: string, basePath: string) => {
-  let subpath = fullpath.substring(basePath.length);
-  if (subpath.startsWith('/')) {
-    subpath = subpath.substring(1);
-  }
-  const nextSlashPos = subpath.indexOf('/');
-  return nextSlashPos >= 0 ? subpath.substring(0, nextSlashPos) : subpath;
-};
-
-/**
  * Compute the right padding to apply on an entity page based on the current route.
  * - Knowledge pages get extra padding (200) for the timeline/graph side panel.
  * - Content pages get padding (350) for the files side panel, except the mapping view which needs full width.

--- a/opencti-platform/opencti-front/tests_e2e/overviewActions/overviewActions.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/overviewActions/overviewActions.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '../fixtures/baseFixtures';
+
+type OverviewRouteCheck = {
+  label: string;
+  listPath: string;
+  entityName: string;
+  hasSecurityCoverageAction?: boolean;
+};
+
+const OVERVIEW_ROUTE_CHECKS: OverviewRouteCheck[] = [
+  {
+    label: 'Campaign',
+    listPath: '/dashboard/threats/campaigns',
+    entityName: 'A new campaign',
+    hasSecurityCoverageAction: true,
+  },
+  {
+    label: 'Intrusion set',
+    listPath: '/dashboard/threats/intrusion_sets',
+    entityName: 'E2E dashboard - Intrusion set - now',
+    hasSecurityCoverageAction: true,
+  },
+  {
+    label: 'Threat actor group',
+    listPath: '/dashboard/threats/threat_actors_group',
+    entityName: 'Disco Team Threat Actor Group',
+  },
+  {
+    label: 'Threat actor individual',
+    listPath: '/dashboard/threats/threat_actors_individual',
+    entityName: 'E2E dashboard - Threat actor - now',
+  },
+  {
+    label: 'Malware',
+    listPath: '/dashboard/arsenal/malwares',
+    entityName: 'E2E dashboard - Malware - now',
+  },
+  {
+    label: 'Sector',
+    listPath: '/dashboard/entities/sectors',
+    entityName: 'Sector e2e',
+  },
+  {
+    label: 'Incident',
+    listPath: '/dashboard/events/incidents',
+    entityName: 'Incident Name',
+    hasSecurityCoverageAction: true,
+  },
+  {
+    label: 'Country',
+    listPath: '/dashboard/locations/countries',
+    entityName: 'Country e2e',
+  },
+  {
+    label: 'Region',
+    listPath: '/dashboard/locations/regions',
+    entityName: 'Region e2e',
+  },
+];
+
+test('Overview routes display AI Insights action button', { tag: ['@ce', '@navigation'] }, async ({ page }) => {
+  for (const routeCheck of OVERVIEW_ROUTE_CHECKS) {
+    await page.goto(routeCheck.listPath);
+    const entityLink = page.getByRole('link', { name: routeCheck.entityName });
+    await expect(entityLink, `${routeCheck.label} list should contain ${routeCheck.entityName}`).toBeVisible();
+    await entityLink.click();
+
+    await page.getByRole('tab', { name: 'Overview' }).click();
+
+    const aiInsightsButton = page.getByLabel('AI Insights', { exact: true });
+    await expect(aiInsightsButton, `${routeCheck.label} overview should display AI Insights`).toBeVisible();
+
+    if (routeCheck.hasSecurityCoverageAction) {
+      const addCoverageButton = page.getByRole('button', { name: 'Add Security coverage' });
+      const existingCoverageLink = page.locator('a[href*="/dashboard/analyses/security_coverages/"]');
+      const hasAddCoverage = await addCoverageButton.isVisible().catch(() => false);
+
+      if (hasAddCoverage) {
+        await expect(addCoverageButton, `${routeCheck.label} overview should display security coverage action`).toBeVisible();
+      } else {
+        await expect(existingCoverageLink.first(), `${routeCheck.label} overview should display security coverage action`).toBeVisible();
+      }
+    }
+  }
+});

--- a/opencti-platform/opencti-front/tests_e2e/overviewActions/overviewActions.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/overviewActions/overviewActions.spec.ts
@@ -58,7 +58,7 @@ const OVERVIEW_ROUTE_CHECKS: OverviewRouteCheck[] = [
   },
 ];
 
-test('Overview routes display AI Insights action button', { tag: ['@ce', '@navigation'] }, async ({ page }) => {
+test('Overview routes display action buttons', { tag: ['@ce', '@navigation'] }, async ({ page }) => {
   for (const routeCheck of OVERVIEW_ROUTE_CHECKS) {
     await page.goto(routeCheck.listPath);
     const entityLink = page.getByRole('link', { name: routeCheck.entityName });
@@ -68,7 +68,7 @@ test('Overview routes display AI Insights action button', { tag: ['@ce', '@navig
     await page.getByRole('tab', { name: 'Overview' }).click();
 
     const aiInsightsButton = page.getByLabel('AI Insights', { exact: true });
-    await expect(aiInsightsButton, `${routeCheck.label} overview should display AI Insights`).toBeVisible();
+    await expect(aiInsightsButton, `${routeCheck.label} overview should display AI Insights button`).toBeVisible();
 
     if (routeCheck.hasSecurityCoverageAction) {
       const addCoverageButton = page.getByRole('button', { name: 'Create a coverage' });
@@ -76,9 +76,9 @@ test('Overview routes display AI Insights action button', { tag: ['@ce', '@navig
       const hasAddCoverage = await addCoverageButton.isVisible().catch(() => false);
 
       if (hasAddCoverage) {
-        await expect(addCoverageButton, `${routeCheck.label} overview should display security coverage action`).toBeVisible();
+        await expect(addCoverageButton, `${routeCheck.label} overview should display security coverage button`).toBeVisible();
       } else {
-        await expect(existingCoverageLink.first(), `${routeCheck.label} overview should display security coverage action`).toBeVisible();
+        await expect(existingCoverageLink.first(), `${routeCheck.label} overview should display security coverage button`).toBeVisible();
       }
     }
   }

--- a/opencti-platform/opencti-front/tests_e2e/overviewActions/overviewActions.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/overviewActions/overviewActions.spec.ts
@@ -71,7 +71,7 @@ test('Overview routes display AI Insights action button', { tag: ['@ce', '@navig
     await expect(aiInsightsButton, `${routeCheck.label} overview should display AI Insights`).toBeVisible();
 
     if (routeCheck.hasSecurityCoverageAction) {
-      const addCoverageButton = page.getByRole('button', { name: 'Add Security coverage' });
+      const addCoverageButton = page.getByRole('button', { name: 'Create a coverage' });
       const existingCoverageLink = page.locator('a[href*="/dashboard/analyses/security_coverages/"]');
       const hasAddCoverage = await addCoverageButton.isVisible().catch(() => false);
 


### PR DESCRIPTION
### Proposed changes
- AI Insights button should be displayed in every entity overview

<img width="1832" height="688" alt="image" src="https://github.com/user-attachments/assets/e412cf3f-a423-4a8f-86fd-112563e2aa58" />

- Campaigns, incidents and intrusion sets should have the 'Security coverage' button visible in their overview
<img width="1827" height="582" alt="image" src="https://github.com/user-attachments/assets/6b3acc72-e1f2-45cf-a93a-a4406c0ba435" />


### Related issues
fixes #16116

fixes #16107