### PR TITLE
fix(backend): fix force local auth env var not bypassing ldap config (#16131)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-domain.ts
@@ -30,7 +30,7 @@ import { notify, redisDeleteAuthLogHistory } from '../../database/redis';
 import conf, { BUS_TOPICS } from '../../config/conf';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
 import { unregisterStrategy } from './providers';
-import {isAuthenticationForcedFromEnv, isLocalAuthForcedEnabledFromEnv} from './providers-configuration';
+import { isAuthenticationForcedFromEnv, isLocalAuthForcedEnabledFromEnv } from './providers-configuration';
 import { getPlatformCrypto } from '../../utils/platformCrypto';
 import { memoize } from '../../utils/memoize';
 import { logAuthInfo } from './providers-logger';
@@ -309,10 +309,10 @@ export const addAuthenticationProvider = async (
 
   // If Local auth is forced through env, do not load the new providers at the risk of being locked out of platform
   if (isLocalAuthForcedEnabledFromEnv()) {
-    logAuthInfo('New provider created but not enforced because Local Auth is currently enforced through env vars', type, {identifier});
+    logAuthInfo('New provider created but not enforced because Local Auth is currently enforced through env vars', type, { identifier });
   } else {
     if (created.enabled) {
-      logAuthInfo('Activating new provider', type, {identifier});
+      logAuthInfo('Activating new provider', type, { identifier });
       await notify(BUS_TOPICS[ENTITY_TYPE_AUTHENTICATION_PROVIDER].EDIT_TOPIC, created, user);
     }
   }

--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/authenticationProvider-domain.ts
@@ -30,7 +30,7 @@ import { notify, redisDeleteAuthLogHistory } from '../../database/redis';
 import conf, { BUS_TOPICS } from '../../config/conf';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
 import { unregisterStrategy } from './providers';
-import { isAuthenticationForcedFromEnv } from './providers-configuration';
+import {isAuthenticationForcedFromEnv, isLocalAuthForcedEnabledFromEnv} from './providers-configuration';
 import { getPlatformCrypto } from '../../utils/platformCrypto';
 import { memoize } from '../../utils/memoize';
 import { logAuthInfo } from './providers-logger';
@@ -307,9 +307,14 @@ export const addAuthenticationProvider = async (
     },
   });
 
-  if (created.enabled) {
-    logAuthInfo('Activating new provider', type, { identifier });
-    await notify(BUS_TOPICS[ENTITY_TYPE_AUTHENTICATION_PROVIDER].EDIT_TOPIC, created, user);
+  // If Local auth is forced through env, do not load the new providers at the risk of being locked out of platform
+  if (isLocalAuthForcedEnabledFromEnv()) {
+    logAuthInfo('New provider created but not enforced because Local Auth is currently enforced through env vars', type, {identifier});
+  } else {
+    if (created.enabled) {
+      logAuthInfo('Activating new provider', type, {identifier});
+      await notify(BUS_TOPICS[ENTITY_TYPE_AUTHENTICATION_PROVIDER].EDIT_TOPIC, created, user);
+    }
   }
   return created;
 };

--- a/opencti-platform/opencti-graphql/src/modules/authenticationProvider/providers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/authenticationProvider/providers.ts
@@ -191,10 +191,15 @@ export const initializeAuthenticationProviders = async (context: AuthContext) =>
     // Init providers from env
     await initializeEnvAuthenticationProviders();
   } else {
-    // Migration first (already created will be not replayed)
-    await runAuthenticationProviderMigration(context, SYSTEM_USER);
-    // In standard mode, init from providers in the database
-    await initDatabaseAuthenticationProviders(context, SYSTEM_USER);
+    // If Local auth is forced through env, do not load other providers at the risk of being locked out of platform
+    if (isLocalAuthForcedEnabledFromEnv()) {
+      logApp.info('[AUTH] Providers were not migrated and enabled because Local Auth is currently enforced through env vars');
+    } else {
+      // Migration first (already created will be not replayed)
+      await runAuthenticationProviderMigration(context, SYSTEM_USER);
+      // In standard mode, init from providers in the database
+      await initDatabaseAuthenticationProviders(context, SYSTEM_USER);
+    }
   }
   // Safety net: force local_auth enabled when no other provider is available
   const finalSettings = await getSettings(context) as unknown as BasicStoreSettings;


### PR DESCRIPTION
### Proposed changes

* Added check to see if APP__AUTHENTICATION__FORCE_LOCAL is set when creating a new provider avoid enforcing it
* Added check to see if APP__AUTHENTICATION__FORCE_LOCAL is set when enabling providers at platform startup to avoid enforcing them 
* Added relevant logs for both cases

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/16131

### Checklist


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e) (_I think it's already covered by existing tests_)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

