### PR TITLE
[frontend/backend] Decay rule filters should not be mandatory (#16219)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRule.tsx
@@ -105,10 +105,10 @@ const DecayRuleComponent = ({ queryRef }: DecayRuleComponentProps) => {
           />
         </div>
         {!decayRule.built_in && (
-          <>
+          <div style={{ display: 'flex', gap: theme.spacing(1) }}>
             <DecayRulePopover decayRule={decayRule} />
             <DecayRuleEdition decayRule={decayRule} />
-          </>
+          </div>
         )}
       </div>
       <Grid

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleCreationForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleCreationForm.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '@mui/material/styles';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { Field, FieldArray, Form, Formik, FormikConfig } from 'formik';
 import { handleErrorInForm } from '../../../../relay/environment';
-import { emptyFilterGroup, serializeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { serializeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import decayRuleValidator from '@components/settings/decay/DecayRuleValidator';
 import TextField from '../../../../components/TextField';
 import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
@@ -48,14 +48,14 @@ type DecayRuleCreationFormData = {
   decay_pound: number;
   decay_points: number[];
   decay_revoke_score: number;
-  decay_filters: string;
+  decay_filters?: string;
 };
 
 const DecayRuleCreationForm = ({ updater, onReset, onCompleted }: DecayRuleCreationFormProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme();
   const [commit] = useApiMutation(decayRuleCreationFormAddMutation);
-  const [filters, filterHelpers] = useFiltersState(emptyFilterGroup);
+  const [filters, filterHelpers] = useFiltersState();
 
   const onSubmit: FormikConfig<DecayRuleCreationFormData>['onSubmit'] = (values, { setSubmitting, resetForm, setErrors }) => {
     const { name, description, order, active, decay_lifetime, decay_pound, decay_points, decay_revoke_score } = values;
@@ -100,7 +100,7 @@ const DecayRuleCreationForm = ({ updater, onReset, onCompleted }: DecayRuleCreat
     decay_pound: 1.0,
     decay_points: [],
     decay_revoke_score: 0,
-    decay_filters: '',
+    decay_filters: undefined,
   };
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleEdition.tsx
@@ -58,7 +58,7 @@ const DecayRuleEditionForm: FunctionComponent<DecayRuleEditionFormProps> = ({
   const { t_i18n } = useFormatter();
   const theme = useTheme();
   const [commitUpdate] = useApiMutation(decayRuleEditionMutation);
-  const [filters, filterHelpers] = useFiltersState(deserializeFilterGroupForFrontend(initialValues.decay_filters) ?? emptyFilterGroup);
+  const [filters, filterHelpers] = useFiltersState(deserializeFilterGroupForFrontend(initialValues.decay_filters) ?? undefined);
 
   useEffect(() => {
     commitUpdate({
@@ -274,7 +274,7 @@ const DecayRuleEdition: FunctionComponent<DecayRuleEditionProps> = ({
     decay_pound: decayRule.decay_pound,
     decay_points: decayRule.decay_points ? [...decayRule.decay_points] : [],
     decay_revoke_score: decayRule.decay_revoke_score,
-    decay_filters: decayRule.decay_filters ?? '',
+    decay_filters: decayRule.decay_filters,
   };
   return (
     <Drawer

--- a/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/decay/DecayRuleEdition.tsx
@@ -23,7 +23,7 @@ import EditEntityControlledDial from '../../../../components/EditEntityControlle
 import Filters from '@components/common/lists/Filters';
 import FilterIconButton from '../../../../components/FilterIconButton';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
-import { deserializeFilterGroupForFrontend, emptyFilterGroup, serializeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, serializeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import { enabledFilters } from './utils/enabledFilters';
 import { useTheme } from '@mui/material/styles';
 
@@ -44,7 +44,7 @@ interface DecayRuleEditionFormData {
   decay_pound: number;
   decay_points: number[];
   decay_revoke_score: number;
-  decay_filters: string;
+  decay_filters?: string | null;
 }
 
 interface DecayRuleEditionFormProps {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -14172,7 +14172,7 @@ type DecayRule implements InternalObject & BasicObject {
   decay_points: [Int!]
   decay_revoke_score: Int!
   decaySettingsChartData: DecayData
-  decay_filters: String!
+  decay_filters: String
 }
 
 type DecayData {
@@ -14205,7 +14205,7 @@ input DecayRuleAddInput {
   decay_pound: Float!
   decay_points: [Int!]
   decay_revoke_score: Int!
-  decay_filters: String!
+  decay_filters: String
 }
 
 type DecayExclusionRule implements InternalObject & BasicObject {

--- a/opencti-platform/opencti-front/tests_e2e/settings/decayRule.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/settings/decayRule.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '../fixtures/baseFixtures';
+import LeftBarPage from '../model/menu/leftBar.pageModel';
+
+test('Check access to the overview of a decay rule', { tag: ['@ce'] }, async ({ page }) => {
+  const leftBarPage = new LeftBarPage(page);
+
+  // Navigate to the decay rules list (built-in rules are always seeded)
+  await page.goto('/dashboard/settings/customization/decay');
+  await leftBarPage.expectBreadcrumb('Settings', 'Customization', 'Decay rules');
+
+  // Open the overview of a built-in decay rule
+  await page.getByRole('link', { name: 'Built-in default' }).click();
+
+  // The overview should display the configuration card with the expected fields
+  await expect(page.getByText('Decay indicator filter', { exact: true })).toBeVisible();
+  await expect(page.getByText('Lifetime (in days)', { exact: true })).toBeVisible();
+});
+

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -7137,7 +7137,7 @@ export type DecayRule = BasicObject & InternalObject & {
   built_in?: Maybe<Scalars['Boolean']['output']>;
   created_at: Scalars['DateTime']['output'];
   decaySettingsChartData?: Maybe<DecayData>;
-  decay_filters: Scalars['String']['output'];
+  decay_filters?: Maybe<Scalars['String']['output']>;
   decay_lifetime: Scalars['Int']['output'];
   decay_points?: Maybe<Array<Scalars['Int']['output']>>;
   decay_pound: Scalars['Float']['output'];
@@ -7156,7 +7156,7 @@ export type DecayRule = BasicObject & InternalObject & {
 
 export type DecayRuleAddInput = {
   active: Scalars['Boolean']['input'];
-  decay_filters: Scalars['String']['input'];
+  decay_filters?: InputMaybe<Scalars['String']['input']>;
   decay_lifetime: Scalars['Int']['input'];
   decay_points?: InputMaybe<Array<Scalars['Int']['input']>>;
   decay_pound: Scalars['Float']['input'];
@@ -43380,7 +43380,7 @@ export type DecayRuleResolvers<ContextType = any, ParentType extends ResolversPa
   built_in?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   decaySettingsChartData?: Resolver<Maybe<ResolversTypes['DecayData']>, ParentType, ContextType>;
-  decay_filters?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  decay_filters?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   decay_lifetime?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   decay_points?: Resolver<Maybe<Array<ResolversTypes['Int']>>, ParentType, ContextType>;
   decay_pound?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
@@ -46,7 +46,7 @@ export interface DecayRuleConfiguration extends DecayModel {
   id?: string;
   name: string;
   description: string;
-  decay_filters: string;
+  decay_filters?: string;
   order: number; // low priority = 0
   active: boolean;
 }
@@ -274,7 +274,7 @@ export const FALLBACK_DECAY_RULE: DecayRuleConfiguration = {
   decay_pound: 0.35,
   decay_points: [80, 50],
   decay_revoke_score: 20,
-  decay_filters: '', // Matches all
+  decay_filters: undefined, // Matches all
   order: 0,
   active: true,
 };

--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule.graphql
@@ -20,7 +20,7 @@ type DecayRule implements InternalObject & BasicObject {
   decay_points: [Int!]
   decay_revoke_score: Int!
   decaySettingsChartData: DecayData
-  decay_filters: String!
+  decay_filters: String
 }
 
 type DecayData {
@@ -67,7 +67,7 @@ input DecayRuleAddInput {
   decay_pound: Float!
   decay_points: [Int!]
   decay_revoke_score: Int!
-  decay_filters: String!
+  decay_filters: String
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule.ts
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule.ts
@@ -26,7 +26,7 @@ const DECAY_RULE_DEFINITION: ModuleDefinition<StoreEntityDecayRule, StixDecayRul
     { name: 'decay_pound', label: 'Decay factor', type: 'numeric', precision: 'float', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'decay_points', label: 'Reaction points', type: 'numeric', precision: 'integer', mandatoryType: 'no', editDefault: false, multiple: true, upsert: false, isFilterable: true },
     { name: 'decay_revoke_score', label: 'Revoke score', type: 'numeric', precision: 'integer', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'decay_filters', label: 'Decay indicator filter', type: 'string', format: 'json', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'decay_filters', label: 'Decay indicator filter', type: 'string', format: 'json', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: false },
   ],
   relations: [],
   representative: (stix: StixDecayRule) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/decayRules/decayRule-unit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/decayRules/decayRule-unit-test.ts
@@ -41,7 +41,7 @@ const TEST_DEFAULT_DECAY_RULE: DecayRuleConfiguration = {
   decay_pound: 1.0,
   decay_points: [80, 60, 40, 20],
   decay_revoke_score: 0,
-  decay_filters: '', // no filter means all
+  decay_filters: undefined, // no filter means all
   order: 0,
   active: true,
 };
@@ -396,7 +396,7 @@ describe('checkDecayRules testing', () => {
     const getEntitiesMock = vi.spyOn(cacheModule, 'getEntitiesListFromCache').mockResolvedValue([
       { id: 'rule-low-priority', order: 1, active: true, decay_filters: '{"mode":"and", "filters":[]}' },
       { id: 'rule-high-priority', order: 5, active: true, decay_filters: '{"mode":"and", "filters":[]}' },
-      { id: 'rule-inactive', order: 10, active: false, decay_filters: '{"mode":"and", "filters":[]}' }
+      { id: 'rule-inactive', order: 10, active: false, decay_filters: '{"mode":"and", "filters":[]}' },
     ] as any);
 
     // Mock filter group match to true so that both active rules match

--- a/opencti-platform/opencti-graphql/tests/02-integration/modules/decayRules/decayRule-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/modules/decayRules/decayRule-resolver-test.ts
@@ -131,6 +131,7 @@ describe('DecayRule resolver standard behavior', () => {
         expect(decayRule.decay_lifetime).toBeDefined();
         expect(decayRule.decay_revoke_score).toBeDefined();
         expect(decayRule.order).toBeDefined();
+        expect(decayRule).toHaveProperty('decay_filters');
         logApp.info('One built-in decay rule is', { decayRule });
         if (decayRule.name === TEST_FALLBACK_DECAY_RULE.name) {
           defaultDecayRuleId = decayRule.id || '';

--- a/opencti-platform/opencti-graphql/tests/02-integration/modules/decayRules/decayRule-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/02-integration/modules/decayRules/decayRule-resolver-test.ts
@@ -129,7 +129,6 @@ describe('DecayRule resolver standard behavior', () => {
         expect(decayRule.id).toBeDefined();
         expect(decayRule.name).toBeDefined();
         expect(decayRule.decay_lifetime).toBeDefined();
-        expect(decayRule.decay_filters).toBeDefined();
         expect(decayRule.decay_revoke_score).toBeDefined();
         expect(decayRule.order).toBeDefined();
         logApp.info('One built-in decay rule is', { decayRule });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/middleware-delete-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/middleware-delete-test.ts
@@ -29,7 +29,6 @@ describe('Delete functional errors behaviors', async () => {
       decay_lifetime: 360,
       decay_pound: 1,
       decay_revoke_score: 10,
-      decay_filters: '',
       name: 'Decay for middleware delete test',
       order: 12,
     };


### PR DESCRIPTION
### Proposed changes
- Decay rules filters should not be mandatory in graphql definition
- Fixes the error when displaying the decay rules created before the introduction of decay_filters
- e2e test to check the display of a decay rule overview
- add margin between 'update' button of a decay rule and the popover menu

### Related issues
fixes #16219