### PR TITLE
[backend] Allow users to exit a draft they cannot edit (#16273)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -997,7 +997,14 @@ export const userEditField = async (context, user, userId, rawInputs) => {
       inputs.push(input);
     }
   }
-  const { element } = await updateAttribute(context, user, userId, ENTITY_TYPE_USER, inputs);
+  // Editing the draft context (entering/exiting a draft) is a navigation action performed on the
+  // user's own entity, which is never part of the draft data. It must run outside of any draft
+  // context, otherwise a user who entered a draft they cannot edit would be blocked by the draft
+  // authorized-members access check and would be unable to exit it (see issue #16273).
+  const isDraftContextEdit = inputs.some((i) => i.key === 'draft_context');
+  const editContext = isDraftContextEdit ? { ...context, draft_context: undefined } : context;
+  const editUser = isDraftContextEdit ? { ...user, draft_context: undefined } : user;
+  const { element } = await updateAttribute(editContext, editUser, userId, ENTITY_TYPE_USER, inputs);
   const input = updatedInputsToData(element, inputs);
   const personalUpdate = user.id === userId;
   const actionEmail = ENABLED_DEMO_MODE ? REDACTED_USER.user_email : element.user_email;

--- a/opencti-platform/opencti-graphql/src/http/httpServer-draft.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpServer-draft.ts
@@ -26,6 +26,13 @@ export const checkDraftInContext = async (executeContext: AuthContext) => {
 
       const isUserCanAccess = await isUserCanAccessStoreElement(executeContext, executeContext.user, draftWorkspace);
       if (!isUserCanAccess) {
+        if (executeContext.user.draft_context === executeContext.draft_context) {
+          // If user is stuck in a draft they cannot access, remove draft context from user so they are not trapped
+          await userEditField(executeContext, executeContext.user, executeContext.user.id, [{
+            key: 'draft_context',
+            value: '',
+          }]);
+        }
         throw FunctionalError(`Draft ${executeContext.draft_context} cannot be found`);
       }
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/draftWorkspace-exit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/draftWorkspace-exit-test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ADMIN_USER, getAuthUser, testContext, USER_DISINFORMATION_ANALYST, USER_EDITOR } from '../../utils/testQuery';
+import { addDraftWorkspace } from '../../../src/modules/draftWorkspace/draftWorkspace-domain';
+import { meEditField } from '../../../src/domain/user';
+import { deleteElementById } from '../../../src/database/middleware';
+import { internalLoadById } from '../../../src/database/middleware-loader';
+import { executionContext } from '../../../src/utils/access';
+import { checkDraftInContext } from '../../../src/http/httpServer-draft';
+import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../../../src/modules/draftWorkspace/draftWorkspace-types';
+import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
+import type { AuthUser } from '../../../src/types/user';
+import type { DraftWorkspaceAddInput } from '../../../src/generated/graphql';
+
+// Regression tests for https://github.com/OpenCTI-Platform/opencti/issues/16273
+// A user must always be able to exit a draft context (a navigation action on their own user
+// entity), even when they do not have edit access on the draft they entered.
+describe('Drafts workspace exit testing', () => {
+  let editorAuthUser: AuthUser;
+  let analystAuthUser: AuthUser;
+  let viewableDraftId: string;
+  let restrictedDraftId: string;
+
+  beforeAll(async () => {
+    editorAuthUser = await getAuthUser(USER_EDITOR.id);
+    analystAuthUser = await getAuthUser(USER_DISINFORMATION_ANALYST.id);
+
+    // A draft where the analyst only has "view" access (can enter/see, but cannot edit)
+    const viewableInput: DraftWorkspaceAddInput = {
+      name: 'Draft exit test - viewable',
+      authorized_members: [
+        { id: editorAuthUser.internal_id, access_right: 'admin' },
+        { id: analystAuthUser.internal_id, access_right: 'view' },
+      ],
+    };
+    viewableDraftId = (await addDraftWorkspace(testContext, editorAuthUser, viewableInput)).id;
+
+    // A draft where the analyst has no access at all
+    const restrictedInput: DraftWorkspaceAddInput = {
+      name: 'Draft exit test - restricted',
+      authorized_members: [
+        { id: editorAuthUser.internal_id, access_right: 'admin' },
+      ],
+    };
+    restrictedDraftId = (await addDraftWorkspace(testContext, editorAuthUser, restrictedInput)).id;
+  });
+
+  afterAll(async () => {
+    if (viewableDraftId) {
+      await deleteElementById(testContext, ADMIN_USER, viewableDraftId, ENTITY_TYPE_DRAFT_WORKSPACE);
+    }
+    if (restrictedDraftId) {
+      await deleteElementById(testContext, ADMIN_USER, restrictedDraftId, ENTITY_TYPE_DRAFT_WORKSPACE);
+    }
+    // Make sure the analyst is not left in any draft context
+    await meEditField(testContext, analystAuthUser, analystAuthUser.id, [{ key: 'draft_context', value: '' }]);
+  });
+
+  it('should let a view-only user exit a draft they cannot edit', async () => {
+    // The analyst can access (view) the draft, so request execution is allowed in that context
+    const analystInDraft = { ...analystAuthUser, draft_context: viewableDraftId };
+    const analystDraftContext = executionContext('testing', analystInDraft, viewableDraftId);
+    await expect(checkDraftInContext(analystDraftContext)).resolves.not.toThrow();
+
+    // Exiting the draft must not be gated by the draft edit access check
+    await expect(
+      meEditField(analystDraftContext, analystInDraft, analystAuthUser.id, [{ key: 'draft_context', value: '' }]),
+    ).resolves.toBeDefined();
+
+    const reloadedAnalyst = await internalLoadById(testContext, ADMIN_USER, analystAuthUser.id, { type: ENTITY_TYPE_USER });
+    expect((reloadedAnalyst as unknown as AuthUser).draft_context).toBeFalsy();
+  });
+
+  it('should self-heal users stuck in a draft they cannot access', async () => {
+    // Force the analyst into a draft they cannot access (simulating a draft created via API)
+    await meEditField(testContext, analystAuthUser, analystAuthUser.id, [{ key: 'draft_context', value: [restrictedDraftId] }]);
+    const stuckAnalyst = await getAuthUser(USER_DISINFORMATION_ANALYST.id);
+    expect(stuckAnalyst.draft_context).toEqual(restrictedDraftId);
+
+    const stuckContext = executionContext('testing', stuckAnalyst, restrictedDraftId);
+    await expect(checkDraftInContext(stuckContext)).rejects.toThrowError(`Draft ${restrictedDraftId} cannot be found`);
+
+    // The draft context must have been removed from the user so they are no longer trapped
+    const reloadedAnalyst = await internalLoadById(testContext, ADMIN_USER, analystAuthUser.id, { type: ENTITY_TYPE_USER });
+    expect((reloadedAnalyst as unknown as AuthUser).draft_context).toBeFalsy();
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Fix the `Exit draft` action returning `You are not allowed to do this.` and trapping users in a draft context. Entering/exiting a draft only updates the user's own `draft_context` (a navigation action on the user entity, which is never part of the draft data). `userEditField` now performs the `draft_context` update **outside** of any draft context, so it is no longer gated by the draft authorized-members access check.
* Make `checkDraftInContext` self-heal: when a user is stuck in a draft they cannot access, their `draft_context` is cleared so they are no longer permanently trapped (e.g. when manually navigating to `/dashboard`).

### Related issues
* closes #16273

### How to test this PR

1. As an admin / via API / service account, create a draft workspace with restricted authorized members (e.g. give another user `User B` only `can view` access — or no access at all).
2. As `User B`, open the draft URL (e.g. `/dashboard/data/import/draft/<draftId>`). You are now in the draft context.
3. Click **Exit draft**.
4. Before this fix: the request fails with `You are not allowed to do this.` and navigating to `/dashboard` keeps redirecting back into the draft.
5. After this fix: `User B` exits the draft and returns to the live platform; the draft context is cleared from the session.

Automated coverage: `opencti-platform/opencti-graphql/tests/03-integration/01-database/draftWorkspace-exit-test.ts`
* a view-only user can exit a draft they cannot edit
* a user stuck in a draft they cannot access gets their `draft_context` self-healed.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case (coverage and e2e)
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

The root cause was in `updateAttribute`: any update performed while in a draft context is checked against the draft's authorized members (`validateUserAccessOperation`). Since exiting a draft is itself an update to the user entity performed while the session is still in the draft context, a user without `edit` access to the draft (created by another user or a service account) could never clear their own `draft_context`. The fix scopes the bypass strictly to `draft_context` edits so all other self-edits keep their existing behaviour.
