### PR TITLE
[frontend] fix search_after sort mismatch (#13239)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.test.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { OrderMode } from '../../components/list_lines';
+import { localStorageToPaginationOptions } from './useLocalStorage';
+
+describe('localStorageToPaginationOptions', () => {
+  it('should not set orderBy/orderMode when sortBy is undefined', () => {
+    const result = localStorageToPaginationOptions({
+      orderAsc: false,
+      sortBy: undefined,
+    });
+    expect(result.orderBy).toBeUndefined();
+    expect(result.orderMode).toBeUndefined();
+  });
+
+  it('should set orderBy and orderMode desc when sortBy is defined and orderAsc is false', () => {
+    const result = localStorageToPaginationOptions({
+      sortBy: 'name',
+      orderAsc: false,
+    });
+    expect(result.orderBy).toBe('name');
+    expect(result.orderMode).toBe(OrderMode.desc);
+  });
+
+  it('should set orderBy and orderMode asc when sortBy is defined and orderAsc is true', () => {
+    const result = localStorageToPaginationOptions({
+      sortBy: 'name',
+      orderAsc: true,
+    });
+    expect(result.orderBy).toBe('name');
+    expect(result.orderMode).toBe(OrderMode.asc);
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -50,7 +50,7 @@ export interface UseLocalStorageHelpers extends handleFilterHelpers {
   handleRemoveSavedFilters: () => void;
 }
 
-const localStorageToPaginationOptions = (
+export const localStorageToPaginationOptions = (
   { searchTerm, filters, sortBy, orderAsc, ...props }: LocalStorage,
 ): PaginationOptions => {
   // Remove only display options, not query linked
@@ -72,7 +72,7 @@ const localStorageToPaginationOptions = (
   if (searchTerm) {
     basePagination.search = searchTerm;
   }
-  if (orderAsc || sortBy) {
+  if (sortBy !== undefined && sortBy !== null) {
     basePagination.orderMode = orderAsc ? OrderMode.asc : OrderMode.desc;
     basePagination.orderBy = sortBy;
   }
@@ -269,6 +269,8 @@ export const usePaginationLocalStorage = <U>(
   const paginationOptions = localStorageToPaginationOptions({
     count: viewStorage.pageSize ? Number.parseInt(viewStorage.pageSize, 10) : 25,
     ...viewStorage,
+    sortBy: viewStorage.sortBy ?? initialValue.sortBy,
+    orderAsc: viewStorage.orderAsc ?? initialValue.orderAsc,
   });
 
   const filterKeysSchema = useFetchFilterKeysSchema();


### PR DESCRIPTION
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes #13239
### Investigation

Clicking next page on list pages (Users, Reports, Observables…) crashes with: IllegalArgumentException: search_after has 1 value(s) but sort has 2. (when localStorage contained stale state)
 
 ### Why it happened
 
 When a user clears a search, `handleSearch('')` can leave localStorage with `{ orderAsc: false }` but no `sortBy`. On the next page load, `usePaginationLocalStorage` passes no `orderBy` to the initial query → backend sorts by 1 field (`standard_id` only). But when Relay fires `loadNext`, it applies the fragment default (`orderBy: name`) → backend sorts by 2 fields. The cursor from page 1 (1 value) doesn't match the sort for page 2 (2 values) → Elastic rejects
 
 ### Tested on
 **Users**, **Reports**, and **Observables pages**. Since the fix is in the shared usePaginationLocalStorage hook, it covers all paginated list pages across the platform. Any page using this hook was vulnerable to the same cursor/sort mismatch when localStorage contained stale state (orderAsc: false without sortBy).
 
### Proposed changes

* In `usePaginationLocalStorage`, fall back to `initialValue.sortBy` and `initialValue.orderAsc` when the stored values are undefined — ensures the initial query always fires with the same sort configuration as `loadNext`
 
 ### How to reproduce
 
 1. Go to Settings > Security > Users OR Analyses > Reports 
 2. Type anything in the search bar (e.g., "admin")
 3. Observe in DevTools localStorage: the key now has {"sortBy":"_score","orderAsc":false,...}
 4. Reload the page while the search is still active
 5. Clear the search bar (delete the text)
 6. Now check localStorage — it has {"orderAsc":false} with no sortBy
 7. Click the next page arrow → 💥 Refetch query error


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->