### PR TITLE
fix(Retention Policies) : Enhance deleteElement logic to support forceRefresh option (#15669)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
@@ -42,17 +42,17 @@ interface DeleteOpts {
 }
 
 export const deleteElement = async (context: AuthContext, scope: string, nodeId: string, opts: DeleteOpts = {}) => {
+  const deleteOpts = { forceDelete: true, forceRefresh: opts.forceRefresh ?? false };
   if (scope === 'knowledge') {
     const { knowledgeType } = opts;
-    const deleteOpts = { forceDelete: true, forceRefresh: opts.forceRefresh ?? false };
     await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, knowledgeType, deleteOpts);
   } else if (scope === 'file' || scope === 'workbench') {
     // forceDelete: true to clean up orphan ES entries even if S3 file doesn't exist
     await deleteFile(context, RETENTION_MANAGER_USER, nodeId, { forceDelete: true });
   } else if (scope === 'history') {
-    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_HISTORY, { forceDelete: true, forceRefresh: false });
+    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_HISTORY, deleteOpts);
   } else if (scope === 'activity') {
-    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_ACTIVITY, { forceDelete: true, forceRefresh: false });
+    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_ACTIVITY, deleteOpts);
   } else {
     throw Error(`[Retention manager] Scope ${scope} not existing for Retention Rule.`);
   }

--- a/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/retentionManager.ts
@@ -50,9 +50,9 @@ export const deleteElement = async (context: AuthContext, scope: string, nodeId:
     // forceDelete: true to clean up orphan ES entries even if S3 file doesn't exist
     await deleteFile(context, RETENTION_MANAGER_USER, nodeId, { forceDelete: true });
   } else if (scope === 'history') {
-    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_HISTORY, { forceDelete: true });
+    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_HISTORY, { forceDelete: true, forceRefresh: false });
   } else if (scope === 'activity') {
-    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_ACTIVITY, { forceDelete: true });
+    await deleteElementById(context, RETENTION_MANAGER_USER, nodeId, ENTITY_TYPE_ACTIVITY, { forceDelete: true, forceRefresh: false });
   } else {
     throw Error(`[Retention manager] Scope ${scope} not existing for Retention Rule.`);
   }

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/retentionManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/retentionManager-test.ts
@@ -17,7 +17,7 @@ import { deleteElementById } from '../../../src/database/middleware';
 import { canDeleteElement } from '../../../src/database/data-consistency';
 import { ENTITY_TYPE_CONTAINER_REPORT, ENTITY_TYPE_IDENTITY_INDIVIDUAL } from '../../../src/schema/stixDomainObject';
 import type { BasicStoreEntityRetentionRule } from '../../../src/modules/retentionRules/retentionRules-types';
-import { ENTITY_TYPE_ACTIVITY } from '../../../src/schema/internalObject';
+import { ENTITY_TYPE_ACTIVITY, ENTITY_TYPE_HISTORY } from '../../../src/schema/internalObject';
 import { BASE_TYPE_ENTITY } from '../../../src/schema/general';
 import { generateInternalId } from '../../../src/schema/identifier';
 
@@ -386,12 +386,33 @@ describe('Retention Manager tests ', () => {
     expect(historyElements.edges.length).toBeGreaterThan(0);
     const historyEntryId = historyElements.edges[0].node.id;
     // Delete it via the retention manager
-    await deleteElement(context, 'history', historyEntryId);
+    await deleteElement(context, 'history', historyEntryId, { forceRefresh: true });
     // Verify it is no longer findable
     const deleted = await elLoadById(testContext, ADMIN_USER, historyEntryId, { indices: READ_INDEX_HISTORY });
     expect(deleted).toBeUndefined();
   });
   it('should execute processing for history scope: patch the rule and collect deleted entries', async () => {
+    // Insert a synthetic History entry old enough to be caught by a 1-minute retention rule
+    const historyId = generateInternalId();
+    const historyDate = utcDate().subtract(5, 'minutes').toDate();
+    const historyEntry = {
+      internal_id: historyId,
+      standard_id: `history--${historyId}`,
+      base_type: BASE_TYPE_ENTITY,
+      entity_type: ENTITY_TYPE_HISTORY,
+      event_type: 'mutation',
+      event_scope: 'create',
+      event_status: 'success',
+      created_at: historyDate,
+      updated_at: historyDate,
+      timestamp: historyDate.toISOString(),
+      user_id: ADMIN_USER.id,
+      group_ids: [],
+      organization_ids: [],
+      context_data: { message: 'test history entry for executeProcessing retention test' },
+    };
+    await elIndex(INDEX_HISTORY, historyEntry);
+
     // Create a history retention rule
     const ruleQuery = await queryAsAdmin({
       query: CREATE_RETENTION_QUERY,
@@ -426,6 +447,8 @@ describe('Retention Manager tests ', () => {
     } finally {
       featureSpy1.mockRestore();
     }
+    // Wait for Elasticsearch automatic index refresh (1s default)
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     // The rule should have been patched with last_execution_date and last_deleted_count
     const updatedRule = await elLoadById(testContext, ADMIN_USER, rule.id) as unknown as BasicStoreEntityRetentionRule;
     expect(updatedRule?.last_execution_date).toBeDefined();
@@ -513,7 +536,7 @@ describe('Retention Manager tests ', () => {
     const indexed = await elLoadById(testContext, ADMIN_USER, activityId, { indices: READ_INDEX_HISTORY });
     expect(indexed).toBeDefined();
     // Delete it via the retention manager
-    await deleteElement(context, 'activity', activityId);
+    await deleteElement(context, 'activity', activityId, { forceRefresh: true });
     // Verify it is no longer findable
     const deleted = await elLoadById(testContext, ADMIN_USER, activityId, { indices: READ_INDEX_HISTORY });
     expect(deleted).toBeUndefined();
@@ -574,6 +597,8 @@ describe('Retention Manager tests ', () => {
     } finally {
       featureSpy3.mockRestore();
     }
+    // Wait for Elasticsearch automatic index refresh (1s default)
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     // The rule should be patched with last_execution_date and last_deleted_count > 0
     const updatedRule = await elLoadById(testContext, ADMIN_USER, rule.id) as unknown as BasicStoreEntityRetentionRule;
     expect(updatedRule?.last_execution_date).toBeDefined();


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
This PR addresses two main issues with retention rules on technical scopes (`history` and `activity`):
- **GraphQL Backend**: Fixes execution timeouts and lock lockout issues during retention manager execution on large `history` and `activity` indices. By default, `deleteElementById` performs a synchronous Elasticsearch index refresh after every document delete. In batch executions (default: 1500 documents), this synchronous overhead blocks the event loop and causes the Redis execution lock to timeout before updating the rule's metadata (e.g. `last_execution_date`). We now ensure `forceRefresh: false` is passed for both scopes during manager executions.

#### **Detailed Changes**
* **Backend (`retentionManager.ts`)**:
  * Refactored `deleteElement` to declare `deleteOpts = { forceDelete: true, forceRefresh: opts.forceRefresh ?? false }` at the function scope and reuse it across `'knowledge'`, `'history'`, and `'activity'` paths.
* **Integration Tests (`retentionManager-test.ts`)**:
  * Modified tests to explicitly request `{ forceRefresh: true }` when validating immediate document deletions.
  * Added a `1.5` seconds delay after `executeProcessing` tests to wait for Elasticsearch's default automatic index refresh interval.
  * Added a synthetic history log creation
  
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #15669 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
