### PR TITLE
[frontend] Refresh playbook AI agent picker when opening component drawer (#16389)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlow.tsx
@@ -13,8 +13,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
+import { useEffect } from 'react';
 import ReactFlow from 'reactflow';
-import { graphql, useFragment } from 'react-relay';
+import { graphql, useFragment, useRefetchableFragment } from 'react-relay';
 import PlaybookFlowAddComponents from './PlaybookFlowAddComponents';
 import PlaybookFlowDeleteNode from './PlaybookFlowDeleteNode';
 import useManipulateComponents from '../hooks/useManipulateComponents';
@@ -37,7 +38,8 @@ const playbookFragment = graphql`
 `;
 
 const playbookComponentsFragment = graphql`
-  fragment PlaybookFlow_playbookComponents on Query {
+  fragment PlaybookFlow_playbookComponents on Query
+  @refetchable(queryName: "PlaybookFlowComponentsRefetchQuery") {
     playbookComponents {
       id
       name
@@ -62,7 +64,10 @@ interface PlaybookFlowProps {
 
 const PlaybookFlow = ({ dataPlaybookComponents, dataPlaybook }: PlaybookFlowProps) => {
   const playbook = useFragment(playbookFragment, dataPlaybook);
-  const { playbookComponents } = useFragment(playbookComponentsFragment, dataPlaybookComponents);
+  const [{ playbookComponents }, refetchComponents] = useRefetchableFragment(
+    playbookComponentsFragment,
+    dataPlaybookComponents,
+  );
   const definition = JSON.parse(playbook.playbook_definition || '{}');
 
   const {
@@ -76,6 +81,21 @@ const PlaybookFlow = ({ dataPlaybookComponents, dataPlaybook }: PlaybookFlowProp
     onConfigReplace,
     deleteNode,
   } = useManipulateComponents(playbook);
+
+  // Some components (the XTM One AI agent nodes) expose a dynamic agent
+  // picker whose options are resolved live from the XTM One intent catalog
+  // when the `playbookComponents` query executes. That query is preloaded
+  // once when the playbook opens, so an agent bound to an intent afterwards
+  // would only show up after a full page reload. Refetch the component
+  // catalog whenever the add / replace / configure drawer opens so newly
+  // bound agents appear without reloading.
+  const isComponentDrawerOpen = (action === 'add' || action === 'replace' || action === 'config')
+    && (selectedNode !== null || selectedEdge !== null);
+  useEffect(() => {
+    if (isComponentDrawerOpen) {
+      refetchComponents({}, { fetchPolicy: 'store-and-network' });
+    }
+  }, [isComponentDrawerOpen, refetchComponents]);
 
   const initialNodes = computeNodes(
     definition.nodes ?? [],


### PR DESCRIPTION
### Proposed changes

* The `Transform with AI agent` / `Send to AI agent` playbook components expose an **AI agent** picker whose `oneOf` options are resolved live from the XTM One intent catalog at GraphQL `schema()` time. The backend already returns this list **fresh on every request**, but the frontend preloads the `playbookComponents` query (which carries each component's `configuration_schema`) **once** when the playbook page mounts and never refetches it — so agents bound to an intent afterwards only appeared after a full page reload / platform restart.
* Make the `PlaybookFlow_playbookComponents` fragment `@refetchable` and refetch the component catalog (`store-and-network`) whenever the add / replace / configure drawer opens, so the agent picker reflects newly bound agents without reloading.

### Related issues

* closes #16389

### How to test this PR

1. Configure XTM One (EE) and open a playbook.
2. Add a `Transform with AI agent` component and note the agents in the **AI agent** picker.
3. In XTM One, bind a new (company-managed or group-shared) agent to the `cti.stix_transformer` intent.
4. Without reloading the OpenCTI page, reopen the add/configure drawer — the new agent now appears in the picker.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The refetch is gated on the drawer `open` transition (add / replace / configure with a selection), so it only fires when a playbook author is actually about to pick a component — not on every render. `ReactFlow` is uncontrolled (`defaultNodes` / `defaultEdges`), so refreshing `playbookComponents` does not reset the canvas.