### PR TITLE
fix(frontend): hide non-clickable add buttons in single-selection widget forms (#16360)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationDataSelection.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationDataSelection.tsx
@@ -100,6 +100,11 @@ const WidgetCreationDataSelection = () => {
 
   const showRelationCountWarning = type && isWidgetUsingRelationsAggregation(type);
 
+  // A widget that only allows a single data selection should not display
+  // the "add" buttons at all, as they would be permanently disabled and
+  // never clickable (e.g. the Number widget). See issue #16360.
+  const canAddDataSelection = getCurrentDataSelectionLimit(type) > 1;
+
   return (
     <div style={{ marginTop: 20 }}>
       {
@@ -159,7 +164,7 @@ const WidgetCreationDataSelection = () => {
         })
       }
 
-      {perspective === 'entities' && (
+      {perspective === 'entities' && canAddDataSelection && (
         <div style={{ display: 'flex' }}>
           <IconButton
             disabled={getCurrentDataSelectionLimit(type) === dataSelection.length}
@@ -177,7 +182,7 @@ const WidgetCreationDataSelection = () => {
         </div>
       )}
 
-      {perspective === 'relationships' && (
+      {perspective === 'relationships' && canAddDataSelection && (
         <Stack direction="row">
           <Button
             disabled={getCurrentDataSelectionLimit(type) === dataSelection.length}
@@ -208,7 +213,7 @@ const WidgetCreationDataSelection = () => {
         </Stack>
       )}
 
-      {perspective === 'audits' && (
+      {perspective === 'audits' && canAddDataSelection && (
         <Stack direction="row">
           <Button
             disabled={


### PR DESCRIPTION
## Summary

Widgets with a data-selection limit of 1 (e.g. Number, donut, timeline) render the form pre-populated with one selection, so the `+` / `+ Entities` / `+ Relationships` add buttons in `WidgetCreationDataSelection.tsx` were always rendered as disabled and never clickable.

This PR hides those add buttons entirely when `getCurrentDataSelectionLimit(type) <= 1`, so they no longer appear as dead greyed-out controls.

Multi-selection widgets keep their add buttons and the existing disable-when-full behavior (the `disabled` prop is preserved).

Fixes #16360

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to test

1. Open a dashboard → Create widget → **Number**.
2. In the **entities** perspective, confirm the previously-disabled `+` button is no longer rendered.
3. Switch to the **knowledge / relationships** perspective and confirm the disabled `+ Entities` / `+ Relationships` buttons are no longer rendered.
4. Create a multi-selection widget (e.g. a multi-line chart) and verify its add buttons still render and enable/disable correctly when the limit is reached.
