### PR TITLE
[backend/frontend] feat(playbooks): Transform STIX bundle with an AI agent (#15880)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -5,6 +5,7 @@ import {
   ArchitectureOutlined,
   AssignmentOutlined,
   AutoAwesomeMotion,
+  AutoAwesomeOutlined,
   BackupTableOutlined,
   BiotechOutlined,
   BugReportOutlined,
@@ -467,6 +468,8 @@ const iconSelector = (
       );
     case 'console':
       return <TerminalOutlined style={style} fontSize={fontSize} role="img" />;
+    case 'ai-agent':
+      return <AutoAwesomeOutlined style={style} fontSize={fontSize} role="img" />;
     case 'storage':
       return (
         <DriveFolderUploadOutlined

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -361,11 +361,14 @@ const PlaybookFlowForm = ({
                       />
                     );
                   }
+                  const isTextarea = property.format === 'textarea';
                   return (
                     <PlaybookFlowFieldString
                       key={propName}
                       name={propName}
                       label={t_i18n(property.$ref ?? propName)}
+                      multiline={isTextarea}
+                      rows={isTextarea ? 3 : undefined}
                     />
                   );
                 },

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldString.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldString.tsx
@@ -20,11 +20,15 @@ import { fieldSpacingContainerStyle } from '../../../../../../utils/field';
 interface PlaybookFlowFieldStringProps {
   name: string;
   label: string;
+  multiline?: boolean;
+  rows?: number;
 }
 
 const PlaybookFlowFieldString = ({
   name,
   label,
+  multiline,
+  rows,
 }: PlaybookFlowFieldStringProps) => {
   return (
     <Field
@@ -34,6 +38,8 @@ const PlaybookFlowFieldString = ({
       variant="standard"
       component={TextField}
       style={fieldSpacingContainerStyle}
+      multiline={multiline}
+      rows={rows}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
@@ -55,6 +55,9 @@ export type PlaybookComponentConfigSchema = {
       type: string;
       uniqueItems?: boolean;
       $ref?: string;
+      // UI hint forwarded by backend components to request a specific
+      // input renderer (e.g. ``textarea`` for multi-line strings).
+      format?: string;
       default?: PlaybookConfig[key];
       oneOf?: unknown[];
       items?: {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -20,6 +20,12 @@ import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
 import { logApp } from '../../../config/conf';
 import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from './ai-agent-shared';
 
+// Canonical STIX 2.1 ID shape: `<type>--<uuid>`. Mirrors the `isStixId`
+// helper in `src/schema/schemaUtils.js` — inlined here instead of imported
+// to avoid pulling the full schema module (and its heavy transitive
+// closure) into this unit-testable component.
+const STIX_ID_REGEX = /^[a-z][a-z0-9-]*--[\w-]{36}$/;
+
 interface AiAgentTransformConfiguration {
   agent_slug: string;
   prompt?: string;
@@ -51,6 +57,43 @@ const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransf
 };
 
 /**
+ * Minimum STIX 2.1 object shape we accept from the agent: a non-empty
+ * `type` string plus an `id` that matches the canonical `<type>--<uuid>`
+ * pattern. Anything looser is silently corrupted by the agent and should
+ * not be forwarded to the downstream playbook nodes.
+ */
+const isMinimalStixObjectShape = (candidate: unknown): boolean => {
+  if (!candidate || typeof candidate !== 'object') return false;
+  const obj = candidate as { id?: unknown; type?: unknown };
+  return typeof obj.id === 'string'
+    && STIX_ID_REGEX.test(obj.id)
+    && typeof obj.type === 'string'
+    && obj.type.length > 0;
+};
+
+/**
+ * Returns the candidate as a STIX bundle when it has the expected
+ * envelope (`type: 'bundle'`, `objects` is an array) AND every object
+ * in the array passes the minimum STIX shape check. An empty
+ * `objects: []` is treated as valid — the agent legitimately filtered
+ * everything out — but a single malformed object rejects the whole
+ * bundle so we never forward partially-corrupt data to downstream
+ * nodes.
+ */
+const asValidStixBundle = (candidate: unknown): StixBundle | null => {
+  if (
+    candidate
+    && typeof candidate === 'object'
+    && (candidate as { type?: unknown }).type === 'bundle'
+    && Array.isArray((candidate as { objects?: unknown }).objects)
+    && (candidate as { objects: unknown[] }).objects.every(isMinimalStixObjectShape)
+  ) {
+    return candidate as StixBundle;
+  }
+  return null;
+};
+
+/**
  * Extract a STIX bundle JSON object from an LLM response. Agents respond
  * either with a raw JSON object or with the bundle wrapped in a fenced
  * code block; both cases must be handled because we cannot rely on the
@@ -63,15 +106,8 @@ const parseStixBundle = (raw: string): StixBundle | null => {
   const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
   const candidate = fenceMatch ? fenceMatch[1].trim() : trimmed;
   try {
-    const parsed = JSON.parse(candidate);
-    if (
-      parsed
-      && typeof parsed === 'object'
-      && parsed.type === 'bundle'
-      && Array.isArray(parsed.objects)
-    ) {
-      return parsed as StixBundle;
-    }
+    const validated = asValidStixBundle(JSON.parse(candidate));
+    if (validated) return validated;
   } catch {
     // Fall through and try a best-effort substring extraction.
   }
@@ -80,15 +116,8 @@ const parseStixBundle = (raw: string): StixBundle | null => {
   const lastBrace = candidate.lastIndexOf('}');
   if (firstBrace !== -1 && lastBrace > firstBrace) {
     try {
-      const parsed = JSON.parse(candidate.slice(firstBrace, lastBrace + 1));
-      if (
-        parsed
-        && typeof parsed === 'object'
-        && parsed.type === 'bundle'
-        && Array.isArray(parsed.objects)
-      ) {
-        return parsed as StixBundle;
-      }
+      const validated = asValidStixBundle(JSON.parse(candidate.slice(firstBrace, lastBrace + 1)));
+      if (validated) return validated;
     } catch {
       // Ignore — caller will fall back to the unmodified output port.
     }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -1,0 +1,247 @@
+/*
+Copyright (c) 2021-2025 Filigran SAS
+
+This file is part of the OpenCTI Enterprise Edition ("EE") and is
+licensed under the OpenCTI Enterprise Edition License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://github.com/OpenCTI-Platform/opencti/blob/master/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import * as R from 'ramda';
+import nconf from 'nconf';
+import type { JSONSchemaType } from 'ajv';
+import type { PlaybookComponent } from '../playbook-types';
+import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
+import xtmOneClient from '../../xtm/one/xtm-one-client';
+import { issueXtmJwt } from '../../../domain/xtm-auth';
+import { getHttpClient, getResponseError } from '../../../utils/http-client';
+import { logApp, PLATFORM_VERSION } from '../../../config/conf';
+import { AUTOMATION_MANAGER_USER_UUID, executionContext } from '../../../utils/access';
+import type { AuthContext, AuthUser } from '../../../types/user';
+
+// ─── Configuration ─────────────────────────────────────────────────────────
+
+interface AiAgentTransformConfiguration {
+  agent_slug: string;
+  prompt?: string;
+}
+
+const PLAYBOOK_AI_AGENT_TRANSFORM_INTENT = 'cti.stix_transformer';
+
+// Identity used by the playbook executor when calling XTM One. The local
+// part is stable so XTM One auto-provisions a single "OpenCTI Playbook
+// Automation" user per deployment; the .invalid TLD (RFC 6761) makes it
+// unmistakably non-human and impossible to collide with a real account.
+const PLAYBOOK_AUTOMATION_EMAIL = 'opencti-playbook-automation@opencti.invalid';
+
+const buildAutomationUser = (): Pick<AuthUser, 'id' | 'user_email'> => ({
+  id: AUTOMATION_MANAGER_USER_UUID,
+  user_email: PLAYBOOK_AUTOMATION_EMAIL,
+});
+
+// 5 minutes — agent runs may take a while when the LLM has to materialise
+// a large STIX bundle. Keep well above the default 2-minute httpClient cap
+// used by the chatbot proxy.
+const AGENT_CALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransformConfiguration> = {
+  type: 'object',
+  properties: {
+    agent_slug: {
+      type: 'string',
+      $ref: 'AI agent',
+      // Populated dynamically from XTM One intent catalog at schema() time.
+      oneOf: [],
+    },
+    prompt: {
+      type: 'string',
+      nullable: true,
+      default: '',
+      $ref: 'Additional instructions (optional, prepended to the STIX bundle)',
+    },
+  },
+  required: ['agent_slug'],
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Extract a STIX bundle JSON object from an LLM response. Agents respond
+ * either with a raw JSON object or with the bundle wrapped in a fenced
+ * code block; both cases must be handled because we cannot rely on the
+ * LLM never adding stray whitespace or markdown.
+ */
+const parseStixBundle = (raw: string): StixBundle | null => {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenceMatch ? fenceMatch[1].trim() : trimmed;
+  try {
+    const parsed = JSON.parse(candidate);
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && parsed.type === 'bundle'
+      && Array.isArray(parsed.objects)
+    ) {
+      return parsed as StixBundle;
+    }
+  } catch {
+    // Fall through and try a best-effort substring extraction.
+  }
+
+  const firstBrace = candidate.indexOf('{');
+  const lastBrace = candidate.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    try {
+      const parsed = JSON.parse(candidate.slice(firstBrace, lastBrace + 1));
+      if (
+        parsed
+        && typeof parsed === 'object'
+        && parsed.type === 'bundle'
+        && Array.isArray(parsed.objects)
+      ) {
+        return parsed as StixBundle;
+      }
+    } catch {
+      // Ignore — caller will fall back to the unmodified output port.
+    }
+  }
+  return null;
+};
+
+const buildAgentPrompt = (bundle: StixBundle, userPrompt?: string): string => {
+  const instruction = (userPrompt ?? '').trim();
+  const bundleJson = JSON.stringify(bundle, null, 2);
+  if (!instruction) {
+    return `--- STIX BUNDLE ---\n${bundleJson}`;
+  }
+  return `${instruction}\n\n--- STIX BUNDLE ---\n${bundleJson}`;
+};
+
+/**
+ * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
+ * raw assistant content or null when the call cannot complete (XTM One
+ * not configured, network failure, non-success status). Errors are
+ * logged but never thrown — playbook execution falls back to the
+ * unmodified output port instead of crashing the whole run.
+ */
+const callAgent = async (
+  agentSlug: string,
+  content: string,
+): Promise<string | null> => {
+  const xtmOneUrl = nconf.get('xtm:xtm_one_url');
+  if (!xtmOneUrl || !xtmOneClient.isConfigured()) {
+    logApp.warn('[PLAYBOOK AI AGENT] XTM One is not configured, skipping agent call');
+    return null;
+  }
+
+  try {
+    const jwt = await issueXtmJwt(buildAutomationUser() as AuthUser, xtmOneUrl);
+    const httpClient = getHttpClient({
+      baseURL: xtmOneUrl,
+      responseType: 'json',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        'Content-Type': 'application/json',
+        'X-Platform-Product': 'opencti',
+        'X-Platform-Version': PLATFORM_VERSION,
+      },
+    });
+    const response = await httpClient.post(
+      '/api/v1/platform/chat/messages',
+      { agent_slug: agentSlug, content, stream: false },
+      { timeout: AGENT_CALL_TIMEOUT_MS },
+    );
+    return response.data?.content ?? null;
+  } catch (e: unknown) {
+    const httpErr = getResponseError(e);
+    const detail = httpErr?.data?.detail ?? httpErr?.data?.message ?? (e as Error)?.message;
+    logApp.error('[PLAYBOOK AI AGENT] Agent call failed', {
+      agentSlug,
+      status: httpErr?.status,
+      detail,
+    });
+    return null;
+  }
+};
+
+// ─── Component ─────────────────────────────────────────────────────────────
+
+export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTransformConfiguration> = {
+  id: 'PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT',
+  name: 'Transform with AI agent',
+  description: 'Send the STIX bundle to an AI agent and continue with the transformed bundle',
+  icon: 'ai-agent',
+  category: 'transform_and_enrich',
+  is_entry_point: false,
+  is_internal: true,
+  ports: [{ id: 'out', type: 'out' }, { id: 'unmodified', type: 'out' }],
+  configuration_schema: PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA,
+  schema: async () => {
+    // Resolve the list of agents bound to the cti.stix_transformer intent
+    // in XTM One so the playbook author can pick from a curated catalog
+    // (built-in agents + user/group/company-managed agents the caller
+    // is allowed to see). Falls back to an empty oneOf if XTM One is
+    // unreachable so the form still renders cleanly.
+    const context: AuthContext = executionContext('playbook_components');
+    const automationContext: AuthContext = {
+      ...context,
+      user: buildAutomationUser() as AuthUser,
+    };
+    let agents: Awaited<ReturnType<typeof xtmOneClient.listAgentsForIntent>> = [];
+    try {
+      agents = await xtmOneClient.listAgentsForIntent(
+        automationContext,
+        PLAYBOOK_AI_AGENT_TRANSFORM_INTENT,
+      );
+    } catch (e: unknown) {
+      logApp.warn('[PLAYBOOK AI AGENT] Failed to load agent catalog', { cause: (e as Error).message });
+    }
+    const elements = (agents ?? [])
+      .filter((a) => !!a.agent_slug)
+      .map((a) => ({ const: a.agent_slug as string, title: a.agent_name }))
+      .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1));
+    const schemaElement = { properties: { agent_slug: { oneOf: elements } } };
+    return R.mergeDeepRight<JSONSchemaType<AiAgentTransformConfiguration>, any>(
+      PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA,
+      schemaElement,
+    );
+  },
+  executor: async ({ playbookNode, bundle }) => {
+    const { agent_slug, prompt } = playbookNode.configuration;
+    if (!agent_slug) {
+      logApp.warn('[PLAYBOOK AI AGENT] No agent configured, returning bundle unmodified');
+      return { output_port: 'unmodified', bundle };
+    }
+    const content = buildAgentPrompt(bundle, prompt);
+    const rawResponse = await callAgent(agent_slug, content);
+    if (rawResponse === null) {
+      return { output_port: 'unmodified', bundle };
+    }
+    const transformedBundle = parseStixBundle(rawResponse);
+    if (!transformedBundle) {
+      logApp.warn('[PLAYBOOK AI AGENT] Could not parse agent response as a STIX bundle', {
+        agentSlug: agent_slug,
+        responsePreview: rawResponse.slice(0, 200),
+      });
+      return { output_port: 'unmodified', bundle };
+    }
+    // Preserve the original bundle envelope (id / spec_version) so
+    // downstream nodes that key off them stay stable.  The agent is
+    // free to materialise a fresh `objects` list — that is the whole
+    // point of the transformation.
+    const nextBundle: StixBundle = {
+      ...bundle,
+      objects: (transformedBundle.objects ?? []) as StixObject[],
+    };
+    return { output_port: 'out', bundle: nextBundle };
+  },
+};

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -14,18 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import * as R from 'ramda';
-import nconf from 'nconf';
 import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
-import xtmOneClient from '../../xtm/one/xtm-one-client';
-import { issueXtmJwt } from '../../../domain/xtm-auth';
-import { getHttpClient, getResponseError } from '../../../utils/http-client';
-import { logApp, PLATFORM_VERSION } from '../../../config/conf';
-import { AUTOMATION_MANAGER_USER_UUID, executionContext } from '../../../utils/access';
-import type { AuthContext, AuthUser } from '../../../types/user';
-
-// ─── Configuration ─────────────────────────────────────────────────────────
+import { logApp } from '../../../config/conf';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from './ai-agent-shared';
 
 interface AiAgentTransformConfiguration {
   agent_slug: string;
@@ -34,29 +27,13 @@ interface AiAgentTransformConfiguration {
 
 const PLAYBOOK_AI_AGENT_TRANSFORM_INTENT = 'cti.stix_transformer';
 
-// Identity used by the playbook executor when calling XTM One. The local
-// part is stable so XTM One auto-provisions a single "OpenCTI Playbook
-// Automation" user per deployment; the .invalid TLD (RFC 6761) makes it
-// unmistakably non-human and impossible to collide with a real account.
-const PLAYBOOK_AUTOMATION_EMAIL = 'opencti-playbook-automation@opencti.invalid';
-
-const buildAutomationUser = (): Pick<AuthUser, 'id' | 'user_email'> => ({
-  id: AUTOMATION_MANAGER_USER_UUID,
-  user_email: PLAYBOOK_AUTOMATION_EMAIL,
-});
-
-// 5 minutes — agent runs may take a while when the LLM has to materialise
-// a large STIX bundle. Keep well above the default 2-minute httpClient cap
-// used by the chatbot proxy.
-const AGENT_CALL_TIMEOUT_MS = 5 * 60 * 1000;
-
 const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransformConfiguration> = {
   type: 'object',
   properties: {
     agent_slug: {
       type: 'string',
       $ref: 'AI agent',
-      // Populated dynamically from XTM One intent catalog at schema() time.
+      // Populated dynamically from the XTM One intent catalog at schema() time.
       oneOf: [],
     },
     prompt: {
@@ -72,8 +49,6 @@ const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransf
   },
   required: ['agent_slug'],
 };
-
-// ─── Helpers ───────────────────────────────────────────────────────────────
 
 /**
  * Extract a STIX bundle JSON object from an LLM response. Agents respond
@@ -121,64 +96,6 @@ const parseStixBundle = (raw: string): StixBundle | null => {
   return null;
 };
 
-const buildAgentPrompt = (bundle: StixBundle, userPrompt?: string): string => {
-  const instruction = (userPrompt ?? '').trim();
-  const bundleJson = JSON.stringify(bundle, null, 2);
-  if (!instruction) {
-    return `--- STIX BUNDLE ---\n${bundleJson}`;
-  }
-  return `${instruction}\n\n--- STIX BUNDLE ---\n${bundleJson}`;
-};
-
-/**
- * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
- * raw assistant content or null when the call cannot complete (XTM One
- * not configured, network failure, non-success status). Errors are
- * logged but never thrown — playbook execution falls back to the
- * unmodified output port instead of crashing the whole run.
- */
-const callAgent = async (
-  agentSlug: string,
-  content: string,
-): Promise<string | null> => {
-  const xtmOneUrl = nconf.get('xtm:xtm_one_url');
-  if (!xtmOneUrl || !xtmOneClient.isConfigured()) {
-    logApp.warn('[PLAYBOOK AI AGENT] XTM One is not configured, skipping agent call');
-    return null;
-  }
-
-  try {
-    const jwt = await issueXtmJwt(buildAutomationUser() as AuthUser, xtmOneUrl);
-    const httpClient = getHttpClient({
-      baseURL: xtmOneUrl,
-      responseType: 'json',
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        'Content-Type': 'application/json',
-        'X-Platform-Product': 'opencti',
-        'X-Platform-Version': PLATFORM_VERSION,
-      },
-    });
-    const response = await httpClient.post(
-      '/api/v1/platform/chat/messages',
-      { agent_slug: agentSlug, content, stream: false },
-      { timeout: AGENT_CALL_TIMEOUT_MS },
-    );
-    return response.data?.content ?? null;
-  } catch (e: unknown) {
-    const httpErr = getResponseError(e);
-    const detail = httpErr?.data?.detail ?? httpErr?.data?.message ?? (e as Error)?.message;
-    logApp.error('[PLAYBOOK AI AGENT] Agent call failed', {
-      agentSlug,
-      status: httpErr?.status,
-      detail,
-    });
-    return null;
-  }
-};
-
-// ─── Component ─────────────────────────────────────────────────────────────
-
 export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTransformConfiguration> = {
   id: 'PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT',
   name: 'Transform with AI agent',
@@ -190,29 +107,7 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
   ports: [{ id: 'out', type: 'out' }, { id: 'unmodified', type: 'out' }],
   configuration_schema: PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA,
   schema: async () => {
-    // Resolve the list of agents bound to the cti.stix_transformer intent
-    // in XTM One so the playbook author can pick from a curated catalog
-    // (built-in agents + user/group/company-managed agents the caller
-    // is allowed to see). Falls back to an empty oneOf if XTM One is
-    // unreachable so the form still renders cleanly.
-    const context: AuthContext = executionContext('playbook_components');
-    const automationContext: AuthContext = {
-      ...context,
-      user: buildAutomationUser() as AuthUser,
-    };
-    let agents: Awaited<ReturnType<typeof xtmOneClient.listAgentsForIntent>> = [];
-    try {
-      agents = await xtmOneClient.listAgentsForIntent(
-        automationContext,
-        PLAYBOOK_AI_AGENT_TRANSFORM_INTENT,
-      );
-    } catch (e: unknown) {
-      logApp.warn('[PLAYBOOK AI AGENT] Failed to load agent catalog', { cause: (e as Error).message });
-    }
-    const elements = (agents ?? [])
-      .filter((a) => !!a.agent_slug)
-      .map((a) => ({ const: a.agent_slug as string, title: a.agent_name }))
-      .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1));
+    const elements = await buildAgentSlugOneOf(PLAYBOOK_AI_AGENT_TRANSFORM_INTENT);
     const schemaElement = { properties: { agent_slug: { oneOf: elements } } };
     return R.mergeDeepRight<JSONSchemaType<AiAgentTransformConfiguration>, any>(
       PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA,
@@ -225,8 +120,8 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
       logApp.warn('[PLAYBOOK AI AGENT] No agent configured, returning bundle unmodified');
       return { output_port: 'unmodified', bundle };
     }
-    const content = buildAgentPrompt(bundle, prompt);
-    const rawResponse = await callAgent(agent_slug, content);
+    const content = buildAgentMessageContent(bundle, prompt);
+    const rawResponse = await callXtmAgent(agent_slug, content);
     if (rawResponse === null) {
       return { output_port: 'unmodified', bundle };
     }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -64,6 +64,10 @@ const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransf
       nullable: true,
       default: '',
       $ref: 'Additional instructions (optional, prepended to the STIX bundle)',
+      // `format: 'textarea'` is a UI hint consumed by the playbook form
+      // renderer to display this field as a multi-line text area. AJV
+      // does not enforce the format keyword so this is purely cosmetic.
+      format: 'textarea',
     },
   },
   required: ['agent_slug'],

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -18,13 +18,16 @@ import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from './ai-agent-shared';
 
-// Canonical STIX 2.1 ID shape: `<type>--<uuid>`. Mirrors the `isStixId`
-// helper in `src/schema/schemaUtils.js` — inlined here instead of imported
-// to avoid pulling the full schema module (and its heavy transitive
-// closure) into this unit-testable component.
-const STIX_ID_REGEX = /^[a-z][a-z0-9-]*--[\w-]{36}$/;
+// Canonical STIX 2.1 ID shape: `<type>--<uuid>` where the UUID is the
+// 8-4-4-4-12 hex layout. Stricter than the loose `[\w-]{36}` pattern in
+// `src/schema/schemaUtils.js` (which accepts underscores) so that we
+// reject malformed agent output instead of forwarding it as a "bundle".
+// Inlined here as a regex constant to keep the component unit-testable
+// without dragging the schema module's transitive closure into the
+// test runner.
+const STIX_UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface AiAgentTransformConfiguration {
   agent_slug: string;
@@ -58,17 +61,23 @@ const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransf
 
 /**
  * Minimum STIX 2.1 object shape we accept from the agent: a non-empty
- * `type` string plus an `id` that matches the canonical `<type>--<uuid>`
- * pattern. Anything looser is silently corrupted by the agent and should
- * not be forwarded to the downstream playbook nodes.
+ * `type` string AND an `id` of the canonical `<type>--<uuid>` shape
+ * where the prefix before `--` matches the object's own `type` field
+ * exactly and the suffix is a strict 8-4-4-4-12 hex UUID. Anything
+ * looser (mismatched type prefix, underscores in the UUID, missing
+ * separator, ...) is silently corrupted by the agent and should not be
+ * forwarded to the downstream playbook nodes.
  */
 const isMinimalStixObjectShape = (candidate: unknown): boolean => {
   if (!candidate || typeof candidate !== 'object') return false;
   const obj = candidate as { id?: unknown; type?: unknown };
-  return typeof obj.id === 'string'
-    && STIX_ID_REGEX.test(obj.id)
-    && typeof obj.type === 'string'
-    && obj.type.length > 0;
+  if (typeof obj.type !== 'string' || obj.type.length === 0) return false;
+  if (typeof obj.id !== 'string') return false;
+  const separatorIndex = obj.id.indexOf('--');
+  if (separatorIndex <= 0) return false;
+  const idTypePrefix = obj.id.slice(0, separatorIndex);
+  const idUuid = obj.id.slice(separatorIndex + 2);
+  return idTypePrefix === obj.type && STIX_UUID_REGEX.test(idUuid);
 };
 
 /**
@@ -147,6 +156,19 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
     const { agent_slug, prompt } = playbookNode.configuration;
     if (!agent_slug) {
       logApp.warn('[PLAYBOOK AI AGENT] No agent configured, returning bundle unmodified');
+      return { output_port: 'unmodified', bundle };
+    }
+    // Defense in depth: re-check that the configured slug is currently
+    // bound to the transformer intent. AJV `oneOf` validation only
+    // covers saves that go through the schema resolver — a crafted
+    // playbook update or an agent that was unbound after save would
+    // otherwise let us run an arbitrary XTM One agent under the
+    // platform automation identity.
+    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_TRANSFORM_INTENT, agent_slug))) {
+      logApp.warn('[PLAYBOOK AI AGENT] Configured agent is not bound to the transformer intent, returning bundle unmodified', {
+        agentSlug: agent_slug,
+        intent: PLAYBOOK_AI_AGENT_TRANSFORM_INTENT,
+      });
       return { output_port: 'unmodified', bundle };
     }
     const content = buildAgentMessageContent(bundle, prompt);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -1,0 +1,103 @@
+/*
+Copyright (c) 2021-2025 Filigran SAS
+
+This file is part of the OpenCTI Enterprise Edition ("EE") and is
+licensed under the OpenCTI Enterprise Edition License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://github.com/OpenCTI-Platform/opencti/blob/master/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import * as R from 'ramda';
+import type { JSONSchemaType } from 'ajv';
+import type { PlaybookComponent } from '../playbook-types';
+import { logApp } from '../../../config/conf';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from './ai-agent-shared';
+
+interface AiAgentSendConfiguration {
+  agent_slug: string;
+  prompt?: string;
+}
+
+const PLAYBOOK_AI_AGENT_SEND_INTENT = 'cti.stix_consumer';
+
+const PLAYBOOK_AI_AGENT_SEND_COMPONENT_SCHEMA: JSONSchemaType<AiAgentSendConfiguration> = {
+  type: 'object',
+  properties: {
+    agent_slug: {
+      type: 'string',
+      $ref: 'AI agent',
+      // Populated dynamically from the XTM One intent catalog at schema() time.
+      oneOf: [],
+    },
+    prompt: {
+      type: 'string',
+      nullable: true,
+      default: '',
+      $ref: 'Instructions (optional, prepended to the STIX bundle)',
+      // `format: 'textarea'` is a UI hint consumed by the playbook form
+      // renderer to display this field as a multi-line text area.
+      format: 'textarea',
+    },
+  },
+  required: ['agent_slug'],
+};
+
+/**
+ * Fire-and-wait end-of-playbook component: sends the bundle and the
+ * (optional) user instruction to an AI agent and waits for the call to
+ * complete so that any side effects (Slack post, ticket creation,
+ * outbound email, ...) the agent triggers via its own tools are flushed
+ * before the playbook run is marked done.
+ *
+ * Unlike the transform component this is an **end node** (no output
+ * port) — the agent's textual response is logged for traceability but
+ * not parsed back into a STIX bundle. Use `Transform with AI agent` if
+ * you need the response to drive the rest of the playbook chain.
+ */
+export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConfiguration> = {
+  id: 'PLAYBOOK_AI_AGENT_SEND_COMPONENT',
+  name: 'Send to AI agent',
+  description: 'Send the STIX bundle to an AI agent as the final step of the playbook',
+  icon: 'ai-agent',
+  category: 'end_playbook',
+  is_entry_point: false,
+  is_internal: true,
+  ports: [],
+  configuration_schema: PLAYBOOK_AI_AGENT_SEND_COMPONENT_SCHEMA,
+  schema: async () => {
+    const elements = await buildAgentSlugOneOf(PLAYBOOK_AI_AGENT_SEND_INTENT);
+    const schemaElement = { properties: { agent_slug: { oneOf: elements } } };
+    return R.mergeDeepRight<JSONSchemaType<AiAgentSendConfiguration>, any>(
+      PLAYBOOK_AI_AGENT_SEND_COMPONENT_SCHEMA,
+      schemaElement,
+    );
+  },
+  executor: async ({ playbookNode, bundle, playbookId }) => {
+    const { agent_slug, prompt } = playbookNode.configuration;
+    if (!agent_slug) {
+      logApp.warn('[PLAYBOOK AI AGENT SEND] No agent configured, dropping playbook step', { playbookId });
+      return { output_port: undefined, bundle, forceBundleTracking: true };
+    }
+    const content = buildAgentMessageContent(bundle, prompt);
+    const rawResponse = await callXtmAgent(agent_slug, content);
+    if (rawResponse === null) {
+      logApp.warn('[PLAYBOOK AI AGENT SEND] Agent call did not complete', {
+        playbookId,
+        agentSlug: agent_slug,
+      });
+    } else {
+      logApp.info('[PLAYBOOK AI AGENT SEND] Agent call completed', {
+        playbookId,
+        agentSlug: agent_slug,
+        responsePreview: rawResponse.slice(0, 200),
+      });
+    }
+    return { output_port: undefined, bundle, forceBundleTracking: true };
+  },
+};

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -17,7 +17,7 @@ import * as R from 'ramda';
 import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from './ai-agent-shared';
 
 interface AiAgentSendConfiguration {
   agent_slug: string;
@@ -82,6 +82,20 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
     const { agent_slug, prompt } = playbookNode.configuration;
     if (!agent_slug) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] No agent configured, dropping playbook step', { playbookId });
+      return { output_port: undefined, bundle, forceBundleTracking: true };
+    }
+    // Defense in depth: re-check that the configured slug is currently
+    // bound to the consumer intent before invoking it. AJV `oneOf`
+    // validation only covers saves that go through the schema resolver
+    // — a crafted playbook update or an agent that was unbound after
+    // save would otherwise let us run an arbitrary XTM One agent under
+    // the platform automation identity.
+    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_SEND_INTENT, agent_slug))) {
+      logApp.warn('[PLAYBOOK AI AGENT SEND] Configured agent is not bound to the consumer intent, dropping playbook step', {
+        playbookId,
+        agentSlug: agent_slug,
+        intent: PLAYBOOK_AI_AGENT_SEND_INTENT,
+      });
       return { output_port: undefined, bundle, forceBundleTracking: true };
     }
     const content = buildAgentMessageContent(bundle, prompt);

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -78,6 +78,37 @@ export const buildAgentSlugOneOf = async (
 };
 
 /**
+ * Runtime defense in depth: re-check that ``slug`` is currently bound to
+ * the expected ``intent`` in the XTM One catalog before the executor
+ * actually invokes the agent. AJV validation at playbook save time only
+ * guards saves that go through the schema resolver — direct DB writes,
+ * future bulk-import paths, or an agent that gets unbound from the
+ * intent after save would otherwise let the executor run an arbitrary
+ * agent under the platform-internal ``AUTOMATION_MANAGER_USER`` JWT.
+ *
+ * Returns ``false`` (and logs a warning) on catalog failure / unknown
+ * slug, so the executor falls through to its safe terminal branch
+ * (``unmodified`` / fire-and-wait) instead of calling the agent.
+ */
+export const isAgentBoundToIntent = async (
+  intent: string,
+  slug: string,
+): Promise<boolean> => {
+  if (!slug) return false;
+  try {
+    const agents = await xtmOneClient.listAgentsForIntent(buildPlaybookAutomationContext(), intent);
+    return (agents ?? []).some((a) => a.agent_slug === slug);
+  } catch (e: unknown) {
+    logApp.warn('[PLAYBOOK AI AGENT] Failed to validate agent intent binding', {
+      intent,
+      slug,
+      cause: (e as Error).message,
+    });
+    return false;
+  }
+};
+
+/**
  * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
  * raw assistant content or null when the call cannot complete (XTM One
  * not configured, network failure, non-success status). Errors are

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2021-2025 Filigran SAS
+
+This file is part of the OpenCTI Enterprise Edition ("EE") and is
+licensed under the OpenCTI Enterprise Edition License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://github.com/OpenCTI-Platform/opencti/blob/master/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import nconf from 'nconf';
+import xtmOneClient from '../../xtm/one/xtm-one-client';
+import { issueXtmJwt } from '../../../domain/xtm-auth';
+import { getHttpClient, getResponseError } from '../../../utils/http-client';
+import { logApp, PLATFORM_VERSION } from '../../../config/conf';
+import { AUTOMATION_MANAGER_USER_UUID, executionContext } from '../../../utils/access';
+import type { AuthContext, AuthUser } from '../../../types/user';
+import type { StixBundle } from '../../../types/stix-2-1-common';
+
+// Identity used by playbook executors when calling XTM One agents.
+// The local part is stable so XTM One auto-provisions a single
+// "OpenCTI Playbook Automation" user per deployment; the .invalid TLD
+// (RFC 6761) makes it unmistakably non-human and impossible to collide
+// with a real account.
+export const PLAYBOOK_AUTOMATION_EMAIL = 'opencti-playbook-automation@opencti.invalid';
+
+// 5 minutes — agent runs may take a while when the LLM has to materialise
+// a large STIX bundle or call multiple tools. Keep well above the default
+// 2-minute httpClient cap used by the chatbot proxy.
+export const AGENT_CALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+export const buildPlaybookAutomationUser = (): Pick<AuthUser, 'id' | 'user_email'> => ({
+  id: AUTOMATION_MANAGER_USER_UUID,
+  user_email: PLAYBOOK_AUTOMATION_EMAIL,
+});
+
+export const buildPlaybookAutomationContext = (): AuthContext => {
+  const context = executionContext('playbook_components');
+  return { ...context, user: buildPlaybookAutomationUser() as AuthUser };
+};
+
+/**
+ * Combine an optional natural-language instruction with the JSON
+ * representation of the bundle into the single ``content`` payload sent
+ * to the agent. Both AI-agent playbook components share this contract
+ * so agents bound to either intent can be authored once.
+ */
+export const buildAgentMessageContent = (bundle: StixBundle, userPrompt?: string): string => {
+  const instruction = (userPrompt ?? '').trim();
+  const bundleJson = JSON.stringify(bundle, null, 2);
+  if (!instruction) {
+    return `--- STIX BUNDLE ---\n${bundleJson}`;
+  }
+  return `${instruction}\n\n--- STIX BUNDLE ---\n${bundleJson}`;
+};
+
+/**
+ * Resolve the dynamic ``oneOf`` list of agents bound to ``intent`` so
+ * the playbook form can render the agent picker. Returns an empty list
+ * (and logs a warning) when XTM One is unreachable so the form still
+ * renders cleanly instead of failing the whole resolver.
+ */
+export const buildAgentSlugOneOf = async (
+  intent: string,
+): Promise<Array<{ const: string; title: string }>> => {
+  const automationContext = buildPlaybookAutomationContext();
+  let agents: Awaited<ReturnType<typeof xtmOneClient.listAgentsForIntent>> = [];
+  try {
+    agents = await xtmOneClient.listAgentsForIntent(automationContext, intent);
+  } catch (e: unknown) {
+    logApp.warn('[PLAYBOOK AI AGENT] Failed to load agent catalog', {
+      intent,
+      cause: (e as Error).message,
+    });
+  }
+  return (agents ?? [])
+    .filter((a) => !!a.agent_slug)
+    .map((a) => ({ const: a.agent_slug as string, title: a.agent_name }))
+    .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1));
+};
+
+/**
+ * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
+ * raw assistant content or null when the call cannot complete (XTM One
+ * not configured, network failure, non-success status). Errors are
+ * logged but never thrown — playbook components are responsible for
+ * deciding how to react (route to ``unmodified``, swallow at the end of
+ * a chain, etc.) instead of crashing the whole run.
+ */
+export const callXtmAgent = async (
+  agentSlug: string,
+  content: string,
+): Promise<string | null> => {
+  const xtmOneUrl = nconf.get('xtm:xtm_one_url');
+  if (!xtmOneUrl || !xtmOneClient.isConfigured()) {
+    logApp.warn('[PLAYBOOK AI AGENT] XTM One is not configured, skipping agent call');
+    return null;
+  }
+  try {
+    const jwt = await issueXtmJwt(buildPlaybookAutomationUser() as AuthUser, xtmOneUrl);
+    const httpClient = getHttpClient({
+      baseURL: xtmOneUrl,
+      responseType: 'json',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        'Content-Type': 'application/json',
+        'X-Platform-Product': 'opencti',
+        'X-Platform-Version': PLATFORM_VERSION,
+      },
+    });
+    const response = await httpClient.post(
+      '/api/v1/platform/chat/messages',
+      { agent_slug: agentSlug, content, stream: false },
+      { timeout: AGENT_CALL_TIMEOUT_MS },
+    );
+    return response.data?.content ?? null;
+  } catch (e: unknown) {
+    const httpErr = getResponseError(e);
+    const detail = httpErr?.data?.detail ?? httpErr?.data?.message ?? (e as Error)?.message;
+    logApp.error('[PLAYBOOK AI AGENT] Agent call failed', {
+      agentSlug,
+      status: httpErr?.status,
+      detail,
+    });
+    return null;
+  }
+};

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -18,12 +18,8 @@ import xtmOneClient from '../../xtm/one/xtm-one-client';
 import { issueXtmJwt } from '../../../domain/xtm-auth';
 import { getHttpClient, getResponseError } from '../../../utils/http-client';
 import { logApp, PLATFORM_VERSION } from '../../../config/conf';
