### PR TITLE
[frontend] Make Ask Ariane aware of the user's current page (#16297)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.4.0",
+    "@filigran/chatbot": "3.3.2",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.3.1",
+    "@filigran/chatbot": "3.4.0",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -78,10 +78,13 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
   // Forward the user's current in-app location so the agent is always aware
   // of the page (URI) the question is being asked from. The router uses
   // `basename={APP_BASE_PATH}`, so `location.pathname` is already
-  // app-relative (e.g. `/dashboard/analyses/reports/<id>/overview`). The
-  // shape is intentionally extensible — more context (page title, selected
-  // entity, etc.) can be added here later.
-  const pageContext = { url: `${location.pathname}${location.search}` };
+  // app-relative (e.g. `/dashboard/analyses/reports/<id>/overview`). Only the
+  // pathname is sent — the query string is intentionally omitted because
+  // OpenCTI encodes UI state (filters, view settings, …) there, which would
+  // bloat the payload and could leak more than the agent needs. The shape is
+  // extensible — more context (page title, selected entity, etc.) can be
+  // added here later.
+  const pageContext = { url: location.pathname };
 
   const handleRelativeLinkClick = (href: string) => {
     const normalizedHref = APP_BASE_PATH && href.startsWith(APP_BASE_PATH)

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ChatPanel, ChatMode } from '@filigran/chatbot';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '@mui/styles';
 import { LogoXtmOneIcon } from 'filigran-icon';
 import type { Theme } from '../../../components/Theme';
@@ -32,6 +32,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
   onResizeEnd,
 }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
   const { me, bannerSettings: { bannerHeightNumber } } = useAuth();
@@ -73,6 +74,14 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
   const draftBorderColor = draftId
     ? theme.palette.designSystem.alert.warning.primary
     : undefined;
+
+  // Forward the user's current in-app location so the agent is always aware
+  // of the page (URI) the question is being asked from. The router uses
+  // `basename={APP_BASE_PATH}`, so `location.pathname` is already
+  // app-relative (e.g. `/dashboard/analyses/reports/<id>/overview`). The
+  // shape is intentionally extensible — more context (page title, selected
+  // entity, etc.) can be added here later.
+  const pageContext = { url: `${location.pathname}${location.search}` };
 
   const handleRelativeLinkClick = (href: string) => {
     const normalizedHref = APP_BASE_PATH && href.startsWith(APP_BASE_PATH)
@@ -140,6 +149,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
       onResizeStart={onResizeStart}
       onResizeEnd={onResizeEnd}
       requestHeaders={requestHeaders}
+      pageContext={pageContext}
       onRelativeLinkClick={handleRelativeLinkClick}
     />,
     container,

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1780,15 +1780,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.1":
-  version: 3.3.1
-  resolution: "@filigran/chatbot@npm:3.3.1"
+"@filigran/chatbot@npm:3.3.2":
+  version: 3.3.2
+  resolution: "@filigran/chatbot@npm:3.3.2"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/9d0c71c52fb010326b2e947ce9bcadcfe5d998003ebfcab28cfa480d3ddf3c0ee2a8ebf4caf72583e108a2b2c2558cf084e9e77d48650496302f2b181aa6eeb4
+  checksum: 10c0/603d18358c9fb9a60c0e383bbec25fd1e60c2eace79e991be6d3275155d7c5add397c1d69e7a772718ef0097edd5d193f75e81ee0fdd8f0c45bf7d7b855cf832
   languageName: node
   linkType: hard
 
@@ -12990,7 +12990,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.1.2"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.1"
+    "@filigran/chatbot": "npm:3.3.2"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
## Proposed changes

Makes the XTM One "Ask Ariane" agent aware of the user's current page by forwarding it as a flexible `context` JSON object on every chat message.

- `AskArianePanel` passes `pageContext={{ url: location.pathname }}` to `ChatPanel`, kept fresh via `useLocation` as the user navigates and read at send time.
- The router uses `basename={APP_BASE_PATH}`, so `useLocation().pathname` is already app-relative (e.g. `/dashboard/analyses/reports/<id>/overview`).
- **Only the pathname is sent** — `location.search` is intentionally omitted, because OpenCTI encodes UI state (filters, view settings, …) in the query string, which would bloat each message and could leak more than the agent needs.
- Pins `@filigran/chatbot` to `3.3.2` (the patch that adds the `pageContext` prop).
- No proxy change needed: `postChatbotMessage` already forwards the request body verbatim, so `context` flows straight through to XTM One.

The shape is intentionally generic (today just the URL; extensible later to page title, selected entity, …) and omitted when empty.

Closes #16297

## Dependency / ordering

Requires `@filigran/chatbot@3.3.2` (FiligranHQ/filigran-ui PR #280, merged + published) to be available. End-to-end, the `context` is consumed by `XTM-One-Platform/xtm-one` #1122, which injects it into the agent system prompt.

## Related issues

Closes #16297

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] `yarn lint` / `yarn check-ts` pass in `opencti-front`
- [ ] Manual: open Ask Ariane, navigate between pages, send a message, confirm the `POST /chatbot/messages` body carries `context: { url: <pathname> }` matching the current page

## Further comments

Part of a coordinated cross-repo change with `FiligranHQ/filigran-ui`, `OpenAEV-Platform/openaev`, and `XTM-One-Platform/xtm-one`.
