### PR TITLE
[frontend] Fix custom views not working on some SDO pages (#16152)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/Root.tsx
@@ -51,6 +51,7 @@ const administrativeAreaQuery = graphql`
   query RootAdministrativeAreaQuery($id: String!) {
     administrativeArea(id: $id) {
       id
+      entity_type
       draftVersion {
         draft_id
         draft_operation

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/Root.tsx
@@ -51,6 +51,7 @@ const cityQuery = graphql`
   query RootCityQuery($id: String!) {
     city(id: $id) {
       id
+      entity_type
       draftVersion {
         draft_id
         draft_operation

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/Root.tsx
@@ -53,6 +53,7 @@ const countryQuery = graphql`
   query RootCountryQuery($id: String!) {
     country(id: $id) {
       id
+      entity_type
       draftVersion {
         draft_id
         draft_operation

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/Root.tsx
@@ -53,6 +53,7 @@ const regionQuery = graphql`
   query RootRegionQuery($id: String!) {
     region(id: $id) {
       id
+      entity_type
       draftVersion {
         draft_id
         draft_operation

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/Root.tsx
@@ -49,6 +49,7 @@ const infrastructureQuery = graphql`
   query RootInfrastructureQuery($id: String!) {
     infrastructure(id: $id) {
       id
+      entity_type
       draftVersion {
         draft_id
         draft_operation


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Type checking was not done on a few pages where we relied on them to pass `id` and `entity_type` for the `StyxDomainObjectMain` component. The result is the Custom Views tabs not displayed on 5 SDO pages (administrative area, region, city, country, infra)
* This PR doesn't remove the `@ts-nocheck` , see next PR for that

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #16152 

### Testing instructions

Custom views work on:

- Administrative areas
- Countries
- Cities
- Regions
- Infrastructures

(See public docs about custom views if needed)

### Checklist

I consider the typechecking like "the test" that I will add in the next PR.

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
