### PR TITLE
[backend] Fix vitest config include patterns (#16200)

### DIFF
--- a/opencti-platform/opencti-graphql/vitest.config.dev.ts
+++ b/opencti-platform/opencti-graphql/vitest.config.dev.ts
@@ -1,4 +1,4 @@
 import { buildIntegrationTestConfig } from './vitest.config.integration';
 
-export default buildIntegrationTestConfig(['tests/**/*-test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']);
+export default buildIntegrationTestConfig(['**/*-test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']);
 // to run one test use yarn test:dev:init ; yarn test:dev:resume <test-name>

--- a/opencti-platform/opencti-graphql/vitest.config.ts
+++ b/opencti-platform/opencti-graphql/vitest.config.ts
@@ -24,4 +24,4 @@ export const buildTestConfig = (include: string[]) => defineConfig({
   },
 });
 
-export default buildTestConfig(['tests/**/*-test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']);
+export default buildTestConfig(['**/*-test.{js,mjs,cjs,ts,mts,cts,jsx,tsx}']);


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Root cause
With dir: `./tests` and include `tests/**/*-test.{...}`, vitest looks for `./tests/tests/**/*-test.{...}` — path that doesn't exist → 0 files discovered

### Proposed changes

* Remove the `tests/` prefix from include patterns as we set the `dir: './tests',` on the `vitest@4 upgrade`

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* closes #16200 
