### PR TITLE
fix(frontend): form intake is_family on malware leads to error when set to false (#16141)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
@@ -237,6 +237,8 @@ const FormViewInner: FunctionComponent<FormViewInnerProps> = ({ queryRef, embedd
       mFields.forEach((field) => {
         if (field.type === 'checkbox' || field.type === 'toggle') {
           fieldsObj[field.name] = field.defaultValue !== undefined ? field.defaultValue : false;
+        } else if (field.name === 'is_family' && inits[field.name] === undefined) {
+          inits[field.name] = false;
         } else if (field.type === 'multiselect' || field.type === 'objectMarking' || field.type === 'objectLabel' || field.type === 'externalReferences' || field.type === 'files') {
           fieldsObj[field.name] = field.defaultValue || [];
         } else if (field.type === 'datetime') {
@@ -363,6 +365,9 @@ const FormViewInner: FunctionComponent<FormViewInnerProps> = ({ queryRef, embedd
             if (field.defaultValue !== undefined && field.defaultValue !== null && field.defaultValue !== '') {
               hasDefaultValues = true;
               entityValues[field.name] = field.defaultValue;
+            } else if (field.name === 'is_family') {
+              hasDefaultValues = true;
+              entityValues[field.name] = false;
             }
           });
 


### PR DESCRIPTION
### Proposed changes

* As suggested by product, I set the value to false at submit when checkbox is empty

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16141

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
Steps to create the smallest reproducible scenario:

* Set up a form intake with primairy entity = report
* add additionnal entity = malware (without adding extra fields)
* with a user that does not have bypass nor bypass mandaotyr values, go in the form intake & try to submit it without ticking the box for "is family"