### PR TITLE
[frontend] Keep XTM One intent connectors usable when XTM One is not configured (#16338)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/LaunchImportDialog.tsx
@@ -28,7 +28,7 @@ import useHelper from '../../../../utils/hooks/useHelper';
 import { useIsMandatoryAttribute } from '../../../../utils/hooks/useEntitySettings';
 import { DraftAddInput, DRAFTWORKSPACE_TYPE } from '@components/drafts/DraftCreation';
 import useDefaultValues from '../../../../utils/hooks/useDefaultValues';
-import { AgentOption, fetchAgentsForIntent } from '../../../../utils/ai/agentApi';
+import { AgentOption, fetchAgentsForIntent, isXtmOneIntentWithoutAgents } from '../../../../utils/ai/agentApi';
 import { useChatbot } from '@components/chatbox/ChatbotContext';
 
 interface LaunchImportDialogProps {
@@ -289,7 +289,11 @@ const LaunchImportDialog: React.FC<LaunchImportDialogProps> = ({
                   const disabled = !file
                     || (connector?.connector_scope && connector?.connector_scope?.length > 0
                       && file?.metaData?.mimetype && !connector?.connector_scope?.includes(file?.metaData?.mimetype));
-                  const noAgents = isXtmOneConfigured && !!connector?.xtm_one_intent && (intentAgentCounts[connector.xtm_one_intent] ?? -1) === 0;
+                  const noAgents = isXtmOneIntentWithoutAgents(
+                    isXtmOneConfigured,
+                    connector?.xtm_one_intent,
+                    connector?.xtm_one_intent ? intentAgentCounts[connector.xtm_one_intent] : undefined,
+                  );
                   return (
                     <MenuItem
                       key={connector?.id}

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesList.tsx
@@ -25,9 +25,12 @@ const ImportFilesList: React.FC<ImportFilesListProps> = ({ connectorsForImport }
   const [agentsByIntent, setAgentsByIntent] = useState<Record<string, AgentOption[]>>({});
 
   // Agent count for an intent, or `undefined` while it has not been fetched yet.
-  const agentCountForIntent = (intent?: string | null): number | undefined => (
-    intent && intent in agentsByIntent ? agentsByIntent[intent].length : undefined
-  );
+  // Uses an own-property check so an intent that collides with a prototype key
+  // (e.g. `constructor`, `toString`) can never read a non-array off the prototype.
+  const agentCountForIntent = (intent?: string | null): number | undefined => {
+    if (!intent || !Object.prototype.hasOwnProperty.call(agentsByIntent, intent)) return undefined;
+    return agentsByIntent[intent].length;
+  };
 
   // A connector is only blocked when XTM One is configured but the intent has no
   // agent. When XTM One is off, intent connectors stay usable via their legacy path.

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesList.tsx
@@ -6,9 +6,10 @@ import { CSV_MAPPER_NAME } from '@components/common/files/import_files/ImportFil
 import { useTheme } from '@mui/styles';
 import { useImportFilesContext } from '@components/common/files/import_files/ImportFilesContext';
 import { ImportFilesContextQuery$data } from '@components/common/files/import_files/__generated__/ImportFilesContextQuery.graphql';
+import { useChatbot } from '@components/chatbox/ChatbotContext';
 import { useFormatter } from '../../../../../components/i18n';
 import type { Theme } from '../../../../../components/Theme';
-import { AgentOption, fetchAgentsForIntent } from '../../../../../utils/ai/agentApi';
+import { AgentOption, fetchAgentsForIntent, isXtmOneIntentWithoutAgents } from '../../../../../utils/ai/agentApi';
 
 interface ImportFilesListProps {
   connectorsForImport: ImportFilesContextQuery$data['connectorsForImport'];
@@ -18,9 +19,21 @@ const ImportFilesList: React.FC<ImportFilesListProps> = ({ connectorsForImport }
   const theme = useTheme<Theme>();
   const { files, setFiles, importMode } = useImportFilesContext();
   const { t_i18n } = useFormatter();
+  const { xtmOneConfigured } = useChatbot();
 
   // Track loaded agents per intent
   const [agentsByIntent, setAgentsByIntent] = useState<Record<string, AgentOption[]>>({});
+
+  // Agent count for an intent, or `undefined` while it has not been fetched yet.
+  const agentCountForIntent = (intent?: string | null): number | undefined => (
+    intent && intent in agentsByIntent ? agentsByIntent[intent].length : undefined
+  );
+
+  // A connector is only blocked when XTM One is configured but the intent has no
+  // agent. When XTM One is off, intent connectors stay usable via their legacy path.
+  const connectorMissingAgent = (intent?: string | null): boolean => (
+    isXtmOneIntentWithoutAgents(xtmOneConfigured, intent, agentCountForIntent(intent))
+  );
 
   // Collect unique xtm_one_intent values from ALL available connectors (not just selected)
   const allIntents = useMemo(() => {
@@ -33,8 +46,10 @@ const ImportFilesList: React.FC<ImportFilesListProps> = ({ connectorsForImport }
     return Array.from(intents);
   }, [connectorsForImport]);
 
-  // Fetch agents for all intents at mount time
+  // Fetch agents for all intents at mount time. Only when XTM One is configured:
+  // otherwise intent connectors run in legacy mode and need no agent catalog.
   useEffect(() => {
+    if (xtmOneConfigured !== true) return;
     for (const intent of allIntents) {
       if (!agentsByIntent[intent]) {
         fetchAgentsForIntent(intent).then((agents) => {
@@ -42,7 +57,7 @@ const ImportFilesList: React.FC<ImportFilesListProps> = ({ connectorsForImport }
         });
       }
     }
-  }, [allIntents]);
+  }, [allIntents, xtmOneConfigured]);
 
   // Auto-preselect first agent for files with XTM One connectors that have no configuration yet
   useEffect(() => {
@@ -254,11 +269,11 @@ const ImportFilesList: React.FC<ImportFilesListProps> = ({ connectorsForImport }
                                     disabled={
                                       !connector?.active
                                       || !connector?.connector_scope?.includes(file.type)
-                                      || (!!connector?.xtm_one_intent && connector.xtm_one_intent in agentsByIntent && agentsByIntent[connector.xtm_one_intent].length === 0)
+                                      || connectorMissingAgent(connector?.xtm_one_intent)
                                     }
                                   >
                                     {connector?.name}
-                                    {connector?.xtm_one_intent && connector.xtm_one_intent in agentsByIntent && agentsByIntent[connector.xtm_one_intent].length === 0
+                                    {connectorMissingAgent(connector?.xtm_one_intent)
                                       ? ` (${t_i18n('No agent available')})`
                                       : ''}
                                   </MenuItem>

--- a/opencti-platform/opencti-front/src/utils/ai/agentApi.test.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/agentApi.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { callAgent, callAgentStream } from './agentApi';
+import { callAgent, callAgentStream, isXtmOneIntentWithoutAgents } from './agentApi';
 
 const buildJsonResponse = (status: number, body: unknown, ok = status >= 200 && status < 300): Response => {
   const json = JSON.stringify(body);
@@ -67,6 +67,37 @@ describe('agentApi', () => {
   });
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('isXtmOneIntentWithoutAgents', () => {
+    it('never blocks when XTM One is not configured, regardless of intent/agents', () => {
+      // Mirrors the backend gate (`connector.xtm_one_intent && xtmOneClient.isConfigured()`):
+      // intent connectors keep a legacy execution path when XTM One is off.
+      expect(isXtmOneIntentWithoutAgents(false, 'cti.stix_harvester', 0)).toBe(false);
+      expect(isXtmOneIntentWithoutAgents(false, 'cti.stix_harvester', 3)).toBe(false);
+    });
+
+    it('never blocks while the config is still loading (null tri-state)', () => {
+      expect(isXtmOneIntentWithoutAgents(null, 'cti.stix_harvester', 0)).toBe(false);
+    });
+
+    it('never blocks a connector that declares no intent', () => {
+      expect(isXtmOneIntentWithoutAgents(true, null, 0)).toBe(false);
+      expect(isXtmOneIntentWithoutAgents(true, undefined, 0)).toBe(false);
+      expect(isXtmOneIntentWithoutAgents(true, '', 0)).toBe(false);
+    });
+
+    it('never blocks while the agent catalog has not been fetched yet (undefined count)', () => {
+      expect(isXtmOneIntentWithoutAgents(true, 'cti.stix_harvester', undefined)).toBe(false);
+    });
+
+    it('blocks only when XTM One is configured, an intent is set and zero agents are bound', () => {
+      expect(isXtmOneIntentWithoutAgents(true, 'cti.stix_harvester', 0)).toBe(true);
+    });
+
+    it('does not block when at least one agent is bound to the intent', () => {
+      expect(isXtmOneIntentWithoutAgents(true, 'cti.stix_harvester', 1)).toBe(false);
+    });
   });
 
   describe('callAgent', () => {

--- a/opencti-platform/opencti-front/src/utils/ai/agentApi.ts
+++ b/opencti-platform/opencti-front/src/utils/ai/agentApi.ts
@@ -30,6 +30,31 @@ export const fetchAgentsForIntent = async (intent: string): Promise<AgentOption[
 };
 
 /**
+ * Decide whether an import connector that declares an `xtm_one_intent` must be
+ * treated as unusable ("No agent available") in the import UIs.
+ *
+ * The intent is only a hard requirement when XTM One is actually configured on
+ * the platform. Such connectors keep a legacy (non-XTM One) execution path, so
+ * when XTM One is off they remain usable and must NOT be disabled. This mirrors
+ * the backend gating in `file-storage.ts`
+ * (`connector.xtm_one_intent && xtmOneClient.isConfigured()`).
+ *
+ * @param xtmOneConfigured tri-state flag from the chatbot config (`null` while loading)
+ * @param intent the connector's `xtm_one_intent` (null/undefined for non-AI connectors)
+ * @param agentCount number of agents bound to the intent, or `undefined` while not yet loaded
+ */
+export const isXtmOneIntentWithoutAgents = (
+  xtmOneConfigured: boolean | null,
+  intent: string | null | undefined,
+  agentCount: number | undefined,
+): boolean => {
+  if (xtmOneConfigured !== true) return false;
+  if (!intent) return false;
+  if (agentCount === undefined) return false;
+  return agentCount === 0;
+};
+
+/**
  * Best-effort JSON `{ error }` body extraction for non-OK fetch responses.
  * The chatbot proxy returns `400 { error: '...' }` for body-validation and
  * draft-authorization failures, and `503 { error: '...' }` when XTM One is


### PR DESCRIPTION
### Proposed changes

* The import wizard (`ImportFilesList`) flagged any connector declaring an `xtm_one_intent` as **`(No agent available)`** and **disabled** as soon as the agent catalog came back empty — which is always the case when XTM One is **not configured**. But such connectors (e.g. `ImportDocumentAI`) keep a legacy execution path and run fine without XTM One, so they were wrongly blocked. This change gates the "no agent" state on `xtmOneConfigured`, matching the backend (`file-storage.ts`: `connector.xtm_one_intent && xtmOneClient.isConfigured()`).
* Introduced a single shared helper `isXtmOneIntentWithoutAgents(xtmOneConfigured, intent, agentCount)` in `utils/ai/agentApi.ts` and used it in **both** `ImportFilesList` (new bulk wizard) and `LaunchImportDialog` (legacy single-file dialog) so the two UIs can no longer drift.
* `ImportFilesList` now only fetches the agent catalog when XTM One is configured, avoiding needless `/chatbot/agents` calls (which `400`/`503` when XTM One is off).
* Hardened the per-intent agent-count lookup in `ImportFilesList` to use an own-property check (`Object.prototype.hasOwnProperty.call`) instead of the `in` operator, so an intent that collides with a prototype key (`__proto__`, `constructor`, `toString`, …) can never read a non-array off the prototype chain.
* Added unit tests for the shared `isXtmOneIntentWithoutAgents` helper covering the full tri-state matrix (XTM One off / loading / on × intent present or absent × agent count unknown / zero / non-zero) so the backend-mirroring gate cannot silently drift.

### Related issues

* closes #16338

### How to test this PR

1. On a platform **without** XTM One configured (no `XTM__XTM_ONE_URL` / `XTM__XTM_ONE_TOKEN`), with the `ImportDocumentAI` connector deployed (image >= 7.260522.0, configured for legacy Ariane mode):
   - Open **Import data** -> Select files -> pick a supported file -> open the **Connectors** dropdown.
   - **Before:** `ImportDocumentAI` is shown `(No agent available)` and disabled. **After:** it is selectable and runs via its legacy path.
2. On a platform **with** XTM One configured but **no agent** bound to the connector's intent:
   - The connector is still shown `(No agent available)` and disabled (unchanged behaviour).
3. On a platform **with** XTM One configured **and** agents available:
   - The connector is enabled and the agent selector appears (unchanged behaviour).
4. Verify `LaunchImportDialog` ("Launch an import") behaves identically to the wizard in all three cases.
5. Run the front unit tests: `yarn vitest run src/utils/ai/agentApi.test.ts` — the `isXtmOneIntentWithoutAgents` suite asserts the three cases above.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The behavioural divergence was amplified by the connector side: newer `connector-import-document-ai` images auto-register `xtm_one_intent = cti.stix_harvester` (backward-compat shim in `main.py`) even when `CONNECTOR_XTM_ONE_INTENT` is unset, while older images leave it `null`. Only the former tripped the faulty UI gate, which is why the same "XTM One not configured" platform state behaved differently across deployments. This PR fixes the platform-side gate; no connector change is required.
