### PR TITLE
feat(RichTextEditor): enhance button spacing and styles in RichTextEditor (#16384)

### DIFF
--- a/opencti-platform/opencti-front/src/components/richTextEditor/TiptapEditorToolbar.tsx
+++ b/opencti-platform/opencti-front/src/components/richTextEditor/TiptapEditorToolbar.tsx
@@ -193,18 +193,25 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
     });
 
     const INTER_GROUP_GAP = 4; // gap: 0.5 = 4px between group Boxes
+    const INTRA_GROUP_GAP = 2; // gap between buttons in same group
 
     const measure = () => {
       const containerWidth = container.clientWidth;
 
-      // Total natural width: one gap per group transition, not per item
+      // Total natural width: gaps between groups + gaps between group items + item widths
       let totalNatural = 0;
       let lastGroup = -1;
       for (const id of itemIds) {
         const w = cachedWidthsRef.current[id] ?? 0;
         if (w === 0) continue;
         const gi = groupOf[id];
-        if (lastGroup !== -1 && gi !== lastGroup) totalNatural += INTER_GROUP_GAP;
+        if (lastGroup !== -1) {
+          if (gi !== lastGroup) {
+            totalNatural += INTER_GROUP_GAP;
+          } else {
+            totalNatural += INTRA_GROUP_GAP;
+          }
+        }
         totalNatural += w;
         lastGroup = gi;
       }
@@ -215,7 +222,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
         return;
       }
 
-      const MORE_BTN_WIDTH = 36;
+      const MORE_BTN_WIDTH = 40; // 36px estimated size + 4px safety buffer
       const available = containerWidth - MORE_BTN_WIDTH;
       let used = 0;
       const newHidden = new Set<string>();
@@ -225,7 +232,15 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
       for (const id of itemIds) {
         const w = cachedWidthsRef.current[id] ?? 0;
         const gi = groupOf[id];
-        const gapCost = (lastVisibleGroup !== -1 && gi !== lastVisibleGroup) ? INTER_GROUP_GAP : 0;
+
+        let gapCost = 0;
+        if (lastVisibleGroup !== -1) {
+          if (gi !== lastVisibleGroup) {
+            gapCost = INTER_GROUP_GAP;
+          } else {
+            gapCost = INTRA_GROUP_GAP;
+          }
+        }
 
         if (!overflowing && used + gapCost + w <= available) {
           used += gapCost + w;
@@ -248,6 +263,45 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
     return () => ro.disconnect();
   }, [itemIds, itemGroups]);
 
+  const toolbarItemStyles = {
+    '& .MuiToggleButtonGroup-root': {
+      border: 'none',
+      gap: '2px',
+      '& .MuiToggleButton-root': {
+        border: 'none',
+        '&:not(:first-of-type)': {
+          borderLeft: 'none',
+          marginLeft: 0,
+        },
+      },
+    },
+    '& .MuiToggleButton-root, & .MuiIconButton-root': {
+      border: 'none',
+      color: 'text.primary',
+      backgroundColor: 'transparent',
+      '&.Mui-disabled': {
+        color: 'text.disabled',
+      },
+      '&:hover': {
+        backgroundColor: 'transparent',
+      },
+      '&:hover:not(.Mui-selected)': {
+        backgroundColor: 'transparent',
+      },
+      '&.Mui-selected': {
+        backgroundColor: 'action.selected',
+        color: 'primary.main',
+        '&.Mui-disabled': {
+          backgroundColor: 'action.selected',
+          color: 'text.disabled',
+        },
+        '&:hover': {
+          backgroundColor: 'action.selected',
+        },
+      },
+    },
+  };
+
   return (
     <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
       <Box
@@ -261,6 +315,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
           p: 0.5,
           minHeight: 40,
           overflow: 'hidden',
+          ...toolbarItemStyles,
         }}
       >
         {/* heading */}
@@ -812,6 +867,7 @@ export const TiptapEditorToolbar: React.FC<TiptapEditorToolbarProps> = ({
             flexWrap: 'wrap',
             alignItems: 'center',
             gap: 0.5,
+            ...toolbarItemStyles,
           }}
         >
           {/* heading */}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Visual and behavioral improvements to the rich-text-editor toolbar to align it with the markdown editor style:

1. **Visual Overhaul of the Toolbar :**
   - Removed borders/contours from the toolbar buttons (`ToggleButton` and `IconButton`).
   - Removed hover background effects for a clean, flat aesthetic.
   - Aligned icon colors with the theme's text color (`text.primary`) so they adapt dynamically (white/light in dark mode, dark in light mode).
   - Applied CSS/MUI overrides cleanly without using the `!important` flag by increasing the specificity of local selectors.

2. **Fix for the Overflow/Resize Calculations (Dynamic Icon Hiding):**
   - Factored in the new `2px` spacing between buttons in the same group (previously ignored by the measurement script, which caused icons to get clipped by the right border before the "More" button could appear).
   - Adjusted the estimated "More" button width to `40px` (including a `4px` safety buffer) to ensure the three-dots button is never cut off.
   
**Before**:
<img width="1014" height="156" alt="Capture d’écran 2026-05-29 à 16 12 30" src="https://github.com/user-attachments/assets/e93e77e5-05d3-4f28-9642-9762355dfe66" />

**After:**
<img width="1035" height="144" alt="Capture d’écran 2026-06-04 à 10 19 52" src="https://github.com/user-attachments/assets/db0761df-fa8b-4c2b-bd42-6756b3f632dc" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* Fixes #16384 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
