### PR TITLE
[client-python] ImportDocument prepare_export should support files with undefined objectMarking (#16261)

### DIFF
--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2385,7 +2385,7 @@ class OpenCTIStix2:
                     "version": file["metaData"].get("version", None),
                     "object_marking_refs": [],
                 }
-                for file_marking_definition in file["objectMarking"]:
+                for file_marking_definition in file.get("objectMarking", []):
                     if file_marking_definition["definition_type"] == "TLP":
                         created = "2017-01-20T00:00:00.000Z"
                     else:


### PR DESCRIPTION
### Proposed changes
- prepare_export function should not throw error if objectMarking of file is undefined

### Related issues
fixes #16261