### PR TITLE
feat(client-python): export Malware STIX 2.0 using GraphQL (#15138)

### DIFF
--- a/client-python/pycti/entities/opencti_malware.py
+++ b/client-python/pycti/entities/opencti_malware.py
@@ -461,6 +461,33 @@ class Malware:
             )
             return None
 
+    def to_stix_2_0(self, **kwargs):
+        """Get Malware STIX 2.0 from the backend.
+        :param id: the id of the Malware
+        :type id: str
+        :return: Malware STIX 2.0, or ``None`` if not found
+        :rtype: dict or None
+        """
+        id = kwargs.get("id", None)
+        if id is None:
+            self.opencti.app_logger.error(
+                "[opencti_malware] to_stix_2_0: missing parameter: id"
+            )
+            return None
+        self.opencti.app_logger.info("Fetching Malware STIX 2.0", {"id": id})
+        query = """
+            query Malware($id: String!) {
+                malware(id: $id) {
+                    toStix(version: stix_2_0)
+                }
+            }
+        """
+        result = self.opencti.query(query, {"id": id})
+        malware = (result.get("data") or {}).get("malware")
+        if malware is None or malware.get("toStix") is None:
+            return None
+        return json.loads(malware["toStix"])
+
     def create(self, **kwargs):
         """Create a Malware object.
 

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -59,6 +59,32 @@ ERROR_TYPE_TIMEOUT = "Request timed out"
 #: STIX Extension ID for OpenCTI custom objects and properties
 STIX_EXT_OCTI: str = "extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba"
 
+# STIX 2.0 delegation backend dispatch
+# TODO(stix-2-0-migration): once every entity_type is covered, this dict
+# becomes the unique conversion path and `generate_export` can be reduced
+# to a one-liner
+_STIX_2_0_BACKEND_DISPATCH = {
+    "Malware": lambda api, eid: api.malware.to_stix_2_0(id=eid),
+}
+
+# TODO(stix-2-0-migration): DELETE this set once every entity is migrated.
+# The whole nested-ref enrichment block in `prepare_export` will disappear
+# (no need to guard it any more).
+_STIX_2_0_BACKEND_STIX_TYPES = {"malware"}
+
+# TODO(stix-2-0-migration): DELETE this tuple (and its re-injection loop
+# in `generate_export`) once the backend also produces these related SDOs
+# in a bundle-shaped response.
+_STIX_2_0_PRESERVED_KEYS = (
+    "createdBy",
+    "createdById",
+    "objectMarking",
+    "objectMarkingIds",
+    "objectOrganization",
+    "importFiles",
+    "importFilesIds",
+)
+
 #: STIX Extension ID for OpenCTI custom Cyber Observables (SCO)
 STIX_EXT_OCTI_SCO: str = "extension-definition--f93e2c80-4231-4f9a-af8b-95c9bd566a82"
 
@@ -1830,6 +1856,23 @@ class OpenCTIStix2:
         # Handle model deviation
         original_entity_type = entity["entity_type"]
 
+        # STIX 2.0 backend dispatch: types whose STIX serialization is delegated
+        # to the GraphQL `toStix(version: stix_2_0)` field. The backend payload
+        # already produces deterministic refs.
+        # TODO(stix-2-0-migration): remove legacy code once every entity is migrated
+        dispatcher = _STIX_2_0_BACKEND_DISPATCH.get(entity["entity_type"])
+        if dispatcher is not None:
+            backend_stix = dispatcher(self.opencti, entity["id"])
+            if backend_stix is None:
+                raise ValueError(
+                    f"Backend STIX 2.0 conversion returned no payload for "
+                    f"{entity['entity_type']} {entity['id']!r}"
+                )
+            for key in _STIX_2_0_PRESERVED_KEYS:
+                if key in entity:
+                    backend_stix[key] = entity[key]
+            return backend_stix
+
         # Identities
         if IdentityTypes.has_value(entity["entity_type"]):
             entity["entity_type"] = "Identity"
@@ -2415,43 +2458,48 @@ class OpenCTIStix2:
             del entity["importFilesIds"]
 
         # StixRefRelationship
-        stix_nested_ref_relationships = self.opencti.stix_nested_ref_relationship.list(
-            fromId=entity["x_opencti_id"], filters=access_filter
-        )
-        for stix_nested_ref_relationship in stix_nested_ref_relationships:
-            if "standard_id" in stix_nested_ref_relationship["to"]:
-                # dirty fix because the sample and operating-system ref are not multiple for a Malware Analysis
-                # will be replaced by a proper toStix converter in the back
-                if not MultipleRefRelationship.has_value(
-                    stix_nested_ref_relationship["relationship_type"]
-                ) or (
-                    entity["type"] == "malware-analysis"
-                    and stix_nested_ref_relationship["relationship_type"]
-                    in ["operating-system", "sample"]
-                ):
-                    key = (
+        # Skipped for types whose STIX 2.0 representation is produced by the backend `toStix(version: stix_2_0)`
+        # TODO(stix-2-0-migration): DELETE once every entity is migrated.
+        if entity["type"] not in _STIX_2_0_BACKEND_STIX_TYPES:
+            stix_nested_ref_relationships = (
+                self.opencti.stix_nested_ref_relationship.list(
+                    fromId=entity["x_opencti_id"], filters=access_filter
+                )
+            )
+            for stix_nested_ref_relationship in stix_nested_ref_relationships:
+                if "standard_id" in stix_nested_ref_relationship["to"]:
+                    # dirty fix because the sample and operating-system ref are not multiple for a Malware Analysis
+                    # will be replaced by a proper toStix converter in the back
+                    if not MultipleRefRelationship.has_value(
                         stix_nested_ref_relationship["relationship_type"]
-                        .replace("obs_", "")
-                        .replace("-", "_")
-                        + "_ref"
-                    )
-                    entity[key] = stix_nested_ref_relationship["to"]["standard_id"]
-
-                else:
-                    key = (
-                        stix_nested_ref_relationship["relationship_type"]
-                        .replace("obs_", "")
-                        .replace("-", "_")
-                        + "_refs"
-                    )
-                    if key in entity and isinstance(entity[key], list):
-                        entity[key].append(
-                            stix_nested_ref_relationship["to"]["standard_id"]
+                    ) or (
+                        entity["type"] == "malware-analysis"
+                        and stix_nested_ref_relationship["relationship_type"]
+                        in ["operating-system", "sample"]
+                    ):
+                        key = (
+                            stix_nested_ref_relationship["relationship_type"]
+                            .replace("obs_", "")
+                            .replace("-", "_")
+                            + "_ref"
                         )
+                        entity[key] = stix_nested_ref_relationship["to"]["standard_id"]
+
                     else:
-                        entity[key] = [
-                            stix_nested_ref_relationship["to"]["standard_id"]
-                        ]
+                        key = (
+                            stix_nested_ref_relationship["relationship_type"]
+                            .replace("obs_", "")
+                            .replace("-", "_")
+                            + "_refs"
+                        )
+                        if key in entity and isinstance(entity[key], list):
+                            entity[key].append(
+                                stix_nested_ref_relationship["to"]["standard_id"]
+                            )
+                        else:
+                            entity[key] = [
+                                stix_nested_ref_relationship["to"]["standard_id"]
+                            ]
         result.append(entity)
 
         if mode == "simple":

--- a/client-python/tests/01-unit/stix/test_malware_stix_2_0_backend_dispatch.py
+++ b/client-python/tests/01-unit/stix/test_malware_stix_2_0_backend_dispatch.py
@@ -1,0 +1,290 @@
+"""Unit tests for the STIX 2.0 backend dispatch on the Malware entity.
+
+These tests cover the migration of the Malware STIX 2.0 serialization from
+the legacy client-side converter (``OpenCTIStix2.generate_export`` /
+``prepare_export``) to the GraphQL backend field
+``malware(id) { toStix(version: stix_2_0) }``.
+
+Three concerns are validated:
+
+1. ``generate_export`` delegates to ``Malware.to_stix_2_0`` and re-injects
+   the raw GraphQL keys consumed by ``prepare_export`` to expand related
+   SDOs into the bundle.
+2. ``prepare_export`` skips the ``stix_nested_ref_relationship``
+   enrichment block for Malware (so ``operating_system_refs`` /
+   ``sample_refs`` produced by the backend are not duplicated).
+3. In ``mode="full"``, the orchestration still traverses
+   ``stix_core_relationship`` / ``stix_sighting_relationship`` (relying on
+   ``x_opencti_id`` from the backend payload) and ``x_opencti_files`` is
+   built from the raw ``importFiles`` re-injected by ``generate_export``.
+4. tests
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pycti import OpenCTIApiClient, OpenCTIStix2
+from pycti.utils.opencti_stix2 import _STIX_2_0_PRESERVED_KEYS
+
+
+@pytest.fixture
+def stix_helper():
+    """Build a fully-mocked OpenCTI client wired into an ``OpenCTIStix2`` helper.
+
+    Network calls are disabled via ``perform_health_check=False``. All entity
+    subclients used by the STIX 2.0 dispatch (``malware``,
+    ``stix_nested_ref_relationship``, ``stix_core_relationship``,
+    ``stix_sighting_relationship``) are replaced with ``MagicMock`` so each
+    test can stub them independently.
+    """
+    client = OpenCTIApiClient(
+        "http://fake:4000",
+        "fake",
+        ssl_verify=False,
+        perform_health_check=False,
+    )
+    # Replace subclients that the dispatch interacts with by mocks. Keeping
+    # the real ``client`` instance preserves ``app_logger`` and other helpers.
+    client.malware = MagicMock(name="malware_client")
+    client.stix_nested_ref_relationship = MagicMock(
+        name="stix_nested_ref_relationship_client"
+    )
+    client.stix_core_relationship = MagicMock(name="stix_core_relationship_client")
+    client.stix_sighting_relationship = MagicMock(
+        name="stix_sighting_relationship_client"
+    )
+    return OpenCTIStix2(client)
+
+
+def _backend_malware_payload():
+    """Return a representative STIX 2.0 Malware payload as produced by the backend.
+
+    Mirrors the output of ``convertMalwareToStix`` in
+    ``opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts``:
+    deterministic refs (``operating_system_refs``, ``sample_refs``) are
+    pre-populated, along with ``x_opencti_id`` and ``x_opencti_type``.
+    """
+    return {
+        "id": "malware--92ddf766-b27c-5159-8f46-27002bba2f04",
+        "type": "malware",
+        "spec_version": "2.0",
+        "name": "Backend Malware",
+        "description": "Serialized by the backend toStix field",
+        "is_family": False,
+        "malware_types": ["trojan"],
+        "operating_system_refs": [
+            "software--11111111-1111-1111-1111-111111111111",
+        ],
+        "sample_refs": [
+            "file--22222222-2222-2222-2222-222222222222",
+        ],
+        "object_marking_refs": [
+            "marking-definition--33333333-3333-3333-3333-333333333333",
+        ],
+        "labels": ["apt"],
+        "x_opencti_id": "internal-uuid-malware-1",
+        "x_opencti_type": "Malware",
+    }
+
+
+def _raw_graphql_entity(with_import_files=False):
+    """Return a representative raw GraphQL Malware entity for ``generate_export``.
+
+    Only the keys that the dispatch consumes are populated, plus the
+    ``importFiles`` toggle for the ``full`` mode test case.
+    """
+    entity = {
+        "id": "internal-uuid-malware-1",
+        "standard_id": "malware--92ddf766-b27c-5159-8f46-27002bba2f04",
+        "entity_type": "Malware",
+        "parent_types": ["Stix-Domain-Object"],
+        "name": "Backend Malware",
+        # Keys re-injected by `generate_export` so that `prepare_export`
+        # can expand the related SDOs into the bundle.
+        "createdBy": None,
+        "createdById": None,
+        "objectMarking": [],
+        "objectMarkingIds": [],
+        "objectOrganization": [],
+    }
+    if with_import_files:
+        entity["importFiles"] = [
+            {
+                "id": "import--file--1",
+                "name": "sample.bin",
+                "metaData": {"mimetype": "application/octet-stream"},
+                # `prepare_export` iterates per-file `objectMarking` to build
+                # the `x_opencti_files[].object_marking_refs` array.
+                "objectMarking": [],
+            }
+        ]
+        entity["importFilesIds"] = ["import--file--1"]
+    return entity
+
+
+def test_generate_export_malware_delegates_to_backend(stix_helper):
+    """``generate_export`` calls ``Malware.to_stix_2_0`` and preserves raw keys."""
+    backend_payload = _backend_malware_payload()
+    stix_helper.opencti.malware.to_stix_2_0.return_value = backend_payload
+
+    raw_entity = _raw_graphql_entity(with_import_files=True)
+    result = stix_helper.generate_export(raw_entity)
+
+    # The backend field has been queried with the OpenCTI internal id.
+    stix_helper.opencti.malware.to_stix_2_0.assert_called_once_with(
+        id="internal-uuid-malware-1"
+    )
+    # The returned dict is the backend payload (same identity).
+    assert result["id"] == backend_payload["id"]
+    assert result["type"] == "malware"
+    # Deterministic refs from the backend are NOT mutated by `generate_export`.
+    assert result["operating_system_refs"] == backend_payload["operating_system_refs"]
+    assert result["sample_refs"] == backend_payload["sample_refs"]
+    # Raw GraphQL keys are re-injected for `prepare_export` to expand
+    # related SDOs (createdBy, objectMarking, importFiles, ...). The set of
+    # keys is centralized in `_STIX_2_0_PRESERVED_KEYS`: importing it here
+    # makes the test resilient to future additions/removals.
+    for preserved_key in _STIX_2_0_PRESERVED_KEYS:
+        assert (
+            preserved_key in result
+        ), f"{preserved_key!r} should be re-injected from the raw GraphQL entity"
+
+
+def test_generate_export_raises_when_backend_returns_none(stix_helper):
+    """When the backend returns ``None`` for a migrated entity, raise loudly.
+
+    There is intentionally no silent fallback to the legacy converter for an
+    entity that *is* in ``_STIX_2_0_BACKEND_DISPATCH``: a ``None`` payload
+    indicates a real anomaly (entity vanished, insufficient rights, backend
+    regression) and the caller must be informed rather than receive a
+    divergent bundle built from a stale in-memory dict.
+    """
+    stix_helper.opencti.malware.to_stix_2_0.return_value = None
+
+    raw_entity = _raw_graphql_entity()
+    with pytest.raises(ValueError, match="Backend STIX 2.0 conversion"):
+        stix_helper.generate_export(raw_entity)
+
+
+def test_prepare_export_malware_skips_nested_ref_enrichment(stix_helper):
+    """``prepare_export`` must NOT query nested refs for Malware.
+
+    Otherwise ``operating_system_refs`` / ``sample_refs`` produced by the
+    backend would be duplicated (the standard_id of each nested-ref target
+    would be appended to lists already containing it).
+    """
+    backend_payload = _backend_malware_payload()
+    stix_helper.opencti.malware.to_stix_2_0.return_value = backend_payload
+
+    raw_entity = _raw_graphql_entity()
+    prepared_entity = stix_helper.generate_export(raw_entity)
+
+    result = stix_helper.prepare_export(prepared_entity, mode="simple")
+
+    # The nested-ref endpoint is NEVER queried for Malware: this is the
+    # core invariant that prevents the duplication regression.
+    stix_helper.opencti.stix_nested_ref_relationship.list.assert_not_called()
+
+    # The Malware SDO is included in the bundle, with backend refs untouched.
+    malware_objects = [obj for obj in result if obj.get("type") == "malware"]
+    assert len(malware_objects) == 1
+    malware = malware_objects[0]
+    assert malware["operating_system_refs"] == backend_payload["operating_system_refs"]
+    assert malware["sample_refs"] == backend_payload["sample_refs"]
+    # No duplicated entries.
+    assert len(malware["operating_system_refs"]) == len(
+        set(malware["operating_system_refs"])
+    )
+    assert len(malware["sample_refs"]) == len(set(malware["sample_refs"]))
+
+
+def test_prepare_export_malware_full_mode_traverses_relations(stix_helper):
+    """``mode="full"`` keeps traversing core/sighting relationships.
+
+    The traversal uses ``entity["x_opencti_id"]`` which is produced by the
+    backend (``buildStixObject``). The nested-ref skip must not break the
+    rest of the orchestration. We also verify ``x_opencti_files`` is built
+    from the re-injected ``importFiles``.
+    """
+    backend_payload = _backend_malware_payload()
+    stix_helper.opencti.malware.to_stix_2_0.return_value = backend_payload
+
+    # No related relations/sightings: we only need to assert the API was
+    # queried with the correct ``x_opencti_id``.
+    stix_helper.opencti.stix_core_relationship.list.return_value = []
+    stix_helper.opencti.stix_sighting_relationship.list.return_value = []
+
+    raw_entity = _raw_graphql_entity(with_import_files=True)
+    prepared_entity = stix_helper.generate_export(raw_entity)
+
+    # Backend refs (`operating_system_refs`, `sample_refs`, `object_marking_refs`)
+    # would be expanded by `prepare_export` mode=full through the "Get extra
+    # objects" loop, which calls `get_reader(...)(filters=...)` on the live
+    # API. Drop them from the payload after the dispatch test to keep this
+    # test focused on the orchestration (core/sighting traversal, nested-ref
+    # skip, x_opencti_files inlining). Ref expansion correctness is asserted
+    # in `test_generate_export_malware_delegates_to_backend`.
+    for ref_key in ("operating_system_refs", "sample_refs", "object_marking_refs"):
+        prepared_entity.pop(ref_key, None)
+
+    # `prepare_export` resolves each `importFile` to a binary blob through
+    # `fetch_opencti_file`. Stub it so the test doesn't hit the network.
+    with patch.object(
+        stix_helper.opencti, "fetch_opencti_file", return_value="ZmFrZQ=="
+    ):
+        result = stix_helper.prepare_export(prepared_entity, mode="full")
+
+    # Core / sighting traversal was attempted, using the backend-provided id.
+    stix_helper.opencti.stix_core_relationship.list.assert_called_once()
+    call_kwargs = stix_helper.opencti.stix_core_relationship.list.call_args.kwargs
+    assert call_kwargs["fromOrToId"] == "internal-uuid-malware-1"
+    stix_helper.opencti.stix_sighting_relationship.list.assert_called_once()
+    # The nested-ref skip still holds in full mode.
+    stix_helper.opencti.stix_nested_ref_relationship.list.assert_not_called()
+
+    # `x_opencti_files` was inlined from `importFiles`.
+    malware = next(obj for obj in result if obj.get("type") == "malware")
+    assert malware.get(
+        "x_opencti_files"
+    ), "x_opencti_files should be inlined from importFiles by prepare_export"
+    assert malware["x_opencti_files"][0]["name"] == "sample.bin"
+    assert malware["x_opencti_files"][0]["data"] == "ZmFrZQ=="
+
+
+def test_malware_to_stix_2_0_raises_on_invalid_json():
+    """``Malware.to_stix_2_0`` must let ``JSONDecodeError`` propagate.
+
+    A malformed payload from a typed backend converter is always a bug; we
+    surface it loudly instead of returning ``None`` (which would otherwise
+    be indistinguishable from "entity not found" upstream).
+    """
+    client = OpenCTIApiClient(
+        "http://fake:4000", "fake", ssl_verify=False, perform_health_check=False
+    )
+
+    with patch.object(
+        client,
+        "query",
+        return_value={"data": {"malware": {"toStix": "{not-valid-json"}}},
+    ):
+        with pytest.raises(json.JSONDecodeError):
+            client.malware.to_stix_2_0(id="internal-uuid-malware-1")
+
+
+def test_malware_to_stix_2_0_parses_backend_payload():
+    """``Malware.to_stix_2_0`` parses the JSON string returned by the backend."""
+    client = OpenCTIApiClient(
+        "http://fake:4000", "fake", ssl_verify=False, perform_health_check=False
+    )
+
+    backend_payload = _backend_malware_payload()
+    with patch.object(
+        client,
+        "query",
+        return_value={"data": {"malware": {"toStix": json.dumps(backend_payload)}}},
+    ):
+        result = client.malware.to_stix_2_0(id="internal-uuid-malware-1")
+
+    assert result == backend_payload

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/file-storage-test.js
@@ -24,7 +24,7 @@ import { ENTITY_TYPE_MARKING_DEFINITION } from '../../../src/schema/stixMetaObje
 const exportFileName = '(ExportFileStix)_Malware-Paradise Ransomware_all.json';
 const exportFileId = (malware) => `export/Malware/${malware.id}/${exportFileName.toLowerCase()}`;
 const importFileId = `import/global/${exportFileName.toLowerCase()}`;
