### PR TITLE
[frontend] DataTable: replace JS width tracking with CSS-native flex layout (#16143)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -4,7 +4,7 @@ import DataTableHeaders from './DataTableHeaders';
 import { DataTableBodyProps, DataTableLineProps, DataTableVariant } from '../dataTableTypes';
 import DataTableLine, { DataTableLinesDummy } from './DataTableLine';
 import { useDataTableContext } from './DataTableContext';
-import { ICON_COLUMN_SIZE, SELECT_COLUMN_SIZE } from './DataTableHeader';
+import { SELECT_COLUMN_SIZE } from './DataTableHeader';
 import callbackResizeObserver from '../../../utils/resizeObservers';
 import { useDataTable } from '../dataTableHooks';
 import DataTableEmptyState from './DataTableEmptyState';
@@ -22,10 +22,6 @@ const DataTableBody = ({
     rootRef,
     variant,
     resolvePath,
-    tableWidthState: [tableWidth],
-    actions,
-    actionsColumnWidth,
-    columns,
     dataQueryArgs,
     useDataTableToggle: {
       selectedElements,
@@ -131,33 +127,17 @@ const DataTableBody = ({
     };
   }, [settingsMessagesBannerHeight, rootRef, filters]);
 
-  const endActionsWidth = actionsColumnWidth ?? SELECT_COLUMN_SIZE;
-  const rowWidth = useMemo(() => (
-    Math.floor(columns.reduce((acc, col) => {
-      if (col.percentWidth) {
-        return acc + tableWidth * (col.percentWidth / 100);
-      }
-      return acc + (col.id === 'icon' ? ICON_COLUMN_SIZE : SELECT_COLUMN_SIZE);
-    }, actions ? endActionsWidth + 9 : 9)) // 9 is for scrollbar.
-  ), [columns, tableWidth, actions, endActionsWidth]);
-
   const containerLinesStyle: CSSProperties = {
     overflow: 'hidden auto',
     maxHeight: `calc(${tableHeight}px - ${hideHeaders ? 0 : SELECT_COLUMN_SIZE}px)`,
-    width: rowWidth,
+    width: '100%',
   };
-
-  if (!tableWidth) {
-    return null;
-  }
 
   return (
     <>
-      <div style={{ width: rowWidth }}>
-        {!hideHeaders && (
-          <DataTableHeaders dataTableToolBarComponent={dataTableToolBarComponent} />
-        )}
-      </div>
+      {!hideHeaders && (
+        <DataTableHeaders dataTableToolBarComponent={dataTableToolBarComponent} />
+      )}
 
       <div style={containerLinesStyle}>
         {resolvedData.length === 0 && !!emptyStateMessage && (

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import * as R from 'ramda';
 import { useAppData } from '../../../utils/hooks/useAppData';
 import { DataTableLinesDummy } from './DataTableLine';
@@ -206,8 +206,6 @@ const DataTableComponent = ({
     return page ? (page - 1) * currentPageSize : 0;
   }, [page, currentPageSize]);
 
-  const tableRef = useRef<HTMLDivElement | null>(null);
-
   const endActionsWidth = actionsColumnWidth ?? SELECT_COLUMN_SIZE;
   const startColumnWidth = useMemo(() => {
     if (startsWithIcon && startsWithAction) {
@@ -267,7 +265,6 @@ const DataTableComponent = ({
       <div
         className="datatable-container"
         style={{ width: '100%', overflow: 'auto hidden' }}
-        ref={tableRef}
       >
         <React.Suspense
           fallback={(

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as R from 'ramda';
 import { useAppData } from '../../../utils/hooks/useAppData';
 import { DataTableLinesDummy } from './DataTableLine';
@@ -17,7 +17,6 @@ import {
 } from '../dataTableHooks';
 import { getDefaultFilterObject } from '../../../utils/filters/filtersUtils';
 import { ICON_COLUMN_SIZE, SELECT_COLUMN_SIZE } from './DataTableHeader';
-import callbackResizeObserver from '../../../utils/resizeObservers';
 
 type DataTableComponentProps = Pick<DataTableProps,
   | 'dataColumns'
@@ -207,8 +206,6 @@ const DataTableComponent = ({
     return page ? (page - 1) * currentPageSize : 0;
   }, [page, currentPageSize]);
 
-  const tableWidthState = useState(0);
-  const [tableWidth, setTableWidth] = tableWidthState;
   const tableRef = useRef<HTMLDivElement | null>(null);
 
   const endActionsWidth = actionsColumnWidth ?? SELECT_COLUMN_SIZE;
@@ -221,27 +218,6 @@ const DataTableComponent = ({
     }
     return SELECT_COLUMN_SIZE;
   }, [startsWithIcon, startsWithAction]);
-
-  // Keep table width up to date.
-  useLayoutEffect(() => {
-    let observer: ResizeObserver;
-    if (tableRef.current) {
-      const resize = (el: Element) => {
-        let offset = 10;
-        if (startsWithAction) offset += SELECT_COLUMN_SIZE;
-        if (startsWithIcon) offset += ICON_COLUMN_SIZE;
-        if (endsWithAction) offset += endActionsWidth;
-        if ((el.clientWidth - offset) !== tableWidth) {
-          setTableWidth(el.clientWidth - offset);
-        }
-      };
-      resize(tableRef.current);
-      observer = callbackResizeObserver(tableRef.current, resize);
-    }
-    return () => {
-      observer?.disconnect();
-    };
-  }, [tableRef.current, tableWidth, endActionsWidth, endsWithAction, startsWithAction, startsWithIcon]);
 
   return (
     <DataTableProvider
@@ -279,7 +255,6 @@ const DataTableComponent = ({
         disableLineSelection,
         page,
         setPage,
-        tableWidthState,
         startsWithAction,
         startsWithIcon,
         startColumnWidth,

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
@@ -82,7 +82,6 @@ const DataTableHeader: FunctionComponent<DataTableHeaderProps> = ({
     disableColumnMenu,
     variant,
     formatter: { t_i18n },
-    tableWidthState: [tableWidth],
   } = useDataTableContext();
 
   // To avoid spamming sorting (and calling API)
@@ -99,13 +98,12 @@ const DataTableHeader: FunctionComponent<DataTableHeaderProps> = ({
   };
 
   const hasColumnMenu = !disableColumnMenu && (column.isSortable || (availableFilterKeys ?? []).includes(column.id));
-  const cellWidth = Math.round(tableWidth * (column.percentWidth / 100));
 
   return (
     <div
       key={column.id}
       className={classes.headerContainer}
-      style={{ width: cellWidth }}
+      style={{ width: `${column.percentWidth}%` }}
     >
       <div className={classes.label} onClick={throttleSortColumn}>
         <Tooltip title={t_i18n(column.label)}>

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeaders.tsx
@@ -173,20 +173,22 @@ const DataTableHeaders: FunctionComponent<DataTableHeadersProps> = ({
             </Menu>
           )}
 
-          {columns
-            .filter(({ id }) => !['select', 'navigate', 'icon'].includes(id))
-            .map((column) => (
-              <DataTableHeader
-                key={column.id}
-                column={column}
-                setAnchorEl={setAnchorEl}
-                isActive={activeColumn?.id === column.id}
-                setActiveColumn={setActiveColumn}
-                containerRef={containerRef}
-                sortBy={sortBy === column.id}
-                orderAsc={!!orderAsc}
-              />
-            ))}
+          <div style={{ flex: '1 1 auto', minWidth: 0, display: 'flex' }}>
+            {columns
+              .filter(({ id }) => !['select', 'navigate', 'icon'].includes(id))
+              .map((column) => (
+                <DataTableHeader
+                  key={column.id}
+                  column={column}
+                  setAnchorEl={setAnchorEl}
+                  isActive={activeColumn?.id === column.id}
+                  setActiveColumn={setActiveColumn}
+                  containerRef={containerRef}
+                  sortBy={sortBy === column.id}
+                  orderAsc={!!orderAsc}
+                />
+              ))}
+          </div>
 
           {(endsWithAction) && <div style={{ width: actionsColumnWidth ?? SELECT_COLUMN_SIZE, flex: '0 0 auto' }} />}
         </>

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -22,24 +22,60 @@ const cellContainerStyle = (theme: Theme) => ({
 
 const DataTableLineDummy = () => {
   const theme = useTheme<Theme>();
-  const { columns, tableWidthState: [tableWidth] } = useDataTableContext();
+  const {
+    columns,
+    startsWithAction,
+    startsWithIcon,
+    startColumnWidth,
+    endsWithAction,
+    actionsColumnWidth,
+    actions,
+    disableNavigation,
+  } = useDataTableContext();
+  const columnsOffset = [startsWithAction, startsWithIcon].filter(Boolean).length;
+  const dataColumns = columns.slice(columnsOffset, (actions || disableNavigation) ? undefined : -1);
+
   return (
     <div style={{ display: 'flex' }}>
-      {columns.map((column) => (
+      {(startsWithAction || startsWithIcon) && (
         <div
-          key={column.id}
           style={{
             paddingLeft: theme.spacing(0.5),
             paddingRight: theme.spacing(1),
             flex: '0 0 auto',
-            width: column.percentWidth
-              ? Math.round(tableWidth * (column.percentWidth / 100))
-              : SELECT_COLUMN_SIZE,
+            width: startColumnWidth,
           }}
         >
           <Skeleton variant="text" height={35} />
         </div>
-      ))}
+      )}
+      <div style={{ flex: '1 1 auto', minWidth: 0, display: 'flex' }}>
+        {dataColumns.map((column) => (
+          <div
+            key={column.id}
+            style={{
+              paddingLeft: theme.spacing(0.5),
+              paddingRight: theme.spacing(1),
+              flex: '0 0 auto',
+              width: `${column.percentWidth}%`,
+            }}
+          >
+            <Skeleton variant="text" height={35} />
+          </div>
+        ))}
+      </div>
+      {endsWithAction && (
+        <div
+          style={{
+            paddingLeft: theme.spacing(0.5),
+            paddingRight: theme.spacing(1),
+            flex: '0 0 auto',
+            width: actionsColumnWidth ?? SELECT_COLUMN_SIZE,
+          }}
+        >
+          <Skeleton variant="text" height={35} />
+        </div>
+      )}
     </div>
   );
 };
@@ -57,7 +93,7 @@ const DataTableCell = ({
   data,
 }: DataTableCellProps) => {
   const theme = useTheme<Theme>();
-  const { useDataCellHelpers, tableWidthState: [tableWidth] } = useDataTableContext();
+  const { useDataCellHelpers } = useDataTableContext();
   const helpers = useDataCellHelpers(cell);
 
   const cellStyle: CSSProperties = {
@@ -75,7 +111,7 @@ const DataTableCell = ({
       key={`${cell.id}_${data.id}`}
       style={{
         ...cellContainerStyle(theme),
-        width: Math.round(tableWidth * (cell.percentWidth / 100)),
+        width: `${cell.percentWidth}%`,
       }}
     >
       <div style={cellStyle}>
@@ -226,13 +262,15 @@ const DataTableLine = ({
           </div>
         )}
 
-        {columns.slice(columnsOffset, (actions || disableNavigation) ? undefined : -1).map((column) => (
-          <DataTableCell
-            key={column.id}
-            cell={column}
-            data={data}
-          />
-        ))}
+        <div style={{ flex: '1 1 auto', minWidth: 0, display: 'flex' }}>
+          {columns.slice(columnsOffset, (actions || disableNavigation) ? undefined : -1).map((column) => (
+            <DataTableCell
+              key={column.id}
+              cell={column}
+              data={data}
+            />
+          ))}
+        </div>
 
         {endsWithAction && (
           <div

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -74,7 +74,6 @@ export interface DataTableContextProps {
   onLineClick: DataTableProps['onLineClick'];
   page: number;
   setPage: Dispatch<SetStateAction<number>>;
-  tableWidthState: [number, Dispatch<SetStateAction<number>>];
   startsWithAction: boolean;
   startsWithIcon: boolean;
   startColumnWidth: number;


### PR DESCRIPTION
### Proposed changes

- Remove the `ResizeObserver`-based `tableWidth` state (`useState` + `useLayoutEffect`) introduced in #10865 from `DataTableComponent`.
- Remove `tableWidthState` from the DataTable context entirely.
- Introduce a `flex: 1 1 auto` wrapper around data columns in `DataTableHeaders`, `DataTableLine`, and `DataTableLineDummy`.
- Column widths are now expressed as `percentWidth%` of their flex data-area container, resolved natively by the browser — no JavaScript computation on resize.

### Motivation

PR #10865 moved table width measurement from `DataTableBody` to `DataTableComponent` to fix skeleton placeholders (#10759). This approach worked but introduced a JS↔CSS feedback loop: every resize event triggered a React state update → re-render of all rows → potential 1px oscillation from scrollbar appearance — visible as jitter ("saccades") when the table container is narrow (e.g. on search-input focus/blur in `DraftReviewEntityList`).

### How it works

```
Before (flat flex, JS-computed px widths):
[select 38px] [col1 Xpx] [col2 Xpx] ... [navigate 38px]

After (flex with data area, CSS-native % widths):
[select 38px │ flex:0] [──── flex:1 1 auto ────] [navigate 38px │ flex:0]
                         [col1 20%] [col2 30%] ...
```

Data columns use `width: percentWidth%` of the `flex: 1 1 auto` container. Fixed columns (select, icon, navigate, actions) keep their pixel widths. The browser resolves sizes natively on every layout pass — no React re-render on resize.

### Related issues

Closes the resize jitter regression. Related: #10865, #10759.
Fixes #16143 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
 URL for manual tests : https://feat-issue-16143.octi.staging.filigran.io/
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
