### PR TITLE
fix(frontend): fix garbled CJK characters in HTML to PDF export (#15624)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
+++ b/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
@@ -66,10 +66,19 @@ export const htmlToPdf = (
     htmlData = renderToString(compiler(htmlData, { wrapper: null }));
   }
 
+  // Detect CJK characters and pick a font that has CJK glyphs.
+  // Roboto (the pdfmake default) has no CJK glyphs, so Japanese/Korean text
+  // would otherwise be garbled in the exported PDF. See issue #15624.
+  const selectedFont = detectLanguage(htmlData);
+
   // Transform html string into a JS object that lib pdfmake can understand.
   const pdfMakeObject = htmlToPdfmake(htmlData, {
     imagesByReference: true,
     ignoreStyles: ['font-family'], // Ignoring fonts to force Roboto later.
+    defaultStyles: {
+      th: { bold: true, fillColor: '', font: selectedFont },
+      td: { font: selectedFont },
+    },
   }) as unknown as TDocumentDefinitions; // Because wrong type when using imagesByReference: true.
 
   pdfMakeObject.images = normalizePdfMakeImageReferences(
@@ -77,9 +86,13 @@ export const htmlToPdf = (
     resolvedEntityBaseUrl,
   );
 
+  pdfMakeObject.defaultStyle = {
+    ...(pdfMakeObject.defaultStyle ?? {}),
+    font: selectedFont,
+  };
+
   return generatePdf(pdfMakeObject, false, isTiptapEnabled);
 };
-
 /**
  * Part to handle the embedded images of a file
  */


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix garbled rendering of CJK (Japanese / Korean) characters in PDFs generated from the HTML content of files and entities (regular content export path).
* Apply the same font-detection logic already used by `htmlToPdfReport()` (Fintel report export) to `htmlToPdf()`: detect the language of the HTML content, then set `defaultStyle.font` on the pdfmake document and `defaultStyles` for `th` / `td` cells so the appropriate font is used. `NotoSansJP` / `NotoSansKR` are already bundled in `opencti-front/src/static/ext/`; no new dependencies or assets are introduced.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right -->
* Closes #15624

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- *NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why* -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

**Root cause**

* `htmlToPdf()` (used by file/entity content exports) was not calling `detectLanguage(htmlData)` before generating the PDF, and was not setting `defaultStyle.font` on the pdfmake document definition.
* As a result, all text fell back to `Roboto`, the pdfmake default font, which contains no CJK glyphs — producing garbled output for Japanese / Korean text.
* The sibling function `htmlToPdfReport()` in the same file already calls `detectLanguage()` and works correctly, so this PR just brings `htmlToPdf()` in line.

**Fix**

Three small additions to `htmlToPdf()` in `opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts`:

1. Call `detectLanguage(htmlData)` to pick a font that has the necessary glyphs.
2. Pass `defaultStyles: { th, td }` to `htmlToPdfmake` so table cells use the selected font.
3. Set `pdfMakeObject.defaultStyle.font` so body text uses the selected font.

`detectLanguage` and `FONTS` are already imported from `./utils/pdfFonts`, so no new imports are needed. No backend or GraphQL schema changes.

**Verification**

* Manually tested locally on OpenCTI `7.260527.0` with a Report containing Japanese AI-generated content.
* **Before**: Japanese characters rendered as boxes / `?` marks.
* **After**: Japanese characters render correctly using `NotoSansJP`.
* English-only content still renders with `Roboto` (unchanged behavior).
* Tested via the Vite dev server pointed at a Docker-based OpenCTI backend.

**Scope note**

This PR addresses the immediate issue reported in #15624 for **Japanese** (also fixes **Korean** for free, since `NotoSansKR` is already bundled and `detectLanguage` already handles it). Extending support to **Simplified / Traditional Chinese** would require bundling `NotoSansSC` / `NotoSansTC` and expanding `detectLanguage()` to detect CJK Unified Ideographs / Hangul-only ranges — happy to do this in a follow-up PR if requested.

**Why no automated tests**

The fix is exercised by an end-to-end PDF rendering pipeline (pdfmake + bundled TTF fonts) that is awkward to assert against in a unit test. The behavior was verified manually with a real PDF render. If a specific test pattern is desired (e.g. asserting that `defaultStyle.font` is set to `NotoSansJp` for a Japanese input string), I'm happy to add it on request.