### PR TITLE
[backend/frontend] Make current API working with new data model (#14716)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "Rolle",
   "entity_Sector": "Sektor",
   "entity_Security-Coverage": "Deckung der Sicherheit",
+  "entity_Security-Coverage-Result": "Ergebnisse der Sicherheitsabdeckung",
   "entity_Securityplatform": "Plattform für Sicherheit",
   "entity_SecurityPlatform": "Sicherheitsplattform",
   "entity_Sighting": "Sichtung",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "Role",
   "entity_Sector": "Sector",
   "entity_Security-Coverage": "Security Coverages",
+  "entity_Security-Coverage-Result": "Security Coverage Results",
   "entity_Securityplatform": "Security Platform",
   "entity_SecurityPlatform": "Security platform",
   "entity_Sighting": "Sighting",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "Función",
   "entity_Sector": "Sector",
   "entity_Security-Coverage": "Cobertura de seguridad",
+  "entity_Security-Coverage-Result": "Resultados de la cobertura de seguridad",
   "entity_Securityplatform": "Plataforma de seguridad",
   "entity_SecurityPlatform": "Plataforma de seguridad",
   "entity_Sighting": "Deteccion",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "Rôle",
   "entity_Sector": "Secteur",
   "entity_Security-Coverage": "Couvertures de sécurité",
+  "entity_Security-Coverage-Result": "Résultats de la couverture de sécurité",
   "entity_Securityplatform": "Plate-forme de sécurité",
   "entity_SecurityPlatform": "Plateforme de sécurité",
   "entity_Sighting": "Détection",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "Ruolo",
   "entity_Sector": "Settore",
   "entity_Security-Coverage": "Copertura di sicurezza",
+  "entity_Security-Coverage-Result": "Risultati della copertura di sicurezza",
   "entity_Securityplatform": "Piattaforma di sicurezza",
   "entity_SecurityPlatform": "Piattaforma di sicurezza",
   "entity_Sighting": "Sighting",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "役割",
   "entity_Sector": "セクター",
   "entity_Security-Coverage": "セキュリティ",
+  "entity_Security-Coverage-Result": "セキュリティ・カバレッジの結果",
   "entity_Securityplatform": "セキュリティ・プラットフォーム",
   "entity_SecurityPlatform": "セキュリティ・プラットフォーム",
   "entity_Sighting": "一斑",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "역할",
   "entity_Sector": "부문",
   "entity_Security-Coverage": "보안 범위",
+  "entity_Security-Coverage-Result": "보안 적용 범위 결과",
   "entity_Securityplatform": "보안 플랫폼",
   "entity_SecurityPlatform": "보안 플랫폼",
   "entity_Sighting": "목격",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "Роль",
   "entity_Sector": "Сектор",
   "entity_Security-Coverage": "Покрытие безопасности",
+  "entity_Security-Coverage-Result": "Результаты охвата безопасности",
   "entity_Securityplatform": "Платформа безопасности",
   "entity_SecurityPlatform": "Платформа безопасности",
   "entity_Sighting": "Прицел",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -1671,6 +1671,7 @@
   "entity_Role": "角色",
   "entity_Sector": "部门",
   "entity_Security-Coverage": "安全保障",
+  "entity_Security-Coverage-Result": "安保覆盖结果",
   "entity_Securityplatform": "安全平台",
   "entity_SecurityPlatform": "安全平台",
   "entity_Sighting": "目击",

--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -357,6 +357,7 @@ const iconSelector = (
         <TaskAlt style={style} fontSize={fontSize} role="img" />
       );
     case 'security-coverage':
+    case 'security-coverage-result':
       return (
         <ShieldCheckOutline style={style} fontSize={fontSize} role="img" />
       );

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -22,6 +22,8 @@ import {
 } from '../../schema/stixDomainObject';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-incident-types';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../grouping/grouping-types';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, INPUT_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
+import { deleteSecurityCoverageResultsByResultOf } from './securityCoverageResult/securityCoverageResult-domain';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -33,9 +35,22 @@ export const COVERED_ENTITIES_TYPE = [
 ];
 
 // region CRUD
-export const findSecurityCoverageById = (context: AuthContext, user: AuthUser, SecurityCoverageId: string) => {
-  const store = storeLoadById<BasicStoreEntitySecurityCoverage>(context, user, SecurityCoverageId, ENTITY_TYPE_SECURITY_COVERAGE);
-  return notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC, store, user);
+export const findSecurityCoverageById = async (
+  context: AuthContext,
+  user: AuthUser,
+  SecurityCoverageId: string,
+): Promise<BasicStoreEntitySecurityCoverage> => {
+  const store = storeLoadById<BasicStoreEntitySecurityCoverage>(
+    context,
+    user,
+    SecurityCoverageId,
+    ENTITY_TYPE_SECURITY_COVERAGE,
+  );
+  return notify(
+    BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC,
+    store,
+    user,
+  );
 };
 
 export const pageSecurityCoverageConnections = (context: AuthContext, user: AuthUser, args: EntityOptions<BasicStoreEntitySecurityCoverage>) => {
@@ -46,9 +61,69 @@ export const findSecurityCoverageByCoveredId = async (context: AuthContext, user
   return loadEntityThroughRelationsPaginated<BasicStoreEntitySecurityCoverage>(context, user, coveredId, RELATION_COVERED, ABSTRACT_STIX_DOMAIN_OBJECT, true);
 };
 
-export const addSecurityCoverage = async (context: AuthContext, user: AuthUser, securityCoverageInput: SecurityCoverageAddInput) => {
-  const created = await createEntity(context, user, securityCoverageInput, ENTITY_TYPE_SECURITY_COVERAGE);
-  return notify(BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE].EDIT_TOPIC, created, user);
+export const addSecurityCoverage = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverageInput: SecurityCoverageAddInput,
+): Promise<BasicStoreEntitySecurityCoverage> => {
+  const {
+    coverage_information,
+    coverage_last_result,
+    coverage_valid_from,
+    coverage_valid_to,
+    external_uri,
+    ...onlySecurityCoverageInput
+  } = securityCoverageInput;
+  const createdSecurityCoverage: BasicStoreEntitySecurityCoverage = await createEntity(
+    context,
+    user,
+    onlySecurityCoverageInput,
+    ENTITY_TYPE_SECURITY_COVERAGE,
+  );
+
+  if (external_uri || (coverage_information ?? []).length > 0) {
+    const {
+      confidence,
+      created,
+      createdBy,
+      fileMarkings,
+      filesMarkings,
+      modified,
+      objectLabel,
+      objectMarking,
+      x_opencti_modified_at,
+    } = onlySecurityCoverageInput;
+    const securityCoverageResultInput = {
+      name: `Result of ${createdSecurityCoverage.name}`,
+      [INPUT_RESULT_OF]: createdSecurityCoverage.id,
+      coverage_information,
+      coverage_last_result,
+      coverage_valid_from,
+      coverage_valid_to,
+      external_uri,
+      confidence,
+      created,
+      createdBy,
+      fileMarkings,
+      filesMarkings,
+      modified,
+      objectLabel,
+      objectMarking,
+      x_opencti_modified_at,
+    };
+    await createEntity(
+      context,
+      user,
+      securityCoverageResultInput,
+      ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+    );
+  }
+
+  return notify(
+    BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE].EDIT_TOPIC,
+    createdSecurityCoverage,
+    user,
+  );
 };
 
 export const securityCoverageStixBundle = async (context: AuthContext, user: AuthUser, SecurityCoverageId: string) => {
@@ -98,9 +173,10 @@ export const objectCovered = async <T extends BasicStoreEntity>(context: AuthCon
   return loadEntityThroughRelationsPaginated<T>(context, user, SecurityCoverageId, RELATION_COVERED, COVERED_ENTITIES_TYPE, false);
 };
 
-export const securityCoverageDelete = async (context: AuthContext, user: AuthUser, SecurityCoverageId: string) => {
-  await deleteElementById(context, user, SecurityCoverageId, ENTITY_TYPE_SECURITY_COVERAGE);
-  await notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].DELETE_TOPIC, SecurityCoverageId, user);
-  return SecurityCoverageId;
+export const securityCoverageDelete = async (context: AuthContext, user: AuthUser, securityCoverageId: string) => {
+  await deleteSecurityCoverageResultsByResultOf(context, user, securityCoverageId);
+  await deleteElementById(context, user, securityCoverageId, ENTITY_TYPE_SECURITY_COVERAGE);
+  await notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].DELETE_TOPIC, securityCoverageId, user);
+  return securityCoverageId;
 };
 // endregion

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
@@ -13,6 +13,7 @@ export interface BasicStoreEntitySecurityCoverage extends BasicStoreEntity {
   duration: string;
   type_affinity: string;
   platforms_affinity: string[];
+  [RELATION_COVERED]: string;
 }
 
 export interface StoreEntitySecurityCoverage extends StoreEntity {

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -1,0 +1,75 @@
+import { deleteElementById } from '../../../database/middleware';
+import { fullEntitiesList } from '../../../database/middleware-loader';
+import { FilterMode, FilterOperator } from '../../../generated/graphql';
+import type { AuthContext, AuthUser } from '../../../types/user';
+import {
+  ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  INPUT_RESULT_OF,
+  type BasicStoreEntitySecurityCoverageResult,
+  type StoreEntitySecurityCoverageResult,
+} from './securityCoverageResult-types';
+
+/**
+ * Find all security coverage results for a security coverage.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param resultOfId ID of the security coverage.
+ * @returns List of security coverage results.
+ */
+export const listSecurityCoverageResultsByResultOf = async (
+  context: AuthContext,
+  user: AuthUser,
+  resultOfId: string,
+) => {
+  return fullEntitiesList<BasicStoreEntitySecurityCoverageResult>(
+    context,
+    user,
+    [ENTITY_TYPE_SECURITY_COVERAGE_RESULT],
+    {
+      filters: {
+        mode: FilterMode.And,
+        filterGroups: [],
+        filters: [
+          {
+            mode: FilterMode.Or,
+            operator: FilterOperator.Eq,
+            key: [INPUT_RESULT_OF],
+            values: [resultOfId],
+          },
+        ],
+      },
+    },
+  );
+};
+
+/**
+ * Delete all security coverage results for a security coverage.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param resultOfId ID of the security coverage.
+ * @returns List of IDs deleted results.
+ */
+export const deleteSecurityCoverageResultsByResultOf = async (
+  context: AuthContext,
+  user: AuthUser,
+  resultOfId: string,
+) => {
+  const deletedIds: string[] = [];
+  const results = await listSecurityCoverageResultsByResultOf(
+    context,
+    user,
+    resultOfId,
+  );
+  for (const result of results) {
+    const deleted = await deleteElementById<StoreEntitySecurityCoverageResult>(
+      context,
+      user,
+      result.id,
+      ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+    );
+    deletedIds.push(deleted.id);
+  }
+  return deletedIds;
+};

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage-domain-test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { addSecurityCoverage, securityCoverageDelete } from '../../../src/modules/securityCoverage/securityCoverage-domain';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { addReport, reportDeleteWithElements } from '../../../src/domain/report';
+import type { StoreEntityReport } from '../../../src/types/store';
+import { listSecurityCoverageResultsByResultOf } from '../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain';
+
+describe('SecurityCoverage domain', () => {
+  let report: StoreEntityReport;
+
+  const BASE_INPUT = () => ({
+    name: 'sc1',
+    objectCovered: report.standard_id,
+    auto_enrichment_disable: true,
+  });
+
+  beforeAll(async () => {
+    report = await addReport(testContext, ADMIN_USER, {
+      name: 'Report for SC tests',
+      published: '2026-04-24T19:15:00.000Z',
+    });
+  });
+
+  afterAll(async () => {
+    await reportDeleteWithElements(testContext, ADMIN_USER, report.standard_id);
+  });
+
+  describe('Function addSecurityCoverage()', () => {
+    it('should create coverage result if contains coverage information', async () => {
+      const input = {
+        ...BASE_INPUT(),
+        coverage_information: [{
+          coverage_name: 'prevention',
+          coverage_score: 10,
+        }],
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      };
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
+      const results = await listSecurityCoverageResultsByResultOf(testContext, ADMIN_USER, securityCoverage.id);
+      expect(results.length).toEqual(1);
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+    });
+
+    it('should create coverage result if contains no information but external_uri', async () => {
+      const input = {
+        ...BASE_INPUT(),
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+      };
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
+      const results = await listSecurityCoverageResultsByResultOf(testContext, ADMIN_USER, securityCoverage.id);
+      expect(results.length).toEqual(1);
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+    });
+
+    it('should not create coverage result if no coverage info neither external_uri', async () => {
+      const input = {
+        ...BASE_INPUT(),
+      };
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
+      const results = await listSecurityCoverageResultsByResultOf(testContext, ADMIN_USER, securityCoverage.id);
+      expect(results.length).toEqual(0);
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+    });
+  });
+
+  describe('Function securityCoverageDelete()', () => {
+    it('should delete security coverage results when deleting a security coverage', async () => {
+      const input = {
+        ...BASE_INPUT(),
+        coverage_information: [{
+          coverage_name: 'prevention',
+          coverage_score: 10,
+        }],
+      };
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
+      let results = await listSecurityCoverageResultsByResultOf(testContext, ADMIN_USER, securityCoverage.id);
+      expect(results.length).toEqual(1);
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+      results = await listSecurityCoverageResultsByResultOf(testContext, ADMIN_USER, securityCoverage.id);
+      expect(results.length).toEqual(0);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
@@ -42,7 +42,6 @@ describe('SecurityCoverage resolver', () => {
     });
 
     const securityCoverageData = securityCoverage.data?.securityCoverageAdd;
-    console.log(securityCoverageData);
     expect(securityCoverageData).toBeDefined();
     expect(securityCoverageData.name).toEqual('SC name');
     expect(securityCoverageData.coverage_last_result.toISOString()).toEqual('2023-08-06T11:39:36.949Z');


### PR DESCRIPTION
### Proposed changes

* When creating a `SecurityCoverage`, if coverage information, creates also a `SecurityCoverageResult`
* When deleting a `SecurityCoverage` it also deletes the associated `SecurityCoverageResult`

### Related issues

* Closes #16173 
* #14716

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality