### PR TITLE
fix(frontend): reduce excessive top padding on support package table (#16419)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/support/SupportPackages.tsx
@@ -129,6 +129,7 @@ const SupportPackages = () => {
         sx={{
           maxHeight: '600px',
           overflowY: 'auto',
+          paddingTop: 1,
         }}
         action={(
           <Tooltip title={(


### PR DESCRIPTION
## Summary

The support package table in `SupportPackages.tsx` is wrapped in the shared `Card` component, which applies `padding: theme.spacing(3)` (24px) on all sides. Combined with the toolbar and `marginTop: 10` inside `ListLines`, the gap above the table looked disproportionately heavy.

This PR overrides only the top padding on this card (24px → 8px) via the `sx` prop, which `Card` merges into its container style. The change is scoped to the support packages card; other cards and the shared `ListLines` / `Card` components are untouched.

Fixes #16419

> Note: the exact value (`paddingTop: 1` = 8px) was chosen from reading the layout code rather than reproducing the rendered view, so a small tweak may be desired once visually compared. Happy to adjust in a follow-up commit if reviewers prefer a different value.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to test

1. Go to **Settings → Support packages**.
2. Confirm the gap between the "Support packages" title and the table header is visibly tighter.
3. Confirm the table content is not clipped (`maxHeight: 600px` + `overflowY: auto` preserved).
4. Verify other settings cards on the page are unchanged.
