### PR TITLE
[client-python] Loosen pyjwt pin to allow 2.13.x and future minor bumps (#16207)

### DIFF
--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -6,7 +6,7 @@ python-magic~=0.4.27; sys_platform == 'linux' or sys_platform == 'darwin'
 python-magic-bin~=0.4.14; sys_platform == 'win32'
 python_json_logger~=4.0.0
 PyYAML~=6.0
-pyjwt[crypto]~=2.12.0
+pyjwt[crypto]>=2.12.0, <3
 pydantic>=2.8.2, <3
 requests~=2.33.0
 setuptools~=82.0.0

--- a/client-python/setup.cfg
+++ b/client-python/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     deprecation~=2.1.0
     fastapi>=0.129.2,<1
     uvicorn[standard]>=0.41.0,<1
-    pyjwt[crypto]~=2.12.0
+    pyjwt[crypto]>=2.12.0, <3
     # OpenCTI
     filigran-sseclient>=1.0.2
     stix2~=3.0.1

--- a/client-python/test-requirements.txt
+++ b/client-python/test-requirements.txt
@@ -9,4 +9,4 @@ pytest_randomly~=4.0
 types-python-dateutil>=2.8
 types-pytz>=2021.3.5
 wheel~=0.38
-pyjwt[crypto]~=2.12.0
+pyjwt[crypto]>=2.12.0, <3


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* `client-python/setup.cfg`, `client-python/requirements.txt`, `client-python/test-requirements.txt` — switch the `pyjwt[crypto]` pin from `~=2.12.0` (compatible-release on the patch range, i.e. `>=2.12.0, <2.13.0`) to `>=2.12.0, <3`, matching the existing `pydantic>=2.8.2, <3` / `fastapi>=0.129.2,<1` pattern already in the same file. Lets `pip` resolve pyjwt 2.12.x today AND pyjwt 2.13.x once Renovate / Dependabot lands the bump downstream, while still forbidding a hypothetical pyjwt 3.x major (which would warrant a real compatibility review).
* pycti's pyjwt usage (`jwt.encode`, `jwt.decode`, `jwt.get_unverified_header`, `jwt.PyJWKSet` in `pycti/connector/opencti_connector_helper.py:42-771`) has been API-stable across every 2.x minor since 2021 — no code change required.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes #16207
* Downstream signal: [XTM-One-Platform/xtm-one#1004](https://github.com/XTM-One-Platform/xtm-one/pull/1004) — currently red on `Backend (Python)` / `Bootstrap (fresh DB)` / `Migrations (Alembic)` because the `pip install` step fails with `ResolutionImpossible: pycti depends on pyjwt~=2.12.0`. The downstream PR unblocks the moment this lands and the bumped `pycti` is released to PyPI.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->

### Further comments

This is a metadata-only pin change in three text files — no Python code touched, no API surface changed, no migration. Test coverage is exercised end-to-end by the existing CI matrix: `client-python` CI (pytest) will install the new pin against the latest pyjwt resolvable in `>=2.12.0, <3` (i.e. pyjwt 2.13.0 today) and run the full test suite against it. Adding a dedicated test for "the pin allows 2.13" would test the resolver rather than pycti behaviour and would have to be torn down at every future pyjwt minor — not worth carrying.

Constraint verified via `packaging`: 2.12.0 ✓, 2.12.1 ✓, 2.13.0 ✓, hypothetical 2.99.0 ✓, 3.0.0 ✗.
