### PR TITLE
feat(frontend): add main color picker to Tree widget

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetTree.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetTree.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { useTheme } from '@mui/styles';
 import { ApexOptions } from 'apexcharts';
 import { useFormatter } from '../i18n';
-import { treeMapOptions } from '../../utils/Charts';
+import { resolveWidgetMainColor, treeMapOptions } from '../../utils/Charts';
 import { getMainRepresentative, isFieldForIdentifier } from '../../utils/defaultRepresentatives';
 import { simpleNumberFormat } from '../../utils/Number';
 
@@ -13,6 +13,7 @@ interface WidgetTreeProps {
   groupBy: string;
   onMounted?: OpenCTIChartProps['onMounted'];
   isDistributed?: boolean;
+  mainColor?: string | null;
 }
 
 const WidgetTree = ({
@@ -20,6 +21,7 @@ const WidgetTree = ({
   groupBy,
   onMounted,
   isDistributed = false,
+  mainColor = null,
 }: WidgetTreeProps) => {
   const theme = useTheme();
   const { t_i18n } = useFormatter();
@@ -43,8 +45,9 @@ const WidgetTree = ({
       simpleNumberFormat,
       'bottom',
       isDistributed,
+      resolveWidgetMainColor(theme, mainColor),
     ) as ApexOptions;
-  }, [theme, isDistributed]);
+  }, [theme, isDistributed, mainColor]);
 
   return (
     <Chart

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
@@ -110,6 +110,7 @@ interface AuditsTreeMapComponentProps {
   queryRef: PreloadedQuery<AuditsTreeMapDistributionQuery>;
   selection: WidgetDataSelection;
   isDistributed?: boolean;
+  mainColor?: string | null;
   onMounted: (chart: ApexCharts) => void;
 }
 
@@ -117,6 +118,7 @@ const AuditsTreeMapComponent: FunctionComponent<AuditsTreeMapComponentProps> = (
   queryRef,
   selection,
   isDistributed,
+  mainColor,
   onMounted,
 }) => {
   const data = usePreloadedQuery<AuditsTreeMapDistributionQuery>(
@@ -130,6 +132,7 @@ const AuditsTreeMapComponent: FunctionComponent<AuditsTreeMapComponentProps> = (
         data={data.auditsDistribution}
         groupBy={selection.attribute!}
         isDistributed={isDistributed}
+        mainColor={mainColor}
         onMounted={onMounted}
       />
     );
@@ -200,6 +203,7 @@ const AuditsTreeMap: FunctionComponent<AuditsTreeMapProps> = ({
   });
   const selection = resolvedDataSelection[0];
   const isDistributed = parameters.distributed ?? undefined;
+  const mainColor = parameters.mainColor ?? undefined;
 
   const renderContent = () => {
     if (isMissingHostEntity) {
@@ -220,6 +224,7 @@ const AuditsTreeMap: FunctionComponent<AuditsTreeMapProps> = ({
           queryRef={queryRef}
           selection={selection}
           isDistributed={isDistributed}
+          mainColor={mainColor}
           onMounted={setChart}
         />
       </Suspense>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
@@ -103,6 +103,7 @@ const StixCoreObjectsTreeMapComponent = ({
       data={distribution}
       groupBy={selection.attribute ?? 'entity_type'}
       isDistributed={parameters?.distributed ?? undefined}
+      mainColor={parameters?.mainColor ?? undefined}
       onMounted={onMounted}
     />
   );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
@@ -120,6 +120,7 @@ const StixRelationshipsTreeMapComponent = ({
       data={distribution}
       groupBy={selection.attribute ?? 'entity_type'}
       isDistributed={parameters?.distributed ?? undefined}
+      mainColor={parameters?.mainColor ?? undefined}
       onMounted={onMounted}
     />
   );

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -4,6 +4,10 @@ import ReactMde from 'react-mde';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
+import ButtonBase from '@mui/material/ButtonBase';
+import { useTheme } from '@mui/material/styles';
+import * as muiColors from '@mui/material/colors';
+import { widgetMainColorPalette } from '../../../utils/Charts';
 import { stixCyberObservablesLinesAttributesQuery } from '@components/observations/stix_cyber_observables/StixCyberObservablesLines';
 import * as R from 'ramda';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -39,6 +43,7 @@ import { Box, Typography } from '@mui/material';
 
 const WidgetCreationParameters = () => {
   const { metricsDefinition } = useAttributes();
+  const theme = useTheme();
 
   const { t_i18n } = useFormatter();
   const {
@@ -887,6 +892,39 @@ const WidgetCreationParameters = () => {
           })}
       </>
 
+      {getCurrentAvailableParameters(type).includes('mainColor') && (
+        <div style={{ display: 'flex', flexDirection: 'column', marginTop: 20 }}>
+          <InputLabel shrink>{t_i18n('Main color')}</InputLabel>
+          <div style={{ display: 'flex', gap: 8, marginTop: 4 }} role="group" aria-label={t_i18n('Main color')}>
+            {widgetMainColorPalette.map((colorKey) => {
+              const selected = parameters.mainColor === colorKey;
+              const shade = theme.palette.mode === 'dark' ? 400 : 600;
+              const palette = (muiColors as unknown as Record<string, Record<number, string>>)[colorKey];
+              const hex = palette?.[shade];
+              return (
+                <ButtonBase
+                  key={colorKey}
+                  aria-label={colorKey}
+                  aria-pressed={selected}
+                  title={colorKey}
+                  onClick={() => handleChangeParameter('mainColor', selected ? '' : colorKey)}
+                  sx={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: '50%',
+                    backgroundColor: hex,
+                    boxShadow: selected ? `0 0 0 2px ${theme.palette.text.primary}` : 'none',
+                    '&.Mui-focusVisible': {
+                      outline: `2px solid ${theme.palette.text.primary}`,
+                      outlineOffset: 2,
+                    },
+                  }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
       <div style={{ display: 'flex', width: '100%', marginTop: 20 }}>
         {getCurrentAvailableParameters(type).includes('stacked') && (
           <FormControlLabel

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_core_objects/PublicStixCoreObjectsTreeMap.tsx
@@ -78,6 +78,7 @@ const PublicStixCoreObjectsTreeMapComponent = ({
         data={[...publicStixCoreObjectsDistribution]}
         groupBy={dataSelection[0].attribute ?? 'entity_type'}
         isDistributed={!!parameters?.distributed}
+        mainColor={parameters?.mainColor}
       />
     );
   }

--- a/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/public/components/dashboard/stix_relationships/PublicStixRelationshipsTreeMap.tsx
@@ -78,6 +78,7 @@ const PublicStixRelationshipsTreeMapComponent = ({
         data={[...publicStixRelationshipsDistribution]}
         groupBy={dataSelection[0].attribute ?? 'entity_type'}
         isDistributed={!!parameters?.distributed}
+        mainColor={parameters?.mainColor}
       />
     );
   }

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -914,6 +914,7 @@ type WidgetParameters {
   stacked: Boolean
   legend: Boolean
   distributed: Boolean
+  mainColor: String
 }
 
 type WidgetLayout {

--- a/opencti-platform/opencti-front/src/utils/Charts.jsx
+++ b/opencti-platform/opencti-front/src/utils/Charts.jsx
@@ -27,6 +27,17 @@ export const colors = (temp) => [
   C.grey[temp],
 ];
 
+export const widgetMainColorPalette = [
+  'blue', 'cyan', 'green', 'teal',
+  'amber', 'orange', 'red', 'purple',
+];
+
+export const resolveWidgetMainColor = (theme, key) => {
+  if (!key) return theme.palette.primary.main;
+  const shade = theme.palette.mode === 'dark' ? 400 : 600;
+  return C[key]?.[shade] ?? theme.palette.primary.main;
+};
+
 const toolbarOptions = {
   show: false,
   export: {
@@ -905,13 +916,16 @@ export const donutChartOptions = (
  * @param {function} formatter
  * @param {string} legendPosition
  * @param {boolean} distributed
+ * @param {string|null} mainColorHex resolved hex color (not a palette key); see resolveWidgetMainColor
  */
 export const treeMapOptions = (
   theme,
   formatter = null,
   legendPosition = 'bottom',
   distributed = false,
+  mainColorHex = null,
 ) => {
+  const resolvedMainColor = mainColorHex || theme.palette.primary.main;
   return {
     chart: {
       type: 'treemap',
@@ -926,7 +940,7 @@ export const treeMapOptions = (
     },
     colors: distributed
       ? colors(theme.palette.mode === 'dark' ? 400 : 600).filter((c) => !isColorCloseToWhite(c))
-      : [theme.palette.primary.main, ...colors(theme.palette.mode === 'dark' ? 400 : 600)],
+      : [resolvedMainColor, ...colors(theme.palette.mode === 'dark' ? 400 : 600)],
     fill: {
       opacity: 1,
     },

--- a/opencti-platform/opencti-front/src/utils/widget/widget.d.ts
+++ b/opencti-platform/opencti-front/src/utils/widget/widget.d.ts
@@ -71,6 +71,7 @@ interface WidgetParameters {
   legend?: boolean | null;
   distributed?: boolean | null;
   content?: string | null;
+  mainColor?: string | null;
 }
 
 interface WidgetLayout {

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
@@ -166,7 +166,7 @@ const widgetVisualizationTypes = [
     name: 'Tree',
     dataSelectionLimit: 1,
     category: 'distribution',
-    availableParameters: ['attribute', 'distributed'],
+    availableParameters: ['attribute', 'distributed', 'mainColor'],
     isRelationships: true,
     isEntities: true,
     isAudits: true,

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -853,6 +853,7 @@ type WidgetParameters {
   stacked: Boolean
   legend: Boolean
   distributed: Boolean
+  mainColor: String
 }
 type WidgetLayout {
   w: Float

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -37450,6 +37450,7 @@ export type WidgetParameters = {
   distributed?: Maybe<Scalars['Boolean']['output']>;
   interval?: Maybe<Scalars['String']['output']>;
   legend?: Maybe<Scalars['Boolean']['output']>;
+  mainColor?: Maybe<Scalars['String']['output']>;
   stacked?: Maybe<Scalars['Boolean']['output']>;
   title?: Maybe<Scalars['String']['output']>;
 };
@@ -52680,6 +52681,7 @@ export type WidgetParametersResolvers<ContextType = any, ParentType extends Reso
   distributed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   interval?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   legend?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  mainColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   stacked?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;


### PR DESCRIPTION
### Proposed changes

* Add a "Main color" picker to the Tree widget in the dashboard widget create/update modal, under the Parameters step. The picker offers 8 colors taken from the existing palette in `utils/Charts.jsx`: blue, cyan, green, teal, amber, orange, red, purple.
* Store the choice on `WidgetParameters.mainColor` as a palette key. At render time it resolves to shade 600 in light mode and shade 400 in dark mode, matching the convention already used for the distributed palette in the same chart.
* When `mainColor` is unset, the widget keeps falling back to `theme.palette.primary.main`, so existing dashboards render exactly as before.
* The control is gated by the widget's `availableParameters` and is currently enabled only for `tree`. Adding the key to another visualization's `availableParameters` is enough to expose the same picker there later.

### Related issues

* N/A

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Storing a palette key instead of a hex value lets the rendered color adapt to the active theme. The same key resolves to a darker shade in light mode and a lighter shade in dark mode through `resolveWidgetMainColor(theme, key)`, mirroring how `colors(theme.palette.mode === 'dark' ? 400 : 600)` is already used for the distributed palette.

When `distributed=true`, ApexCharts paints tiles from the multi-color palette and the main color is ignored. That is the existing behavior and is preserved. The new control sits next to the `distributed` toggle in the Parameters step.

The frontend wiring touches the three private Tree consumers (`StixCoreObjectsTreeMap`, `StixRelationshipsTreeMap`, `AuditsTreeMap`) and the two public-dashboard variants, so the chosen color is honored everywhere a tree is rendered, including on public dashboards. The backend change is limited to exposing the new field on the `WidgetParameters` GraphQL type. The workspace manifest itself is already a JSON blob, so no resolver, migration, or storage change is needed.

<details>
<summary>Screenshots</summary>

Dark theme, `mainColor: "red"` (resolved to `red[400]`):

![Tree widget, red, dark theme](https://raw.githubusercontent.com/hugodocto/opencti/pr-assets/assets/tree-red-dark.png)

Light theme, `mainColor: "green"` (resolved to `green[600]`):

![Tree widget, green, light theme](https://raw.githubusercontent.com/hugodocto/opencti/pr-assets/assets/tree-green-light.png)

</details>