### PR TITLE
fix(api): restrict background tasks visibility to their initiator (#16212)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -46,7 +46,18 @@ export const findById = async (context, user, taskId) => {
 };
 
 export const findBackgroundTaskPaginated = (context, user, args) => {
-  return pageEntitiesConnection(context, user, [ENTITY_TYPE_BACKGROUND_TASK], args);
+  const initiatorFilter = {
+    mode: 'and',
+    filters: [{ key: ['initiator_id'], values: [user.internal_id] }],
+    filterGroups: [],
+  };
+  const updatedArgs = {
+    ...args,
+    filters: args.filters
+      ? { mode: 'and', filters: [], filterGroups: [args.filters, initiatorFilter] }
+      : initiatorFilter,
+  };
+  return pageEntitiesConnection(context, user, [ENTITY_TYPE_BACKGROUND_TASK], updatedArgs);
 };
 
 export const findBackgroundTask = (context, user, args) => {

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -4,7 +4,7 @@ import { elIndex, elPaginate } from '../database/engine';
 import { INDEX_INTERNAL_OBJECTS, READ_DATA_INDICES } from '../database/utils';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_INTERNAL_FILE, ENTITY_TYPE_USER } from '../schema/internalObject';
 import { deleteElementById, patchAttribute } from '../database/middleware';
-import { getUserAccessRight, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../utils/access';
+import { getUserAccessRight, isBypassUser, MEMBER_ACCESS_RIGHT_ADMIN, SYSTEM_USER } from '../utils/access';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_CORE_RELATIONSHIP, RULE_PREFIX } from '../schema/general';
 import { buildEntityFilters, countAllThings, topEntitiesList, pageEntitiesConnection, storeLoadById } from '../database/middleware-loader';
 import { checkActionValidity, createDefaultTask, TASK_TYPE_QUERY, TASK_TYPE_RULE } from './backgroundTask-common';
