### PR TITLE
[backend/frontend] Cache AI Insights responses powered by XTM One agents (#16258)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryActivity.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryActivity.tsx
@@ -238,13 +238,13 @@ const XtmOneActivity = ({ id, loading, setLoading, selectedAgent }: XtmOneActivi
     setLoading(streamLoading);
   }, [streamLoading, setLoading]);
 
-  const executeCall = useCallback(() => {
+  const executeCall = useCallback((forceRefresh = false) => {
     if (!selectedAgent) return;
     const prompt = `Analyse the activity of the OpenCTI entity with ID: ${id}. `
       + 'Get time-series statistics about entity related indicators, relationships and sightings and analyze the trend for each. '
       + 'Finally evaluate whether the overall activity trend is increasing, stable, or decreasing. '
       + `Answer using ${language} language.`;
-    execute(selectedAgent.slug, prompt);
+    execute(selectedAgent.slug, prompt, forceRefresh);
   }, [selectedAgent, id, language, execute]);
 
   useEffect(() => {
@@ -263,7 +263,7 @@ const XtmOneActivity = ({ id, loading, setLoading, selectedAgent }: XtmOneActivi
       loading={loading}
       content={content}
       generatedAt={generatedAt}
-      onRetry={executeCall}
+      onRetry={() => executeCall(true)}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryContainers.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryContainers.tsx
@@ -232,10 +232,10 @@ const XtmOneContainerSummary = ({ isContainer, filters, loading, setLoading, sel
       + `Answer using ${language} language.`;
   }, [filters, isContainer, language]);
 
-  const executeCall = useCallback(() => {
+  const executeCall = useCallback((forceRefresh = false) => {
     if (!selectedAgent) return;
     const prompt = buildPrompt();
-    execute(selectedAgent.slug, prompt);
+    execute(selectedAgent.slug, prompt, forceRefresh);
   }, [selectedAgent, buildPrompt, execute]);
 
   // Auto-execute when agent changes (selected from header) or first load
@@ -255,7 +255,7 @@ const XtmOneContainerSummary = ({ isContainer, filters, loading, setLoading, sel
       loading={loading}
       content={content}
       generatedAt={generatedAt}
-      onRetry={executeCall}
+      onRetry={() => executeCall(true)}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryForecast.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryForecast.tsx
@@ -177,13 +177,13 @@ const XtmOneForecast = ({ id, loading, setLoading, selectedAgent }: XtmOneForeca
     setLoading(streamLoading);
   }, [streamLoading, setLoading]);
 
-  const executeCall = useCallback(() => {
+  const executeCall = useCallback((forceRefresh = false) => {
     if (!selectedAgent) return;
     const prompt = `Forecast the future activity of the OpenCTI entity with ID: ${id}. `
       + 'Get ranked distribution of related entities and time-series statistics. '
       + 'Based on current trends, provide a forward-looking assessment of expected activity evolution. '
       + `Answer using ${language} language.`;
-    execute(selectedAgent.slug, prompt);
+    execute(selectedAgent.slug, prompt, forceRefresh);
   }, [selectedAgent, id, language, execute]);
 
   useEffect(() => {
@@ -202,7 +202,7 @@ const XtmOneForecast = ({ id, loading, setLoading, selectedAgent }: XtmOneForeca
       loading={loading}
       content={content}
       generatedAt={generatedAt}
-      onRetry={executeCall}
+      onRetry={() => executeCall(true)}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryHistory.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/ai/AISummaryHistory.tsx
@@ -174,12 +174,12 @@ const XtmOneHistory = ({ id, loading, setLoading, selectedAgent }: XtmOneHistory
     setLoading(streamLoading);
   }, [streamLoading, setLoading]);
 
-  const executeCall = useCallback(() => {
+  const executeCall = useCallback((forceRefresh = false) => {
     if (!selectedAgent) return;
     const prompt = `Summarize the internal history (audit logs, modifications) of the OpenCTI entity with ID: ${id}. `
       + 'Provide a chronological summary of significant changes.'
       + `Answer using ${language} language.`;
-    execute(selectedAgent.slug, prompt);
+    execute(selectedAgent.slug, prompt, forceRefresh);
   }, [selectedAgent, id, language, execute]);
 
   useEffect(() => {
@@ -198,7 +198,7 @@ const XtmOneHistory = ({ id, loading, setLoading, selectedAgent }: XtmOneHistory
       loading={loading}
       content={content}
       generatedAt={generatedAt}
-      onRetry={executeCall}
+      onRetry={() => executeCall(true)}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/utils/ai/agentApi.test.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/agentApi.test.ts
@@ -3,25 +3,36 @@ import { callAgent, callAgentStream } from './agentApi';
 
 const buildJsonResponse = (status: number, body: unknown, ok = status >= 200 && status < 300): Response => {
   const json = JSON.stringify(body);
-  return {
+  let statusText = 'OK';
+  if (status === 400) statusText = 'Bad Request';
+  if (status === 503) statusText = 'Service Unavailable';
+  const response = {
     ok,
     status,
-    statusText: status === 400 ? 'Bad Request' : status === 503 ? 'Service Unavailable' : 'OK',
+    statusText,
     json: async () => JSON.parse(json),
-    clone() { return buildJsonResponse(status, body, ok); },
+    clone() {
+      return buildJsonResponse(status, body, ok);
+    },
     body: null,
-  } as unknown as Response;
+  };
+  return response as unknown as Response;
 };
 
 const buildPlainResponse = (status: number, text: string, ok = status >= 200 && status < 300): Response => {
-  return {
+  const response = {
     ok,
     status,
     statusText: 'Bad Request',
-    json: async () => { throw new SyntaxError('Unexpected token in JSON'); },
-    clone() { return buildPlainResponse(status, text, ok); },
+    json: async () => {
+      throw new SyntaxError('Unexpected token in JSON');
+    },
+    clone() {
+      return buildPlainResponse(status, text, ok);
+    },
     body: null,
-  } as unknown as Response;
+  };
+  return response as unknown as Response;
 };
 
 const buildSseStreamResponse = (chunks: string[]): Response => {
@@ -37,14 +48,17 @@ const buildSseStreamResponse = (chunks: string[]): Response => {
     }),
     releaseLock: vi.fn(),
   };
-  return {
+  const response = {
     ok: true,
     status: 200,
     statusText: 'OK',
     body: { getReader: () => reader },
     json: async () => ({}),
-    clone() { return this as Response; },
-  } as unknown as Response;
+    clone() {
+      return response as unknown as Response;
+    },
+  };
+  return response as unknown as Response;
 };
 
 describe('agentApi', () => {

--- a/opencti-platform/opencti-front/src/utils/ai/agentApi.test.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/agentApi.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { callAgent, callAgentStream } from './agentApi';
+
+const buildJsonResponse = (status: number, body: unknown, ok = status >= 200 && status < 300): Response => {
+  const json = JSON.stringify(body);
+  return {
+    ok,
+    status,
+    statusText: status === 400 ? 'Bad Request' : status === 503 ? 'Service Unavailable' : 'OK',
+    json: async () => JSON.parse(json),
+    clone() { return buildJsonResponse(status, body, ok); },
+    body: null,
+  } as unknown as Response;
+};
+
+const buildPlainResponse = (status: number, text: string, ok = status >= 200 && status < 300): Response => {
+  return {
+    ok,
+    status,
+    statusText: 'Bad Request',
+    json: async () => { throw new SyntaxError('Unexpected token in JSON'); },
+    clone() { return buildPlainResponse(status, text, ok); },
+    body: null,
+  } as unknown as Response;
+};
+
+const buildSseStreamResponse = (chunks: string[]): Response => {
+  let i = 0;
+  const reader = {
+    read: vi.fn(async () => {
+      if (i >= chunks.length) {
+        return { done: true, value: undefined as unknown as Uint8Array };
+      }
+      const chunk = new TextEncoder().encode(chunks[i]);
+      i += 1;
+      return { done: false, value: chunk };
+    }),
+    releaseLock: vi.fn(),
+  };
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    body: { getReader: () => reader },
+    json: async () => ({}),
+    clone() { return this as Response; },
+  } as unknown as Response;
+};
+
+describe('agentApi', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('callAgent', () => {
+    it('surfaces the backend `{ error }` JSON message on non-OK responses', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildJsonResponse(400, { error: 'Could not find draft workspace' }),
+      );
+
+      const result = await callAgent('test-agent', 'hello');
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('Could not find draft workspace');
+      expect(result.code).toBe(400);
+      expect(result.content).toBe('');
+    });
+
+    it('falls back to statusText when the error body is not JSON', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildPlainResponse(400, 'plain text error'),
+      );
+
+      const result = await callAgent('test-agent', 'hello');
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('Agent call failed: Bad Request');
+      expect(result.code).toBe(400);
+    });
+
+    it('returns the parsed body content on success', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildJsonResponse(200, { content: 'hello world', status: 'success' }),
+      );
+
+      const result = await callAgent('test-agent', 'hello');
+
+      expect(result.status).toBe('success');
+      expect(result.content).toBe('hello world');
+    });
+  });
+
+  describe('callAgentStream', () => {
+    it('surfaces the backend `{ error }` JSON message on non-OK responses', async () => {
+      // Regression guard for the new draft-validation 400 path: without
+      // `readAgentErrorBody`, the UI would see a generic "Bad Request"
+      // built from `response.statusText` instead of the actionable
+      // backend message.
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildJsonResponse(400, { error: 'Could not find draft workspace' }),
+      );
+
+      const onChunk = vi.fn();
+      const result = await callAgentStream('test-agent', 'hello', onChunk);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('Could not find draft workspace');
+      expect(result.code).toBe(400);
+      expect(onChunk).not.toHaveBeenCalled();
+    });
+
+    it('falls back to statusText when the error body is not JSON', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildPlainResponse(400, 'plain text error'),
+      );
+
+      const result = await callAgentStream('test-agent', 'hello', vi.fn());
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('Agent call failed: Bad Request');
+    });
+
+    it('parses streamed `stream` and `done` SSE events and surfaces backend timestamps on cache hits', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildSseStreamResponse([
+          'data: {"type":"stream","content":"Hel"}\n\n',
+          'data: {"type":"stream","content":"Hello"}\n\n',
+          'data: {"type":"done","content":"Hello world","cached":true,"generated_at":"2026-05-28T10:00:00.000Z"}\n\n',
+        ]),
+      );
+
+      const chunks: string[] = [];
+      const result = await callAgentStream('test-agent', 'hello', (partial) => chunks.push(partial));
+
+      expect(result.status).toBe('success');
+      expect(result.content).toBe('Hello world');
+      expect(result.fromCache).toBe(true);
+      expect(result.generatedAt).toBe('2026-05-28T10:00:00.000Z');
+      expect(chunks.at(-1)).toBe('Hello world');
+    });
+
+    it('forwards `force_refresh: true` to the backend when the caller opts to bypass the cache', async () => {
+      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        buildSseStreamResponse([
+          'data: {"type":"done","content":"fresh"}\n\n',
+        ]),
+      );
+
+      await callAgentStream('test-agent', 'hello', vi.fn(), undefined, true);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.force_refresh).toBe(true);
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/ai/agentApi.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/agentApi.ts
@@ -29,6 +29,27 @@ export const fetchAgentsForIntent = async (intent: string): Promise<AgentOption[
   }
 };
 
+/**
+ * Best-effort JSON `{ error }` body extraction for non-OK fetch responses.
+ * The chatbot proxy returns `400 { error: '...' }` for body-validation and
+ * draft-authorization failures, and `503 { error: '...' }` when XTM One is
+ * unreachable — surfacing those messages in the UI is much more actionable
+ * than a generic "Bad Request" derived from `response.statusText`. Falls
+ * back to `statusText` if the body is not JSON, has no `error` field, or
+ * has already been consumed.
+ */
+const readAgentErrorBody = async (response: Response): Promise<string> => {
+  try {
+    const data = await response.clone().json();
+    if (data && typeof data.error === 'string' && data.error.length > 0) {
+      return data.error;
+    }
+  } catch {
+    // Body is not JSON or already consumed — fall through to statusText.
+  }
+  return `Agent call failed: ${response.statusText}`;
+};
+
 export const callAgent = async (agentSlug: string, content: string): Promise<AgentResponse> => {
   const response = await fetch('/chatbot/agent', {
     method: 'POST',
@@ -36,7 +57,7 @@ export const callAgent = async (agentSlug: string, content: string): Promise<Age
     body: JSON.stringify({ agent_slug: agentSlug, content }),
   });
   if (!response.ok) {
-    return { content: '', status: 'error', error: `Agent call failed: ${response.statusText}`, code: response.status };
+    return { content: '', status: 'error', error: await readAgentErrorBody(response), code: response.status };
   }
   const data = await response.json();
   return {
@@ -70,7 +91,7 @@ export const callAgentStream = async (
   });
 
   if (!response.ok) {
-    return { content: '', status: 'error', error: `Agent call failed: ${response.statusText}`, code: response.status };
+    return { content: '', status: 'error', error: await readAgentErrorBody(response), code: response.status };
   }
 
   const reader = response.body?.getReader();

--- a/opencti-platform/opencti-front/src/utils/ai/agentApi.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/agentApi.ts
@@ -13,6 +13,10 @@ export interface AgentResponse {
   status: 'success' | 'error';
   error?: string;
   code?: number;
+  /** ISO timestamp returned by the backend when the response was served from cache. */
+  generatedAt?: string;
+  /** True when the backend served the response from cache. */
+  fromCache?: boolean;
 }
 
 export const fetchAgentsForIntent = async (intent: string): Promise<AgentOption[]> => {
@@ -48,17 +52,20 @@ export const callAgent = async (agentSlug: string, content: string): Promise<Age
  * as each text chunk arrives. Returns the final AgentResponse.
  *
  * @param signal - optional AbortSignal to cancel the stream
+ * @param forceRefresh - bypass the backend response cache (set when the user
+ *   explicitly retries to force a fresh agent execution).
  */
 export const callAgentStream = async (
   agentSlug: string,
   content: string,
   onChunk: (partialContent: string) => void,
   signal?: AbortSignal,
+  forceRefresh?: boolean,
 ): Promise<AgentResponse> => {
   const response = await fetch('/chatbot/agent/stream', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ agent_slug: agentSlug, content }),
+    body: JSON.stringify({ agent_slug: agentSlug, content, force_refresh: forceRefresh === true }),
     signal,
   });
 
@@ -75,6 +82,8 @@ export const callAgentStream = async (
   let accumulated = '';
   let buffer = '';
   let lastError: string | undefined;
+  let generatedAt: string | undefined;
+  let fromCache = false;
 
   try {
     for (;;) {
@@ -100,6 +109,12 @@ export const callAgentStream = async (
           } else if (event.type === 'done' && typeof event.content === 'string') {
             // Final message — use authoritative full content
             accumulated = event.content;
+            if (typeof event.generated_at === 'string') {
+              generatedAt = event.generated_at;
+            }
+            if (event.cached === true) {
+              fromCache = true;
+            }
             onChunk(accumulated);
           } else if (event.type === 'error') {
             lastError = event.content ?? 'Unknown error';
@@ -117,5 +132,5 @@ export const callAgentStream = async (
   if (lastError) {
     return { content: lastError, status: 'error', error: lastError };
   }
-  return { content: accumulated, status: 'success' };
+  return { content: accumulated, status: 'success', generatedAt, fromCache };
 };

--- a/opencti-platform/opencti-front/src/utils/ai/useAgentStream.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/useAgentStream.ts
@@ -12,7 +12,11 @@ interface UseAgentStreamReturn {
   loading: boolean;
   error: string | undefined;
   generatedAt: string | null;
-  execute: (agentSlug: string, prompt: string) => void;
+  /**
+   * Trigger an agent stream. Pass `forceRefresh: true` to bypass the
+   * backend response cache (used by the Retry button).
+   */
+  execute: (agentSlug: string, prompt: string, forceRefresh?: boolean) => void;
   abort: () => void;
 }
 
@@ -45,7 +49,7 @@ const useAgentStream = (options?: UseAgentStreamOptions): UseAgentStreamReturn =
     abortRef.current?.abort();
   }, []);
 
-  const execute = useCallback((agentSlug: string, prompt: string) => {
+  const execute = useCallback((agentSlug: string, prompt: string, forceRefresh?: boolean) => {
     abortRef.current?.abort();
     if (rafRef.current !== null) {
       cancelAnimationFrame(rafRef.current);
@@ -73,6 +77,7 @@ const useAgentStream = (options?: UseAgentStreamOptions): UseAgentStreamReturn =
         }
       },
       controller.signal,
+      forceRefresh,
     )
       .then((result) => {
         if (rafRef.current !== null) {
@@ -83,7 +88,10 @@ const useAgentStream = (options?: UseAgentStreamOptions): UseAgentStreamReturn =
           setError(result.error ?? 'An unknown error occurred');
         } else {
           setContent(transform(result.content));
-          setGeneratedAt(new Date().toISOString());
+          // Prefer the backend-provided timestamp (set on cache hits) so the
+          // UI shows when the response was originally generated rather than
+          // the time it was replayed from cache.
+          setGeneratedAt(result.generatedAt ?? new Date().toISOString());
         }
         setLoading(false);
       })

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -209,6 +209,7 @@
     "model_images": "",
     "max_tokens": 30000,
     "insights_refresh_timeout": 60,
+    "agents_refresh_timeout": 1440,
     "ai_azure_instance": "",
     "ai_azure_deployment": "",
     "timeout": 60000

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -876,11 +876,29 @@ export interface XtmAgentCachedResponse {
   cached_at: string;
 }
 
+const isXtmAgentCachedResponse = (value: unknown): value is XtmAgentCachedResponse => {
+  return !!value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && typeof (value as XtmAgentCachedResponse).content === 'string'
+    && typeof (value as XtmAgentCachedResponse).cached_at === 'string';
+};
+
 export const redisGetXtmAgentResponse = async (cacheKey: string): Promise<XtmAgentCachedResponse | null> => {
   try {
     const raw = await getClientBase().get(`${XTM_AGENT_CACHE_KEY_PREFIX}${cacheKey}`);
     if (!raw) return null;
-    return JSON.parse(raw) as XtmAgentCachedResponse;
+    const parsed = JSON.parse(raw);
+    // Defensive shape check — Redis can hold any JSON the writer puts in
+    // (legacy entries, manual edits, attacker-set keys), so refuse to
+    // replay anything that isn't a `{ content: string, cached_at: string }`
+    // object instead of letting the consumer emit a `done` SSE event with
+    // `content: undefined`.
+    if (!isXtmAgentCachedResponse(parsed)) {
+      logApp.warn('[XTM One] Agent response cache payload has unexpected shape, ignoring', { cacheKey });
+      return null;
+    }
+    return parsed;
   } catch (err) {
     logApp.warn('[XTM One] Agent response cache read failed', { cause: err });
     return null;

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -864,3 +864,41 @@ export const redisGetXtmRegistrationResult = async (): Promise<object | null> =>
   }
 };
 // endregion - XTM One registration result
+
+// region - XTM agent response cache
+// Caches the full content returned by an XTM One agent stream call so that
+// reopening AI Insights for the same entity within the TTL window returns
+// instantly instead of re-running an expensive agent execution.
+const XTM_AGENT_CACHE_KEY_PREFIX = 'xtm_agent_cache:';
+
+export interface XtmAgentCachedResponse {
+  content: string;
+  cached_at: string;
+}
+
+export const redisGetXtmAgentResponse = async (cacheKey: string): Promise<XtmAgentCachedResponse | null> => {
+  try {
+    const raw = await getClientBase().get(`${XTM_AGENT_CACHE_KEY_PREFIX}${cacheKey}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as XtmAgentCachedResponse;
+  } catch (err) {
+    logApp.warn('[XTM One] Agent response cache read failed', { cause: err });
+    return null;
+  }
+};
+
+export const redisSetXtmAgentResponse = async (cacheKey: string, content: string, ttlSeconds: number): Promise<void> => {
+  if (ttlSeconds <= 0) return;
+  try {
+    const value: XtmAgentCachedResponse = { content, cached_at: new Date().toISOString() };
+    await getClientBase().set(
+      `${XTM_AGENT_CACHE_KEY_PREFIX}${cacheKey}`,
+      JSON.stringify(value),
+      'EX',
+      ttlSeconds,
+    );
+  } catch (err) {
+    logApp.warn('[XTM One] Agent response cache write failed', { cause: err });
+  }
+};
+// endregion - XTM agent response cache

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -562,6 +562,14 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
     }
 
     const headers = await generateBasicHeaders(req, context);
+    // Force the upstream `opencti-draft-id` header to match the validated
+    // `context.draft_context` used for the cache key. `generateBasicHeaders`
+    // forwards the raw request header, but `context.draft_context` falls back
+    // to `user.draft_context` when the request header is absent — without this
+    // override, a user with an active session draft and no explicit header
+    // would run the agent in the live workspace while the response gets
+    // cached under the draft key (and vice-versa on the next cache hit).
+    headers['opencti-draft-id'] = draftId;
     const httpClient = getXtmClient('stream', headers);
     const response = await httpClient.post('/api/v1/platform/chat/messages', {
       agent_slug,

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type Express from 'express';
 import nconf from 'nconf';
 import Busboy from 'busboy';
@@ -14,6 +15,7 @@ import xtmOneClient from '../modules/xtm/one/xtm-one-client';
 import { issueXtmJwt } from '../domain/xtm-auth';
 import type { AuthContext } from '../types/user';
 import { getHttpClient, getResponseError } from '../utils/http-client';
+import { redisGetXtmAgentResponse, redisSetXtmAgentResponse } from '../database/redis';
 
 const XTM_ONE_URL = nconf.get('xtm:xtm_one_url');
 export const XTM_ONE_CHATBOT_URL = `${XTM_ONE_URL}/chatbot`;
@@ -25,6 +27,12 @@ const DEFAULT_XTM_TIMEOUT = 2 * 60 * 1000; // 2 minutes.
 // Extended timeout for multipart file-based agent calls (10 minutes).
 // File upload and analysis can take significantly longer than text-based calls.
 const MULTIPART_XTM_TIMEOUT = 10 * 60 * 1000; // 10 minutes.
+
+// TTL (in minutes) for caching XTM One agent responses in Redis. The cache
+// is keyed by agent_slug + content hash so that reopening AI Insights for the
+// same entity within the window returns instantly. Set to 0 to disable.
+const AI_AGENTS_REFRESH_TIMEOUT_MINUTES = Number(nconf.get('ai:agents_refresh_timeout') ?? 1440);
+const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = AI_AGENTS_REFRESH_TIMEOUT_MINUTES * 60;
 
 // ── HTTP client (proxy-aware) ────────────────────────────────────────────
 const getXtmClient = (responseType: 'json' | 'stream', headers?: Record<string, string>) => {
@@ -434,20 +442,88 @@ export const postAgentMessage = async (req: Express.Request, res: Express.Respon
   }
 };
 
+// ── Agent response cache helpers ────────────────────────────────────────
+
+// Build a stable cache key from the agent slug and the user prompt.
+const buildAgentCacheKey = (agentSlug: string, content: string): string => {
+  return createHash('sha256').update(`${agentSlug}::${content}`).digest('hex');
+};
+
+// Set the SSE response headers once for both cache hits and live streams.
+const writeAgentStreamHeaders = (res: Express.Response): void => {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+};
+
+// Parse a buffered SSE stream and return the content of the final `done` event,
+// or null if the stream did not complete successfully (e.g. produced an error
+// event, was aborted, or never emitted a `done`). Used to avoid caching
+// partial / failed responses.
+const extractFinalContent = (raw: string): string | null => {
+  const lines = raw.split('\n');
+  let lastDoneContent: string | null = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data: ')) continue;
+    try {
+      const event = JSON.parse(trimmed.slice(6));
+      if (event.type === 'error') {
+        return null;
+      }
+      if (event.type === 'done' && typeof event.content === 'string') {
+        lastDoneContent = event.content;
+      }
+    } catch {
+      // Skip malformed SSE lines
+    }
+  }
+  return lastDoneContent;
+};
+
 // ── POST /chatbot/agent/stream ──────────────────────────────────────────
 // Streaming agent call: sends a message with stream=true and pipes the
 // SSE event stream back to the client for real-time rendering.
-// Body: { agent_slug, content }
+// Body: { agent_slug, content, force_refresh? }
 // AskIA / Insight (no files), streamed to client
+//
+// Responses are cached in Redis keyed by sha256(agent_slug + content) so that
+// reopening AI Insights for the same entity within the TTL window
+// (ai:agents_refresh_timeout, in minutes, default 1440) returns instantly
+// instead of re-running an expensive agent execution. Pass `force_refresh: true`
+// to bypass the cache (e.g. when the user clicks the retry button).
 export const postAgentMessageStream = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);
     if (!context?.user) return;
-    const { agent_slug, content } = req.body || {};
+    const { agent_slug, content, force_refresh } = req.body || {};
     if (!agent_slug || !content) {
       res.status(400).json({ error: 'agent_slug and content are required' });
       return;
     }
+
+    writeAgentStreamHeaders(res);
+
+    // Cache lookup — replay as a single `done` event so the client display
+    // logic (which already handles `done`) doesn't need to know about cache.
+    const cacheEnabled = AI_AGENTS_REFRESH_TIMEOUT_SECONDS > 0;
+    const cacheKey = cacheEnabled ? buildAgentCacheKey(agent_slug, content) : null;
+    if (cacheEnabled && cacheKey && !force_refresh) {
+      const cached = await redisGetXtmAgentResponse(cacheKey);
+      if (cached) {
+        logApp.info('Agent response served from cache', { agent_slug });
+        res.write(`data: ${JSON.stringify({
+          type: 'done',
+          content: cached.content,
+          cached: true,
+          generated_at: cached.cached_at,
+        })}\n\n`);
+        res.end();
+        return;
+      }
+    }
+
     const headers = await generateBasicHeaders(req, context);
     const httpClient = getXtmClient('stream', headers);
     const response = await httpClient.post('/api/v1/platform/chat/messages', {
@@ -458,12 +534,38 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       decompress: false,
       timeout: 0,
     });
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache, no-transform');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no');
+
+    // Capture the upstream bytes alongside the pipe so we can persist the
+    // final content to Redis when the stream completes. A 2MB ceiling caps
+    // memory usage for unusually large agent responses.
+    let clientAborted = false;
+    let captureBytes = 0;
+    let captureOverflow = false;
+    const captureLimit = 2 * 1024 * 1024;
+    const captureChunks: Buffer[] = [];
+    response.data.on('data', (chunk: Buffer) => {
+      if (captureOverflow) return;
+      captureBytes += chunk.length;
+      if (captureBytes > captureLimit) {
+        captureOverflow = true;
+        captureChunks.length = 0;
+        return;
+      }
+      captureChunks.push(Buffer.from(chunk));
+    });
+    response.data.on('end', async () => {
+      if (!cacheEnabled || !cacheKey || clientAborted || captureOverflow) return;
+      const raw = Buffer.concat(captureChunks).toString('utf-8');
+      const finalContent = extractFinalContent(raw);
+      if (finalContent !== null && finalContent.length > 0) {
+        await redisSetXtmAgentResponse(cacheKey, finalContent, AI_AGENTS_REFRESH_TIMEOUT_SECONDS);
+      }
+    });
+
     response.data.pipe(res);
+
     req.on('close', () => {
+      clientAborted = true;
       response.data.destroy();
     });
     response.data.on('error', (error: Error) => {

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -35,12 +35,16 @@ const MULTIPART_XTM_TIMEOUT = 10 * 60 * 1000; // 10 minutes.
 // live-workspace and draft views never share a cache entry. Set to 0 to
 // disable. A non-numeric or negative override is treated as a misconfiguration
 // and falls back to the default rather than silently disabling the cache.
+// The seconds value is floored to an integer because Redis `SET ... EX` only
+// accepts integer TTLs — a fractional minute override (e.g. `0.01`) would
+// otherwise produce a `0.6s` TTL and fail with `ERR value is not an integer`,
+// silently turning caching off.
 const AI_AGENTS_REFRESH_TIMEOUT_DEFAULT_MINUTES = 1440;
 const parsedAgentsRefreshTimeoutMinutes = Number(nconf.get('ai:agents_refresh_timeout'));
 const AI_AGENTS_REFRESH_TIMEOUT_MINUTES = Number.isFinite(parsedAgentsRefreshTimeoutMinutes) && parsedAgentsRefreshTimeoutMinutes >= 0
   ? parsedAgentsRefreshTimeoutMinutes
   : AI_AGENTS_REFRESH_TIMEOUT_DEFAULT_MINUTES;
-const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = AI_AGENTS_REFRESH_TIMEOUT_MINUTES * 60;
+const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = Math.floor(AI_AGENTS_REFRESH_TIMEOUT_MINUTES * 60);
 
 // ── HTTP client (proxy-aware) ────────────────────────────────────────────
 const getXtmClient = (responseType: 'json' | 'stream', headers?: Record<string, string>) => {
@@ -589,6 +593,7 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
     // final content to Redis when the stream completes. A 2MB ceiling caps
     // memory usage for unusually large agent responses.
     let clientAborted = false;
+    let streamErrored = false;
     let captureBytes = 0;
     let captureOverflow = false;
     const captureLimit = 2 * 1024 * 1024;
@@ -604,7 +609,13 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       captureChunks.push(Buffer.from(chunk));
     });
     response.data.on('end', async () => {
-      if (!cacheEnabled || !cacheKey || clientAborted || captureOverflow) return;
+      // Skip caching on transport errors (Node `'error'` event), client
+      // aborts, capture overflow, or when the cache is disabled. Node
+      // typically does not emit `'end'` after `'error'`, but the explicit
+      // `streamErrored` guard is cheap insurance against caching a partial
+      // or transport-failed response if a future Node / undici / axios
+      // version reorders events.
+      if (!cacheEnabled || !cacheKey || clientAborted || streamErrored || captureOverflow) return;
       const raw = Buffer.concat(captureChunks).toString('utf-8');
       const finalContent = extractFinalContent(raw);
       if (finalContent !== null && finalContent.length > 0) {
@@ -619,6 +630,7 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       response.data.destroy();
     });
     response.data.on('error', (error: Error) => {
+      streamErrored = true;
       logApp.error('Stream error in agent stream proxy', { cause: error });
       if (!res.headersSent) {
         res.status(500).send({ status: 'error', error: error.message });

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -444,9 +444,13 @@ export const postAgentMessage = async (req: Express.Request, res: Express.Respon
 
 // ── Agent response cache helpers ────────────────────────────────────────
 
-// Build a stable cache key from the agent slug and the user prompt.
-const buildAgentCacheKey = (agentSlug: string, content: string): string => {
-  return createHash('sha256').update(`${agentSlug}::${content}`).digest('hex');
+// Build a stable cache key from the agent slug, the draft context, and the
+// user prompt. The draft id is part of the key because the same prompt run
+// against the live workspace vs a draft would return different stats from
+// the agent's OpenCTI-side callbacks, and replaying a live cache hit to a
+// draft viewer (or vice-versa) would be incorrect.
+const buildAgentCacheKey = (agentSlug: string, draftId: string, content: string): string => {
+  return createHash('sha256').update(`${agentSlug}::${draftId}::${content}`).digest('hex');
 };
 
 // Set the SSE response headers once for both cache hits and live streams.
@@ -507,8 +511,13 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
 
     // Cache lookup — replay as a single `done` event so the client display
     // logic (which already handles `done`) doesn't need to know about cache.
+    // The cache is intentionally not namespaced by user identity (matching
+    // the pre-XTM-One in-memory `aiResponseCache` in `domain/container.js`),
+    // but it MUST be namespaced by draft so live and draft views never
+    // contaminate each other.
+    const draftId = (req.headers['opencti-draft-id'] as string) || '';
     const cacheEnabled = AI_AGENTS_REFRESH_TIMEOUT_SECONDS > 0;
-    const cacheKey = cacheEnabled ? buildAgentCacheKey(agent_slug, content) : null;
+    const cacheKey = cacheEnabled ? buildAgentCacheKey(agent_slug, draftId, content) : null;
     if (cacheEnabled && cacheKey && !force_refresh) {
       const cached = await redisGetXtmAgentResponse(cacheKey);
       if (cached) {

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -16,6 +16,7 @@ import { issueXtmJwt } from '../domain/xtm-auth';
 import type { AuthContext } from '../types/user';
 import { getHttpClient, getResponseError } from '../utils/http-client';
 import { redisGetXtmAgentResponse, redisSetXtmAgentResponse } from '../database/redis';
+import { checkDraftInContext } from './httpServer-draft';
 
 const XTM_ONE_URL = nconf.get('xtm:xtm_one_url');
 export const XTM_ONE_CHATBOT_URL = `${XTM_ONE_URL}/chatbot`;
@@ -32,8 +33,13 @@ const MULTIPART_XTM_TIMEOUT = 10 * 60 * 1000; // 10 minutes.
 // is keyed by sha256(agent_slug + opencti-draft-id + content) so reopening
 // AI Insights for the same entity within the window returns instantly, and
 // live-workspace and draft views never share a cache entry. Set to 0 to
-// disable.
-const AI_AGENTS_REFRESH_TIMEOUT_MINUTES = Number(nconf.get('ai:agents_refresh_timeout') ?? 1440);
+// disable. A non-numeric or negative override is treated as a misconfiguration
+// and falls back to the default rather than silently disabling the cache.
+const AI_AGENTS_REFRESH_TIMEOUT_DEFAULT_MINUTES = 1440;
+const parsedAgentsRefreshTimeoutMinutes = Number(nconf.get('ai:agents_refresh_timeout'));
+const AI_AGENTS_REFRESH_TIMEOUT_MINUTES = Number.isFinite(parsedAgentsRefreshTimeoutMinutes) && parsedAgentsRefreshTimeoutMinutes >= 0
+  ? parsedAgentsRefreshTimeoutMinutes
+  : AI_AGENTS_REFRESH_TIMEOUT_DEFAULT_MINUTES;
 const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = AI_AGENTS_REFRESH_TIMEOUT_MINUTES * 60;
 
 // ── HTTP client (proxy-aware) ────────────────────────────────────────────
@@ -512,13 +518,31 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       return;
     }
 
+    // REST routes don't go through the GraphQL `checkDraftInContext` middleware,
+    // so validate the draft context explicitly before either serving a cached
+    // response or hitting the upstream agent. Without this guard a caller could
+    // pass an arbitrary `opencti-draft-id` header and get a cached response (or
+    // a fresh agent run) for a draft they don't have access to, bypassing draft
+    // authorization entirely. `checkDraftInContext` is a no-op when the
+    // authenticated context has no draft, so the live-workspace path is
+    // unaffected.
+    try {
+      await checkDraftInContext(context);
+    } catch (draftErr: unknown) {
+      logApp.warn('Agent stream rejected due to invalid draft context', { cause: draftErr });
+      res.status(400).json({ error: (draftErr as Error)?.message || 'Invalid draft context' });
+      return;
+    }
+
     // Cache lookup — replay as a single `done` event so the client display
     // logic (which already handles `done`) doesn't need to know about cache.
     // The cache is intentionally not namespaced by user identity (matching
     // the pre-XTM-One in-memory `aiResponseCache` in `domain/container.js`),
     // but it MUST be namespaced by draft so live and draft views never
-    // contaminate each other.
-    const draftId = (req.headers['opencti-draft-id'] as string) || '';
+    // contaminate each other. We read the draft id from `context.draft_context`
+    // (rather than the raw header) so that the value has gone through the same
+    // shape validation the rest of the platform uses.
+    const draftId = context.draft_context ?? '';
     const cacheEnabled = AI_AGENTS_REFRESH_TIMEOUT_SECONDS > 0;
     const cacheKey = cacheEnabled ? buildAgentCacheKey(agent_slug, draftId, content) : null;
     if (cacheEnabled && cacheKey && !force_refresh) {

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -29,8 +29,10 @@ const DEFAULT_XTM_TIMEOUT = 2 * 60 * 1000; // 2 minutes.
 const MULTIPART_XTM_TIMEOUT = 10 * 60 * 1000; // 10 minutes.
 
 // TTL (in minutes) for caching XTM One agent responses in Redis. The cache
-// is keyed by agent_slug + content hash so that reopening AI Insights for the
-// same entity within the window returns instantly. Set to 0 to disable.
+// is keyed by sha256(agent_slug + opencti-draft-id + content) so reopening
+// AI Insights for the same entity within the window returns instantly, and
+// live-workspace and draft views never share a cache entry. Set to 0 to
+// disable.
 const AI_AGENTS_REFRESH_TIMEOUT_MINUTES = Number(nconf.get('ai:agents_refresh_timeout') ?? 1440);
 const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = AI_AGENTS_REFRESH_TIMEOUT_MINUTES * 60;
 
@@ -492,11 +494,14 @@ const extractFinalContent = (raw: string): string | null => {
 // Body: { agent_slug, content, force_refresh? }
 // AskIA / Insight (no files), streamed to client
 //
-// Responses are cached in Redis keyed by sha256(agent_slug + content) so that
-// reopening AI Insights for the same entity within the TTL window
+// Responses are cached in Redis keyed by
+// sha256(agent_slug + opencti-draft-id + content) so that reopening AI
+// Insights for the same entity within the TTL window
 // (ai:agents_refresh_timeout, in minutes, default 1440) returns instantly
-// instead of re-running an expensive agent execution. Pass `force_refresh: true`
-// to bypass the cache (e.g. when the user clicks the retry button).
+// instead of re-running an expensive agent execution. The draft id is
+// part of the key so live-workspace and draft views never share a cache
+// entry. Pass `force_refresh: true` to bypass the cache (e.g. when the
+// user clicks the retry button).
 export const postAgentMessageStream = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -507,8 +507,6 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       return;
     }
 
-    writeAgentStreamHeaders(res);
-
     // Cache lookup — replay as a single `done` event so the client display
     // logic (which already handles `done`) doesn't need to know about cache.
     // The cache is intentionally not namespaced by user identity (matching
@@ -522,6 +520,7 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       const cached = await redisGetXtmAgentResponse(cacheKey);
       if (cached) {
         logApp.info('Agent response served from cache', { agent_slug });
+        writeAgentStreamHeaders(res);
         res.write(`data: ${JSON.stringify({
           type: 'done',
           content: cached.content,
@@ -543,6 +542,11 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       decompress: false,
       timeout: 0,
     });
+
+    // Only set SSE response headers now that we know the upstream stream is
+    // open. Setting them earlier would leak `Content-Type: text/event-stream`
+    // into the catch branches below that respond with JSON.
+    writeAgentStreamHeaders(res);
 
     // Capture the upstream bytes alongside the pipe so we can persist the
     // final content to Redis when the stream completes. A 2MB ceiling caps

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -48,13 +48,20 @@ vi.mock('../../../src/config/conf', () => ({
   loadCert: vi.fn(() => ''),
 }));
 
-// Mock heavy I/O modules that get pulled in transitively
+// Mock heavy I/O modules that get pulled in transitively. vi.hoisted is
+// required so the mock fns are available when vi.mock is hoisted above imports.
+const { mockRedisGetXtmAgentResponse, mockRedisSetXtmAgentResponse } = vi.hoisted(() => ({
+  mockRedisGetXtmAgentResponse: vi.fn(() => Promise.resolve(null)),
+  mockRedisSetXtmAgentResponse: vi.fn(() => Promise.resolve()),
+}));
 vi.mock('../../../src/database/redis', () => ({
   getClientBase: vi.fn(() => ({ set: vi.fn(), get: vi.fn(), del: vi.fn() })),
   pubSubSubscription: vi.fn(),
   storeNotifiersForStream: vi.fn(),
   redisSetXtmRegistrationResult: vi.fn(),
   redisGetXtmRegistrationResult: vi.fn(() => null),
+  redisGetXtmAgentResponse: mockRedisGetXtmAgentResponse,
+  redisSetXtmAgentResponse: mockRedisSetXtmAgentResponse,
 }));
 
 vi.mock('../../../src/lock/master-lock', () => ({
@@ -164,6 +171,9 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupAuthenticatedContext();
+    // Default to cache miss so the existing tests exercise the XTM One path.
+    mockRedisGetXtmAgentResponse.mockResolvedValue(null);
+    mockRedisSetXtmAgentResponse.mockResolvedValue(undefined);
     res = buildRes();
   });
 
@@ -302,5 +312,135 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.send).toHaveBeenCalledWith({ status: 503, error: 'XTM One is unreachable' });
+  });
+
+  it('should serve a cached response as a single SSE done event without calling XTM One', async () => {
+    mockRedisGetXtmAgentResponse.mockResolvedValue({
+      content: '<p>Cached summary content</p>',
+      cached_at: '2026-05-28T10:00:00.000Z',
+    } as any);
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    await postAgentMessageStream(req, res);
+
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+    expect(res.write).toHaveBeenCalledTimes(1);
+    const written = (res.write as any).mock.calls[0][0] as string;
+    expect(written).toContain('"type":"done"');
+    expect(written).toContain('"cached":true');
+    expect(written).toContain('Cached summary content');
+    expect(written).toContain('2026-05-28T10:00:00.000Z');
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('should bypass the cache when force_refresh is true', async () => {
+    mockRedisGetXtmAgentResponse.mockResolvedValue({
+      content: '<p>Cached summary content</p>',
+      cached_at: '2026-05-28T10:00:00.000Z',
+    } as any);
+    const fakeStream = { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello', force_refresh: true });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    expect(mockRedisGetXtmAgentResponse).not.toHaveBeenCalled();
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(fakeStream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it('should store the final SSE done content in Redis after the stream completes', async () => {
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    // Simulate the upstream stream emitting tokens then a final done event.
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"stream","content":"Hel"}\n\n')));
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"stream","content":"Hello"}\n\n')));
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"done","content":"Hello world"}\n\n')));
+
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).toHaveBeenCalledTimes(1);
+    const [cacheKey, storedContent, ttlSeconds] = mockRedisSetXtmAgentResponse.mock.calls[0] as any;
+    expect(typeof cacheKey).toBe('string');
+    expect(cacheKey).toHaveLength(64); // sha256 hex length
+    expect(storedContent).toBe('Hello world');
+    expect(ttlSeconds).toBeGreaterThan(0);
+  });
+
+  it('should not cache the response when the stream emits an error event', async () => {
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"stream","content":"partial"}\n\n')));
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"error","content":"Quota exceeded"}\n\n')));
+
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
+  });
+
+  it('should not cache the response when the client aborts mid-stream', async () => {
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    const reqOn = vi.fn();
+    (req as any).on = reqOn;
+
+    await postAgentMessageStream(req, res);
+
+    // Trigger client close before the stream emits a done event.
+    const closeHandler = reqOn.mock.calls.find((c: any[]) => c[0] === 'close')?.[1];
+    expect(closeHandler).toBeDefined();
+    closeHandler();
+
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"done","content":"partial"}\n\n')));
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -72,6 +72,10 @@ vi.mock('../../../src/http/httpAuthenticatedContext', () => ({
   createAuthenticatedContext: vi.fn(),
 }));
 
+vi.mock('../../../src/http/httpServer-draft', () => ({
+  checkDraftInContext: vi.fn(),
+}));
+
 vi.mock('../../../src/database/cache', () => ({
   getEntityFromCache: vi.fn(),
 }));
@@ -135,6 +139,7 @@ import { createAuthenticatedContext } from '../../../src/http/httpAuthenticatedC
 import { getEntityFromCache } from '../../../src/database/cache';
 import { getEnterpriseEditionActivePem, getEnterpriseEditionInfo } from '../../../src/modules/settings/licensing';
 import { postAgentMessageStream } from '../../../src/http/httpChatbotProxy';
+import { checkDraftInContext } from '../../../src/http/httpServer-draft';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -154,9 +159,9 @@ const buildRes = () => {
 };
 
 /** Configure all mocks so that authentication + license + CGU pass. */
-const setupAuthenticatedContext = () => {
+const setupAuthenticatedContext = (overrides: Record<string, unknown> = {}) => {
   const fakeUser = { id: 'user-1', name: 'Test User' };
-  const fakeContext = { user: fakeUser };
+  const fakeContext = { user: fakeUser, ...overrides };
   vi.mocked(createAuthenticatedContext).mockResolvedValue(fakeContext as any);
   vi.mocked(getEntityFromCache).mockResolvedValue({ filigran_chatbot_ai_cgu_status: 'enabled' } as any);
   vi.mocked(getEnterpriseEditionActivePem).mockReturnValue({ pem: 'pem-data' } as any);
@@ -174,6 +179,8 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
     // Default to cache miss so the existing tests exercise the XTM One path.
     mockRedisGetXtmAgentResponse.mockResolvedValue(null);
     mockRedisSetXtmAgentResponse.mockResolvedValue(undefined);
+    // Default the draft check to a no-op (live workspace, no draft).
+    vi.mocked(checkDraftInContext).mockResolvedValue(undefined);
     res = buildRes();
   });
 
@@ -504,6 +511,70 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
     await Promise.all(endHandlers.map((h) => h()));
 
     expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
+  });
+
+  it('should reject with 400 when the draft context fails validation, without calling cache or upstream', async () => {
+    // Simulate a caller passing an `opencti-draft-id` they do not have access
+    // to (or that is closed). The REST proxy MUST refuse — without this guard
+    // a cached response (or a fresh agent run) computed for another draft
+    // could be replayed across draft authorization boundaries.
+    setupAuthenticatedContext({ draft_context: 'forged-draft-id' });
+    vi.mocked(checkDraftInContext).mockRejectedValue(new Error('Could not find draft workspace'));
+    mockRedisGetXtmAgentResponse.mockResolvedValue({
+      content: '<p>This MUST NEVER be replayed</p>',
+      cached_at: '2026-05-28T10:00:00.000Z',
+    } as any);
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    await postAgentMessageStream(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Could not find draft workspace' });
+    expect(mockRedisGetXtmAgentResponse).not.toHaveBeenCalled();
+    expect(mockPost).not.toHaveBeenCalled();
+    // Also verify no SSE headers leaked into the JSON 400 response.
+    expect(res.setHeader).not.toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+  });
+
+  it('should derive the cache key from context.draft_context, not the raw header', async () => {
+    // Two requests with the same agent + prompt but different
+    // `context.draft_context` values must produce different cache keys, so a
+    // live-workspace cache hit cannot leak into a draft view (and vice-versa).
+    // We capture the cache key written on stream completion and assert the
+    // two are distinct.
+    const captureCacheKey = async (draftContext: string | undefined) => {
+      vi.clearAllMocks();
+      setupAuthenticatedContext(draftContext === undefined ? {} : { draft_context: draftContext });
+      vi.mocked(checkDraftInContext).mockResolvedValue(undefined);
+      mockRedisGetXtmAgentResponse.mockResolvedValue(null);
+      mockRedisSetXtmAgentResponse.mockResolvedValue(undefined);
+      const dataHandlers: ((chunk: Buffer) => void)[] = [];
+      const endHandlers: (() => void | Promise<void>)[] = [];
+      const fakeStream = {
+        pipe: vi.fn(),
+        destroy: vi.fn(),
+        on: vi.fn((event: string, handler: any) => {
+          if (event === 'data') dataHandlers.push(handler);
+          if (event === 'end') endHandlers.push(handler);
+          return fakeStream;
+        }),
+      };
+      mockPost.mockResolvedValue({ data: fakeStream });
+      const req = buildReq({ agent_slug: 'same-agent', content: 'same prompt' });
+      (req as any).on = vi.fn();
+      const localRes = buildRes();
+      await postAgentMessageStream(req, localRes);
+      dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"done","content":"final"}\n\n')));
+      await Promise.all(endHandlers.map((h) => h()));
+      const [cacheKey] = mockRedisSetXtmAgentResponse.mock.calls[0] as any;
+      return cacheKey as string;
+    };
+
+    const liveKey = await captureCacheKey(undefined);
+    const draftKey = await captureCacheKey('draft-123');
+    expect(liveKey).toHaveLength(64);
+    expect(draftKey).toHaveLength(64);
+    expect(liveKey).not.toEqual(draftKey);
   });
 
   it('should skip caching when the upstream response exceeds the 2MB capture limit', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -312,6 +312,10 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.send).toHaveBeenCalledWith({ status: 503, error: 'XTM One is unreachable' });
+    // Regression guard: must NOT leak SSE response headers into a JSON
+    // error body. SSE headers are only set once the upstream stream is
+    // actually open (or we hit a cache replay) — never on the JSON 503 path.
+    expect(res.setHeader).not.toHaveBeenCalledWith('Content-Type', 'text/event-stream');
   });
 
   it('should serve a cached response as a single SSE done event without calling XTM One', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -577,6 +577,34 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
     expect(liveKey).not.toEqual(draftKey);
   });
 
+  it('should forward context.draft_context to XTM One even when the request header is empty', async () => {
+    // Regression guard for the cache-vs-upstream draft mismatch:
+    // `context.draft_context` falls back to `user.draft_context` when the
+    // request omits `opencti-draft-id`, so without the explicit override
+    // `generateBasicHeaders` would forward an empty draft header while the
+    // cache key was scoped to the user's session draft — running the agent
+    // live but storing the result under the draft key.
+    setupAuthenticatedContext({ draft_context: 'user-session-draft-id' });
+    const fakeStream = { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    // The mocked HTTP client factory is invoked with the headers we want to assert
+    // on, but we only have access to the post() mock. Instead, verify by checking
+    // that the http-client `getHttpClient` mock was called with headers including
+    // the right draft id.
+    const { getHttpClient } = await import('../../../src/utils/http-client');
+    const headerCalls = vi.mocked(getHttpClient).mock.calls
+      .map((c) => c[0]?.headers)
+      .filter((h): h is Record<string, string> => !!h && 'opencti-draft-id' in h);
+    expect(headerCalls.length).toBeGreaterThan(0);
+    expect(headerCalls[headerCalls.length - 1]['opencti-draft-id']).toBe('user-session-draft-id');
+  });
+
   it('should skip caching when the upstream response exceeds the 2MB capture limit', async () => {
     const dataHandlers: ((chunk: Buffer) => void)[] = [];
     const endHandlers: (() => void | Promise<void>)[] = [];

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -443,4 +443,93 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
 
     expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
   });
+
+  it('should tolerate malformed SSE lines and still cache the final done content', async () => {
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    // Mix of: a heartbeat comment, a non-`data:` line, a malformed JSON
+    // payload, and finally a valid `done` event.
+    dataHandlers.forEach((h) => h(Buffer.from(': heartbeat\n\n')));
+    dataHandlers.forEach((h) => h(Buffer.from('event: ping\n\n')));
+    dataHandlers.forEach((h) => h(Buffer.from('data: {not valid json}\n\n')));
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"done","content":"final"}\n\n')));
+
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).toHaveBeenCalledTimes(1);
+    const [, storedContent] = mockRedisSetXtmAgentResponse.mock.calls[0] as any;
+    expect(storedContent).toBe('final');
+  });
+
+  it('should not cache when the stream completes without a done event', async () => {
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"stream","content":"partial"}\n\n')));
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
+  });
+
+  it('should skip caching when the upstream response exceeds the 2MB capture limit', async () => {
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    // Push 3MB of bytes — well above the 2MB capture ceiling.
+    const oneMb = Buffer.alloc(1024 * 1024, 0x41);
+    dataHandlers.forEach((h) => h(oneMb));
+    dataHandlers.forEach((h) => h(oneMb));
+    dataHandlers.forEach((h) => h(oneMb));
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"done","content":"final"}\n\n')));
+
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -605,6 +605,41 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
     expect(headerCalls[headerCalls.length - 1]['opencti-draft-id']).toBe('user-session-draft-id');
   });
 
+  it('should not cache when the upstream stream emits a Node `error` event', async () => {
+    // Belt-and-suspenders guard for transport errors. Node typically does
+    // not emit `'end'` after `'error'`, but if a future runtime/library
+    // version reordered events, we'd otherwise risk caching a partial or
+    // failed response. Simulate the upstream emitting a fully-formed `done`
+    // SSE chunk, then a Node-level `'error'`, then `'end'` — we MUST not
+    // call `redisSetXtmAgentResponse` even though `extractFinalContent`
+    // would otherwise return a non-null value.
+    const dataHandlers: ((chunk: Buffer) => void)[] = [];
+    const errorHandlers: ((error: Error) => void)[] = [];
+    const endHandlers: (() => void | Promise<void>)[] = [];
+    const fakeStream = {
+      pipe: vi.fn(),
+      destroy: vi.fn(),
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'data') dataHandlers.push(handler);
+        if (event === 'error') errorHandlers.push(handler);
+        if (event === 'end') endHandlers.push(handler);
+        return fakeStream;
+      }),
+    };
+    mockPost.mockResolvedValue({ data: fakeStream });
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+    (req as any).on = vi.fn();
+
+    await postAgentMessageStream(req, res);
+
+    dataHandlers.forEach((h) => h(Buffer.from('data: {"type":"done","content":"complete"}\n\n')));
+    errorHandlers.forEach((h) => h(new Error('socket hang up')));
+    await Promise.all(endHandlers.map((h) => h()));
+
+    expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
+  });
+
   it('should skip caching when the upstream response exceeds the 2MB capture limit', async () => {
     const dataHandlers: ((chunk: Buffer) => void)[] = [];
     const endHandlers: (() => void | Promise<void>)[] = [];

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
@@ -182,12 +182,14 @@ describe('Redis XTM agent response cache', () => {
 
   it('should expire a cached agent response after the TTL elapses', async () => {
     const cacheKey = `agent-cache-ttl-${uuid()}`;
-    await redisSetXtmAgentResponse(cacheKey, 'short-lived', 1);
+    const ttlSeconds = 1;
+    await redisSetXtmAgentResponse(cacheKey, 'short-lived', ttlSeconds);
     const initial = await redisGetXtmAgentResponse(cacheKey);
     expect(initial?.content).toEqual('short-lived');
 
+    // Wait ttl + 1s to absorb Redis scheduling jitter under CI load.
     await new Promise((resolve) => {
-      setTimeout(() => resolve(), 1500);
+      setTimeout(() => resolve(), (ttlSeconds + 1) * 1000);
     });
 
     const expired = await redisGetXtmAgentResponse(cacheKey);

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
@@ -211,4 +211,28 @@ describe('Redis XTM agent response cache', () => {
     const cached = await redisGetXtmAgentResponse(cacheKey);
     expect(cached).toBeNull();
   });
+
+  it('should return null when the cached payload is valid JSON but the wrong shape', async () => {
+    // Cover the cases a defensive shape check should reject: bare scalars,
+    // arrays, objects missing `content`, and objects whose `content` /
+    // `cached_at` are not strings. Any of these slipping through would
+    // make the consumer emit an SSE `done` event with `content:
+    // undefined`, which is exactly what the validation prevents.
+    const corruptPayloads = [
+      JSON.stringify('a bare string'),
+      JSON.stringify(42),
+      JSON.stringify(null),
+      JSON.stringify(['arr']),
+      JSON.stringify({ cached_at: '2026-05-28T00:00:00.000Z' }), // missing content
+      JSON.stringify({ content: 'x' }), // missing cached_at
+      JSON.stringify({ content: 123, cached_at: '2026-05-28T00:00:00.000Z' }), // non-string content
+      JSON.stringify({ content: 'x', cached_at: 123 }), // non-string cached_at
+    ];
+    for (const payload of corruptPayloads) {
+      const cacheKey = `agent-cache-shape-${uuid()}`;
+      await getClientBase().set(`xtm_agent_cache:${cacheKey}`, payload, 'EX', 60);
+      const cached = await redisGetXtmAgentResponse(cacheKey);
+      expect(cached, `payload ${payload} should be rejected`).toBeNull();
+    }
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
@@ -6,6 +6,7 @@ import {
   deleteAllPlaybookExecutions,
   delUserContext,
   fetchEditContext,
+  getClientBase,
   getLastPlaybookExecutions,
   getRedisVersion,
   lockResource,
@@ -13,10 +14,12 @@ import {
   redisClearTelemetry,
   redisGetForgotPasswordOtp,
   redisGetTelemetry,
+  redisGetXtmAgentResponse,
   redisInit,
   redisPlaybookUpdate,
   redisSetForgotPasswordOtp,
   redisSetTelemetryAdd,
+  redisSetXtmAgentResponse,
   setEditContext,
 } from '../../../src/database/redis';
 import { OPENCTI_ADMIN_UUID } from '../../../src/schema/general';
@@ -159,5 +162,51 @@ describe('Redis playbook executions tests', () => {
     await deleteAllPlaybookExecutions(PLAYBOOK_ID);
     const executions = await getLastPlaybookExecutions(PLAYBOOK_ID);
     expect(executions.length).toEqual(0);
+  });
+});
+
+describe('Redis XTM agent response cache', () => {
+  it('should return null when no cached response exists', async () => {
+    const cached = await redisGetXtmAgentResponse(`missing-key-${uuid()}`);
+    expect(cached).toBeNull();
+  });
+
+  it('should store and read back a cached agent response with timestamp', async () => {
+    const cacheKey = `agent-cache-${uuid()}`;
+    await redisSetXtmAgentResponse(cacheKey, '<p>Agent summary</p>', 60);
+    const cached = await redisGetXtmAgentResponse(cacheKey);
+    expect(cached).not.toBeNull();
+    expect(cached.content).toEqual('<p>Agent summary</p>');
+    expect(cached.cached_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('should expire a cached agent response after the TTL elapses', async () => {
+    const cacheKey = `agent-cache-ttl-${uuid()}`;
+    await redisSetXtmAgentResponse(cacheKey, 'short-lived', 1);
+    const initial = await redisGetXtmAgentResponse(cacheKey);
+    expect(initial?.content).toEqual('short-lived');
+
+    await new Promise((resolve) => {
+      setTimeout(() => resolve(), 1500);
+    });
+
+    const expired = await redisGetXtmAgentResponse(cacheKey);
+    expect(expired).toBeNull();
+  });
+
+  it('should be a no-op when ttl is zero or negative', async () => {
+    const cacheKey = `agent-cache-disabled-${uuid()}`;
+    await redisSetXtmAgentResponse(cacheKey, 'should-not-be-stored', 0);
+    expect(await redisGetXtmAgentResponse(cacheKey)).toBeNull();
+
+    await redisSetXtmAgentResponse(cacheKey, 'should-not-be-stored', -10);
+    expect(await redisGetXtmAgentResponse(cacheKey)).toBeNull();
+  });
+
+  it('should return null and not throw when the cached payload is not valid JSON', async () => {
+    const cacheKey = `agent-cache-corrupt-${uuid()}`;
+    await getClientBase().set(`xtm_agent_cache:${cacheKey}`, 'this is not json', 'EX', 60);
+    const cached = await redisGetXtmAgentResponse(cacheKey);
+    expect(cached).toBeNull();
   });
 });


### PR DESCRIPTION
### Proposed changes

* Add a **Redis-backed response cache** for the XTM One agent stream proxy (`POST /chatbot/agent/stream`), keyed by `sha256(agent_slug + opencti-draft-id + content)`. On a cache hit, the proxy replays the result as a single `done` SSE event so the existing frontend display logic works unchanged — no agent re-execution, no upstream call.
* Capture the upstream SSE bytes alongside the pipe (`'data'` / `'end'` / `'error'` listeners) and store the final `done` content in Redis when the stream completes successfully. Skip caching when the stream emits an `error` SSE event, when the underlying Node stream emits an `'error'` event, when the client aborts, or when the response exceeds a 2MB safety ceiling.
* Add a new `ai:agents_refresh_timeout` configuration (in minutes, default **1440** — 24 hours) — environment override: `AI__AGENTS_REFRESH_TIMEOUT`. Set to `0` to disable the cache entirely. A non-numeric or negative override is treated as a misconfiguration and falls back to the default rather than silently disabling the cache. The seconds value is floored to an integer so a fractional minute override (e.g. `0.01`) cannot break Redis `SET ... EX`.
* **Authorize the draft context before serving (or refreshing) a cache hit.** The endpoint reads the draft id from `context.draft_context` (set by `createAuthenticatedContext`) and runs `checkDraftInContext` immediately after the body validation, before either the cache lookup or the upstream call. REST routes don't go through the GraphQL `checkDraftInContext` middleware, so without this guard a caller could pass an arbitrary `opencti-draft-id` header and (on a hit) get a cached response — or a fresh agent run — for a draft they don't have access to. A draft validation failure now returns a clean `400 { error }` JSON instead of falling into the outer catch as a misleading `503 "XTM One is unreachable"`.
* **Align the upstream `opencti-draft-id` header with the cache-key draft id.** `generateBasicHeaders` forwards the raw request header, but `context.draft_context` falls back to `user.draft_context` when the request omits the header — so the two could diverge for a user with an active session draft, leading to a live-workspace agent run cached under the draft key. The streaming proxy now overrides `headers['opencti-draft-id']` with the validated `draftId` after `generateBasicHeaders`, so the upstream draft context always matches the cache-key draft id by construction.
* Propagate a `force_refresh` body flag through the proxy so the **Retry** button on every AI Insights tab (Container summary, Activity, Forecast, History) bypasses the cache and forces a fresh agent execution.
* Surface the backend-provided `generated_at` timestamp on cache hits, so the UI shows when the response was _originally_ generated rather than the moment it was replayed from cache.
* Validate the cached payload shape on read via an `isXtmAgentCachedResponse` predicate, so a corrupt-but-valid-JSON Redis entry can never be replayed as an SSE `done` event with `content: undefined`.
* **Surface backend `{ error }` JSON bodies in the agent API client.** `callAgent` and `callAgentStream` previously discarded the JSON body on non-2xx responses and built the UI error message from `response.statusText`, so the new draft-validation `400 { error: '...' }` and the `503 { error: '...' }` paths surfaced as generic "Bad Request" / "Service Unavailable". A `readAgentErrorBody` helper now parses the JSON body when available (using `response.clone()` so the original `Response` is not consumed) and falls back to `statusText` when the body is not JSON.
* Cover the new behavior with **11 new unit tests** in `httpChatbotProxy-test.ts` (cache hit, `force_refresh` bypass, cache write on `done`, no cache on SSE `error`, no cache on Node stream `'error'`, no cache on client abort, malformed-SSE tolerance, no cache without `done`, 2MB overflow, draft auth rejection short-circuit, draft-context-driven cache key, upstream draft header sourced from `context.draft_context`), **5 new integration tests** in `redis-test.js` for the cache helpers (read/set roundtrip with timestamp, TTL expiry, no-op on `ttl <= 0`, corrupt-payload safety, and a matrix of corrupt-but-valid-JSON shapes), and **7 new frontend tests** in `agentApi.test.ts` covering the new error-body parsing for both `callAgent` and `callAgentStream`, plus the SSE stream parsing and the `force_refresh` body flag forwarding.

### Related issues

* Fixes #16258

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

**Why backend Redis instead of frontend `sessionStorage`?**

Caching in the proxy means:
- The cache is **shared across replicas** — any pod can serve a hit generated by any other pod.
- The cache **survives Node restarts**.
- The cache is **shared across users** in the same way the pre-XTM-One in-memory `aiResponseCache` was (the legacy `domain/container.js` cache key did not include user identity either) — keeping the cross-user hit rate that makes the cache valuable for entity-level insights repeatedly opened by different analysts.
- The cache is **NOT shared across drafts** — `context.draft_context` is part of the cache key, the endpoint runs `checkDraftInContext(context)` before either the cache lookup or the upstream call, and the upstream `opencti-draft-id` header is taken from the same validated `context.draft_context`. So a cached live-workspace response can never be replayed to a draft viewer (or vice-versa), a forged `opencti-draft-id` header cannot bypass draft authorization, and the upstream agent always runs in the same draft context the cache key encodes.
- The frontend display code stays untouched — the existing `done` SSE event handler already does the right thing, the proxy just synthesizes a single `done` event on hit.

**Why a new `agents_refresh_timeout` config rather than reusing `insights_refresh_timeout`?**

The legacy `ai:insights_refresh_timeout` (default 60 minutes) controls the in-memory cache used by `domain/container.js` and `domain/stixCoreObject.js`, which is only exercised when XTM One is **not** configured. Keeping it independent lets operators tune the XTM One agent cache (which guards much more expensive agent runs) to a longer TTL — 24 hours by default to match the pre-XTM-One UX expectation — without changing legacy-path behavior.

**Stream tapping strategy**

The proxy attaches a `'data'` listener on the upstream stream _in addition to_ piping it to the response. Once a Readable is in flowing mode (which `.pipe()` triggers), `'data'` events fire for every chunk regardless of how many consumers are attached, so we get the bytes for cache storage with no buffering tee and no impact on the pipe.

The cache-write `'end'` handler skips on any of: cache disabled, client aborted, Node stream `'error'`, capture overflow (>2MB), or `extractFinalContent` returning `null` (no `done` SSE event, or an `error` SSE event was seen). This is symmetric with the rest of the cache-skip predicate so a partial / failed response can never end up in Redis.

The capture is hard-capped at 2MB; beyond that, we drop the buffer and skip caching to avoid memory pressure from unusually large agent outputs (typical AI Insights responses are 1–10KB).

**SSE response headers**

`writeAgentStreamHeaders(res)` is deferred to the two call sites that actually emit SSE — the cache-hit branch (right before writing the synthesized `done` event) and the live-stream branch (right after `httpClient.post` resolves). The non-`httpErr` 503 branch and the new draft-validation 400 branch therefore send clean JSON responses with no SSE headers leaking through.
