### PR TITLE
fix(csv-feed): Formatting export CSV feeds description (#13664)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpRollingFeed.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpRollingFeed.ts
@@ -40,11 +40,8 @@ const errorConverter = (e: any) => {
 };
 
 const escapeCsvField = (separator: string, data: string) => {
-  let escapedData: string;
-
-  if (data.includes('"') || data.includes(separator)
-  ) {
-    escapedData = data.replaceAll('"', '""');
+  if (data.includes('"') || data.includes(separator) || data.includes('\n') || data.includes('\r')) {
+    const escapedData = data.replaceAll('"', '""');
     return `"${escapedData}"`;
   }
   return data;

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/http/httpRollingFeed-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/http/httpRollingFeed-test.ts
@@ -68,7 +68,7 @@ const elements = [{ _index: 'opencti_stix_domain_objects-000001', _id: 'test-id'
 describe('buildCsvLines', () => {
   it('should convert elements to CSV expected format', () => {
     const expectedResultLines: string[] = [
-      `CSV test;Triggered risk rules:
+      `CSV test;"Triggered risk rules:
 
 |Rule|Severity|Score|
 |----|---|----|
@@ -79,9 +79,19 @@ describe('buildCsvLines', () => {
 
 *italic test*
 ~~strikethrough~~
-test`,
+test"`,
     ];
     const resultLines = buildCsvLines(elements, feed);
+    expect(resultLines).toEqual(expectedResultLines);
+  });
+
+  it('should quote fields containing newlines (CRLF) without separator or double quotes', () => {
+    const descriptionWithNewlines = 'line1\nline2\nline3';
+    const elementsWithNewlines = [{ ...elements[0], description: descriptionWithNewlines }];
+
+    const expectedResultLines: string[] = ['CSV test;"line1\nline2\nline3"'];
+
+    const resultLines = buildCsvLines(elementsWithNewlines, feed);
     expect(resultLines).toEqual(expectedResultLines);
   });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix "escapeCsvField" to quote CSV fields containing newline or carriage return characters (\n, \r), preventing broken rows in CSV feed exports when entity descriptions contain multi-line text.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #13664 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
- Create a CSV Feed configured under Data > Sharing > CSV Feeds with the description field included
( ex: Entity -> Indicator ) 
- Create an Indicator with a description containing line breaks, e.g.:
test1
test2

test3


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
<img width="916" height="265" alt="Screenshot 2026-06-03 at 12 00 16 PM" src="https://github.com/user-attachments/assets/7f6aff85-11e8-4a8e-8282-efd7559ea0bd" />
