### PR TITLE
[frontend] Bump @filigran/chatbot to 3.3.4

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.3.3",
+    "@filigran/chatbot": "3.3.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1780,15 +1780,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.3.3":
-  version: 3.3.3
-  resolution: "@filigran/chatbot@npm:3.3.3"
+"@filigran/chatbot@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@filigran/chatbot@npm:3.3.4"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/08b015995ebbeca4fbe06185892a9d8de680d9e327925c35b4657fa77325507132823e48adc31f551f4d8c8cd216113da12f56355d7fb7cd077812c110296d5c
+  checksum: 10c0/a30da0e6aab12ebb7f92f5df8b325c4592aa0638f0531c34771ecd9911aed6c9fe3bbfd264aa9b40bb5259d15402bc7e76782a3d03abc9b8ba321f12c98d76cd
   languageName: node
   linkType: hard
 
@@ -12990,7 +12990,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.1.2"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.3.3"
+    "@filigran/chatbot": "npm:3.3.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
## Proposed changes

Bumps the embedded chatbot `@filigran/chatbot` from `3.3.3` to `3.3.4`, picking up two bug fixes from [FiligranHQ/filigran-ui#283](https://github.com/FiligranHQ/filigran-ui/pull/283):

- **Streaming affordances no longer leak onto previous messages** — the blinking caret and the reasoning "i" button stay scoped to the message currently streaming, instead of appearing on / disappearing from every previous assistant message while a new response generates.
- **Uploaded files are downloadable** — files a user uploads are now rendered as download cards (not static chips), served via the existing chat file download proxy.

`@filigran/chatbot@3.3.4` is published on npm and `yarn.lock` has been regenerated.

## Related

- filigran-ui PR: FiligranHQ/filigran-ui#283
- filigran-ui issue: FiligranHQ/filigran-ui#282
