### PR TITLE
[frontend] add Div extension to preserve <div> elements in RichTextEditor (#16228)

### DIFF
--- a/opencti-platform/opencti-front/src/components/RichTextEditor.tsx
+++ b/opencti-platform/opencti-front/src/components/RichTextEditor.tsx
@@ -40,6 +40,7 @@ import { Paragraph } from './richTextEditor/extensions/Paragraph';
 import type { Theme } from './Theme';
 import { TaskList } from './richTextEditor/extensions/TaskList';
 import { TaskItem } from './richTextEditor/extensions/TaskListItem';
+import { Div } from './richTextEditor/extensions/Div';
 
 import '../static/css/TiptapEditor.css';
 
@@ -239,6 +240,7 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
       Placeholder.configure({ placeholder }),
       PageBreak,
       TableCellSplit,
+      Div,
     ],
     content: initialContentRef.current,
     editable: !disabled,

--- a/opencti-platform/opencti-front/src/components/richTextEditor/extensions/Div.ts
+++ b/opencti-platform/opencti-front/src/components/richTextEditor/extensions/Div.ts
@@ -1,0 +1,45 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+/**
+ * TipTap node extension that preserves <div> elements from externally-created HTML.
+ *
+ * Without this extension TipTap (ProseMirror) has no schema node for <div>, so it
+ * silently unwraps every <div> and discards its inline style / class attributes.
+ * This means font-size, color and layout styles defined on parent divs are lost.
+ *
+ */
+export const Div = Node.create({
+  name: 'div',
+  group: 'block',
+  content: 'block+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      style: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('style') || null,
+        renderHTML: (attrs: Record<string, string | null>) => {
+          if (!attrs.style) return {};
+          return { style: attrs.style };
+        },
+      },
+      class: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('class') || null,
+        renderHTML: (attrs: Record<string, string | null>) => {
+          if (!attrs.class) return {};
+          return { class: attrs.class };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes), 0];
+  },
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  add Div extension to preserve `<div>` elements in RichTextEditor

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Fixes #16228 
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
