### PR TITLE
fix(frontend): fix Add label dialog has too large padding (#16266)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects_or_stix_relationships/StixCoreObjectOrCoreRelationshipLabelsView.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects_or_stix_relationships/StixCoreObjectOrCoreRelationshipLabelsView.jsx
@@ -4,8 +4,6 @@ import Tag from '@common/tag/Tag';
 import { Add } from '@mui/icons-material';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import { Box, Stack } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Field, Form, Formik } from 'formik';
@@ -254,39 +252,37 @@ const StixCoreObjectOrCoreRelationshipLabelsView = (props) => {
             slots={{ transition: Transition }}
             onClose={handleCloseAdd}
             fullWidth={true}
-            style={{ paddingTop: 0 }}
+            title={t_i18n('Add new labels')}
+            contentProps={{ sx: { overflowY: 'hidden' }, style: { padding: 24 } }}
           >
-            <DialogTitle style={{ padding: '0 0 24px 0' }}>{t_i18n('Add new labels')}</DialogTitle>
-            <DialogContent style={{ overflowY: 'hidden', padding: 0 }}>
-              <Form>
-                <Field
-                  component={AutocompleteField}
-                  name="new_labels"
-                  multiple={true}
-                  textfieldprops={{
-                    variant: 'standard',
-                    label: t_i18n('Labels'),
-                    onFocus: searchLabels,
-                  }}
-                  noOptionsText={t_i18n('No available options')}
-                  options={stateLabels}
-                  onInputChange={searchLabels}
-                  openCreate={isLabelManager ? handleOpenCreate : null}
-                  renderOption={(optionsProps, option) => (
-                    <li {...optionsProps}>
-                      <div
-                        className={classes.icon}
-                        style={{ color: option.color }}
-                      >
-                        <MdiLabel />
-                      </div>
-                      <div className={classes.text}>{option.label}</div>
-                    </li>
-                  )}
-                  classes={{ clearIndicator: classes.autoCompleteIndicator }}
-                />
-              </Form>
-            </DialogContent>
+            <Form>
+              <Field
+                component={AutocompleteField}
+                name="new_labels"
+                multiple={true}
+                textfieldprops={{
+                  variant: 'standard',
+                  label: t_i18n('Labels'),
+                  onFocus: searchLabels,
+                }}
+                noOptionsText={t_i18n('No available options')}
+                options={stateLabels}
+                onInputChange={searchLabels}
+                openCreate={isLabelManager ? handleOpenCreate : null}
+                renderOption={(optionsProps, option) => (
+                  <li {...optionsProps}>
+                    <div
+                      className={classes.icon}
+                      style={{ color: option.color }}
+                    >
+                      <MdiLabel />
+                    </div>
+                    <div className={classes.text}>{option.label}</div>
+                  </li>
+                )}
+                classes={{ clearIndicator: classes.autoCompleteIndicator }}
+              />
+            </Form>
             <DialogActions>
               <Button variant="secondary" onClick={handleReset} disabled={isSubmitting}>
                 {t_i18n('Close')}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects_or_stix_relationships/StixCoreObjectOrCoreRelationshipLabelsView.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects_or_stix_relationships/StixCoreObjectOrCoreRelationshipLabelsView.jsx
@@ -254,9 +254,10 @@ const StixCoreObjectOrCoreRelationshipLabelsView = (props) => {
             slots={{ transition: Transition }}
             onClose={handleCloseAdd}
             fullWidth={true}
+            style={{ paddingTop: 0 }}
           >
-            <DialogTitle>{t_i18n('Add new labels')}</DialogTitle>
-            <DialogContent style={{ overflowY: 'hidden' }}>
+            <DialogTitle style={{ padding: '0 0 24px 0' }}>{t_i18n('Add new labels')}</DialogTitle>
+            <DialogContent style={{ overflowY: 'hidden', padding: 0 }}>
               <Form>
                 <Field
                   component={AutocompleteField}


### PR DESCRIPTION
### Proposed changes

* Fix padding

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/16266

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