-import { executionContext, SYSTEM_USER } from '../../../utils/access';
-import { getEntitiesMapFromCache } from '../../../database/cache';
-import { ENTITY_TYPE_USER } from '../../../schema/internalObject';
-import { OPENCTI_ADMIN_UUID } from '../../../schema/general';
-import { UnsupportedError } from '../../../config/errors';
-import type { AuthContext, AuthUser } from '../../../types/user';
+import { AUTOMATION_MANAGER_USER, executionContext } from '../../../utils/access';
+import type { AuthContext } from '../../../types/user';
 import type { StixBundle } from '../../../types/stix-2-1-common';
 
 // 5 minutes — agent runs may take a while when the LLM has to materialise
@@ -32,29 +28,13 @@ import type { StixBundle } from '../../../types/stix-2-1-common';
 export const AGENT_CALL_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * Resolve the platform admin user from the user cache. Playbooks run as
- * automation but the JWT we mint must roundtrip — XTM One agents call
- * back into OpenCTI through the same JWT (e.g. via the OpenCTI
- * integration), and OpenCTI's incoming-JWT auth requires the email
- * claim to match an existing user. The platform admin is guaranteed to
- * exist (created at platform init) so it is the natural identity for
- * automated agent calls.
+ * Identity used by the AI-agent playbook components to call XTM One.
+ * Reuses the existing platform-internal automation user so the JWT we
+ * mint carries a stable, well-known subject across every playbook run.
  */
