### PR TITLE
chore(telemetry): improve queue to connector correlation (#16315)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -2380,6 +2380,14 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             metrics_subsystem,
             metrics_port,
         )
+
+        self.metric.set_info(
+            connector_id=self.connect_id,
+            connector_name=self.connect_name,
+            connector_type=self.connect_type,
+            connector_scope=self.connect_scope,
+        )
+
         # Register the connector in OpenCTI
         self.connector = OpenCTIConnector(
             connector_id=self.connect_id,

--- a/client-python/pycti/connector/opencti_metric_handler.py
+++ b/client-python/pycti/connector/opencti_metric_handler.py
@@ -6,14 +6,14 @@ allowing monitoring of connector performance and health.
 
 from typing import Type, Union
 
-from prometheus_client import Counter, Enum, start_http_server
+from prometheus_client import Counter, Enum, Info, start_http_server
 
 
 class OpenCTIMetricHandler:
     """Handler for Prometheus metrics in OpenCTI connectors.
 
     This class manages Prometheus metrics for monitoring connector behavior,
-    including bundle sends, records processed, run counts, API pings, and errors.
+    including general info, bundle sends, records processed, run counts, API pings, and errors.
 
     When activated, it starts an HTTP server to expose metrics for scraping
     by Prometheus or compatible monitoring systems.
@@ -117,10 +117,16 @@ class OpenCTIMetricHandler:
                     namespace=namespace,
                     subsystem=subsystem,
                 ),
+                "identity": Info(
+                    "identity",
+                    "Identity and configuration of the connector",
+                    namespace=namespace,
+                    subsystem=subsystem,
+                ),
             }
 
     def _metric_exists(
-        self, name: str, expected_type: Union[Type[Counter], Type[Enum]]
+        self, name: str, expected_type: Union[Type[Counter], Type[Enum], Type[Info]]
     ) -> bool:
         """Check if a metric exists and has the expected type.
 
@@ -129,8 +135,8 @@ class OpenCTIMetricHandler:
 
         :param name: Name of the metric to validate
         :type name: str
-        :param expected_type: Expected Prometheus metric type (Counter or Enum)
-        :type expected_type: Union[Type[Counter], Type[Enum]]
+        :param expected_type: Expected Prometheus metric type (Counter, Enum or Info)
+        :type expected_type: Union[Type[Counter], Type[Enum], Type[Info]]
 
         :return: True if metric exists and has correct type, False otherwise
         :rtype: bool
@@ -198,3 +204,20 @@ class OpenCTIMetricHandler:
         if self.activated:
             if self._metric_exists(name, Enum):
                 self._metrics[name].state(state)
+
+    def set_info(
+        self,
+        connector_id: str,
+        connector_name: str,
+        connector_type: str,
+        connector_scope: str,
+    ) -> None:
+        if self.activated:
+            self._metrics["identity"].info(
+                {
+                    "id": connector_id,
+                    "name": connector_name,
+                    "type": connector_type,
+                    "scope": connector_scope,
+                }
+            )

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -122,7 +122,8 @@ services:
       - "15672:15672" # management UI
       - "15692:15692" # prometheus metrics
     command: >
-      sh -c "rabbitmq-plugins enable --offline rabbitmq_prometheus && exec rabbitmq-server"
+      sh -c "rabbitmq-plugins enable --offline rabbitmq_prometheus && exec
+      rabbitmq-server"
 
   ## Telemetry + tracing dependencies
   ## podman compose --profile telemetry up -d (launch everything + telemetry)
@@ -182,8 +183,9 @@ services:
       - opencti-dev-telemetry-prometheus
     volumes:
       - "grafanadata:/var/lib/grafana"
-      - "./grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datas\
-        ources.yaml"
+      - "./grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml"
+    profiles:
+      - "telemetry"
 
   # SAML / OpenId provider with keycloak - disabled by default
   # docker compose --profile keycloak up -d

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -122,8 +122,7 @@ services:
       - "15672:15672" # management UI
       - "15692:15692" # prometheus metrics
     command: >
-      sh -c "rabbitmq-plugins enable rabbitmq_prometheus && docker-entrypoint.sh
-      rabbitmq-server"
+      sh -c "rabbitmq-plugins enable --offline rabbitmq_prometheus && exec rabbitmq-server"
 
   ## Telemetry + tracing dependencies
   ## podman compose --profile telemetry up -d (launch everything + telemetry)

--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -118,8 +118,12 @@ services:
     volumes:
       - ./rabbitmq.config:/etc/rabbitmq/conf.d/90-userdefined.conf
     ports:
-      - 5672:5672
-      - 15672:15672
+      - "5672:5672"
+      - "15672:15672" # management UI
+      - "15692:15692" # prometheus metrics
+    command: >
+      sh -c "rabbitmq-plugins enable rabbitmq_prometheus && docker-entrypoint.sh
+      rabbitmq-server"
 
   ## Telemetry + tracing dependencies
   ## podman compose --profile telemetry up -d (launch everything + telemetry)
@@ -156,10 +160,14 @@ services:
       - "telemetry"
   opencti-dev-telemetry-prometheus:
     container_name: opencti-dev-telemetry-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
     image: prom/prometheus:v3.12.0
     restart: unless-stopped
     volumes:
-      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "./prometheus/rules:/etc/prometheus/rules"
     ports:
       - "9090:9090"
     profiles:
@@ -173,6 +181,10 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     depends_on:
       - opencti-dev-telemetry-prometheus
+    volumes:
+      - "grafanadata:/var/lib/grafana"
+      - "./grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datas\
+        ources.yaml"
 
   # SAML / OpenId provider with keycloak - disabled by default
   # docker compose --profile keycloak up -d
@@ -214,4 +226,6 @@ volumes:
   ossnapshots:
     driver: local
   keycloakdata:
+    driver: local
+  grafanadata:
     driver: local

--- a/opencti-platform/opencti-dev/grafana/datasources.yaml
+++ b/opencti-platform/opencti-dev/grafana/datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: OpenCTI Dev Prometheus
+    type: prometheus
+    access: proxy
+    url: http://opencti-dev-telemetry-prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: "15s"

--- a/opencti-platform/opencti-dev/prometheus.yml
+++ b/opencti-platform/opencti-dev/prometheus.yml
@@ -1,9 +1,0 @@
-global:
-  scrape_interval: 15s
-
-scrape_configs:
-  - job_name: 'opencti-dev-telemetry-prometheus'
-    static_configs:
-      - targets: ['host.docker.internal:14269']
-        labels:
-          app: 'opencti'

--- a/opencti-platform/opencti-dev/prometheus/prometheus.yml
+++ b/opencti-platform/opencti-dev/prometheus/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: "15s"
+
+scrape_configs:
+  - job_name: 'opencti-dev-telemetry-prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:14269']
+        labels:
+          app: "opencti"
+  - job_name: "rabbitmq"
+    metrics_path: "/metrics/detailed"
+    params:
+      family: ["queue_coarse_metrics"]
+    static_configs:
+      - targets: ["host.docker.internal:15692"]
+        labels:
+          app: 'opencti'
+  - job_name: "connectors"
+    static_configs:
+      - targets: ["host.docker.internal:9095"]
+        labels:
+          app: "opencti"
+
+rule_files:
+  - "/etc/prometheus/rules/*.yml"

