### PR TITLE
chore: document multi-issue reference convention & widen PR-title checks (#16433)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -30,9 +30,13 @@ type(scope?)!?: description (#issue)
 - `description` **starts with a lowercase letter** and has **no trailing period**.
   Preserve acronyms and proper nouns: `OpenCTI`, `OpenAEV`, `XTM One`, `OpenGRC`,
   `STIX`, `LLM`, `Docker`, `Redis`.
-- `(#issue)` is a **required reference on pull request titles** (the PR title
-  becomes the squash-merge commit, so the reference lands on `master`/`main`).
-  Issue titles omit it (the issue *is* the reference).
+- `(#issue)` is a **required reference on pull request titles**. Use a single
+  parenthesised group: one issue `(#1234)`, or several comma-separated
+  `(#1234, #1235, #1236)`. When the PR is squash-merged, GitHub **automatically
+  appends the PR number**, so the commit on `master`/`main` reads
+  `… (#1234, #1235) (#5678)` — the trailing `(#5678)` is the PR id added by GitHub,
+  never typed in the title. Issue titles omit the reference (the issue *is* the
+  reference).
 
 Enforcement is preventive and lives at the organization (enterprise) level; the
 [`FiligranHQ/filigran-ci-tools` `pr-title-check`](https://github.com/FiligranHQ/filigran-ci-tools/tree/main/actions/pr-title-check)

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@76166c63ec0b25cdbe693e5e972e83ca186313fb
         with:
-          regexp: '^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z0-9._/-]+\))?!?: .+ \(#[0-9]+\)$'
+          regexp: '^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z0-9._/-]+\))?!?: .+ \(#[0-9]+(, ?#[0-9]+)*\)$'
           flags: "gm"
           helpMessage: "Format: 'type(scope?): description (#issue)' for example 'docs: updating a doc page (#1234)'. see https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md#how-can-you-contribute"
   check-signed-commits:


### PR DESCRIPTION
## Summary

Documents the multi-issue reference convention `(#XX, #YY, #ZZ)` (GitHub appends the PR id `(#AA)` to the squash commit automatically) and widens the PR-title check regex to accept multiple comma-separated issues.

Closes #16433