### PR TITLE
fix(ingestion): creating an Artifact with file or url (#12081)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -6,6 +6,7 @@ import { graphql } from 'react-relay';
 import * as Yup from 'yup';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import MarkdownField from '../../../../components/fields/markdownField/MarkdownField';
+import TextField from '../../../../components/TextField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
@@ -39,6 +40,31 @@ const artifactMutation = graphql`
   }
 `;
 
+const artifactAddObservableMutation = graphql`
+  mutation ArtifactCreationObservableMutation(
+    $type: String!
+    $x_opencti_description: String
+    $createdBy: String
+    $objectMarking: [String]
+    $objectLabel: [String]
+    $Artifact: ArtifactAddInput
+  ) {
+    stixCyberObservableAdd(
+      type: $type
+      x_opencti_description: $x_opencti_description
+      createdBy: $createdBy
+      objectMarking: $objectMarking
+      objectLabel: $objectLabel
+      Artifact: $Artifact
+    ) {
+      id
+      ... on Artifact {
+        ...ArtifactsLine_node
+      }
+    }
+  }
+`;
+
 const artifactDescriptionPatchMutation = graphql`
   mutation ArtifactCreationDescriptionPatchMutation($id: ID!, $input: [EditInput]!) {
     stixCyberObservableEdit(id: $id) {
@@ -50,9 +76,10 @@ const artifactDescriptionPatchMutation = graphql`
 `;
 
 const artifactValidation = (t) => Yup.object().shape({
-  file: Yup.mixed().required(t('This field is required')),
+  file: Yup.mixed().nullable(),
+  url: Yup.string().url(t('The value must be an URL')).nullable(),
   x_opencti_description: Yup.string().nullable(),
-});
+}).test('file-or-url', t('A file or a URL must be provided'), (values) => !!(values.file || values.url));
 
 const ArtifactCreation = ({
   paginationOptions,
@@ -61,6 +88,11 @@ const ArtifactCreation = ({
   const [open, setOpen] = useState(false);
   const [commit] = useApiMutation(
     artifactMutation,
+    undefined,
+    { successMessage: `${t_i18n('entity_Artifact')} ${t_i18n('successfully created')}` },
+  );
+  const [commitObservable] = useApiMutation(
+    artifactAddObservableMutation,
     undefined,
     { successMessage: `${t_i18n('entity_Artifact')} ${t_i18n('successfully created')}` },
   );
@@ -84,48 +116,79 @@ const ArtifactCreation = ({
       },
       values,
     );
-    commit({
-      variables: {
-        file: values.file,
-        ...adaptedValues,
-      },
-      updater: (store) => insertNode(
-        store,
-        'Pagination_stixCyberObservables',
-        paginationOptions,
-        'artifactImport',
-      ),
-      onError: (error) => {
-        handleErrorInForm(error, setErrors);
-        setSubmitting(false);
-      },
-      onCompleted: async (response) => {
-        try {
-          const artifactId = response?.artifactImport?.id;
-          const hasPendingMarkdownImages = (markdownControllerRef.current?.getPendingImageFiles().length ?? 0) > 0;
 
-          if (artifactId && hasPendingMarkdownImages) {
-            const finalizedDescription = await markdownControllerRef.current?.persistTempImages(artifactId);
-            if (typeof finalizedDescription === 'string' && finalizedDescription !== values.x_opencti_description) {
-              await new Promise((resolve, reject) => {
-                commitDescriptionPatch({
-                  variables: {
-                    id: artifactId,
-                    input: [{ key: 'x_opencti_description', value: finalizedDescription }],
-                  },
-                  onCompleted: resolve,
-                  onError: reject,
+    if (values.file) {
+      // File provided → use artifactImport
+      commit({
+        variables: {
+          file: values.file,
+          ...adaptedValues,
+        },
+        updater: (store) => insertNode(
+          store,
+          'Pagination_stixCyberObservables',
+          paginationOptions,
+          'artifactImport',
+        ),
+        onError: (error) => {
+          handleErrorInForm(error, setErrors);
+          setSubmitting(false);
+        },
+        onCompleted: async (response) => {
+          try {
+            const artifactId = response?.artifactImport?.id;
+            const hasPendingMarkdownImages = (markdownControllerRef.current?.getPendingImageFiles().length ?? 0) > 0;
+
+            if (artifactId && hasPendingMarkdownImages) {
+              const finalizedDescription = await markdownControllerRef.current?.persistTempImages(artifactId);
+              if (typeof finalizedDescription === 'string' && finalizedDescription !== values.x_opencti_description) {
+                await new Promise((resolve, reject) => {
+                  commitDescriptionPatch({
+                    variables: {
+                      id: artifactId,
+                      input: [{ key: 'x_opencti_description', value: finalizedDescription }],
+                    },
+                    onCompleted: resolve,
+                    onError: reject,
+                  });
                 });
-              });
+              }
             }
+          } finally {
+            setSubmitting(false);
+            resetForm();
+            handleClose();
           }
-        } finally {
+        },
+      });
+    } else {
+      // No file, only URL → use stixCyberObservableAdd
+      commitObservable({
+        variables: {
+          type: 'Artifact',
+          x_opencti_description: adaptedValues.x_opencti_description || null,
+          createdBy: adaptedValues.createdBy || null,
+          objectMarking: adaptedValues.objectMarking,
+          objectLabel: adaptedValues.objectLabel,
+          Artifact: { url: values.url },
+        },
+        updater: (store) => insertNode(
+          store,
+          'Pagination_stixCyberObservables',
+          paginationOptions,
+          'stixCyberObservableAdd',
+        ),
+        onError: (error) => {
+          handleErrorInForm(error, setErrors);
+          setSubmitting(false);
+        },
+        onCompleted: () => {
           setSubmitting(false);
           resetForm();
           handleClose();
-        }
-      },
-    });
+        },
+      });
+    }
   };
 
   const onReset = () => {
@@ -147,6 +210,7 @@ const ArtifactCreation = ({
           initialValues={{
             x_opencti_description: '',
             file: '',
+            url: '',
             createdBy: '',
             objectMarking: [],
             objectLabel: [],
@@ -168,7 +232,14 @@ const ArtifactCreation = ({
                 setFieldValue={setFieldValue}
                 formikErrors={errors}
                 noMargin
-                required
+              />
+              <Field
+                component={TextField}
+                variant="standard"
+                name="url"
+                label={t_i18n('URL')}
+                fullWidth={true}
+                style={{ marginTop: 20 }}
               />
               <Field
                 component={MarkdownField}

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -79,7 +79,7 @@ const artifactValidation = (t) => Yup.object().shape({
   file: Yup.mixed().nullable(),
   url: Yup.string().url(t('The value must be an URL')).nullable(),
   x_opencti_description: Yup.string().nullable(),
-}).test('file-or-url', t('A file or a URL must be provided'), function(values) {
+}).test('file-or-url', t('A file or a URL must be provided'), (values) => {
   if (!values.file && !values.url) {
     return this.createError({ path: 'file', message: t('A file or a URL must be provided') });
   }

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -79,7 +79,7 @@ const artifactValidation = (t) => Yup.object().shape({
   file: Yup.mixed().nullable(),
   url: Yup.string().url(t('The value must be an URL')).nullable(),
   x_opencti_description: Yup.string().nullable(),
-}).test('file-or-url', t('A file or a URL must be provided'), function(values) {
+}).test('file-or-url', t('A file or a URL must be provided'), function (values) {
   if (!values.file && !values.url) {
     return this.createError({ path: 'file', message: t('A file or a URL must be provided') });
   }

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -79,7 +79,12 @@ const artifactValidation = (t) => Yup.object().shape({
   file: Yup.mixed().nullable(),
   url: Yup.string().url(t('The value must be an URL')).nullable(),
   x_opencti_description: Yup.string().nullable(),
-}).test('file-or-url', t('A file or a URL must be provided'), (values) => !!(values.file || values.url));
+}).test('file-or-url', t('A file or a URL must be provided'), function(values) {
+  if (!values.file && !values.url) {
+    return this.createError({ path: 'file', message: t('A file or a URL must be provided') });
+  }
+  return true;
+});
 
 const ArtifactCreation = ({
   paginationOptions,

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactCreation.jsx
@@ -79,7 +79,7 @@ const artifactValidation = (t) => Yup.object().shape({
   file: Yup.mixed().nullable(),
   url: Yup.string().url(t('The value must be an URL')).nullable(),
   x_opencti_description: Yup.string().nullable(),
-}).test('file-or-url', t('A file or a URL must be provided'), (values) => {
+}).test('file-or-url', t('A file or a URL must be provided'), function(values) {
   if (!values.file && !values.url) {
     return this.createError({ path: 'file', message: t('A file or a URL must be provided') });
   }

--- a/opencti-platform/opencti-front/tests_e2e/artifact/createArtifact.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/artifact/createArtifact.spec.ts
@@ -2,7 +2,7 @@ import ArtifactPage from '../model/Artifact.pageModel';
 import ArtifactImportPage from '../model/ArtifactImport.pageModel';
 import { expect, test } from '../fixtures/baseFixtures';
 
-test('Artifact error message in the absence of a file.', { tag: ['@ce'] }, async ({ page }) => {
+test('Artifact error message in the absence of a file or a URL.', { tag: ['@ce'] }, async ({ page }) => {
   const artifactPage = new ArtifactPage(page);
   const artifactImport = new ArtifactImportPage(page);
   await page.goto('/dashboard/observations/artifacts');

--- a/opencti-platform/opencti-front/tests_e2e/model/ArtifactImport.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/ArtifactImport.pageModel.ts
@@ -12,6 +12,6 @@ export default class ArtifactImportPage {
   }
 
   getErrorMessage() {
-    return this.page.getByText('This field is required');
+    return this.page.getByText('A file or a URL must be provided');
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* File is not mandatory anymore
* New field URL
* Different mutation depending on whether a file exists or not

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #12081 

### How to test this PR

#### 1) Access path
1. Go to **Observations > Artifacts**.
2. Click **Create an artifact**.
3. Keep the creation drawer open to run the cases below.

#### 2) Test cases
1. **Empty payload is rejected**
   - Action: Leave **File** empty and **URL** empty, then click **Create**.
   - Expected result: Creation is blocked with error **A file or a URL must be provided**.
   - Verification: No success toast and no new artifact in the list.

2. **Invalid URL is rejected**
   - Action: Leave **File** empty, set **URL** to `not-a-url`, click **Create**.
   - Expected result: Creation is blocked with URL validation error.
   - Verification: No success toast and no new artifact in the list.

3. **File-only creation still works**
   - Action: Upload a valid file, keep **URL** empty, fill optional metadata (Description, Created by, Labels, Markings), click **Create**.
   - Expected result: Artifact is created successfully.
   - Verification: Success toast appears and artifact is visible in list with metadata persisted.

4. **URL-only creation works (new behavior)**
   - Action: Leave **File** empty, set **URL** to a valid value (e.g. `https://example.com`), fill optional metadata, click **Create**.
   - Expected result: Artifact is created successfully.
   - Verification: Success toast appears and artifact is visible in list with URL and metadata persisted.

5. **File + URL prioritizes file flow safely**
   - Action: Provide both a valid file and a valid URL, then click **Create**.
   - Expected result: Creation succeeds without validation errors.
   - Verification: Artifact is created once (no duplicate) and behaves like a standard file import.

6. **Regression: form reset + drawer close**
   - Action: After each successful creation (file-only and URL-only), reopen **Create an artifact**.
   - Expected result: Drawer closed after submit, then reopened with a clean form.
   - Verification: File and URL fields are empty; no stale errors.
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

