### PR TITLE
feat(backend): refresh token support for OAuth2 SMTP (#15924)

### DIFF
--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -248,26 +248,36 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 
 #### SMTP Service
 
-| Parameter                | Environment variable      | Default value | Description                                            |
-|:-------------------------|:--------------------------|:--------------|:-------------------------------------------------------|
-| smtp:hostname            | SMTP__HOSTNAME            |               | SMTP Server hostname                                   |
-| smtp:port                | SMTP__PORT                | 465           | SMTP Port (25 or 465 for TLS)                          |
-| smtp:use_ssl             | SMTP__USE_SSL             | `false`       | SMTP over TLS                                          |
-| smtp:reject_unauthorized | SMTP__REJECT_UNAUTHORIZED | `false`       | Enable TLS certificate check                           |
-| smtp:username            | SMTP__USERNAME            |               | SMTP Username if authentication is needed (Basic Auth) |
-| smtp:password            | SMTP__PASSWORD            |               | SMTP Password if authentication is needed (Basic Auth) |
-| smtp:auth_type           | SMTP__AUTH_TYPE           | `basic`       | Authentication type: `basic` or `oauth2`               |
-| smtp:oauth_user          | SMTP__OAUTH_USER          |               | OAuth2: email address of the SMTP user                 |
-| smtp:oauth_client_id     | SMTP__OAUTH_CLIENT_ID     |               | OAuth2: Azure AD application (client) ID               |
-| smtp:oauth_client_secret | SMTP__OAUTH_CLIENT_SECRET |               | OAuth2: Azure AD client secret                         |
-| smtp:oauth_access_token  | SMTP__OAUTH_ACCESS_TOKEN  |               | OAuth2: static access token                            |
+| Parameter                  | Environment variable        | Default value | Description                                                                                                          |
+|:---------------------------|:----------------------------|:--------------|:----------------------------------------------------------------------------------------------------------------------------------|
+| smtp:hostname              | SMTP__HOSTNAME              |               | SMTP Server hostname                                                                                                 |
+| smtp:port                  | SMTP__PORT                  | 465           | SMTP Port (25 or 465 for TLS)                                                                                        |
+| smtp:use_ssl               | SMTP__USE_SSL               | `false`       | SMTP over TLS                                                                                                        |
+| smtp:reject_unauthorized   | SMTP__REJECT_UNAUTHORIZED   | `false`       | Enable TLS certificate check                                                                                         |
+| smtp:auth_type             | SMTP__AUTH_TYPE             | `basic`       | Authentication type: `basic` or `oauth2`                                                                             |
+| smtp:username              | SMTP__USERNAME              |               | SMTP username (Basic Auth only)                                                                                      |
+| smtp:password              | SMTP__PASSWORD              |               | SMTP password (Basic Auth only)                                                                                      |
+| smtp:oauth_user            | SMTP__OAUTH_USER            |               | OAuth2: email address of the SMTP mailbox                                                                            |
+| smtp:oauth_client_id       | SMTP__OAUTH_CLIENT_ID       |               | OAuth2: client ID registered with the identity provider                                                              |
+| smtp:oauth_client_secret   | SMTP__OAUTH_CLIENT_SECRET   |               | OAuth2: client secret associated with the client ID                                                                  |
+| smtp:oauth_issuer          | SMTP__OAUTH_ISSUER          |               | OAuth2: OIDC issuer URL of the identity provider (used for discovery and refresh token grant)                        |
+| smtp:oauth_refresh_token   | SMTP__OAUTH_REFRESH_TOKEN   |               | OAuth2: long-lived refresh token used to obtain a fresh access token before each email is sent                       |
+
+!!! note "OAuth2 authentication (provider-agnostic)"
+
+    Many SMTP providers no longer accept Basic Authentication (for example Microsoft 365 deprecated it in 2025). OpenCTI supports OAuth2 with the **Refresh Token Grant** for any OIDC-compliant identity provider: Microsoft Entra ID, Google Workspace, Okta, Keycloak, and others.
+
+    Set `smtp:auth_type` to `oauth2` and provide the five `oauth_*` fields. The platform refreshes the access token before every email is sent, so OpenCTI instances stay able to send mail indefinitely once the refresh token is valid.
+
+    Example `oauth_issuer` values:
 
 !!! note "OAuth2 authentication (Microsoft/Office 365)"
 
-    If your SMTP server requires OAuth2 (e.g. `smtp.office365.com` after Microsoft retired Basic Auth in April 2026),
-    set `smtp:auth_type` to `oauth2` and provide the four `oauth_*` fields.
-    All four fields are required when `oauth2` is selected.
-    Basic Auth (`smtp:auth_type: basic`) remains the default and is unaffected by this change.
+    !!! warning "Required SMTP scope"
+
+        The OAuth2 refresh token must have been granted the scope that allows sending email through SMTP. For Microsoft 365 this is `https://outlook.office.com/SMTP.Send` together with `offline_access`. For Google Workspace this is `https://mail.google.com/`. Refer to your provider's documentation for the exact scope.
+
+    Basic Auth (`smtp:auth_type: basic`) remains the default and is unaffected by this configuration.
 
 #### AI Service
 

--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -269,9 +269,9 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 
     Set `smtp:auth_type` to `oauth2` and provide the five `oauth_*` fields. The platform refreshes the access token before every email is sent, so OpenCTI instances stay able to send mail indefinitely once the refresh token is valid.
 
-    Example `oauth_issuer` values:
+!!! note "OAuth2 authentication (provider-specific configuration)"
 
-!!! note "OAuth2 authentication (Microsoft/Office 365)"
+     Some providers require additional configuration for the OAuth2 client. For example, Microsoft 365 requires the client to be registered as a "public client" and to use the "OAuth 2.0 authorization grant flow for devices" (device code flow) to obtain the refresh token. Refer to your provider's documentation for any specific requirements.
 
     !!! warning "Required SMTP scope"
 

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -26,20 +26,12 @@ const baseSmtpOptions = {
 };
 
 // OAuth2 caches:
-// - the OIDC discovery result is essentially static for an issuer and can be
-//   reused for the whole lifetime of the process.
-// - the access token is reused until shortly before its expiration, so a busy
-//   platform does not hammer the IdP /.well-known and /token endpoints on
-//   every email (and does not get rate-limited by Entra ID / Google / etc.).
-// - concurrent refresh attempts are coalesced via an in-flight Promise so only
-//   one network roundtrip happens at any given time.
 let cachedDiscoveryConfig;
 let cachedAccessToken;
 let cachedAccessTokenExpiresAt = 0;
-let inFlightRefresh;
-// Refresh the token a bit before it actually expires to absorb clock skew and
-// the duration of the SMTP exchange that follows.
-const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+let inFlightRefresh; // concurrent refresh attempts are coalesced via an in-flight Promise
+
+const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000; // Refresh the token a bit before it actually expires
 
 const refreshSmtpAccessToken = async ({ oauthClientId, oauthClientSecret, oauthIssuer, oauthRefreshToken }) => {
   if (cachedAccessToken && Date.now() < cachedAccessTokenExpiresAt - ACCESS_TOKEN_REFRESH_MARGIN_MS) {

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import { discovery as oidcDiscovery, refreshTokenGrant } from 'openid-client';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { meterManager } from '../config/tracing';
 import { getEntityFromCache } from './cache';
@@ -12,7 +13,7 @@ const USE_SSL = booleanConf('smtp:use_ssl', false);
 const REJECT_UNAUTHORIZED = booleanConf('smtp:reject_unauthorized', false);
 const SMTP_ENABLE = booleanConf('smtp:enabled', true);
 
-const smtpOptions = {
+const baseSmtpOptions = {
   host: conf.get('smtp:hostname') || 'localhost',
   port: conf.get('smtp:port') || 25,
   secure: USE_SSL,
@@ -24,17 +25,46 @@ const smtpOptions = {
   },
 };
 
-export const buildSmtpAuth = (authType, { username, password, oauthUser, oauthClientId, oauthClientSecret, oauthAccessToken }) => {
+const refreshSmtpAccessToken = async ({ oauthClientId, oauthClientSecret, oauthIssuer, oauthRefreshToken }) => {
+  let tokens;
+  try {
+    const issuerUrl = new URL(oauthIssuer);
+    const config = await oidcDiscovery(issuerUrl, oauthClientId, { client_secret: oauthClientSecret });
+    tokens = await refreshTokenGrant(config, oauthRefreshToken);
+  } catch (err) {
+    throw new Error(`Unable to refresh SMTP OAuth2 access token: ${err.message}`, { cause: err });
+  }
+  if (!tokens?.access_token) {
+    throw new Error('Unable to refresh SMTP OAuth2 access token: refresh token grant did not return an access_token');
+  }
+  return tokens.access_token;
+};
+
+export const buildSmtpAuth = async (authType, {
+  username,
+  password,
+  oauthUser,
+  oauthClientId,
+  oauthClientSecret,
+  oauthIssuer,
+  oauthRefreshToken,
+} = {}) => {
   if (authType === 'oauth2') {
-    if (!oauthUser || !oauthClientId || !oauthClientSecret || !oauthAccessToken) {
-      throw new Error('SMTP OAuth2 configuration is incomplete: oauth_user, oauth_client_id, oauth_client_secret and oauth_access_token are all required.');
+    if (!oauthUser || !oauthClientId || !oauthClientSecret || !oauthIssuer || !oauthRefreshToken) {
+      throw new Error('SMTP OAuth2 configuration is incomplete: oauth_user, oauth_client_id, oauth_client_secret, oauth_issuer and oauth_refresh_token are all required.');
     }
+    const freshAccessToken = await refreshSmtpAccessToken({
+      oauthClientId,
+      oauthClientSecret,
+      oauthIssuer,
+      oauthRefreshToken,
+    });
     return {
       type: 'OAuth2',
       user: oauthUser,
       clientId: oauthClientId,
       clientSecret: oauthClientSecret,
-      accessToken: oauthAccessToken,
+      accessToken: freshAccessToken,
     };
   }
   if (username?.length > 0) {
@@ -47,19 +77,30 @@ export const buildSmtpAuth = (authType, { username, password, oauthUser, oauthCl
 };
 
 const authType = conf.get('smtp:auth_type') || 'basic';
-const smtpAuth = buildSmtpAuth(authType, {
+
+const getSmtpAuthParams = () => ({
   username: conf.get('smtp:username'),
   password: conf.get('smtp:password'),
   oauthUser: conf.get('smtp:oauth_user'),
   oauthClientId: conf.get('smtp:oauth_client_id'),
   oauthClientSecret: conf.get('smtp:oauth_client_secret'),
-  oauthAccessToken: conf.get('smtp:oauth_access_token'),
+  oauthIssuer: conf.get('smtp:oauth_issuer'),
+  oauthRefreshToken: conf.get('smtp:oauth_refresh_token'),
 });
-if (smtpAuth) {
-  smtpOptions.auth = smtpAuth;
-}
 
-export const transporter = nodemailer.createTransport(smtpOptions);
+/**
+ * Build a fresh nodemailer transporter. For OAuth2 the access token is
+ * refreshed at call time so that long-running instances do not fail once the
+ * initial token has expired (Microsoft tokens typically live for ~1h).
+ */
+const createSmtpTransporter = async () => {
+  const options = { ...baseSmtpOptions, tls: { ...baseSmtpOptions.tls } };
+  const smtpAuth = await buildSmtpAuth(authType, getSmtpAuthParams());
+  if (smtpAuth) {
+    options.auth = smtpAuth;
+  }
+  return nodemailer.createTransport(options);
+};
 
 export const smtpConfiguredEmail = (settings) => {
   return ALLOW_EMAIL_REWRITE ? settings.platform_email : SMTP_FORCED_EMAIL;
@@ -77,6 +118,7 @@ export const smtpIsAlive = async () => {
   logApp.info('[CHECK] Checking if SMTP is available');
   if (SMTP_ENABLE) {
     try {
+      const transporter = await createSmtpTransporter();
       await transporter.verify();
       logApp.info('[CHECK] SMTP is alive');
     } catch {
@@ -91,6 +133,9 @@ export const smtpIsAlive = async () => {
 export const sendMail = async (args, meterMetadata) => {
   if (SMTP_ENABLE) {
     const { from, to, bcc, subject, html, attachments } = args;
+    // For OAuth2 the transporter is recreated so that the access token is
+    // refreshed before each send (avoids failures once the token has expired).
+    const transporter = await createSmtpTransporter();
     await transporter.sendMail({ from, to, bcc, subject, html, attachments });
     meterManager.emailSent(meterMetadata);
   }

--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -25,19 +25,53 @@ const baseSmtpOptions = {
   },
 };
 
+// OAuth2 caches:
+// - the OIDC discovery result is essentially static for an issuer and can be
+//   reused for the whole lifetime of the process.
+// - the access token is reused until shortly before its expiration, so a busy
+//   platform does not hammer the IdP /.well-known and /token endpoints on
+//   every email (and does not get rate-limited by Entra ID / Google / etc.).
+// - concurrent refresh attempts are coalesced via an in-flight Promise so only
+//   one network roundtrip happens at any given time.
+let cachedDiscoveryConfig;
+let cachedAccessToken;
+let cachedAccessTokenExpiresAt = 0;
+let inFlightRefresh;
+// Refresh the token a bit before it actually expires to absorb clock skew and
+// the duration of the SMTP exchange that follows.
+const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
 const refreshSmtpAccessToken = async ({ oauthClientId, oauthClientSecret, oauthIssuer, oauthRefreshToken }) => {
-  let tokens;
+  if (cachedAccessToken && Date.now() < cachedAccessTokenExpiresAt - ACCESS_TOKEN_REFRESH_MARGIN_MS) {
+    return cachedAccessToken;
+  }
+  if (inFlightRefresh) {
+    return inFlightRefresh;
+  }
+  inFlightRefresh = (async () => {
+    let tokens;
+    try {
+      if (!cachedDiscoveryConfig) {
+        const issuerUrl = new URL(oauthIssuer);
+        cachedDiscoveryConfig = await oidcDiscovery(issuerUrl, oauthClientId, { client_secret: oauthClientSecret });
+      }
+      tokens = await refreshTokenGrant(cachedDiscoveryConfig, oauthRefreshToken);
+    } catch (err) {
+      throw new Error(`Unable to refresh SMTP OAuth2 access token: ${err.message}`, { cause: err });
+    }
+    if (!tokens?.access_token) {
+      throw new Error('Unable to refresh SMTP OAuth2 access token: refresh token grant did not return an access_token');
+    }
+    cachedAccessToken = tokens.access_token;
+    const expiresInSeconds = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600;
+    cachedAccessTokenExpiresAt = Date.now() + expiresInSeconds * 1000;
+    return cachedAccessToken;
+  })();
   try {
-    const issuerUrl = new URL(oauthIssuer);
-    const config = await oidcDiscovery(issuerUrl, oauthClientId, { client_secret: oauthClientSecret });
-    tokens = await refreshTokenGrant(config, oauthRefreshToken);
-  } catch (err) {
-    throw new Error(`Unable to refresh SMTP OAuth2 access token: ${err.message}`, { cause: err });
+    return await inFlightRefresh;
+  } finally {
+    inFlightRefresh = null;
   }
-  if (!tokens?.access_token) {
-    throw new Error('Unable to refresh SMTP OAuth2 access token: refresh token grant did not return an access_token');
-  }
-  return tokens.access_token;
 };
 
 export const buildSmtpAuth = async (authType, {
@@ -89,17 +123,45 @@ const getSmtpAuthParams = () => ({
 });
 
 /**
- * Build a fresh nodemailer transporter. For OAuth2 the access token is
- * refreshed at call time so that long-running instances do not fail once the
- * initial token has expired (Microsoft tokens typically live for ~1h).
+ * Build a nodemailer transporter.
+ *
+ * For OAuth2 a fresh transporter is created on every call, but the underlying
+ * access token is cached (see {@link refreshSmtpAccessToken}) so the IdP is
+ * only contacted when the cached token is close to expiration.
+ *
+ * For non-OAuth2 auth types (basic / anonymous) the transporter has no
+ * time-bound credential, so it is built once and cached for the lifetime of
+ * the process — matching the historical singleton behaviour.
  */
+let cachedNonOauthTransporter;
 const createSmtpTransporter = async () => {
+  if (authType !== 'oauth2' && cachedNonOauthTransporter) {
+    return cachedNonOauthTransporter;
+  }
   const options = { ...baseSmtpOptions, tls: { ...baseSmtpOptions.tls } };
   const smtpAuth = await buildSmtpAuth(authType, getSmtpAuthParams());
   if (smtpAuth) {
     options.auth = smtpAuth;
   }
-  return nodemailer.createTransport(options);
+  const transporter = nodemailer.createTransport(options);
+  if (authType !== 'oauth2') {
+    cachedNonOauthTransporter = transporter;
+  }
+  return transporter;
+};
+
+/**
+ * Test-only helper. Resets all module-level caches (OIDC discovery, OAuth2
+ * access token, in-flight refresh, basic-auth transporter) so unit tests can
+ * run independently of each other. Not meant to be called from production code.
+ * @internal
+ */
+export const __resetSmtpCachesForTests = () => {
+  cachedDiscoveryConfig = undefined;
+  cachedAccessToken = undefined;
+  cachedAccessTokenExpiresAt = 0;
+  inFlightRefresh = null;
+  cachedNonOauthTransporter = undefined;
 };
 
 export const smtpConfiguredEmail = (settings) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -29,6 +29,49 @@ vi.mock('../../../src/database/cache', () => ({
   })),
 }));
 
+// Stub `../config/conf` to guarantee deterministic SMTP module-level constants
+// (auth_type, enabled, ...) regardless of the developer's local config files.
+// Without this, a developer with `smtp.auth_type = "oauth2"` in their
+// development.json would make createSmtpTransporter throw on missing fields
+// before nodemailer.createTransport is invoked, breaking these tests.
+// Partial mock: we keep everything else from the real conf module so the rest
+// of the imported codebase keeps working (TEST_MODE, logger, etc.).
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/conf')>();
+  const smtpOverrides: Record<string, unknown> = {
+    'smtp:enabled': true,
+    'smtp:auth_type': 'basic',
+    'smtp:use_ssl': false,
+    'smtp:reject_unauthorized': false,
+    'smtp:hostname': 'localhost',
+    'smtp:port': 25,
+    'smtp:username': '',
+    'smtp:password': '',
+    'smtp:forced_sender_email': '',
+  };
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: (key: string) => (key in smtpOverrides ? smtpOverrides[key] : (actual.default as { get: (k: string) => unknown }).get(key)),
+    },
+    booleanConf: (key: string, fallback: boolean) => {
+      const value = smtpOverrides[key];
+      if (typeof value === 'boolean') return value;
+      return actual.booleanConf(key, fallback);
+    },
+  };
+});
+
+// Stub tracing to avoid pulling in the full telemetry stack.
+vi.mock('../../../src/config/tracing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/tracing')>();
+  return {
+    ...actual,
+    meterManager: { ...actual.meterManager, emailSent: vi.fn() },
+  };
+});
+
 import { __resetSmtpCachesForTests, buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
 import {
   sendMail,

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -7,7 +7,35 @@ vi.mock('openid-client', () => ({
   refreshTokenGrant: vi.fn(async () => ({ access_token: 'refreshed-access-token', expires_in: 3600 })),
 }));
 
+// Stub `nodemailer` so transporter creation/verify/sendMail are observable
+// without opening real SMTP connections. `vi.hoisted` is required because
+// `vi.mock` is hoisted to the top of the file — regular `const` would not be
+// initialized when the factory runs.
+const nodemailerMocks = vi.hoisted(() => {
+  const verify = vi.fn(async () => true);
+  const sendMail = vi.fn(async () => ({ messageId: 'stub' }));
+  const createTransport = vi.fn(() => ({ verify, sendMail }));
+  return { verify, sendMail, createTransport };
+});
+vi.mock('nodemailer', () => ({
+  default: { createTransport: nodemailerMocks.createTransport },
+}));
+
+// Stub the cache lookup used by smtpComputeFrom so we don't need a live cache.
+vi.mock('../../../src/database/cache', () => ({
+  getEntityFromCache: vi.fn(async () => ({
+    platform_title: 'OpenCTI',
+    platform_email: 'platform@example.com',
+  })),
+}));
+
 import { __resetSmtpCachesForTests, buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
+import {
+  sendMail,
+  smtpComputeFrom,
+  smtpConfiguredEmail,
+  smtpIsAlive,
+} from '../../../src/database/smtp';
 
 type SmtpCredentials = {
   username?: string;
@@ -265,3 +293,102 @@ describe('buildSmtpAuth — security', () => {
     expect(Object.keys(result ?? {})).toStrictEqual(['type', 'user', 'clientId', 'clientSecret', 'accessToken']);
   });
 });
+
+// ==========================================================================
+// smtpConfiguredEmail
+// ==========================================================================
+
+describe('smtpConfiguredEmail', () => {
+  it('should return the platform email when no forced sender email is configured', () => {
+    // Default config (default.json) sets forced_sender_email to "" → ALLOW_EMAIL_REWRITE is true.
+    const settings = { platform_email: 'platform@example.com' } as unknown as { platform_email: string };
+    expect(smtpConfiguredEmail(settings)).toBe('platform@example.com');
+  });
+});
+
+// ==========================================================================
+// smtpComputeFrom
+// ==========================================================================
+
+describe('smtpComputeFrom', () => {
+  it('should format the From header with the provided sender name and platform email', async () => {
+    const result = await smtpComputeFrom('Acme Notifications');
+    expect(result).toBe('Acme Notifications <platform@example.com>');
+  });
+
+  it('should fall back to platform_title when no sender name is provided', async () => {
+    const result = await smtpComputeFrom();
+    expect(result).toBe('OpenCTI <platform@example.com>');
+  });
+});
+
+// ==========================================================================
+// createSmtpTransporter (covered indirectly via smtpIsAlive / sendMail)
+// ==========================================================================
+
+describe('createSmtpTransporter — non-OAuth2 caching & sendMail / smtpIsAlive', () => {
+  const { createTransport: nodemailerCreateTransport, verify: nodemailerVerify, sendMail: nodemailerSendMail } = nodemailerMocks;
+
+  beforeEach(() => {
+    __resetSmtpCachesForTests();
+    nodemailerCreateTransport.mockClear();
+    nodemailerVerify.mockClear();
+    nodemailerSendMail.mockClear();
+  });
+
+  it('smtpIsAlive should call transporter.verify and log success when SMTP is reachable', async () => {
+    nodemailerVerify.mockResolvedValueOnce(true);
+    const result = await smtpIsAlive();
+    expect(result).toBe(true);
+    expect(nodemailerCreateTransport).toHaveBeenCalledTimes(1);
+    expect(nodemailerVerify).toHaveBeenCalledTimes(1);
+  });
+
+  it('smtpIsAlive should swallow transporter.verify errors and still return true', async () => {
+    nodemailerVerify.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+    const result = await smtpIsAlive();
+    expect(result).toBe(true);
+    expect(nodemailerVerify).toHaveBeenCalledTimes(1);
+  });
+
+  it('sendMail should build a transporter and forward the message fields to nodemailer', async () => {
+    await sendMail(
+      {
+        from: 'Sender <sender@example.com>',
+        to: 'rcpt@example.com',
+        bcc: 'bcc@example.com',
+        subject: 'Hello',
+        html: '<p>Hi</p>',
+        attachments: [],
+      },
+      { kind: 'test' },
+    );
+    expect(nodemailerSendMail).toHaveBeenCalledTimes(1);
+    expect(nodemailerSendMail).toHaveBeenCalledWith({
+      from: 'Sender <sender@example.com>',
+      to: 'rcpt@example.com',
+      bcc: 'bcc@example.com',
+      subject: 'Hello',
+      html: '<p>Hi</p>',
+      attachments: [],
+    });
+  });
+
+  it('should reuse the cached non-OAuth2 transporter across calls (no fresh createTransport)', async () => {
+    // First call populates the cache.
+    await sendMail({ from: 'f', to: 't', bcc: '', subject: 's', html: 'h', attachments: [] }, {});
+    // Subsequent calls must reuse it.
+    await sendMail({ from: 'f', to: 't', bcc: '', subject: 's', html: 'h', attachments: [] }, {});
+    await smtpIsAlive();
+    expect(nodemailerCreateTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it('should rebuild the transporter on the next call after the cache is reset', async () => {
+    await sendMail({ from: 'f', to: 't', bcc: '', subject: 's', html: 'h', attachments: [] }, {});
+    expect(nodemailerCreateTransport).toHaveBeenCalledTimes(1);
+    __resetSmtpCachesForTests();
+    await sendMail({ from: 'f', to: 't', bcc: '', subject: 's', html: 'h', attachments: [] }, {});
+    expect(nodemailerCreateTransport).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -1,13 +1,13 @@
-﻿import { describe, expect, it, vi } from 'vitest';
+﻿import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // `openid-client` performs an HTTP discovery + token exchange that we don't
 // want to run during unit tests — stub it so OAuth2 tests stay hermetic.
 vi.mock('openid-client', () => ({
   discovery: vi.fn(async () => ({})),
-  refreshTokenGrant: vi.fn(async () => ({ access_token: 'refreshed-access-token' })),
+  refreshTokenGrant: vi.fn(async () => ({ access_token: 'refreshed-access-token', expires_in: 3600 })),
 }));
 
-import { buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
+import { __resetSmtpCachesForTests, buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
 
 type SmtpCredentials = {
   username?: string;
@@ -37,6 +37,13 @@ describe('buildSmtpAuth — OAuth2', () => {
     oauthIssuer: 'https://login.example.com/v2.0',
     oauthRefreshToken: 'my-refresh-token',
   };
+
+  beforeEach(async () => {
+    __resetSmtpCachesForTests();
+    const { discovery, refreshTokenGrant } = await import('openid-client');
+    (discovery as unknown as ReturnType<typeof vi.fn>).mockClear();
+    (refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).mockClear();
+  });
 
   it('should return an OAuth2 auth object with a refreshed access token', async () => {
     const result = await buildSmtpAuth('oauth2', oauth2Config);
@@ -90,6 +97,29 @@ describe('buildSmtpAuth — OAuth2', () => {
     await expect(buildSmtpAuth('oauth2', oauth2Config)).rejects.toThrow(
       'Unable to refresh SMTP OAuth2 access token: boom',
     );
+  });
+
+  it('should cache the access token and skip refresh on subsequent calls within the validity window', async () => {
+    const { discovery, refreshTokenGrant } = await import('openid-client');
+    await buildSmtpAuth('oauth2', oauth2Config);
+    await buildSmtpAuth('oauth2', oauth2Config);
+    await buildSmtpAuth('oauth2', oauth2Config);
+    // OIDC discovery happens once, refresh token grant happens once for three sends.
+    expect(discovery as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    expect(refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+  });
+
+  it('should coalesce concurrent refresh attempts into a single network call', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    const results = await Promise.all([
+      buildSmtpAuth('oauth2', oauth2Config),
+      buildSmtpAuth('oauth2', oauth2Config),
+      buildSmtpAuth('oauth2', oauth2Config),
+      buildSmtpAuth('oauth2', oauth2Config),
+      buildSmtpAuth('oauth2', oauth2Config),
+    ]);
+    expect(refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    results.forEach((result) => expect(result).toHaveProperty('accessToken', 'refreshed-access-token'));
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -1,4 +1,12 @@
-﻿import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it, vi } from 'vitest';
+
+// `openid-client` performs an HTTP discovery + token exchange that we don't
+// want to run during unit tests — stub it so OAuth2 tests stay hermetic.
+vi.mock('openid-client', () => ({
+  discovery: vi.fn(async () => ({})),
+  refreshTokenGrant: vi.fn(async () => ({ access_token: 'refreshed-access-token' })),
+}));
+
 import { buildSmtpAuth as buildSmtpAuthImpl } from '../../../src/database/smtp';
 
 type SmtpCredentials = {
@@ -7,7 +15,8 @@ type SmtpCredentials = {
   oauthUser?: string;
   oauthClientId?: string;
   oauthClientSecret?: string;
-  oauthAccessToken?: string;
+  oauthIssuer?: string;
+  oauthRefreshToken?: string;
 };
 
 // The JS source infers all destructured params as required; cast to the intended optional API.
@@ -25,22 +34,23 @@ describe('buildSmtpAuth — OAuth2', () => {
     oauthUser: 'user@example.com',
     oauthClientId: 'my-client-id',
     oauthClientSecret: 'my-client-secret',
-    oauthAccessToken: 'my-access-token',
+    oauthIssuer: 'https://login.example.com/v2.0',
+    oauthRefreshToken: 'my-refresh-token',
   };
 
-  it('should return an OAuth2 auth object when authType is "oauth2"', () => {
-    const result = buildSmtpAuth('oauth2', oauth2Config);
+  it('should return an OAuth2 auth object with a refreshed access token', async () => {
+    const result = await buildSmtpAuth('oauth2', oauth2Config);
     expect(result).toStrictEqual({
       type: 'OAuth2',
       user: 'user@example.com',
       clientId: 'my-client-id',
       clientSecret: 'my-client-secret',
-      accessToken: 'my-access-token',
+      accessToken: 'refreshed-access-token',
     });
   });
 
-  it('should use oauthUser and not username even when both are provided', () => {
-    const result = buildSmtpAuth('oauth2', {
+  it('should use oauthUser and not username even when both are provided', async () => {
+    const result = await buildSmtpAuth('oauth2', {
       ...oauth2Config,
       username: 'legacy@example.com',
       password: 'legacy-pass',
@@ -50,15 +60,35 @@ describe('buildSmtpAuth — OAuth2', () => {
     expect(result).not.toHaveProperty('pass');
   });
 
-  it('should throw an error when oauth_* required fields are missing', () => {
-    expect(() => buildSmtpAuth('oauth2', {})).toThrow(
-      'SMTP OAuth2 configuration is incomplete: oauth_user, oauth_client_id, oauth_client_secret and oauth_access_token are all required.',
+  it('should throw an error when oauth_* required fields are missing', async () => {
+    await expect(buildSmtpAuth('oauth2', {})).rejects.toThrow(
+      'SMTP OAuth2 configuration is incomplete: oauth_user, oauth_client_id, oauth_client_secret, oauth_issuer and oauth_refresh_token are all required.',
     );
   });
 
-  it('should throw an error when only some oauth_* fields are provided', () => {
-    expect(() => buildSmtpAuth('oauth2', { oauthUser: 'user@example.com' })).toThrow(
+  it('should throw an error when only some oauth_* fields are provided', async () => {
+    await expect(buildSmtpAuth('oauth2', { oauthUser: 'user@example.com' })).rejects.toThrow(
       'SMTP OAuth2 configuration is incomplete',
+    );
+  });
+
+  it('should work with any OIDC-compliant issuer URL (provider-agnostic)', async () => {
+    const result = await buildSmtpAuth('oauth2', {
+      oauthUser: 'user@example.com',
+      oauthClientId: 'my-client-id',
+      oauthClientSecret: 'my-client-secret',
+      oauthIssuer: 'https://accounts.google.com',
+      oauthRefreshToken: 'my-refresh-token',
+    });
+    expect(result).toHaveProperty('type', 'OAuth2');
+    expect(result).toHaveProperty('accessToken', 'refreshed-access-token');
+  });
+
+  it('should wrap refresh failures in a clear error message', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    (refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
+    await expect(buildSmtpAuth('oauth2', oauth2Config)).rejects.toThrow(
+      'Unable to refresh SMTP OAuth2 access token: boom',
     );
   });
 });
@@ -68,28 +98,28 @@ describe('buildSmtpAuth — OAuth2', () => {
 // ==========================================================================
 
 describe('buildSmtpAuth — Basic Auth', () => {
-  it('should return a Basic Auth object when authType is "basic" and username is set', () => {
-    const result = buildSmtpAuth('basic', { username: 'user@example.com', password: 'mypassword' });
+  it('should return a Basic Auth object when authType is "basic" and username is set', async () => {
+    const result = await buildSmtpAuth('basic', { username: 'user@example.com', password: 'mypassword' });
     expect(result).toStrictEqual({ user: 'user@example.com', pass: 'mypassword' });
   });
 
-  it('should return a Basic Auth object when authType is not set (defaults to basic)', () => {
-    const result = buildSmtpAuth(undefined, { username: 'user@example.com', password: 'mypassword' });
+  it('should return a Basic Auth object when authType is not set (defaults to basic)', async () => {
+    const result = await buildSmtpAuth(undefined, { username: 'user@example.com', password: 'mypassword' });
     expect(result).toStrictEqual({ user: 'user@example.com', pass: 'mypassword' });
   });
 
-  it('should set pass to empty string when password is absent', () => {
-    const result = buildSmtpAuth('basic', { username: 'user@example.com' });
+  it('should set pass to empty string when password is absent', async () => {
+    const result = await buildSmtpAuth('basic', { username: 'user@example.com' });
     expect(result).toStrictEqual({ user: 'user@example.com', pass: '' });
   });
 
-  it('should return undefined when username is absent', () => {
-    const result = buildSmtpAuth('basic', {});
+  it('should return undefined when username is absent', async () => {
+    const result = await buildSmtpAuth('basic', {});
     expect(result).toBeUndefined();
   });
 
-  it('should return undefined when username is an empty string', () => {
-    const result = buildSmtpAuth('basic', { username: '', password: 'mypassword' });
+  it('should return undefined when username is an empty string', async () => {
+    const result = await buildSmtpAuth('basic', { username: '', password: 'mypassword' });
     expect(result).toBeUndefined();
   });
 });
@@ -99,12 +129,13 @@ describe('buildSmtpAuth — Basic Auth', () => {
 // ==========================================================================
 
 describe('buildSmtpAuth — security', () => {
-  it('should only expose the expected keys in the returned OAuth2 object', () => {
-    const result = buildSmtpAuth('oauth2', {
+  it('should only expose the expected keys in the returned OAuth2 object', async () => {
+    const result = await buildSmtpAuth('oauth2', {
       oauthUser: 'user@example.com',
       oauthClientId: 'client-id',
       oauthClientSecret: 'super-secret',
-      oauthAccessToken: 'super-token',
+      oauthIssuer: 'https://login.example.com/v2.0',
+      oauthRefreshToken: 'refresh-token',
     });
     expect(Object.keys(result ?? {})).toStrictEqual(['type', 'user', 'clientId', 'clientSecret', 'accessToken']);
   });

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -121,6 +121,85 @@ describe('buildSmtpAuth — OAuth2', () => {
     expect(refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
     results.forEach((result) => expect(result).toHaveProperty('accessToken', 'refreshed-access-token'));
   });
+
+  it('should throw a dedicated error when the IdP returns no access_token', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    (refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ expires_in: 3600 });
+    await expect(buildSmtpAuth('oauth2', oauth2Config)).rejects.toThrow(
+      'Unable to refresh SMTP OAuth2 access token: refresh token grant did not return an access_token',
+    );
+  });
+
+  it('should preserve the original error as the cause when refresh fails', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    const originalError = new Error('network down');
+    (refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(originalError);
+    await expect(buildSmtpAuth('oauth2', oauth2Config)).rejects.toMatchObject({
+      message: 'Unable to refresh SMTP OAuth2 access token: network down',
+      cause: originalError,
+    });
+  });
+
+  it('should clear the in-flight refresh after a failure so the next call can retry', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    const refreshMock = refreshTokenGrant as unknown as ReturnType<typeof vi.fn>;
+    refreshMock.mockRejectedValueOnce(new Error('transient'));
+    await expect(buildSmtpAuth('oauth2', oauth2Config)).rejects.toThrow('transient');
+    // After a rejected refresh, a subsequent call must perform a new refresh (no stuck promise).
+    const result = await buildSmtpAuth('oauth2', oauth2Config);
+    expect(result).toHaveProperty('accessToken', 'refreshed-access-token');
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should re-refresh the access token after it expires and reuse the cached OIDC discovery', async () => {
+    const { discovery, refreshTokenGrant } = await import('openid-client');
+    const refreshMock = refreshTokenGrant as unknown as ReturnType<typeof vi.fn>;
+    // 1s lifetime so the cache invalidates almost immediately.
+    refreshMock.mockResolvedValueOnce({ access_token: 'token-1', expires_in: 1 });
+    refreshMock.mockResolvedValueOnce({ access_token: 'token-2', expires_in: 3600 });
+
+    const first = await buildSmtpAuth('oauth2', oauth2Config);
+    expect(first).toHaveProperty('accessToken', 'token-1');
+
+    // Force the cached token to look expired (5min margin → push 6min into the future).
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 6 * 60 * 1000);
+    try {
+      const second = await buildSmtpAuth('oauth2', oauth2Config);
+      expect(second).toHaveProperty('accessToken', 'token-2');
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    // OIDC discovery is reused across token refreshes — it must run only once.
+    expect(discovery as unknown as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+  });
+
+  it('should default the token TTL to ~1h when the IdP omits expires_in', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    const refreshMock = refreshTokenGrant as unknown as ReturnType<typeof vi.fn>;
+    // No expires_in → code path that falls back to a 3600s default.
+    refreshMock.mockResolvedValueOnce({ access_token: 'token-no-ttl' });
+
+    await buildSmtpAuth('oauth2', oauth2Config);
+    // Subsequent calls within the default 1h window must hit the cache.
+    await buildSmtpAuth('oauth2', oauth2Config);
+    await buildSmtpAuth('oauth2', oauth2Config);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['oauth_user', { ...{}, oauthClientId: 'c', oauthClientSecret: 's', oauthIssuer: 'i', oauthRefreshToken: 'r' }],
+    ['oauth_client_id', { oauthUser: 'u', oauthClientSecret: 's', oauthIssuer: 'i', oauthRefreshToken: 'r' }],
+    ['oauth_client_secret', { oauthUser: 'u', oauthClientId: 'c', oauthIssuer: 'i', oauthRefreshToken: 'r' }],
+    ['oauth_issuer', { oauthUser: 'u', oauthClientId: 'c', oauthClientSecret: 's', oauthRefreshToken: 'r' }],
+    ['oauth_refresh_token', { oauthUser: 'u', oauthClientId: 'c', oauthClientSecret: 's', oauthIssuer: 'i' }],
+  ])('should reject when %s is missing', async (_field, partial) => {
+    await expect(buildSmtpAuth('oauth2', partial as SmtpCredentials)).rejects.toThrow(
+      /SMTP OAuth2 configuration is incomplete/,
+    );
+  });
 });
 
 // ==========================================================================
@@ -150,6 +229,22 @@ describe('buildSmtpAuth — Basic Auth', () => {
 
   it('should return undefined when username is an empty string', async () => {
     const result = await buildSmtpAuth('basic', { username: '', password: 'mypassword' });
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when called with no credentials at all (default param)', async () => {
+    // Exercises the default `= {}` destructuring branch of buildSmtpAuth.
+    const result = await (buildSmtpAuthImpl as unknown as (a?: string) => Promise<unknown>)('basic');
+    expect(result).toBeUndefined();
+  });
+
+  it('should treat unknown auth types as non-OAuth2 (basic fallback behaviour)', async () => {
+    const result = await buildSmtpAuth('something-else', { username: 'user@example.com', password: 'p' });
+    expect(result).toStrictEqual({ user: 'user@example.com', pass: 'p' });
+  });
+
+  it('should treat unknown auth types with no username as no-auth (undefined)', async () => {
+    const result = await buildSmtpAuth('something-else', {});
     expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
 For OAuth2 the access token is refreshed at call time so that long-running instances do not fail once the initial token has expired

* We use` openid-client` library (already in use in the project) to smtp refresh access token
* No more static `oauthAccessToken `: replaced by `oauthIssuer `+ `oauthRefreshToken`
* we build a fresh transporter at each call to have a fresh token for Oauth2
* unit tests 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/15924


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
