### PR TITLE
fix(rabbitmq): do not reset persistent channel on publish failure (#16403)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -300,9 +300,12 @@ const publishWithConfirm = (channel, exchangeName, routingKey, message) => {
         });
       }
     } catch (err) {
-      // Channel might have been closed between getting it and publishing
-      // Reset channel and reject so caller can retry
-      persistentChannel = null;
+      // Channel might have been closed between getting it and publishing.
+      // Do not reset persistentChannel here: the channel 'error'/'close' handlers
+      // are the single source of truth that invalidate it and trigger a clean
+      // reconnection. Nulling it here (without closing the connection) races with
+      // those handlers and can leave the publisher stuck retrying on a zombie state.
+      // Just reject so the caller can retry.
       reject(err);
     }
   });


### PR DESCRIPTION
### Proposed changes

* Remove the `persistentChannel = null;` reset from the synchronous `catch` block in `publishWithConfirm` (`opencti-platform/opencti-graphql/src/database/rabbitmq.js`), as proposed by @aHenryJard.
* The channel `error`/`close` handlers are the single source of truth that invalidate `persistentChannel` and trigger a clean reconnection (they also close the underlying connection). Nulling `persistentChannel` from the publish path - without closing the connection - races with those handlers and can leave the persistent publisher stuck retrying forever on a zombie channel after a transient RabbitMQ disconnect. The caller's retry loop now simply rejects and retries, while reconnection is owned by the lifecycle handlers.

### Related issues

* closes #16403

### How to test this PR

* Publish under load (e.g. let connectors push messages) and trigger a transient RabbitMQ disruption (broker restart, network blip, or a channel-level error) while the platform is publishing.
* Before this change, the publisher could get stuck emitting `WARN [RABBITMQ] Send failed (attempt N), retrying in 30000ms` indefinitely without recovering, requiring a platform restart.
* After this change, the channel `error`/`close` handlers invalidate the channel and reconnect cleanly, and `send()` resumes once the connection recovers - no process restart required.

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

This is the minimal fix proposed by @aHenryJard on the issue, superseding the more elaborate approach in the closed PR #16404. The accompanying comment in the code was updated to document why `persistentChannel` must not be reset from the publish path.
