### PR TITLE
[frontend] Added coverage edition to has-covered relationship view (#13133)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import testRender, { createMockUserContext } from '../../../../utils/tests/test-render';
+import { StixCoreRelationshipEditionOverviewComponent } from './StixCoreRelationshipEditionOverview';
+import { screen } from '@testing-library/react';
+import { StixCoreRelationshipEditionOverview_stixCoreRelationship$data } from './__generated__/StixCoreRelationshipEditionOverview_stixCoreRelationship.graphql';
+
+vi.mock('../../../../utils/hooks/useFormEditor', () => ({
+  default: () => ({
+    fieldPatch: vi.fn(),
+    changeFocus: vi.fn(),
+    changeField: vi.fn(),
+    changeKillChainPhases: vi.fn(),
+    changeCreated: vi.fn(),
+    changeMarking: vi.fn(),
+  }),
+}));
+
+describe('Component: StixCoreRelationshipEditionOverviewComponent', () => {
+  const userContext = createMockUserContext({
+    entitySettings: { edges: [] },
+  });
+
+  const relationship = (relationshipType: string) => {
+    return {
+      relationship_type: relationshipType,
+      coverage_information: [],
+      editContext: [],
+    } as unknown as StixCoreRelationshipEditionOverview_stixCoreRelationship$data;
+  };
+
+  it('should display Coverage Information if isCoverage is true and relationship is not has-covered', () => {
+    testRender(
+      <StixCoreRelationshipEditionOverviewComponent
+        isCoverage={true}
+        stixCoreRelationship={relationship('targets')}
+        handleClose={vi.fn()}
+        noStoreUpdate
+      />,
+      { userContext },
+    );
+
+    const coverageEdition = screen.queryByText('Coverage Information');
+    expect(coverageEdition).toBeInTheDocument();
+  });
+
+  it('should display Coverage Information if isCoverage is false and relationship is has-covered', () => {
+    testRender(
+      <StixCoreRelationshipEditionOverviewComponent
+        isCoverage={false}
+        stixCoreRelationship={relationship('has-covered')}
+        handleClose={vi.fn()}
+        noStoreUpdate
+      />,
+      { userContext },
+    );
+
+    const coverageEdition = screen.queryByText('Coverage Information');
+    expect(coverageEdition).toBeInTheDocument();
+  });
+
+  it('should not display Coverage Information if isCoverage is false and relationship is not has-covered', () => {
+    testRender(
+      <StixCoreRelationshipEditionOverviewComponent
+        isCoverage={false}
+        stixCoreRelationship={relationship('targets')}
+        handleClose={vi.fn()}
+        noStoreUpdate
+      />,
+      { userContext },
+    );
+
+    const coverageEdition = screen.queryByText('Coverage Information');
+    expect(coverageEdition).not.toBeInTheDocument();
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipEditionOverview.tsx
@@ -177,7 +177,7 @@ interface StixCoreRelationshipAddInput {
   }[] | undefined;
 }
 
-const StixCoreRelationshipEditionOverviewComponent: FunctionComponent<
+export const StixCoreRelationshipEditionOverviewComponent: FunctionComponent<
   Omit<StixCoreRelationshipEditionOverviewProps, 'queryRef'>
 > = ({ handleClose, handleDelete, stixCoreRelationship, noStoreUpdate, isCoverage = false }) => {
   const stixCoreRelationshipType = 'stix-core-relationship';
@@ -185,7 +185,9 @@ const StixCoreRelationshipEditionOverviewComponent: FunctionComponent<
   const { t_i18n } = useFormatter();
   const enableReferences = useIsEnforceReference(stixCoreRelationshipType);
 
-  const { editContext } = stixCoreRelationship;
+  const { editContext, relationship_type } = stixCoreRelationship;
+
+  const displayCoverage = isCoverage || relationship_type === 'has-covered';
 
   const basicShape = {
     confidence: Yup.number().nullable(),
@@ -273,7 +275,7 @@ const StixCoreRelationshipEditionOverviewComponent: FunctionComponent<
     createdBy: convertCreatedBy(stixCoreRelationship) as FieldOption,
     objectMarking: convertMarkings(stixCoreRelationship),
     references: [],
-    ...(isCoverage ? { coverage_information: stixCoreRelationship.coverage_information || [] } : {}),
+    ...(displayCoverage ? { coverage_information: stixCoreRelationship.coverage_information || [] } : {}),
   };
   return (
     <Stack>
@@ -354,7 +356,7 @@ const StixCoreRelationshipEditionOverviewComponent: FunctionComponent<
                 />
               )}
             />
-            {isCoverage && (
+            {displayCoverage && (
               <CoverageInformationFieldEdit
                 id={stixCoreRelationship.id}
                 name="coverage_information"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added coverage edition to has-covered relationship view

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #13133 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
