### PR TITLE
fix(query): use terms query for keyword to avoid too_many_clauses (#16400)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -189,7 +189,7 @@ import type {
 } from '../types/store';
 import type { BasicStoreSettings } from '../types/settings';
 import { completeSpecialFilterKeys } from '../utils/filtering/filtering-completeSpecialFilterKeys';
-import { IDS_ATTRIBUTES } from '../domain/attribute-utils';
+import { IDS_ATTRIBUTES, KEYWORD_TERMS_ATTRIBUTES } from '../domain/attribute-utils';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import type { FiltersWithNested } from './middleware-loader';
 import { pushAll, unshiftAll } from '../utils/arrayUtil';
@@ -2565,7 +2565,7 @@ export const buildLocalMustFilter = (validFilter: any) => {
     } else {
       // case where we would like to build a terms query
       const isTermsQuery = (operator === 'eq' || operator === 'not_eq') && values.length > 0 && !values.includes('EXISTS')
-        && arrayKeys.every((k) => (!k.includes('*') && (k.endsWith(ID_INTERNAL) || k.endsWith(ID_INFERRED))) || IDS_ATTRIBUTES.includes(k));
+        && arrayKeys.every((k) => (!k.includes('*') && (k.endsWith(ID_INTERNAL) || k.endsWith(ID_INFERRED))) || IDS_ATTRIBUTES.includes(k) || KEYWORD_TERMS_ATTRIBUTES.includes(k));
       if (isTermsQuery) {
         if (operator === 'eq') {
           for (let i = 0; i < arrayKeys.length; i += 1) {

--- a/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attribute-utils.ts
@@ -26,6 +26,8 @@ import {
 
 export const IDS_ATTRIBUTES = [internalId.name, standardId.name, xOpenctiStixIds.name, iAliasedIds.name];
 
+export const KEYWORD_TERMS_ATTRIBUTES = ['contact_information'];
+
 export const INTERNAL_ATTRIBUTES = [
   // ID
   id.name,

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -90,4 +90,26 @@ describe('buildLocalMustFilter testing', () => {
       },
     });
   });
+
+  it('should buildLocalMustFilter with contact_information emit a single terms clause for multiple values', () => {
+    const emails = ['user@example.com', 'user2@example.com', 'user3@example.com'];
+    const filter = {
+      key: ['contact_information'],
+      values: emails,
+      operator: 'eq',
+    };
+
+    const result = buildLocalMustFilter(filter);
+
+    expect(result).toStrictEqual({
+      bool: {
+        minimum_should_match: 1,
+        should: [
+          {
+            terms: { 'contact_information.keyword': emails },
+          },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Batch (500) individual lookup queries to stay under the search engine clause limit

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16400 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
 1. Start the platform with OpenSearch and confirm it boots normally
 2. Create 1024+ users via the GraphQL API to exceed the default clause limit (e.g script)
 3. Restart the platform and check the logs:
  -- Before this fix: the platform logs a `max_clause_count` error from OpenSearch during cache initialization
  -- After this fix: the platform boots successfully, users are resolved in batches of 500
 
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality
