### PR TITLE
fix(backend): change security coverage resolver for compatibility (#14716)

### DIFF
--- a/client-python/examples/create_security_coverage_result.py
+++ b/client-python/examples/create_security_coverage_result.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+import os
+from datetime import datetime, timedelta, timezone
+from pprint import pprint
+
+from pycti import OpenCTIApiClient
+
+# Variables
+api_url = os.getenv("OPENCTI_API_URL", "http://opencti:4000")
+api_token = os.getenv("OPENCTI_API_TOKEN", "bfa014e0-e02e-4aa6-a42b-603b19dcf159")
+
+# OpenCTI initialization
+opencti_api_client = OpenCTIApiClient(api_url, api_token)
+now = datetime.now(timezone.utc)
+in_4_weeks = now + timedelta(weeks=4)
+
+# Setup, create a security coverage to link to the result
+report = opencti_api_client.report.create(
+    name="Report for SCR",
+    published=now.isoformat(),
+)
+if not report or "id" not in report:
+    raise RuntimeError("Failed to create report")
+securityCoverage = opencti_api_client.security_coverage.create(
+    name="SC for SCR",
+    description="Super Security Coverage",
+    objectCovered=report["id"],
+    auto_enrichment_disable=False,
+)
+if not securityCoverage or "id" not in report:
+    raise RuntimeError("Failed to create security coverage")
+
+# Create a security coverage result
+scr = opencti_api_client.security_coverage_result.create(
+    resultOf=securityCoverage["id"],
+    external_uri="my-oaev-instance-1",
+    coverage_last_result=now.isoformat(),
+    coverage_valid_from=now.isoformat(),
+    coverage_valid_to=in_4_weeks.isoformat(),
+    coverage_information=[
+        {"coverage_name": "Prevention", "coverage_score": 45},
+        {"coverage_name": "Detection", "coverage_score": 90},
+    ],
+)
+pprint(scr)

--- a/client-python/examples/get_security_coverage_result.py
+++ b/client-python/examples/get_security_coverage_result.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+import os
+from pprint import pprint
+
+from pycti import OpenCTIApiClient
+
+# Variables
+api_url = os.getenv("OPENCTI_API_URL", "http://opencti:4000")
+api_token = os.getenv("OPENCTI_API_TOKEN", "bfa014e0-e02e-4aa6-a42b-603b19dcf159")
+
+# OpenCTI initialization
+opencti_api_client = OpenCTIApiClient(api_url, api_token)
+
+# Search
+all_results = opencti_api_client.security_coverage_result.list(getAll=True)
+print(f"Found {len(all_results)} Security Coverage Results")
+pprint(all_results)
+
+# Get by ID
+scr = opencti_api_client.security_coverage_result.read(
+    id="security-coverage-result--7e7aed66-151d-52c4-956c-ee68322dda69"
+)
+pprint(scr)

--- a/client-python/pycti/__init__.py
+++ b/client-python/pycti/__init__.py
@@ -44,6 +44,7 @@ from .entities.opencti_opinion import Opinion
 from .entities.opencti_report import Report
 from .entities.opencti_role import Role
 from .entities.opencti_security_coverage import SecurityCoverage
+from .entities.opencti_security_coverage_result import SecurityCoverageResult
 from .entities.opencti_settings import Settings
 from .entities.opencti_stix import Stix
 from .entities.opencti_stix_core_object import StixCoreObject
@@ -148,6 +149,7 @@ __all__ = [
     "Opinion",
     "Report",
     "SecurityCoverage",
+    "SecurityCoverageResult",
     "Stix",
     "StixCoreObject",
     "StixCoreRelationship",

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -60,6 +60,7 @@ from pycti.entities.opencti_opinion import Opinion
 from pycti.entities.opencti_report import Report
 from pycti.entities.opencti_role import Role
 from pycti.entities.opencti_security_coverage import SecurityCoverage
+from pycti.entities.opencti_security_coverage_result import SecurityCoverageResult
 from pycti.entities.opencti_settings import Settings
 from pycti.entities.opencti_stix import Stix
 from pycti.entities.opencti_stix_core_object import StixCoreObject
@@ -317,6 +318,7 @@ class OpenCTIApiClient:
         self.language = Language(self)
         self.vulnerability = Vulnerability(self)
         self.security_coverage = SecurityCoverage(self)
+        self.security_coverage_result = SecurityCoverageResult(self)
         self.attack_pattern = AttackPattern(self)
         self.course_of_action = CourseOfAction(self)
         self.data_component = DataComponent(self)

--- a/client-python/pycti/entities/opencti_security_coverage_result.py
+++ b/client-python/pycti/entities/opencti_security_coverage_result.py
@@ -1,0 +1,435 @@
+# coding: utf-8
+
+import json
+import uuid
+
+from stix2.canonicalization.Canonicalize import canonicalize
+
+
+class SecurityCoverageResult:
+    """Main SecurityCoverageResult class for OpenCTI
+
+    Manages security coverage results in the OpenCTI platform.
+
+    :param opencti: instance of :py:class:`~pycti.api.opencti_api_client.OpenCTIApiClient`
+    :type opencti: OpenCTIApiClient
+    """
+
+    def __init__(self, opencti):
+        """Initialize the SecurityCoverageResult instance.
+
+        :param opencti: OpenCTI API client instance
+        :type opencti: OpenCTIApiClient
+        """
+        self.opencti = opencti
+        self.properties = """
+            id
+            standard_id
+            entity_type
+            parent_types
+            spec_version
+            created_at
+            updated_at
+            external_uri
+            coverage_last_result
+            coverage_valid_from
+            coverage_valid_to
+            coverage_information {
+                coverage_name
+                coverage_score
+            }
+            objectMarking {
+                id
+                standard_id
+                entity_type
+                definition_type
+                definition
+                created
+                modified
+                x_opencti_order
+                x_opencti_color
+            }
+        """
+
+    @staticmethod
+    def generate_id(name, external_uri, result_of_ref):
+        """Generate a STIX ID for a Security Coverage Result.
+
+        :param name: The name of the security coverage result (can be None)
+        :type name: str or None
+        :param external_uri: The external URI of the result (can be None)
+        :type external_uri: str or None
+        :param result_of_ref: The standard_id of the parent SecurityCoverage
+        :type result_of_ref: str
+        :return: STIX ID for the security coverage result
+        :rtype: str
+        """
+        data = {"result_of_ref": result_of_ref.strip()}
+        if name is not None:
+            data["name"] = name.lower().strip()
+        if external_uri is not None:
+            data["external_uri"] = external_uri.strip()
+        data = canonicalize(data, utf8=False)
+        id = str(uuid.uuid5(uuid.UUID("00abedb4-aa42-466c-9c01-fed23315a9b7"), data))
+        return "security-coverage-result--" + id
+
+    @staticmethod
+    def generate_id_from_data(data):
+        """Generate a STIX ID from security coverage result data.
+
+        :param data: Dictionary containing 'result_of_ref', and optionally 'name' and 'external_uri'
+        :type data: dict
+        :return: STIX ID for the security coverage result
+        :rtype: str
+        """
+        return SecurityCoverageResult.generate_id(
+            # Using .get instead of direct access because can be None
+            data.get("name"),
+            data.get("external_uri"),
+            data["result_of_ref"],
+        )
+
+    def list(self, **kwargs):
+        """List SecurityCoverageResult objects.
+
+        :param filters: the filters to apply
+        :param search: the search keyword
+        :param first: return the first n rows from the after ID (or the beginning if not set)
+        :param after: ID of the first row for pagination
+        :return: List of SecurityCoverageResult objects
+        :rtype: list
+        """
+        filters = kwargs.get("filters", None)
+        search = kwargs.get("search", None)
+        first = kwargs.get("first", 100)
+        after = kwargs.get("after", None)
+        order_by = kwargs.get("orderBy", None)
+        order_mode = kwargs.get("orderMode", None)
+        custom_attributes = kwargs.get("customAttributes", None)
+        get_all = kwargs.get("getAll", False)
+        with_pagination = kwargs.get("withPagination", False)
+
+        self.opencti.app_logger.info(
+            "Listing SecurityCoverageResult with filters",
+            {"filters": json.dumps(filters)},
+        )
+        query = (
+            """
+                query SecurityCoverageResults($filters: FilterGroup, $search: String, $first: Int, $after: ID, $orderBy: SecurityCoverageResultOrdering, $orderMode: OrderingMode) {
+                    securityCoverageResults(filters: $filters, search: $search, first: $first, after: $after, orderBy: $orderBy, orderMode: $orderMode) {
+                        edges {
+                            node {
+                                """
+            + (custom_attributes if custom_attributes is not None else self.properties)
+            + """
+                        }
+                    }
+                    pageInfo {
+                        startCursor
+                        endCursor
+                        hasNextPage
+                        hasPreviousPage
+                        globalCount
+                    }
+                }
+            }
+        """
+        )
+        result = self.opencti.query(
+            query,
+            {
+                "filters": filters,
+                "search": search,
+                "first": first,
+                "after": after,
+                "orderBy": order_by,
+                "orderMode": order_mode,
+            },
+        )
+
+        if get_all:
+            final_data = []
+            data = self.opencti.process_multiple(
+                result["data"]["securityCoverageResults"]
+            )
+            final_data = final_data + data
+            while result["data"]["securityCoverageResults"]["pageInfo"]["hasNextPage"]:
+                after = result["data"]["securityCoverageResults"]["pageInfo"][
+                    "endCursor"
+                ]
+                self.opencti.app_logger.info(
+                    "Listing SecurityCoverageResult", {"after": after}
+                )
+                result = self.opencti.query(
+                    query,
+                    {
+                        "filters": filters,
+                        "search": search,
+                        "first": first,
+                        "after": after,
+                        "orderBy": order_by,
+                        "orderMode": order_mode,
+                    },
+                )
+                data = self.opencti.process_multiple(
+                    result["data"]["securityCoverageResults"]
+                )
+                final_data = final_data + data
+            return final_data
+        else:
+            return self.opencti.process_multiple(
+                result["data"]["securityCoverageResults"], with_pagination
+            )
+
+    def read(self, **kwargs):
+        """Read a SecurityCoverageResult object.
+
+        :param id: the id of the SecurityCoverageResult
+        :type id: str
+        :param filters: the filters to apply if no id provided
+        :type filters: dict
+        :param customAttributes: custom attributes to return
+        :type customAttributes: str
+        :return: SecurityCoverageResult object
+        :rtype: dict or None
+        """
+        id = kwargs.get("id", None)
+        filters = kwargs.get("filters", None)
+        custom_attributes = kwargs.get("customAttributes", None)
+        if id is not None:
+            self.opencti.app_logger.info("Reading SecurityCoverageResult", {"id": id})
+            query = (
+                """
+                    query SecurityCoverageResult($id: String!) {
+                        securityCoverageResult(id: $id) {
+                            """
+                + (
+                    custom_attributes
+                    if custom_attributes is not None
+                    else self.properties
+                )
+                + """
+                    }
+                }
+             """
+            )
+            result = self.opencti.query(query, {"id": id})
+            return self.opencti.process_multiple_fields(
+                result["data"]["securityCoverageResult"]
+            )
+        elif filters is not None:
+            result = self.list(filters=filters)
+            if len(result) > 0:
+                return result[0]
+            else:
+                return None
+        else:
+            self.opencti.app_logger.error(
+                "[opencti_security_coverage_result] Missing parameters: id or filters"
+            )
+            return None
+
+    def create(self, **kwargs):
+        """Create a Security Coverage Result object.
+
+        :param name: the name of the Security Coverage Result (optional)
+        :type name: str or None
+        :param resultOf: the parent SecurityCoverage ID (required)
+        :type resultOf: str
+        :param stix_id: (optional) the STIX ID
+        :type stix_id: str
+        :param description: (optional) description
+        :type description: str
+        :param createdBy: (optional) the author ID
+        :type createdBy: str
+        :param objectMarking: (optional) list of marking definition IDs
+        :type objectMarking: list
+        :param objectLabel: (optional) list of label IDs
+        :type objectLabel: list
+        :param externalReferences: (optional) list of external reference IDs
+        :type externalReferences: list
+        :param external_uri: (optional) external URI
+        :type external_uri: str
+        :param coverage_last_result: (optional) last result date
+        :type coverage_last_result: str
+        :param coverage_valid_from: (optional) valid from date
+        :type coverage_valid_from: str
+        :param coverage_valid_to: (optional) valid to date
+        :type coverage_valid_to: str
+        :param coverage_information: (optional) coverage information
+        :type coverage_information: list
+        :param files: (optional) list of File objects to attach
+        :type files: list
+        :param filesMarkings: (optional) list of lists of marking definition IDs for each file
+        :type filesMarkings: list
+        :return: Security Coverage Result object
+        :rtype: dict or None
+        """
+        stix_id = kwargs.get("stix_id", None)
+        name = kwargs.get("name", None)
+        description = kwargs.get("description", None)
+        created_by = kwargs.get("createdBy", None)
+        object_marking = kwargs.get("objectMarking", None)
+        object_label = kwargs.get("objectLabel", None)
+        result_of = kwargs.get("resultOf", None)
+        external_references = kwargs.get("externalReferences", None)
+        external_uri = kwargs.get("external_uri", None)
+        coverage_last_result = kwargs.get("coverage_last_result", None)
+        coverage_valid_from = kwargs.get("coverage_valid_from", None)
+        coverage_valid_to = kwargs.get("coverage_valid_to", None)
+        coverage_information = kwargs.get("coverage_information", None)
+        x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
+        files = kwargs.get("files", None)
+        files_markings = kwargs.get("filesMarkings", None)
+        no_trigger_import = kwargs.get("noTriggerImport", None)
+        embedded = kwargs.get("embedded", None)
+
+        if result_of is not None:
+            self.opencti.app_logger.info(
+                "Creating Security Coverage Result", {"name": name}
+            )
+            query = (
+                """
+                mutation SecurityCoverageResultAdd($input: SecurityCoverageResultAddInput!) {
+                    securityCoverageResultAdd(input: $input) {"""
+                + self.properties
+                + """
+                    }
+                }
+            """
+            )
+            result = self.opencti.query(
+                query,
+                {
+                    "input": {
+                        "stix_id": stix_id,
+                        "name": name,
+                        "description": description,
+                        "createdBy": created_by,
+                        "objectMarking": object_marking,
+                        "objectLabel": object_label,
+                        "resultOf": result_of,
+                        "external_uri": external_uri,
+                        "externalReferences": external_references,
+                        "coverage_last_result": coverage_last_result,
+                        "coverage_valid_from": coverage_valid_from,
+                        "coverage_valid_to": coverage_valid_to,
+                        "coverage_information": coverage_information,
+                        "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "files": files,
+                        "filesMarkings": files_markings,
+                        "noTriggerImport": no_trigger_import,
+                        "embedded": embedded,
+                    }
+                },
+            )
+            return self.opencti.process_multiple_fields(
+                result["data"]["securityCoverageResultAdd"]
+            )
+        else:
+            self.opencti.app_logger.error(
+                "[opencti_security_coverage_result] " "Missing parameters: result_of"
+            )
+            return None
+
+    def import_from_stix2(self, **kwargs):
+        """Import a Security Coverage Result from a STIX2 object.
+
+        :param stixObject: the STIX2 Security Coverage Result object
+        :type stixObject: dict
+        :param extras: extra parameters including created_by_id, object_marking_ids, etc.
+        :type extras: dict
+        :param update: whether to update if the entity already exists
+        :type update: bool
+        :return: Security Coverage Result object
+        :rtype: dict or None
+        """
+        stix_object = kwargs.get("stixObject", None)
+        extras = kwargs.get("extras", {})
+        if stix_object is not None:
+            # Search in extensions
+            if "x_opencti_stix_ids" not in stix_object:
+                stix_object["x_opencti_stix_ids"] = (
+                    self.opencti.get_attribute_in_extension("stix_ids", stix_object)
+                )
+            if "x_opencti_granted_refs" not in stix_object:
+                stix_object["x_opencti_granted_refs"] = (
+                    self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+
+            raw_coverages = stix_object["coverage"] if "coverage" in stix_object else []
+            coverage_information = list(
+                map(
+                    lambda cov: {
+                        "coverage_name": cov["name"],
+                        "coverage_score": cov["score"],
+                    },
+                    raw_coverages,
+                )
+            )
+
+            return self.create(
+                stix_id=stix_object["id"],
+                name=stix_object["name"],
+                external_uri=(
+                    stix_object["external_uri"]
+                    if "external_uri" in stix_object
+                    else None
+                ),
+                coverage_last_result=(
+                    stix_object["coverage_last_result"]
+                    if "coverage_last_result" in stix_object
+                    else None
+                ),
+                coverage_valid_from=(
+                    stix_object["coverage_valid_from"]
+                    if "coverage_valid_from" in stix_object
+                    else None
+                ),
+                coverage_valid_to=(
+                    stix_object["coverage_valid_to"]
+                    if "coverage_valid_to" in stix_object
+                    else None
+                ),
+                coverage_information=coverage_information,
+                description=(
+                    self.opencti.stix2.convert_markdown(stix_object["description"])
+                    if "description" in stix_object
+                    else None
+                ),
+                createdBy=(
+                    extras["created_by_id"] if "created_by_id" in extras else None
+                ),
+                objectMarking=(
+                    extras["object_marking_ids"]
+                    if "object_marking_ids" in extras
+                    else None
+                ),
+                objectLabel=(
+                    extras["object_label_ids"] if "object_label_ids" in extras else None
+                ),
+                resultOf=(
+                    stix_object["result_of_ref"]
+                    if "result_of_ref" in stix_object
+                    else None
+                ),
+                externalReferences=(
+                    extras["external_references_ids"]
+                    if "external_references_ids" in extras
+                    else None
+                ),
+                x_opencti_stix_ids=(
+                    stix_object["x_opencti_stix_ids"]
+                    if "x_opencti_stix_ids" in stix_object
+                    else None
+                ),
+                files=extras.get("files"),
+                filesMarkings=extras.get("filesMarkings"),
+                noTriggerImport=extras.get("noTriggerImport", None),
+                embedded=extras.get("embedded", None),
+            )
+        else:
+            self.opencti.app_logger.error(
+                "[opencti_security_coverage_result] Missing parameters: stixObject"
+            )
+            return None

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -1111,6 +1111,7 @@ class OpenCTIStix2:
             "Vocabulary": self.opencti.vocabulary.read,
             "Vulnerability": self.opencti.vulnerability.read,
             "Security-Coverage": self.opencti.security_coverage.read,
+            "Security-Coverage-Result": self.opencti.security_coverage_result.read,
         }
 
     def get_reader(self, entity_type: str):
@@ -1189,6 +1190,7 @@ class OpenCTIStix2:
             "task": self.opencti.task,
             "x-opencti-task": self.opencti.task,
             "security-coverage": self.opencti.security_coverage,
+            "security-coverage-result": self.opencti.security_coverage_result,
             "vocabulary": self.opencti.vocabulary,
             # relationships
             "relationship": self.opencti.stix_core_relationship,

--- a/client-python/pycti/utils/opencti_stix2_utils.py
+++ b/client-python/pycti/utils/opencti_stix2_utils.py
@@ -75,6 +75,7 @@ STIX_CORE_OBJECTS = [
     "tool",
     "vulnerability",
     "security-coverage",
+    "security-coverage-result",
 ]
 
 SUPPORTED_STIX_ENTITY_OBJECTS = STIX_META_OBJECTS + STIX_CORE_OBJECTS

--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -880,6 +880,7 @@
   "Search": "Suche",
   "Secondary motivation": "Sekundäre Motivation",
   "Security coverage": "Sicherheitsabdeckung",
+  "Security coverage results": "Ergebnisse der Sicherheitsüberprüfung",
   "Security platform type": "Typ der Sicherheitsplattform",
   "Selected attribute date": "Ausgewähltes Attribut Datum",
   "Selected IDs": "Ausgewählte IDs",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -880,6 +880,7 @@
   "Search": "Search",
   "Secondary motivation": "Secondary motivation",
   "Security coverage": "Security coverage",
+  "Security coverage results": "Security coverage results",
   "Security platform type": "Security platform type",
   "Selected attribute date": "Selected attribute date",
   "Selected IDs": "Selected IDs",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -880,6 +880,7 @@
   "Search": "Búsqueda",
   "Secondary motivation": "Motivación secundaria",
   "Security coverage": "Cobertura de seguridad",
+  "Security coverage results": "Resultados de la cobertura de seguridad",
   "Security platform type": "Tipo de plataforma de seguridad",
   "Selected attribute date": "Fecha del atributo seleccionado",
   "Selected IDs": "IDs seleccionados",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -880,6 +880,7 @@
   "Search": "Recherche",
   "Secondary motivation": "Motivation secondaire",
   "Security coverage": "Couverture de sécurité",
+  "Security coverage results": "Résultats de la couverture de sécurité",
   "Security platform type": "Type de plateforme de sécurité",
   "Selected attribute date": "Date de l'attribut sélectionné",
   "Selected IDs": "ID sélectionnées",

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -880,6 +880,7 @@
   "Search": "Cerca",
   "Secondary motivation": "Motivazione secondaria",
   "Security coverage": "Copertura di sicurezza",
+  "Security coverage results": "Risultati della copertura di sicurezza",
   "Security platform type": "Tipo di piattaforma di sicurezza",
   "Selected attribute date": "Data attributo selezionato",
   "Selected IDs": "ID selezionati",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -880,6 +880,7 @@
   "Search": "検索",
   "Secondary motivation": "郵便番号",
   "Security coverage": "安全保障",
+  "Security coverage results": "セキュリティー取材結果",
   "Security platform type": "セキュリティ・プラットフォーム・タイプ",
   "Selected attribute date": "選択された属性の日付",
   "Selected IDs": "選択されたID",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -880,6 +880,7 @@
   "Search": "검색",
   "Secondary motivation": "부차적 동기",
   "Security coverage": "보안 범위",
+  "Security coverage results": "보안 적용 범위 결과",
   "Security platform type": "보안 플랫폼 유형",
   "Selected attribute date": "선택된 속성 날짜",
   "Selected IDs": "선택된 ID",

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -880,6 +880,7 @@
   "Search": "Поиск",
   "Secondary motivation": "Вторичная мотивация",
   "Security coverage": "Защитное покрытие",
+  "Security coverage results": "Результаты покрытия безопасности",
   "Security platform type": "Тип платформы безопасности",
   "Selected attribute date": "Дата выбранного атрибута",
   "Selected IDs": "Выбранные идентификаторы",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -880,6 +880,7 @@
   "Search": "搜索",
   "Secondary motivation": "次要动机",
   "Security coverage": "安保范围",
+  "Security coverage results": "安保覆盖结果",
   "Security platform type": "安全平台类型",
   "Selected attribute date": "选定属性日期",
   "Selected IDs": "选定的 ID",

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9772,6 +9772,9 @@ type Query {
   securityPlatforms(first: Int, after: ID, orderBy: SecurityPlatformOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): SecurityPlatformConnection
   securityCoverage(id: String!): SecurityCoverage
   securityCoverages(first: Int, after: ID, orderBy: SecurityCoverageOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): SecurityCoverageConnection
+  securityCoverageResult(id: String!): SecurityCoverageResult
+  listSecurityCoverageResultsByResultOf(id: String!): [SecurityCoverageResult!]
+  securityCoverageResults(first: Int, after: ID, orderBy: SecurityCoverageResultOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): SecurityCoverageResultConnection
   emailTemplate(id: ID!): EmailTemplate
   emailTemplates(first: Int, after: ID, orderBy: EmailTemplateOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): EmailTemplateConnection
   form(id: ID!): Form
@@ -10721,6 +10724,8 @@ type Mutation {
   securityCoverageContextClean(id: ID!): SecurityCoverage
   securityCoverageRelationAdd(id: ID!, input: StixRefRelationshipAddInput!): StixRefRelationship
   securityCoverageRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): SecurityCoverage
+  securityCoverageResultAdd(input: SecurityCoverageResultAddInput!): SecurityCoverageResult
+  securityCoverageResultDelete(id: ID!): ID
   askSendOtp(input: AskSendOtpInput!): String
   verifyOtp(input: VerifyOtpInput!): VerifyOtp
   verifyMfa(input: VerifyMfaInput!): Boolean
@@ -15759,11 +15764,6 @@ input SecurityPlatformAddInput {
   upsertOperations: [EditInput!]
 }
 
-type CoverageResult {
-  coverage_name: String!
-  coverage_score: Int!
-}
-
 type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & StixDomainObject {
   id: ID!
   standard_id: String!
@@ -15817,7 +15817,6 @@ type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & Sti
   roles: [String]
   x_opencti_aliases: [String]
   x_opencti_reliability: String
-  security_platform_type: String
   creators: [Creator!]
   toStix(version: Version): String
   importFiles(first: Int, prefixMimeType: String, after: ID, orderBy: FileOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): FileConnection
@@ -15841,6 +15840,7 @@ type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & Sti
   auto_enrichment_disable: Boolean
   objectCovered: StixDomainObject
   toStixBundle: String
+  security_platform_type: String
 }
 
 enum SecurityCoverageOrdering {
@@ -15882,7 +15882,6 @@ input SecurityCoverageAddInput {
   x_opencti_stix_ids: [StixId]
   x_opencti_workflow_id: String
   x_opencti_modified_at: DateTime
-  external_uri: String
   externalReferences: [String]
   file: Upload
   fileMarkings: [String]
@@ -15891,6 +15890,7 @@ input SecurityCoverageAddInput {
   noTriggerImport: [Boolean]
   embedded: [Boolean]
   update: Boolean
+  external_uri: String
   auto_enrichment_disable: Boolean!
   periodicity: String
   duration: String
@@ -15900,6 +15900,134 @@ input SecurityCoverageAddInput {
   coverage_valid_from: DateTime
   coverage_valid_to: DateTime
   coverage_information: [SecurityCoverageExpectation!]
+}
+
+type CoverageResult {
+  coverage_name: String!
+  coverage_score: Int!
+}
+
+type SecurityCoverageResult implements BasicObject & StixObject & StixCoreObject & StixDomainObject {
+  id: ID!
+  standard_id: String!
+  entity_type: String!
+  parent_types: [String!]!
+  metrics: [Metric]
+  representative: Representative!
+  x_opencti_stix_ids: [StixId]
+  is_inferred: Boolean!
+  spec_version: String!
+  created_at: DateTime!
+  updated_at: DateTime!
+  x_opencti_modified_at: DateTime
+  draftVersion: DraftVersion
+  refreshed_at: DateTime
+  x_opencti_inferences: [Inference]
+  createdBy: Identity
+  currentUserAccessRight: String
+  numberOfConnectedElement: Int!
+  objectMarking: [MarkingDefinition!]
+  objectOrganization: [Organization!]
+  objectLabel: [Label!]
+  externalReferences(first: Int): ExternalReferenceConnection
+  containersNumber: Number
+  containers(first: Int, entityTypes: [String!]): ContainerConnection
+  reports(first: Int): ReportConnection
+  notes(first: Int): NoteConnection
+  opinions(first: Int): OpinionConnection
+  observedData(first: Int): ObservedDataConnection
+  groupings(first: Int): GroupingConnection
+  cases(first: Int): CaseConnection
+  stixCoreRelationships(first: Int, after: ID, orderBy: StixCoreRelationshipsOrdering, orderMode: OrderingMode, fromId: StixRef, toId: StixRef, fromTypes: [String], toTypes: [String], relationship_type: String, startTimeStart: DateTime, startTimeStop: DateTime, stopTimeStart: DateTime, stopTimeStop: DateTime, firstSeenStart: DateTime, firstSeenStop: DateTime, lastSeenStart: DateTime, lastSeenStop: DateTime, confidences: [Int], search: String, filters: FilterGroup): StixCoreRelationshipConnection
+  stixCoreObjectsDistribution(relationship_type: [String], toTypes: [String], field: String!, startDate: DateTime, endDate: DateTime, dateAttribute: String, operation: StatsOperation!, limit: Int, order: String, types: [String], filters: FilterGroup, search: String): [Distribution]
+  stixCoreRelationshipsDistribution(field: String!, operation: StatsOperation!, startDate: DateTime, endDate: DateTime, dateAttribute: String, isTo: Boolean, limit: Int, order: String, elementWithTargetTypes: [String], fromId: [String], fromRole: String, fromTypes: [String], toId: [String], toRole: String, toTypes: [String], relationship_type: [String], confidences: [Int], search: String, filters: FilterGroup): [Distribution]
+  opinions_metrics: OpinionsMetrics
+  revoked: Boolean!
+  confidence: Int
+  lang: String
+  created: DateTime
+  modified: DateTime
+  x_opencti_graph_data: String
+  objectAssignee: [Assignee!]
+  objectParticipant: [Participant!]
+  avatar: OpenCtiFile
+  fintelTemplates: [FintelTemplate!]
+  filesFromTemplate(first: Int, prefixMimeType: String, after: ID, orderBy: FileOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): FileConnection
+  identity_class: String!
+  name: String
+  description: String
+  contact_information: String
+  roles: [String]
+  x_opencti_aliases: [String]
+  x_opencti_reliability: String
+  creators: [Creator!]
+  toStix(version: Version): String
+  importFiles(first: Int, prefixMimeType: String, after: ID, orderBy: FileOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): FileConnection
+  pendingFiles(first: Int, after: ID, orderBy: FileOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): FileConnection
+  exportFiles(first: Int): FileConnection
+  editContext: [EditUserContext!]
+  connectors(onlyAlive: Boolean): [Connector]
+  jobs(first: Int): [Work]
+  status: Status
+  workflowEnabled: Boolean
+  pirInformation(pirId: ID!): PirInformation
+  coverage_last_result: DateTime
+  coverage_valid_from: DateTime
+  coverage_valid_to: DateTime
+  coverage_information: [CoverageResult!]
+  external_uri: String
+}
+
+enum SecurityCoverageResultOrdering {
+  name
+  confidence
+  created
+  created_at
+  creator
+  modified
+  updated_at
+  objectMarking
+  _score
+}
+
+type SecurityCoverageResultConnection {
+  pageInfo: PageInfo!
+  edges: [SecurityCoverageResultEdge!]!
+}
+
+type SecurityCoverageResultEdge {
+  cursor: String!
+  node: SecurityCoverageResult!
+}
+
+input SecurityCoverageResultAddInput {
+  name: String
+  description: String
+  confidence: Int
+  createdBy: String
+  objectMarking: [String]
+  objectLabel: [String]
+  created: DateTime
+  modified: DateTime
+  revoked: Boolean
+  stix_id: StixId
+  x_opencti_stix_ids: [StixId]
+  x_opencti_workflow_id: String
+  x_opencti_modified_at: DateTime
+  externalReferences: [String]
+  file: Upload
+  fileMarkings: [String]
+  files: [Upload]
+  filesMarkings: [[String]]
+  noTriggerImport: [Boolean]
+  embedded: [Boolean]
+  update: Boolean
+  external_uri: String
+  coverage_last_result: DateTime
+  coverage_valid_from: DateTime
+  coverage_valid_to: DateTime
+  coverage_information: [SecurityCoverageExpectation!]
+  resultOf: String!
 }
 
 input AskSendOtpInput {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9773,7 +9773,6 @@ type Query {
   securityCoverage(id: String!): SecurityCoverage
   securityCoverages(first: Int, after: ID, orderBy: SecurityCoverageOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): SecurityCoverageConnection
   securityCoverageResult(id: String!): SecurityCoverageResult
-  listSecurityCoverageResultsByResultOf(id: String!): [SecurityCoverageResult!]
   securityCoverageResults(first: Int, after: ID, orderBy: SecurityCoverageResultOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String, toStix: Boolean): SecurityCoverageResultConnection
   emailTemplate(id: ID!): EmailTemplate
   emailTemplates(first: Int, after: ID, orderBy: EmailTemplateOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): EmailTemplateConnection

--- a/opencti-platform/opencti-graphql/graphql-codegen.yml
+++ b/opencti-platform/opencti-graphql/graphql-codegen.yml
@@ -67,6 +67,7 @@ generates:
         Pir: ../modules/pir/pir-types#BasicStoreEntityPir
         SecurityPlatform: ../modules/securityPlatform/securityPlatform-types#BasicStoreEntitySecurityPlatform
         SecurityCoverage: ../modules/securityCoverage/securityCoverage-types#BasicStoreEntitySecurityCoverage
+        SecurityCoverageResult: ../modules/securityCoverage/securityCoverageResult/securityCoverageResult-types#BasicStoreEntitySecurityCoverageResult
         EmailTemplate: ../modules/emailTemplate/emailTemplate-types#BasicStoreEntityEmailTemplate
         Form: ../modules/form/form-types#BasicStoreEntityForm
         AuthenticationProvider: ../modules/authenticationProvider/authenticationProvider-types#BasicStoreEntityAuthenticationProvider

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -46,6 +46,7 @@ import { ENTITY_TYPE_EMAIL_TEMPLATE } from '../modules/emailTemplate/emailTempla
 import { ENTITY_TYPE_AUTHENTICATION_PROVIDER } from '../modules/authenticationProvider/authenticationProvider-types';
 import { ENTITY_TYPE_SECURITY_COVERAGE } from '../modules/securityCoverage/securityCoverage-types';
 import { ENTITY_TYPE_NEWS_FEED_ITEM, NEWS_FEED_NUMBER } from '../modules/xtm/hub/news-feed/news-feed-types';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT } from '../modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 
 // https://golang.org/src/crypto/x509/root_linux.go
 const LINUX_CERTFILES = [
@@ -720,6 +721,10 @@ export const BUS_TOPICS = {
   [ENTITY_TYPE_SECURITY_COVERAGE]: {
     EDIT_TOPIC: `${TOPIC_PREFIX}SECURITY_COVERAGE_EDIT_TOPIC`,
     ADDED_TOPIC: `${TOPIC_PREFIX}SECURITY_COVERAGE_ADDED_TOPIC`,
+  },
+  [ENTITY_TYPE_SECURITY_COVERAGE_RESULT]: {
+    EDIT_TOPIC: `${TOPIC_PREFIX}SECURITY_COVERAGE_RESULT_EDIT_TOPIC`,
+    ADDED_TOPIC: `${TOPIC_PREFIX}SECURITY_COVERAGE_RESULT_ADDED_TOPIC`,
   },
   [ENTITY_TYPE_DECAY_RULE]: {
     EDIT_TOPIC: `${TOPIC_PREFIX}ENTITY_TYPE_DECAY_RULE_EDIT_TOPIC`,

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -24486,7 +24486,6 @@ export type Query = {
   labels?: Maybe<LabelConnection>;
   language?: Maybe<Language>;
   languages?: Maybe<LanguageConnection>;
-  listSecurityCoverageResultsByResultOf?: Maybe<Array<SecurityCoverageResult>>;
   location?: Maybe<Location>;
   locations?: Maybe<LocationConnection>;
   log?: Maybe<Log>;
@@ -25962,11 +25961,6 @@ export type QueryLanguagesArgs = {
   orderBy?: InputMaybe<LanguagesOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
   search?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type QueryListSecurityCoverageResultsByResultOfArgs = {
-  id: Scalars['String']['input'];
 };
 
 
@@ -49548,7 +49542,6 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   labels?: Resolver<Maybe<ResolversTypes['LabelConnection']>, ParentType, ContextType, Partial<QueryLabelsArgs>>;
   language?: Resolver<Maybe<ResolversTypes['Language']>, ParentType, ContextType, RequireFields<QueryLanguageArgs, 'id'>>;
   languages?: Resolver<Maybe<ResolversTypes['LanguageConnection']>, ParentType, ContextType, Partial<QueryLanguagesArgs>>;
-  listSecurityCoverageResultsByResultOf?: Resolver<Maybe<Array<ResolversTypes['SecurityCoverageResult']>>, ParentType, ContextType, RequireFields<QueryListSecurityCoverageResultsByResultOfArgs, 'id'>>;
   location?: Resolver<Maybe<ResolversTypes['Location']>, ParentType, ContextType, RequireFields<QueryLocationArgs, 'id'>>;
   locations?: Resolver<Maybe<ResolversTypes['LocationConnection']>, ParentType, ContextType, Partial<QueryLocationsArgs>>;
   log?: Resolver<Maybe<ResolversTypes['Log']>, ParentType, ContextType, RequireFields<QueryLogArgs, 'id'>>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -44,6 +44,7 @@ import type { BasicStoreEntityFintelDesign } from '../modules/fintelDesign/finte
 import type { BasicStoreEntityPir } from '../modules/pir/pir-types';
 import type { BasicStoreEntitySecurityPlatform } from '../modules/securityPlatform/securityPlatform-types';
 import type { BasicStoreEntitySecurityCoverage } from '../modules/securityCoverage/securityCoverage-types';
+import type { BasicStoreEntitySecurityCoverageResult } from '../modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 import type { BasicStoreEntityEmailTemplate } from '../modules/emailTemplate/emailTemplate-types';
 import type { BasicStoreEntityForm } from '../modules/form/form-types';
 import type { BasicStoreEntityAuthenticationProvider } from '../modules/authenticationProvider/authenticationProvider-types';
@@ -17303,6 +17304,8 @@ export type Mutation = {
   securityCoverageFieldPatch?: Maybe<SecurityCoverage>;
   securityCoverageRelationAdd?: Maybe<StixRefRelationship>;
   securityCoverageRelationDelete?: Maybe<SecurityCoverage>;
+  securityCoverageResultAdd?: Maybe<SecurityCoverageResult>;
+  securityCoverageResultDelete?: Maybe<Scalars['ID']['output']>;
   securityPlatformAdd?: Maybe<SecurityPlatform>;
   securityPlatformContextClean?: Maybe<SecurityPlatform>;
   securityPlatformContextPatch?: Maybe<SecurityPlatform>;
@@ -19363,6 +19366,16 @@ export type MutationSecurityCoverageRelationDeleteArgs = {
   id: Scalars['ID']['input'];
   relationship_type: Scalars['String']['input'];
   toId: Scalars['StixRef']['input'];
+};
+
+
+export type MutationSecurityCoverageResultAddArgs = {
+  input: SecurityCoverageResultAddInput;
+};
+
+
+export type MutationSecurityCoverageResultDeleteArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -24473,6 +24486,7 @@ export type Query = {
   labels?: Maybe<LabelConnection>;
   language?: Maybe<Language>;
   languages?: Maybe<LanguageConnection>;
+  listSecurityCoverageResultsByResultOf?: Maybe<Array<SecurityCoverageResult>>;
   location?: Maybe<Location>;
   locations?: Maybe<LocationConnection>;
   log?: Maybe<Log>;
@@ -24577,6 +24591,8 @@ export type Query = {
   sector?: Maybe<Sector>;
   sectors?: Maybe<SectorConnection>;
   securityCoverage?: Maybe<SecurityCoverage>;
+  securityCoverageResult?: Maybe<SecurityCoverageResult>;
+  securityCoverageResults?: Maybe<SecurityCoverageResultConnection>;
   securityCoverages?: Maybe<SecurityCoverageConnection>;
   securityOrganizations?: Maybe<OrganizationConnection>;
   securityPlatform?: Maybe<SecurityPlatform>;
@@ -25949,6 +25965,11 @@ export type QueryLanguagesArgs = {
 };
 
 
+export type QueryListSecurityCoverageResultsByResultOfArgs = {
+  id: Scalars['String']['input'];
+};
+
+
 export type QueryLocationArgs = {
   id: Scalars['String']['input'];
 };
@@ -26666,6 +26687,22 @@ export type QuerySectorsArgs = {
 
 export type QuerySecurityCoverageArgs = {
   id: Scalars['String']['input'];
+};
+
+
+export type QuerySecurityCoverageResultArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QuerySecurityCoverageResultsArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<SecurityCoverageResultOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  toStix?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
@@ -29854,6 +29891,293 @@ export enum SecurityCoverageOrdering {
   Score = '_score',
   Confidence = 'confidence',
   CoverageLastResult = 'coverage_last_result',
+  Created = 'created',
+  CreatedAt = 'created_at',
+  Creator = 'creator',
+  Modified = 'modified',
+  Name = 'name',
+  ObjectMarking = 'objectMarking',
+  UpdatedAt = 'updated_at'
+}
+
+export type SecurityCoverageResult = BasicObject & StixCoreObject & StixDomainObject & StixObject & {
+  __typename?: 'SecurityCoverageResult';
+  avatar?: Maybe<OpenCtiFile>;
+  cases?: Maybe<CaseConnection>;
+  confidence?: Maybe<Scalars['Int']['output']>;
+  connectors?: Maybe<Array<Maybe<Connector>>>;
+  contact_information?: Maybe<Scalars['String']['output']>;
+  containers?: Maybe<ContainerConnection>;
+  containersNumber?: Maybe<Number>;
+  coverage_information?: Maybe<Array<CoverageResult>>;
+  coverage_last_result?: Maybe<Scalars['DateTime']['output']>;
+  coverage_valid_from?: Maybe<Scalars['DateTime']['output']>;
+  coverage_valid_to?: Maybe<Scalars['DateTime']['output']>;
+  created?: Maybe<Scalars['DateTime']['output']>;
+  createdBy?: Maybe<Identity>;
+  created_at: Scalars['DateTime']['output'];
+  creators?: Maybe<Array<Creator>>;
+  currentUserAccessRight?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  draftVersion?: Maybe<DraftVersion>;
+  editContext?: Maybe<Array<EditUserContext>>;
+  entity_type: Scalars['String']['output'];
+  exportFiles?: Maybe<FileConnection>;
+  externalReferences?: Maybe<ExternalReferenceConnection>;
+  external_uri?: Maybe<Scalars['String']['output']>;
+  filesFromTemplate?: Maybe<FileConnection>;
+  fintelTemplates?: Maybe<Array<FintelTemplate>>;
+  groupings?: Maybe<GroupingConnection>;
+  id: Scalars['ID']['output'];
+  identity_class: Scalars['String']['output'];
+  importFiles?: Maybe<FileConnection>;
+  is_inferred: Scalars['Boolean']['output'];
+  jobs?: Maybe<Array<Maybe<Work>>>;
+  lang?: Maybe<Scalars['String']['output']>;
+  metrics?: Maybe<Array<Maybe<Metric>>>;
+  modified?: Maybe<Scalars['DateTime']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  notes?: Maybe<NoteConnection>;
+  numberOfConnectedElement: Scalars['Int']['output'];
+  objectAssignee?: Maybe<Array<Assignee>>;
+  objectLabel?: Maybe<Array<Label>>;
+  objectMarking?: Maybe<Array<MarkingDefinition>>;
+  objectOrganization?: Maybe<Array<Organization>>;
+  objectParticipant?: Maybe<Array<Participant>>;
+  observedData?: Maybe<ObservedDataConnection>;
+  opinions?: Maybe<OpinionConnection>;
+  opinions_metrics?: Maybe<OpinionsMetrics>;
+  parent_types: Array<Scalars['String']['output']>;
+  pendingFiles?: Maybe<FileConnection>;
+  pirInformation?: Maybe<PirInformation>;
+  refreshed_at?: Maybe<Scalars['DateTime']['output']>;
+  reports?: Maybe<ReportConnection>;
+  representative: Representative;
+  revoked: Scalars['Boolean']['output'];
+  roles?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  spec_version: Scalars['String']['output'];
+  standard_id: Scalars['String']['output'];
+  status?: Maybe<Status>;
+  stixCoreObjectsDistribution?: Maybe<Array<Maybe<Distribution>>>;
+  stixCoreRelationships?: Maybe<StixCoreRelationshipConnection>;
+  stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<Distribution>>>;
+  toStix?: Maybe<Scalars['String']['output']>;
+  updated_at: Scalars['DateTime']['output'];
+  workflowEnabled?: Maybe<Scalars['Boolean']['output']>;
+  x_opencti_aliases?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  x_opencti_graph_data?: Maybe<Scalars['String']['output']>;
+  x_opencti_inferences?: Maybe<Array<Maybe<Inference>>>;
+  x_opencti_modified_at?: Maybe<Scalars['DateTime']['output']>;
+  x_opencti_reliability?: Maybe<Scalars['String']['output']>;
+  x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
+};
+
+
+export type SecurityCoverageResultCasesArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultConnectorsArgs = {
+  onlyAlive?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type SecurityCoverageResultContainersArgs = {
+  entityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultExportFilesArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultExternalReferencesArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultFilesFromTemplateArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<FileOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  prefixMimeType?: InputMaybe<Scalars['String']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type SecurityCoverageResultGroupingsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultImportFilesArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<FileOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  prefixMimeType?: InputMaybe<Scalars['String']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type SecurityCoverageResultJobsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultNotesArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultObservedDataArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultOpinionsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultPendingFilesArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<FileOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type SecurityCoverageResultPirInformationArgs = {
+  pirId: Scalars['ID']['input'];
+};
+
+
+export type SecurityCoverageResultReportsArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type SecurityCoverageResultStixCoreObjectsDistributionArgs = {
+  dateAttribute?: InputMaybe<Scalars['String']['input']>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  field: Scalars['String']['input'];
+  filters?: InputMaybe<FilterGroup>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  operation: StatsOperation;
+  order?: InputMaybe<Scalars['String']['input']>;
+  relationship_type?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  startDate?: InputMaybe<Scalars['DateTime']['input']>;
+  toTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  types?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type SecurityCoverageResultStixCoreRelationshipsArgs = {
+  after?: InputMaybe<Scalars['ID']['input']>;
+  confidences?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  filters?: InputMaybe<FilterGroup>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  firstSeenStart?: InputMaybe<Scalars['DateTime']['input']>;
+  firstSeenStop?: InputMaybe<Scalars['DateTime']['input']>;
+  fromId?: InputMaybe<Scalars['StixRef']['input']>;
+  fromTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  lastSeenStart?: InputMaybe<Scalars['DateTime']['input']>;
+  lastSeenStop?: InputMaybe<Scalars['DateTime']['input']>;
+  orderBy?: InputMaybe<StixCoreRelationshipsOrdering>;
+  orderMode?: InputMaybe<OrderingMode>;
+  relationship_type?: InputMaybe<Scalars['String']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  startTimeStart?: InputMaybe<Scalars['DateTime']['input']>;
+  startTimeStop?: InputMaybe<Scalars['DateTime']['input']>;
+  stopTimeStart?: InputMaybe<Scalars['DateTime']['input']>;
+  stopTimeStop?: InputMaybe<Scalars['DateTime']['input']>;
+  toId?: InputMaybe<Scalars['StixRef']['input']>;
+  toTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type SecurityCoverageResultStixCoreRelationshipsDistributionArgs = {
+  confidences?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  dateAttribute?: InputMaybe<Scalars['String']['input']>;
+  elementWithTargetTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  endDate?: InputMaybe<Scalars['DateTime']['input']>;
+  field: Scalars['String']['input'];
+  filters?: InputMaybe<FilterGroup>;
+  fromId?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fromRole?: InputMaybe<Scalars['String']['input']>;
+  fromTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  isTo?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  operation: StatsOperation;
+  order?: InputMaybe<Scalars['String']['input']>;
+  relationship_type?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  startDate?: InputMaybe<Scalars['DateTime']['input']>;
+  toId?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  toRole?: InputMaybe<Scalars['String']['input']>;
+  toTypes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+export type SecurityCoverageResultToStixArgs = {
+  version?: InputMaybe<Version>;
+};
+
+export type SecurityCoverageResultAddInput = {
+  confidence?: InputMaybe<Scalars['Int']['input']>;
+  coverage_information?: InputMaybe<Array<SecurityCoverageExpectation>>;
+  coverage_last_result?: InputMaybe<Scalars['DateTime']['input']>;
+  coverage_valid_from?: InputMaybe<Scalars['DateTime']['input']>;
+  coverage_valid_to?: InputMaybe<Scalars['DateTime']['input']>;
+  created?: InputMaybe<Scalars['DateTime']['input']>;
+  createdBy?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  embedded?: InputMaybe<Array<InputMaybe<Scalars['Boolean']['input']>>>;
+  externalReferences?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  external_uri?: InputMaybe<Scalars['String']['input']>;
+  file?: InputMaybe<Scalars['Upload']['input']>;
+  fileMarkings?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  files?: InputMaybe<Array<InputMaybe<Scalars['Upload']['input']>>>;
+  filesMarkings?: InputMaybe<Array<InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>>>;
+  modified?: InputMaybe<Scalars['DateTime']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  noTriggerImport?: InputMaybe<Array<InputMaybe<Scalars['Boolean']['input']>>>;
+  objectLabel?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  objectMarking?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  resultOf: Scalars['String']['input'];
+  revoked?: InputMaybe<Scalars['Boolean']['input']>;
+  stix_id?: InputMaybe<Scalars['StixId']['input']>;
+  update?: InputMaybe<Scalars['Boolean']['input']>;
+  x_opencti_modified_at?: InputMaybe<Scalars['DateTime']['input']>;
+  x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
+  x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type SecurityCoverageResultConnection = {
+  __typename?: 'SecurityCoverageResultConnection';
+  edges: Array<SecurityCoverageResultEdge>;
+  pageInfo: PageInfo;
+};
+
+export type SecurityCoverageResultEdge = {
+  __typename?: 'SecurityCoverageResultEdge';
+  cursor: Scalars['String']['output'];
+  node: SecurityCoverageResult;
+};
+
+export enum SecurityCoverageResultOrdering {
+  Score = '_score',
+  Confidence = 'confidence',
   Created = 'created',
   CreatedAt = 'created_at',
   Creator = 'creator',
@@ -38894,6 +39218,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( BasicStoreEntitySavedFilter )
     | ( Omit<Sector, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'parentSectors' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'subSectors' | 'targetedOrganizations' | 'x_opencti_inferences'> & { avatar?: Maybe<_RefType['OpenCtiFile']>, cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<_RefType['FileConnection']>, fintelTemplates?: Maybe<Array<_RefType['FintelTemplate']>>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, parentSectors?: Maybe<_RefType['SectorConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, status?: Maybe<_RefType['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, subSectors?: Maybe<_RefType['SectorConnection']>, targetedOrganizations?: Maybe<_RefType['StixCoreRelationshipConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( BasicStoreEntitySecurityCoverage )
+    | ( BasicStoreEntitySecurityCoverageResult )
     | ( BasicStoreEntitySecurityPlatform )
     | ( Omit<Settings, 'activity_listeners' | 'editContext' | 'messages_administration' | 'platform_critical_alerts' | 'platform_messages' | 'platform_organization' | 'platform_theme'> & { activity_listeners?: Maybe<Array<_RefType['Member']>>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, messages_administration?: Maybe<Array<_RefType['SettingsMessage']>>, platform_critical_alerts: Array<_RefType['PlatformCriticalAlert']>, platform_messages?: Maybe<Array<_RefType['SettingsMessage']>>, platform_organization?: Maybe<_RefType['Organization']>, platform_theme?: Maybe<_RefType['Theme']> } )
     | ( Omit<Software, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'vulnerabilities' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, vulnerabilities?: Maybe<_RefType['VulnerabilityConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
@@ -39076,6 +39401,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( Omit<SshKey, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( Omit<Sector, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'parentSectors' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'subSectors' | 'targetedOrganizations' | 'x_opencti_inferences'> & { avatar?: Maybe<_RefType['OpenCtiFile']>, cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<_RefType['FileConnection']>, fintelTemplates?: Maybe<Array<_RefType['FintelTemplate']>>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, parentSectors?: Maybe<_RefType['SectorConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, status?: Maybe<_RefType['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, subSectors?: Maybe<_RefType['SectorConnection']>, targetedOrganizations?: Maybe<_RefType['StixCoreRelationshipConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( BasicStoreEntitySecurityCoverage )
+    | ( BasicStoreEntitySecurityCoverageResult )
     | ( BasicStoreEntitySecurityPlatform )
     | ( Omit<Software, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'vulnerabilities' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, vulnerabilities?: Maybe<_RefType['VulnerabilityConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( Omit<StixFile, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'obsContent' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, obsContent?: Maybe<_RefType['Artifact']>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
@@ -39167,6 +39493,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( Omit<Report, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'objects' | 'observedData' | 'opinions' | 'pendingFiles' | 'relatedContainers' | 'reports' | 'securityCoverage' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<_RefType['OpenCtiFile']>, cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<_RefType['FileConnection']>, fintelTemplates?: Maybe<Array<_RefType['FintelTemplate']>>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, objects?: Maybe<_RefType['StixObjectOrStixRelationshipRefConnection']>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, relatedContainers?: Maybe<_RefType['ContainerConnection']>, reports?: Maybe<_RefType['ReportConnection']>, securityCoverage?: Maybe<_RefType['SecurityCoverage']>, status?: Maybe<_RefType['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( Omit<Sector, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'parentSectors' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'subSectors' | 'targetedOrganizations' | 'x_opencti_inferences'> & { avatar?: Maybe<_RefType['OpenCtiFile']>, cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<_RefType['FileConnection']>, fintelTemplates?: Maybe<Array<_RefType['FintelTemplate']>>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, parentSectors?: Maybe<_RefType['SectorConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, status?: Maybe<_RefType['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, subSectors?: Maybe<_RefType['SectorConnection']>, targetedOrganizations?: Maybe<_RefType['StixCoreRelationshipConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( BasicStoreEntitySecurityCoverage )
+    | ( BasicStoreEntitySecurityCoverageResult )
     | ( BasicStoreEntitySecurityPlatform )
     | ( Omit<System, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'organizations' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<_RefType['OpenCtiFile']>, cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<_RefType['FileConnection']>, fintelTemplates?: Maybe<Array<_RefType['FintelTemplate']>>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, organizations?: Maybe<_RefType['OrganizationConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, status?: Maybe<_RefType['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( BasicStoreEntityTask )
@@ -39247,6 +39574,7 @@ export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = 
     | ( Omit<SshKey, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( Omit<Sector, 'avatar' | 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'parentSectors' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'subSectors' | 'targetedOrganizations' | 'x_opencti_inferences'> & { avatar?: Maybe<_RefType['OpenCtiFile']>, cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<_RefType['FileConnection']>, fintelTemplates?: Maybe<Array<_RefType['FintelTemplate']>>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, parentSectors?: Maybe<_RefType['SectorConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, status?: Maybe<_RefType['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, subSectors?: Maybe<_RefType['SectorConnection']>, targetedOrganizations?: Maybe<_RefType['StixCoreRelationshipConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( BasicStoreEntitySecurityCoverage )
+    | ( BasicStoreEntitySecurityCoverageResult )
     | ( BasicStoreEntitySecurityPlatform )
     | ( Omit<Software, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'vulnerabilities' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, vulnerabilities?: Maybe<_RefType['VulnerabilityConnection']>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
     | ( Omit<StixFile, 'cases' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'groupings' | 'importFiles' | 'indicators' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'obsContent' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { cases?: Maybe<_RefType['CaseConnection']>, connectors?: Maybe<Array<Maybe<_RefType['Connector']>>>, containers?: Maybe<_RefType['ContainerConnection']>, createdBy?: Maybe<_RefType['Identity']>, editContext?: Maybe<Array<_RefType['EditUserContext']>>, exportFiles?: Maybe<_RefType['FileConnection']>, externalReferences?: Maybe<_RefType['ExternalReferenceConnection']>, groupings?: Maybe<_RefType['GroupingConnection']>, importFiles?: Maybe<_RefType['FileConnection']>, indicators?: Maybe<_RefType['IndicatorConnection']>, jobs?: Maybe<Array<Maybe<_RefType['Work']>>>, notes?: Maybe<_RefType['NoteConnection']>, objectLabel?: Maybe<Array<_RefType['Label']>>, objectMarking?: Maybe<Array<_RefType['MarkingDefinition']>>, objectOrganization?: Maybe<Array<_RefType['Organization']>>, obsContent?: Maybe<_RefType['Artifact']>, observedData?: Maybe<_RefType['ObservedDataConnection']>, opinions?: Maybe<_RefType['OpinionConnection']>, pendingFiles?: Maybe<_RefType['FileConnection']>, reports?: Maybe<_RefType['ReportConnection']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, stixCoreRelationships?: Maybe<_RefType['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<_RefType['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<_RefType['Inference']>>> } )
@@ -40139,6 +40467,11 @@ export type ResolversTypes = ResolversObject<{
   SecurityCoverageEdge: ResolverTypeWrapper<Omit<SecurityCoverageEdge, 'node'> & { node: ResolversTypes['SecurityCoverage'] }>;
   SecurityCoverageExpectation: SecurityCoverageExpectation;
   SecurityCoverageOrdering: SecurityCoverageOrdering;
+  SecurityCoverageResult: ResolverTypeWrapper<BasicStoreEntitySecurityCoverageResult>;
+  SecurityCoverageResultAddInput: SecurityCoverageResultAddInput;
+  SecurityCoverageResultConnection: ResolverTypeWrapper<Omit<SecurityCoverageResultConnection, 'edges'> & { edges: Array<ResolversTypes['SecurityCoverageResultEdge']> }>;
+  SecurityCoverageResultEdge: ResolverTypeWrapper<Omit<SecurityCoverageResultEdge, 'node'> & { node: ResolversTypes['SecurityCoverageResult'] }>;
+  SecurityCoverageResultOrdering: SecurityCoverageResultOrdering;
   SecurityPlatform: ResolverTypeWrapper<BasicStoreEntitySecurityPlatform>;
   SecurityPlatformAddInput: SecurityPlatformAddInput;
   SecurityPlatformConnection: ResolverTypeWrapper<Omit<SecurityPlatformConnection, 'edges'> & { edges: Array<ResolversTypes['SecurityPlatformEdge']> }>;
@@ -41164,6 +41497,10 @@ export type ResolversParentTypes = ResolversObject<{
   SecurityCoverageConnection: Omit<SecurityCoverageConnection, 'edges'> & { edges: Array<ResolversParentTypes['SecurityCoverageEdge']> };
   SecurityCoverageEdge: Omit<SecurityCoverageEdge, 'node'> & { node: ResolversParentTypes['SecurityCoverage'] };
   SecurityCoverageExpectation: SecurityCoverageExpectation;
+  SecurityCoverageResult: BasicStoreEntitySecurityCoverageResult;
+  SecurityCoverageResultAddInput: SecurityCoverageResultAddInput;
+  SecurityCoverageResultConnection: Omit<SecurityCoverageResultConnection, 'edges'> & { edges: Array<ResolversParentTypes['SecurityCoverageResultEdge']> };
+  SecurityCoverageResultEdge: Omit<SecurityCoverageResultEdge, 'node'> & { node: ResolversParentTypes['SecurityCoverageResult'] };
   SecurityPlatform: BasicStoreEntitySecurityPlatform;
   SecurityPlatformAddInput: SecurityPlatformAddInput;
   SecurityPlatformConnection: Omit<SecurityPlatformConnection, 'edges'> & { edges: Array<ResolversParentTypes['SecurityPlatformEdge']> };
@@ -42123,7 +42460,7 @@ export type BankAccountResolvers<ContextType = any, ParentType extends Resolvers
 }>;
 
 export type BasicObjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['BasicObject'] = ResolversParentTypes['BasicObject']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AuthenticationProvider' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'Capability' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'CaseTemplate' | 'Catalog' | 'Channel' | 'City' | 'Connector' | 'ConnectorManager' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'CsvMapper' | 'CustomView' | 'DataComponent' | 'DataSource' | 'DecayExclusionRule' | 'DecayRule' | 'DeleteOperation' | 'Directory' | 'DisseminationList' | 'DomainName' | 'DraftWorkspace' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'EmailTemplate' | 'EntitySetting' | 'Event' | 'ExclusionList' | 'ExternalReference' | 'Feedback' | 'FintelDesign' | 'FintelTemplate' | 'Form' | 'Group' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IngestionCsv' | 'IngestionJson' | 'IngestionRss' | 'IngestionTaxii' | 'IngestionTaxiiCollection' | 'IntrusionSet' | 'JsonMapper' | 'KillChainPhase' | 'Label' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'ManagedConnector' | 'ManagerConfiguration' | 'MarkingDefinition' | 'MeUser' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'NewsFeedItem' | 'Note' | 'Notification' | 'Notifier' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Pir' | 'Playbook' | 'Position' | 'Process' | 'PublicDashboard' | 'Region' | 'Report' | 'Role' | 'SSHKey' | 'SavedFilter' | 'Sector' | 'SecurityCoverage' | 'SecurityPlatform' | 'Settings' | 'Software' | 'StixFile' | 'SupportPackage' | 'System' | 'Task' | 'TaskTemplate' | 'Text' | 'Theme' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Trigger' | 'Url' | 'User' | 'UserAccount' | 'UserAgent' | 'Vocabulary' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'Workspace' | 'X509Certificate', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AuthenticationProvider' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'Capability' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'CaseTemplate' | 'Catalog' | 'Channel' | 'City' | 'Connector' | 'ConnectorManager' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'CsvMapper' | 'CustomView' | 'DataComponent' | 'DataSource' | 'DecayExclusionRule' | 'DecayRule' | 'DeleteOperation' | 'Directory' | 'DisseminationList' | 'DomainName' | 'DraftWorkspace' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'EmailTemplate' | 'EntitySetting' | 'Event' | 'ExclusionList' | 'ExternalReference' | 'Feedback' | 'FintelDesign' | 'FintelTemplate' | 'Form' | 'Group' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IngestionCsv' | 'IngestionJson' | 'IngestionRss' | 'IngestionTaxii' | 'IngestionTaxiiCollection' | 'IntrusionSet' | 'JsonMapper' | 'KillChainPhase' | 'Label' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'ManagedConnector' | 'ManagerConfiguration' | 'MarkingDefinition' | 'MeUser' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'NewsFeedItem' | 'Note' | 'Notification' | 'Notifier' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Pir' | 'Playbook' | 'Position' | 'Process' | 'PublicDashboard' | 'Region' | 'Report' | 'Role' | 'SSHKey' | 'SavedFilter' | 'Sector' | 'SecurityCoverage' | 'SecurityCoverageResult' | 'SecurityPlatform' | 'Settings' | 'Software' | 'StixFile' | 'SupportPackage' | 'System' | 'Task' | 'TaskTemplate' | 'Text' | 'Theme' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Trigger' | 'Url' | 'User' | 'UserAccount' | 'UserAgent' | 'Vocabulary' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'Workspace' | 'X509Certificate', ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
@@ -47505,6 +47842,8 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   securityCoverageFieldPatch?: Resolver<Maybe<ResolversTypes['SecurityCoverage']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageFieldPatchArgs, 'id' | 'input'>>;
   securityCoverageRelationAdd?: Resolver<Maybe<ResolversTypes['StixRefRelationship']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageRelationAddArgs, 'id' | 'input'>>;
   securityCoverageRelationDelete?: Resolver<Maybe<ResolversTypes['SecurityCoverage']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageRelationDeleteArgs, 'id' | 'relationship_type' | 'toId'>>;
+  securityCoverageResultAdd?: Resolver<Maybe<ResolversTypes['SecurityCoverageResult']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageResultAddArgs, 'input'>>;
+  securityCoverageResultDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageResultDeleteArgs, 'id'>>;
   securityPlatformAdd?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<MutationSecurityPlatformAddArgs, 'input'>>;
   securityPlatformContextClean?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<MutationSecurityPlatformContextCleanArgs, 'id'>>;
   securityPlatformContextPatch?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<MutationSecurityPlatformContextPatchArgs, 'id' | 'input'>>;
@@ -49209,6 +49548,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   labels?: Resolver<Maybe<ResolversTypes['LabelConnection']>, ParentType, ContextType, Partial<QueryLabelsArgs>>;
   language?: Resolver<Maybe<ResolversTypes['Language']>, ParentType, ContextType, RequireFields<QueryLanguageArgs, 'id'>>;
   languages?: Resolver<Maybe<ResolversTypes['LanguageConnection']>, ParentType, ContextType, Partial<QueryLanguagesArgs>>;
+  listSecurityCoverageResultsByResultOf?: Resolver<Maybe<Array<ResolversTypes['SecurityCoverageResult']>>, ParentType, ContextType, RequireFields<QueryListSecurityCoverageResultsByResultOfArgs, 'id'>>;
   location?: Resolver<Maybe<ResolversTypes['Location']>, ParentType, ContextType, RequireFields<QueryLocationArgs, 'id'>>;
   locations?: Resolver<Maybe<ResolversTypes['LocationConnection']>, ParentType, ContextType, Partial<QueryLocationsArgs>>;
   log?: Resolver<Maybe<ResolversTypes['Log']>, ParentType, ContextType, RequireFields<QueryLogArgs, 'id'>>;
@@ -49313,6 +49653,8 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   sector?: Resolver<Maybe<ResolversTypes['Sector']>, ParentType, ContextType, Partial<QuerySectorArgs>>;
   sectors?: Resolver<Maybe<ResolversTypes['SectorConnection']>, ParentType, ContextType, Partial<QuerySectorsArgs>>;
   securityCoverage?: Resolver<Maybe<ResolversTypes['SecurityCoverage']>, ParentType, ContextType, RequireFields<QuerySecurityCoverageArgs, 'id'>>;
+  securityCoverageResult?: Resolver<Maybe<ResolversTypes['SecurityCoverageResult']>, ParentType, ContextType, RequireFields<QuerySecurityCoverageResultArgs, 'id'>>;
+  securityCoverageResults?: Resolver<Maybe<ResolversTypes['SecurityCoverageResultConnection']>, ParentType, ContextType, Partial<QuerySecurityCoverageResultsArgs>>;
   securityCoverages?: Resolver<Maybe<ResolversTypes['SecurityCoverageConnection']>, ParentType, ContextType, Partial<QuerySecurityCoveragesArgs>>;
   securityOrganizations?: Resolver<Maybe<ResolversTypes['OrganizationConnection']>, ParentType, ContextType, Partial<QuerySecurityOrganizationsArgs>>;
   securityPlatform?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<QuerySecurityPlatformArgs, 'id'>>;
@@ -50159,6 +50501,88 @@ export type SecurityCoverageEdgeResolvers<ContextType = any, ParentType extends 
   node?: Resolver<ResolversTypes['SecurityCoverage'], ParentType, ContextType>;
 }>;
 
+export type SecurityCoverageResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['SecurityCoverageResult'] = ResolversParentTypes['SecurityCoverageResult']> = ResolversObject<{
+  avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
+  cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultCasesArgs>>;
+  confidence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  connectors?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType, Partial<SecurityCoverageResultConnectorsArgs>>;
+  contact_information?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  containers?: Resolver<Maybe<ResolversTypes['ContainerConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultContainersArgs>>;
+  containersNumber?: Resolver<Maybe<ResolversTypes['Number']>, ParentType, ContextType>;
+  coverage_information?: Resolver<Maybe<Array<ResolversTypes['CoverageResult']>>, ParentType, ContextType>;
+  coverage_last_result?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  coverage_valid_from?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  coverage_valid_to?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  created?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  createdBy?: Resolver<Maybe<ResolversTypes['Identity']>, ParentType, ContextType>;
+  created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  creators?: Resolver<Maybe<Array<ResolversTypes['Creator']>>, ParentType, ContextType>;
+  currentUserAccessRight?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  draftVersion?: Resolver<Maybe<ResolversTypes['DraftVersion']>, ParentType, ContextType>;
+  editContext?: Resolver<Maybe<Array<ResolversTypes['EditUserContext']>>, ParentType, ContextType>;
+  entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  exportFiles?: Resolver<Maybe<ResolversTypes['FileConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultExportFilesArgs>>;
+  externalReferences?: Resolver<Maybe<ResolversTypes['ExternalReferenceConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultExternalReferencesArgs>>;
+  external_uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  filesFromTemplate?: Resolver<Maybe<ResolversTypes['FileConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultFilesFromTemplateArgs>>;
+  fintelTemplates?: Resolver<Maybe<Array<ResolversTypes['FintelTemplate']>>, ParentType, ContextType>;
+  groupings?: Resolver<Maybe<ResolversTypes['GroupingConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultGroupingsArgs>>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  identity_class?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  importFiles?: Resolver<Maybe<ResolversTypes['FileConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultImportFilesArgs>>;
+  is_inferred?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  jobs?: Resolver<Maybe<Array<Maybe<ResolversTypes['Work']>>>, ParentType, ContextType, Partial<SecurityCoverageResultJobsArgs>>;
+  lang?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
+  modified?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['NoteConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultNotesArgs>>;
+  numberOfConnectedElement?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  objectAssignee?: Resolver<Maybe<Array<ResolversTypes['Assignee']>>, ParentType, ContextType>;
+  objectLabel?: Resolver<Maybe<Array<ResolversTypes['Label']>>, ParentType, ContextType>;
+  objectMarking?: Resolver<Maybe<Array<ResolversTypes['MarkingDefinition']>>, ParentType, ContextType>;
+  objectOrganization?: Resolver<Maybe<Array<ResolversTypes['Organization']>>, ParentType, ContextType>;
+  objectParticipant?: Resolver<Maybe<Array<ResolversTypes['Participant']>>, ParentType, ContextType>;
+  observedData?: Resolver<Maybe<ResolversTypes['ObservedDataConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultObservedDataArgs>>;
+  opinions?: Resolver<Maybe<ResolversTypes['OpinionConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultOpinionsArgs>>;
+  opinions_metrics?: Resolver<Maybe<ResolversTypes['OpinionsMetrics']>, ParentType, ContextType>;
+  parent_types?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  pendingFiles?: Resolver<Maybe<ResolversTypes['FileConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultPendingFilesArgs>>;
+  pirInformation?: Resolver<Maybe<ResolversTypes['PirInformation']>, ParentType, ContextType, RequireFields<SecurityCoverageResultPirInformationArgs, 'pirId'>>;
+  refreshed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  reports?: Resolver<Maybe<ResolversTypes['ReportConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultReportsArgs>>;
+  representative?: Resolver<ResolversTypes['Representative'], ParentType, ContextType>;
+  revoked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  roles?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  spec_version?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  standard_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['Status']>, ParentType, ContextType>;
+  stixCoreObjectsDistribution?: Resolver<Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, ParentType, ContextType, RequireFields<SecurityCoverageResultStixCoreObjectsDistributionArgs, 'field' | 'operation'>>;
+  stixCoreRelationships?: Resolver<Maybe<ResolversTypes['StixCoreRelationshipConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultStixCoreRelationshipsArgs>>;
+  stixCoreRelationshipsDistribution?: Resolver<Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, ParentType, ContextType, RequireFields<SecurityCoverageResultStixCoreRelationshipsDistributionArgs, 'field' | 'operation'>>;
+  toStix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType, Partial<SecurityCoverageResultToStixArgs>>;
+  updated_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  workflowEnabled?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  x_opencti_aliases?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  x_opencti_graph_data?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
+  x_opencti_modified_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  x_opencti_reliability?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type SecurityCoverageResultConnectionResolvers<ContextType = any, ParentType extends ResolversParentTypes['SecurityCoverageResultConnection'] = ResolversParentTypes['SecurityCoverageResultConnection']> = ResolversObject<{
+  edges?: Resolver<Array<ResolversTypes['SecurityCoverageResultEdge']>, ParentType, ContextType>;
+  pageInfo?: Resolver<ResolversTypes['PageInfo'], ParentType, ContextType>;
+}>;
+
+export type SecurityCoverageResultEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['SecurityCoverageResultEdge'] = ResolversParentTypes['SecurityCoverageResultEdge']> = ResolversObject<{
+  cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<ResolversTypes['SecurityCoverageResult'], ParentType, ContextType>;
+}>;
+
 export type SecurityPlatformResolvers<ContextType = any, ParentType extends ResolversParentTypes['SecurityPlatform'] = ResolversParentTypes['SecurityPlatform']> = ResolversObject<{
   avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<SecurityPlatformCasesArgs>>;
@@ -50458,7 +50882,7 @@ export type StatusTemplateEdgeResolvers<ContextType = any, ParentType extends Re
 }>;
 
 export type StixCoreObjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['StixCoreObject'] = ResolversParentTypes['StixCoreObject']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'Channel' | 'City' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'DataComponent' | 'DataSource' | 'Directory' | 'DomainName' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'Event' | 'Feedback' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IntrusionSet' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'Note' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Position' | 'Process' | 'Region' | 'Report' | 'SSHKey' | 'Sector' | 'SecurityCoverage' | 'SecurityPlatform' | 'Software' | 'StixFile' | 'System' | 'Task' | 'Text' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Url' | 'UserAccount' | 'UserAgent' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'X509Certificate', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'Channel' | 'City' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'DataComponent' | 'DataSource' | 'Directory' | 'DomainName' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'Event' | 'Feedback' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IntrusionSet' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'Note' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Position' | 'Process' | 'Region' | 'Report' | 'SSHKey' | 'Sector' | 'SecurityCoverage' | 'SecurityCoverageResult' | 'SecurityPlatform' | 'Software' | 'StixFile' | 'System' | 'Task' | 'Text' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Url' | 'UserAccount' | 'UserAgent' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'X509Certificate', ParentType, ContextType>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<StixCoreObjectCasesArgs>>;
   connectors?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connector']>>>, ParentType, ContextType, Partial<StixCoreObjectConnectorsArgs>>;
   containers?: Resolver<Maybe<ResolversTypes['ContainerConnection']>, ParentType, ContextType, Partial<StixCoreObjectContainersArgs>>;
@@ -50691,7 +51115,7 @@ export type StixCyberObservableEditMutationsResolvers<ContextType = any, ParentT
 }>;
 
 export type StixDomainObjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['StixDomainObject'] = ResolversParentTypes['StixDomainObject']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AdministrativeArea' | 'AttackPattern' | 'Campaign' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'Channel' | 'City' | 'Country' | 'CourseOfAction' | 'DataComponent' | 'DataSource' | 'Event' | 'Feedback' | 'Grouping' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IntrusionSet' | 'Language' | 'Malware' | 'MalwareAnalysis' | 'Narrative' | 'Note' | 'ObservedData' | 'Opinion' | 'Organization' | 'Position' | 'Region' | 'Report' | 'Sector' | 'SecurityCoverage' | 'SecurityPlatform' | 'System' | 'Task' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'Vulnerability', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AdministrativeArea' | 'AttackPattern' | 'Campaign' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'Channel' | 'City' | 'Country' | 'CourseOfAction' | 'DataComponent' | 'DataSource' | 'Event' | 'Feedback' | 'Grouping' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IntrusionSet' | 'Language' | 'Malware' | 'MalwareAnalysis' | 'Narrative' | 'Note' | 'ObservedData' | 'Opinion' | 'Organization' | 'Position' | 'Region' | 'Report' | 'Sector' | 'SecurityCoverage' | 'SecurityCoverageResult' | 'SecurityPlatform' | 'System' | 'Task' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'Vulnerability', ParentType, ContextType>;
   avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<StixDomainObjectCasesArgs>>;
   confidence?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -50885,7 +51309,7 @@ export type StixMetaObjectEdgeResolvers<ContextType = any, ParentType extends Re
 }>;
 
 export type StixObjectResolvers<ContextType = any, ParentType extends ResolversParentTypes['StixObject'] = ResolversParentTypes['StixObject']> = ResolversObject<{
-  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'Channel' | 'City' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'DataComponent' | 'DataSource' | 'Directory' | 'DomainName' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'Event' | 'ExternalReference' | 'Feedback' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IntrusionSet' | 'KillChainPhase' | 'Label' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'MarkingDefinition' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'Note' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Position' | 'Process' | 'Region' | 'Report' | 'SSHKey' | 'Sector' | 'SecurityCoverage' | 'SecurityPlatform' | 'Software' | 'StixFile' | 'System' | 'Task' | 'Text' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Url' | 'UserAccount' | 'UserAgent' | 'Vocabulary' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'X509Certificate', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'AIPrompt' | 'AdministrativeArea' | 'Artifact' | 'AttackPattern' | 'AutonomousSystem' | 'BankAccount' | 'Campaign' | 'CaseIncident' | 'CaseRfi' | 'CaseRft' | 'Channel' | 'City' | 'Country' | 'CourseOfAction' | 'Credential' | 'CryptocurrencyWallet' | 'CryptographicKey' | 'DataComponent' | 'DataSource' | 'Directory' | 'DomainName' | 'EmailAddr' | 'EmailMessage' | 'EmailMimePartType' | 'Event' | 'ExternalReference' | 'Feedback' | 'Grouping' | 'Hostname' | 'ICCID' | 'IMEI' | 'IMSI' | 'IPv4Addr' | 'IPv6Addr' | 'Incident' | 'Indicator' | 'Individual' | 'Infrastructure' | 'IntrusionSet' | 'KillChainPhase' | 'Label' | 'Language' | 'MacAddr' | 'Malware' | 'MalwareAnalysis' | 'MarkingDefinition' | 'MediaContent' | 'Mutex' | 'Narrative' | 'NetworkTraffic' | 'Note' | 'ObservedData' | 'Opinion' | 'Organization' | 'PaymentCard' | 'Persona' | 'PhoneNumber' | 'Position' | 'Process' | 'Region' | 'Report' | 'SSHKey' | 'Sector' | 'SecurityCoverage' | 'SecurityCoverageResult' | 'SecurityPlatform' | 'Software' | 'StixFile' | 'System' | 'Task' | 'Text' | 'ThreatActorGroup' | 'ThreatActorIndividual' | 'Tool' | 'TrackingNumber' | 'Url' | 'UserAccount' | 'UserAgent' | 'Vocabulary' | 'Vulnerability' | 'WindowsRegistryKey' | 'WindowsRegistryValueType' | 'X509Certificate', ParentType, ContextType>;
   created_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   creators?: Resolver<Maybe<Array<ResolversTypes['Creator']>>, ParentType, ContextType>;
   draftVersion?: Resolver<Maybe<ResolversTypes['DraftVersion']>, ParentType, ContextType>;
@@ -53545,6 +53969,9 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   SecurityCoverage?: SecurityCoverageResolvers<ContextType>;
   SecurityCoverageConnection?: SecurityCoverageConnectionResolvers<ContextType>;
   SecurityCoverageEdge?: SecurityCoverageEdgeResolvers<ContextType>;
+  SecurityCoverageResult?: SecurityCoverageResultResolvers<ContextType>;
+  SecurityCoverageResultConnection?: SecurityCoverageResultConnectionResolvers<ContextType>;
+  SecurityCoverageResultEdge?: SecurityCoverageResultEdgeResolvers<ContextType>;
   SecurityPlatform?: SecurityPlatformResolvers<ContextType>;
   SecurityPlatformConnection?: SecurityPlatformConnectionResolvers<ContextType>;
   SecurityPlatformEdge?: SecurityPlatformEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -154,6 +154,7 @@ import './pir/pir-graphql';
 import './fintelDesign/fintelDesign-graphql';
 import './securityPlatform/securityPlatform-graphql';
 import './securityCoverage/securityCoverage-graphql';
+import './securityCoverage/securityCoverageResult/securityCoverageResult-graphql';
 import './auth/auth-graphql';
 import './emailTemplate/emailTemplate-graphql';
 import './form/form-graphql';

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-converter.ts
@@ -1,7 +1,8 @@
-import { INPUT_COVERED, type StixSecurityCoverage, type StoreEntitySecurityCoverage } from './securityCoverage-types';
+import { ATTRIBUTE_COVERED, INPUT_COVERED, type StixSecurityCoverage, type StoreEntitySecurityCoverage } from './securityCoverage-types';
 import { buildStixDomain } from '../../database/stix-2-1-converter';
 import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
 import { cleanObject } from '../../database/stix-converter-utils';
+import { ATTRIBUTE_RESULT_OF, INPUT_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
 
 const convertSecurityCoverageToStix = (instance: StoreEntitySecurityCoverage): StixSecurityCoverage => {
   const stixDomainObject = buildStixDomain(instance);
@@ -13,7 +14,8 @@ const convertSecurityCoverageToStix = (instance: StoreEntitySecurityCoverage): S
     type_affinity: instance.type_affinity,
     platforms_affinity: instance.platforms_affinity,
     duration: instance.duration,
-    covered_ref: instance[INPUT_COVERED].standard_id,
+    [ATTRIBUTE_COVERED]: instance[INPUT_COVERED].standard_id,
+    [ATTRIBUTE_RESULT_OF]: (instance[INPUT_RESULT_OF] ?? []).map((scr) => scr.standard_id),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixDomainObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -1,19 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
-import {
-  type EntityOptions,
-  fullEntitiesList,
-  fullRelationsList,
-  loadEntityThroughRelationsPaginated,
-  pageEntitiesConnection,
-  storeLoadById,
-} from '../../database/middleware-loader';
+import { type EntityOptions, fullRelationsList, loadEntityThroughRelationsPaginated, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { type BasicStoreEntitySecurityCoverage, ENTITY_TYPE_SECURITY_COVERAGE, INPUT_COVERED, RELATION_COVERED, type StoreEntitySecurityCoverage } from './securityCoverage-types';
 import { notify } from '../../database/redis';
-import { BUS_TOPICS } from '../../config/conf';
+import { BUS_TOPICS, logApp } from '../../config/conf';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import { createEntity, deleteElementById, storeLoadByIdsWithRefs, storeLoadByIdWithRefs } from '../../database/middleware';
-import { FilterMode, FilterOperator, type SecurityCoverageAddInput } from '../../generated/graphql';
+import { type SecurityCoverageAddInput } from '../../generated/graphql';
 import type { BasicStoreEntity, StoreObject, StoreRelation } from '../../types/store';
 import { convertStoreToStix_2_1 } from '../../database/stix-2-1-converter';
 import { STIX_SPEC_VERSION } from '../../database/stix';
@@ -31,6 +24,7 @@ import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../grouping/grouping-types';
 import { deleteSecurityCoverageResultsByResultOf } from './securityCoverageResult/securityCoverageResult-domain';
 import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, INPUT_RESULT_OF, type BasicStoreEntitySecurityCoverageResult } from './securityCoverageResult/securityCoverageResult-types';
+import { loadThroughDenormalized } from '../../resolvers/stix';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -118,12 +112,15 @@ export const addSecurityCoverage = async (
       objectMarking,
       x_opencti_modified_at,
     };
-    await createEntity(
+    const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
       context,
       user,
       securityCoverageResultInput,
       ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
     );
+    // Manually add it here to be able to resolve dynamyc attributes
+    createdSecurityCoverage['result-of'] = [result.id];
+    logApp.info(`[SECURITY-COVERAGE-RESULT][${createdSecurityCoverage.id}] SCR created: ${result.standard_id}`);
   }
 
   return notify(
@@ -181,7 +178,8 @@ export const objectCovered = async <T extends BasicStoreEntity>(context: AuthCon
 };
 
 export const securityCoverageDelete = async (context: AuthContext, user: AuthUser, securityCoverageId: string) => {
-  await deleteSecurityCoverageResultsByResultOf(context, user, securityCoverageId);
+  const deletedResults = await deleteSecurityCoverageResultsByResultOf(context, user, securityCoverageId);
+  logApp.info(`[SECURITY-COVERAGE-RESULT][${securityCoverageId}] SCR deleted: ${deletedResults}`);
   await deleteElementById(context, user, securityCoverageId, ENTITY_TYPE_SECURITY_COVERAGE);
   await notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].DELETE_TOPIC, securityCoverageId, user);
   return securityCoverageId;
@@ -191,29 +189,10 @@ export const securityCoverageDelete = async (context: AuthContext, user: AuthUse
 export const getSecurityCoverageResultProperty = async (
   context: AuthContext,
   user: AuthUser,
-  securityCoverageId: string,
+  securityCoverage: BasicStoreEntitySecurityCoverage,
   property: keyof BasicStoreEntitySecurityCoverageResult,
 ) => {
-  // TODO : replace with function from chunk 2 : listSecurityCoverageResultsByResultOf
-  const results = await fullEntitiesList<BasicStoreEntitySecurityCoverageResult>(
-    context,
-    user,
-    [ENTITY_TYPE_SECURITY_COVERAGE_RESULT],
-    {
-      filters: {
-        mode: FilterMode.And,
-        filterGroups: [],
-        filters: [
-          {
-            mode: FilterMode.Or,
-            operator: FilterOperator.Eq,
-            key: [INPUT_RESULT_OF],
-            values: [securityCoverageId],
-          },
-        ],
-      },
-    },
-  );
+  const results = await loadThroughDenormalized(context, user, securityCoverage, INPUT_RESULT_OF);
 
   if (!results[0]) {
     return undefined;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -120,7 +120,7 @@ export const addSecurityCoverage = async (
     );
     // Manually add it here to be able to resolve dynamyc attributes
     createdSecurityCoverage['result-of'] = [result.id];
-    logApp.info(`[SECURITY-COVERAGE-RESULT][${createdSecurityCoverage.id}] SCR created: ${result.standard_id}`);
+    logApp.debug(`[SECURITY-COVERAGE-RESULT][${createdSecurityCoverage.id}] SCR created: ${result.standard_id}`);
   }
 
   return notify(

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -36,7 +36,7 @@ export const COVERED_ENTITIES_TYPE = [
 ];
 
 // region CRUD
-export const findSecurityCoverageById = async (
+export const findById = async (
   context: AuthContext,
   user: AuthUser,
   SecurityCoverageId: string,
@@ -54,7 +54,7 @@ export const findSecurityCoverageById = async (
   );
 };
 
-export const pageSecurityCoverageConnections = (context: AuthContext, user: AuthUser, args: EntityOptions<BasicStoreEntitySecurityCoverage>) => {
+export const pageSecurityCoveragePaginated = (context: AuthContext, user: AuthUser, args: EntityOptions<BasicStoreEntitySecurityCoverage>) => {
   return pageEntitiesConnection<BasicStoreEntitySecurityCoverage>(context, user, [ENTITY_TYPE_SECURITY_COVERAGE], args);
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -54,7 +54,7 @@ export const findById = async (
   );
 };
 
-export const pageSecurityCoveragePaginated = (context: AuthContext, user: AuthUser, args: EntityOptions<BasicStoreEntitySecurityCoverage>) => {
+export const findSecurityCoveragePaginated = (context: AuthContext, user: AuthUser, args: EntityOptions<BasicStoreEntitySecurityCoverage>) => {
   return pageEntitiesConnection<BasicStoreEntitySecurityCoverage>(context, user, [ENTITY_TYPE_SECURITY_COVERAGE], args);
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -1,12 +1,19 @@
 import { v4 as uuidv4 } from 'uuid';
-import { type EntityOptions, fullRelationsList, loadEntityThroughRelationsPaginated, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
+import {
+  type EntityOptions,
+  fullEntitiesList,
+  fullRelationsList,
+  loadEntityThroughRelationsPaginated,
+  pageEntitiesConnection,
+  storeLoadById,
+} from '../../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { type BasicStoreEntitySecurityCoverage, ENTITY_TYPE_SECURITY_COVERAGE, INPUT_COVERED, RELATION_COVERED, type StoreEntitySecurityCoverage } from './securityCoverage-types';
 import { notify } from '../../database/redis';
 import { BUS_TOPICS } from '../../config/conf';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import { createEntity, deleteElementById, storeLoadByIdsWithRefs, storeLoadByIdWithRefs } from '../../database/middleware';
-import type { SecurityCoverageAddInput } from '../../generated/graphql';
+import { FilterMode, FilterOperator, type SecurityCoverageAddInput } from '../../generated/graphql';
 import type { BasicStoreEntity, StoreObject, StoreRelation } from '../../types/store';
 import { convertStoreToStix_2_1 } from '../../database/stix-2-1-converter';
 import { STIX_SPEC_VERSION } from '../../database/stix';
@@ -22,8 +29,8 @@ import {
 } from '../../schema/stixDomainObject';
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-incident-types';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../grouping/grouping-types';
-import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, INPUT_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
 import { deleteSecurityCoverageResultsByResultOf } from './securityCoverageResult/securityCoverageResult-domain';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, INPUT_RESULT_OF, type BasicStoreEntitySecurityCoverageResult } from './securityCoverageResult/securityCoverageResult-types';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -180,3 +187,37 @@ export const securityCoverageDelete = async (context: AuthContext, user: AuthUse
   return securityCoverageId;
 };
 // endregion
+
+export const getSecurityCoverageResultProperty = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverageId: string,
+  property: keyof BasicStoreEntitySecurityCoverageResult,
+) => {
+  // TODO : replace with function from chunk 2 : listSecurityCoverageResultsByResultOf
+  const results = await fullEntitiesList<BasicStoreEntitySecurityCoverageResult>(
+    context,
+    user,
+    [ENTITY_TYPE_SECURITY_COVERAGE_RESULT],
+    {
+      filters: {
+        mode: FilterMode.And,
+        filterGroups: [],
+        filters: [
+          {
+            mode: FilterMode.Or,
+            operator: FilterOperator.Eq,
+            key: [INPUT_RESULT_OF],
+            values: [securityCoverageId],
+          },
+        ],
+      },
+    },
+  );
+
+  if (!results[0]) {
+    return undefined;
+  }
+
+  return results[0][property];
+};

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -25,13 +25,14 @@ const SecurityCoverageResolvers: Resolvers = {
     securityCoverages: (_, args, context) => pageSecurityCoverageConnections(context, context.user, args),
   },
   SecurityCoverage: {
-    objectCovered: (SecurityCoverage, _, context) => objectCovered<any>(context, context.user, SecurityCoverage.id),
-    toStixBundle: (SecurityCoverage, _, context) => securityCoverageStixBundle(context, context.user, SecurityCoverage.id),
-    coverage_last_result: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_last_result'),
-    coverage_valid_from: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_valid_from'),
-    coverage_valid_to: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_valid_to'),
-    coverage_information: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_information'),
-    external_uri: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'external_uri'),
+    objectCovered: (securityCoverage, _, context) => objectCovered<any>(context, context.user, securityCoverage.id),
+    toStixBundle: (securityCoverage, _, context) => securityCoverageStixBundle(context, context.user, securityCoverage.id),
+    // security coverage result info
+    coverage_last_result: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_last_result'),
+    coverage_valid_from: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_from'),
+    coverage_valid_to: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_to'),
+    coverage_information: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_information'),
+    external_uri: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'external_uri'),
   },
   Mutation: {
     securityCoverageAdd: (_, { input }, context) => addSecurityCoverage(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -1,7 +1,7 @@
 import {
   addSecurityCoverage,
-  pageSecurityCoverageConnections,
-  findSecurityCoverageById,
+  pageSecurityCoveragePaginated,
+  findById,
   securityCoverageDelete,
   securityCoverageStixBundle,
   objectCovered,
@@ -21,8 +21,8 @@ import { ENTITY_TYPE_SECURITY_COVERAGE } from './securityCoverage-types';
 
 const SecurityCoverageResolvers: Resolvers = {
   Query: {
-    securityCoverage: (_, { id }, context) => findSecurityCoverageById(context, context.user, id),
-    securityCoverages: (_, args, context) => pageSecurityCoverageConnections(context, context.user, args),
+    securityCoverage: (_, { id }, context) => findById(context, context.user, id),
+    securityCoverages: (_, args, context) => pageSecurityCoveragePaginated(context, context.user, args),
   },
   SecurityCoverage: {
     objectCovered: (securityCoverage, _, context) => objectCovered<any>(context, context.user, securityCoverage.id),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -5,6 +5,7 @@ import {
   securityCoverageDelete,
   securityCoverageStixBundle,
   objectCovered,
+  getSecurityCoverageResultProperty,
 } from './securityCoverage-domain';
 import {
   stixDomainObjectAddRelation,
@@ -26,6 +27,11 @@ const SecurityCoverageResolvers: Resolvers = {
   SecurityCoverage: {
     objectCovered: (SecurityCoverage, _, context) => objectCovered<any>(context, context.user, SecurityCoverage.id),
     toStixBundle: (SecurityCoverage, _, context) => securityCoverageStixBundle(context, context.user, SecurityCoverage.id),
+    coverage_last_result: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_last_result'),
+    coverage_valid_from: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_valid_from'),
+    coverage_valid_to: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_valid_to'),
+    coverage_information: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'coverage_information'),
+    external_uri: (SecurityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, SecurityCoverage.id, 'external_uri'),
   },
   Mutation: {
     securityCoverageAdd: (_, { input }, context) => addSecurityCoverage(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -1,6 +1,6 @@
 import {
   addSecurityCoverage,
-  pageSecurityCoveragePaginated,
+  findSecurityCoveragePaginated,
   findById,
   securityCoverageDelete,
   securityCoverageStixBundle,
@@ -22,7 +22,7 @@ import { ENTITY_TYPE_SECURITY_COVERAGE } from './securityCoverage-types';
 const SecurityCoverageResolvers: Resolvers = {
   Query: {
     securityCoverage: (_, { id }, context) => findById(context, context.user, id),
-    securityCoverages: (_, args, context) => pageSecurityCoveragePaginated(context, context.user, args),
+    securityCoverages: (_, args, context) => findSecurityCoveragePaginated(context, context.user, args),
   },
   SecurityCoverage: {
     objectCovered: (securityCoverage, _, context) => objectCovered<any>(context, context.user, securityCoverage.id),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
@@ -1,7 +1,7 @@
 import type { BasicStoreEntity, StoreEntity } from '../../types/store';
 import type { StixDomainObject, StixOpenctiExtensionSDO } from '../../types/stix-2-1-common';
 import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
-import type { BasicStoreEntitySecurityCoverageResult, INPUT_RESULT_OF, RELATION_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
+import type { ATTRIBUTE_RESULT_OF, BasicStoreEntitySecurityCoverageResult, INPUT_RESULT_OF, RELATION_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
 
 export const ENTITY_TYPE_SECURITY_COVERAGE = 'Security-Coverage';
 export const RELATION_COVERED = 'object-covered';
@@ -36,7 +36,8 @@ export interface StixSecurityCoverage extends StixDomainObject {
   duration: string;
   type_affinity: string;
   platforms_affinity: string[];
-  covered_ref: string;
+  [ATTRIBUTE_COVERED]: string;
+  [ATTRIBUTE_RESULT_OF]: string[];
   extensions: {
     [STIX_EXT_OCTI]: StixOpenctiExtensionSDO;
   };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-types.ts
@@ -1,6 +1,7 @@
 import type { BasicStoreEntity, StoreEntity } from '../../types/store';
 import type { StixDomainObject, StixOpenctiExtensionSDO } from '../../types/stix-2-1-common';
 import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
+import type { BasicStoreEntitySecurityCoverageResult, INPUT_RESULT_OF, RELATION_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
 
 export const ENTITY_TYPE_SECURITY_COVERAGE = 'Security-Coverage';
 export const RELATION_COVERED = 'object-covered';
@@ -14,6 +15,7 @@ export interface BasicStoreEntitySecurityCoverage extends BasicStoreEntity {
   type_affinity: string;
   platforms_affinity: string[];
   [RELATION_COVERED]: string;
+  [RELATION_RESULT_OF]: string[];
 }
 
 export interface StoreEntitySecurityCoverage extends StoreEntity {
@@ -22,6 +24,7 @@ export interface StoreEntitySecurityCoverage extends StoreEntity {
   type_affinity: string;
   platforms_affinity: string[];
   [INPUT_COVERED]: BasicStoreEntity;
+  [INPUT_RESULT_OF]: BasicStoreEntitySecurityCoverageResult[];
 }
 // endregion
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.ts
@@ -14,6 +14,7 @@ import convertSecurityCoverageToStix from './securityCoverage-converter';
 import { createdBy, objectLabel, objectMarking, objectOrganization } from '../../schema/stixRefRelationship';
 import { COVERED_ENTITIES_TYPE, securityCoverageStixBundle } from './securityCoverage-domain';
 import type { StoreEntity } from '../../types/store';
+import { ATTRIBUTE_RESULT_OF, ENTITY_TYPE_SECURITY_COVERAGE_RESULT, INPUT_RESULT_OF, RELATION_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
 
 const SECURITY_COVERAGE_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverage, StixSecurityCoverage> = {
   type: {
@@ -65,6 +66,22 @@ const SECURITY_COVERAGE_DEFINITION: ModuleDefinition<StoreEntitySecurityCoverage
       },
       isFilterable: true,
       toTypes: COVERED_ENTITIES_TYPE,
+    },
+    {
+      name: INPUT_RESULT_OF,
+      type: 'ref',
+      databaseName: RELATION_RESULT_OF,
+      stixName: ATTRIBUTE_RESULT_OF,
+      label: 'Security coverage results',
+      mandatoryType: 'external',
+      editDefault: false,
+      multiple: true,
+      upsert: true,
+      isRefExistingForTypes(this, fromType, toType) {
+        return fromType === ENTITY_TYPE_SECURITY_COVERAGE && this.toTypes.includes(toType);
+      },
+      isFilterable: true,
+      toTypes: [ENTITY_TYPE_SECURITY_COVERAGE_RESULT],
     },
     objectLabel,
     objectMarking,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter.ts
@@ -16,7 +16,7 @@ const convertSecurityCoverageResultToStix = (instance: StoreEntitySecurityCovera
     covered: isNotEmptyField(instance.coverage_information),
     coverage: (instance.coverage_information ?? [])
       .map((c) => ({ name: c.coverage_name, score: c.coverage_score })),
-    [ATTRIBUTE_RESULT_OF]: (instance[INPUT_RESULT_OF] ?? []).standard_id,
+    [ATTRIBUTE_RESULT_OF]: instance[INPUT_RESULT_OF]?.standard_id,
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixDomainObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-converter.ts
@@ -16,7 +16,7 @@ const convertSecurityCoverageResultToStix = (instance: StoreEntitySecurityCovera
     covered: isNotEmptyField(instance.coverage_information),
     coverage: (instance.coverage_information ?? [])
       .map((c) => ({ name: c.coverage_name, score: c.coverage_score })),
-    [ATTRIBUTE_RESULT_OF]: instance[INPUT_RESULT_OF].standard_id,
+    [ATTRIBUTE_RESULT_OF]: (instance[INPUT_RESULT_OF] ?? []).standard_id,
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({
         ...stixDomainObject.extensions[STIX_EXT_OCTI],

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -43,7 +43,7 @@ export const findById = async (
  * @param args Options to customize the query.
  * @returns Security coverage result.
  */
-export const pageSecurityCoverageResultPaginated = (
+export const findSecurityCoverageResultPaginated = (
   context: AuthContext,
   user: AuthUser,
   args: EntityOptions<BasicStoreEntitySecurityCoverageResult>,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -1,3 +1,4 @@
+import { logApp } from '../../../config/conf';
 import { deleteElementById } from '../../../database/middleware';
 import { fullEntitiesList } from '../../../database/middleware-loader';
 import { FilterMode, FilterOperator } from '../../../generated/graphql';
@@ -63,13 +64,14 @@ export const deleteSecurityCoverageResultsByResultOf = async (
     resultOfId,
   );
   for (const result of results) {
+    logApp.info(`[SECURITY-COVERAGE-RESULT][${resultOfId}] SCR to delete: ${result.standard_id}`);
     const deleted = await deleteElementById<StoreEntitySecurityCoverageResult>(
       context,
       user,
       result.id,
       ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
     );
-    deletedIds.push(deleted.id);
+    deletedIds.push(deleted.standard_id);
   }
   return deletedIds;
 };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -1,4 +1,4 @@
-import { BUS_TOPICS, logApp } from '../../../config/conf';
+import { BUS_TOPICS } from '../../../config/conf';
 import { FunctionalError } from '../../../config/errors';
 import { createEntity, deleteElementById } from '../../../database/middleware';
 import { fullEntitiesList, pageEntitiesConnection, storeLoadById, type EntityOptions } from '../../../database/middleware-loader';
@@ -118,7 +118,6 @@ export const addSecurityCoverageResult = async (
     throw FunctionalError('Security coverage not found', { securityCoverageResultInput });
   }
 
-  logApp.info(`[SECURITY-COVERAGE-RESULT] Create SCR for ${securityCoverage.id}`, { securityCoverageResultInput, securityCoverage });
   const input = {
     ...securityCoverageResultInput,
   };
@@ -176,7 +175,6 @@ export const deleteSecurityCoverageResultsByResultOf = async (
     resultOfId,
   );
   for (const result of results) {
-    logApp.info(`[SECURITY-COVERAGE-RESULT][${resultOfId}] SCR to delete: ${result.standard_id}`);
     const deleted = await deleteElementById<StoreEntitySecurityCoverageResult>(
       context,
       user,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -1,14 +1,65 @@
-import { logApp } from '../../../config/conf';
-import { deleteElementById } from '../../../database/middleware';
-import { fullEntitiesList } from '../../../database/middleware-loader';
-import { FilterMode, FilterOperator } from '../../../generated/graphql';
+import { BUS_TOPICS, logApp } from '../../../config/conf';
+import { FunctionalError } from '../../../config/errors';
+import { createEntity, deleteElementById } from '../../../database/middleware';
+import { fullEntitiesList, pageEntitiesConnection, storeLoadById, type EntityOptions } from '../../../database/middleware-loader';
+import { notify } from '../../../database/redis';
+import { FilterMode, FilterOperator, type SecurityCoverageResultAddInput } from '../../../generated/graphql';
+import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../../schema/general';
 import type { AuthContext, AuthUser } from '../../../types/user';
+import { ENTITY_TYPE_SECURITY_COVERAGE, type BasicStoreEntitySecurityCoverage } from '../securityCoverage-types';
 import {
   ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
   INPUT_RESULT_OF,
   type BasicStoreEntitySecurityCoverageResult,
   type StoreEntitySecurityCoverageResult,
 } from './securityCoverageResult-types';
+
+/**
+ * Find a security coverage results by its ID.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param resultOfId ID of the security coverage result.
+ * @returns Security coverage result.
+ */
+export const findSecurityCoverageResultById = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverageId: string,
+): Promise<BasicStoreEntitySecurityCoverageResult> => {
+  const store = storeLoadById<BasicStoreEntitySecurityCoverageResult>(
+    context,
+    user,
+    securityCoverageId,
+    ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  );
+  return notify(
+    BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC,
+    store,
+    user,
+  );
+};
+
+/**
+ * Find all security coverage results using pagination.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param args Options to customize the query.
+ * @returns Security coverage result.
+ */
+export const pageSecurityCoverageResults = (
+  context: AuthContext,
+  user: AuthUser,
+  args: EntityOptions<BasicStoreEntitySecurityCoverageResult>,
+) => {
+  return pageEntitiesConnection<BasicStoreEntitySecurityCoverageResult>(
+    context,
+    user,
+    [ENTITY_TYPE_SECURITY_COVERAGE_RESULT],
+    args,
+  );
+};
 
 /**
  * Find all security coverage results for a security coverage.
@@ -42,6 +93,67 @@ export const listSecurityCoverageResultsByResultOf = async (
       },
     },
   );
+};
+
+/**
+ * Add a security coverage result.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param  securityCoverageResultInput Data of the security coverage result.
+ * @returns Created result.
+ */
+export const addSecurityCoverageResult = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverageResultInput: SecurityCoverageResultAddInput,
+): Promise<BasicStoreEntitySecurityCoverageResult> => {
+  const securityCoverage = await storeLoadById<BasicStoreEntitySecurityCoverage>(
+    context,
+    user,
+    securityCoverageResultInput.resultOf,
+    ENTITY_TYPE_SECURITY_COVERAGE,
+  );
+  if (!securityCoverage) {
+    throw FunctionalError('Security coverage not found', { securityCoverageResultInput });
+  }
+
+  logApp.info(`[SECURITY-COVERAGE-RESULT] Create SCR for ${securityCoverage.id}`, { securityCoverageResultInput, securityCoverage });
+  const input = {
+    ...securityCoverageResultInput,
+  };
+  if (!securityCoverageResultInput.name) {
+    input.name = `Result of ${securityCoverage.name}`;
+  }
+  const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
+    context,
+    user,
+    input,
+    ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  );
+  return notify(
+    BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE_RESULT].EDIT_TOPIC,
+    result,
+    user,
+  );
+};
+
+/**
+ * Delete a security coverage result by id.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param id ID of the security coverage result.
+ * @returns ID of deleted result.
+ */
+export const deleteSecurityCoverageResult = async (
+  context: AuthContext,
+  user: AuthUser,
+  id: string,
+) => {
+  const deleted = await deleteElementById(context, user, id, ENTITY_TYPE_SECURITY_COVERAGE_RESULT);
+  await notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].DELETE_TOPIC, id, user);
+  return deleted.id;
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -22,21 +22,16 @@ import {
  * @param resultOfId ID of the security coverage result.
  * @returns Security coverage result.
  */
-export const findSecurityCoverageResultById = async (
+export const findById = async (
   context: AuthContext,
   user: AuthUser,
   securityCoverageId: string,
 ): Promise<BasicStoreEntitySecurityCoverageResult> => {
-  const store = storeLoadById<BasicStoreEntitySecurityCoverageResult>(
+  return storeLoadById<BasicStoreEntitySecurityCoverageResult>(
     context,
     user,
     securityCoverageId,
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
-  );
-  return notify(
-    BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC,
-    store,
-    user,
   );
 };
 
@@ -48,7 +43,7 @@ export const findSecurityCoverageResultById = async (
  * @param args Options to customize the query.
  * @returns Security coverage result.
  */
-export const pageSecurityCoverageResults = (
+export const pageSecurityCoverageResultPaginated = (
   context: AuthContext,
   user: AuthUser,
   args: EntityOptions<BasicStoreEntitySecurityCoverageResult>,
@@ -131,7 +126,7 @@ export const addSecurityCoverageResult = async (
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
   );
   return notify(
-    BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE_RESULT].EDIT_TOPIC,
+    BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE_RESULT].ADDED_TOPIC,
     result,
     user,
   );

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-graphql.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-graphql.ts
@@ -1,0 +1,8 @@
+import { registerGraphqlSchema } from '../../../graphql/schema';
+import securityCoverageResultResolvers from './securityCoverageResult-resolver';
+import securityCoverageResultTypeDefs from './securityCoverageResult.graphql';
+
+registerGraphqlSchema({
+  schema: securityCoverageResultTypeDefs,
+  resolver: securityCoverageResultResolvers,
+});

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
@@ -1,10 +1,10 @@
 import type { Resolvers } from '../../../generated/graphql';
-import { addSecurityCoverageResult, deleteSecurityCoverageResult, findById, pageSecurityCoverageResultPaginated } from './securityCoverageResult-domain';
+import { addSecurityCoverageResult, deleteSecurityCoverageResult, findById, findSecurityCoverageResultPaginated } from './securityCoverageResult-domain';
 
 const SecurityCoverageResultResolvers: Resolvers = {
   Query: {
     securityCoverageResult: (_, { id }, context) => findById(context, context.user, id),
-    securityCoverageResults: (_, args, context) => pageSecurityCoverageResultPaginated(context, context.user, args),
+    securityCoverageResults: (_, args, context) => findSecurityCoverageResultPaginated(context, context.user, args),
   },
   Mutation: {
     securityCoverageResultAdd: (_, { input }, context) => addSecurityCoverageResult(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
@@ -1,17 +1,10 @@
 import type { Resolvers } from '../../../generated/graphql';
-import {
-  addSecurityCoverageResult,
-  deleteSecurityCoverageResult,
-  findSecurityCoverageResultById,
-  listSecurityCoverageResultsByResultOf,
-  pageSecurityCoverageResults,
-} from './securityCoverageResult-domain';
+import { addSecurityCoverageResult, deleteSecurityCoverageResult, findById, pageSecurityCoverageResultPaginated } from './securityCoverageResult-domain';
 
 const SecurityCoverageResultResolvers: Resolvers = {
   Query: {
-    securityCoverageResult: (_, { id }, context) => findSecurityCoverageResultById(context, context.user, id),
-    securityCoverageResults: (_, args, context) => pageSecurityCoverageResults(context, context.user, args),
-    listSecurityCoverageResultsByResultOf: (_, { id }, context) => listSecurityCoverageResultsByResultOf(context, context.user, id),
+    securityCoverageResult: (_, { id }, context) => findById(context, context.user, id),
+    securityCoverageResults: (_, args, context) => pageSecurityCoverageResultPaginated(context, context.user, args),
   },
   Mutation: {
     securityCoverageResultAdd: (_, { input }, context) => addSecurityCoverageResult(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
@@ -1,0 +1,22 @@
+import type { Resolvers } from '../../../generated/graphql';
+import {
+  addSecurityCoverageResult,
+  deleteSecurityCoverageResult,
+  findSecurityCoverageResultById,
+  listSecurityCoverageResultsByResultOf,
+  pageSecurityCoverageResults,
+} from './securityCoverageResult-domain';
+
+const SecurityCoverageResultResolvers: Resolvers = {
+  Query: {
+    securityCoverageResult: (_, { id }, context) => findSecurityCoverageResultById(context, context.user, id),
+    securityCoverageResults: (_, args, context) => pageSecurityCoverageResults(context, context.user, args),
+    listSecurityCoverageResultsByResultOf: (_, { id }, context) => listSecurityCoverageResultsByResultOf(context, context.user, id),
+  },
+  Mutation: {
+    securityCoverageResultAdd: (_, { input }, context) => addSecurityCoverageResult(context, context.user, input),
+    securityCoverageResultDelete: (_, { id }, context) => deleteSecurityCoverageResult(context, context.user, id),
+  },
+};
+
+export default SecurityCoverageResultResolvers;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
@@ -184,7 +184,6 @@ type SecurityCoverageResultEdge {
 # Queries
 type Query {
   securityCoverageResult(id: String!): SecurityCoverageResult @auth(for: [KNOWLEDGE])
-  listSecurityCoverageResultsByResultOf(id: String!): [SecurityCoverageResult!] @auth(for: [KNOWLEDGE])
   securityCoverageResults(
     first: Int
     after: ID

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
@@ -1,4 +1,9 @@
-type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & StixDomainObject {
+type CoverageResult {
+  coverage_name: String!
+  coverage_score: Int!
+}
+
+type SecurityCoverageResult implements BasicObject & StixObject & StixCoreObject & StixDomainObject {
   id: ID! # internal_id
   standard_id: String!
   entity_type: String!
@@ -112,7 +117,7 @@ type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & Sti
   ): FileConnection
   # Identity
   identity_class: String!
-  name: String!
+  name: String
   description: String
   contact_information: String
   roles: [String]
@@ -145,24 +150,16 @@ type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & Sti
   status: Status
   workflowEnabled: Boolean
   pirInformation(pirId: ID!): PirInformation @auth(for: [PIRAPI])
-  # SecurityCoverage
+  # SecurityCoverageResult
   coverage_last_result: DateTime
   coverage_valid_from: DateTime
   coverage_valid_to: DateTime
   coverage_information: [CoverageResult!]
   external_uri: String
-  periodicity: String
-  duration: String
-  type_affinity: String
-  platforms_affinity: [String!]
-  auto_enrichment_disable: Boolean
-  objectCovered: StixDomainObject
-  toStixBundle: String
-  security_platform_type: String
 }
 
 # Ordering
-enum SecurityCoverageOrdering {
+enum SecurityCoverageResultOrdering {
   name
   confidence
   created
@@ -171,45 +168,42 @@ enum SecurityCoverageOrdering {
   modified
   updated_at
   objectMarking
-  coverage_last_result
   _score
 }
 
 # Relay connections
-type SecurityCoverageConnection {
+type SecurityCoverageResultConnection {
   pageInfo: PageInfo!
-  edges: [SecurityCoverageEdge!]!
+  edges: [SecurityCoverageResultEdge!]!
 }
-type SecurityCoverageEdge {
+type SecurityCoverageResultEdge {
   cursor: String!
-  node: SecurityCoverage!
+  node: SecurityCoverageResult!
 }
 
 # Queries
 type Query {
-  securityCoverage(id: String!): SecurityCoverage @auth(for: [KNOWLEDGE])
-  securityCoverages(
+  securityCoverageResult(id: String!): SecurityCoverageResult @auth(for: [KNOWLEDGE])
+  listSecurityCoverageResultsByResultOf(id: String!): [SecurityCoverageResult!] @auth(for: [KNOWLEDGE])
+  securityCoverageResults(
     first: Int
     after: ID
-    orderBy: SecurityCoverageOrdering
+    orderBy: SecurityCoverageResultOrdering
     orderMode: OrderingMode
     filters: FilterGroup
     search: String
     toStix: Boolean
-  ): SecurityCoverageConnection @auth(for: [KNOWLEDGE])
+  ): SecurityCoverageResultConnection @auth(for: [KNOWLEDGE])
 }
 
-
-
 # Mutations
-input SecurityCoverageAddInput {
-  name: String! @constraint(minLength: 2, format: "not-blank")
+input SecurityCoverageResultAddInput {
+  name: String
   description: String
   confidence: Int
   createdBy: String
   objectMarking: [String]
   objectLabel: [String]
-  objectCovered: String!
   created: DateTime
   modified: DateTime
   revoked: Boolean
@@ -228,27 +222,14 @@ input SecurityCoverageAddInput {
   update: Boolean
   # coverage specific
   external_uri: String
-  auto_enrichment_disable: Boolean!
-  periodicity: String
-  duration: String
-  type_affinity: String
-  platforms_affinity: [String]
   coverage_last_result: DateTime
   coverage_valid_from: DateTime
   coverage_valid_to: DateTime
   coverage_information: [SecurityCoverageExpectation!]
+  resultOf: String!
 }
 
 type Mutation {
-  securityCoverageAdd(input: SecurityCoverageAddInput!): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
-  securityCoverageDelete(id: ID!): ID @auth(for: [KNOWLEDGE_KNUPDATE_KNDELETE])
-  securityCoverageFieldPatch(id: ID!, input: [EditInput]!, commitMessage: String, references: [String]): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
-  securityCoverageContextPatch(id: ID!, input: EditContext!): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
-  securityCoverageContextClean(id: ID!): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
-  securityCoverageRelationAdd(id: ID!, input: StixRefRelationshipAddInput!): StixRefRelationship @auth(for: [KNOWLEDGE_KNUPDATE])
-  securityCoverageRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
-}
-
-extend type Subscription {
-    securityCoverage(id: ID!): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
+  securityCoverageResultAdd(input: SecurityCoverageResultAddInput!): SecurityCoverageResult @auth(for: [KNOWLEDGE_KNUPDATE])
+  securityCoverageResultDelete(id: ID!): ID @auth(for: [KNOWLEDGE_KNUPDATE_KNDELETE])
 }

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
@@ -5,127 +5,72 @@ import { generateStandardId } from '../../../../src/schema/identifier';
 import '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult';
 
 describe('SecurityCoverageResult identifier', () => {
-  const generateId = (data: any) => generateStandardId(
+  const NAME_1 = 'Result #1';
+  const NAME_2 = 'Result #2';
+  const SC_1 = 'security-coverage-1232121a12e';
+  const SC_2 = 'security-coverage-1232121472165';
+  const URI_1 = 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131';
+  const URI_2 = 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd39375';
+
+  const generateId = (
+    sc: string | null,
+    name: string | null,
+    uri: string | null,
+  ) => generateStandardId(
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
     {
-      resultOf: { standard_id: 'security-coverage-1232121a12e' },
-      ...data,
+      resultOf: { standard_id: sc },
+      name,
+      external_uri: uri,
     },
   );
 
-  it('should throw an error if no data given', () => {});
+  it('should generate all different identifiers', () => {
+    const identifiers = [
+      generateId(SC_1, null, null),
+      generateId(SC_2, null, null),
+      generateId(null, NAME_1, null),
+      generateId(null, NAME_2, null),
+      generateId(null, null, URI_1),
+      generateId(null, null, URI_2),
+      generateId(SC_1, NAME_1, null),
+      generateId(SC_1, NAME_2, null),
+      generateId(SC_1, null, URI_1),
+      generateId(SC_1, null, URI_2),
+      generateId(SC_2, NAME_1, null),
+      generateId(null, NAME_1, URI_1),
+      generateId(null, NAME_1, URI_2),
+      generateId(SC_2, null, URI_1),
+      generateId(null, NAME_2, URI_1),
+      generateId(SC_1, NAME_1, URI_1),
+      generateId(SC_1, NAME_2, URI_1),
+      generateId(SC_1, NAME_1, URI_2),
+      generateId(SC_2, NAME_1, URI_1),
+      generateId(SC_2, NAME_2, URI_1),
+      generateId(SC_2, NAME_1, URI_2),
+      generateId(SC_1, NAME_2, URI_2),
+      generateId(SC_2, NAME_2, URI_2),
+    ];
+    expect(identifiers.length).toEqual(new Set(identifiers).size);
+  });
 
   describe('using same ref resultOf', () => {
     it('should have same ID if given same name (no external_uri)', () => {
-      const standardId1 = generateId({
-        name: 'My security coverage',
-      });
-      const standardId2 = generateId({
-        name: 'My security coverage',
-      });
+      const standardId1 = generateId(SC_1, NAME_1, null);
+      const standardId2 = generateId(SC_1, NAME_1, null);
       expect(standardId1).toEqual(standardId2);
-    });
-
-    it('should have different ID if given different name (no external_uri)', () => {
-      const standardId1 = generateId({
-        name: 'My security coverage',
-      });
-      const standardId2 = generateId({
-        name: 'My security coverage bis',
-      });
-      expect(standardId1).not.toEqual(standardId2);
     });
 
     it('should have same ID if given same external_uri (no name)', () => {
-      const standardId1 = generateId({
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
+      const standardId1 = generateId(SC_1, null, URI_1);
+      const standardId2 = generateId(SC_1, null, URI_1);
       expect(standardId1).toEqual(standardId2);
-    });
-
-    it('should have different ID if given different external_uri (no name)', () => {
-      const standardId1 = generateId({
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd35294',
-      });
-      expect(standardId1).not.toEqual(standardId2);
     });
 
     it('should have same ID if given same couple (name/external_uri)', () => {
-      const standardId1 = generateId({
-        name: 'Super result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        name: 'Super result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
+      const standardId1 = generateId(SC_1, NAME_1, URI_1);
+      const standardId2 = generateId(SC_1, NAME_1, URI_1);
       expect(standardId1).toEqual(standardId2);
-    });
-
-    it('should have different ID if given same name but different external_uri', () => {
-      const standardId1 = generateId({
-        name: 'Super result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        name: 'Super result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd39375',
-      });
-      expect(standardId1).not.toEqual(standardId2);
-    });
-
-    it('should have different ID if given same external_uri but different name', () => {
-      const standardId1 = generateId({
-        name: 'Super result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        name: 'Super coverage result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      expect(standardId1).not.toEqual(standardId2);
-    });
-
-    it('should have different ID if given different external_uri but different name', () => {
-      const standardId1 = generateId({
-        name: 'Super result',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        name: 'Super result bis',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd37351',
-      });
-      expect(standardId1).not.toEqual(standardId2);
-    });
-  });
-
-  describe('using different ref resultOf', () => {
-    it('should have different ID with same name but different ref', () => {
-      const standardId1 = generateId({
-        name: 'Super result',
-      });
-      const standardId2 = generateId({
-        name: 'Super result',
-        resultOf: { standard_id: 'security-coverage-1232121472165' },
-      });
-      expect(standardId1).not.toEqual(standardId2);
-    });
-
-    it('should have different ID with same external_uri but different ref', () => {
-      const standardId1 = generateId({
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
-      });
-      const standardId2 = generateId({
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd39375',
-        resultOf: { standard_id: 'security-coverage-1232121472165' },
-      });
-      expect(standardId1).not.toEqual(standardId2);
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage-domain-test.ts
@@ -44,7 +44,7 @@ describe('SecurityCoverage domain', () => {
     it('should create coverage result if contains no information but external_uri', async () => {
       const input = {
         ...BASE_INPUT(),
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a132',
       };
       const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
       const results = await listSecurityCoverageResultsByResultOf(testContext, ADMIN_USER, securityCoverage.id);
@@ -67,6 +67,7 @@ describe('SecurityCoverage domain', () => {
     it('should delete security coverage results when deleting a security coverage', async () => {
       const input = {
         ...BASE_INPUT(),
+        name: 'sc to delete',
         coverage_information: [{
           coverage_name: 'prevention',
           coverage_score: 10,

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
@@ -32,7 +32,7 @@ describe('SecurityCoverage resolver', () => {
           coverage_name: 'prevention',
           coverage_score: 10,
         }],
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175',
       },
     };
 
@@ -47,7 +47,7 @@ describe('SecurityCoverage resolver', () => {
     expect(securityCoverageData.coverage_last_result.toISOString()).toEqual('2023-08-06T11:39:36.949Z');
     expect(securityCoverageData.coverage_valid_from.toISOString()).toEqual('2023-07-06T11:39:36.949Z');
     expect(securityCoverageData.coverage_valid_to.toISOString()).toEqual('2023-12-06T11:39:36.949Z');
-    expect(securityCoverageData.external_uri).toEqual('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131');
+    expect(securityCoverageData.external_uri).toEqual('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
     expect(securityCoverageData.coverage_information[0].coverage_name).toEqual('prevention');
     expect(securityCoverageData.coverage_information[0].coverage_score).toEqual(10);
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverageResult-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverageResult-test.ts
@@ -1,0 +1,192 @@
+import gql from 'graphql-tag';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { queryAsAdmin } from '../../../utils/testQueryHelper';
+
+const GET_SECURITY_COVERAGES = gql`
+ query SecurityCoverages {
+    securityCoverages {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const GET_ALL_QUERY = gql`
+ query SecurityCoverageResults {
+    securityCoverageResults {
+      pageInfo {
+        globalCount
+      }
+      edges {
+        node {
+          external_uri
+          coverage_last_result
+          coverage_valid_from
+          coverage_valid_to
+          coverage_information {
+            coverage_name
+            coverage_score
+          }
+        }
+      }
+    }
+  }
+`;
+
+const GET_ALL_BY_ID_QUERY = gql`
+ query SecurityCoverageResultById($id: String!) {
+    listSecurityCoverageResultsByResultOf(id: $id) {
+      external_uri
+      coverage_last_result
+      coverage_valid_from
+      coverage_valid_to
+      coverage_information {
+        coverage_name
+        coverage_score
+      }
+    }
+  }
+`;
+
+const GET_ONE_QUERY = gql`
+ query SecurityCoverageResult($id: String!) {
+    securityCoverageResult(id: $id) {
+      external_uri
+      coverage_last_result
+      coverage_valid_from
+      coverage_valid_to
+      coverage_information {
+        coverage_name
+        coverage_score
+      }
+    }
+  }
+`;
+
+const CREATE_MUTATION = gql`
+  mutation CreateSecurityCoverageResult($input: SecurityCoverageResultAddInput!) {
+    securityCoverageResultAdd(input: $input) {
+      id
+      external_uri
+      coverage_last_result
+      coverage_valid_from
+      coverage_valid_to
+      coverage_information {
+        coverage_name
+        coverage_score
+      }
+    }
+  }
+`;
+
+const DELETE_MUTATION = gql`
+  mutation DeleteSecurityCoverageResult($id: ID!) {
+    securityCoverageResultDelete(id: $id)
+  }
+`;
+
+describe('SecurityCoverageResult resolver', () => {
+  let securityCoverageId: string;
+  let createdScrId: string;
+
+  beforeAll(async () => {
+    const { data } = await queryAsAdmin({ query: GET_SECURITY_COVERAGES });
+    securityCoverageId = data?.securityCoverages.edges[0].node.id;
+  });
+
+  it('should create a new result for a security coverage', async () => {
+    const scr = await queryAsAdmin({
+      query: CREATE_MUTATION,
+      variables: {
+        input: {
+          resultOf: securityCoverageId,
+          coverage_last_result: '2025-08-06T11:39:36.949Z',
+          coverage_valid_from: '2025-07-06T11:39:36.949Z',
+          coverage_valid_to: '2026-12-06T11:39:36.949Z',
+          coverage_information: [{
+            coverage_name: 'vulnerability',
+            coverage_score: 50,
+          }],
+          external_uri: 'http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322',
+        },
+      },
+    });
+
+    const securityCoverageResultData = scr.data?.securityCoverageResultAdd;
+    expect(securityCoverageResultData).toBeDefined();
+    expect(securityCoverageResultData.coverage_last_result.toISOString()).toEqual('2025-08-06T11:39:36.949Z');
+    expect(securityCoverageResultData.coverage_valid_from.toISOString()).toEqual('2025-07-06T11:39:36.949Z');
+    expect(securityCoverageResultData.coverage_valid_to.toISOString()).toEqual('2026-12-06T11:39:36.949Z');
+    expect(securityCoverageResultData.external_uri).toEqual('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
+    expect(securityCoverageResultData.coverage_information[0].coverage_name).toEqual('vulnerability');
+    expect(securityCoverageResultData.coverage_information[0].coverage_score).toEqual(50);
+    createdScrId = securityCoverageResultData.id;
+  });
+
+  it('should fetch all security coverage results with pagination', async () => {
+    const securityCoverageResults = await queryAsAdmin({
+      query: GET_ALL_QUERY,
+    });
+
+    const securityCoverageResultsData = securityCoverageResults.data?.securityCoverageResults;
+    expect(securityCoverageResultsData).toBeDefined();
+    expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(2);
+    const uris = securityCoverageResultsData.edges.map((e: any) => e.node.external_uri);
+    expect(uris).toContain('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
+    expect(uris).toContain('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
+  });
+
+  it('should fetch all results by security coverage ID', async () => {
+    const securityCoverageResults = await queryAsAdmin({
+      query: GET_ALL_BY_ID_QUERY,
+      variables: {
+        id: securityCoverageId,
+      },
+    });
+
+    const securityCoverageResultsData = securityCoverageResults.data?.listSecurityCoverageResultsByResultOf;
+    expect(securityCoverageResultsData).toBeDefined();
+    expect(securityCoverageResultsData.length).toEqual(2);
+    const uris = securityCoverageResultsData.map((scr: any) => scr.external_uri);
+    expect(uris).toContain('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
+    expect(uris).toContain('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
+  });
+
+  it('should fetch a security coverage result by its ID', async () => {
+    const scr = await queryAsAdmin({
+      query: GET_ONE_QUERY,
+      variables: {
+        id: createdScrId,
+      },
+    });
+
+    const securityCoverageResultData = scr.data?.securityCoverageResult;
+    expect(securityCoverageResultData).toBeDefined();
+    expect(securityCoverageResultData.coverage_last_result.toISOString()).toEqual('2025-08-06T11:39:36.949Z');
+    expect(securityCoverageResultData.coverage_valid_from.toISOString()).toEqual('2025-07-06T11:39:36.949Z');
+    expect(securityCoverageResultData.coverage_valid_to.toISOString()).toEqual('2026-12-06T11:39:36.949Z');
+    expect(securityCoverageResultData.external_uri).toEqual('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
+    expect(securityCoverageResultData.coverage_information[0].coverage_name).toEqual('vulnerability');
+    expect(securityCoverageResultData.coverage_information[0].coverage_score).toEqual(50);
+  });
+
+  it('should delete a security coverage result by its ID', async () => {
+    const result = await queryAsAdmin({
+      query: DELETE_MUTATION,
+      variables: {
+        id: createdScrId,
+      },
+    });
+    const securityCoverageResults = await queryAsAdmin({
+      query: GET_ALL_QUERY,
+    });
+
+    const deletedId = result.data?.securityCoverageResultDelete;
+    const securityCoverageResultsData = securityCoverageResults.data?.securityCoverageResults;
+    expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(1);
+    expect(deletedId).toEqual(createdScrId);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverageResult-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverageResult-test.ts
@@ -36,21 +36,6 @@ const GET_ALL_QUERY = gql`
   }
 `;
 
-const GET_ALL_BY_ID_QUERY = gql`
- query SecurityCoverageResultById($id: String!) {
-    listSecurityCoverageResultsByResultOf(id: $id) {
-      external_uri
-      coverage_last_result
-      coverage_valid_from
-      coverage_valid_to
-      coverage_information {
-        coverage_name
-        coverage_score
-      }
-    }
-  }
-`;
-
 const GET_ONE_QUERY = gql`
  query SecurityCoverageResult($id: String!) {
     securityCoverageResult(id: $id) {
@@ -135,22 +120,6 @@ describe('SecurityCoverageResult resolver', () => {
     expect(securityCoverageResultsData).toBeDefined();
     expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(2);
     const uris = securityCoverageResultsData.edges.map((e: any) => e.node.external_uri);
-    expect(uris).toContain('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
-    expect(uris).toContain('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
-  });
-
-  it('should fetch all results by security coverage ID', async () => {
-    const securityCoverageResults = await queryAsAdmin({
-      query: GET_ALL_BY_ID_QUERY,
-      variables: {
-        id: securityCoverageId,
-      },
-    });
-
-    const securityCoverageResultsData = securityCoverageResults.data?.listSecurityCoverageResultsByResultOf;
-    expect(securityCoverageResultsData).toBeDefined();
-    expect(securityCoverageResultsData.length).toEqual(2);
-    const uris = securityCoverageResultsData.map((scr: any) => scr.external_uri);
     expect(uris).toContain('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
     expect(uris).toContain('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/stixDomainObject-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/stixDomainObject-test.js
@@ -174,7 +174,7 @@ describe('StixDomainObject resolver standard behavior', () => {
       }
     `;
     const queryResult = await queryAsAdmin({ query: NUMBER_QUERY });
-    expect(queryResult.data.stixDomainObjectsNumber.total).toEqual(107);
+    expect(queryResult.data.stixDomainObjectsNumber.total).toEqual(108);
   });
   it('should timeseries stixDomainObjects to be accurate', async () => {
     const TIMESERIES_QUERY = gql`

--- a/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
@@ -64,7 +64,7 @@ testCreatedCounter['tracking-number'] = 1;
 testCreatedCounter.vocabulary = VOCABULARY_NUMBERS;
 testCreatedCounter.vulnerability = 9;
 testCreatedCounter['security-coverage'] = 5;
-testCreatedCounter['security-coverage-result'] = 4;
+testCreatedCounter['security-coverage-result'] = 5;
 
 export const testUpdatedCounter: Record<string, number> = {};
 testUpdatedCounter['marking-definition'] = 2;
@@ -159,7 +159,7 @@ testDeletedCounter.iccid = 3;
 testDeletedCounter.imei = 2;
 testDeletedCounter.imsi = 1;
 testDeletedCounter['security-coverage'] = 4;
-testDeletedCounter['security-coverage-result'] = 3;
+testDeletedCounter['security-coverage-result'] = 4;
 
 export const doTotal = (eventCounter: Record<string, number>) => {
   const allRecordKeys = Object.keys(eventCounter);

--- a/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/syncCountHelper.ts
@@ -55,7 +55,7 @@ testCreatedCounter.persona = 1;
 testCreatedCounter['phone-number'] = 2;
 testCreatedCounter['ssh-key'] = 1;
 testCreatedCounter.relationship = 141;
-testCreatedCounter.report = 39;
+testCreatedCounter.report = 40;
 testCreatedCounter.sighting = 4;
 testCreatedCounter.software = 2;
 testCreatedCounter['threat-actor'] = 21;
@@ -63,7 +63,8 @@ testCreatedCounter.tool = 5;
 testCreatedCounter['tracking-number'] = 1;
 testCreatedCounter.vocabulary = VOCABULARY_NUMBERS;
 testCreatedCounter.vulnerability = 9;
-testCreatedCounter['security-coverage'] = 1;
+testCreatedCounter['security-coverage'] = 5;
+testCreatedCounter['security-coverage-result'] = 4;
 
 export const testUpdatedCounter: Record<string, number> = {};
 testUpdatedCounter['marking-definition'] = 2;
@@ -147,7 +148,7 @@ testDeletedCounter.opinion = 4;
 testDeletedCounter.persona = 1;
 testDeletedCounter['phone-number'] = 2;
 testDeletedCounter.relationship = 3;
-testDeletedCounter.report = 30;
+testDeletedCounter.report = 31;
 testDeletedCounter.sighting = 1;
 testDeletedCounter['ssh-key'] = 1;
 testDeletedCounter['threat-actor'] = 12;
@@ -157,6 +158,8 @@ testDeletedCounter.software = 1;
 testDeletedCounter.iccid = 3;
 testDeletedCounter.imei = 2;
 testDeletedCounter.imsi = 1;
+testDeletedCounter['security-coverage'] = 4;
+testDeletedCounter['security-coverage-result'] = 3;
 
 export const doTotal = (eventCounter: Record<string, number>) => {
   const allRecordKeys = Object.keys(eventCounter);

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const SYNC_LIVE_EVENTS_SIZE = 634;
+export const SYNC_LIVE_EVENTS_SIZE = 635;
 
 export const PYTHON_PATH = './src/python/testing';
 export const API_URI = `http://localhost:${conf.get('app:port')}`;

--- a/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
+++ b/opencti-platform/opencti-graphql/tests/utils/testQuery.ts
@@ -22,7 +22,7 @@ export const SYNC_LIVE_START_REMOTE_URI = conf.get('app:sync_live_start_remote_u
 export const SYNC_DIRECT_START_REMOTE_URI = conf.get('app:sync_direct_start_remote_uri');
 export const SYNC_RESTORE_START_REMOTE_URI = conf.get('app:sync_restore_start_remote_uri');
 export const SYNC_TEST_REMOTE_URI = `http://api-tests:${PORT}`;
-export const SYNC_LIVE_EVENTS_SIZE = 635;
+export const SYNC_LIVE_EVENTS_SIZE = 628;
 
 export const PYTHON_PATH = './src/python/testing';
 export const API_URI = `http://localhost:${conf.get('app:port')}`;


### PR DESCRIPTION
### Proposed changes

* Define the ref RESULT_OF in both sides
* New helper function to resolve the different fields that are now in the result
* Non-regression test is now OK
* Full-fill the backend module securityCoverageResult
* Update client-python

### Related issues

* Closes #16310
* #14716

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality