### PR TITLE
[backend/frontend] Support agent-generated file downloads from XTM One (#16294)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.3.0",
+    "@filigran/chatbot": "3.3.1",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.2.2",
+    "@filigran/chatbot": "3.3.0",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -125,6 +125,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
         messages: '/messages',
         sessions: '/sessions',
         upload: '/upload',
+        download: '/files',
       }}
       user={{ firstName }}
       disableFileManagement={false}

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1780,15 +1780,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.2.2":
-  version: 3.2.2
-  resolution: "@filigran/chatbot@npm:3.2.2"
+"@filigran/chatbot@npm:3.3.1":
+  version: 3.3.1
+  resolution: "@filigran/chatbot@npm:3.3.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/7ba9ad5a560dbd4077682cfcd509d6ea90d101c0f080d620da83fb6e28f6cda66be5a36dc8a569598e2adaa20c93562c52be8185451a00d94a84cc291213ef5f
+  checksum: 10c0/9d0c71c52fb010326b2e947ce9bcadcfe5d998003ebfcab28cfa480d3ddf3c0ee2a8ebf4caf72583e108a2b2c2558cf084e9e77d48650496302f2b181aa6eeb4
   languageName: node
   linkType: hard
 
@@ -12990,7 +12990,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.1.2"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.2.2"
+    "@filigran/chatbot": "npm:3.3.1"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -356,6 +356,70 @@ export const postChatbotUpload = async (req: Express.Request, res: Express.Respo
   }
 };
 
