### PR TITLE
[ci] add ci-status job to verify workflow completion and job result (#16177)

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -93,10 +93,19 @@ jobs:
           echo "Client Python Test: $client_python_test"
           echo "License Check: $license_check"
           
-          for result in "$build_image" "$backend_test" "$frontend_test" "$client_python_test" "$license_check"; do
+          jobs="Build-Image:$build_image Backend-Test:$backend_test Frontend-Test:$frontend_test Client-Python-Test:$client_python_test License-Check:$license_check"
+          
+          has_failed=false
+          for job in $jobs; do
+            name="${job%%:*}"
+            result="${job#*:}"
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
-              echo "Error: One or more jobs failed or were cancelled."
-              exit 1
+              echo "Error: Job '$name' has status '$result'."
+              has_failed=true
             fi
           done
+          
+          if [ "$has_failed" = "true" ]; then
+            exit 1
+          fi
           echo "All jobs succeeded or were skipped."

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -72,3 +72,31 @@ jobs:
       with:
         checkout_ref: ${{ github.event_name == 'pull_request'  && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
       secrets: inherit
+
+  ci-status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    needs: [wf-build-image, wf-backend-test, wf-frontend-test, wf-client-python-test, wf-license-check]
+    if: always()
+    steps:
+      - name: Verify job results
+        run: |
+          build_image="${{ needs.wf-build-image.result }}"
+          backend_test="${{ needs.wf-backend-test.result }}"
+          frontend_test="${{ needs.wf-frontend-test.result }}"
+          client_python_test="${{ needs.wf-client-python-test.result }}"
+          license_check="${{ needs.wf-license-check.result }}"
+          
+          echo "Build Image: $build_image"
+          echo "Backend Test: $backend_test"
+          echo "Frontend Test: $frontend_test"
+          echo "Client Python Test: $client_python_test"
+          echo "License Check: $license_check"
+          
+          for result in "$build_image" "$backend_test" "$frontend_test" "$client_python_test" "$license_check"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "Error: One or more jobs failed or were cancelled."
+              exit 1
+            fi
+          done
+          echo "All jobs succeeded or were skipped."

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -76,25 +76,27 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [wf-build-image, wf-backend-test, wf-frontend-test, wf-client-python-test, wf-license-check]
+    needs: [changes, wf-build-image, wf-backend-test, wf-frontend-test, wf-client-python-test, wf-license-check]
     if: always()
     steps:
       - name: Verify job results
+        shell: bash
         run: |
+          changes="${{ needs.changes.result }}"
           build_image="${{ needs.wf-build-image.result }}"
           backend_test="${{ needs.wf-backend-test.result }}"
           frontend_test="${{ needs.wf-frontend-test.result }}"
           client_python_test="${{ needs.wf-client-python-test.result }}"
           license_check="${{ needs.wf-license-check.result }}"
           
+          echo "Changes: $changes"
           echo "Build Image: $build_image"
           echo "Backend Test: $backend_test"
           echo "Frontend Test: $frontend_test"
           echo "Client Python Test: $client_python_test"
           echo "License Check: $license_check"
           
-          jobs="Build-Image:$build_image Backend-Test:$backend_test Frontend-Test:$frontend_test Client-Python-Test:$client_python_test License-Check:$license_check"
-          
+          jobs="Changes:$changes Build-Image:$build_image Backend-Test:$backend_test Frontend-Test:$frontend_test Client-Python-Test:$client_python_test License-Check:$license_check"
           has_failed=false
           for job in $jobs; do
             name="${job%%:*}"


### PR DESCRIPTION
### Proposed changes

To resolve the issue where skipped required status checks inside reusable workflows remain in a "Pending / Expected" state (blocking merges on documentation-only changes), this PR introduces a central status check aggregator:
- **Add `CI Status` aggregator job** at the end of `.github/workflows/ci-main.yml` that depends on all primary jobs (`wf-build-image`, `wf-backend-test`, `wf-frontend-test`, `wf-client-python-test`, `wf-license-check`).
- The `CI Status` job runs dynamically (`if: always()`) and verifies the results of its dependencies:
  - It succeeds if all executed jobs pass OR if they were skipped.
  - It fails if any job fails or is cancelled.

> [!NOTE]
> Once this PR is merged, repository administrators will need to update the Branch Protection settings to:
> 1. Remove individual nested jobs (`Frontend / Unit tests`, `Frontend / Verify translation`, `License check / License check`) from the required status checks.
> 2. Mark the new **`CI Status`** job as the only required status check.

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #16177 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
