### PR TITLE
fix(backend): parse startDateParsed to the start of the hour (#16413)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/utils.ts
@@ -195,6 +195,7 @@ export const fillTimeSeries = (startDate: Date, endDate: Date, interval: string,
       break;
     case 'hour':
       dateFormat = 'YYYY-MM-DD HH:mm:ss';
+      startDateParsed = startDateParsed.startOf('hour');
       break;
     default:
       dateFormat = 'YYYY-MM-DD';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* fillTimeSeries method breaks in case interval is set as hour if the start time has hour, min, sec or millisecond in it.
* eg: if following is passed in start date then it returns 0 for all hours
*   "startDate": "2026-05-26T03:50:20.100Z",
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16413

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
Query:
`query StixCoreObjectsMultiLineChartTimeSeriesQuery(
  $startDate: DateTime!
  $endDate: DateTime!
  $interval: String!
  $timeSeriesParameters: [StixCoreObjectsTimeSeriesParameters]
) {
  stixCoreObjectsMultiTimeSeries(
    startDate: $startDate
    endDate: $endDate
    interval: $interval
    timeSeriesParameters: $timeSeriesParameters
  ) {
    data {
      date
      value
    }
  }
}
`
Parameters:
`{
  "startDate": "2026-05-26T03:50:20.100Z",
  "endDate": "2026-05-26T10:30:00.000Z",
  "interval": "hour",
  "timeSeriesParameters": [
    {
      "field": "created",
      "types": [
        "Stix-Core-Object"
      ],
      "filters": {
        "mode": "and",
        "filters": [],
        "filterGroups": []
      }
    }
  ]
}`
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: Test coverage are, by default, mandatory. It will help us to improve stability of the platform. If you consider test are not relevant for this PR, reach out and explain why_ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