--- a/opencti-platform/opencti-dev/prometheus/rules/opencti_rabbitmq_enriched.yml
+++ b/opencti-platform/opencti-dev/prometheus/rules/opencti_rabbitmq_enriched.yml
@@ -1,0 +1,55 @@
+groups:
+  - name: opencti_rabbitmq_enriched
+    interval: 15s
+    rules:
+      - record: opencti:rabbitmq_detailed_queue_messages_persistent:enriched
+        expr: |
+          label_replace(
+            rabbitmq_detailed_queue_messages_persistent,
+            "connector_id",
+            "$3",
+            "queue",
+            "(.*)(listen|push)_([a-f0-9-]{36}).*"
+          )
+          * on(connector_id) group_left(name, type)
+          label_replace(
+            opencti_connector_identity_info,
+            "connector_id",
+            "$1",
+            "id",
+            "(.*)"
+          )
+      - record: opencti:rabbitmq_detailed_queue_consumers:enriched
+        expr: |
+          label_replace(
+            rabbitmq_detailed_queue_consumers,
+            "connector_id",
+            "$3",
+            "queue",
+            "(.*)(listen|push)_([a-f0-9-]{36}).*"
+          )
+          * on(connector_id) group_left(name, type)
+          label_replace(
+            opencti_connector_identity_info,
+            "connector_id",
+            "$1",
+            "id",
+            "(.*)"
+          )
+      - record: opencti:rabbitmq_queue_messages_acked_total:enriched
+        expr: |
+          label_replace(
+            rabbitmq_queue_messages_acked_total,
+            "connector_id",
+            "$3",
+            "queue",
+            "(.*)(listen|push)_([a-f0-9-]{36}).*"
+          )
+          * on(connector_id) group_left(name, type)
+          label_replace(
+            opencti_connector_identity_info,
+            "connector_id",
+            "$1",
+            "id",
+            "(.*)"
+          )


### PR DESCRIPTION
### Proposed changes

* Emit a new `opencti_connector_identity_info` metric from the connectors that contain following info:

```
opencti_connector_identity_info{
id="e1e82feb-4b0b-4358-89ca-31d2b627e6db",
name="OpenCTI Datasets",
scope="marking-definition,identity,location",
type="EXTERNAL_IMPORT"
} 1.0
```

This metric of type `Info` will be helpful to write Prometheus `recording rules`.

* Continues to enrich the local telemetry setup 
* Creates 3 recording records to enrich `rabbitmq` metrics with `connector name` and `connector type` info by doing joins resulting in 3 new "derived" metrics: `opencti:rabbitmq_detailed_queue_messages_persistent:enriched`, `opencti:rabbitmq_detailed_queue_consumers:enriched` and `opencti:rabbitmq_queue_messages_acked_total:enriched`.
These serve as a proof of concept before going to prod.

### Related issues

* Fixes #16315 

### How to test this PR

* Launch the local telemetry stack: `podman compose --profile telemetry up -d`
* Launch a OCTI instance with a connector and a worker
* Navigate to the local grafana instance on `http://localhost:3100/`; go to "Metrics > Drilldown" or "Explore" and checkout the new metrics.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
