### PR TITLE
refactor(frontend): convert frontend filters before sending them to backend  (#16483)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -1,6 +1,6 @@
 import { ChipOwnProps } from '@mui/material/Chip/Chip';
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
-import { FilterSearchContext, FiltersRestrictions, GqlFilterGroup, isFilterGroupNotEmpty, removeIdFromFilterGroupObject } from '../utils/filters/filtersUtils';
+import { FilterSearchContext, FiltersRestrictions, isFilterGroupNotEmpty, sanitizeFilterGroupForBackend } from '../utils/filters/filtersUtils';
 import useQueryLoading from '../utils/hooks/useQueryLoading';
 import { DataColumns } from './list_lines';
 
@@ -66,7 +66,7 @@ const FilterIconButtonWithRepresentativesQuery: FunctionComponent<FilterIconButt
   const filtersRepresentativesQueryRef = useQueryLoading<FilterValuesContentQuery>(
     filterValuesContentQuery,
     {
-      filters: removeIdFromFilterGroupObject(filters) as unknown as GqlFilterGroup,
+      filters: sanitizeFilterGroupForBackend(filters),
       isMeValueForbidden: searchContext?.elementType === 'Playbook-Stix-Component',
     },
   );

--- a/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButton.tsx
@@ -1,6 +1,6 @@
 import { ChipOwnProps } from '@mui/material/Chip/Chip';
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
-import { FilterSearchContext, FiltersRestrictions, isFilterGroupNotEmpty, sanitizeFilterGroupForBackend } from '../utils/filters/filtersUtils';
+import { FilterSearchContext, FiltersRestrictions, isFilterGroupNotEmpty, normalizeFilterGroupForBackend } from '../utils/filters/filtersUtils';
 import useQueryLoading from '../utils/hooks/useQueryLoading';
 import { DataColumns } from './list_lines';
 
@@ -66,7 +66,7 @@ const FilterIconButtonWithRepresentativesQuery: FunctionComponent<FilterIconButt
   const filtersRepresentativesQueryRef = useQueryLoading<FilterValuesContentQuery>(
     filterValuesContentQuery,
     {
-      filters: sanitizeFilterGroupForBackend(filters),
+      filters: normalizeFilterGroupForBackend(filters),
       isMeValueForbidden: searchContext?.elementType === 'Playbook-Stix-Component',
     },
   );

--- a/opencti-platform/opencti-front/src/components/TasksFilterValueContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/TasksFilterValueContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { normalizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../utils/filters/filtersUtils';
+import { emptyFilterGroup, normalizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../utils/filters/filtersUtils';
 import { filterValuesContentQuery } from './FilterValuesContent';
 import useQueryLoading from '../utils/hooks/useQueryLoading';
 import TaskFilterValue from './TaskFilterValue';
@@ -8,7 +8,7 @@ import { FilterValuesContentQuery } from './__generated__/FilterValuesContentQue
 import { FilterGroup } from '../utils/filters/filtersHelpers-types';
 
 const TasksFilterValueContainer = ({ filters, entityTypes }: { filters: FilterGroup; entityTypes?: string[] }) => {
-  const cleanUpFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, entityTypes) as FilterGroup;
+  const cleanUpFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, entityTypes) ?? emptyFilterGroup;
   const queryRef = useQueryLoading<FilterValuesContentQuery>(
     filterValuesContentQuery,
     { filters: normalizeFilterGroupForBackend(cleanUpFilters) },

--- a/opencti-platform/opencti-front/src/components/TasksFilterValueContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/TasksFilterValueContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GqlFilterGroup, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../utils/filters/filtersUtils';
+import { sanitizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../utils/filters/filtersUtils';
 import { filterValuesContentQuery } from './FilterValuesContent';
 import useQueryLoading from '../utils/hooks/useQueryLoading';
 import TaskFilterValue from './TaskFilterValue';
@@ -11,7 +11,7 @@ const TasksFilterValueContainer = ({ filters, entityTypes }: { filters: FilterGr
   const cleanUpFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, entityTypes) as FilterGroup;
   const queryRef = useQueryLoading<FilterValuesContentQuery>(
     filterValuesContentQuery,
-    { filters: cleanUpFilters as unknown as GqlFilterGroup },
+    { filters: sanitizeFilterGroupForBackend(cleanUpFilters) },
   );
   return (
     <>

--- a/opencti-platform/opencti-front/src/components/TasksFilterValueContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/TasksFilterValueContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { sanitizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../utils/filters/filtersUtils';
 import { filterValuesContentQuery } from './FilterValuesContent';
 import useQueryLoading from '../utils/hooks/useQueryLoading';
 import TaskFilterValue from './TaskFilterValue';
@@ -11,7 +11,7 @@ const TasksFilterValueContainer = ({ filters, entityTypes }: { filters: FilterGr
   const cleanUpFilters = useRemoveIdAndIncorrectKeysFromFilterGroupObject(filters, entityTypes) as FilterGroup;
   const queryRef = useQueryLoading<FilterValuesContentQuery>(
     filterValuesContentQuery,
-    { filters: sanitizeFilterGroupForBackend(cleanUpFilters) },
+    { filters: normalizeFilterGroupForBackend(cleanUpFilters) },
   );
   return (
     <>

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.test.ts
@@ -3,7 +3,7 @@ import { formatDate } from '../../utils/Time';
 import { fromB64, toB64 } from '../../utils/String';
 import { deserializeDashboardManifestForFrontend, serializeDashboardManifestForBackend } from './dashboard-utils';
 import type { DashboardManifest, DashboardWidget } from './dashboard-types';
-import { GqlFilterGroup, sanitizeFilterGroupKeysForBackend, sanitizeFilterGroupKeysForFrontend } from '../../utils/filters/filtersUtils';
+import { GqlFilterGroup, sanitizeFilterGroupForBackend, sanitizeFilterGroupKeysForFrontend } from '../../utils/filters/filtersUtils';
 
 describe('dashboard serialization', () => {
   describe('serializeDashboardManifestForBackend', () => {
@@ -101,9 +101,9 @@ describe('dashboard serialization', () => {
             ...widget,
             dataSelection: [{
               ...widget.dataSelection[0],
-              dynamicTo: sanitizeFilterGroupKeysForBackend(widget.dataSelection[0].dynamicTo!),
-              dynamicFrom: sanitizeFilterGroupKeysForBackend(widget.dataSelection[0].dynamicFrom!),
-              filters: sanitizeFilterGroupKeysForBackend(widget.dataSelection[0].filters!),
+              dynamicTo: sanitizeFilterGroupForBackend(widget.dataSelection[0].dynamicTo!),
+              dynamicFrom: sanitizeFilterGroupForBackend(widget.dataSelection[0].dynamicFrom!),
+              filters: sanitizeFilterGroupForBackend(widget.dataSelection[0].filters!),
             }],
           },
         },

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.test.ts
@@ -3,7 +3,7 @@ import { formatDate } from '../../utils/Time';
 import { fromB64, toB64 } from '../../utils/String';
 import { deserializeDashboardManifestForFrontend, serializeDashboardManifestForBackend } from './dashboard-utils';
 import type { DashboardManifest, DashboardWidget } from './dashboard-types';
-import { GqlFilterGroup, sanitizeFilterGroupForBackend, sanitizeFilterGroupKeysForFrontend } from '../../utils/filters/filtersUtils';
+import { GqlFilterGroup, normalizeFilterGroupForBackend, normalizeFilterGroupForFrontend } from '../../utils/filters/filtersUtils';
 
 describe('dashboard serialization', () => {
   describe('serializeDashboardManifestForBackend', () => {
@@ -101,9 +101,9 @@ describe('dashboard serialization', () => {
             ...widget,
             dataSelection: [{
               ...widget.dataSelection[0],
-              dynamicTo: sanitizeFilterGroupForBackend(widget.dataSelection[0].dynamicTo!),
-              dynamicFrom: sanitizeFilterGroupForBackend(widget.dataSelection[0].dynamicFrom!),
-              filters: sanitizeFilterGroupForBackend(widget.dataSelection[0].filters!),
+              dynamicTo: normalizeFilterGroupForBackend(widget.dataSelection[0].dynamicTo!),
+              dynamicFrom: normalizeFilterGroupForBackend(widget.dataSelection[0].dynamicFrom!),
+              filters: normalizeFilterGroupForBackend(widget.dataSelection[0].filters!),
             }],
           },
         },
@@ -169,14 +169,14 @@ describe('dashboard serialization', () => {
       };
       const result = deserializeDashboardManifestForFrontend(toB64(JSON.stringify(dashboard)));
       expect(typeof result).toBe('object');
-      const sanitizedFilterGroup = sanitizeFilterGroupKeysForFrontend(filterGroup);
+      const normalizedFilterGroup = normalizeFilterGroupForFrontend(filterGroup);
       const expectedFilterGroup = {
-        ...sanitizedFilterGroup,
-        filters: sanitizedFilterGroup.filters.map((f) => ({
+        ...normalizedFilterGroup,
+        filters: normalizedFilterGroup.filters.map((f) => ({
           ...f,
           id: expect.any(String),
         })),
-        filterGroups: sanitizedFilterGroup.filterGroups.map((fg) => ({
+        filterGroups: normalizedFilterGroup.filterGroups.map((fg) => ({
           ...fg,
           filters: fg.filters.map((f) => ({ ...f, id: expect.any(String) })),
         })),

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.ts
@@ -1,6 +1,6 @@
 import type { GqlWidgetDataSelection, WidgetLayout } from '../../utils/widget/widget';
 import { fromB64, toB64 } from '../../utils/String';
-import { sanitizeFilterGroupKeysForBackend, sanitizeFilterGroupKeysForFrontend } from '../../utils/filters/filtersUtils';
+import { sanitizeFilterGroupForBackend, sanitizeFilterGroupKeysForFrontend } from '../../utils/filters/filtersUtils';
 import type { DashboardManifest, DashboardWidget } from './dashboard-types';
 
 /**
@@ -19,15 +19,9 @@ export const serializeDashboardManifestForBackend = (
       dataSelection: widget.dataSelection.map(
         (selection) => ({
           ...selection,
-          filters: selection.filters
-            ? sanitizeFilterGroupKeysForBackend(selection.filters)
-            : undefined,
-          dynamicFrom: selection.dynamicFrom
-            ? sanitizeFilterGroupKeysForBackend(selection.dynamicFrom)
-            : undefined,
-          dynamicTo: selection.dynamicTo
-            ? sanitizeFilterGroupKeysForBackend(selection.dynamicTo)
-            : undefined,
+          filters: sanitizeFilterGroupForBackend(selection.filters),
+          dynamicFrom: sanitizeFilterGroupForBackend(selection.dynamicFrom),
+          dynamicTo: sanitizeFilterGroupForBackend(selection.dynamicTo),
         }),
       ),
     };

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboard-utils.ts
@@ -1,6 +1,6 @@
 import type { GqlWidgetDataSelection, WidgetLayout } from '../../utils/widget/widget';
 import { fromB64, toB64 } from '../../utils/String';
-import { sanitizeFilterGroupForBackend, sanitizeFilterGroupKeysForFrontend } from '../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend, normalizeFilterGroupForFrontend } from '../../utils/filters/filtersUtils';
 import type { DashboardManifest, DashboardWidget } from './dashboard-types';
 
 /**
@@ -19,9 +19,9 @@ export const serializeDashboardManifestForBackend = (
       dataSelection: widget.dataSelection.map(
         (selection) => ({
           ...selection,
-          filters: sanitizeFilterGroupForBackend(selection.filters),
-          dynamicFrom: sanitizeFilterGroupForBackend(selection.dynamicFrom),
-          dynamicTo: sanitizeFilterGroupForBackend(selection.dynamicTo),
+          filters: normalizeFilterGroupForBackend(selection.filters),
+          dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+          dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
         }),
       ),
     };
@@ -61,13 +61,13 @@ export const deserializeDashboardManifestForFrontend = (
         (selection: GqlWidgetDataSelection) => ({
           ...selection,
           filters: selection.filters
-            ? sanitizeFilterGroupKeysForFrontend(selection.filters)
+            ? normalizeFilterGroupForFrontend(selection.filters)
             : undefined,
           dynamicFrom: selection.dynamicFrom
-            ? sanitizeFilterGroupKeysForFrontend(selection.dynamicFrom)
+            ? normalizeFilterGroupForFrontend(selection.dynamicFrom)
             : undefined,
           dynamicTo: selection.dynamicTo
-            ? sanitizeFilterGroupKeysForFrontend(selection.dynamicTo)
+            ? normalizeFilterGroupForFrontend(selection.dynamicTo)
             : undefined,
         }),
       ),

--- a/opencti-platform/opencti-front/src/components/filters/FilterValuesForDynamicSubKey.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValuesForDynamicSubKey.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../i18n';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../Loader';
 import { FilterValuesForDynamicSubKeyQuery } from './__generated__/FilterValuesForDynamicSubKeyQuery.graphql';
-import { sanitizeFilterGroupForBackend } from '../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend } from '../../utils/filters/filtersUtils';
 import { useTheme } from '@mui/styles';
 import { Theme } from '../../components/Theme';
 
@@ -94,7 +94,7 @@ const FilterValuesForDynamicSubKey = ({
 }: FilterValuesForDynamicSubKeyProps) => {
   const queryRef = useQueryLoading<FilterValuesForDynamicSubKeyQuery>(
     filterValuesForDynamicSubKeyQuery,
-    { filters: sanitizeFilterGroupForBackend(filterValue) },
+    { filters: normalizeFilterGroupForBackend(filterValue) },
   );
 
   return (

--- a/opencti-platform/opencti-front/src/components/filters/FilterValuesForDynamicSubKey.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValuesForDynamicSubKey.tsx
@@ -11,7 +11,7 @@ import { useFormatter } from '../i18n';
 import useQueryLoading from '../../utils/hooks/useQueryLoading';
 import Loader, { LoaderVariant } from '../Loader';
 import { FilterValuesForDynamicSubKeyQuery } from './__generated__/FilterValuesForDynamicSubKeyQuery.graphql';
-import { sanitizeFilterGroupKeysForBackend } from '../../utils/filters/filtersUtils';
+import { sanitizeFilterGroupForBackend } from '../../utils/filters/filtersUtils';
 import { useTheme } from '@mui/styles';
 import { Theme } from '../../components/Theme';
 
@@ -94,7 +94,7 @@ const FilterValuesForDynamicSubKey = ({
 }: FilterValuesForDynamicSubKeyProps) => {
   const queryRef = useQueryLoading<FilterValuesForDynamicSubKeyQuery>(
     filterValuesForDynamicSubKeyQuery,
-    { filters: sanitizeFilterGroupKeysForBackend(filterValue) },
+    { filters: sanitizeFilterGroupForBackend(filterValue) },
   );
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDistributionList.tsx
@@ -29,6 +29,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsDistributionListDistributionQuery = graphql`
   query AuditsDistributionListDistributionQuery(
@@ -205,23 +206,7 @@ const AuditsDistributionList: FunctionComponent<AuditsDistributionListProps> = (
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDistributionList.tsx
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React, { FunctionComponent, ReactNode, Suspense, useCallback } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { AuditsDistributionListDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsDistributionListDistributionQuery.graphql';
+import { AuditsDistributionListDistributionQuery } from '@components/common/audits/__generated__/AuditsDistributionListDistributionQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/defaultRepresentatives';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
@@ -28,6 +28,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsDistributionListDistributionQuery = graphql`
   query AuditsDistributionListDistributionQuery(
@@ -181,7 +182,7 @@ const AuditsDistributionList: FunctionComponent<AuditsDistributionListProps> = (
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDonut.tsx
@@ -29,6 +29,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsDonutDistributionQuery = graphql`
   query AuditsDonutDistributionQuery(
@@ -176,23 +177,7 @@ const AuditsDonut: FunctionComponent<AuditsDonutProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsDonut.tsx
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsDonutDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsDonutDistributionQuery.graphql';
+import { AuditsDonutDistributionQuery } from '@components/common/audits/__generated__/AuditsDonutDistributionQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
@@ -28,6 +28,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsDonutDistributionQuery = graphql`
   query AuditsDonutDistributionQuery(
@@ -152,7 +153,7 @@ const AuditsDonut: FunctionComponent<AuditsDonutProps> = ({
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
@@ -35,7 +35,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsHorizontalBarsDistributionQuery = graphql`
   query AuditsHorizontalBarsDistributionQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
@@ -35,6 +35,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsHorizontalBarsDistributionQuery = graphql`
   query AuditsHorizontalBarsDistributionQuery(
@@ -212,23 +213,7 @@ const AuditsHorizontalBars: FunctionComponent<AuditsHorizontalBarsProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsHorizontalBars.tsx
@@ -15,11 +15,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import ApexCharts from 'apexcharts';
 import type { ApexOptions } from 'apexcharts';
+import ApexCharts from 'apexcharts';
 import { useTheme } from '@mui/styles';
 import { useNavigate } from 'react-router-dom';
-import { AuditsHorizontalBarsDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsHorizontalBarsDistributionQuery.graphql';
+import { AuditsHorizontalBarsDistributionQuery } from '@components/common/audits/__generated__/AuditsHorizontalBarsDistributionQuery.graphql';
 import Chart from '../charts/Chart';
 import { useFormatter } from '../../../../components/i18n';
 import { horizontalBarsChartOptions } from '../../../../utils/Charts';
@@ -34,6 +34,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsHorizontalBarsDistributionQuery = graphql`
   query AuditsHorizontalBarsDistributionQuery(
@@ -188,7 +189,7 @@ const AuditsHorizontalBars: FunctionComponent<AuditsHorizontalBarsProps> = ({
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
@@ -28,7 +28,7 @@ import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsListComponentQuery = graphql`
   query AuditsListComponentQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
@@ -19,7 +19,7 @@ import { AuditsListComponentQuery, FilterGroup as GqlFilterGroup, LogsOrdering, 
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import type { FilterGroup as FilterHelpersFilterGroup } from '../../../../utils/filters/filtersHelpers-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
@@ -15,15 +15,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React, { FunctionComponent, ReactNode, Suspense, useCallback } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { AuditsListComponentQuery, FilterGroup as GqlFilterGroup, LogsOrdering, OrderingMode } from './__generated__/AuditsListComponentQuery.graphql';
+import { AuditsListComponentQuery, LogsOrdering, OrderingMode } from './__generated__/AuditsListComponentQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import type { FilterGroup as FilterHelpersFilterGroup } from '../../../../utils/filters/filtersHelpers-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import type { WidgetHost, WidgetDataSelection, WidgetParameters } from '../../../../utils/widget/widget';
+import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import WidgetListAudits from '../../../../components/dashboard/WidgetListAudits';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
@@ -133,9 +132,7 @@ const AuditsList: FunctionComponent<AuditsListProps> = ({
       first: selection.number ?? 10,
       orderBy: dateAttribute,
       orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-      filters: (filters
-        ? sanitizeFilterGroupKeysForBackend(filters as unknown as FilterHelpersFilterGroup)
-        : undefined) as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(filters),
     };
   }, [startDate, endDate]);
 

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
@@ -28,6 +28,7 @@ import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsListComponentQuery = graphql`
   query AuditsListComponentQuery(
@@ -157,21 +158,7 @@ const AuditsList: FunctionComponent<AuditsListProps> = ({
       showPreviewTag={isPreviewMode}
     >
       {(!isGrantedToSettings || !isEnterpriseEdition)
-        ? (
-            <div style={{ display: 'table', height: '100%', width: '100%' }}>
-              <span
-                style={{
-                  display: 'table-cell',
-                  verticalAlign: 'middle',
-                  textAlign: 'center',
-                }}
-              >
-                {!isEnterpriseEdition
-                  ? t_i18n('This feature is only available in OpenCTI Enterprise Edition.')
-                  : t_i18n('You are not authorized to see this data.')}
-              </span>
-            </div>
-          )
+        ? <WidgetAccessDenied />
         : isMissingHostEntity
           ? <WidgetNoHostEntity host={host} />
           : (

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsList.tsx
@@ -19,7 +19,7 @@ import { AuditsListComponentQuery, FilterGroup as GqlFilterGroup, LogsOrdering, 
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import type { FilterGroup as FilterHelpersFilterGroup } from '../../../../utils/filters/filtersHelpers-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import Loader, { LoaderVariant } from '../../../../components/Loader';

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiAreaChart.tsx
@@ -28,6 +28,7 @@ import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas'
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 import { showEstimationWarningForUniqCount, UNIQUE_COUNT_ESTIMATION_WARNING } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetMultiTimeSeries, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
@@ -193,23 +194,7 @@ const AuditsMultiAreaChart: FunctionComponent<AuditsMultiAreaChartProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiAreaChart.tsx
@@ -16,19 +16,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsMultiAreaChartTimeSeriesQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsMultiAreaChartTimeSeriesQuery.graphql';
+import { AuditsMultiAreaChartTimeSeriesQuery } from '@components/common/audits/__generated__/AuditsMultiAreaChartTimeSeriesQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend, removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import { UNIQUE_COUNT_ESTIMATION_WARNING, showEstimationWarningForUniqCount } from '../../../../utils/widget/widgetUtils';
+import { showEstimationWarningForUniqCount, UNIQUE_COUNT_ESTIMATION_WARNING } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetMultiTimeSeries, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 
@@ -158,7 +158,7 @@ const AuditsMultiAreaChart: FunctionComponent<AuditsMultiAreaChartProps> = ({
             ? selection.date_attribute
             : 'timestamp',
         types: ['History', 'Activity'],
-        filters: removeEntityTypeAllFromFilterGroup(selection.filters ?? undefined) as unknown as GqlFilterGroup,
+        filters: normalizeFilterGroupForBackend(removeEntityTypeAllFromFilterGroup(selection.filters)),
         countField: selection.attribute,
         unique: selection.unique,
       };

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
@@ -30,7 +30,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsMultiHeatMapTimeSeriesQuery = graphql`
   query AuditsMultiHeatMapTimeSeriesQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
@@ -30,6 +30,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsMultiHeatMapTimeSeriesQuery = graphql`
   query AuditsMultiHeatMapTimeSeriesQuery(
@@ -181,23 +182,7 @@ const AuditsMultiHeatMap: FunctionComponent<AuditsMultiHeatMapProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
@@ -16,12 +16,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsMultiHeatMapTimeSeriesQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsMultiHeatMapTimeSeriesQuery.graphql';
+import { AuditsMultiHeatMapTimeSeriesQuery } from '@components/common/audits/__generated__/AuditsMultiHeatMapTimeSeriesQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend, removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiHeatMap from '../../../../components/dashboard/WidgetMultiHeatMap';
@@ -151,7 +151,7 @@ const AuditsMultiHeatMap: FunctionComponent<AuditsMultiHeatMapProps> = ({
             ? selection.date_attribute
             : 'timestamp',
         types: ['History', 'Activity'],
-        filters: removeEntityTypeAllFromFilterGroup(selection.filters ?? undefined) as unknown as GqlFilterGroup,
+        filters: normalizeFilterGroupForBackend(removeEntityTypeAllFromFilterGroup(selection.filters)),
       };
     });
 

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
@@ -31,6 +31,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import { UNIQUE_COUNT_ESTIMATION_WARNING, showEstimationWarningForUniqCount } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsMultiLineChartTimeSeriesQuery = graphql`
   query AuditsMultiLineChartTimeSeriesQuery(
@@ -189,23 +190,7 @@ const AuditsMultiLineChart: FunctionComponent<AuditsMultiLineChartProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
@@ -16,12 +16,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsMultiLineChartTimeSeriesQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsMultiLineChartTimeSeriesQuery.graphql';
+import { AuditsMultiLineChartTimeSeriesQuery } from '@components/common/audits/__generated__/AuditsMultiLineChartTimeSeriesQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend, removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines';
@@ -154,7 +154,7 @@ const AuditsMultiLineChart: FunctionComponent<AuditsMultiLineChartProps> = ({
             ? selection.date_attribute
             : 'timestamp',
         types: ['History', 'Activity'],
-        filters: removeEntityTypeAllFromFilterGroup(selection.filters ?? undefined) as unknown as GqlFilterGroup,
+        filters: normalizeFilterGroupForBackend(removeEntityTypeAllFromFilterGroup(selection.filters)),
         countField: selection.attribute,
         unique: selection.unique,
       };

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
@@ -31,7 +31,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import { UNIQUE_COUNT_ESTIMATION_WARNING, showEstimationWarningForUniqCount } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsMultiLineChartTimeSeriesQuery = graphql`
   query AuditsMultiLineChartTimeSeriesQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
@@ -30,7 +30,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsMultiVerticalBarsTimeSeriesQuery = graphql`
   query AuditsMultiVerticalBarsTimeSeriesQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
@@ -30,6 +30,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsMultiVerticalBarsTimeSeriesQuery = graphql`
   query AuditsMultiVerticalBarsTimeSeriesQuery(
@@ -177,23 +178,7 @@ const AuditsMultiVerticalBars: FunctionComponent<AuditsMultiVerticalBarsProps> =
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
@@ -16,12 +16,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsMultiVerticalBarsTimeSeriesQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsMultiVerticalBarsTimeSeriesQuery.graphql';
+import { AuditsMultiVerticalBarsTimeSeriesQuery } from '@components/common/audits/__generated__/AuditsMultiVerticalBarsTimeSeriesQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
-import { removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend, removeEntityTypeAllFromFilterGroup } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetVerticalBars from '../../../../components/dashboard/WidgetVerticalBars';
@@ -144,7 +144,7 @@ const AuditsMultiVerticalBars: FunctionComponent<AuditsMultiVerticalBarsProps> =
             ? selection.date_attribute
             : 'timestamp',
         types: ['History', 'Activity'],
-        filters: removeEntityTypeAllFromFilterGroup(selection.filters ?? undefined) as unknown as GqlFilterGroup,
+        filters: normalizeFilterGroupForBackend(removeEntityTypeAllFromFilterGroup(selection.filters)),
       };
     });
 

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsNumber.tsx
@@ -13,7 +13,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
-import React, { FunctionComponent, ReactNode, Suspense, useState, useEffect, useCallback } from 'react';
+import React, { FunctionComponent, ReactNode, Suspense, useCallback, useEffect, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { AuditsNumberNumberSeriesQuery } from '@components/common/audits/__generated__/AuditsNumberNumberSeriesQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
@@ -31,7 +31,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import { UNIQUE_COUNT_ESTIMATION_THRESHOLD, UNIQUE_COUNT_ESTIMATION_WARNING } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsNumberNumberQuery = graphql`
   query AuditsNumberNumberSeriesQuery(
@@ -146,7 +146,7 @@ const AuditsNumber: FunctionComponent<AuditsNumberProps> = ({
     );
     return {
       types,
-      filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+      filters: normalizeFilterGroupForBackend(filters),
       startDate: startDate ?? undefined,
       endDate: dayAgo(),
       field: selection.attribute,

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsPolarArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsPolarArea.tsx
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import React, { CSSProperties, ReactNode, Suspense, useCallback, useState } from 'react';
 import ApexCharts from 'apexcharts';
-import { AuditsPolarAreaDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsPolarAreaDistributionQuery.graphql';
+import { AuditsPolarAreaDistributionQuery } from '@components/common/audits/__generated__/AuditsPolarAreaDistributionQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetPolarArea from '../../../../components/dashboard/WidgetPolarArea';
@@ -25,11 +25,12 @@ import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_OR
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import type { WidgetHost, WidgetDataSelection, WidgetParameters } from '../../../../utils/widget/widget';
+import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { OpenCTIChartProps } from '../charts/Chart';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsPolarAreaDistributionQuery = graphql`
   query AuditsPolarAreaDistributionQuery(
@@ -156,7 +157,7 @@ const AuditsPolarAreaQueyRef = ({
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsRadar.tsx
@@ -29,7 +29,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsRadarDistributionQuery = graphql`
   query AuditsRadarDistributionQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsRadar.tsx
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsRadarDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsRadarDistributionQuery.graphql';
+import { AuditsRadarDistributionQuery } from '@components/common/audits/__generated__/AuditsRadarDistributionQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
@@ -28,6 +28,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsRadarDistributionQuery = graphql`
   query AuditsRadarDistributionQuery(
@@ -163,7 +164,7 @@ const AuditsRadar: FunctionComponent<AuditsRadarProps> = ({
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);
@@ -195,9 +196,7 @@ const AuditsRadar: FunctionComponent<AuditsRadarProps> = ({
             }}
           >
             {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
+              ? t_i18n('This feature is only available in OpenCTI Enterprise Edition.')
               : t_i18n('You are not authorized to see this data.')}
           </span>
         </div>

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsRadar.tsx
@@ -29,6 +29,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsRadarDistributionQuery = graphql`
   query AuditsRadarDistributionQuery(
@@ -186,21 +187,7 @@ const AuditsRadar: FunctionComponent<AuditsRadarProps> = ({
       return <WidgetNoHostEntity host={host} />;
     }
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n('This feature is only available in OpenCTI Enterprise Edition.')
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
     if (!queryRef) {
       return <Loader variant={LoaderVariant.inElement} />;

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
@@ -29,7 +29,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsTreeMapDistributionQuery = graphql`
   query AuditsTreeMapDistributionQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
@@ -29,6 +29,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsTreeMapDistributionQuery = graphql`
   query AuditsTreeMapDistributionQuery(
@@ -206,21 +207,7 @@ const AuditsTreeMap: FunctionComponent<AuditsTreeMapProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n('This feature is only available in OpenCTI Enterprise Edition.')
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsTreeMap.tsx
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import { AuditsTreeMapDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsTreeMapDistributionQuery.graphql';
+import { AuditsTreeMapDistributionQuery } from '@components/common/audits/__generated__/AuditsTreeMapDistributionQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
@@ -28,6 +28,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsTreeMapDistributionQuery = graphql`
   query AuditsTreeMapDistributionQuery(
@@ -181,7 +182,7 @@ const AuditsTreeMap: FunctionComponent<AuditsTreeMapProps> = ({
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);
@@ -215,9 +216,7 @@ const AuditsTreeMap: FunctionComponent<AuditsTreeMapProps> = ({
             }}
           >
             {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
+              ? t_i18n('This feature is only available in OpenCTI Enterprise Edition.')
               : t_i18n('You are not authorized to see this data.')}
           </span>
         </div>

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsWordCloud.tsx
@@ -28,7 +28,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
+import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
 
 const auditsWordCloudDistributionQuery = graphql`
   query AuditsWordCloudDistributionQuery(

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsWordCloud.tsx
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import React, { CSSProperties, FunctionComponent, ReactNode, Suspense, useCallback } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { AuditsWordCloudDistributionQuery, FilterGroup as GqlFilterGroup } from '@components/common/audits/__generated__/AuditsWordCloudDistributionQuery.graphql';
+import { AuditsWordCloudDistributionQuery } from '@components/common/audits/__generated__/AuditsWordCloudDistributionQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SECURITYACTIVITY, SETTINGS_SETACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../../../../utils/hooks/useGranted';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
@@ -27,6 +27,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const auditsWordCloudDistributionQuery = graphql`
   query AuditsWordCloudDistributionQuery(
@@ -151,7 +152,7 @@ const AuditsWordCloud: FunctionComponent<AuditsWordCloudProps> = ({
         selection.date_attribute && selection.date_attribute.length > 0
           ? selection.date_attribute
           : 'timestamp',
-      filters: selection.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(selection.filters),
       limit: selection.number ?? 10,
     };
   }, [startDate, endDate]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsWordCloud.tsx
@@ -28,6 +28,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import WidgetAccessDenied from "../../../../components/dashboard/WidgetAccessDenied";
 
 const auditsWordCloudDistributionQuery = graphql`
   query AuditsWordCloudDistributionQuery(
@@ -175,23 +176,7 @@ const AuditsWordCloud: FunctionComponent<AuditsWordCloudProps> = ({
     }
 
     if (!isGrantedToSettings || !isEnterpriseEdition) {
-      return (
-        <div style={{ display: 'table', height: '100%', width: '100%' }}>
-          <span
-            style={{
-              display: 'table-cell',
-              verticalAlign: 'middle',
-              textAlign: 'center',
-            }}
-          >
-            {!isEnterpriseEdition
-              ? t_i18n(
-                  'This feature is only available in OpenCTI Enterprise Edition.',
-                )
-              : t_i18n('You are not authorized to see this data.')}
-          </span>
-        </div>
-      );
+      return <WidgetAccessDenied />;
     }
 
     if (!queryRef) {

--- a/opencti-platform/opencti-front/src/private/components/common/form/ArtifactField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ArtifactField.tsx
@@ -3,7 +3,7 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ReferenceField from './ReferenceField';
 import { ArtifactFieldGetQuery } from './__generated__/ArtifactFieldGetQuery.graphql';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import { FieldOption } from '../../../../utils/field';
 
 interface ArtifactFieldProps {
@@ -79,7 +79,7 @@ const ArtifactField: FunctionComponent<ArtifactFieldProps> = ({
     filterGroups: [],
   };
   const queryRef = useQueryLoading<ArtifactFieldGetQuery>(artifactQuery, {
-    filters: sanitizeFilterGroupForBackend(filters),
+    filters: normalizeFilterGroupForBackend(filters),
   });
   return (
     <>

--- a/opencti-platform/opencti-front/src/private/components/common/form/ArtifactField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ArtifactField.tsx
@@ -79,7 +79,7 @@ const ArtifactField: FunctionComponent<ArtifactFieldProps> = ({
     filterGroups: [],
   };
   const queryRef = useQueryLoading<ArtifactFieldGetQuery>(artifactQuery, {
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: sanitizeFilterGroupForBackend(filters),
   });
   return (
     <>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDistributionList.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDistributionList from '../../../../components/dashboard/WidgetDistributionList';
@@ -163,7 +163,7 @@ const buildQueryVariables = (resolvedDataSelection: WidgetDataSelection[], confi
     startDate: config?.startDate,
     endDate: config?.endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDonut.tsx
@@ -11,7 +11,7 @@ import { StixCoreObjectsDonutDistributionQuery } from './__generated__/StixCoreO
 import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const stixCoreObjectsDonutDistributionQuery = graphql`
   query StixCoreObjectsDonutDistributionQuery(
@@ -153,7 +153,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsHorizontalBars.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetHorizontalBars from '../../../../components/dashboard/WidgetHorizontalBars';
@@ -174,7 +174,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense, useRef } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { getDefaultWidgetColumns } from '../../widgets/WidgetListsDefaultColumns';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetListCoreObjects from '../../../../components/dashboard/WidgetListCoreObjects';
@@ -425,7 +425,7 @@ interface StixCoreObjectsListComponentProps {
   queryRef: PreloadedQuery<StixCoreObjectsListQuery>;
   dataSelection: Widget['dataSelection'];
   widgetId: string;
-};
+}
 
 const StixCoreObjectsListComponent = ({
   dataSelection,
@@ -484,7 +484,7 @@ const buildQueryVariables = (resolvedDataSelection: WidgetDataSelection[], confi
     first,
     orderBy,
     orderMode,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas';
@@ -115,7 +115,7 @@ const buildQueryVariables = (
     return {
       field: dateAttribute,
       types: DATA_SELECTION_TYPES,
-      filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+      filters: normalizeFilterGroupForBackend(filters),
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
@@ -13,7 +13,7 @@ import { computeStartEndDates } from '../../../../components/dashboard/dashboard
 import { monthsAgo, now } from '../../../../utils/Time';
 import ApexCharts from 'apexcharts';
 import { StixCoreObjectsMultiHeatMapTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiHeatMapTimeSeriesQuery.graphql';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const stixCoreObjectsMultiHeatMapTimeSeriesQuery = graphql`
   query StixCoreObjectsMultiHeatMapTimeSeriesQuery(
@@ -112,7 +112,7 @@ const buildQueryVariables = (
     return {
       field: dateAttribute,
       types: DATA_SELECTION_TYPES,
-      filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+      filters: normalizeFilterGroupForBackend(filters),
     };
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.tsx
@@ -7,7 +7,7 @@ import { horizontalBarsChartOptions } from '../../../../utils/Charts';
 import { simpleNumberFormat } from '../../../../utils/Number';
 import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/defaultRepresentatives';
 import { itemColor } from '../../../../utils/Colors';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
@@ -525,7 +525,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
     subDistributionField: subSelection?.attribute ?? 'entity_type',
     subDistributionOperation: 'count',
@@ -533,9 +533,7 @@ const buildQueryVariables = (
     subDistributionEndDate: endDate,
     subDistributionDateAttribute: subDateAttribute,
     subDistributionTypes: DATA_SELECTION_TYPES,
-    subDistributionFilters: subFilters
-      ? sanitizeFilterGroupKeysForBackend(subFilters)
-      : undefined,
+    subDistributionFilters: normalizeFilterGroupForBackend(subFilters),
     subDistributionLimit: subSelection?.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines';
@@ -112,7 +112,7 @@ const buildQueryVariables = (
     return {
       field: dateAttribute,
       types: DATA_SELECTION_TYPES,
-      filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+      filters: normalizeFilterGroupForBackend(filters),
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetVerticalBars from '../../../../components/dashboard/WidgetVerticalBars';
@@ -114,7 +114,7 @@ const buildQueryVariables = (
     return {
       field: dateAttribute,
       types: DATA_SELECTION_TYPES,
-      filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+      filters: normalizeFilterGroupForBackend(filters),
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsNumber.tsx
@@ -1,7 +1,7 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -98,7 +98,7 @@ const buildQueryVariables = (
   return {
     types: DATA_SELECTION_TYPES,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     startDate,
     endDate: dayAgo(),
   };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsPolarArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsPolarArea.tsx
@@ -13,7 +13,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const stixCoreObjectsPolarAreaDistributionQuery = graphql`
   query StixCoreObjectsPolarAreaDistributionQuery(
@@ -147,7 +147,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsRadar.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetRadar from '../../../../components/dashboard/WidgetRadar';
@@ -156,7 +156,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTimeline.tsx
@@ -1,14 +1,14 @@
 import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { StixCoreObjectsTimelineQuery, OrderingMode, StixCoreObjectsOrdering } from './__generated__/StixCoreObjectsTimelineQuery.graphql';
+import { OrderingMode, StixCoreObjectsOrdering, StixCoreObjectsTimelineQuery } from './__generated__/StixCoreObjectsTimelineQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetTimeline from '../../../../components/dashboard/WidgetTimeline';
 import { resolveLink } from '../../../../utils/Entity';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
-import type { WidgetHost, WidgetDataSelection, WidgetParameters } from '../../../../utils/widget/widget';
+import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
@@ -134,7 +134,7 @@ const buildQueryVariables = (
     first: selection.number ?? 10,
     orderBy: dateAttribute as StixCoreObjectsOrdering,
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetTree from '../../../../components/dashboard/WidgetTree';
@@ -134,7 +134,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsWordCloud.tsx
@@ -11,7 +11,7 @@ import { StixCoreObjectsWordCloudDistributionQuery } from '@components/common/st
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 
 const stixCoreObjectsWordCloudDistributionQuery = graphql`
   query StixCoreObjectsWordCloudDistributionQuery(
@@ -143,7 +143,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
@@ -31,7 +31,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ListLines from '../../../../components/list_lines/ListLines';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
-import { emptyFilterGroup, removeIdFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, sanitizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 import Drawer from '../drawer/Drawer';
 
@@ -486,7 +486,7 @@ const StixNestedRefRelationshipCreationFromEntity = ({
   const renderSelectEntity = () => {
     const searchPaginationOptions = {
       search: searchTerm,
-      filters: removeIdFromFilterGroupObject(filters),
+      filters: sanitizeFilterGroupForBackend(filters),
       orderBy: sortBy,
       orderMode: orderAsc ? 'asc' : 'desc',
       types: targetStixCoreObjectTypes,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreationFromEntity.jsx
@@ -31,7 +31,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import ListLines from '../../../../components/list_lines/ListLines';
 import useFiltersState from '../../../../utils/filters/useFiltersState';
-import { emptyFilterGroup, sanitizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import useEntityToggle from '../../../../utils/hooks/useEntityToggle';
 import Drawer from '../drawer/Drawer';
 
@@ -486,7 +486,7 @@ const StixNestedRefRelationshipCreationFromEntity = ({
   const renderSelectEntity = () => {
     const searchPaginationOptions = {
       search: searchTerm,
-      filters: sanitizeFilterGroupForBackend(filters),
+      filters: normalizeFilterGroupForBackend(filters),
       orderBy: sortBy,
       orderMode: orderAsc ? 'asc' : 'desc',
       types: targetStixCoreObjectTypes,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDistributionList.tsx
@@ -3,7 +3,7 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/defaultRepresentatives';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetDistributionList from '../../../../components/dashboard/WidgetDistributionList';
@@ -170,7 +170,7 @@ const buildQueryVariables = (
     dateAttribute,
     limit: selection.number ?? 10,
     isTo: selection.isTo ?? undefined,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     dynamicFrom: selection.dynamicFrom
       ? (selection.dynamicFrom as unknown as StixRelationshipsDistributionListDistributionQuery['variables']['dynamicFrom'])
       : null,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDistributionList.tsx
@@ -171,12 +171,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     isTo: selection.isTo ?? undefined,
     filters: normalizeFilterGroupForBackend(filters),
-    dynamicFrom: selection.dynamicFrom
-      ? (selection.dynamicFrom as unknown as StixRelationshipsDistributionListDistributionQuery['variables']['dynamicFrom'])
-      : null,
-    dynamicTo: selection.dynamicTo
-      ? (selection.dynamicTo as unknown as StixRelationshipsDistributionListDistributionQuery['variables']['dynamicTo'])
-      : null,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDonut.tsx
@@ -149,17 +149,14 @@ const buildQueryVariables = (
     { startDate, endDate, dateAttribute, isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsDonutDistributionQuery['variables']['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDonut.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDonut from '../../../../components/dashboard/WidgetDonut';
@@ -156,7 +156,7 @@ const buildQueryVariables = (
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.tsx
@@ -1,6 +1,6 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetHorizontalBars from '../../../../components/dashboard/WidgetHorizontalBars';
@@ -171,7 +171,7 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.tsx
@@ -161,9 +161,6 @@ const buildQueryVariables = (
     { isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsHorizontalBarsDistributionQuery['variables']['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -173,8 +170,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.tsx
@@ -2,21 +2,17 @@ import React, { ReactNode, Suspense, useRef } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { getDefaultWidgetColumns } from '../../widgets/WidgetListsDefaultColumns';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetListRelationships from '../../../../components/dashboard/WidgetListRelationships';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import type {
-  FilterGroup as GQLFilterGroup,
-  StixRelationshipsListQuery,
-  StixRelationshipsOrdering,
-} from '@components/common/stix_relationships/__generated__/StixRelationshipsListQuery.graphql';
+import type { StixRelationshipsListQuery, StixRelationshipsOrdering } from '@components/common/stix_relationships/__generated__/StixRelationshipsListQuery.graphql';
+import { OrderingMode } from '@components/common/stix_relationships/__generated__/StixRelationshipsListQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { OrderingMode } from '@components/common/stix_relationships/__generated__/StixRelationshipsListQuery.graphql';
 
 export const stixRelationshipsListQuery = graphql`
   query StixRelationshipsListQuery(
@@ -4531,17 +4527,9 @@ const buildQueryVariables = (
     first: selection.number ?? 50,
     orderBy: (dateAttribute as StixRelationshipsOrdering),
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-    filters: filters
-      ? (filters as unknown as GQLFilterGroup)
-      : undefined,
-
-    dynamicFrom: selection.dynamicFrom
-      ? (selection.dynamicFrom as unknown as GQLFilterGroup)
-      : undefined,
-
-    dynamicTo: selection.dynamicTo
-      ? (selection.dynamicTo as unknown as GQLFilterGroup)
-      : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMap.tsx
@@ -163,9 +163,6 @@ const buildQueryVariables = (
     { isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsMapStixRelationshipsDistributionQuery['variables']['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -175,8 +172,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMap.tsx
@@ -3,7 +3,7 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import LocationMiniMapTargets from '../location/LocationMiniMapTargets';
 import { computeLevel } from '../../../../utils/Number';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -173,7 +173,7 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.tsx
@@ -1,7 +1,7 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas';
@@ -96,11 +96,11 @@ const buildQueryVariables = (
   const fallbackEnd = now();
   const startDate = config.startDate ?? fallbackStart;
   const endDate = config.endDate ?? fallbackEnd;
-  type TimeSeriesParam = NonNullable<NonNullable<StixRelationshipsMultiAreaChartTimeSeriesQuery['variables']['timeSeriesParameters']>[number]>;
 
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
+    const dateAttribute = selection.date_attribute?.length
+      ? selection.date_attribute
+      : 'created_at';
     const { filters } = buildFiltersAndOptionsForWidgets(
       selection.filters,
       { startDate, endDate, isKnowledgeRelationshipWidget: true },
@@ -108,9 +108,9 @@ const buildQueryVariables = (
 
     return {
       field: dateAttribute,
-      filters: filters as unknown as TimeSeriesParam['filters'],
-      dynamicFrom: selection.dynamicFrom as unknown as TimeSeriesParam['dynamicFrom'],
-      dynamicTo: selection.dynamicTo as unknown as TimeSeriesParam['dynamicTo'],
+      filters: normalizeFilterGroupForBackend(filters),
+      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
@@ -108,13 +108,12 @@ const buildQueryVariables = (
       selection.filters,
       { isKnowledgeRelationshipWidget: true },
     );
-    type QueryFilterGroup = NonNullable<NonNullable<StixRelationshipsMultiHeatMapTimeSeriesQuery['variables']['timeSeriesParameters']>[number]>['dynamicFrom'];
 
     return {
       field: dateAttribute,
       filters: normalizeFilterGroupForBackend(filters),
-      dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-      dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiHeatMap from '../../../../components/dashboard/WidgetMultiHeatMap';
@@ -112,7 +112,7 @@ const buildQueryVariables = (
 
     return {
       field: dateAttribute,
-      filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+      filters: normalizeFilterGroupForBackend(filters),
       dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
       dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
     };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.tsx
@@ -1,10 +1,10 @@
 import React, { CSSProperties, FunctionComponent, Suspense, useEffect, useRef, useState, useTransition } from 'react';
-import { graphql, usePreloadedQuery } from 'react-relay';
 import type { PreloadedQuery } from 'react-relay';
+import { graphql, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
-import type { WidgetHost, WidgetDataSelection, WidgetParameters } from '../../../../../utils/widget/widget';
+import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../../utils/widget/widget';
 import { useFormatter } from '../../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, GqlFilterGroup } from '../../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../../utils/filters/filtersUtils';
 import type { DashboardConfig } from '../../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../../components/dashboard/WidgetNoData';
@@ -486,10 +486,10 @@ const StixRelationshipsMultiHorizontalBars: FunctionComponent<StixRelationshipsM
       endDate,
       dateAttribute: selection.date_attribute ?? 'created_at',
       limit: selection.number ?? 10,
-      filters: filtersAndOptions?.filters as unknown as GqlFilterGroup,
+      filters: normalizeFilterGroupForBackend(filtersAndOptions?.filters),
       isTo: selection.isTo,
-      dynamicFrom: selection.dynamicFrom as unknown as GqlFilterGroup,
-      dynamicTo: selection.dynamicTo as unknown as GqlFilterGroup,
+      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
       subDistributionField: finalSubDistributionField,
       subDistributionOperation: 'count',
     };
@@ -505,7 +505,7 @@ const StixRelationshipsMultiHorizontalBars: FunctionComponent<StixRelationshipsM
           : 'created_at',
       subDistributionLimit: subSelection.number ?? 15,
       subDistributionTypes,
-      subDistributionFilters: subDistributionFiltersAndOptions?.filters as unknown as GqlFilterGroup,
+      subDistributionFilters: normalizeFilterGroupForBackend(subDistributionFiltersAndOptions?.filters),
     } as StixRelationshipsMultiHorizontalBarsWithEntitiesDistributionQuery['variables'];
   } else {
     variables = {
@@ -518,7 +518,7 @@ const StixRelationshipsMultiHorizontalBars: FunctionComponent<StixRelationshipsM
           : 'created_at',
       subDistributionIsTo: subSelection.isTo,
       subDistributionLimit: subSelection.number ?? 15,
-      subDistributionFilters: subDistributionFiltersAndOptions?.filters as unknown as GqlFilterGroup,
+      subDistributionFilters: normalizeFilterGroupForBackend(subDistributionFiltersAndOptions?.filters),
     } as StixRelationshipsMultiHorizontalBarsWithRelationshipsDistributionQuery['variables'];
   }
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines';
@@ -101,18 +101,12 @@ const buildQueryVariables = (
       endDate,
       isKnowledgeRelationshipWidget: true,
     });
-    type TimeSeriesParam
-      = NonNullable<
-        NonNullable<
-          StixRelationshipsMultiLineChartTimeSeriesQuery['variables']['timeSeriesParameters']
-        >[number]
-      >;
 
     return {
       field: dateAttribute,
-      filters: filters as unknown as TimeSeriesParam['filters'],
-      dynamicFrom: selection.dynamicFrom as unknown as TimeSeriesParam['dynamicFrom'],
-      dynamicTo: selection.dynamicTo as unknown as TimeSeriesParam['dynamicTo'],
+      filters: normalizeFilterGroupForBackend(filters),
+      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetVerticalBars from '../../../../components/dashboard/WidgetVerticalBars';
@@ -93,19 +93,19 @@ const buildQueryVariables = (
   const startDate = config.startDate ?? fallbackStart;
   const endDate = config.endDate ?? fallbackEnd;
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
+    const dateAttribute = selection.date_attribute?.length
+      ? selection.date_attribute
+      : 'created_at';
     const { filters } = buildFiltersAndOptionsForWidgets(
       selection.filters,
       { startDate, endDate, isKnowledgeRelationshipWidget: true },
     );
-    type TimeSeriesParam = NonNullable<NonNullable<StixRelationshipsMultiVerticalBarsTimeSeriesQuery['variables']['timeSeriesParameters']>[number]>;
 
     return {
       field: dateAttribute,
-      filters: filters as unknown as TimeSeriesParam['filters'],
-      dynamicFrom: selection.dynamicFrom as unknown as TimeSeriesParam['dynamicFrom'],
-      dynamicTo: selection.dynamicTo as unknown as TimeSeriesParam['dynamicTo'],
+      filters: normalizeFilterGroupForBackend(filters),
+      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
@@ -1,7 +1,7 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import Loader, { LoaderVariant } from '../../../../components/Loader';
@@ -13,7 +13,6 @@ import { StixRelationshipsNumberNumberSeriesQuery } from '@components/common/sti
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { ReactNode, Suspense } from 'react';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import type { FilterGroup as GQLFilterGroup } from '@components/common/stix_relationships/__generated__/StixRelationshipsNumberNumberSeriesQuery.graphql';
 
 const stixRelationshipsNumberNumberQuery = graphql`
     query StixRelationshipsNumberNumberSeriesQuery(
@@ -116,17 +115,11 @@ const buildQueryVariables = (
   );
 
   return {
-    filters: filters
-      ? (filters as unknown as GQLFilterGroup)
-      : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     dateAttribute,
     endDate: dayAgo(),
-    dynamicFrom: selection.dynamicFrom
-      ? (selection.dynamicFrom as unknown as GQLFilterGroup)
-      : undefined,
-    dynamicTo: selection.dynamicTo
-      ? (selection.dynamicTo as unknown as GQLFilterGroup)
-      : undefined,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsPolarArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsPolarArea.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetPolarArea from '../../../../components/dashboard/WidgetPolarArea';
@@ -160,7 +160,7 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsPolarArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsPolarArea.tsx
@@ -150,9 +150,6 @@ const buildQueryVariables = (
     { isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsPolarAreaDistributionQuery['variables']['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -162,8 +159,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetRadar from '../../../../components/dashboard/WidgetRadar';
@@ -164,7 +164,7 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.tsx
@@ -154,9 +154,6 @@ const buildQueryVariables = (
     { isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsRadarDistributionQuery['variables']['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -166,8 +163,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { resolveLink } from '../../../../utils/Entity';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetTimeline from '../../../../components/dashboard/WidgetTimeline';
@@ -1058,7 +1058,7 @@ const buildQueryVariables = (
     first: selection.number ?? 10,
     orderBy: dateAttribute as StixRelationshipsOrdering,
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
   };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -1051,16 +1051,13 @@ const buildQueryVariables = (
     },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsTimelineStixRelationshipQuery['variables']['dynamicFrom'];
-
   return {
     first: selection.number ?? 10,
     orderBy: dateAttribute as StixRelationshipsOrdering,
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
     filters: normalizeFilterGroupForBackend(filters),
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
@@ -12,7 +12,6 @@ import { StixRelationshipsTreeMapDistributionQuery } from './__generated__/StixR
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { OpenCTIChartProps } from '@components/common/charts/Chart';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { StixRelationshipsMultiHeatMapTimeSeriesQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsMultiHeatMapTimeSeriesQuery.graphql';
 
 const stixRelationshipsTreeMapsDistributionQuery = graphql`
   query StixRelationshipsTreeMapDistributionQuery(
@@ -141,8 +140,6 @@ const buildQueryVariables = (
     { isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup = NonNullable<NonNullable<StixRelationshipsMultiHeatMapTimeSeriesQuery['variables']['timeSeriesParameters']>[number]>['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -152,8 +149,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties, ReactNode, Suspense, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetTree from '../../../../components/dashboard/WidgetTree';
@@ -150,7 +150,7 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsWordCloud.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, Suspense } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, sanitizeFilterGroupKeysForBackend } from '../../../../utils/filters/filtersUtils';
+import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetWordCloud from '../../../../components/dashboard/WidgetWordCloud';
@@ -163,7 +163,7 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
     dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
     dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsWordCloud.tsx
@@ -153,9 +153,6 @@ const buildQueryVariables = (
     { isKnowledgeRelationshipWidget: true },
   );
 
-  type QueryFilterGroup
-    = StixRelationshipsWordCloudDistributionQuery['variables']['dynamicFrom'];
-
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -165,8 +162,8 @@ const buildQueryVariables = (
     limit: selection.number ?? 10,
     filters: normalizeFilterGroupForBackend(filters),
     isTo: selection.isTo,
-    dynamicFrom: selection.dynamicFrom as unknown as QueryFilterGroup,
-    dynamicTo: selection.dynamicTo as unknown as QueryFilterGroup,
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/pir/PirCriteriaDisplay.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/PirCriteriaDisplay.tsx
@@ -22,7 +22,7 @@ import { FilterGroup } from '../../../utils/filters/filtersHelpers-types';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { FilterValuesContentQuery } from '../../../components/__generated__/FilterValuesContentQuery.graphql';
 import { filterValuesContentQuery } from '../../../components/FilterValuesContent';
-import { GqlFilterGroup, removeIdFromFilterGroupObject } from '../../../utils/filters/filtersUtils';
+import { isFilterGroupNotEmpty, sanitizeFilterGroupForBackend } from '../../../utils/filters/filtersUtils';
 import { useFormatter } from '../../../components/i18n';
 import type { Theme } from '../../../components/Theme';
 import Tag from '@common/tag/Tag';
@@ -92,16 +92,16 @@ const PirCriteriaDisplayComponent = ({
 type PirCriteriaDisplayProps = Omit<PirFiltersDisplayComponentProps, 'queryRef'>;
 
 const PirCriteriaDisplay = ({ criteria, ...props }: PirCriteriaDisplayProps) => {
-  const filters = removeIdFromFilterGroupObject({
+  const filters = sanitizeFilterGroupForBackend({
     mode: 'and',
     filters: [],
     filterGroups: criteria,
   });
-  if (!filters) return null;
+  if (!filters || !isFilterGroupNotEmpty((filters))) return null;
 
   const filtersRepresentativesQueryRef = useQueryLoading<FilterValuesContentQuery>(
     filterValuesContentQuery,
-    { filters: filters as unknown as GqlFilterGroup },
+    { filters },
   );
 
   return filtersRepresentativesQueryRef && (

--- a/opencti-platform/opencti-front/src/private/components/pir/PirCriteriaDisplay.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/PirCriteriaDisplay.tsx
@@ -22,7 +22,7 @@ import { FilterGroup } from '../../../utils/filters/filtersHelpers-types';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import { FilterValuesContentQuery } from '../../../components/__generated__/FilterValuesContentQuery.graphql';
 import { filterValuesContentQuery } from '../../../components/FilterValuesContent';
-import { isFilterGroupNotEmpty, sanitizeFilterGroupForBackend } from '../../../utils/filters/filtersUtils';
+import { isFilterGroupNotEmpty, normalizeFilterGroupForBackend } from '../../../utils/filters/filtersUtils';
 import { useFormatter } from '../../../components/i18n';
 import type { Theme } from '../../../components/Theme';
 import Tag from '@common/tag/Tag';
@@ -92,7 +92,7 @@ const PirCriteriaDisplayComponent = ({
 type PirCriteriaDisplayProps = Omit<PirFiltersDisplayComponentProps, 'queryRef'>;
 
 const PirCriteriaDisplay = ({ criteria, ...props }: PirCriteriaDisplayProps) => {
-  const filters = sanitizeFilterGroupForBackend({
+  const filters = normalizeFilterGroupForBackend({
     mode: 'and',
     filters: [],
     filterGroups: criteria,

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_analyses/PirAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_analyses/PirAnalyses.tsx
@@ -19,7 +19,7 @@ import { Chip, Tooltip, Alert } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { PirAnalysesContainersListQuery, PirAnalysesContainersListQuery$variables } from './__generated__/PirAnalysesContainersListQuery.graphql';
 import { PirAnalyses_ContainersFragment$data } from './__generated__/PirAnalyses_ContainersFragment.graphql';
-import { emptyFilterGroup, getFilterKeyValues, sanitizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, getFilterKeyValues, normalizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import useAuth from '../../../../utils/hooks/useAuth';
@@ -189,7 +189,7 @@ const PirAnalyses = ({ data }: PirAnalysesProps) => {
     ...paginationOptions,
     id,
     count: 100,
-    filters: sanitizeFilterGroupForBackend(filters),
+    filters: normalizeFilterGroupForBackend(filters),
     objectsFilters: {
       mode: 'or',
       filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_analyses/PirAnalyses.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_analyses/PirAnalyses.tsx
@@ -19,7 +19,7 @@ import { Chip, Tooltip, Alert } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { PirAnalysesContainersListQuery, PirAnalysesContainersListQuery$variables } from './__generated__/PirAnalysesContainersListQuery.graphql';
 import { PirAnalyses_ContainersFragment$data } from './__generated__/PirAnalyses_ContainersFragment.graphql';
-import { emptyFilterGroup, getFilterKeyValues, sanitizeFilterGroupKeysForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
+import { emptyFilterGroup, getFilterKeyValues, sanitizeFilterGroupForBackend, useRemoveIdAndIncorrectKeysFromFilterGroupObject } from '../../../../utils/filters/filtersUtils';
 import { usePaginationLocalStorage } from '../../../../utils/hooks/useLocalStorage';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import useAuth from '../../../../utils/hooks/useAuth';
@@ -189,7 +189,7 @@ const PirAnalyses = ({ data }: PirAnalysesProps) => {
     ...paginationOptions,
     id,
     count: 100,
-    filters: filters ? sanitizeFilterGroupKeysForBackend(filters) : undefined,
+    filters: sanitizeFilterGroupForBackend(filters),
     objectsFilters: {
       mode: 'or',
       filterGroups: [],

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplateWidgetsSidebar.tsx
@@ -14,7 +14,7 @@ import type { Theme } from '../../../../../components/Theme';
 import { MESSAGING$ } from '../../../../../relay/environment';
 import WidgetConfig from '../../../widgets/WidgetConfig';
 import type { Widget } from '../../../../../utils/widget/widget';
-import { deserializeFilterGroupForFrontend, emptyFilterGroup, removeIdFromFilterGroupObject } from '../../../../../utils/filters/filtersUtils';
+import { deserializeFilterGroupForFrontend, emptyFilterGroup, serializeFilterGroupForBackend } from '../../../../../utils/filters/filtersUtils';
 import DeleteDialog from '../../../../../components/DeleteDialog';
 import useDeletion from '../../../../../utils/hooks/useDeletion';
 import { toCamelCase } from '../../../../../utils/String';
@@ -176,9 +176,9 @@ const FintelTemplateWidgetsSidebar: FunctionComponent<FintelTemplateWidetsSideba
           ...widget,
           dataSelection: widget.dataSelection.map((selection) => ({
             ...selection,
-            filters: JSON.stringify(removeIdFromFilterGroupObject(selection.filters)),
-            dynamicFrom: JSON.stringify(removeIdFromFilterGroupObject(selection.dynamicFrom)),
-            dynamicTo: JSON.stringify(removeIdFromFilterGroupObject(selection.dynamicTo)),
+            filters: serializeFilterGroupForBackend(selection.filters),
+            dynamicFrom: serializeFilterGroupForBackend(selection.dynamicFrom),
+            dynamicTo: serializeFilterGroupForBackend(selection.dynamicTo),
           })),
         },
       };

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -1282,10 +1282,10 @@ describe('Function normalizeFilterGroupForFrontend', () => {
     const input = {
       mode: 'and',
       filters: [
-        { key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+        { key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' },
       ],
       filterGroups: [],
-    } as unknown as GqlFilterGroup;
+    } as GqlFilterGroup;
     const result = normalizeFilterGroupForFrontend(input);
     expect(result.filters[0].key).toEqual('entity_type');
   });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -8,12 +8,14 @@ import {
   getEntityTypeThreeFirstLevelsFilterValues,
   isFilterGroupFormatCorrect,
   isRegardingOfFilterWarning,
+  normalizeFilterGroupForBackend,
+  normalizeFilterGroupForFrontend,
   removeFrontendIdAndEmptyFiltersFromFilterGroupObject,
   removeIdAndIncorrectKeysFromFilterGroupObject,
-  sanitizeFilterGroupForBackend,
   serializeFilterGroupForBackend,
   useBuildEntityTypeBasedFilterContext,
   useBuildFilterKeysMapFromEntityType,
+  GqlFilterGroup,
 } from './filtersUtils';
 import { createMockUserContext, testRenderHook } from '../tests/test-render';
 import filterKeysSchema from '../tests/FilterUtilsConstants';
@@ -661,7 +663,7 @@ describe('Function findFilterFromKey: should return the filters of the specified
   });
 });
 
-describe('Function sanitizeFilterGroupForBackend', () => {
+describe('Function normalizeFilterGroupForBackend', () => {
   it('should convert string keys to arrays', () => {
     const input: FilterGroup = {
       mode: 'and',
@@ -670,7 +672,7 @@ describe('Function sanitizeFilterGroupForBackend', () => {
       ],
       filterGroups: [],
     };
-    const result = sanitizeFilterGroupForBackend(input);
+    const result = normalizeFilterGroupForBackend(input);
     expect(result?.filters[0].key).toEqual(['entity_type']);
   });
 
@@ -682,7 +684,7 @@ describe('Function sanitizeFilterGroupForBackend', () => {
       ],
       filterGroups: [],
     } as unknown as FilterGroup;
-    const result = sanitizeFilterGroupForBackend(input);
+    const result = normalizeFilterGroupForBackend(input);
     expect(result?.filters[0].key).toEqual(['objectMarking']);
   });
 
@@ -694,7 +696,7 @@ describe('Function sanitizeFilterGroupForBackend', () => {
       ],
       filterGroups: [],
     };
-    const result = sanitizeFilterGroupForBackend(input);
+    const result = normalizeFilterGroupForBackend(input);
     expect(result?.filters[0]).not.toHaveProperty('id');
   });
 
@@ -707,7 +709,7 @@ describe('Function sanitizeFilterGroupForBackend', () => {
       ],
       filterGroups: [],
     };
-    const result = sanitizeFilterGroupForBackend(input);
+    const result = normalizeFilterGroupForBackend(input);
     expect(result?.filters.length).toEqual(1);
     expect(result?.filters[0].key).toEqual(['entity_type']);
   });
@@ -721,7 +723,7 @@ describe('Function sanitizeFilterGroupForBackend', () => {
       ],
       filterGroups: [],
     };
-    const result = sanitizeFilterGroupForBackend(input);
+    const result = normalizeFilterGroupForBackend(input);
     expect(result?.filters.length).toEqual(2);
   });
 
@@ -741,7 +743,7 @@ describe('Function sanitizeFilterGroupForBackend', () => {
         },
       ],
     };
-    const result = sanitizeFilterGroupForBackend(input);
+    const result = normalizeFilterGroupForBackend(input);
     expect(result?.filterGroups![0].filters[0].key).toEqual(['name']);
     expect(result?.filterGroups![0].filters[0]).not.toHaveProperty('id');
   });
@@ -1234,5 +1236,72 @@ describe('buildFiltersForCustomView', () => {
         }],
       }],
     });
+  });
+});
+
+describe('Function normalizeFilterGroupForFrontend', () => {
+  it('should convert array keys to single string keys', () => {
+    const input: GqlFilterGroup = {
+      mode: 'and',
+      filters: [
+        { key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' },
+        { key: ['objectMarking'], values: ['marking1'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    };
+    const result = normalizeFilterGroupForFrontend(input);
+    expect(result.filters[0].key).toEqual('entity_type');
+    expect(result.filters[1].key).toEqual('objectMarking');
+    expect(result.filters[0].id).toBeDefined();
+    expect(typeof result.filters[0].id).toBe('string');
+    expect(result.filters[0].id!.length).toBeGreaterThan(0);
+  });
+
+  it('should recursively process nested filterGroups', () => {
+    const input: GqlFilterGroup = {
+      mode: 'and',
+      filters: [
+        { key: ['entity_type'], values: ['Report'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [
+        {
+          mode: 'or',
+          filters: [
+            { key: ['objectLabel'], values: ['label1'], operator: 'eq', mode: 'or' },
+          ],
+          filterGroups: [],
+        },
+      ],
+    };
+    const result = normalizeFilterGroupForFrontend(input);
+    expect(result.filterGroups[0].filters[0].key).toEqual('objectLabel');
+    expect(result.filterGroups[0].filters[0].id).toBeDefined();
+  });
+
+  it('should handle key that is already a string (non-array)', () => {
+    const input = {
+      mode: 'and',
+      filters: [
+        { key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    } as unknown as GqlFilterGroup;
+    const result = normalizeFilterGroupForFrontend(input);
+    expect(result.filters[0].key).toEqual('entity_type');
+  });
+
+  it('should preserve mode and other filter properties', () => {
+    const input: GqlFilterGroup = {
+      mode: 'or',
+      filters: [
+        { key: ['name'], values: ['val1', 'val2'], operator: 'not_eq', mode: 'and' },
+      ],
+      filterGroups: [],
+    };
+    const result = normalizeFilterGroupForFrontend(input);
+    expect(result.mode).toEqual('or');
+    expect(result.filters[0].operator).toEqual('not_eq');
+    expect(result.filters[0].mode).toEqual('and');
+    expect(result.filters[0].values).toEqual(['val1', 'val2']);
   });
 });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -1282,10 +1282,10 @@ describe('Function normalizeFilterGroupForFrontend', () => {
     const input = {
       mode: 'and',
       filters: [
-        { key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' },
+        { key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
       ],
       filterGroups: [],
-    } as GqlFilterGroup;
+    } as unknown as GqlFilterGroup;
     const result = normalizeFilterGroupForFrontend(input);
     expect(result.filters[0].key).toEqual('entity_type');
   });

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -8,8 +8,9 @@ import {
   getEntityTypeThreeFirstLevelsFilterValues,
   isFilterGroupFormatCorrect,
   isRegardingOfFilterWarning,
+  removeFrontendIdAndEmptyFiltersFromFilterGroupObject,
   removeIdAndIncorrectKeysFromFilterGroupObject,
-  removeIdFromFilterGroupObject,
+  sanitizeFilterGroupForBackend,
   serializeFilterGroupForBackend,
   useBuildEntityTypeBasedFilterContext,
   useBuildFilterKeysMapFromEntityType,
@@ -43,9 +44,9 @@ describe('Filters utils', () => {
     });
   });
 
-  describe('removeIdFromFilterGroupObject', () => {
+  describe('removeFrontendIdAndEmptyFiltersFromFilterGroupObject', () => {
     it('should remove id from filters', () => {
-      expect(removeIdFromFilterGroupObject(emptyFilterGroup)).toStrictEqual(emptyFilterGroup);
+      expect(removeFrontendIdAndEmptyFiltersFromFilterGroupObject(emptyFilterGroup)).toStrictEqual(emptyFilterGroup);
       const filters = {
         mode: 'and',
         filters: [
@@ -100,7 +101,7 @@ describe('Filters utils', () => {
           },
         ],
       };
-      expect(removeIdFromFilterGroupObject(filters as unknown as FilterGroup)).toStrictEqual(filtersResult);
+      expect(removeFrontendIdAndEmptyFiltersFromFilterGroupObject(filters as unknown as FilterGroup)).toStrictEqual(filtersResult);
     });
   });
 
@@ -163,6 +164,51 @@ describe('Filters utils', () => {
         ],
       };
       expect(removeIdAndIncorrectKeysFromFilterGroupObject(filters as unknown as FilterGroup, availableFilterKeys)).toStrictEqual(filtersResult);
+    });
+
+    it('should return undefined for null or undefined input', () => {
+      expect(removeIdAndIncorrectKeysFromFilterGroupObject(null, ['entity_type'])).toBeUndefined();
+      expect(removeIdAndIncorrectKeysFromFilterGroupObject(undefined, ['entity_type'])).toBeUndefined();
+    });
+
+    it('should strip filters with empty values (non-nil operator)', () => {
+      const filters: FilterGroup = {
+        mode: 'and',
+        filters: [
+          { id: 'f1', key: 'entity_type', values: [], operator: 'eq', mode: 'or' },
+          { id: 'f2', key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+        ],
+        filterGroups: [],
+      };
+      const result = removeIdAndIncorrectKeysFromFilterGroupObject(filters, ['entity_type']);
+      expect(result!.filters.length).toEqual(1);
+      expect(result!.filters[0].values).toEqual(['Malware']);
+    });
+
+    it('should keep filters with nil/not_nil operator even with empty values', () => {
+      const filters: FilterGroup = {
+        mode: 'and',
+        filters: [
+          { id: 'f1', key: 'objectLabel', values: [], operator: 'nil', mode: 'or' },
+          { id: 'f2', key: 'objectLabel', values: [], operator: 'not_nil', mode: 'or' },
+        ],
+        filterGroups: [],
+      };
+      const result = removeIdAndIncorrectKeysFromFilterGroupObject(filters, ['objectLabel']);
+      expect(result!.filters.length).toEqual(2);
+    });
+
+    it('should remove all filters if none match the available keys', () => {
+      const filters: FilterGroup = {
+        mode: 'and',
+        filters: [
+          { id: 'f1', key: 'unknown_key', values: ['val'], operator: 'eq', mode: 'or' },
+          { id: 'f2', key: 'another_bad_key', values: ['val'], operator: 'eq', mode: 'or' },
+        ],
+        filterGroups: [],
+      };
+      const result = removeIdAndIncorrectKeysFromFilterGroupObject(filters, ['entity_type']);
+      expect(result!.filters.length).toEqual(0);
     });
   });
 
@@ -612,6 +658,92 @@ describe('Function findFilterFromKey: should return the filters of the specified
     const result = findFiltersFromKeys(filtersList, ['value', 'test', 'created_at']);
     expect(result).toEqual([{ key: 'value', values: ['value1'], operator: 'eq' },
       { key: 'created_at', values: ['XX', 'YY'], mode: 'or' }]);
+  });
+});
+
+describe('Function sanitizeFilterGroupForBackend', () => {
+  it('should convert string keys to arrays', () => {
+    const input: FilterGroup = {
+      mode: 'and',
+      filters: [
+        { id: 'f1', key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    };
+    const result = sanitizeFilterGroupForBackend(input);
+    expect(result?.filters[0].key).toEqual(['entity_type']);
+  });
+
+  it('should keep keys that are already arrays', () => {
+    const input = {
+      mode: 'and',
+      filters: [
+        { id: 'f1', key: ['objectMarking'], values: ['marking1'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    } as unknown as FilterGroup;
+    const result = sanitizeFilterGroupForBackend(input);
+    expect(result?.filters[0].key).toEqual(['objectMarking']);
+  });
+
+  it('should remove filter IDs', () => {
+    const input: FilterGroup = {
+      mode: 'and',
+      filters: [
+        { id: 'should-be-removed', key: 'name', values: ['test'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    };
+    const result = sanitizeFilterGroupForBackend(input);
+    expect(result?.filters[0]).not.toHaveProperty('id');
+  });
+
+  it('should strip filters with empty values and no nil operator', () => {
+    const input: FilterGroup = {
+      mode: 'and',
+      filters: [
+        { id: 'f1', key: 'name', values: [], operator: 'eq', mode: 'or' },
+        { id: 'f2', key: 'entity_type', values: ['Report'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    };
+    const result = sanitizeFilterGroupForBackend(input);
+    expect(result?.filters.length).toEqual(1);
+    expect(result?.filters[0].key).toEqual(['entity_type']);
+  });
+
+  it('should keep filters with nil/not_nil operator even if values are empty', () => {
+    const input: FilterGroup = {
+      mode: 'and',
+      filters: [
+        { id: 'f1', key: 'description', values: [], operator: 'nil', mode: 'or' },
+        { id: 'f2', key: 'name', values: [], operator: 'not_nil', mode: 'or' },
+      ],
+      filterGroups: [],
+    };
+    const result = sanitizeFilterGroupForBackend(input);
+    expect(result?.filters.length).toEqual(2);
+  });
+
+  it('should recursively process nested filterGroups', () => {
+    const input: FilterGroup = {
+      mode: 'and',
+      filters: [
+        { id: 'f1', key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [
+        {
+          mode: 'or',
+          filters: [
+            { id: 'f2', key: 'name', values: ['test'], operator: 'eq', mode: 'or' },
+          ],
+          filterGroups: [],
+        },
+      ],
+    };
+    const result = sanitizeFilterGroupForBackend(input);
+    expect(result?.filterGroups![0].filters[0].key).toEqual(['name']);
+    expect(result?.filterGroups![0].filters[0]).not.toHaveProperty('id');
   });
 });
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -163,7 +163,7 @@ const getStringFilterKey = (key: string | string[]): string => {
   return Array.isArray(key) ? key[0] : key;
 };
 
-export const isFilterGroupNotEmpty = (filterGroup?: FilterGroup | null) => {
+export const isFilterGroupNotEmpty = (filterGroup?: FilterGroup | GqlFilterGroup | null) => {
   return !!(
     filterGroup
     && (filterGroup.filters?.length > 0 || filterGroup.filterGroups?.length > 0)
@@ -499,27 +499,34 @@ export const sanitizeFiltersStructure = (filterGroup: FilterGroup): FilterGroup 
   ),
 });
 
-// when a filter group is serialized, we need to make sure the keys are all arrays as per graphql TS typing emission
-// GQL input coercion allows to use non-array value of same type as inside the array
-// but when we serialize (stringify) filters they end up parsed inside the backend, that expects strictly arrays
-// --> saved filters MUST be properly sanitized
-export const sanitizeFilterGroupKeysForBackend = (
-  filterGroup: FilterGroup,
-): GqlFilterGroup => {
+/**
+ * Sanitizes a FilterGroup for backend persistence:
+ * - Converts filter keys from string to string[] (backend expects arrays).
+ * - Removes filter IDs (not persisted).
+ * - Strips empty filters (no values and no nil/not_nil operator).
+ * - Recursively processes nested filterGroups.
+ *
+ * This is required because GQL input coercion accepts single values in place of arrays,
+ * but when filters are stringified and parsed server-side, strict array format is expected.
+ */
+export function sanitizeFilterGroupForBackend(filterGroup: FilterGroup): GqlFilterGroup;
+export function sanitizeFilterGroupForBackend(filterGroup?: FilterGroup | null): GqlFilterGroup | undefined;
+export function sanitizeFilterGroupForBackend(
+  filterGroup?: FilterGroup | null,
+): GqlFilterGroup | undefined {
+  if (!filterGroup || !isFilterGroupNotEmpty(filterGroup)) {
+    return undefined;
+  }
   return {
     ...filterGroup,
-    filters: filterGroup?.filters?.filter((f) => f.values.length > 0 || ['nil', 'not_nil'].includes(f.operator ?? 'eq'))
-      .map((f) => {
-        const transformFilter = {
-          ...f,
-          key: Array.isArray(f.key) ? f.key : [f.key],
-        };
-        delete transformFilter.id;
-        return transformFilter;
-      }),
-    filterGroups: filterGroup?.filterGroups?.map((fg) => sanitizeFilterGroupKeysForBackend(fg)),
+    filters: removeFrontendIdAndEmptyFiltersFromFiltersArray(filterGroup.filters)
+      .map((f) => ({
+        ...f,
+        key: Array.isArray(f.key) ? f.key : [f.key],
+      })),
+    filterGroups: filterGroup.filterGroups.map((fg) => sanitizeFilterGroupForBackend(fg)),
   } as GqlFilterGroup;
-};
+}
 
 // reverse operation of sanitizeFilterGroupKeysForBackend
 export const sanitizeFilterGroupKeysForFrontend = (
@@ -548,7 +555,7 @@ export const serializeFilterGroupForBackend = (
   if (!filterGroup) {
     return JSON.stringify(emptyFilterGroup);
   }
-  return JSON.stringify(sanitizeFilterGroupKeysForBackend(filterGroup));
+  return JSON.stringify(sanitizeFilterGroupForBackend(filterGroup));
 };
 
 /**
@@ -833,30 +840,45 @@ const isFilterKeyAvailable = (key: string, availableFilterKeys: string[]) => {
   return completedAvailableFilterKeys.includes(key);
 };
 
-export const removeIdFromFilterGroupObject = (filters?: FilterGroup | null): FilterGroup | undefined => {
+/**
+ * Removes the `id` property from all filters in a FilterGroup (recursively).
+ * Also strips filters with empty values (unless operator is nil/not_nil).
+ * For `dynamicRegardingOf` filters, recursively cleans nested dynamic filter values.
+ */
+export const removeFrontendIdAndEmptyFiltersFromFilterGroupObject = (filters?: FilterGroup | null): FilterGroup | undefined => {
   if (!filters) {
     return undefined;
   }
   return {
-    mode: filters.mode,
-    filters: filters.filters
-      .filter((f) => ['nil', 'not_nil'].includes(f.operator ?? 'eq') || f.values.length > 0)
-      .map((f) => {
-        const newFilter = { ...f };
-        delete newFilter.id;
-        if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
-          const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
-            .map((dynamic) => ({
-              ...dynamic,
-              values: dynamic.values.map((dynamicFilter: FilterGroup) => removeIdFromFilterGroupObject(dynamicFilter)),
-            }));
-          const relationshipTypeValues = newFilter.values.filter((value) => value.key === 'relationship_type');
-          newFilter.values = [...dynamicValues, ...relationshipTypeValues];
-        }
-        return newFilter;
-      }),
-    filterGroups: filters.filterGroups.map((group) => removeIdFromFilterGroupObject(group)) as FilterGroup[],
+    ...filters,
+    filters: removeFrontendIdAndEmptyFiltersFromFiltersArray(filters.filters),
+    filterGroups: filters.filterGroups.map((group) => removeFrontendIdAndEmptyFiltersFromFilterGroupObject(group)) as FilterGroup[],
   };
+};
+
+/**
+ * Removes the frontend-only `id` property from a single filter.
+ * For `dynamicRegardingOf` filters, also recursively cleans nested dynamic FilterGroup values.
+ */
+const removeFrontendIdAndEmptyFiltersFromFiltersArray = (filtersArray: Filter[]): Filter[] => {
+  const removeFrontendIdFromFilter = (f: Filter): Filter => {
+    const newFilter = { ...f };
+    delete newFilter.id;
+    if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
+      const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
+        .map((dynamic) => ({
+          ...dynamic,
+          values: dynamic.values.map((dynamicFilter: FilterGroup) => removeFrontendIdAndEmptyFiltersFromFilterGroupObject(dynamicFilter)),
+        }));
+      const relationshipTypeValues = newFilter.values.filter((value) => value.key === 'relationship_type');
+      newFilter.values = [...dynamicValues, ...relationshipTypeValues];
+    }
+    return newFilter;
+  };
+
+  return filtersArray
+    .filter((f) => ['nil', 'not_nil'].includes(f.operator ?? 'eq') || f.values.length > 0)
+    .map((f) => removeFrontendIdFromFilter(f));
 };
 
 // TODO use useRemoveIdAndIncorrectKeysFromFilterGroupObject instead when all the calling files are in pure function
@@ -866,23 +888,8 @@ export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGro
   }
   return {
     mode: filters.mode,
-    filters: filters.filters
-      .filter((f) => isFilterKeyAvailable(f.key, availableFilterKeys))
-      .filter((f) => ['nil', 'not_nil'].includes(f.operator ?? 'eq') || f.values.length > 0)
-      .map((f) => {
-        const newFilter = { ...f };
-        delete newFilter.id;
-        if (newFilter.key === 'dynamicRegardingOf') { // remove id from filters contained in dynamic values of dynamicRegardingOf filter
-          const dynamicValues = newFilter.values.filter((value) => value.key === 'dynamic')
-            .map((dynamic) => ({
-              ...dynamic,
-              values: dynamic.values.map((dynamicFilter: FilterGroup) => removeIdFromFilterGroupObject(dynamicFilter)),
-            }));
-          const relationshipTypeValues = newFilter.values.filter((value) => value.key === 'relationship_type');
-          newFilter.values = [...dynamicValues, ...relationshipTypeValues];
-        }
-        return newFilter;
-      }),
+    filters: removeFrontendIdAndEmptyFiltersFromFiltersArray(filters.filters
+      .filter((f) => isFilterKeyAvailable(f.key, availableFilterKeys))),
     filterGroups: filters.filterGroups.map((group) => removeIdAndIncorrectKeysFromFilterGroupObject(group, availableFilterKeys)) as FilterGroup[],
   };
 };

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -379,7 +379,7 @@ export const buildFiltersAndOptionsForWidgets = (
   let filters = inputFilters ?? undefined;
   // remove 'all' in filter with key=entity_type
   if (removeTypeAll) {
-    filters = removeEntityTypeAllFromFilterGroup(filters);
+    filters = removeEntityTypeAllFromFilterGroup(filters) ?? undefined;
   }
   // handle startDate and endDate options
   const dateFiltersContent = [];

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -500,7 +500,7 @@ export const sanitizeFiltersStructure = (filterGroup: FilterGroup): FilterGroup 
 });
 
 /**
- * Sanitizes a FilterGroup for backend persistence:
+ * Normalizes a FilterGroup for backend persistence:
  * - Converts filter keys from string to string[] (backend expects arrays).
  * - Removes filter IDs (not persisted).
  * - Strips empty filters (no values and no nil/not_nil operator).
@@ -509,9 +509,9 @@ export const sanitizeFiltersStructure = (filterGroup: FilterGroup): FilterGroup 
  * This is required because GQL input coercion accepts single values in place of arrays,
  * but when filters are stringified and parsed server-side, strict array format is expected.
  */
-export function sanitizeFilterGroupForBackend(filterGroup: FilterGroup): GqlFilterGroup;
-export function sanitizeFilterGroupForBackend(filterGroup?: FilterGroup | null): GqlFilterGroup | undefined;
-export function sanitizeFilterGroupForBackend(
+export function normalizeFilterGroupForBackend(filterGroup: FilterGroup): GqlFilterGroup;
+export function normalizeFilterGroupForBackend(filterGroup?: FilterGroup | null): GqlFilterGroup | undefined;
+export function normalizeFilterGroupForBackend(
   filterGroup?: FilterGroup | null,
 ): GqlFilterGroup | undefined {
   if (!filterGroup || !isFilterGroupNotEmpty(filterGroup)) {
@@ -524,12 +524,16 @@ export function sanitizeFilterGroupForBackend(
         ...f,
         key: Array.isArray(f.key) ? f.key : [f.key],
       })),
-    filterGroups: filterGroup.filterGroups.map((fg) => sanitizeFilterGroupForBackend(fg)),
+    filterGroups: filterGroup.filterGroups.map((fg) => normalizeFilterGroupForBackend(fg)),
   } as GqlFilterGroup;
 }
 
-// reverse operation of sanitizeFilterGroupKeysForBackend
-export const sanitizeFilterGroupKeysForFrontend = (
+/**
+ * Reverse operation of normalizeFilterGroupForBackend:
+ * converts a GqlFilterGroup (backend format with array keys) into a FilterGroup (frontend format with single string key).
+ * Also assigns a unique `id` to each filter for React rendering purposes.
+ */
+export const normalizeFilterGroupForFrontend = (
   filterGroup: GqlFilterGroup,
 ): FilterGroup => {
   return {
@@ -540,7 +544,7 @@ export const sanitizeFilterGroupKeysForFrontend = (
       key: Array.isArray(f.key) ? f.key[0] : f.key,
       values: f.values.map((v) => v || 'todo: delete this'),
     })),
-    filterGroups: filterGroup?.filterGroups?.map((fg) => sanitizeFilterGroupKeysForFrontend(fg)),
+    filterGroups: filterGroup?.filterGroups?.map((fg) => normalizeFilterGroupForFrontend(fg)),
   } as FilterGroup;
 };
 
@@ -555,7 +559,7 @@ export const serializeFilterGroupForBackend = (
   if (!filterGroup) {
     return JSON.stringify(emptyFilterGroup);
   }
-  return JSON.stringify(sanitizeFilterGroupForBackend(filterGroup));
+  return JSON.stringify(normalizeFilterGroupForBackend(filterGroup));
 };
 
 /**
@@ -575,7 +579,7 @@ export const deserializeFilterGroupForFrontend = (
   } else {
     filters = filterGroup;
   }
-  return sanitizeFilterGroupKeysForFrontend(filters);
+  return normalizeFilterGroupForFrontend(filters);
 };
 
 // ----------------------------------------------------------------------------------------------------------------------

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -285,7 +285,7 @@ export const addFilter = (
 
 // remove filter with key=entity_type and values contains 'all'
 // because in this case we want everything, so no need for filters
-export const removeEntityTypeAllFromFilterGroup = (inputFilters?: FilterGroup) => {
+export const removeEntityTypeAllFromFilterGroup = (inputFilters?: FilterGroup | null) => {
   if (inputFilters && isFilterGroupNotEmpty(inputFilters)) {
     const { filters, filterGroups } = inputFilters;
     const newFilters = filters.filter((f) => !(f.key === 'entity_type' && f.values.includes('all')));


### PR DESCRIPTION
### Proposed changes
- Convert frontend filters via sanitizeFilterGroupForBackend before sending them to frontend
- Remove 'as unknown as GqlFilterGroup' force typing
- Add tests for normalizeFilterGroupForBackend and normalizeFilterGroupForFrontend
- Improve removeFrontendIdAndEmptyFiltersFromFilterGroupObject logic to avoid code duplication in filterUtils
- Rename sanitizeFilterGroupKeysForBackend into normalizeFilterGroupForBackend (same for normalizeFilterGroupForFrontend)
- use WidgetAccessDenied in widgets to avoid code repetition

### Related issues
fixes #16483