### PR TITLE
[frontend] Stick Ask Ariane chatbot panel under the top bar when floating banners are shown (#16256)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianeButton.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianeButton.tsx
@@ -17,15 +17,17 @@ import AskArianePanel from './AskArianePanel';
 import ChatbotManager from './ChatbotManager';
 import { useChatbot } from './ChatbotContext';
 import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
+import useTopBanner from '../../../utils/hooks/useTopBanner';
 
 const AskArianeButton = () => {
   const { t_i18n } = useFormatter();
   const { isChatbotAiEnabled } = useHelper();
-  const { settings: { filigran_chatbot_ai_cgu_status } } = useAuth();
+  const { settings: { filigran_chatbot_ai_cgu_status }, bannerSettings: { bannerHeightNumber } } = useAuth();
   const theme = useTheme<Theme>();
   const isEnterpriseEdition = useEnterpriseEdition();
   const hasRightToValidateCGU = useGranted([SETTINGS_SETPARAMETERS]);
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
+  const { height: topBannerHeight } = useTopBanner();
   const {
     isOpen, mode, openChat, closeChat, setMode,
     setSidebarWidth, setIsResizing, xtmOneConfigured,
@@ -37,14 +39,18 @@ const AskArianeButton = () => {
   const isChatbotEnabled = isEnterpriseEdition && isChatbotAiEnabled();
   const useLegacy = xtmOneConfigured === false;
 
+  // Total height of all floating banners stacked above the top bar.
+  // Forwarded to the legacy chatbot so its window sticks under the real top bar.
+  const totalBannerHeight = bannerHeightNumber + topBannerHeight + settingsMessagesBannerHeight;
+
   // Legacy v1 web-component management (only active when XTM One is NOT configured)
   const chatbotManager = useRef(ChatbotManager.getInstance());
 
   useEffect(() => {
     if (useLegacy && isChatbotEnabled) {
-      chatbotManager.current.configure(theme, t_i18n, settingsMessagesBannerHeight);
+      chatbotManager.current.configure(theme, t_i18n, totalBannerHeight);
     }
-  }, [useLegacy, isChatbotEnabled, theme, t_i18n, settingsMessagesBannerHeight]);
+  }, [useLegacy, isChatbotEnabled, theme, t_i18n, totalBannerHeight]);
 
   useEffect(() => {
     if (useLegacy && !isChatbotEnabled && chatbotManager.current.isReady()) {

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -9,7 +9,10 @@ import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
 import { APP_BASE_PATH } from '../../../relay/environment';
 import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
+import useTopBanner from '../../../utils/hooks/useTopBanner';
 import FiligranIcon from '@components/common/FiligranIcon';
+
+const TOP_BAR_HEIGHT = 64;
 
 interface AskArianePanelProps {
   mode: ChatMode;
@@ -31,12 +34,19 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
   const navigate = useNavigate();
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
-  const { me } = useAuth();
+  const { me, bannerSettings: { bannerHeightNumber } } = useAuth();
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
+  const { height: topBannerHeight } = useTopBanner();
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [xtmOneUrl, setXtmOneUrl] = useState<string | null>(null);
 
-  const topOffset = 64 + settingsMessagesBannerHeight;
+  // Stack all the floating banners that sit above the top bar so the chatbot
+  // panel sticks right under the actual top bar in every configuration.
+  // See `TopBar.tsx` which uses the same sum to offset its toolbar.
+  const topOffset = TOP_BAR_HEIGHT
+    + bannerHeightNumber
+    + topBannerHeight
+    + settingsMessagesBannerHeight;
 
   const firstName = me.user_email?.split('@')[0] ?? 'User';
 


### PR DESCRIPTION
### Proposed changes

* `AskArianePanel.tsx` (XTM One v3 `ChatPanel`) now computes its `topOffset` as `64 + bannerHeightNumber + topBannerHeight + settingsMessagesBannerHeight`, matching the offset already used by `TopBar`, `LeftBar` and `Index`, so the panel stays flush with the real top bar no matter which floating banners are stacked above it (EE trial / license, XTM Hub register, system classification banner, settings messages).
* `AskArianeButton.tsx` forwards the same total banner height (system classification + top banner + settings messages) to the legacy v1 `ChatbotManager` web-component, so the legacy chatbot window also sticks under the top bar in every configuration.

### Related issues

* Closes #16256

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The previous offset (`64 + settingsMessagesBannerHeight`) only accounted for the dynamic settings messages banner and ignored:

- `bannerHeightNumber` — system classification banner (20px when active),
- `topBannerHeight` — EE trial / license / register-to-Hub banner (30px when shown, from `useTopBanner()`).

This is the same trio used everywhere else in the layout (e.g. `TopBar.tsx`: `marginTop: bannerHeightNumber + settingsMessagesBannerHeight + topBannerHeight`), so the chatbot is now consistent with the rest of the chrome.

No new translation strings, no GraphQL schema or backend changes.