### PR TITLE
chore(migration): introduce opencti_api_migration_duration metric (#16263)

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/tracing.ts
+++ b/opencti-platform/opencti-graphql/src/config/tracing.ts
@@ -22,6 +22,8 @@ class MeterManager {
 
   private latencyHistogram: Histogram | null = null;
 
+  private migrationDurationHistogram: Histogram | null = null;
+
   private directBulkGauge: Gauge | null = null;
 
   private sideBulkGauge: Gauge | null = null;
@@ -44,6 +46,14 @@ class MeterManager {
 
   latency(val: number, attributes: any) {
     this.latencyHistogram?.record(val, attributes);
+  }
+
+  migrationDuration(val: number, attributes: {
+    migrationTitle: string;
+  }) {
+    this.migrationDurationHistogram?.record(val, {
+      'opencti.migration.title': attributes.migrationTitle,
+    });
   }
 
   directBulk(val: number, attributes: any) {
@@ -74,6 +84,12 @@ class MeterManager {
       valueType: ValueType.INT,
       description: 'Latency computing per query',
       advice: { explicitBucketBoundaries: [0, 100, 500, 2000, 5000, 10000, 20000, 30000] },
+    });
+    this.migrationDurationHistogram = meter.createHistogram('opencti_api_migration_duration', {
+      valueType: ValueType.INT,
+      description: 'Duration of each migration',
+      unit: 's',
+      advice: { explicitBucketBoundaries: [1, 5, 15, 30, 60, 120, 300, 3600, 18000] },
     });
     // - Gauges
     this.directBulkGauge = meter.createGauge('opencti_api_direct_bulk', {

--- a/opencti-platform/opencti-graphql/src/database/migration-metrics.ts
+++ b/opencti-platform/opencti-graphql/src/database/migration-metrics.ts
@@ -1,0 +1,34 @@
+import type { MigrationSet } from 'migrate';
+import { meterManager } from '../config/tracing';
+
+export class MigrationsMetricsRecorder {
+  constructor(
+    meter: typeof meterManager,
+    migrationSet: MigrationSet,
+  ) {
+    this.meter = meter;
+    this.set = migrationSet;
+    this.set.on('migration', (migration) => {
+      this.startTimestamps[migration.title] = Date.now();
+    });
+  }
+
+  /**
+   * Telemetry: report migration metrics.
+   */
+  record() {
+    this.set.migrations.forEach((migration) => {
+      const endTimestamp = migration.timestamp ?? 0;
+      if (migration.title in this.startTimestamps && endTimestamp > 0) {
+        const migrationDurationSecs = Math.floor((endTimestamp - this.startTimestamps[migration.title]) / 1000);
+        this.meter.migrationDuration(migrationDurationSecs, {
+          migrationTitle: migration.title,
+        });
+      }
+    });
+  };
+
+  private meter: typeof meterManager;
+  private set: MigrationSet;
+  private startTimestamps: Record<string, number> = {};
+}

--- a/opencti-platform/opencti-graphql/src/database/migration.js
+++ b/opencti-platform/opencti-graphql/src/database/migration.js
@@ -10,6 +10,8 @@ import { executionContext, SYSTEM_USER } from '../utils/access';
 
 import migrations, { filenames as migrationsFilenames } from '../migrations/*.{js,ts}';
 import { fullEntitiesThroughRelationsToList } from './middleware-loader';
+import { meterManager } from '../config/tracing';
+import { MigrationsMetricsRecorder } from './migration-metrics';
 
 const normalizeMigrationName = (rawName) => {
   if (rawName.startsWith('./')) {
@@ -91,6 +93,7 @@ const migrationStorage = {
 
 export const applyMigration = (context) => {
   const set = new MigrationSet(migrationStorage);
+  const metricsRecorder = new MigrationsMetricsRecorder(meterManager, set);
   return new Promise((resolve, reject) => {
     migrationStorage.load((err, state) => {
       if (err) {
@@ -121,14 +124,16 @@ export const applyMigration = (context) => {
         }
         set.addMigration(migration);
       }
-      // Start the set migration
+      // Start the migration set
       set.up((migrationError) => {
         if (migrationError) {
           logApp.error('Migration up error', { cause: migrationError });
+          metricsRecorder.record();
           reject(migrationError);
           return;
         }
         logMigration.info('[MIGRATION] Migration process completed');
+        metricsRecorder.record();
         resolve(state);
       });
     }).catch((reason) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/migration-metrics-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/migration-metrics-test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileStore, MigrationSet } from 'migrate';
+import { MigrationsMetricsRecorder } from '../../../src/database/migration-metrics';
+import type { meterManager } from '../../../src/config/tracing';
+
+describe('MigrationMetricsRecorder', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports duration metric for finished migrations', () => {
+    const set = new MigrationSet({} as FileStore);
+    const migrationTitle = 'test-migration';
+    set.addMigration(migrationTitle, (next: () => void) => {
+      next();
+    }, () => {});
+    const meterSpy = {
+      migrationDuration: vi.fn(),
+    } as unknown as typeof meterManager;
+    const metricsRecorder = new MigrationsMetricsRecorder(meterSpy, set);
+    const date = new Date(2026, 1, 1, 13);
+    vi.setSystemTime(date);
+    const deltaSeconds = 60;
+    // Mimic `migrate` lib behaviour
+    set.emit('migration', set.migrations[0], 'up');
+    set.migrations[0].timestamp = date.getTime() + deltaSeconds * 1000;
+
+    metricsRecorder.record();
+    expect(meterSpy.migrationDuration).toHaveBeenCalledWith(deltaSeconds, {
+      migrationTitle,
+    });
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Add `opencti_api_migration_duration` histogram metric to measure migrations duration
*  No refactoring of the meter manager. The solution is not modular yet. We have another ticket to address the modularity issue and refactor.

Prepares for dashboard vizualizations:

<img width="2816" height="678" alt="image" src="https://github.com/user-attachments/assets/38790441-ec09-409b-987a-4915b216dc87" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16263 

### How to test this PR

* Run the telemetry stack: `podman compose --profile telemetry up -d`
* Add a new migration using the `yarn migration test-new-migration` command in the backend
* Start the backend
* Inspect metrics at `http://localhost:14269/metrics`

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
