### PR TITLE
fix(backend): harden RabbitMQ publisher reconnection to avoid stuck send retries (#16403)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -538,9 +538,11 @@ export const send = async (exchangeName, routingKey, message) => {
         // Channel was lost: a background reconnection is (or will be) in progress, wait for it before retrying
         logApp.info('[RABBITMQ] Waiting for connection recovery before retry...');
         await getPersistentChannel();
-      } else if (attemptNumber >= SEND_FORCE_RECONNECT_AFTER) {
+      } else if (attemptNumber % SEND_FORCE_RECONNECT_AFTER === 0) {
         // Channel still looks open but keeps rejecting: force a clean reconnection so we don't loop
-        // forever on a zombie channel. The next iteration waits for the rebuilt channel.
+        // forever on a zombie channel. Throttled to once every SEND_FORCE_RECONNECT_AFTER failures
+        // (instead of on every attempt past the threshold) to avoid churning connections and flooding
+        // the logs while a publish keeps failing. The next iteration waits for the rebuilt channel.
         logApp.warn(`[RABBITMQ] Forcing publisher reconnection after ${attemptNumber} consecutive send failures`, logMeta);
         resetPersistentConnection();
       }

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -75,6 +75,11 @@ const RECONNECT_INITIAL_DELAY = 1000; // 1 second
 const RECONNECT_MAX_DELAY = 30000; // 30 seconds max
 const RECONNECT_MULTIPLIER = 2; // Exponential backoff
 
+// Configuration for the send() retry loop
+const SEND_WARN_MAX_ATTEMPTS = 5; // Log the first failures at warn level
+const SEND_ERROR_LOG_INTERVAL = 10; // Then escalate to error every N attempts (also throttles log volume)
+const SEND_FORCE_RECONNECT_AFTER = 3; // Force a clean reconnection after this many consecutive failures on a seemingly-open channel
+
 /**
  * Create a new connection to RabbitMQ with automatic reconnection
  */
@@ -94,7 +99,21 @@ const createConnection = () => {
         logApp.error('[RABBITMQ] Persistent connection error', { cause: connError });
       });
 