@@ -46,6 +46,9 @@ export const findById = async (context, user, taskId) => {
 };
 
 export const findBackgroundTaskPaginated = (context, user, args) => {
+  if (isBypassUser(user)) {
+    return pageEntitiesConnection(context, user, [ENTITY_TYPE_BACKGROUND_TASK], args);
+  }
   const initiatorFilter = {
     mode: 'and',
     filters: [{ key: ['initiator_id'], values: [user.internal_id] }],

--- a/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
+++ b/opencti-platform/opencti-graphql/src/domain/backgroundTask.js
@@ -47,7 +47,7 @@ export const findById = async (context, user, taskId) => {
 
 export const findBackgroundTaskPaginated = (context, user, args) => {
   if (isBypassUser(user)) {
-    return pageEntitiesConnection(context, user, [ENTITY_TYPE_BACKGROUND_TASK], args);
+    return pageEntitiesConnection(context, user, [ENTITY_TYPE_BACKGROUND_TASK], { ...args, includeAuthorities: true });
   }
   const initiatorFilter = {
     mode: 'and',

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/backgroundTask-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/backgroundTask-test.ts
@@ -1,16 +1,42 @@
 import { expect, describe, it } from 'vitest';
 import gql from 'graphql-tag';
-import { queryUnauthenticatedIsExpectedForbidden } from '../../utils/testQueryHelper';
+import { queryAsAdminWithSuccess, queryAsUserWithSuccess, queryUnauthenticatedIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { deleteWork } from '../../../src/domain/work';
-import { ADMIN_USER, queryInitPlatformAsAdmin, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, queryInitPlatformAsAdmin, testContext, USER_EDITOR, USER_PARTICIPATE } from '../../utils/testQuery';
 import { getBestBackgroundConnectorId } from '../../../src/database/rabbitmq';
 import { createWorkForBackgroundTask } from '../../../src/domain/backgroundTask-common';
+import type { BackgroundTaskConnectionEdge, ListTask } from '../../../src/generated/graphql';
 
 const DELETE_QUERY = gql`
   mutation deleteBackgroundTask($id: ID!) {
     deleteBackgroundTask(id: $id)
   }
 `;
+
+const LIST_TASK_ADD_MUTATION = gql`  
+  mutation listTaskAdd($input: ListTaskAddInput!) {
+    listTaskAdd(input: $input) {
+      id
+      ... on ListTask {
+        description
+      }
+    }
+  }`;
+
+const BACKGROUND_TASKS_QUERY = gql`  
+  query backgroundTasks {
+    backgroundTasks {
+      edges {
+        node {
+          id
+          ... on ListTask {
+            description
+          }
+        }
+      }
+    }
+  }`;
+
 describe('Background task graphQL API permission checks', () => {
   it('should Anonymous not be allowed to delete a BackgroundTask.', async () => {
     await queryUnauthenticatedIsExpectedForbidden({
@@ -32,5 +58,67 @@ describe('Verify deleted works', () => {
       error = err;
     }
     expect(error?.response.data.errors[0].name).toEqual('WORK_NOT_ALIVE');
+  });
+});
+describe('Background task visibility per initiator', () => {
+  let taskCreatedByEditor: string;
+  let taskCreatedByParticipate: string;
+  it('should USER_EDITOR create a background task', async () => {
+    const result = await queryAsUserWithSuccess(USER_EDITOR, {
+      query: LIST_TASK_ADD_MUTATION,
+      variables: {
+        input: {
+          description: 'Task created by editor',
+          ids: [], // liste vide pour le test
+          actions: [{ type: 'DELETE' }],
+          scope: 'KNOWLEDGE',
+        },
+      },
+    });
+    taskCreatedByEditor = (result.data.listTaskAdd as ListTask).id;
+    expect(taskCreatedByEditor).toBeDefined();
+  });
+
+  it('should USER_PARTICIPATE create a background task', async () => {
+    const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
+      query: LIST_TASK_ADD_MUTATION,
+      variables: {
+        input: {
+          description: 'Task created by participate',
+          ids: [],
+          actions: [{ type: 'DELETE' }],
+          scope: 'KNOWLEDGE',
+        },
+      },
+    });
+    taskCreatedByParticipate = (result.data.listTaskAdd as ListTask).id;
+    expect(taskCreatedByParticipate).toBeDefined();
+  });
+
+  it('should USER_EDITOR only see its own tasks, not tasks from USER_PARTICIPATE', async () => {
+    const result = await queryAsUserWithSuccess(USER_EDITOR, {
+      query: BACKGROUND_TASKS_QUERY,
+    });
+    const ids = result.data.backgroundTasks.edges.map((e: BackgroundTaskConnectionEdge) => e.node.id);
+    expect(ids).toContain(taskCreatedByEditor);
+    expect(ids).not.toContain(taskCreatedByParticipate);
+  });
+
+  it('should USER_PARTICIPATE only see its own tasks, not tasks from USER_EDITOR', async () => {
+    const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
+      query: BACKGROUND_TASKS_QUERY,
+    });
+    const ids = result.data.backgroundTasks.edges.map((e: BackgroundTaskConnectionEdge) => e.node.id);
+    expect(ids).toContain(taskCreatedByParticipate);
+    expect(ids).not.toContain(taskCreatedByEditor);
+  });
+
+  it('should ADMIN see all tasks', async () => {
+    const result = await queryAsAdminWithSuccess({
+      query: BACKGROUND_TASKS_QUERY,
+    });
+    const ids = result.data.backgroundTasks.edges.map((e: BackgroundTaskConnectionEdge) => e.node.id);
+    expect(ids).toContain(taskCreatedByEditor);
+    expect(ids).toContain(taskCreatedByParticipate);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/backgroundTask-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/backgroundTask-test.ts
@@ -2,7 +2,7 @@ import { expect, describe, it } from 'vitest';
 import gql from 'graphql-tag';
 import { queryAsAdminWithSuccess, queryAsUserWithSuccess, queryUnauthenticatedIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { deleteWork } from '../../../src/domain/work';
-import { ADMIN_USER, queryInitPlatformAsAdmin, testContext, USER_EDITOR, USER_PARTICIPATE } from '../../utils/testQuery';
+import { ADMIN_USER, queryInitPlatformAsAdmin, testContext, USER_EDITOR, USER_SECURITY } from '../../utils/testQuery';
 import { getBestBackgroundConnectorId } from '../../../src/database/rabbitmq';
 import { createWorkForBackgroundTask } from '../../../src/domain/backgroundTask-common';
 import type { BackgroundTaskConnectionEdge, ListTask } from '../../../src/generated/graphql';
@@ -62,14 +62,14 @@ describe('Verify deleted works', () => {
 });
 describe('Background task visibility per initiator', () => {
   let taskCreatedByEditor: string;
-  let taskCreatedByParticipate: string;
+  let taskCreatedBySecurity: string;
   it('should USER_EDITOR create a background task', async () => {
     const result = await queryAsUserWithSuccess(USER_EDITOR, {
       query: LIST_TASK_ADD_MUTATION,
       variables: {
         input: {
           description: 'Task created by editor',
-          ids: [], // liste vide pour le test
+          ids: [],
           actions: [{ type: 'DELETE' }],
           scope: 'KNOWLEDGE',
         },
@@ -79,37 +79,37 @@ describe('Background task visibility per initiator', () => {
     expect(taskCreatedByEditor).toBeDefined();
   });
 
-  it('should USER_PARTICIPATE create a background task', async () => {
-    const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
+  it('should USER_SECURITY create a background task', async () => {
+    const result = await queryAsUserWithSuccess(USER_SECURITY, {
       query: LIST_TASK_ADD_MUTATION,
       variables: {
         input: {
-          description: 'Task created by participate',
+          description: 'Task created by security',
           ids: [],
           actions: [{ type: 'DELETE' }],
           scope: 'KNOWLEDGE',
         },
       },
     });
-    taskCreatedByParticipate = (result.data.listTaskAdd as ListTask).id;
-    expect(taskCreatedByParticipate).toBeDefined();
+    taskCreatedBySecurity = (result.data.listTaskAdd as ListTask).id;
+    expect(taskCreatedBySecurity).toBeDefined();
   });
 
-  it('should USER_EDITOR only see its own tasks, not tasks from USER_PARTICIPATE', async () => {
+  it('should USER_EDITOR only see its own tasks, not tasks from USER_SECURITY', async () => {
     const result = await queryAsUserWithSuccess(USER_EDITOR, {
       query: BACKGROUND_TASKS_QUERY,
     });
     const ids = result.data.backgroundTasks.edges.map((e: BackgroundTaskConnectionEdge) => e.node.id);
     expect(ids).toContain(taskCreatedByEditor);
-    expect(ids).not.toContain(taskCreatedByParticipate);
+    expect(ids).not.toContain(taskCreatedBySecurity);
   });
 
-  it('should USER_PARTICIPATE only see its own tasks, not tasks from USER_EDITOR', async () => {
-    const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
+  it('should USER_SECURITY only see its own tasks, not tasks from USER_EDITOR', async () => {
+    const result = await queryAsUserWithSuccess(USER_SECURITY, {
       query: BACKGROUND_TASKS_QUERY,
     });
     const ids = result.data.backgroundTasks.edges.map((e: BackgroundTaskConnectionEdge) => e.node.id);
-    expect(ids).toContain(taskCreatedByParticipate);
+    expect(ids).toContain(taskCreatedBySecurity);
     expect(ids).not.toContain(taskCreatedByEditor);
   });
 
@@ -119,6 +119,6 @@ describe('Background task visibility per initiator', () => {
     });
     const ids = result.data.backgroundTasks.edges.map((e: BackgroundTaskConnectionEdge) => e.node.id);
     expect(ids).toContain(taskCreatedByEditor);
-    expect(ids).toContain(taskCreatedByParticipate);
+    expect(ids).toContain(taskCreatedBySecurity);
   });
 });


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add filter in `findBackgroundTaskPaginated` to only return BGT for their initiator
* Tests

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/16212

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
