### PR TITLE
docs: remove discontinued commit-message-format section from copilot instructions (#16473)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,15 +103,6 @@ docker compose up -d
 2. Present a **clear, plain-language summary** of exactly what would be lost (e.g. "This will discard your unsaved changes to `src/foo.ts` and `src/bar.ts`").
 3. **Wait for explicit approval** before proceeding.
 
-## Commit Message Format
-
-**Required**: `[component] Message (#issuenumber)`
-
-Components: `backend`, `frontend`, `client-python`, `worker`, `docs`, `tools`, `CI`
-
-Example: `[backend] Fix authentication error handling (#1234)`
-
-
 <!-- filigran-conventions:start -->
 ## Commit, PR & issue conventions
 


### PR DESCRIPTION
### Proposed changes

* Remove the stale hand-written `## Commit Message Format` section from `.github/copilot-instructions.md`. It mandated the discontinued `[component] Message (#issuenumber)` format and directly contradicted the managed `filigran-conventions` block in the same file, as well as `.github/LABELS.md` and `CONTRIBUTING.md`, which require Conventional Commits (`type(scope?)!?: description (#issue)`).
* The managed `filigran-conventions` and `filigran-model-policy` blocks are left untouched - they are synced from the org tooling and are already correct. After this change they are the single source of truth for commit / PR / issue titles in the AI instructions.

### Related issues

* closes #16473

### How to test this PR

* Open `.github/copilot-instructions.md` and confirm there is no longer a `## Commit Message Format` section telling contributors to use `[component] Message (#issuenumber)`.
* Confirm the managed `filigran-conventions` block (Conventional Commits) and `filigran-model-policy` block are still present and unchanged.
* A repo-wide pass of the other instruction files (`.github/instructions/*.md`, `code-review.instructions.md`) and `CONTRIBUTING.md` found no remaining commit / PR / label convention conflicts.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The conflicting section pre-dated the convention alignment in #16424 / #16425, which appended the managed Conventional Commits block but left the old section in place. This PR removes the leftover so AI agents stop emitting `[backend] ...` style commits that fail `pr-title-check`.
