### PR TITLE
chore: audit & align issue templates (#16435)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/OpenCTI-Platform/opencti/security/policy
-    about: Please review our security policy and report vulnerabilities privately and responsibly.
-  - name: Filigran community Slack
-    url: https://community.filigran.io
-    about: Ask questions and chat with the Filigran community.


### PR DESCRIPTION
## Summary

Audits and aligns the GitHub issue templates in `.github/ISSUE_TEMPLATE/` to the shared Filigran convention.

The bug report, feature request, question, documentation request, and Client Python (pycti) bug/feature templates already matched the shared convention (names, titles, labels, types) and were left unchanged.

The only divergence was `config.yml`:
- Removed the `Report a security vulnerability` contact link. This repository is **public** with **native private vulnerability reporting enabled**, so GitHub already surfaces a `Report a security vulnerability` entry in the issue chooser automatically — the manual contact link was a **duplicate**.
- Removed the legacy `Filigran community Slack` contact link.

`config.yml` now contains only `blank_issues_enabled: true`.

## Test plan
- [ ] Open the `New issue` chooser and confirm the templates (Bug report, Feature request, Question, Documentation request, Client Python bug, Client Python feature request) appear correctly.
- [ ] Confirm there is exactly **one** `Report a security vulnerability` entry (GitHub-native) and **no** Slack contact link.

Closes #16435