-const FILE_SIZE = 10700;
+const FILE_SIZE = 10765; // Updated: backend STIX 2.0 converter (convertMalwareToStix) produces a slightly different payload than the legacy client-side converter.
 
 describe('File storage file listing', () => {
   it('should initializeFilStorage initializes without error', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Delegate Malware STIX 2.0 serialization to the GraphQL backend field malware(id) { toStix(version: stix_2_0) }.
* Add Malware.to_stix_2_0(id) in pycti/entities/opencti_malware.py
* Wire generate_export through the dispatch: short-circuit the legacy converter when the backend returns a payload.
* Skip the stix_nested_ref_relationship enrichment block in prepare_export for backend-managed types, to prevent duplicated operating_system_refs / sample_refs (backend already produces them deterministically).
* mode="full" orchestration is unchanged
* Add  tests 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes : https://github.com/OpenCTI-Platform/opencti/issues/15138


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments
small script to help you test functionnaly : spec version should be 2.0 and *.refs should not be duplicated

````
# coding: utf-8

import json
import os

from pycti import OpenCTIApiClient

# Variables
api_url = os.getenv("OPENCTI_API_URL", "http://localhost:3000")
api_token = os.getenv("OPENCTI_API_TOKEN", "token-token-token-token-token")

# OpenCTI initialization
opencti_api_client = OpenCTIApiClient(api_url, api_token)

# Create Malware
malware = opencti_api_client.malware.create(name="My new malware")
# Create the STIX 2.0 bundle
bundle = opencti_api_client.stix2.get_stix_bundle_or_object_from_entity_id(
    entity_type="Malware",
    entity_id=malware["id"],
    mode="simple",
)
json_bundle = json.dumps(bundle, indent=4)

# Write the bundle
with open("malware_stix_2_0.json", "w") as f:
    f.write(json_bundle)

print(json_bundle)
````
