### PR TITLE
[frontend] Bump @filigran/chatbot to 3.3.3 to recover from a stale chatbot conversation id

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.3.2",
+    "@filigran/chatbot": "3.3.3",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1780,15 +1780,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.2":
-  version: 3.3.2
-  resolution: "@filigran/chatbot@npm:3.3.2"
+"@filigran/chatbot@npm:3.3.3":
+  version: 3.3.3
+  resolution: "@filigran/chatbot@npm:3.3.3"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/603d18358c9fb9a60c0e383bbec25fd1e60c2eace79e991be6d3275155d7c5add397c1d69e7a772718ef0097edd5d193f75e81ee0fdd8f0c45bf7d7b855cf832
+  checksum: 10c0/08b015995ebbeca4fbe06185892a9d8de680d9e327925c35b4657fa77325507132823e48adc31f551f4d8c8cd216113da12f56355d7fb7cd077812c110296d5c
   languageName: node
   linkType: hard
 
@@ -12990,7 +12990,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.1.2"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.2"
+    "@filigran/chatbot": "npm:3.3.3"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
### Proposed changes

* Bump `@filigran/chatbot` from `3.3.2` to `3.3.3` in `opencti-platform/opencti-front`.
* This release ([FiligranHQ/filigran-ui#281](https://github.com/FiligranHQ/filigran-ui/pull/281)) makes the "Ask Ariane" chatbot recover gracefully from a **stale** conversation id stored in `localStorage` (e.g. when the same URL is reused for a fresh/reset platform). Instead of showing `conversation does not exist` and forcing the user to click **New conversation**, the chatbot now adopts the conversation id resolved by the backend (or silently starts a fresh one) and persists it.

No OpenCTI code change is needed: `AskArianePanel.tsx` only passes props and `httpChatbotProxy.ts` already forwards the resolved `conversation_id`.

### Related issues

* closes #16318

### How to test this PR

1. Open Ask Ariane and start a conversation so a `filigranChatConversationId` is stored in `localStorage`.
2. Point the same browser/URL at a fresh platform (or delete the conversation server-side) so the stored id no longer exists.
3. Reopen Ask Ariane → the chatbot silently uses a fresh conversation; the first message sends successfully with **no error** and without having to click **New conversation**.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Dependency bump only (`package.json` + `yarn.lock`). The underlying fix and its test plan live in the upstream PR FiligranHQ/filigran-ui#281.