+      // RabbitMQ pauses publishers when a resource alarm fires (memory/disk watermark exceeded).
+      // The connection stays open but no message is confirmed, so surface it explicitly: this is the
+      // typical cause of "queues growing while the platform stops sending" with no obvious error.
+      conn.on('blocked', (reason) => {
+        logApp.error('[RABBITMQ] Publisher connection BLOCKED by broker resource alarm, publishing is paused until the broker recovers', { reason });
+      });
+      conn.on('unblocked', () => {
+        logApp.info('[RABBITMQ] Publisher connection unblocked by broker, publishing resumed');
+      });
+
       conn.on('close', () => {
+        // Ignore close events coming from a stale connection that is no longer the active one
+        if (_persistentConnection && _persistentConnection !== conn) {
+          return;
+        }
         logApp.warn('[RABBITMQ] Persistent connection closed');
         _persistentConnection = null;
         persistentChannel = null;
@@ -126,28 +145,32 @@ const createConnection = () => {
         }
 
         channel.on('error', (chError) => {
+          // Ignore errors coming from a stale channel that is no longer the active one
+          if (persistentChannel && persistentChannel !== channel) {
+            return;
+          }
           logApp.error('[RABBITMQ] Persistent channel error', { cause: chError });
           persistentChannel = null;
           // Close the connection to trigger reconnection and avoid dangling connections
-          if (_persistentConnection) {
-            try {
-              _persistentConnection.close();
-            } catch (_e) {
-              // Ignore close errors - connection may already be closing
-            }
+          try {
+            conn.close();
+          } catch (_e) {
+            // Ignore close errors - connection may already be closing
           }
         });
 
         channel.on('close', () => {
+          // Ignore close events coming from a stale channel that is no longer the active one
+          if (persistentChannel && persistentChannel !== channel) {
+            return;
+          }
           logApp.warn('[RABBITMQ] Persistent channel closed');
           persistentChannel = null;
           // Close the connection to trigger reconnection and avoid dangling connections
-          if (_persistentConnection) {
-            try {
-              _persistentConnection.close();
-            } catch (_e) {
-              // Ignore close errors - connection may already be closing
-            }
+          try {
+            conn.close();
+          } catch (_e) {
+            // Ignore close errors - connection may already be closing
           }
         });
 
@@ -438,6 +461,26 @@ const amqpExecute = async (execute) => {
 };
 
 /**
+ * Drop the current publisher channel and tear down its connection so the next send
+ * rebuilds a clean one. Used when publishing keeps failing while the channel still
+ * looks "open" (half-open connection or lingering broker rejection), to avoid
+ * retrying forever on a zombie channel. The background reconnection (triggered by
+ * the connection 'close' handler) owns rebuilding the connection.
+ */
+const resetPersistentConnection = () => {
+  const staleConnection = _persistentConnection;
+  persistentChannel = null;
+  _persistentConnection = null;
+  if (staleConnection) {
+    try {
+      staleConnection.close();
+    } catch (_closeError) {
+      // Ignore close errors - the connection may already be closing
+    }
+  }
+};
+
+/**
  * Send a message using the persistent connection for high performance
  *
  * Guarantees:
@@ -455,14 +498,32 @@ export const send = async (exchangeName, routingKey, message) => {
 
   while (true) {
     try {
-      return await sendPersistent(exchangeName, routingKey, message);
+      const result = await sendPersistent(exchangeName, routingKey, message);
+      if (attemptNumber > 0) {
+        logApp.info(`[RABBITMQ] Send recovered after ${attemptNumber} failed attempt(s)`, { exchangeName, routingKey });
+      }
+      return result;
     } catch (err) {
-      logApp.warn(`[RABBITMQ] Send failed (attempt ${++attemptNumber}), retrying in ${retryDelay}ms`, { cause: err, exchangeName, routingKey });
+      attemptNumber += 1;
+      const errorMessage = err?.message ?? String(err);
+      const logMeta = { cause: err, exchangeName, routingKey, attempt: attemptNumber };
+      // Escalate to error after repeated failures so monitoring can alert, while throttling the
+      // log volume (a permanently failing send would otherwise flood the logs with identical warnings).
+      if (attemptNumber <= SEND_WARN_MAX_ATTEMPTS) {
+        logApp.warn(`[RABBITMQ] Send failed (attempt ${attemptNumber}), retrying in ${retryDelay}ms: ${errorMessage}`, logMeta);
+      } else if (attemptNumber % SEND_ERROR_LOG_INTERVAL === 0) {
+        logApp.error(`[RABBITMQ] Send still failing after ${attemptNumber} attempts, retrying in ${retryDelay}ms: ${errorMessage}`, logMeta);
+      }
 
-      // If channel was lost, wait for reconnection before retry
       if (!persistentChannel) {
+        // Channel was lost: a background reconnection is (or will be) in progress, wait for it before retrying
         logApp.info('[RABBITMQ] Waiting for connection recovery before retry...');
         await getPersistentChannel();
+      } else if (attemptNumber >= SEND_FORCE_RECONNECT_AFTER) {
+        // Channel still looks open but keeps rejecting: force a clean reconnection so we don't loop
+        // forever on a zombie channel. The next iteration waits for the rebuilt channel.
+        logApp.warn(`[RABBITMQ] Forcing publisher reconnection after ${attemptNumber} consecutive send failures`, logMeta);
+        resetPersistentConnection();
       }
 
       // Wait with exponential backoff before retrying

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -80,6 +80,13 @@ const SEND_WARN_MAX_ATTEMPTS = 5; // Log the first failures at warn level
 const SEND_ERROR_LOG_INTERVAL = 10; // Then escalate to error every N attempts (also throttles log volume)
 const SEND_FORCE_RECONNECT_AFTER = 3; // Force a clean reconnection after this many consecutive failures on a seemingly-open channel
 
+// A connection/channel can emit late 'error'/'close'/'blocked'/'unblocked' events after it has been
+// replaced by a fresh one (e.g. after a forced reconnection or a transient drop). Those stale events
+// must be ignored so they don't clobber the live connection state, start a competing reconnect, or
+// raise misleading resource-alarm logs on a connection that is actually healthy.
+const isStaleConnection = (conn) => _persistentConnection !== null && _persistentConnection !== conn;
+const isStaleChannel = (channel) => persistentChannel !== null && persistentChannel !== channel;
+
 /**
  * Create a new connection to RabbitMQ with automatic reconnection
  */
@@ -96,6 +103,10 @@ const createConnection = () => {
       logApp.info('[RABBITMQ] Persistent publisher connection established');
 
       conn.on('error', (connError) => {
+        // Ignore errors coming from a stale connection that is no longer the active one
+        if (isStaleConnection(conn)) {
+          return;
+        }
         logApp.error('[RABBITMQ] Persistent connection error', { cause: connError });
       });
 
@@ -103,15 +114,23 @@ const createConnection = () => {
       // The connection stays open but no message is confirmed, so surface it explicitly: this is the
       // typical cause of "queues growing while the platform stops sending" with no obvious error.
       conn.on('blocked', (reason) => {
+        // Ignore events coming from a stale connection that is no longer the active one
+        if (isStaleConnection(conn)) {
+          return;
+        }
         logApp.error('[RABBITMQ] Publisher connection BLOCKED by broker resource alarm, publishing is paused until the broker recovers', { reason });
       });
       conn.on('unblocked', () => {
+        // Ignore events coming from a stale connection that is no longer the active one
+        if (isStaleConnection(conn)) {
+          return;
+        }
         logApp.info('[RABBITMQ] Publisher connection unblocked by broker, publishing resumed');
       });
 
       conn.on('close', () => {
         // Ignore close events coming from a stale connection that is no longer the active one
-        if (_persistentConnection && _persistentConnection !== conn) {
+        if (isStaleConnection(conn)) {
           return;
         }
         logApp.warn('[RABBITMQ] Persistent connection closed');
@@ -146,7 +165,7 @@ const createConnection = () => {
 
         channel.on('error', (chError) => {
           // Ignore errors coming from a stale channel that is no longer the active one
-          if (persistentChannel && persistentChannel !== channel) {
+          if (isStaleChannel(channel)) {
             return;
           }
           logApp.error('[RABBITMQ] Persistent channel error', { cause: chError });
@@ -161,7 +180,7 @@ const createConnection = () => {
 
         channel.on('close', () => {
           // Ignore close events coming from a stale channel that is no longer the active one
-          if (persistentChannel && persistentChannel !== channel) {
+          if (isStaleChannel(channel)) {
             return;
           }
           logApp.warn('[RABBITMQ] Persistent channel closed');

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -355,7 +355,7 @@ const loadFreshPublisher = async () => {
   vi.resetModules();
   amqpFake.reset();
   const confModule = await import('../../../src/config/conf');
-  publisherLogApp = confModule.logApp as typeof publisherLogApp;
+  publisherLogApp = confModule.logApp as unknown as typeof publisherLogApp;
   const rabbitmq = await import('../../../src/database/rabbitmq');
   send = rabbitmq.send;
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -410,6 +410,22 @@ describe('rabbitmq persistent publisher: send() retry loop', () => {
     expect(infoMessages().some((m) => m.includes('Send recovered'))).toBe(true);
   });
 
+  it('should throttle forced reconnections instead of forcing on every attempt past the threshold', async () => {
+    // 7 consecutive failures on a seemingly-open channel, then success.
+    amqpFake.state.publishOutcomes = Array.from({ length: 7 }, () => new Error('nack'));
+
+    const result = await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+
+    expect(result).toBe(true);
+    const forcing = warnMessages().filter((m) => m.includes('Forcing publisher reconnection'));
+    // Throttled to once every SEND_FORCE_RECONNECT_AFTER (3) attempts -> attempts 3 and 6 only,
+    // NOT on every attempt past the threshold (which would be attempts 3, 4, 5, 6 and 7).
+    expect(forcing).toHaveLength(2);
+    expect(forcing.some((m) => m.includes('after 3 consecutive send failures'))).toBe(true);
+    expect(forcing.some((m) => m.includes('after 6 consecutive send failures'))).toBe(true);
+    expect(forcing.some((m) => m.includes('after 4 consecutive send failures'))).toBe(false);
+  });
+
   it('should wait for background recovery when the channel is lost (publish throws)', async () => {
     amqpFake.state.publishOutcomes = ['THROW'];
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -1,5 +1,85 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Controllable in-memory amqplib so the persistent-publisher tests below can
+// drive publish failures, forced reconnections and stale event handlers without
+// a real broker. Everything lives in vi.hoisted so the amqplib mock factory
+// (hoisted above the imports) and the tests share the same state.
+const amqpFake = vi.hoisted(() => {
+  type Handlers = Record<string, (...args: any[]) => void>;
+
+  const state = {
+    connections: [] as any[],
+    // Queue of publish outcomes consumed in order: null = confirmed, an Error =
+    // broker nack (confirm callback rejects), 'THROW' = synchronous publish throw.
+    publishOutcomes: [] as Array<Error | null | 'THROW'>,
+    publishCallCount: 0,
+  };
+
+  const makeChannel = () => {
+    const handlers: Handlers = {};
+    const channel: any = {
+      __handlers: handlers,
+      on: (event: string, h: (...args: any[]) => void) => {
+        handlers[event] = h;
+      },
+      once: (event: string, h: (...args: any[]) => void) => {
+        handlers[event] = h;
+      },
+      publish: (_exchange: string, _routingKey: string, _content: Buffer, _options: unknown, cb: (err?: Error | null) => void) => {
+        state.publishCallCount += 1;
+        const outcome = state.publishOutcomes.length > 0 ? state.publishOutcomes.shift() : null;
+        if (outcome === 'THROW') {
+          throw new Error('synchronous publish failure');
+        }
+        cb(outcome ?? null);
+        return true; // canContinue (no backpressure)
+      },
+      close: () => { /* no-op for channels */ },
+      emit: (event: string, ...args: any[]) => handlers[event]?.(...args),
+    };
+    return channel;
+  };
+
+  const makeConn = () => {
+    const handlers: Handlers = {};
+    const channel = makeChannel();
+    const conn: any = {
+      __handlers: handlers,
+      __channel: channel,
+      closeCount: 0,
+      on: (event: string, h: (...args: any[]) => void) => {
+        handlers[event] = h;
+      },
+      createConfirmChannel: (cb: (err: Error | null, channel: any) => void) => cb(null, channel),
+      close: () => {
+        conn.closeCount += 1;
+        // amqplib emits 'close' once the connection is torn down.
+        handlers.close?.();
+      },
+      emit: (event: string, ...args: any[]) => handlers[event]?.(...args),
+    };
+    state.connections.push(conn);
+    return conn;
+  };
+
+  const connect = (_uri: string, _opts: unknown, cb: (err: Error | null, conn: any) => void) => cb(null, makeConn());
+
+  const reset = () => {
+    state.connections = [];
+    state.publishOutcomes = [];
+    state.publishCallCount = 0;
+  };
+
+  return { state, makeConn, connect, reset };
+});
+
+vi.mock('amqplib/callback_api', () => ({
+  default: {
+    connect: amqpFake.connect,
+    credentials: { plain: () => ({}) },
+  },
+}));
+
 const mockHttpClient = {
   get: vi.fn(),
   delete: vi.fn(),
@@ -257,5 +337,184 @@ describe('rabbitmq: getConnectorQueueSize', () => {
 
     const result = await getConnectorQueueSize(context, user, 'connector-abc');
     expect(result).toBe(15);
+  });
+});
+
+// ── Persistent publisher: send() retry loop and connection event handlers ────
+
+const EXCHANGE = 'test.exchange';
+const ROUTING_KEY = 'test.routing';
+const MESSAGE = 'hello';
+
+let publisherLogApp: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn> };
+let send: (exchangeName: string, routingKey: string, message: string) => Promise<boolean>;
+
+// Re-import the (mocked) conf and the module under test against a fresh module
+// graph so rabbitmq.js internal connection state is reset between tests.
+const loadFreshPublisher = async () => {
+  vi.resetModules();
+  amqpFake.reset();
+  const confModule = await import('../../../src/config/conf');
+  publisherLogApp = confModule.logApp as typeof publisherLogApp;
+  const rabbitmq = await import('../../../src/database/rabbitmq');
+  send = rabbitmq.send;
+};
+
+const warnMessages = () => publisherLogApp.warn.mock.calls.map((c) => String(c[0]));
+const errorMessages = () => publisherLogApp.error.mock.calls.map((c) => String(c[0]));
+const infoMessages = () => publisherLogApp.info.mock.calls.map((c) => String(c[0]));
+
+describe('rabbitmq persistent publisher: send() retry loop', () => {
+  beforeEach(async () => {
+    await loadFreshPublisher();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should publish on the first attempt and not log any recovery', async () => {
+    const result = await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+
+    expect(result).toBe(true);
+    expect(amqpFake.state.publishCallCount).toBe(1);
+    expect(infoMessages().some((m) => m.includes('Send recovered'))).toBe(false);
+    expect(warnMessages().some((m) => m.includes('Send failed'))).toBe(false);
+  });
+
+  it('should retry a transient publish failure and log recovery once', async () => {
+    amqpFake.state.publishOutcomes = [new Error('transient nack')];
+
+    const result = await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+
+    expect(result).toBe(true);
+    expect(amqpFake.state.publishCallCount).toBe(2);
+    expect(warnMessages().some((m) => m.includes('Send failed (attempt 1)'))).toBe(true);
+    expect(infoMessages().some((m) => m.includes('Send recovered after 1 failed attempt(s)'))).toBe(true);
+    // A single transient failure must not force a reconnection.
+    expect(amqpFake.state.connections.every((c) => c.closeCount === 0)).toBe(true);
+  });
+
+  it('should force a clean reconnection after repeated failures on a seemingly-open channel', async () => {
+    // Channel keeps confirming-nacking while it still looks open: 3 failures then success.
+    amqpFake.state.publishOutcomes = [new Error('nack'), new Error('nack'), new Error('nack')];
+
+    const result = await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+
+    expect(result).toBe(true);
+    expect(warnMessages().some((m) => m.includes('Forcing publisher reconnection after 3 consecutive send failures'))).toBe(true);
+    // The first (zombie) connection must have been torn down by resetPersistentConnection.
+    expect(amqpFake.state.connections[0].closeCount).toBeGreaterThan(0);
+    // A fresh connection must have been rebuilt.
+    expect(amqpFake.state.connections.length).toBeGreaterThan(1);
+    expect(infoMessages().some((m) => m.includes('Send recovered'))).toBe(true);
+  });
+
+  it('should wait for background recovery when the channel is lost (publish throws)', async () => {
+    amqpFake.state.publishOutcomes = ['THROW'];
+
+    const result = await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+
+    expect(result).toBe(true);
+    expect(infoMessages().some((m) => m.includes('Waiting for connection recovery before retry'))).toBe(true);
+  });
+
+  it('should escalate to error logging once the warn threshold is exceeded', async () => {
+    // 10 consecutive failures then success: the 10th attempt hits the error interval.
+    amqpFake.state.publishOutcomes = Array.from({ length: 10 }, () => new Error('persistent nack'));
+
+    const result = await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+
+    expect(result).toBe(true);
+    expect(errorMessages().some((m) => m.includes('Send still failing after 10 attempts'))).toBe(true);
+  });
+});
+
+describe('rabbitmq persistent publisher: connection event handlers', () => {
+  beforeEach(async () => {
+    await loadFreshPublisher();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should log broker resource alarms on the active connection', async () => {
+    await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+    const activeConn = amqpFake.state.connections[0];
+    publisherLogApp.error.mockClear();
+    publisherLogApp.info.mockClear();
+
+    activeConn.emit('blocked', 'low on memory');
+    activeConn.emit('unblocked');
+    activeConn.emit('error', new Error('connection boom'));
+
+    expect(errorMessages().some((m) => m.includes('BLOCKED by broker resource alarm'))).toBe(true);
+    expect(infoMessages().some((m) => m.includes('unblocked by broker'))).toBe(true);
+    expect(errorMessages().some((m) => m.includes('Persistent connection error'))).toBe(true);
+  });
+
+  it('should ignore stale connection events after the connection has been replaced', async () => {
+    await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+    const staleConn = amqpFake.state.connections[0];
+
+    // Emitting close on the active connection triggers a background reconnect,
+    // so a fresh connection becomes the active one and staleConn becomes stale.
+    staleConn.emit('close');
+    expect(amqpFake.state.connections.length).toBeGreaterThan(1);
+
+    publisherLogApp.error.mockClear();
+    publisherLogApp.info.mockClear();
+    publisherLogApp.warn.mockClear();
+
+    // Late events from the leaked/old connection must be ignored entirely.
+    staleConn.emit('blocked', 'late alarm');
+    staleConn.emit('unblocked');
+    staleConn.emit('error', new Error('late error'));
+    staleConn.emit('close');
+
+    expect(errorMessages().some((m) => m.includes('BLOCKED by broker resource alarm'))).toBe(false);
+    expect(infoMessages().some((m) => m.includes('unblocked by broker'))).toBe(false);
+    expect(errorMessages().some((m) => m.includes('Persistent connection error'))).toBe(false);
+    expect(warnMessages().some((m) => m.includes('Persistent connection closed'))).toBe(false);
+  });
+
+  it('should tear down the connection when the active channel errors', async () => {
+    await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+    const conn = amqpFake.state.connections[0];
+
+    conn.__channel.emit('error', new Error('channel boom'));
+
+    expect(errorMessages().some((m) => m.includes('Persistent channel error'))).toBe(true);
+    expect(conn.closeCount).toBeGreaterThan(0);
+  });
+
+  it('should tear down the connection when the active channel closes', async () => {
+    await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+    const conn = amqpFake.state.connections[0];
+
+    conn.__channel.emit('close');
+
+    expect(warnMessages().some((m) => m.includes('Persistent channel closed'))).toBe(true);
+    expect(conn.closeCount).toBeGreaterThan(0);
+  });
+
+  it('should ignore stale channel error and close events after the channel has been replaced', async () => {
+    await send(EXCHANGE, ROUTING_KEY, MESSAGE);
+    const staleChannel = amqpFake.state.connections[0].__channel;
+
+    // Closing the active channel rebuilds a fresh connection/channel, so the
+    // original channel becomes stale.
+    staleChannel.emit('close');
+    expect(amqpFake.state.connections.length).toBeGreaterThan(1);
+
+    publisherLogApp.error.mockClear();
+    publisherLogApp.warn.mockClear();
+
+    staleChannel.emit('error', new Error('late channel error'));
+    staleChannel.emit('close');
+
+    expect(errorMessages().some((m) => m.includes('Persistent channel error'))).toBe(false);
+    expect(warnMessages().some((m) => m.includes('Persistent channel closed'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Proposed changes

Follow-up to #14920. Fixes #16403.

In production (7.260527.0) the persistent RabbitMQ publisher got stuck in an infinite `send()` retry loop after a transient disconnect: the logs flooded with `[RABBITMQ] Send failed (attempt N), retrying in 30000ms`, connector `listen_*` queues backed up to hundreds of thousands of messages, and the platform never recovered until the deployment was restarted. The broker itself was healthy, so the stuck state was in-process on the publisher side.

This PR hardens `opencti-graphql/src/database/rabbitmq.js`:

* **Force a clean reconnection after repeated failures.** `send()` previously only reconnected when `persistentChannel` was already `null`. If publishes kept failing while the channel still looked "open" (half-open connection / lingering broker rejection), it retried forever on the same zombie channel. We now tear down and rebuild the connection once `SEND_FORCE_RECONNECT_AFTER` consecutive failures are reached, and then only at a throttled cadence (once every `SEND_FORCE_RECONNECT_AFTER` failures) so a permanently failing publish doesn't churn connections or re-emit the reconnection log on every retry.
* **Guard stale event handlers.** Connection/channel `close`/`error`/`blocked`/`unblocked` handlers now ignore events coming from a connection/channel that is no longer the active one, so a late event from a leaked/old connection can't clobber the live connection state, start a competing reconnect, or raise a misleading resource-alarm log on a healthy connection. The shared guards are factored into `isStaleConnection`/`isStaleChannel` helpers, and channel handlers close their own `conn` (captured in closure) instead of the shared global.
* **Surface broker resource alarms.** Handle `connection.blocked` / `connection.unblocked` (emitted by amqplib when RabbitMQ hits a memory/disk watermark and pauses publishers) and log them clearly. This is the typical "queues grow while the platform stops sending, with no obvious error" situation.
* **Make the retry actionable.** Escalate the retry log to `ERROR` after a threshold (so monitoring can alert), include the underlying error message inline, throttle the volume to avoid flooding, and log once on recovery.

No behavior change on the happy path: the new identity guards are no-ops while a single connection is active, and the forced reconnection only triggers after sustained failures.

## Tests

Added focused unit tests (`tests/01-unit/database/rabbitmq-test.ts`) for the persistent publisher covering: single-attempt success (no recovery noise), transient-failure recovery logging, warn→error escalation past the threshold, forced reconnection after repeated failures on a seemingly-open channel, the throttled reconnection cadence (forced reconnection fires once every `SEND_FORCE_RECONNECT_AFTER` failures, not on every attempt past the threshold), the wait-for-recovery path when the channel is lost, and the connection/channel event handlers including the stale-event guards. The existing `metrics` / `getConnectorQueueSize` tests in the same file are preserved.

## Related issues

Fixes #16403
Follow-up to #14920

## Checklist

* [x] I have read the CONTRIBUTING document
* [x] `eslint` passes on the modified files
* [x] Unit tests added and passing for the new retry/reconnect/handler logic
* [ ] If the change touches delivery semantics, reviewer to confirm at-least-once expectations still hold (consumers are idempotent)

## Further comments

The publisher keeps at-least-once semantics (unbounded retry with exponential backoff capped at 30s). The trade-off worth discussing in review: because callers `await send()` sequentially, a permanently undeliverable message still blocks the pipeline by design — this PR ensures the connection itself can always recover, but a future improvement could add a dead-letter / give-up path so a single poison message can't stall ingestion.
