### PR TITLE
[frontend] update report pdf name file default (#16119)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -31,7 +31,8 @@ import TextField from '../../../../components/TextField';
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import useAI from '../../../../utils/hooks/useAI';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { now } from '../../../../utils/Time';
+import { nowUTC } from '../../../../utils/Time';
+import { buildExportFileName } from './StixCoreObjectFileExportForm.utils';
 import FintelDesignField, { FintelDesignFieldOption } from './FintelDesignField';
 
 export type FileOption = Pick<FieldOption, 'label' | 'value'> & {
@@ -230,21 +231,16 @@ const StixCoreObjectFileExportForm = ({
             setFieldValue('template', (templates ?? [])[0] ?? null);
           }
         }, [values.connector]);
+
         useEffect(() => {
-          if (values.template) {
-            setFieldValue('exportFileName', `${values.template.label}_${now()}`);
+          if (values.template || values.fileToExport) {
+            setFieldValue('exportFileName', buildExportFileName({
+              entityName: scoName,
+              markings: values.fileMarkings,
+              utcIsoDate: nowUTC(),
+            }));
           }
-        }, [values.template]);
-        useEffect(() => {
-          if (values.fileToExport) {
-            setFieldValue(
-              'exportFileName',
-              values.fileToExport.value === 'mappableContent' && scoName
-                ? `${scoName}_${now()}`
-                : `${values.fileToExport.label.split('.')[0]}_${now()}`,
-            );
-          }
-        }, [values.fileToExport]);
+        }, [values.template, values.fileToExport, values.fileMarkings, scoName, setFieldValue]);
 
         useEffect(() => {
           setSelectedContentMaxMarkingsIds((values.contentMaxMarkings ?? []).map(({ value }) => value));
@@ -423,13 +419,13 @@ const StixCoreObjectFileExportForm = ({
                       )}
                       {((values.connector.value === BUILT_IN_FROM_TEMPLATE.value && values.format === 'application/pdf')
                         || (values.connector.value === BUILT_IN_HTML_TO_PDF.value && values.fileToExport?.value.startsWith('fromTemplate/')))
-                      && (
-                        <FintelDesignField
-                          name="fintelDesign"
-                          label={t_i18n('Fintel design')}
-                          style={fieldSpacingContainerStyle}
-                        />
-                      )}
+                        && (
+                          <FintelDesignField
+                            name="fintelDesign"
+                            label={t_i18n('Fintel design')}
+                            style={fieldSpacingContainerStyle}
+                          />
+                        )}
                       {!isBuiltInConnector(values.connector.value) && (
                         <Field
                           component={SelectField}

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -246,6 +246,11 @@ const StixCoreObjectFileExportForm = ({
           setSelectedContentMaxMarkingsIds((values.contentMaxMarkings ?? []).map(({ value }) => value));
         }, [values.contentMaxMarkings]);
 
+        const shouldDisplayFintelDesign = (
+          (values.connector?.value === BUILT_IN_FROM_TEMPLATE.value && values.format === 'application/pdf')
+          || (values.connector?.value === BUILT_IN_HTML_TO_PDF.value && values.fileToExport?.value.startsWith('fromTemplate/'))
+        );
+
         return (
 
           <Dialog
@@ -417,15 +422,13 @@ const StixCoreObjectFileExportForm = ({
                           optionLength={80}
                         />
                       )}
-                      {((values.connector.value === BUILT_IN_FROM_TEMPLATE.value && values.format === 'application/pdf')
-                        || (values.connector.value === BUILT_IN_HTML_TO_PDF.value && values.fileToExport?.value.startsWith('fromTemplate/')))
-                        && (
-                          <FintelDesignField
-                            name="fintelDesign"
-                            label={t_i18n('Fintel design')}
-                            style={fieldSpacingContainerStyle}
-                          />
-                        )}
+                      {shouldDisplayFintelDesign && (
+                        <FintelDesignField
+                          name="fintelDesign"
+                          label={t_i18n('Fintel design')}
+                          style={fieldSpacingContainerStyle}
+                        />
+                      )}
                       {!isBuiltInConnector(values.connector.value) && (
                         <Field
                           component={SelectField}

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -237,8 +237,8 @@ const StixCoreObjectFileExportForm = ({
           if (values.template || values.fileToExport) {
             const selectedEntityName = values.connector?.value === BUILT_IN_HTML_TO_PDF.value
               ? (values.fileToExport?.value === 'mappableContent'
-                ? scoName
-                : normalizeExportSourceEntityName(values.fileToExport?.fileName))
+                  ? scoName
+                  : normalizeExportSourceEntityName(values.fileToExport?.fileName))
               : scoName;
             setFieldValue('exportFileName', buildExportFileName({
               entityName: selectedEntityName,

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.tsx
@@ -32,10 +32,11 @@ import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field
 import useAI from '../../../../utils/hooks/useAI';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { nowUTC } from '../../../../utils/Time';
-import { buildExportFileName } from './StixCoreObjectFileExportForm.utils';
+import { buildExportFileName, normalizeExportSourceEntityName } from './StixCoreObjectFileExportForm.utils';
 import FintelDesignField, { FintelDesignFieldOption } from './FintelDesignField';
 
 export type FileOption = Pick<FieldOption, 'label' | 'value'> & {
+  fileName?: string;
   fileMarkings: {
     id: string;
     name: string;
@@ -234,8 +235,13 @@ const StixCoreObjectFileExportForm = ({
 
         useEffect(() => {
           if (values.template || values.fileToExport) {
+            const selectedEntityName = values.connector?.value === BUILT_IN_HTML_TO_PDF.value
+              ? (values.fileToExport?.value === 'mappableContent'
+                ? scoName
+                : normalizeExportSourceEntityName(values.fileToExport?.fileName))
+              : scoName;
             setFieldValue('exportFileName', buildExportFileName({
-              entityName: scoName,
+              entityName: selectedEntityName,
               markings: values.fileMarkings,
               utcIsoDate: nowUTC(),
             }));

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { buildExportFileName, formatExportUtcTimestamp, normalizeMarkingForFileName, sanitizeFileNamePart } from './StixCoreObjectFileExportForm.utils';
+
+describe('StixCoreObjectFileExportForm utils', () => {
+  it('sanitizes and truncates entity name to 100 chars', () => {
+    const sourceName = `${'A'.repeat(120)} / report`;
+
+    const sanitized = sanitizeFileNamePart(sourceName, 'Entity', 100);
+
+    expect(sanitized.length).toBe(100);
+    expect(sanitized).toBe('A'.repeat(100));
+  });
+
+  it('returns fallback entity name when empty', () => {
+    expect(sanitizeFileNamePart('   ', 'Entity', 100)).toBe('Entity');
+  });
+
+  it('formats timestamp in UTC as YYYYMMDDTHHmmZ', () => {
+    expect(formatExportUtcTimestamp('2026-05-25T13:55:10+02:00')).toBe('20260525T1155Z');
+  });
+
+  it('normalizes TLP:AMBER to TLP-AMBER', () => {
+    expect(normalizeMarkingForFileName([{ label: 'TLP:AMBER', value: 'id-1' }])).toBe('TLP-AMBER');
+  });
+
+  it('normalizes TLP:AMBER+STRICT replacing + with -', () => {
+    expect(normalizeMarkingForFileName([{ label: 'TLP:AMBER+STRICT', value: 'id-1' }])).toBe('TLP-AMBER-STRICT');
+  });
+
+  it('normalizes a PAP marking replacing : with -', () => {
+    expect(normalizeMarkingForFileName([{ label: 'PAP:RED', value: 'id-2' }])).toBe('PAP-RED');
+  });
+
+  it('collapses multiple consecutive separators into a single -', () => {
+    expect(normalizeMarkingForFileName([{ label: 'TLP::AMBER  STRICT', value: 'id-3' }])).toBe('TLP-AMBER-STRICT');
+  });
+
+  it('preserves marking already in correct TLP-XXXX format', () => {
+    expect(normalizeMarkingForFileName([{ label: 'TLP-GREEN', value: 'id-4' }])).toBe('TLP-GREEN');
+  });
+
+  it('normalizes marking and truncates it to 100 chars', () => {
+    const marking = [{ label: `TLP:AMBER-${'X'.repeat(120)}`, value: 'id-5' }];
+
+    const normalized = normalizeMarkingForFileName(marking);
+
+    expect(normalized?.startsWith('TLP-AMBER-')).toBe(true);
+    expect(normalized?.length).toBe(100);
+  });
+
+  it('returns null when there is no marking', () => {
+    expect(normalizeMarkingForFileName([])).toBeNull();
+    expect(normalizeMarkingForFileName(undefined)).toBeNull();
+  });
+
+  it('builds default export file name with marking', () => {
+    const fileName = buildExportFileName({
+      entityName: 'APT29 Campaign Analysis',
+      utcIsoDate: '2026-05-21T13:55:10Z',
+      markings: [{ label: 'TLP:AMBER', value: 'marking--amber' }],
+    });
+
+    expect(fileName).toBe('APT29_Campaign_Analysis_20260521T1355Z_TLP-AMBER');
+  });
+
+  it('builds default export file name without marking segment when no marking', () => {
+    const fileName = buildExportFileName({
+      entityName: 'My report',
+      utcIsoDate: '2026-05-21T13:55:10Z',
+      markings: [],
+    });
+
+    expect(fileName).toBe('My_report_20260521T1355Z');
+  });
+
+  it('falls back to Export when entity name is missing', () => {
+    const fileName = buildExportFileName({
+      entityName: null,
+      utcIsoDate: '2026-05-21T13:55:10Z',
+      markings: [{ label: 'TLP:CLEAR', value: 'marking--clear' }],
+    });
+
+    expect(fileName).toBe('Export_20260521T1355Z_TLP-CLEAR');
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildExportFileName, formatExportUtcTimestamp, normalizeMarkingForFileName, sanitizeFileNamePart } from './StixCoreObjectFileExportForm.utils';
+import {
+  buildExportFileName,
+  formatExportUtcTimestamp,
+  normalizeExportSourceEntityName,
+  normalizeMarkingForFileName,
+  sanitizeFileNamePart,
+} from './StixCoreObjectFileExportForm.utils';
 
 describe('StixCoreObjectFileExportForm utils', () => {
   it('sanitizes and truncates entity name to 100 chars', () => {
@@ -81,5 +87,17 @@ describe('StixCoreObjectFileExportForm utils', () => {
     });
 
     expect(fileName).toBe('Export_20260521T1355Z_TLP-CLEAR');
+  });
+
+  it('normalizes source file name by removing extension only for plain files', () => {
+    expect(normalizeExportSourceEntityName('petit coincoin.html')).toBe('petit coincoin');
+  });
+
+  it('normalizes source file name by stripping existing export timestamp and marking suffix', () => {
+    expect(normalizeExportSourceEntityName('petit_coincoin_20260526T1015Z_TLP-RED.html')).toBe('petit_coincoin');
+  });
+
+  it('normalizes source file name by stripping existing export timestamp suffix without marking', () => {
+    expect(normalizeExportSourceEntityName('petit_coincoin_20260526T1015Z.md')).toBe('petit_coincoin');
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.ts
@@ -3,6 +3,7 @@ import { FieldOption } from '../../../../utils/field';
 
 const MAX_ENTITY_NAME_LENGTH = 100;
 const MAX_MARKING_LENGTH = 100;
+const EXPORT_FILE_SUFFIX_REGEXP = /_\d{8}T\d{4}Z(?:_[A-Z0-9]+(?:-[A-Z0-9]+)*)?$/;
 
 export const sanitizeFileNamePart = (
   input: string | null | undefined,
@@ -45,6 +46,17 @@ export const normalizeMarkingForFileName = (markings?: FieldOption[] | null): st
   }
 
   return normalized.length > MAX_MARKING_LENGTH ? normalized.slice(0, MAX_MARKING_LENGTH) : normalized;
+};
+
+export const normalizeExportSourceEntityName = (fileName?: string | null): string | null => {
+  if (!fileName) {
+    return null;
+  }
+
+  const fileBaseName = fileName.replace(/\.[^./\\]+$/, '');
+  // If the selected source is already an export, strip trailing "_timestamp[_marking]"
+  // so a new export does not duplicate those segments in the generated filename.
+  return fileBaseName.replace(EXPORT_FILE_SUFFIX_REGEXP, '');
 };
 
 interface BuildExportFileNameInput {

--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectFileExportForm.utils.ts
@@ -1,0 +1,70 @@
+import { parse } from '../../../../utils/Time';
+import { FieldOption } from '../../../../utils/field';
+
+const MAX_ENTITY_NAME_LENGTH = 100;
+const MAX_MARKING_LENGTH = 100;
+
+export const sanitizeFileNamePart = (
+  input: string | null | undefined,
+  fallback: string,
+  maxLength: number,
+): string => {
+  const base = (input ?? '').trim();
+  const cleaned = base
+    .replace(/[\\/:*?"<>|]+/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  const value = cleaned || fallback;
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+};
+
+export const formatExportUtcTimestamp = (utcIsoDate: string): string => {
+  return parse(utcIsoDate).utc().format('YYYYMMDDTHHmm[Z]');
+};
+
+export const normalizeMarkingForFileName = (markings?: FieldOption[] | null): string | null => {
+  const firstMarking = markings?.[0]?.label;
+  if (!firstMarking) {
+    return null;
+  }
+
+  const normalized = firstMarking
+    .trim()
+    .toUpperCase()
+    // replace any non-alphanumeric character with a hyphen
+    .replace(/[^A-Z0-9]+/g, '-')
+    // collapse consecutive hyphens
+    .replace(/-{2,}/g, '-')
+    // strip leading/trailing hyphens
+    .replace(/^-+|-+$/g, '');
+
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.length > MAX_MARKING_LENGTH ? normalized.slice(0, MAX_MARKING_LENGTH) : normalized;
+};
+
+interface BuildExportFileNameInput {
+  entityName?: string | null;
+  markings?: FieldOption[] | null;
+  utcIsoDate: string;
+}
+
+export const buildExportFileName = ({
+  entityName,
+  markings,
+  utcIsoDate,
+}: BuildExportFileNameInput): string => {
+  const safeEntityName = sanitizeFileNamePart(entityName, 'Export', MAX_ENTITY_NAME_LENGTH);
+  const timestamp = formatExportUtcTimestamp(utcIsoDate);
+  const marking = normalizeMarkingForFileName(markings);
+
+  if (!marking) {
+    return `${safeEntityName}_${timestamp}`;
+  }
+
+  return `${safeEntityName}_${timestamp}_${marking}`;
+};

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
@@ -49,6 +49,8 @@ const stixCoreObjectFileExportQuery = graphql`
       }
       objectMarking {
         id
+        definition
+        definition_type
         representative {
           main
         }
@@ -63,6 +65,8 @@ const stixCoreObjectFileExportQuery = graphql`
             }
             objectMarking {
               id
+              definition
+              definition_type
               representative {
                 main
               }
@@ -80,6 +84,8 @@ const stixCoreObjectFileExportQuery = graphql`
             }
             objectMarking {
               id
+              definition
+              definition_type
               representative {
                 main
               }
@@ -102,6 +108,8 @@ const stixCoreObjectFileExportQuery = graphql`
               }
               objectMarking {
                 id
+                definition
+                definition_type
                 representative {
                   main
                 }
@@ -194,6 +202,7 @@ const StixCoreObjectFileExportComponent = ({
     return {
       value: e.node.id,
       label: getMainRepresentative(e.node),
+      fileName: e.node.name,
       fileMarkings: e.node.objectMarking.map((o) => ({
         id: o.id,
         name: getMainRepresentative(o),
@@ -204,6 +213,7 @@ const StixCoreObjectFileExportComponent = ({
   fileOptions.push({
     value: 'mappableContent',
     label: t_i18n('Mappable main content'),
+    fileName: 'mappableContent',
     fileMarkings: (stixCoreObject?.objectMarking ?? []).map((o) => ({
       id: o.id,
       name: getMainRepresentative(o),
@@ -452,7 +462,7 @@ const StixCoreObjectFileExport = (props: StixCoreObjectFileExportProps) => {
   return (
     <>
       {!connectorsQueryRef && (
-        <OpenFormComponent onOpen={() => {}} isExportPossible={false} />
+        <OpenFormComponent onOpen={() => { }} isExportPossible={false} />
       )}
       {connectorsQueryRef && (
         <React.Suspense>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* update export report name by default with [entityName]_[timestampUTC]_[marking]

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* fixes #16119 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
