### PR TITLE
docs: align copyright year and unify contact email to contact@filigran.io (#16375)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at contact@opencti.io. All
+reported by contacting the project team at contact@filigran.io. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for reading this documentation and considering making your contributio
 
 In order to help you understand the project, where we are heading and how you can contribute, below are several resources and answers.
 
-Do not hesitate to shoot us an [email](mailto:contact@opencti.io) or join us on our [Slack channel](https://community.filigran.io). Most of the articles below are an introduction for our [detailed documentation](https://docs.opencti.io/latest/).
+Do not hesitate to shoot us an [email](mailto:contact@filigran.io) or join us on our [Slack channel](https://community.filigran.io). Most of the articles below are an introduction for our [detailed documentation](https://docs.opencti.io/latest/).
 
 
 ## Why contribute?
@@ -70,4 +70,4 @@ For general suggestions or questions about the project or the documentation, you
 
 ### How can you get in touch for other questions?
 
-If you need support or you wish to engage a discussion about the OpenCTI platform, feel free to join us on our [Slack channel](https://community.filigran.io). You can also send us an [email](mailto:contact@opencti.io).
+If you need support or you wish to engage a discussion about the OpenCTI platform, feel free to join us on our [Slack channel](https://community.filigran.io). You can also send us an [email](mailto:contact@filigran.io).

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2025 Filigran SAS
+Copyright (c) 2021-2026 Filigran SAS
 
 -----------------------------------------------------------------
 
@@ -350,7 +350,7 @@ Examples of License Headers in File
 
 OpenCTI Community Edition License
 -----------------------------------------------------------------
-Copyright (c) 2021-2025 Filigran SAS
+Copyright (c) 2021-2026 Filigran SAS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -367,7 +367,7 @@ limitations under the License.
 
 OpenCTI Enterprise Edition License
 -----------------------------------------------------------------
-Copyright (c) 2021-2025 Filigran SAS
+Copyright (c) 2021-2026 Filigran SAS
 
 This file is part of the OpenCTI Enterprise Edition ("EE") and is
 licensed under the OpenCTI Enterprise Edition License (the "License");

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Only the current stable major release (ie. X.X) is supported for updates and bug fixes (as of October 2023, 5.11.X). Any previous versions are currently not supported and users are advised to use them "at their own risk".
+Only the current stable major release (ie. X.X) is supported for updates and bug fixes. Any previous versions are currently not supported and users are advised to use them "at their own risk".
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Aligns the open-source meta files with the other Filigran platforms (OpenAEV, XTM One):

- **`LICENSE`** — bump the copyright year to `2021-2026`.
- **`CODE_OF_CONDUCT.md`** / **`CONTRIBUTING.md`** — unify the contact email to `contact@filigran.io` (instead of `contact@opencti.io`).
- **`SECURITY.md`** — remove the stale `(as of October 2023, 5.11.X)` reference so the supported-versions statement stays accurate over time.

No functional or code changes.

## Test plan

- [ ] Files render correctly on GitHub.
- [ ] No remaining `contact@opencti.io` references in the policy files.

Closes #16375
