### PR TITLE
feat(backend): add azure blob storage integration

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -396,6 +396,16 @@
     "excluded_files": [".DS_Store"],
     "disable_checksum_validation": false
   },
+  "storage": {
+    "provider": "s3",
+    "azure": {
+      "account_name": "",
+      "endpoint_suffix": "blob.core.windows.net",
+      "container_name": "opencti-bucket",
+      "client_id": "",
+      "connection_string": ""
+    }
+  },
   "rabbitmq": {
     "queue_prefix": "",
     "hostname": "localhost",

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -55,6 +55,8 @@
     "@aws-sdk/client-sts": "3.1046.0",
     "@aws-sdk/credential-provider-node": "3.972.40",
     "@aws-sdk/lib-storage": "3.1046.0",
+    "@azure/identity": "4.13.1",
+    "@azure/storage-blob": "12.31.0",
     "@datadog/pprof": "5.14.1",
     "@elastic/elasticsearch": "8.19.1",
     "@escape.tech/graphql-armor": "3.2.0",

--- a/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
+++ b/opencti-platform/opencti-graphql/src/connector/importCsv/importCsv-connector.ts
@@ -1,6 +1,5 @@
 import { Readable } from 'stream';
 import * as readline from 'node:readline';
-import type { SdkStream } from '@smithy/types/dist-types/serde';
 import conf, { logApp } from '../../config/conf';
 import { executionContext } from '../../utils/access';
 import type { AuthContext, AuthUser } from '../../types/user';
@@ -35,7 +34,7 @@ const LOG_PREFIX = `[OPENCTI-MODULE][${connectorConfig.id}]`;
 /** @deprecated Will be removed when workbench are replaced by draft */
 const processCSVforWorkbench = async (context: AuthContext, fileId: string, opts: CsvBundlerIngestionOpts) => {
   const { workId, applicantUser, csvMapper, entity } = opts;
-  const stream: SdkStream<Readable> | null | undefined = await downloadFile(fileId) as SdkStream<Readable> | null | undefined;
+  const stream: Readable | null = await downloadFile(fileId);
   if (stream) {
     // Starting to work, importing file = 1 operation
     await updateExpectationsNumber(context, applicantUser, workId, 1);
@@ -87,7 +86,7 @@ export const processCSVforWorkers = async (context: AuthContext, fileId: string,
     // - ** close file
     // - process the bulk count lines.
 
-    const stream: SdkStream<Readable> | null | undefined = await downloadFile(fileId) as SdkStream<Readable> | null | undefined;
+    const stream: Readable | null = await downloadFile(fileId);
     if (stream) {
       const lines: string[] = [];
       const readStream = readline.createInterface({ input: stream, crlfDelay: Infinity });

--- a/opencti-platform/opencti-graphql/src/database/file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/file-storage.ts
@@ -2,7 +2,6 @@ import path, { join } from 'node:path';
 import crypto from 'node:crypto';
 import mime from 'mime-types';
 import nconf from 'nconf';
-import type { _Object } from '@aws-sdk/client-s3';
 import fs from 'node:fs';
 import { Readable } from 'stream';
 import type { AuthContext, AuthUser } from '../types/user';
@@ -35,7 +34,7 @@ import { internalLoadById } from './middleware-loader';
 import { getDraftContext } from '../utils/draftContext';
 import { isModuleActivated } from './cluster-module';
 import { getDraftFilePrefix, isDraftFile } from './draft-utils';
-import { deleteFileFromStorage, getFileSize, rawCopyFile, rawListObjects, rawUpload } from './raw-file-storage';
+import { deleteFileFromStorage, getFileSize, rawCopyFile, rawListObjects, rawUpload, type StorageObject } from './raw-file-storage';
 import { promiseMap } from '../utils/promiseUtils';
 import { ENTITY_TYPE_SUPPORT_PACKAGE } from '../modules/support/support-types';
 import { pushAll } from '../utils/arrayUtil';
@@ -365,20 +364,18 @@ export const isFileObjectExcluded = (id: string): boolean => {
 };
 
 /**
- * Transforms raw S3 objects into S3FileObject format with mime type detection.
- * Filters out objects without keys and applies exclusion rules.
- * @param {_Object[]} objects - Array of raw S3 objects from AWS SDK
- * @returns {S3FileObject[]} Filtered and transformed array of S3 file objects with mime types
+ * Transforms backend-agnostic storage objects into S3FileObject format with mime type detection.
+ * Applies exclusion rules. Object keys are guaranteed defined by the provider listing contract.
+ * @param {StorageObject[]} objects - Array of storage objects from the active provider
+ * @returns {S3FileObject[]} Filtered and transformed array of file objects with mime types
  */
-const filesAdaptation = (objects: _Object[]): S3FileObject[] => {
-  const storageObjects = objects
-    .filter((obj): obj is Required<Pick<_Object, 'Key'>> & _Object => obj.Key !== undefined)
-    .map((obj) => {
-      return {
-        Key: obj.Key,
-        mimeType: guessMimeType(obj.Key),
-      };
-    });
+const filesAdaptation = (objects: StorageObject[]): S3FileObject[] => {
+  const storageObjects = objects.map((obj) => {
+    return {
+      Key: obj.Key,
+      mimeType: guessMimeType(obj.Key),
+    };
+  });
   return storageObjects.filter((obj: S3FileObject) => {
     return !isFileObjectExcluded(obj.Key);
   });
@@ -417,7 +414,7 @@ export const loadedFilesListing = async (
   while (truncated) {
     try {
       const response = await rawListObjects(directory, recursive ?? false, continuationToken);
-      const resultFiles = filesAdaptation(response.Contents ?? []);
+      const resultFiles = filesAdaptation(response.objects);
       const resultLoaded = await promiseMap(
         resultFiles,
         (f: S3FileObject) => loadFile(context, user, f.Key, { dontThrow }),
@@ -428,9 +425,9 @@ export const loadedFilesListing = async (
       } else {
         pushAll(files, resultLoaded.filter((n) => n !== undefined));
       }
-      truncated = response.IsTruncated ?? false;
+      truncated = response.isTruncated;
       if (truncated) {
-        continuationToken = response.NextContinuationToken;
+        continuationToken = response.nextContinuationToken;
       }
     } catch (err) {
       logApp.error('[FILE STORAGE] Storage files read fail', { cause: err });

--- a/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
+++ b/opencti-platform/opencti-graphql/src/database/raw-file-storage.ts
@@ -1,235 +1,71 @@
-import * as s3 from '@aws-sdk/client-s3';
-import {
-  CopyObjectCommand,
-  type GetObjectCommandOutput,
-  type HeadObjectCommandOutput,
-  type ListObjectsV2CommandInput,
-  type ListObjectsV2CommandOutput,
-  S3Client,
-  type S3ClientConfig,
-} from '@aws-sdk/client-s3';
-import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { Upload } from '@aws-sdk/lib-storage';
 import type { Readable } from 'stream';
-import { enrichWithRemoteCredentials } from '../config/credentials';
-import conf, { booleanConf, logApp, logS3Debug } from '../config/conf';
+import conf, { logApp } from '../config/conf';
 import { UnsupportedError } from '../config/errors';
 import type { AuthUser } from '../types/user';
-import { getRoleAssumerWithWebIdentity, setupAwsClient } from '../utils/awsSdk';
-
-// Minio configuration
-const clientEndpoint = conf.get('minio:endpoint');
-const clientPort = conf.get('minio:port') || 9000;
-const clientAccessKey = conf.get('minio:access_key');
-const clientSecretKey = conf.get('minio:secret_key');
-const clientSessionToken = conf.get('minio:session_token');
-const bucketName = conf.get('minio:bucket_name') || 'opencti-bucket';
-const bucketRegion = conf.get('minio:bucket_region') || 'us-east-1';
-const useSslConnection = booleanConf('minio:use_ssl', false);
-const useAwsRole = booleanConf('minio:use_aws_role', false);
-const useAwsLogs = booleanConf('minio:use_aws_logs', false);
-const disableChecksumValidation = booleanConf('minio:disable_checksum_validation', false);
-export const defaultValidationMode = conf.get('app:validation_mode');
+import { type StorageListResult, streamToString } from './storage/file-storage-provider';
+import { getStorageProvider } from './storage/storage-provider-factory';
 
 /**
- * Export S3 connection configuration for connectors.
- * This allows connectors to upload bundles directly to S3 storage.
+ * Public storage facade. This module used to wrap the AWS S3 SDK directly; it is now a thin,
+ * provider-agnostic facade over {@link FileStorageProvider} (S3/MinIO or Azure Blob). The exported
+ * function names and signatures are unchanged so every consumer stays untouched.
  */
-export const s3ConnectionConfig = () => ({
-  endpoint: clientEndpoint,
-  port: clientPort,
-  use_ssl: useSslConnection,
-  bucket_name: bucketName,
-  bucket_region: bucketRegion,
-  access_key: clientAccessKey,
-  secret_key: clientSecretKey,
-});
 
-let s3Client: S3Client; // Client reference
+export { streamToString };
+export type { StorageObject, StorageListResult, StorageConnectionConfig } from './storage/file-storage-provider';
 
-const buildCredentialProvider = async () => {
-  // If aws role must be used
-  if (useAwsRole) {
-    return () => {
-      return defaultProvider({
-        roleAssumerWithWebIdentity: getRoleAssumerWithWebIdentity({
-          // You must explicitly pass a region if you are not using us-east-1
-          region: bucketRegion,
-        }),
-      });
-    };
-  }
-  // If direct configuration
-  const baseAuth = { accessKeyId: clientAccessKey, secretAccessKey: clientSecretKey };
-  const userPasswordAuth = await enrichWithRemoteCredentials('minio', baseAuth);
-  return () => {
-    return {
-      ...userPasswordAuth,
-      ...(clientSessionToken && { sessionToken: clientSessionToken }),
-    };
-  };
-};
+export const defaultValidationMode = conf.get('app:validation_mode');
 
-const getEndpoint = () => {
-  // If using AWS S3, unset the endpoint to let the library choose the best endpoint
-  if (clientEndpoint === 's3.amazonaws.com') {
-    return undefined;
-  }
-  return `${(useSslConnection ? 'https' : 'http')}://${clientEndpoint}:${clientPort}`;
-};
+const provider = getStorageProvider();
 
+/** @deprecated Use {@link storageInit} instead. */
 export const initializeFileStorageClient = async () => {
-  const s3Config: S3ClientConfig = {
-    region: bucketRegion,
-    endpoint: getEndpoint(),
-    forcePathStyle: true,
-    credentialDefaultProvider: await buildCredentialProvider(),
-    tls: useSslConnection,
-    requestChecksumCalculation: disableChecksumValidation ? 'WHEN_REQUIRED' : 'WHEN_SUPPORTED',
-    responseChecksumValidation: disableChecksumValidation ? 'WHEN_REQUIRED' : 'WHEN_SUPPORTED',
-  };
-  if (useAwsLogs) {
-    s3Config.logger = logS3Debug;
-  }
-  s3Client = setupAwsClient(new s3.S3Client(s3Config));
+  await provider.initialize();
 };
 
-export const initializeBucket = async () => {
-  try {
-    // Try to access to the bucket
-    await s3Client.send(new s3.HeadBucketCommand({ Bucket: bucketName }));
-    return true;
-  } catch (_err) {
-    // If bucket not exist, try to create it.
-    // If creation fail, propagate the exception
-    await s3Client.send(new s3.CreateBucketCommand({ Bucket: bucketName }));
-    return true;
-  }
-};
+/** @deprecated Use {@link storageInit} instead. */
+export const initializeBucket = async () => provider.ensureBucket();
 
-export const deleteBucket = async () => {
-  try {
-    // Try to access to the bucket
-    await s3Client.send(new s3.DeleteBucketCommand({ Bucket: bucketName }));
-  } catch (err) {
-    // Dont care
-    logApp.info('[FILE STORAGE] Bucket cannot be deleted.', { err });
-  }
-};
+export const deleteBucket = async () => provider.deleteBucket();
+
+export const isStorageAlive = () => provider.isAlive();
 
 export const storageInit = async () => {
   logApp.info('[CHECK] Checking if File Storage is available');
-  await initializeFileStorageClient();
-  await initializeBucket();
+  await provider.initialize();
+  await provider.ensureBucket();
   logApp.info('[CHECK] File Storage is alive');
   return true;
 };
 
-export const isStorageAlive = () => initializeBucket();
-
-export const deleteFileFromStorage = async (id: string) => {
-  return s3Client.send(new s3.DeleteObjectCommand({
-    Bucket: bucketName,
-    Key: id,
-  }));
-};
+export const deleteFileFromStorage = async (id: string) => provider.delete(id);
 
 /**
- * Download a file from S3 at given S3 key (id)
- * @param id
+ * Download a file from storage at the given key (id).
  * @returns {Promise<Readable | null>} Readable stream of the file content, or null if file doesn't exist
- * @throws {UnsupportedError} when file body is null or undefined
  */
-export const downloadFile = async (id: string): Promise<Readable | null> => {
-  try {
-    const object = await s3Client.send(new s3.GetObjectCommand({
-      Bucket: bucketName,
-      Key: id,
-    }));
-    if (!object || !object.Body) {
-      logApp.error('[FILE STORAGE] Cannot retrieve file from S3, null body in response', { fileId: id });
-      throw UnsupportedError('File body is null or undefined', { fileId: id });
-    }
-    return object.Body as Readable;
-  } catch (err: any) {
-    // If file doesn't exist, return null instead of throwing
-    if (err.name === 'NoSuchKey') {
-      return null;
-    }
-    // For other errors, log and throw
-    logApp.error('[FILE STORAGE] Cannot retrieve file from S3', { cause: err, fileId: id });
-    throw err;
-  }
-};
+export const downloadFile = (id: string): Promise<Readable | null> => provider.download(id);
 
-export const streamToString = (stream: any, encoding: BufferEncoding = 'utf8'): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    if (!stream) {
-      reject();
-    }
-    const chunks: Uint8Array[] = [];
-    stream?.on('data', (chunk: Uint8Array) => chunks.push(chunk));
-    stream?.on('error', reject);
-    stream?.on('end', () => resolve(Buffer.concat(chunks).toString(encoding)));
-  });
-};
+export const getFileContent = (id: string, encoding: BufferEncoding = 'utf8'): Promise<string | undefined> => provider.getContent(id, encoding);
 
-export const getFileContent = async (id: string, encoding: BufferEncoding = 'utf8'): Promise<string | undefined> => {
-  const object: GetObjectCommandOutput = await s3Client.send(new s3.GetObjectCommand({
-    Bucket: bucketName,
-    Key: id,
-  }));
-  if (!object.Body) {
-    return undefined;
-  }
-  return streamToString(object.Body, encoding);
-};
+export const rawCopyFile = async (sourceId: string, targetId: string) => provider.copy(sourceId, targetId);
 
-export const rawCopyFile = async (sourceId: string, targetId: string) => {
-  const input = {
-    Bucket: bucketName,
-    CopySource: `${bucketName}/${sourceId}`, // CopySource must start with bucket name, but not Key
-    Key: targetId,
-  };
-  const command = new CopyObjectCommand(input);
-  await s3Client.send(command);
-};
-
-/**
- * Get file size from S3 (calling HEAD on S3 file).
- */
 export const getFileSize = async (user: AuthUser, fileS3Path: string): Promise<number | undefined> => {
   try {
-    const object: HeadObjectCommandOutput = await s3Client.send(new s3.HeadObjectCommand({
-      Bucket: bucketName,
-      Key: fileS3Path,
-    }));
-    return object.ContentLength;
+    return await provider.getSize(fileS3Path);
   } catch (err) {
     throw UnsupportedError('Load file from storage fail', { cause: err, user_id: user.id, filename: fileS3Path });
   }
 };
 
-export const rawUpload = async (key: string, body: string | Readable | Buffer) => {
-  const s3Upload = new Upload({
-    client: s3Client,
-    params: {
-      Bucket: bucketName,
-      Key: key,
-      Body: body,
-    },
-  });
-  await s3Upload.done();
+export const rawUpload = async (key: string, body: string | Readable | Buffer) => provider.upload(key, body);
+
+export const rawListObjects = (directory: string, recursive: boolean, continuationToken?: string): Promise<StorageListResult> => {
+  return provider.list(directory, recursive, continuationToken);
 };
 
-export const rawListObjects = async (directory: string, recursive: boolean, continuationToken?: string): Promise<ListObjectsV2CommandOutput> => {
-  const requestParams: ListObjectsV2CommandInput = {
-    Bucket: bucketName,
-    Prefix: directory,
-    Delimiter: recursive ? undefined : '/',
-  };
-  if (continuationToken) {
-    requestParams.ContinuationToken = continuationToken;
-  }
-  return s3Client.send(new s3.ListObjectsV2Command(requestParams));
-};
+/**
+ * Export the active provider's connection configuration for connectors (direct-upload).
+ * Kept named `s3ConnectionConfig` for backward compatibility with consumers and the GraphQL schema.
+ */
+export const s3ConnectionConfig = () => provider.connectionConfig();

--- a/opencti-platform/opencti-graphql/src/database/storage/azure-file-storage-provider.ts
+++ b/opencti-platform/opencti-graphql/src/database/storage/azure-file-storage-provider.ts
@@ -1,0 +1,196 @@
+import { Readable } from 'stream';
+import type { BlobItem, BlobServiceClient, ContainerClient } from '@azure/storage-blob';
+import conf, { logApp } from '../../config/conf';
+import { ConfigurationError, UnsupportedError } from '../../config/errors';
+import { type FileStorageProvider, type StorageConnectionConfig, type StorageListResult, type StorageObject, streamToString } from './file-storage-provider';
+
+const azureAccountName = conf.get('storage:azure:account_name');
+const azureEndpointSuffix = conf.get('storage:azure:endpoint_suffix') || 'blob.core.windows.net';
+const azureContainerName = conf.get('storage:azure:container_name') || 'opencti-bucket';
+const azureClientId = conf.get('storage:azure:client_id');
+const azureConnectionString = conf.get('storage:azure:connection_string');
+
+const AZURE_UPLOAD_BLOCK_SIZE = 8 * 1024 * 1024;
+const AZURE_UPLOAD_CONCURRENCY = 5;
+const AZURE_DOWNLOAD_MAX_RETRIES = 5;
+const AZURE_LIST_PAGE_SIZE = 1000;
+
+const isBlobNotFound = (err: any): boolean => {
+  return err?.statusCode === 404 || err?.code === 'BlobNotFound' || err?.details?.errorCode === 'BlobNotFound';
+};
+
+const toStorageObject = (name: string, contentLength?: number, lastModified?: Date): StorageObject => ({
+  Key: name,
+  Size: contentLength,
+  LastModified: lastModified,
+});
+
+/**
+ * Azure Blob Storage implementation of the storage contract. The Azure container is the analog of
+ * the S3 bucket.
+ *
+ * Authentication uses `DefaultAzureCredential` so a single code path covers Workload Identity (AKS),
+ * Managed Identity (VM/VMSS/ACI) and service-principal env vars (CI). A connection string is accepted
+ * for local Azurite only. Note: the identity needs the `Storage Blob Data Contributor` role on the
+ * account/container, otherwise every call returns `403 AuthorizationPermissionMismatch`.
+ */
+export class AzureFileStorageProvider implements FileStorageProvider {
+  private containerClient!: ContainerClient;
+
+  async initialize(): Promise<void> {
+    const { BlobServiceClient } = await import('@azure/storage-blob');
+    let serviceClient: BlobServiceClient;
+    if (azureConnectionString) {
+      // Dev / Azurite path — never use in production (shared-key secret).
+      serviceClient = BlobServiceClient.fromConnectionString(azureConnectionString);
+    } else {
+      if (!azureAccountName) {
+        throw ConfigurationError('Azure storage requires storage:azure:account_name (STORAGE__AZURE__ACCOUNT_NAME) when no connection string is provided');
+      }
+      const { DefaultAzureCredential } = await import('@azure/identity');
+      // managedIdentityClientId pins a specific user-assigned identity / workload-identity app.
+      const credential = azureClientId
+        ? new DefaultAzureCredential({ managedIdentityClientId: azureClientId })
+        : new DefaultAzureCredential();
+      serviceClient = new BlobServiceClient(`https://${azureAccountName}.${azureEndpointSuffix}`, credential);
+    }
+    this.containerClient = serviceClient.getContainerClient(azureContainerName);
+  }
+
+  async ensureBucket(): Promise<boolean> {
+    try {
+      await this.containerClient.createIfNotExists();
+      return true;
+    } catch (err: any) {
+      if (err?.statusCode === 403) {
+        logApp.error('[FILE STORAGE] Azure authorization failure creating container. '
+          + 'Assign the "Storage Blob Data Contributor" role to the identity on the storage account/container.', { cause: err, container: azureContainerName });
+      }
+      throw err;
+    }
+  }
+
+  isAlive(): Promise<boolean> {
+    // Liveness probe only — does not mutate (unlike the S3 path which head-then-creates).
+    return this.containerClient.exists();
+  }
+
+  async deleteBucket(): Promise<void> {
+    try {
+      await this.containerClient.deleteIfExists();
+    } catch (err) {
+      logApp.info('[FILE STORAGE] Container cannot be deleted.', { err });
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const blobClient = this.containerClient.getBlobClient(key);
+    await blobClient.deleteIfExists();
+  }
+
+  /**
+   * @returns Readable stream of the blob content, or null if the blob doesn't exist (parity with S3).
+   * @throws {UnsupportedError} when the blob body is null or undefined
+   */
+  async download(key: string): Promise<Readable | null> {
+    try {
+      const blockBlobClient = this.containerClient.getBlockBlobClient(key);
+      const response = await blockBlobClient.download(0, undefined, { maxRetryRequests: AZURE_DOWNLOAD_MAX_RETRIES });
+      const body = response.readableStreamBody;
+      if (!body) {
+        logApp.error('[FILE STORAGE] Cannot retrieve file from Azure, null body in response', { fileId: key });
+        throw UnsupportedError('File body is null or undefined', { fileId: key });
+      }
+      return body as Readable;
+    } catch (err: any) {
+      if (isBlobNotFound(err)) {
+        return null;
+      }
+      logApp.error('[FILE STORAGE] Cannot retrieve file from Azure', { cause: err, fileId: key });
+      throw err;
+    }
+  }
+
+  async getContent(key: string, encoding: BufferEncoding = 'utf8'): Promise<string | undefined> {
+    // Mirrors S3 getContent: throws (RestError 404, like S3 NoSuchKey) when the blob is missing.
+    const blockBlobClient = this.containerClient.getBlockBlobClient(key);
+    const response = await blockBlobClient.download(0);
+    const body = response.readableStreamBody;
+    if (!body) {
+      return undefined;
+    }
+    return streamToString(body, encoding);
+  }
+
+  /**
+   * Server-side copy. Uses a streamed download→upload (works under Managed Identity without minting a
+   * SAS on the source). Copies are infrequent (drafts/exports) so this is acceptable; a future
+   * optimization can switch to `syncCopyFromURL` + a short-lived user-delegation SAS.
+   */
+  async copy(sourceKey: string, targetKey: string): Promise<void> {
+    const sourceBlob = this.containerClient.getBlockBlobClient(sourceKey);
+    const downloadResponse = await sourceBlob.download(0, undefined, { maxRetryRequests: AZURE_DOWNLOAD_MAX_RETRIES });
+    const body = downloadResponse.readableStreamBody;
+    if (!body) {
+      throw UnsupportedError('Source file body is null or undefined', { sourceKey, targetKey });
+    }
+    const targetBlob = this.containerClient.getBlockBlobClient(targetKey);
+    await targetBlob.uploadStream(body as Readable, AZURE_UPLOAD_BLOCK_SIZE, AZURE_UPLOAD_CONCURRENCY);
+  }
+
+  async getSize(key: string): Promise<number | undefined> {
+    const blobClient = this.containerClient.getBlobClient(key);
+    const properties = await blobClient.getProperties();
+    return properties.contentLength;
+  }
+
+  async upload(key: string, body: string | Readable | Buffer): Promise<void> {
+    const blockBlobClient = this.containerClient.getBlockBlobClient(key);
+    if (typeof body === 'string' || Buffer.isBuffer(body)) {
+      const buffer = typeof body === 'string' ? Buffer.from(body) : body;
+      await blockBlobClient.uploadData(buffer);
+    } else {
+      // Readable stream — block-staging upload (auto-multipart), bounded memory.
+      await blockBlobClient.uploadStream(body, AZURE_UPLOAD_BLOCK_SIZE, AZURE_UPLOAD_CONCURRENCY);
+    }
+  }
+
+  async list(prefix: string, recursive: boolean, continuationToken?: string): Promise<StorageListResult> {
+    const byPageSettings = { continuationToken: continuationToken || undefined, maxPageSize: AZURE_LIST_PAGE_SIZE };
+    // Recursive => flat listing of every blob under the prefix.
+    // Non-recursive => single virtual folder via delimiter '/'. Only blob items are returned; blob
+    // prefixes (sub-folders) are ignored to match the S3 behavior of reading `Contents` only.
+    // Branch the byPage().next() per listing kind so each iterator keeps a concrete type.
+    const page = recursive
+      ? (await this.containerClient.listBlobsFlat({ prefix }).byPage(byPageSettings).next()).value
+      : (await this.containerClient.listBlobsByHierarchy('/', { prefix }).byPage(byPageSettings).next()).value;
+    if (!page) {
+      return { objects: [], isTruncated: false };
+    }
+    const blobItems: BlobItem[] = page.segment?.blobItems ?? [];
+    const objects = blobItems.map((blob) => toStorageObject(blob.name, blob.properties?.contentLength, blob.properties?.lastModified));
+    const nextToken = page.continuationToken;
+    return {
+      objects,
+      isTruncated: Boolean(nextToken),
+      nextContinuationToken: nextToken || undefined,
+    };
+  }
+
+  /**
+   * Connector connection config (used only by the opt-in connector direct-upload sink). Under Managed
+   * Identity there are no static keys, so credentials are returned empty and the sink cannot target
+   * the container — a future enhancement can mint a scoped User Delegation SAS here.
+   */
+  connectionConfig(): StorageConnectionConfig {
+    return {
+      endpoint: '',
+      port: 0,
+      use_ssl: true,
+      bucket_name: azureContainerName,
+      bucket_region: '',
+      access_key: '',
+      secret_key: '',
+    };
+  }
+}

--- a/opencti-platform/opencti-graphql/src/database/storage/file-storage-provider.ts
+++ b/opencti-platform/opencti-graphql/src/database/storage/file-storage-provider.ts
@@ -1,0 +1,52 @@
+import type { Readable } from 'stream';
+
+export interface StorageObject {
+  Key: string;
+  Size?: number;
+  LastModified?: Date;
+}
+
+/** Backend-agnostic listing result, replacing the S3-specific `ListObjectsV2CommandOutput`. */
+export interface StorageListResult {
+  objects: StorageObject[];
+  isTruncated: boolean;
+  nextContinuationToken?: string;
+}
+
+export interface StorageConnectionConfig {
+  endpoint: string;
+  port: number;
+  use_ssl: boolean;
+  bucket_name: string;
+  bucket_region: string;
+  access_key: string;
+  secret_key: string;
+}
+
+export interface FileStorageProvider {
+  initialize: () => Promise<void>;
+  ensureBucket: () => Promise<boolean>;
+  isAlive: () => Promise<boolean>;
+  deleteBucket: () => Promise<void>;
+  upload: (key: string, body: string | Readable | Buffer) => Promise<void>;
+  download: (key: string) => Promise<Readable | null>;
+  getContent: (key: string, encoding?: BufferEncoding) => Promise<string | undefined>;
+  getSize: (key: string) => Promise<number | undefined>;
+  copy: (sourceKey: string, targetKey: string) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+  list: (prefix: string, recursive: boolean, continuationToken?: string) => Promise<StorageListResult>;
+  connectionConfig: () => StorageConnectionConfig;
+}
+
+export const streamToString = (stream: any, encoding: BufferEncoding = 'utf8'): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    if (!stream) {
+      reject(new Error('Stream is null or undefined'));
+      return;
+    }
+    const chunks: Uint8Array[] = [];
+    stream?.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+    stream?.on('error', reject);
+    stream?.on('end', () => resolve(Buffer.concat(chunks).toString(encoding)));
+  });
+};

--- a/opencti-platform/opencti-graphql/src/database/storage/s3-file-storage-provider.ts
+++ b/opencti-platform/opencti-graphql/src/database/storage/s3-file-storage-provider.ts
@@ -1,0 +1,207 @@
+import * as s3 from '@aws-sdk/client-s3';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { Upload } from '@aws-sdk/lib-storage';
+import type { Readable } from 'stream';
+import { enrichWithRemoteCredentials } from '../../config/credentials';
+import conf, { booleanConf, logApp, logS3Debug } from '../../config/conf';
+import { UnsupportedError } from '../../config/errors';
+import { getRoleAssumerWithWebIdentity, setupAwsClient } from '../../utils/awsSdk';
+import { type FileStorageProvider, type StorageConnectionConfig, type StorageListResult, streamToString } from './file-storage-provider';
+
+// S3 / MinIO configuration. Read from the historical `minio:` block for backward compatibility.
+const clientEndpoint = conf.get('minio:endpoint');
+const clientPort = conf.get('minio:port') || 9000;
+const clientAccessKey = conf.get('minio:access_key');
+const clientSecretKey = conf.get('minio:secret_key');
+const clientSessionToken = conf.get('minio:session_token');
+const bucketName = conf.get('minio:bucket_name') || 'opencti-bucket';
+const bucketRegion = conf.get('minio:bucket_region') || 'us-east-1';
+const useSslConnection = booleanConf('minio:use_ssl', false);
+const useAwsRole = booleanConf('minio:use_aws_role', false);
+const useAwsLogs = booleanConf('minio:use_aws_logs', false);
+const disableChecksumValidation = booleanConf('minio:disable_checksum_validation', false);
+
+const buildCredentialProvider = async () => {
+  if (useAwsRole) {
+    return () => {
+      return defaultProvider({
+        roleAssumerWithWebIdentity: getRoleAssumerWithWebIdentity({
+          // You must explicitly pass a region if you are not using us-east-1
+          region: bucketRegion,
+        }),
+      });
+    };
+  }
+  const baseAuth = { accessKeyId: clientAccessKey, secretAccessKey: clientSecretKey };
+  const userPasswordAuth = await enrichWithRemoteCredentials('minio', baseAuth);
+  return () => {
+    return {
+      ...userPasswordAuth,
+      ...(clientSessionToken && { sessionToken: clientSessionToken }),
+    };
+  };
+};
+
+const getEndpoint = () => {
+  // If using AWS S3, unset the endpoint to let the library choose the best endpoint
+  if (clientEndpoint === 's3.amazonaws.com') {
+    return undefined;
+  }
+  return `${(useSslConnection ? 'https' : 'http')}://${clientEndpoint}:${clientPort}`;
+};
+
+/**
+ * S3 / MinIO implementation of the storage contract. Holds every S3-ism (endpoint special-case,
+ * forcePathStyle, bucket_region, checksum flags) so it never leaks past this module.
+ */
+export class S3FileStorageProvider implements FileStorageProvider {
+  private client!: s3.S3Client;
+
+  async initialize(): Promise<void> {
+    const s3Config: s3.S3ClientConfig = {
+      region: bucketRegion,
+      endpoint: getEndpoint(),
+      forcePathStyle: true,
+      credentialDefaultProvider: await buildCredentialProvider(),
+      tls: useSslConnection,
+      requestChecksumCalculation: disableChecksumValidation ? 'WHEN_REQUIRED' : 'WHEN_SUPPORTED',
+      responseChecksumValidation: disableChecksumValidation ? 'WHEN_REQUIRED' : 'WHEN_SUPPORTED',
+    };
+    if (useAwsLogs) {
+      s3Config.logger = logS3Debug;
+    }
+    this.client = setupAwsClient(new s3.S3Client(s3Config));
+  }
+
+  async ensureBucket(): Promise<boolean> {
+    try {
+      await this.client.send(new s3.HeadBucketCommand({ Bucket: bucketName }));
+      return true;
+    } catch (_err) {
+      // Bucket missing — create it; propagate if creation fails.
+      await this.client.send(new s3.CreateBucketCommand({ Bucket: bucketName }));
+      return true;
+    }
+  }
+
+  isAlive(): Promise<boolean> {
+    return this.ensureBucket();
+  }
+
+  async deleteBucket(): Promise<void> {
+    try {
+      await this.client.send(new s3.DeleteBucketCommand({ Bucket: bucketName }));
+    } catch (err) {
+      logApp.info('[FILE STORAGE] Bucket cannot be deleted.', { err });
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.client.send(new s3.DeleteObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+    }));
+  }
+
+  /**
+   * Download a file from S3 at given S3 key (id).
+   * @returns Readable stream of the file content, or null if file doesn't exist
+   * @throws {UnsupportedError} when file body is null or undefined
+   */
+  async download(key: string): Promise<Readable | null> {
+    try {
+      const object = await this.client.send(new s3.GetObjectCommand({
+        Bucket: bucketName,
+        Key: key,
+      }));
+      if (!object || !object.Body) {
+        logApp.error('[FILE STORAGE] Cannot retrieve file from S3, null body in response', { fileId: key });
+        throw UnsupportedError('File body is null or undefined', { fileId: key });
+      }
+      return object.Body as Readable;
+    } catch (err: any) {
+      if (err.name === 'NoSuchKey') {
+        return null;
+      }
+      logApp.error('[FILE STORAGE] Cannot retrieve file from S3', { cause: err, fileId: key });
+      throw err;
+    }
+  }
+
+  async getContent(key: string, encoding: BufferEncoding = 'utf8'): Promise<string | undefined> {
+    const object: s3.GetObjectCommandOutput = await this.client.send(new s3.GetObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+    }));
+    if (!object.Body) {
+      return undefined;
+    }
+    return streamToString(object.Body, encoding);
+  }
+
+  async copy(sourceKey: string, targetKey: string): Promise<void> {
+    const input = {
+      Bucket: bucketName,
+      CopySource: `${bucketName}/${sourceKey}`, // CopySource must start with bucket name, but not Key
+      Key: targetKey,
+    };
+    const command = new s3.CopyObjectCommand(input);
+    await this.client.send(command);
+  }
+
+  async getSize(key: string): Promise<number | undefined> {
+    const object: s3.HeadObjectCommandOutput = await this.client.send(new s3.HeadObjectCommand({
+      Bucket: bucketName,
+      Key: key,
+    }));
+    return object.ContentLength;
+  }
+
+  async upload(key: string, body: string | Readable | Buffer): Promise<void> {
+    const s3Upload = new Upload({
+      client: this.client,
+      params: {
+        Bucket: bucketName,
+        Key: key,
+        Body: body,
+      },
+    });
+    await s3Upload.done();
+  }
+
+  async list(prefix: string, recursive: boolean, continuationToken?: string): Promise<StorageListResult> {
+    const requestParams: s3.ListObjectsV2CommandInput = {
+      Bucket: bucketName,
+      Prefix: prefix,
+      Delimiter: recursive ? undefined : '/',
+    };
+    if (continuationToken) {
+      requestParams.ContinuationToken = continuationToken;
+    }
+    const response = await this.client.send(new s3.ListObjectsV2Command(requestParams));
+    const objects = (response.Contents ?? [])
+      .filter((obj): obj is s3._Object & { Key: string } => obj.Key !== undefined)
+      .map((obj) => ({ Key: obj.Key, Size: obj.Size, LastModified: obj.LastModified }));
+    return {
+      objects,
+      isTruncated: response.IsTruncated ?? false,
+      nextContinuationToken: response.NextContinuationToken,
+    };
+  }
+
+  /**
+   * Export S3 connection configuration for connectors.
+   * This allows connectors to upload bundles directly to S3 storage.
+   */
+  connectionConfig(): StorageConnectionConfig {
+    return {
+      endpoint: clientEndpoint,
+      port: clientPort,
+      use_ssl: useSslConnection,
+      bucket_name: bucketName,
+      bucket_region: bucketRegion,
+      access_key: clientAccessKey,
+      secret_key: clientSecretKey,
+    };
+  }
+}

--- a/opencti-platform/opencti-graphql/src/database/storage/storage-provider-factory.ts
+++ b/opencti-platform/opencti-graphql/src/database/storage/storage-provider-factory.ts
@@ -1,0 +1,34 @@
+import conf, { logApp } from '../../config/conf';
+import { ConfigurationError } from '../../config/errors';
+import type { FileStorageProvider } from './file-storage-provider';
+import { S3FileStorageProvider } from './s3-file-storage-provider';
+import { AzureFileStorageProvider } from './azure-file-storage-provider';
+
+export const STORAGE_PROVIDER_S3 = 's3';
+export const STORAGE_PROVIDER_AZURE = 'azure';
+
+export const createStorageProvider = (providerName?: string): FileStorageProvider => {
+  const selected = String(providerName || STORAGE_PROVIDER_S3).toLowerCase();
+  if (selected === STORAGE_PROVIDER_AZURE) {
+    logApp.info('[FILE STORAGE] Using Azure Blob Storage provider');
+    return new AzureFileStorageProvider();
+  }
+  if (selected === STORAGE_PROVIDER_S3) {
+    return new S3FileStorageProvider();
+  }
+  throw ConfigurationError(`Unsupported storage provider '${selected}', expected '${STORAGE_PROVIDER_S3}' or '${STORAGE_PROVIDER_AZURE}'`);
+};
+
+let providerInstance: FileStorageProvider | undefined;
+
+/**
+ * Resolve the configured storage provider. Defaults to `s3` (which reads the historical `minio:`
+ * config) so existing deployments are unaffected. One provider per deployment, memoized for the
+ * process lifetime.
+ */
+export const getStorageProvider = (): FileStorageProvider => {
+  if (!providerInstance) {
+    providerInstance = createStorageProvider(conf.get('storage:provider'));
+  }
+  return providerInstance;
+};

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/azure-file-storage-provider-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/azure-file-storage-provider-test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Readable } from 'stream';
+import { RestError } from '@azure/storage-blob';
+import { AzureFileStorageProvider } from '../../../src/database/storage/azure-file-storage-provider';
+
+const makePage = (names: string[], continuationToken: string) => ({
+  segment: {
+    blobItems: names.map((name) => ({ name, properties: { contentLength: name.length, lastModified: new Date('2026-01-01') } })),
+  },
+  continuationToken,
+});
+
+const injectContainer = (provider: AzureFileStorageProvider, container: unknown) => {
+  (provider as unknown as { containerClient: unknown }).containerClient = container;
+};
+
+describe('AzureFileStorageProvider', () => {
+  describe('list pagination mapping', () => {
+    it('should map a recursive (flat) page to StorageListResult and carry the continuation token', async () => {
+      const provider = new AzureFileStorageProvider();
+      injectContainer(provider, {
+        listBlobsFlat: () => ({ byPage: () => ({ next: async () => ({ value: makePage(['import/a.json', 'import/b.json'], 'TOKEN-2') }) }) }),
+      });
+      const result = await provider.list('import/', true);
+      expect(result.objects.map((o) => o.Key)).toEqual(['import/a.json', 'import/b.json']);
+      expect(result.objects[0].Size).toBe('import/a.json'.length);
+      expect(result.isTruncated).toBe(true);
+      expect(result.nextContinuationToken).toBe('TOKEN-2');
+    });
+
+    it('should map a non-recursive (hierarchy) page using delimiter "/" and report not-truncated on empty token', async () => {
+      const provider = new AzureFileStorageProvider();
+      let usedDelimiter: string | undefined;
+      injectContainer(provider, {
+        listBlobsByHierarchy: (delimiter: string) => {
+          usedDelimiter = delimiter;
+          return { byPage: () => ({ next: async () => ({ value: makePage(['export/file.json'], '') }) }) };
+        },
+      });
+      const result = await provider.list('export/', false);
+      expect(usedDelimiter).toBe('/');
+      expect(result.objects.map((o) => o.Key)).toEqual(['export/file.json']);
+      expect(result.isTruncated).toBe(false);
+      expect(result.nextContinuationToken).toBeUndefined();
+    });
+
+    it('should return an empty result when the page is undefined (iterator done)', async () => {
+      const provider = new AzureFileStorageProvider();
+      injectContainer(provider, {
+        listBlobsFlat: () => ({ byPage: () => ({ next: async () => ({ value: undefined, done: true }) }) }),
+      });
+      const result = await provider.list('import/', true);
+      expect(result.objects).toEqual([]);
+      expect(result.isTruncated).toBe(false);
+    });
+  });
+
+  describe('download not-found mapping', () => {
+    it('should return null when the blob does not exist (RestError 404, parity with S3 NoSuchKey)', async () => {
+      const provider = new AzureFileStorageProvider();
+      injectContainer(provider, {
+        getBlockBlobClient: () => ({
+          download: async () => {
+            throw new RestError('not found', { statusCode: 404 });
+          },
+        }),
+      });
+      const result = await provider.download('missing');
+      expect(result).toBeNull();
+    });
+
+    it('should return the readable stream body when the blob exists', async () => {
+      const provider = new AzureFileStorageProvider();
+      const body = Readable.from(['hello']);
+      injectContainer(provider, {
+        getBlockBlobClient: () => ({ download: async () => ({ readableStreamBody: body }) }),
+      });
+      const result = await provider.download('exists');
+      expect(result).toBe(body);
+    });
+
+    it('should rethrow non-404 errors', async () => {
+      const provider = new AzureFileStorageProvider();
+      injectContainer(provider, {
+        getBlockBlobClient: () => ({
+          download: async () => {
+            throw new RestError('server error', { statusCode: 500 });
+          },
+        }),
+      });
+      await expect(provider.download('boom')).rejects.toThrow();
+    });
+  });
+
+  describe('upload routing', () => {
+    it('should use uploadData for string/Buffer bodies and uploadStream for readable streams', async () => {
+      const provider = new AzureFileStorageProvider();
+      const uploadData = vi.fn(async () => {});
+      const uploadStream = vi.fn(async () => {});
+      injectContainer(provider, { getBlockBlobClient: () => ({ uploadData, uploadStream }) });
+      await provider.upload('k1', 'a string');
+      await provider.upload('k2', Buffer.from('buf'));
+      await provider.upload('k3', Readable.from(['stream']));
+      expect(uploadData).toHaveBeenCalledTimes(2);
+      expect(uploadStream).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/storage-provider-factory-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/storage-provider-factory-test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createStorageProvider, getStorageProvider, STORAGE_PROVIDER_AZURE, STORAGE_PROVIDER_S3 } from '../../../src/database/storage/storage-provider-factory';
+import { S3FileStorageProvider } from '../../../src/database/storage/s3-file-storage-provider';
+import { AzureFileStorageProvider } from '../../../src/database/storage/azure-file-storage-provider';
+
+describe('storage provider factory', () => {
+  it('should default to the S3 provider when no provider is configured (backward compatible)', () => {
+    expect(createStorageProvider(undefined)).toBeInstanceOf(S3FileStorageProvider);
+    expect(createStorageProvider('')).toBeInstanceOf(S3FileStorageProvider);
+    expect(createStorageProvider(STORAGE_PROVIDER_S3)).toBeInstanceOf(S3FileStorageProvider);
+  });
+
+  it('should select the Azure provider (case-insensitive)', () => {
+    expect(createStorageProvider(STORAGE_PROVIDER_AZURE)).toBeInstanceOf(AzureFileStorageProvider);
+    expect(createStorageProvider('AZURE')).toBeInstanceOf(AzureFileStorageProvider);
+  });
+
+  it('should throw on an unsupported provider', () => {
+    expect(() => createStorageProvider('gcs')).toThrowError(/Unsupported storage provider/);
+  });
+
+  it('should memoize the configured provider instance', () => {
+    // Default test config has no storage:provider => s3.
+    const first = getStorageProvider();
+    const second = getStorageProvider();
+    expect(first).toBe(second);
+    expect(first).toBeInstanceOf(S3FileStorageProvider);
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Add Azure object storage provider

### Related issues
* closes 16380

### How to test this PR

* Provision Azure Resources: In an Azure environment, create a Storage Account (v2) and a Blob container.
* Configure Identity: On the compute instance that will host the application (VM, container, etc.), activate a Managed Identity.
* Assign Permissions: Grant the Managed Identity the Storage Blob Data Operator role for the Storage Account.
* Update Environment Variables: Configure the platform with the following variables (replacing the MINIO_* configurations):
`
STORAGE__PROVIDER=azure
STORAGE__AZURE__ACCOUNT_NAME=mystorageaccount
STORAGE__AZURE__CONTAINER_NAME=opencti-bucket
`


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

This is my first PR writing in TypeScript! Any feedback, tips, or reviews on the code structure are highly appreciated.

For the connectors, CONNECTOR_SEND_TO_S3 will not work for now, it needs a dedicated PR