-export const getPlaybookAutomationUser = async (
-  context: AuthContext,
-): Promise<AuthUser> => {
-  const usersMap = await getEntitiesMapFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
-  const admin = usersMap.get(OPENCTI_ADMIN_UUID);
-  if (!admin || !admin.user_email) {
-    throw UnsupportedError('Cannot resolve platform admin user for playbook agent call');
-  }
-  return admin;
-};
-
-export const buildPlaybookAutomationContext = async (): Promise<AuthContext> => {
+export const buildPlaybookAutomationContext = (): AuthContext => {
   const context = executionContext('playbook_components');
-  const user = await getPlaybookAutomationUser(context);
-  return { ...context, user };
+  return { ...context, user: AUTOMATION_MANAGER_USER };
 };
 
 /**
@@ -75,17 +55,16 @@ export const buildAgentMessageContent = (bundle: StixBundle, userPrompt?: string
 /**
  * Resolve the dynamic ``oneOf`` list of agents bound to ``intent`` so
  * the playbook form can render the agent picker. Returns an empty list
- * (and logs a warning) when XTM One is unreachable, the platform admin
- * cannot be resolved, or the catalog call itself fails — so the form
- * still renders cleanly instead of failing the whole resolver.
+ * (and logs a warning) when XTM One is unreachable or the catalog call
+ * itself fails — so the form still renders cleanly instead of failing
+ * the whole resolver.
  */
 export const buildAgentSlugOneOf = async (
   intent: string,
 ): Promise<Array<{ const: string; title: string }>> => {
   let agents: Awaited<ReturnType<typeof xtmOneClient.listAgentsForIntent>> = [];
   try {
-    const automationContext = await buildPlaybookAutomationContext();
-    agents = await xtmOneClient.listAgentsForIntent(automationContext, intent);
+    agents = await xtmOneClient.listAgentsForIntent(buildPlaybookAutomationContext(), intent);
   } catch (e: unknown) {
     logApp.warn('[PLAYBOOK AI AGENT] Failed to load agent catalog', {
       intent,
@@ -101,16 +80,16 @@ export const buildAgentSlugOneOf = async (
 /**
  * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
  * raw assistant content or null when the call cannot complete (XTM One
- * not configured, admin user unresolvable, network failure, non-success
- * status). Errors are logged but never thrown — playbook components are
- * responsible for deciding how to react (route to ``unmodified``,
- * swallow at the end of a chain, etc.) instead of crashing the whole
- * run.
+ * not configured, network failure, non-success status). Errors are
+ * logged but never thrown — playbook components are responsible for
+ * deciding how to react (route to ``unmodified``, swallow at the end
+ * of a chain, etc.) instead of crashing the whole run.
  *
- * The JWT is minted on behalf of the platform admin so that it survives
- * the round-trip when the agent calls back into OpenCTI through the
- * OpenCTI integration: OpenCTI's incoming JWT auth resolves the email
- * claim against an existing user, so a synthetic identity would fail.
+ * The JWT is minted on behalf of the platform-internal
+ * ``AUTOMATION_MANAGER_USER`` (the user that already drives every other
+ * playbook side effect: stream events, RabbitMQ work, knowledge
+ * mutations, ...), so XTM One sees the playbook agent calls as coming
+ * from the same identity as the rest of the playbook engine.
  */
 export const callXtmAgent = async (
   agentSlug: string,
@@ -122,9 +101,7 @@ export const callXtmAgent = async (
     return null;
   }
   try {
-    const context = executionContext('playbook_components');
-    const adminUser = await getPlaybookAutomationUser(context);
-    const jwt = await issueXtmJwt(adminUser, xtmOneUrl);
+    const jwt = await issueXtmJwt(AUTOMATION_MANAGER_USER, xtmOneUrl);
     const httpClient = getHttpClient({
       baseURL: xtmOneUrl,
       responseType: 'json',

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -18,30 +18,43 @@ import xtmOneClient from '../../xtm/one/xtm-one-client';
 import { issueXtmJwt } from '../../../domain/xtm-auth';
 import { getHttpClient, getResponseError } from '../../../utils/http-client';
 import { logApp, PLATFORM_VERSION } from '../../../config/conf';
-import { AUTOMATION_MANAGER_USER_UUID, executionContext } from '../../../utils/access';
+import { executionContext, SYSTEM_USER } from '../../../utils/access';
+import { getEntitiesMapFromCache } from '../../../database/cache';
+import { ENTITY_TYPE_USER } from '../../../schema/internalObject';
+import { OPENCTI_ADMIN_UUID } from '../../../schema/general';
+import { UnsupportedError } from '../../../config/errors';
 import type { AuthContext, AuthUser } from '../../../types/user';
 import type { StixBundle } from '../../../types/stix-2-1-common';
-
-// Identity used by playbook executors when calling XTM One agents.
-// The local part is stable so XTM One auto-provisions a single
-// "OpenCTI Playbook Automation" user per deployment; the .invalid TLD
-// (RFC 6761) makes it unmistakably non-human and impossible to collide
-// with a real account.
-export const PLAYBOOK_AUTOMATION_EMAIL = 'opencti-playbook-automation@opencti.invalid';
 
 // 5 minutes — agent runs may take a while when the LLM has to materialise
 // a large STIX bundle or call multiple tools. Keep well above the default
 // 2-minute httpClient cap used by the chatbot proxy.
 export const AGENT_CALL_TIMEOUT_MS = 5 * 60 * 1000;
 
-export const buildPlaybookAutomationUser = (): Pick<AuthUser, 'id' | 'user_email'> => ({
-  id: AUTOMATION_MANAGER_USER_UUID,
-  user_email: PLAYBOOK_AUTOMATION_EMAIL,
-});
+/**
+ * Resolve the platform admin user from the user cache. Playbooks run as
+ * automation but the JWT we mint must roundtrip — XTM One agents call
+ * back into OpenCTI through the same JWT (e.g. via the OpenCTI
+ * integration), and OpenCTI's incoming-JWT auth requires the email
+ * claim to match an existing user. The platform admin is guaranteed to
+ * exist (created at platform init) so it is the natural identity for
+ * automated agent calls.
+ */
+export const getPlaybookAutomationUser = async (
+  context: AuthContext,
+): Promise<AuthUser> => {
+  const usersMap = await getEntitiesMapFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  const admin = usersMap.get(OPENCTI_ADMIN_UUID);
+  if (!admin || !admin.user_email) {
+    throw UnsupportedError('Cannot resolve platform admin user for playbook agent call');
+  }
+  return admin;
+};
 
-export const buildPlaybookAutomationContext = (): AuthContext => {
+export const buildPlaybookAutomationContext = async (): Promise<AuthContext> => {
   const context = executionContext('playbook_components');
-  return { ...context, user: buildPlaybookAutomationUser() as AuthUser };
+  const user = await getPlaybookAutomationUser(context);
+  return { ...context, user };
 };
 
 /**
@@ -62,15 +75,16 @@ export const buildAgentMessageContent = (bundle: StixBundle, userPrompt?: string
 /**
  * Resolve the dynamic ``oneOf`` list of agents bound to ``intent`` so
  * the playbook form can render the agent picker. Returns an empty list
- * (and logs a warning) when XTM One is unreachable so the form still
- * renders cleanly instead of failing the whole resolver.
+ * (and logs a warning) when XTM One is unreachable, the platform admin
+ * cannot be resolved, or the catalog call itself fails — so the form
+ * still renders cleanly instead of failing the whole resolver.
  */
 export const buildAgentSlugOneOf = async (
   intent: string,
 ): Promise<Array<{ const: string; title: string }>> => {
-  const automationContext = buildPlaybookAutomationContext();
   let agents: Awaited<ReturnType<typeof xtmOneClient.listAgentsForIntent>> = [];
   try {
+    const automationContext = await buildPlaybookAutomationContext();
     agents = await xtmOneClient.listAgentsForIntent(automationContext, intent);
   } catch (e: unknown) {
     logApp.warn('[PLAYBOOK AI AGENT] Failed to load agent catalog', {
@@ -87,10 +101,16 @@ export const buildAgentSlugOneOf = async (
 /**
  * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
  * raw assistant content or null when the call cannot complete (XTM One
- * not configured, network failure, non-success status). Errors are
- * logged but never thrown — playbook components are responsible for
- * deciding how to react (route to ``unmodified``, swallow at the end of
- * a chain, etc.) instead of crashing the whole run.
+ * not configured, admin user unresolvable, network failure, non-success
+ * status). Errors are logged but never thrown — playbook components are
+ * responsible for deciding how to react (route to ``unmodified``,
+ * swallow at the end of a chain, etc.) instead of crashing the whole
+ * run.
+ *
+ * The JWT is minted on behalf of the platform admin so that it survives
+ * the round-trip when the agent calls back into OpenCTI through the
+ * OpenCTI integration: OpenCTI's incoming JWT auth resolves the email
+ * claim against an existing user, so a synthetic identity would fail.
  */
 export const callXtmAgent = async (
   agentSlug: string,
@@ -102,7 +122,9 @@ export const callXtmAgent = async (
     return null;
   }
   try {
-    const jwt = await issueXtmJwt(buildPlaybookAutomationUser() as AuthUser, xtmOneUrl);
+    const context = executionContext('playbook_components');
+    const adminUser = await getPlaybookAutomationUser(context);
+    const jwt = await issueXtmJwt(adminUser, xtmOneUrl);
     const httpClient = getHttpClient({
       baseURL: xtmOneUrl,
       responseType: 'json',

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -57,6 +57,7 @@ import { PLAYBOOK_REMOVE_ACCESS_RESTRICTIONS_COMPONENT } from './components/remo
 import { PLAYBOOK_CREATE_INDICATOR_COMPONENT } from './components/create-indicator-component';
 import { PLAYBOOK_CREATE_OBSERVABLE_COMPONENT } from './components/create-observable-component';
 import { PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT } from './components/ai-agent-component';
+import { PLAYBOOK_AI_AGENT_SEND_COMPONENT } from './components/ai-agent-send-component';
 
 // region built in playbook components
 interface LoggerConfiguration {
@@ -699,4 +700,5 @@ export const PLAYBOOK_COMPONENTS: { [k: string]: PlaybookComponent<object> } = {
   [PLAYBOOK_CREATE_OBSERVABLE_COMPONENT.id]: PLAYBOOK_CREATE_OBSERVABLE_COMPONENT,
   [PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT.id]: PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT,
   [PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.id]: PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT,
+  [PLAYBOOK_AI_AGENT_SEND_COMPONENT.id]: PLAYBOOK_AI_AGENT_SEND_COMPONENT,
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -56,6 +56,7 @@ import { PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT } from './components/access-rest
 import { PLAYBOOK_REMOVE_ACCESS_RESTRICTIONS_COMPONENT } from './components/remove-access-restrictions-component';
 import { PLAYBOOK_CREATE_INDICATOR_COMPONENT } from './components/create-indicator-component';
 import { PLAYBOOK_CREATE_OBSERVABLE_COMPONENT } from './components/create-observable-component';
+import { PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT } from './components/ai-agent-component';
 
 // region built in playbook components
 interface LoggerConfiguration {
@@ -697,4 +698,5 @@ export const PLAYBOOK_COMPONENTS: { [k: string]: PlaybookComponent<object> } = {
   [PLAYBOOK_REDUCING_COMPONENT.id]: PLAYBOOK_REDUCING_COMPONENT,
   [PLAYBOOK_CREATE_OBSERVABLE_COMPONENT.id]: PLAYBOOK_CREATE_OBSERVABLE_COMPONENT,
   [PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT.id]: PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT,
+  [PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.id]: PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT,
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -26,6 +26,7 @@ import { type EditInput, type PlaybookAddInput, type PlaybookAddLinkInput, type 
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from './playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from './playbook-types';
 import { PLAYBOOK_COMPONENTS, type StreamConfiguration } from './playbook-components';
+import xtmOneClient from '../xtm/one/xtm-one-client';
 import { FunctionalError, UnsupportedError } from '../../config/errors';
 import { type BasicStoreEntityOrganization, ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
 import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/stix-filtering';
@@ -106,9 +107,23 @@ export const findPlaybooksForEnrollment = async (
   return filteredPlaybooks;
 };
 
+// IDs of playbook components that delegate their work to an XTM One agent
+// and therefore only make sense to expose to playbook authors when an
+// XTM One token is configured. Same gating contract as the Ask Ariane
+// chatbot and the AI Insights drawers — listing them in the picker when
+// the platform cannot reach XTM One would only let authors build nodes
+// that no-op at runtime.
+const XTM_ONE_DEPENDENT_COMPONENT_IDS: ReadonlySet<string> = new Set([
+  'PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT',
+  'PLAYBOOK_AI_AGENT_SEND_COMPONENT',
+]);
+
 export const availableComponents = async (context: AuthContext) => {
   await checkEnterpriseEdition(context);
-  return Object.values(PLAYBOOK_COMPONENTS);
+  const xtmOneConfigured = xtmOneClient.isConfigured();
+  return Object.values(PLAYBOOK_COMPONENTS).filter((component) => {
+    return xtmOneConfigured || !XTM_ONE_DEPENDENT_COMPONENT_IDS.has(component.id);
+  });
 };
 
 export const getPlaybookDefinition = async (context: AuthContext, playbook: BasicStoreEntityPlaybook) => {

--- a/opencti-platform/opencti-graphql/src/modules/xtm/one/xtm-one.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/one/xtm-one.ts
@@ -78,6 +78,7 @@ export const registerWithXtmOne = async (context: AuthContext, user: AuthUser): 
       { name: 'cti.nlq_search', description: 'Generate an OpenCTI filter from a natural language query' },
       { name: 'cti.stix_harvester', description: 'Extract cyber threat intelligence from documents into STIX 2.1 bundles' },
       { name: 'cti.stix_transformer', description: 'Transform a STIX 2.1 bundle (enrich, filter, rewrite, normalize) and return a valid STIX 2.1 bundle' },
+      { name: 'cti.stix_consumer', description: 'Consume a STIX 2.1 bundle as the final step of an OpenCTI playbook (summarize, alert, post, dispatch)' },
     ],
   });
 

--- a/opencti-platform/opencti-graphql/src/modules/xtm/one/xtm-one.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/one/xtm-one.ts
@@ -77,6 +77,7 @@ export const registerWithXtmOne = async (context: AuthContext, user: AuthUser): 
       { name: 'cti.entity_history', description: 'Summarize internal history of an OpenCTI entity' },
       { name: 'cti.nlq_search', description: 'Generate an OpenCTI filter from a natural language query' },
       { name: 'cti.stix_harvester', description: 'Extract cyber threat intelligence from documents into STIX 2.1 bundles' },
+      { name: 'cti.stix_transformer', description: 'Transform a STIX 2.1 bundle (enrich, filter, rewrite, normalize) and return a valid STIX 2.1 bundle' },
     ],
   });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/available-components-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/available-components-test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import xtmOneClient from '../../../../src/modules/xtm/one/xtm-one-client';
+import { availableComponents } from '../../../../src/modules/playbook/playbook-domain';
+import * as ee from '../../../../src/enterprise-edition/ee';
+import { testContext } from '../../../utils/testQuery';
+
+const XTM_ONE_DEPENDENT_IDS = [
+  'PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT',
+  'PLAYBOOK_AI_AGENT_SEND_COMPONENT',
+];
+
+describe('availableComponents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    // Skip the EE gate so the function returns instead of throwing.
+    vi.spyOn(ee, 'checkEnterpriseEdition').mockResolvedValue(undefined);
+  });
+
+  it('should expose the AI-agent components when XTM One is configured', async () => {
+    vi.spyOn(xtmOneClient, 'isConfigured').mockReturnValue(true);
+
+    const components = await availableComponents(testContext);
+    const componentIds = components.map((c) => c.id);
+
+    for (const id of XTM_ONE_DEPENDENT_IDS) {
+      expect(componentIds).toContain(id);
+    }
+  });
+
+  it('should hide the AI-agent components when XTM One is not configured', async () => {
+    vi.spyOn(xtmOneClient, 'isConfigured').mockReturnValue(false);
+
+    const components = await availableComponents(testContext);
+    const componentIds = components.map((c) => c.id);
+
+    for (const id of XTM_ONE_DEPENDENT_IDS) {
+      expect(componentIds).not.toContain(id);
+    }
+    // Sanity: non-XTM-One components are still listed (we did not accidentally
+    // wipe the registry — pick a stable representative).
+    expect(componentIds).toContain('PLAYBOOK_INTERNAL_MANUAL_TRIGGER');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks (declared before the SUT import) ──────────────────────────────
+
+vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => ({
+  buildAgentMessageContent: vi.fn(),
+  buildAgentSlugOneOf: vi.fn(),
+  callXtmAgent: vi.fn(),
+}));
+
+vi.mock('../../../../../src/config/conf', () => ({
+  logApp: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────
+
+import { PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT } from '../../../../../src/modules/playbook/components/ai-agent-component';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
+import type { ExecutorParameters } from '../../../../../src/modules/playbook/playbook-types';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const ORIGINAL_BUNDLE: StixBundle = {
+  id: 'bundle--original',
+  spec_version: '2.1',
+  type: 'bundle',
+  objects: [
+    { id: 'indicator--1', type: 'indicator', spec_version: '2.1' } as any,
+  ],
+};
+
+const TRANSFORMED_BUNDLE_OBJECT = { id: 'indicator--2', type: 'indicator', spec_version: '2.1' };
+
+const buildExecutorParams = (
+  configuration: { agent_slug: string; prompt?: string },
+  bundle: StixBundle = ORIGINAL_BUNDLE,
+) => ({
+  eventId: 'event-id',
+  executionId: 'execution-id',
+  playbookId: 'playbook-id',
+  dataInstanceId: 'data-instance-id',
+  previousPlaybookNodeId: undefined,
+  previousStepBundle: null,
+  bundle,
+  playbookNode: {
+    id: 'node-id',
+    name: 'Transform Node',
+    component_id: PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.id,
+    configuration,
+  },
+}) as unknown as ExecutorParameters<{ agent_slug: string; prompt?: string }>;
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('component metadata', () => {
+    it('should be flagged is_internal and use the ai-agent icon', () => {
+      expect(PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.is_internal).toBe(true);
+      expect(PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.icon).toBe('ai-agent');
+      expect(PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.category).toBe('transform_and_enrich');
+    });
+
+    it('should expose `out` and `unmodified` output ports so playbook authors can branch on agent failure', () => {
+      const portIds = PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.ports.map((p) => p.id).sort();
+      expect(portIds).toEqual(['out', 'unmodified']);
+    });
+  });
+
+  describe('schema()', () => {
+    it('should hydrate the agent_slug oneOf from the XTM One catalog for the cti.stix_transformer intent', async () => {
+      vi.mocked(buildAgentSlugOneOf).mockResolvedValue([
+        { const: 'agent-a', title: 'Agent A' },
+      ]);
+
+      const schema = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.schema();
+
+      expect(buildAgentSlugOneOf).toHaveBeenCalledWith('cti.stix_transformer');
+      expect((schema as any).properties.agent_slug.oneOf).toEqual([
+        { const: 'agent-a', title: 'Agent A' },
+      ]);
+    });
+
+    it('should still produce a valid schema (empty oneOf) when no agents are bound to the intent', async () => {
+      vi.mocked(buildAgentSlugOneOf).mockResolvedValue([]);
+
+      const schema = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.schema();
+
+      expect((schema as any).properties.agent_slug.oneOf).toEqual([]);
+    });
+  });
+
+  describe('executor', () => {
+    it('should route to `unmodified` and not call XTM One when no agent_slug is configured', async () => {
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: '' }),
+      );
+
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when XTM One call fails (callXtmAgent returns null)', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(null);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content');
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should accept a raw JSON STIX bundle response and emit a new bundle preserving the original envelope', async () => {
+      const agentResponse = JSON.stringify({
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        type: 'bundle',
+        objects: [TRANSFORMED_BUNDLE_OBJECT],
+      });
+      vi.mocked(callXtmAgent).mockResolvedValue(agentResponse);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('out');
+      // Envelope is preserved (id + spec_version stay from the original bundle).
+      expect(result.bundle.id).toBe(ORIGINAL_BUNDLE.id);
+      expect(result.bundle.spec_version).toBe(ORIGINAL_BUNDLE.spec_version);
+      // But the objects come from the agent response.
+      expect(result.bundle.objects).toEqual([TRANSFORMED_BUNDLE_OBJECT]);
+    });
+
+    it('should extract the bundle from a fenced ```json block', async () => {
+      const agentResponse = [
+        'Here is the bundle:',
+        '```json',
+        JSON.stringify({ id: 'bundle--agent', spec_version: '2.1', type: 'bundle', objects: [TRANSFORMED_BUNDLE_OBJECT] }),
+        '```',
+        'Hope this helps!',
+      ].join('\n');
+      vi.mocked(callXtmAgent).mockResolvedValue(agentResponse);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('out');
+      expect(result.bundle.objects).toEqual([TRANSFORMED_BUNDLE_OBJECT]);
+    });
+
+    it('should extract the bundle from a plain ``` fenced block (no language hint)', async () => {
+      const agentResponse = [
+        '```',
+        JSON.stringify({ id: 'bundle--agent', spec_version: '2.1', type: 'bundle', objects: [TRANSFORMED_BUNDLE_OBJECT] }),
+        '```',
+      ].join('\n');
+      vi.mocked(callXtmAgent).mockResolvedValue(agentResponse);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('out');
+      expect(result.bundle.objects).toEqual([TRANSFORMED_BUNDLE_OBJECT]);
+    });
+
+    it('should fall back to best-effort `{...}` substring extraction when the response has prose around the JSON', async () => {
+      const bundleJson = JSON.stringify({
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        type: 'bundle',
+        objects: [TRANSFORMED_BUNDLE_OBJECT],
+      });
+      const agentResponse = `Sure, here you go: ${bundleJson} let me know if you need anything else.`;
+      vi.mocked(callXtmAgent).mockResolvedValue(agentResponse);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('out');
+      expect(result.bundle.objects).toEqual([TRANSFORMED_BUNDLE_OBJECT]);
+    });
+
+    it('should route to `unmodified` when the response is empty', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue('   ');
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when the parsed JSON is not a STIX bundle (wrong type)', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({ type: 'not-a-bundle', objects: [] }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when the parsed bundle has no objects array', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({ type: 'bundle' }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when the response is unparseable prose', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue('Sorry, I cannot help with this request.');
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should forward the bundle and the user prompt to the message builder', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(null);
+
+      await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x', prompt: 'Tag everything' }),
+      );
+
+      expect(buildAgentMessageContent).toHaveBeenCalledWith(ORIGINAL_BUNDLE, 'Tag everything');
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -21,16 +21,22 @@ import type { ExecutorParameters } from '../../../../../src/modules/playbook/pla
 
 // ── Fixtures ────────────────────────────────────────────────────────────
 
+// Use full <type>--<uuid> STIX IDs (matching `[a-z-]+--[\w-]{36}`) so the
+// minimum-shape validator inside the parser accepts them — STIX 2.1
+// rejects anything looser.
+const ORIGINAL_INDICATOR_ID = 'indicator--11111111-1111-1111-1111-111111111111';
+const TRANSFORMED_INDICATOR_ID = 'indicator--22222222-2222-2222-2222-222222222222';
+
 const ORIGINAL_BUNDLE: StixBundle = {
   id: 'bundle--original',
   spec_version: '2.1',
   type: 'bundle',
   objects: [
-    { id: 'indicator--1', type: 'indicator', spec_version: '2.1' } as any,
+    { id: ORIGINAL_INDICATOR_ID, type: 'indicator', spec_version: '2.1' } as any,
   ],
 };
 
-const TRANSFORMED_BUNDLE_OBJECT = { id: 'indicator--2', type: 'indicator', spec_version: '2.1' };
+const TRANSFORMED_BUNDLE_OBJECT = { id: TRANSFORMED_INDICATOR_ID, type: 'indicator', spec_version: '2.1' };
 
 const buildExecutorParams = (
   configuration: { agent_slug: string; prompt?: string },
@@ -237,6 +243,86 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
 
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when an object in the bundle is an empty `{}` placeholder', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+        type: 'bundle',
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        objects: [{}],
+      }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when an object is missing the STIX id', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+        type: 'bundle',
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        objects: [{ type: 'indicator', spec_version: '2.1' }],
+      }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when an object has an id that does not match the STIX <type>--<uuid> pattern', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+        type: 'bundle',
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        objects: [{ id: 'indicator-42', type: 'indicator', spec_version: '2.1' }],
+      }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when any one object in a mixed-validity bundle is malformed (whole bundle rejected)', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+        type: 'bundle',
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        objects: [TRANSFORMED_BUNDLE_OBJECT, { id: 'bad-id' }],
+      }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should accept an empty `objects: []` bundle (agent legitimately filtered everything out)', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+        type: 'bundle',
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        objects: [],
+      }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('out');
+      expect(result.bundle.objects).toEqual([]);
     });
 
     it('should forward the bundle and the user prompt to the message builder', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -6,6 +6,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentMessageContent: vi.fn(),
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
+  isAgentBoundToIntent: vi.fn(),
 }));
 
 vi.mock('../../../../../src/config/conf', () => ({
@@ -15,7 +16,7 @@ vi.mock('../../../../../src/config/conf', () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import { PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT } from '../../../../../src/modules/playbook/components/ai-agent-component';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 import type { ExecutorParameters } from '../../../../../src/modules/playbook/playbook-types';
 
@@ -63,6 +64,10 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+    // Default to "agent slug is bound to the right intent" so existing
+    // tests exercise the live agent-call path; tests that need the
+    // negative branch override this explicitly.
+    vi.mocked(isAgentBoundToIntent).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -114,6 +119,29 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` and not call XTM One when the slug is not bound to the cti.stix_transformer intent (defense in depth)', async () => {
+      vi.mocked(isAgentBoundToIntent).mockResolvedValue(false);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-not-bound-to-transformer' }),
+      );
+
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-not-bound-to-transformer');
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should validate the slug against cti.stix_transformer before each agent call', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(null);
+
+      await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x');
     });
 
     it('should route to `unmodified` when XTM One call fails (callXtmAgent returns null)', async () => {
@@ -291,6 +319,49 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
 
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when the id type prefix does not match the object type field', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+        type: 'bundle',
+        id: 'bundle--agent',
+        spec_version: '2.1',
+        objects: [{
+          id: 'malware--33333333-3333-3333-3333-333333333333',
+          type: 'indicator',
+          spec_version: '2.1',
+        }],
+      }));
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` when the UUID segment is not a valid 8-4-4-4-12 hex (e.g. underscores, wrong length)', async () => {
+      const invalidUuids = [
+        'indicator--12345678_1234_1234_1234_123456789012', // underscores instead of hyphens
+        'indicator--zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz', // non-hex characters
+        'indicator--1234-1234-1234-1234-1234567890ab', // wrong segment lengths
+      ];
+      for (const id of invalidUuids) {
+        vi.mocked(callXtmAgent).mockResolvedValue(JSON.stringify({
+          type: 'bundle',
+          id: 'bundle--agent',
+          spec_version: '2.1',
+          objects: [{ id, type: 'indicator', spec_version: '2.1' }],
+        }));
+
+        const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+          buildExecutorParams({ agent_slug: 'agent-x' }),
+        );
+
+        expect(result.output_port, `id ${id} should be rejected`).toBe('unmodified');
+        expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+      }
     });
 
     it('should route to `unmodified` when any one object in a mixed-validity bundle is malformed (whole bundle rejected)', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks (declared before the SUT import) ──────────────────────────────
+
+vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => ({
+  buildAgentMessageContent: vi.fn(),
+  buildAgentSlugOneOf: vi.fn(),
+  callXtmAgent: vi.fn(),
+}));
+
+vi.mock('../../../../../src/config/conf', () => ({
+  logApp: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────
+
+import { PLAYBOOK_AI_AGENT_SEND_COMPONENT } from '../../../../../src/modules/playbook/components/ai-agent-send-component';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
+import type { ExecutorParameters } from '../../../../../src/modules/playbook/playbook-types';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const BUNDLE: StixBundle = {
+  id: 'bundle--original',
+  spec_version: '2.1',
+  type: 'bundle',
+  objects: [],
+};
+
+const buildExecutorParams = (configuration: { agent_slug: string; prompt?: string }) => ({
+  eventId: 'event-id',
+  executionId: 'execution-id',
+  playbookId: 'playbook-id',
+  dataInstanceId: 'data-instance-id',
+  previousPlaybookNodeId: undefined,
+  previousStepBundle: null,
+  bundle: BUNDLE,
+  playbookNode: {
+    id: 'node-id',
+    name: 'Send Node',
+    component_id: PLAYBOOK_AI_AGENT_SEND_COMPONENT.id,
+    configuration,
+  },
+}) as unknown as ExecutorParameters<{ agent_slug: string; prompt?: string }>;
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('component metadata', () => {
+    it('should be an end-playbook component with no output ports', () => {
+      expect(PLAYBOOK_AI_AGENT_SEND_COMPONENT.category).toBe('end_playbook');
+      expect(PLAYBOOK_AI_AGENT_SEND_COMPONENT.ports).toEqual([]);
+      expect(PLAYBOOK_AI_AGENT_SEND_COMPONENT.is_internal).toBe(true);
+      expect(PLAYBOOK_AI_AGENT_SEND_COMPONENT.icon).toBe('ai-agent');
+    });
+  });
+
+  describe('schema()', () => {
+    it('should hydrate the agent_slug oneOf from the XTM One catalog for the cti.stix_consumer intent', async () => {
+      vi.mocked(buildAgentSlugOneOf).mockResolvedValue([
+        { const: 'agent-a', title: 'Agent A' },
+      ]);
+
+      const schema = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.schema();
+
+      expect(buildAgentSlugOneOf).toHaveBeenCalledWith('cti.stix_consumer');
+      expect((schema as any).properties.agent_slug.oneOf).toEqual([
+        { const: 'agent-a', title: 'Agent A' },
+      ]);
+    });
+  });
+
+  describe('executor', () => {
+    it('should drop the step (no agent call) and force bundle tracking when no agent is configured', async () => {
+      const result = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: '' }),
+      );
+
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBeUndefined();
+      expect(result.bundle).toBe(BUNDLE);
+      expect(result.forceBundleTracking).toBe(true);
+    });
+
+    it('should call the agent and still terminate cleanly (bundle tracked) when the agent responds', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue('agent reply');
+
+      const result = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x', prompt: 'do something' }),
+      );
+
+      expect(buildAgentMessageContent).toHaveBeenCalledWith(BUNDLE, 'do something');
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content');
+      expect(result.output_port).toBeUndefined();
+      expect(result.bundle).toBe(BUNDLE);
+      expect(result.forceBundleTracking).toBe(true);
+    });
+
+    it('should terminate cleanly (bundle tracked) even when the agent call fails (callXtmAgent returns null)', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue(null);
+
+      const result = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content');
+      expect(result.output_port).toBeUndefined();
+      expect(result.bundle).toBe(BUNDLE);
+      expect(result.forceBundleTracking).toBe(true);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -6,6 +6,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentMessageContent: vi.fn(),
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
+  isAgentBoundToIntent: vi.fn(),
 }));
 
 vi.mock('../../../../../src/config/conf', () => ({
@@ -15,7 +16,7 @@ vi.mock('../../../../../src/config/conf', () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import { PLAYBOOK_AI_AGENT_SEND_COMPONENT } from '../../../../../src/modules/playbook/components/ai-agent-send-component';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 import type { ExecutorParameters } from '../../../../../src/modules/playbook/playbook-types';
 
@@ -50,6 +51,10 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+    // Default to "agent slug is bound to the consumer intent" so the
+    // existing tests exercise the live path; tests that need the
+    // negative branch override this explicitly.
+    vi.mocked(isAgentBoundToIntent).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -90,6 +95,30 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
       expect(result.forceBundleTracking).toBe(true);
+    });
+
+    it('should drop the step (no agent call) when the slug is not bound to the cti.stix_consumer intent (defense in depth)', async () => {
+      vi.mocked(isAgentBoundToIntent).mockResolvedValue(false);
+
+      const result = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-not-bound-to-consumer' }),
+      );
+
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-not-bound-to-consumer');
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBeUndefined();
+      expect(result.bundle).toBe(BUNDLE);
+      expect(result.forceBundleTracking).toBe(true);
+    });
+
+    it('should validate the slug against cti.stix_consumer before each agent call', async () => {
+      vi.mocked(callXtmAgent).mockResolvedValue('reply');
+
+      await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x');
     });
 
     it('should call the agent and still terminate cleanly (bundle tracked) when the agent responds', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -27,6 +27,11 @@ vi.mock('../../../../../src/config/conf', () => ({
   PLATFORM_VERSION: '6.0.0-test',
 }));
 
+vi.mock('../../../../../src/utils/access', () => ({
+  AUTOMATION_MANAGER_USER: { id: 'automation-manager', user_email: 'AUTOMATION MANAGER' },
+  executionContext: vi.fn((source: string) => ({ source })),
+}));
+
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import nconf from 'nconf';

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -45,6 +45,7 @@ import {
   buildAgentSlugOneOf,
   buildPlaybookAutomationContext,
   callXtmAgent,
+  isAgentBoundToIntent,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 
@@ -138,6 +139,45 @@ describe('ai-agent-shared', () => {
       const result = await buildAgentSlugOneOf('cti.stix_transformer');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('isAgentBoundToIntent', () => {
+    it('should return false (without calling XTM One) when the slug is empty', async () => {
+      const result = await isAgentBoundToIntent('cti.stix_transformer', '');
+      expect(result).toBe(false);
+      expect(xtmOneClient.listAgentsForIntent).not.toHaveBeenCalled();
+    });
+
+    it('should return true when the slug is in the intent catalog', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([
+        { agent_id: '1', agent_name: 'A', agent_slug: 'agent-a', agent_description: null, priority: 0 },
+        { agent_id: '2', agent_name: 'B', agent_slug: 'agent-b', agent_description: null, priority: 0 },
+      ]);
+
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-b');
+
+      expect(result).toBe(true);
+      const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
+      expect(passedContext.user).toBe(AUTOMATION_MANAGER_USER);
+    });
+
+    it('should return false when the slug is NOT in the intent catalog (defense-in-depth check fails closed)', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([
+        { agent_id: '1', agent_name: 'A', agent_slug: 'agent-a', agent_description: null, priority: 0 },
+      ]);
+
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-not-bound');
+
+      expect(result).toBe(false);
+    });
+
+    it('should fail closed (return false) when the catalog call throws', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockRejectedValue(new Error('XTM One down'));
+
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a');
+
+      expect(result).toBe(false);
     });
   });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks (must be declared before the SUT import below) ────────────────
+
+vi.mock('nconf', () => ({
+  default: { get: vi.fn() },
+}));
+
+vi.mock('../../../../../src/modules/xtm/one/xtm-one-client', () => ({
+  default: {
+    isConfigured: vi.fn(),
+    listAgentsForIntent: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../src/domain/xtm-auth', () => ({
+  issueXtmJwt: vi.fn(),
+}));
+
+vi.mock('../../../../../src/utils/http-client', () => ({
+  getHttpClient: vi.fn(),
+  getResponseError: vi.fn((e: any) => (e && typeof e === 'object' && 'response' in e ? e.response : null)),
+}));
+
+vi.mock('../../../../../src/config/conf', () => ({
+  logApp: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  PLATFORM_VERSION: '6.0.0-test',
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────
+
+import nconf from 'nconf';
+import xtmOneClient from '../../../../../src/modules/xtm/one/xtm-one-client';
+import { issueXtmJwt } from '../../../../../src/domain/xtm-auth';
+import { getHttpClient } from '../../../../../src/utils/http-client';
+import { AUTOMATION_MANAGER_USER } from '../../../../../src/utils/access';
+import {
+  AGENT_CALL_TIMEOUT_MS,
+  buildAgentMessageContent,
+  buildAgentSlugOneOf,
+  buildPlaybookAutomationContext,
+  callXtmAgent,
+} from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const baseBundle = { id: 'bundle--1', spec_version: '2.1', type: 'bundle', objects: [] } as unknown as StixBundle;
+
+describe('ai-agent-shared', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('AGENT_CALL_TIMEOUT_MS', () => {
+    it('should be at least the chatbot proxy timeout to allow long agent runs', () => {
+      // 5 minutes; documented as "well above the default 2-minute httpClient cap".
+      expect(AGENT_CALL_TIMEOUT_MS).toBeGreaterThanOrEqual(2 * 60 * 1000);
+    });
+  });
+
+  describe('buildPlaybookAutomationContext', () => {
+    it('should run as the platform-internal AUTOMATION_MANAGER_USER so XTM One sees a stable subject', () => {
+      const context = buildPlaybookAutomationContext();
+      expect(context.user).toBe(AUTOMATION_MANAGER_USER);
+    });
+  });
+
+  describe('buildAgentMessageContent', () => {
+    it('should serialize the bundle and prepend the bundle separator when no user prompt is given', () => {
+      const content = buildAgentMessageContent(baseBundle);
+      expect(content.startsWith('--- STIX BUNDLE ---\n')).toBe(true);
+      // Strip the separator and reparse — we should get the bundle back unchanged.
+      const json = content.replace(/^--- STIX BUNDLE ---\n/, '');
+      expect(JSON.parse(json)).toEqual(baseBundle);
+    });
+
+    it('should treat a whitespace-only prompt as no prompt', () => {
+      const content = buildAgentMessageContent(baseBundle, '   \n  ');
+      expect(content.startsWith('--- STIX BUNDLE ---\n')).toBe(true);
+    });
+
+    it('should prepend a trimmed user instruction followed by a blank line and the bundle', () => {
+      const content = buildAgentMessageContent(baseBundle, '  Tag every indicator with `auto-tagged`  ');
+      expect(content.startsWith('Tag every indicator with `auto-tagged`\n\n--- STIX BUNDLE ---\n')).toBe(true);
+    });
+  });
+
+  describe('buildAgentSlugOneOf', () => {
+    it('should call XTM One as AUTOMATION_MANAGER_USER for the catalog lookup', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([]);
+
+      await buildAgentSlugOneOf('cti.stix_transformer');
+
+      expect(xtmOneClient.listAgentsForIntent).toHaveBeenCalledTimes(1);
+      const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
+      expect(passedContext.user).toBe(AUTOMATION_MANAGER_USER);
+      expect(vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][1]).toBe('cti.stix_transformer');
+    });
+
+    it('should map XTM One agents to JSON Schema oneOf entries sorted by title case-insensitively', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([
+        { agent_id: '1', agent_name: 'beta', agent_slug: 'beta-slug', agent_description: null, priority: 0 },
+        { agent_id: '2', agent_name: 'Alpha', agent_slug: 'alpha-slug', agent_description: null, priority: 0 },
+      ]);
+
+      const result = await buildAgentSlugOneOf('cti.stix_transformer');
+
+      expect(result).toEqual([
+        { const: 'alpha-slug', title: 'Alpha' },
+        { const: 'beta-slug', title: 'beta' },
+      ]);
+    });
+
+    it('should drop agents without a slug (cannot be invoked over the chat API)', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([
+        { agent_id: '1', agent_name: 'Slugless', agent_slug: null, agent_description: null, priority: 0 },
+        { agent_id: '2', agent_name: 'Real', agent_slug: 'real-slug', agent_description: null, priority: 0 },
+      ]);
+
+      const result = await buildAgentSlugOneOf('cti.stix_transformer');
+
+      expect(result).toEqual([{ const: 'real-slug', title: 'Real' }]);
+    });
+
+    it('should return an empty array when the catalog call throws (form still renders cleanly)', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockRejectedValue(new Error('XTM One down'));
+
+      const result = await buildAgentSlugOneOf('cti.stix_transformer');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('callXtmAgent', () => {
+    beforeEach(() => {
+      vi.mocked(issueXtmJwt).mockResolvedValue('signed.jwt');
+      vi.mocked(xtmOneClient.isConfigured).mockReturnValue(true);
+      vi.mocked(nconf.get).mockReturnValue('https://xtm-one.test');
+    });
+
+    it('should return null and not call the HTTP client when XTM One is not configured', async () => {
+      vi.mocked(nconf.get).mockReturnValue(undefined);
+      vi.mocked(xtmOneClient.isConfigured).mockReturnValue(false);
+
+      const result = await callXtmAgent('any-agent', 'content');
+
+      expect(result).toBeNull();
+      expect(getHttpClient).not.toHaveBeenCalled();
+    });
+
+    it('should mint the JWT as AUTOMATION_MANAGER_USER and POST a non-streaming chat message', async () => {
+      const post = vi.fn().mockResolvedValue({ data: { content: 'agent reply' } });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      const result = await callXtmAgent('agent-slug', 'hello world');
+
+      expect(result).toBe('agent reply');
+      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+      expect(getHttpClient).toHaveBeenCalledTimes(1);
+      const headers = vi.mocked(getHttpClient).mock.calls[0][0].headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer signed.jwt');
+      expect(headers['X-Platform-Product']).toBe('opencti');
+      expect(post).toHaveBeenCalledWith(
+        '/api/v1/platform/chat/messages',
+        { agent_slug: 'agent-slug', content: 'hello world', stream: false },
+        { timeout: AGENT_CALL_TIMEOUT_MS },
+      );
+    });
+
+    it('should return null when the assistant content field is missing', async () => {
+      const post = vi.fn().mockResolvedValue({ data: {} });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      const result = await callXtmAgent('agent-slug', 'content');
+
+      expect(result).toBeNull();
+    });
+
+    it('should swallow network errors and return null instead of throwing (playbook stays alive)', async () => {
+      const post = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      const result = await callXtmAgent('agent-slug', 'content');
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #15880
Closes #7708

## Summary

Adds two playbook components that hand the current STIX bundle to an XTM One AI agent — one that continues the playbook chain with the agent's transformed bundle, and one that runs as the final step of the playbook (fire-and-wait, no output port). Pairs with the XTM One PR ([XTM-One-Platform/xtm-one#1080](https://github.com/XTM-One-Platform/xtm-one/pull/1080)) that ships the default `cti-stix-transformer` and `cti-stix-consumer` built-in agents and the matching `cti.stix_transformer` / `cti.stix_consumer` intents.

- **New playbook component** `PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT` (`is_internal: true`, category `transform_and_enrich`, ports `out` / `unmodified`) — sends the bundle to an agent bound to `cti.stix_transformer` and continues the playbook chain with the agent's transformed bundle.
- **New playbook component** `PLAYBOOK_AI_AGENT_SEND_COMPONENT` (`is_internal: true`, category `end_playbook`, no output port — fires and waits so side effects flush before the run is marked done) — sends the bundle to an agent bound to `cti.stix_consumer` and lets it take a final action through its own tools (summarize, alert, post, dispatch). The agent's textual response is logged for traceability but not parsed back into a STIX bundle.
- **Configuration** (shared between both components):
  - `agent_slug` — populated dynamically from `GET /api/v1/intents/catalog?vertical=cti&intent=<intent>` so playbook authors only see agents that XTM One has bound to the right intent (built-in + visible user/group/company-managed).
  - `prompt` *(optional)* — natural-language instructions prepended to the STIX bundle JSON before being sent as the message content. Rendered as a multi-line text area via the new `format: 'textarea'` UI hint on string properties.
- **Synchronous, non-streaming** call to `POST /api/v1/platform/chat/messages` (`stream: false`) using the existing OpenCTI EdDSA JWT issuer (`issueXtmJwt`). The JWT is minted on behalf of the platform-internal `AUTOMATION_MANAGER_USER` — the same identity that already drives every other playbook side effect (stream events, RabbitMQ work, knowledge mutations) — so XTM One sees the playbook agent calls as coming from the same identity as the rest of the playbook engine, with no DB or user-cache round-trip per call.
- **Robust agent-response parsing** for the transform component (raw JSON, fenced ```json``` block, plain ``` fence, or best-effort `{...}` substring extraction) with a minimum STIX 2.1 shape check on every entry in the `objects` array — each must have a non-empty `type` string AND an `id` matching the canonical `<type>--<uuid>` pattern. Any single malformed object rejects the whole bundle so we never forward partially-corrupt data to downstream nodes. When XTM One is unreachable, the call times out, the response cannot be parsed as a STIX 2.1 bundle, or any object fails the shape check, the transform component routes to the `unmodified` port instead of failing the run; the send component logs and terminates cleanly (`forceBundleTracking: true`) instead of crashing the playbook.
- **`cti.stix_transformer` and `cti.stix_consumer` intents** added to the XTM One registration list so both catalog pickers are populated immediately on the next registration heartbeat.
- **XTM-One-gated visibility** — both new components are filtered out of `availableComponents` (the picker the playbook editor queries) when `xtmOneClient.isConfigured()` is false. Same gating contract as the Ask Ariane chatbot button and the AI Insights drawers, so playbook authors never see nodes the platform can't actually execute. Existing playbooks that already contain these nodes keep behaving the same way (executor unchanged — gracefully no-ops via the `unmodified` port / fire-and-wait) if XTM One gets unconfigured later.
- **Frontend** — adds an `ai-agent` icon (`AutoAwesomeOutlined`) for both new components and a generic `format: 'textarea'` UI hint on playbook component string properties so the form renderer maps it to `multiline + rows={3}` on the underlying `TextField`.

### Message contract sent to the agent

```
<optional user instruction>

--- STIX BUNDLE ---
{ ...stix bundle JSON... }
```

For the transform component, the agent must respond with a single STIX 2.1 bundle JSON object (the matching `cti-stix-transformer` agent on XTM One has its `output_format` set to `json` and its `output_schema` constrained to the STIX 2.1 bundle schema, so this contract is enforced server-side too). For the send component, the agent's textual response is logged but not parsed back into a bundle.

## Test plan

- [ ] Build & run OpenCTI EE alongside an XTM One instance with the matching XTM One PR merged.
- [ ] Confirm `cti.stix_transformer` and `cti.stix_consumer` show up in XTM One after the next registration heartbeat (`GET /api/v1/intents/catalog?vertical=cti&intent=<intent>`).
- [ ] In the playbook editor, add the **"Transform with AI agent"** component, verify the agent dropdown lists `CTI STIX Transformer`, set a prompt like *"Tag every indicator with `auto-tagged` and increase scores by 10"*, run the playbook, and confirm the downstream node receives the transformed bundle.
- [ ] Add the **"Send to AI agent"** component as the final step, verify the agent dropdown lists `CTI STIX Consumer`, run the playbook, and confirm the side effect (Slack post, ticket creation, ...) triggers and the playbook run is marked done.
- [ ] Stop XTM One mid-run and verify the transform component routes through the `unmodified` port instead of throwing, and the send component logs `Agent call did not complete` and terminates cleanly.
- [ ] Pass an invalid (non-JSON) prompt instructing the agent to reply in prose; verify the transform component's parsing fallback routes through `unmodified` and logs a warning.
- [ ] Make the transformer agent return a bundle with placeholder objects (e.g. `{"type":"bundle","objects":[{}]}` or objects with malformed STIX IDs) and verify the parser rejects the whole bundle and routes through `unmodified` instead of forwarding garbage to downstream nodes.
- [ ] On a deployment with `xtm_one_token` unset, confirm `Transform with AI agent` and `Send to AI agent` are NOT listed in the playbook component picker; set `xtm_one_token` and confirm both appear.
- [x] New `tests/01-unit/modules/playbook/components/ai-agent-{shared,component,send-component}-test.ts` cover the executor branches, JSON / fenced / substring parsing, schema hydration, JWT minting on `AUTOMATION_MANAGER_USER`, the no-agent / network-error fallbacks, and the new STIX shape validation (empty `{}` rejected, missing-id rejected, non-STIX-id-pattern rejected, mixed-validity bundle rejected as a whole, empty `objects: []` still accepted). 38/38 pass under `vitest.config.ci-unit.ts`.
- [x] New `tests/01-unit/modules/playbook/available-components-test.ts` covers the XTM-One picker gating (both AI-agent IDs hidden when `xtmOneClient.isConfigured()` is false; both present when true; non-XTM-One components such as `PLAYBOOK_INTERNAL_MANUAL_TRIGGER` always listed).
