### PR TITLE
chore: align issue templates across repositories (#16431)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
-name: Bug report OpenCTI
+name: Bug report
 about: Create a bug report to help us improve OpenCTI
 title: 'fix: '
-labels: needs triage,bug
+labels: needs triage, bug
 assignees: ''
 type: bug
 
@@ -14,28 +14,25 @@ type: bug
 
 ## Environment
 
-1. OS (where OpenCTI server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenCTI version: { e.g. OpenCTI 1.0.2 }
-3. OpenCTI client: { e.g. frontend or python }
-4. Other environment details:
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
-## Reproducible Steps
+## Reproducible steps
 
 Steps to create the smallest reproducible scenario:
 1. { e.g. Run ... }
 2. { e.g. Click ... }
 3. { e.g. Error ... }
 
-## Expected Output
+## Expected output
 
 <!-- Please describe what you expected to happen. -->
 
-## Actual Output
+## Actual output
 
 <!-- Please describe what actually happened. -->
 
 ## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
-
-## Screenshots (optional)

--- a/.github/ISSUE_TEMPLATE/bug_report_pycti.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_pycti.yaml
@@ -1,44 +1,40 @@
----
 name: Client Python bug
-description: Report a bug in the Python client.
-title: "[BUG] <short summary>"
-type: bug
+description: Report a bug in the Python client (pycti).
+title: "fix(client-python): "
 labels:
   - needs triage
-  - client-python
   - bug
-assignees: []
+type: bug
 body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: "A clear and concise description of the bug."
+    validations:
+      required: true
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: "Describe your environment: OpenCTI version, Python version, client version, etc."
-  - type: textarea
-    id: steps-to-reproduce
-    attributes:
-      label: Reproducible Steps
-      description: "List the steps needed to reproduce the issue."
+      description: "Python version, pycti version, OpenCTI version, OS."
       placeholder: |
-        1. Do X  
-        2. Call Y  
-        3. Observe Z
+        1. Python: 3.12
+        2. pycti: 6.x
+        3. OpenCTI: 6.x
+        4. OS: Ubuntu 22.04
+    validations:
+      required: true
   - type: textarea
-    id: actual-outcome
+    id: reproduce
     attributes:
-      label: Actual Outcome
-      description: "What actually happens?"
-      placeholder: "Describe the incorrect behavior or error message."
+      label: Reproducible steps
+      description: "Smallest reproducible scenario (code snippet welcome)."
+    validations:
+      required: true
   - type: textarea
-    id: expected-outcome
+    id: expected-actual
     attributes:
-      label: Expected Outcome
-      description: "What did you expect to happen?"
-      placeholder: "Describe the expected behavior."
-  - type: textarea
-    id: media
-    attributes:
-      label: Add any file, screenshots, video
-      description: "Upload screenshots, videos, or log files."
-
----
+      label: Expected vs actual output
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/OpenCTI-Platform/opencti/security/policy
+    about: Please review our security policy and report vulnerabilities privately and responsibly.
+  - name: Filigran community Slack
+    url: https://community.filigran.io
+    about: Ask questions and chat with the Filigran community.

--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -1,16 +1,22 @@
----
 name: Documentation request
-description: Request new or improved documentation for Client Python or OpenCTI.
-title: "[DOC] <short summary>"
+description: Request new or improved documentation for OpenCTI.
+title: "docs: "
 labels:
+  - needs triage
   - documentation
-assignees: []
 body:
   - type: textarea
     id: request-details
     attributes:
-      label: Documentation Request
+      label: Documentation request
       description: "Please explain what you want to document or clarify."
       placeholder: "Describe the missing documentation, unclear section, or new topic you would like to see covered."
-
----
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: "Any links, screenshots or references that help."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
-name: Feature request OpenCTI
-about: Ask for a new feature to be implemented in OpenCTI
+name: Feature request
+about: Suggest a new feature or capability for OpenCTI
 title: 'feat: '
-labels: needs triage,feature
+labels: needs triage, feature
 assignees: ''
 type: feature
 
@@ -10,20 +10,20 @@ type: feature
 
 ## Use case
 
-<!-- Please describe the use case for which you need a solution -->
+<!-- Please describe the use case for which you need a solution. -->
 
-## Current Workaround
+## Current workaround
 
-<!-- Please describe how you currently solve or work around this problem, given OpenCTI's limitation. -->
+<!-- Please describe how you currently solve or work around this problem. -->
 
-## Proposed Solution
+## Proposed solution
 
-<!-- Please describe the solution you would like OpenCTI to provide, to solve the problem above. -->
+<!-- Please describe the solution you would like to be provided. -->
 
-## Additional Information
+## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
 
 ## If the feature request is approved, would you be willing to submit a PR?
 
-Yes / No (Help can be provided if you need assistance submitting a PR)
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/feature_request_pycti.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_pycti.yaml
@@ -1,49 +1,28 @@
----
 name: Client Python feature request
-description: Request a new feature for the Client Python (Pycti) package.
-title: "[FEATURE] <short summary>"
-type: feature
+description: Request a new feature for the Python client (pycti).
+title: "feat(client-python): "
 labels:
   - needs triage
-  - client-python
   - feature
-assignees: []
+type: feature
 body:
   - type: textarea
     id: use-case
     attributes:
-      label: Use Case
+      label: Use case
       description: "Describe the use case for which you need a solution."
-      placeholder: "Explain the scenario or need driving this feature request."
-
-  - type: textarea
-    id: current-workaround
-    attributes:
-      label: Current Workaround
-      description: "How are you currently solving or working around this limitation?"
-      placeholder: "Describe your current workaround, if any."
-
+    validations:
+      required: true
   - type: textarea
     id: proposed-solution
     attributes:
-      label: Proposed Solution
-      description: "Describe the solution you would like OpenCTI to provide."
-      placeholder: "Explain the ideal behavior or implementation."
-
+      label: Proposed solution
+      description: "Describe the solution you would like pycti to provide."
+    validations:
+      required: true
   - type: textarea
-    id: additional-information
+    id: additional
     attributes:
-      label: Additional Information
-      description: "Add any additional information, logs, screenshots, or videos. You may drag & drop files here."
-      placeholder: "Include screenshots, examples, references, etc."
-
-  - type: dropdown
-    id: willing-to-submit-pr
-    attributes:
-      label: If the feature request is approved, would you be willing to submit a PR?
-      options:
-        - "Yes"
-        - "No"
-      description: "Let us know whether you would be willing to contribute a PR. Assistance can be provided if needed."
-
----
+      label: Additional information
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Ask a question concerning OpenCTI
+about: Ask a question about OpenCTI
 title: ''
 labels: needs triage, question
 assignees: ''
@@ -9,9 +9,9 @@ assignees: ''
 
 ## Prerequisites
 
-- [ ] I read the [Deployment and Setup](https://docs.opencti.io/latest/deployment/overview) section of the OpenCTI documentation as well as the [Troubleshooting](https://docs.opencti.io/latest/deployment/troubleshooting) page and didn't find anything relevant to my problem.
-- [ ] I went through old GitHub issues and couldn't find anything relevant
-- [ ] I googled the issue and didn't find anything relevant
+- [ ] I read the documentation and didn't find anything relevant to my problem.
+- [ ] I went through old GitHub issues and couldn't find anything relevant.
+- [ ] I searched the web and didn't find anything relevant.
 
 ## Description
 
@@ -19,17 +19,9 @@ assignees: ''
 
 ## Environment
 
-1. OS (where OpenCTI server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. OpenCTI version: { e.g. OpenCTI 1.0.2 }
-3. OpenCTI client: { e.g. frontend or python }
-4. Other environment details:
-
-## Reproducible Steps
-
-Steps to create the smallest reproducible scenario:
-1. { e.g. Run ... }
-2. { e.g. Click ... }
-3. { e.g. Error ... }
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #16431