+// ── GET /chatbot/files/:fileId/download ─────────────────────────────────
+// Streams an agent-generated file from XTM One back to the browser.
+//
+// The OpenCTI user is authenticated here (platform session) and the XTM One
+// JWT is minted server-side via `generateBasicHeaders` → `issueXtmJwt`. The
+// user therefore never authenticates to XTM One directly: the embedded
+// chatbot points its download URL at this proxy (relative to its
+// `apiBaseUrl` of `${APP_BASE_PATH}/chatbot`), not at XTM One.
+const FILE_ID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export const getChatbotFileDownload = async (req: Express.Request, res: Express.Response) => {
+  try {
+    const context = await authenticateAndVerify(req, res);
+    if (!context?.user) return;
+
+    const { fileId } = req.params;
+    if (!fileId || !FILE_ID_RE.test(fileId)) {
+      res.status(400).json({ error: 'Invalid file id' });
+      return;
+    }
+
+    const headers = await generateBasicHeaders(req, context);
+    const httpClient = getXtmClient('stream', headers);
+    const response = await httpClient.get(`/api/v1/chat/files/${fileId}/download`, {
+      decompress: false,
+      timeout: DEFAULT_XTM_TIMEOUT,
+    });
+
+    // Forward the content headers so the browser saves the file with the
+    // right name and type. `content-disposition` is built CRLF-safe by XTM One.
+    const forwardHeaders = ['content-type', 'content-disposition', 'content-length', 'cache-control'];
+    Object.entries(response.headers).forEach(([key, value]) => {
+      if (forwardHeaders.includes(key.toLowerCase()) && value) {
+        res.setHeader(key, value as string);
+      }
+    });
+
+    response.data.pipe(res);
+
+    req.on('close', () => {
+      response.data.destroy();
+    });
+
+    response.data.on('error', (error: Error) => {
+      logApp.error('Stream error in chatbot file download proxy', { cause: error });
+      if (!res.headersSent) {
+        res.status(500).send({ status: 'error', error: error.message });
+      } else {
+        res.end();
+      }
+    });
+  } catch (e: unknown) {
+    logApp.error('Error in chatbot file download proxy', { cause: e });
+    const { message } = e as Error;
+    const httpErr = getResponseError(e);
+    setCookieError(res, message);
+    if (httpErr) {
+      res.status(httpErr.status).json({ error: message });
+    } else {
+      res.status(503).json({ error: 'XTM One is unreachable' });
+    }
+  }
+};
+
 // ── POST /chatbot/agent ─────────────────────────────────────────────────
 // Non-streaming agent call.
 // Accepts two Content-Type modes:

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -381,12 +381,18 @@ export const getChatbotFileDownload = async (req: Express.Request, res: Express.
     const httpClient = getXtmClient('stream', headers);
     const response = await httpClient.get(`/api/v1/chat/files/${fileId}/download`, {
       decompress: false,
-      timeout: DEFAULT_XTM_TIMEOUT,
+      // Streaming pipe — no response timeout (matches the other streaming
+      // proxy calls). A 2-minute cap could abort a large/slow download
+      // prematurely; the stream ends naturally and `req.on('close')` below
+      // tears it down if the client disconnects.
+      timeout: 0,
     });
 
     // Forward the content headers so the browser saves the file with the
     // right name and type. `content-disposition` is built CRLF-safe by XTM One.
-    const forwardHeaders = ['content-type', 'content-disposition', 'content-length', 'cache-control'];
+    // `content-encoding` MUST be forwarded because `decompress: false` leaves a
+    // gzip/br payload compressed — the browser needs the header to decode it.
+    const forwardHeaders = ['content-type', 'content-disposition', 'content-length', 'content-encoding', 'cache-control'];
     Object.entries(response.headers).forEach(([key, value]) => {
       if (forwardHeaders.includes(key.toLowerCase()) && value) {
         res.setHeader(key, value as string);
@@ -413,7 +419,29 @@ export const getChatbotFileDownload = async (req: Express.Request, res: Express.
     const httpErr = getResponseError(e);
     setCookieError(res, message);
     if (httpErr) {
-      res.status(httpErr.status).json({ error: message });
+      // Surface the upstream `detail` (e.g. "File not found" / "Access denied")
+      // instead of the generic axios "Request failed with status code N".
+      // With responseType 'stream' the error body may arrive as a stream, so
+      // handle both the parsed-object and stream cases (matches the
+      // `postChatbotMessage` error path).
+      let detail = message;
+      try {
+        if (typeof httpErr.data === 'object' && httpErr.data !== null) {
+          if ('detail' in httpErr.data) {
+            detail = httpErr.data.detail;
+          } else if (typeof httpErr.data.pipe === 'function') {
+            const chunks: Buffer[] = [];
+            for await (const chunk of httpErr.data) {
+              chunks.push(Buffer.from(chunk));
+            }
+            const body = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+            detail = body.detail ?? message;
+          }
+        }
+      } catch {
+        // If parsing fails, fall back to the generic error message.
+      }
+      res.status(httpErr.status).json({ error: detail });
     } else {
       res.status(503).json({ error: 'XTM One is unreachable' });
     }

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -380,7 +380,30 @@ export const getChatbotFileDownload = async (req: Express.Request, res: Express.
       return;
     }
 
+    // REST routes don't go through the GraphQL `checkDraftInContext` middleware,
+    // so validate the draft context explicitly before forwarding upstream.
+    // Without this guard a caller could forge an `opencti-draft-id` header and
+    // download files scoped to a draft they don't have access to, bypassing
+    // draft authorization. `checkDraftInContext` is a no-op when the
+    // authenticated context has no draft, so the live-workspace path is
+    // unaffected.
+    try {
+      await checkDraftInContext(context);
+    } catch (draftErr: unknown) {
+      logApp.warn('Chatbot file download rejected due to invalid draft context', { cause: draftErr });
+      res.status(400).json({ error: (draftErr as Error)?.message || 'Invalid draft context' });
+      return;
+    }
+
     const headers = await generateBasicHeaders(req, context);
+    // Force the upstream `opencti-draft-id` to the validated `context.draft_context`
+    // (which falls back to the user's session draft when the request omits the
+    // header) so the download resolves in the same workspace the rest of the
+    // platform would use, rather than trusting the raw request header. File
+    // downloads are frequently triggered without custom headers, so without this
+    // a draft user would otherwise hit the live workspace and 404 on a
+    // draft-scoped file.
+    headers['opencti-draft-id'] = context.draft_context ?? '';
     const httpClient = getXtmClient('stream', headers);
     const response = await httpClient.get(`/api/v1/chat/files/${fileId}/download`, {
       decompress: false,

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -371,7 +371,10 @@ export const getChatbotFileDownload = async (req: Express.Request, res: Express.
     const context = await authenticateAndVerify(req, res);
     if (!context?.user) return;
 
-    const { fileId } = req.params;
+    // `req.params` values are typed `string | string[]` in this codebase; a
+    // single route segment is always a string at runtime, but coerce
+    // defensively so a malformed value simply fails the UUID check below.
+    const fileId = String(req.params.fileId ?? '');
     if (!fileId || !FILE_ID_RE.test(fileId)) {
       res.status(400).json({ error: 'Invalid file id' });
       return;

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -38,6 +38,7 @@ import {
   postChatbotSession,
   postChatbotMessage,
   postChatbotUpload,
+  getChatbotFileDownload,
   postAgentMessage,
   postAgentMessageStream,
   getLegacyChatbotProxy,
@@ -538,6 +539,7 @@ const createApp = async (app, schema) => {
   app.post(`${basePath}/chatbot/sessions`, postChatbotSession);
   app.post(`${basePath}/chatbot/messages`, postChatbotMessage);
   app.post(`${basePath}/chatbot/upload`, postChatbotUpload);
+  app.get(`${basePath}/chatbot/files/:fileId/download`, getChatbotFileDownload);
   app.post(`${basePath}/chatbot/agent`, postAgentMessage);
   app.post(`${basePath}/chatbot/agent/stream`, postAgentMessageStream);
   // Legacy Flowise proxy (used when xtm_one_token is NOT set)

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -681,6 +681,8 @@ describe('httpChatbotProxy: getChatbotFileDownload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupAuthenticatedContext();
+    // Default the draft check to a no-op (live workspace, no draft).
+    vi.mocked(checkDraftInContext).mockResolvedValue(undefined);
     res = buildRes();
   });
 
@@ -703,6 +705,41 @@ describe('httpChatbotProxy: getChatbotFileDownload', () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ error: 'Invalid file id' });
     expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('should reject with 400 when the draft context fails validation, without calling XTM One', async () => {
+    // Simulate a caller forging an `opencti-draft-id` they cannot access (or a
+    // closed draft). The REST proxy MUST refuse before reaching XTM One —
+    // without this guard a draft-scoped file could be downloaded across draft
+    // authorization boundaries.
+    setupAuthenticatedContext({ draft_context: 'forged-draft-id' });
+    vi.mocked(checkDraftInContext).mockRejectedValue(new Error('Could not find draft workspace'));
+
+    await getChatbotFileDownload(buildDownloadReq(VALID_FILE_ID), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Could not find draft workspace' });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('should forward the validated context.draft_context to XTM One, not the raw request header', async () => {
+    // File downloads are frequently triggered without custom headers, so the
+    // upstream draft id must come from the validated `context.draft_context`
+    // (which falls back to the user's session draft) rather than the raw
+    // request header — otherwise a draft user would hit the live workspace.
+    setupAuthenticatedContext({ draft_context: 'user-session-draft-id' });
+    const fakeStream = { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() };
+    mockGet.mockResolvedValue({ data: fakeStream, headers: {} });
+
+    await getChatbotFileDownload(buildDownloadReq(VALID_FILE_ID), res);
+
+    const { getHttpClient } = await import('../../../src/utils/http-client');
+    const headerCalls = vi.mocked(getHttpClient).mock.calls
+      .map((c) => c[0]?.headers)
+      .filter((h): h is Record<string, string> => !!h && 'opencti-draft-id' in h);
+    expect(headerCalls.length).toBeGreaterThan(0);
+    expect(headerCalls[headerCalls.length - 1]['opencti-draft-id']).toBe('user-session-draft-id');
+    expect(mockGet).toHaveBeenCalledTimes(1);
   });
 
   it('should stream the file and forward content headers on success', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -138,7 +138,7 @@ vi.mock('../../../src/utils/http-client', () => ({
 import { createAuthenticatedContext } from '../../../src/http/httpAuthenticatedContext';
 import { getEntityFromCache } from '../../../src/database/cache';
 import { getEnterpriseEditionActivePem, getEnterpriseEditionInfo } from '../../../src/modules/settings/licensing';
-import { postAgentMessageStream } from '../../../src/http/httpChatbotProxy';
+import { getChatbotFileDownload, postAgentMessageStream } from '../../../src/http/httpChatbotProxy';
 import { checkDraftInContext } from '../../../src/http/httpServer-draft';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -669,5 +669,105 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
     await Promise.all(endHandlers.map((h) => h()));
 
     expect(mockRedisSetXtmAgentResponse).not.toHaveBeenCalled();
+  });
+});
+
+describe('httpChatbotProxy: getChatbotFileDownload', () => {
+  const VALID_FILE_ID = '11111111-1111-1111-1111-111111111111';
+  let res: ReturnType<typeof buildRes>;
+
+  const buildDownloadReq = (fileId: string) => ({ params: { fileId }, headers: {}, on: vi.fn() } as any);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupAuthenticatedContext();
+    res = buildRes();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return 403 when user is not authenticated', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({ user: null } as any);
+
+    await getChatbotFileDownload(buildDownloadReq(VALID_FILE_ID), res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for a non-UUID file id without calling XTM One', async () => {
+    await getChatbotFileDownload(buildDownloadReq('../etc/passwd'), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid file id' });
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('should stream the file and forward content headers on success', async () => {
+    const fakeStream = { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() };
+    mockGet.mockResolvedValue({
+      data: fakeStream,
+      headers: {
+        'content-type': 'text/csv',
+        'content-disposition': 'attachment; filename="iocs.csv"',
+        'content-length': '21',
+        'content-encoding': 'gzip',
+        'cache-control': 'private, max-age=86400',
+        'x-should-not-forward': 'secret',
+      },
+    });
+
+    const req = buildDownloadReq(VALID_FILE_ID);
+    await getChatbotFileDownload(req, res);
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockGet.mock.calls[0];
+    expect(url).toBe(`/api/v1/chat/files/${VALID_FILE_ID}/download`);
+    expect(opts.timeout).toBe(0);
+    expect(opts.decompress).toBe(false);
+
+    expect(res.setHeader).toHaveBeenCalledWith('content-type', 'text/csv');
+    expect(res.setHeader).toHaveBeenCalledWith('content-disposition', 'attachment; filename="iocs.csv"');
+    expect(res.setHeader).toHaveBeenCalledWith('content-length', '21');
+    expect(res.setHeader).toHaveBeenCalledWith('content-encoding', 'gzip');
+    expect(res.setHeader).toHaveBeenCalledWith('cache-control', 'private, max-age=86400');
+    // Non-allowlisted upstream headers must not be forwarded.
+    expect(res.setHeader).not.toHaveBeenCalledWith('x-should-not-forward', 'secret');
+    expect(fakeStream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it('should destroy the upstream stream when the client disconnects', async () => {
+    const fakeStream = { pipe: vi.fn(), on: vi.fn(), destroy: vi.fn() };
+    mockGet.mockResolvedValue({ data: fakeStream, headers: {} });
+
+    const req = buildDownloadReq(VALID_FILE_ID);
+    await getChatbotFileDownload(req, res);
+
+    const closeHandler = req.on.mock.calls.find((c: any[]) => c[0] === 'close')?.[1];
+    expect(closeHandler).toBeDefined();
+    closeHandler();
+    expect(fakeStream.destroy).toHaveBeenCalled();
+  });
+
+  it('should propagate the upstream status and detail message on HTTP error', async () => {
+    const httpError = new Error('Request failed with status code 404') as any;
+    httpError.response = { status: 404, data: { detail: 'File not found' } };
+    mockGet.mockRejectedValue(httpError);
+
+    await getChatbotFileDownload(buildDownloadReq(VALID_FILE_ID), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'File not found' });
+  });
+
+  it('should return 503 when a non-HTTP error is thrown', async () => {
+    mockGet.mockRejectedValue(new Error('Network failure'));
+
+    await getChatbotFileDownload(buildDownloadReq(VALID_FILE_ID), res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({ error: 'XTM One is unreachable' });
   });
 });


### PR DESCRIPTION
## Summary

Closes #16294.

XTM One agents can now produce downloadable files (`generate_file` / `$output_files`, XTM One #810 + XTM-One-Platform/xtm-one#1120, both merged). This adds the OpenCTI side so the embedded **Ask Ariane** chatbot can render and download those files — **without the user ever authenticating to XTM One**.

## What changed

- **`httpChatbotProxy.ts`** — new `GET /chatbot/files/:fileId/download`. Authenticates the OpenCTI user (platform session + CGU/license gate), validates the draft context server-side (`checkDraftInContext`, since REST routes bypass the GraphQL middleware), mints the XTM One JWT server-side (`issueXtmJwt` via `generateBasicHeaders`), streams the file from XTM One `/api/v1/chat/files/{id}/download`, and forwards `content-type` / `content-disposition` / `content-length` / `content-encoding` / `cache-control`. `fileId` is validated against a strict UUID pattern. Uses `timeout: 0` (streaming) and surfaces the upstream `detail` on error.
- **`httpPlatform.js`** — registers the route alongside the other `/chatbot/*` routes.
- **`AskArianePanel.tsx`** — points the chatbot at the new route via `apiEndpoints.download = '/files'`.
- Bumps `@filigran/chatbot` to **3.3.1** (renders download cards + strips `[[FILE:]]` markers); `yarn.lock` refreshed.

## Auth & draft model — no XTM One login

The chatbot downloads from `${APP_BASE_PATH}/chatbot/files/{id}/download` (this proxy) with the OpenCTI session cookie; the XTM One JWT is minted server-side, so the end user authenticates only to OpenCTI. The draft context is validated with `checkDraftInContext` and the upstream `opencti-draft-id` is forced to the resolved `context.draft_context` (which falls back to the user's session draft when the request omits the header), so a forged or inaccessible draft id is rejected and draft-scoped downloads resolve in the right workspace — matching the sibling `postAgentMessageStream`.

## Tests

- `getChatbotFileDownload` unit tests in `tests/01-unit/http/httpChatbotProxy-test.ts`: unauthenticated → 403, invalid id → 400, invalid draft context → 400 (no upstream call), success → headers forwarded (allowlist) + stream piped, validated `context.draft_context` forwarded upstream (not the raw header), client disconnect → stream destroyed, HTTP error → propagated status + detail, non-HTTP error → 503. 30 passing.

## Cross-repo

- XTM One backend: XTM-One-Platform/xtm-one#1120 (merged)
- filigran-ui (`@filigran/chatbot@3.3.1`): FiligranHQ/filigran-ui#278 (merged, published to npm)
- OpenAEV (sibling proxy): OpenAEV-Platform/openaev#5993
