### PR TITLE
fix(pdf-toolbar): correct vertical spacing around zoom buttons (#16308)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentBar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentBar.tsx
@@ -88,6 +88,8 @@ const StixCoreObjectContentBar: FunctionComponent<
             marginLeft: navOpen ? OPEN_BAR_WIDTH : SMALL_BAR_WIDTH,
             height: '100%',
             display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing(1),
           }}
         >
           {handleSave && (


### PR DESCRIPTION
### Proposed changes

* Fix vertical alignment

### Related issues

* closes #16308

### How to test this PR

Go to Content tab of a report; display a PDF, see zoom buttons in the bottom toolbar

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Missing download button is expected behavior.