### PR TITLE
fix(capabilities): ensure capa in draft are disabled only if applicable (#16466)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/CapabilitiesList.tsx
@@ -73,8 +73,9 @@ const CapabilitiesList: FunctionComponent<CapabilitiesListProps> = ({
               && r.name.includes(capability.name)
               && capability.name !== 'BYPASS',
           );
-          const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name.includes(capability.name));
-          const isDisabled = isCapabilitiesInDraft ? matchingCapabilities.length > 0 || draftCapaMatchingMainCapa.length > 0 : matchingCapabilities.length > 0;
+          const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name?.includes(capability.name));
+          const draftCapaLockedByMain = draftCapaMatchingMainCapa.length > 0 && roleCapability === undefined;
+          const isDisabled = isCapabilitiesInDraft ? matchingCapabilities.length > 0 || draftCapaLockedByMain : matchingCapabilities.length > 0;
           const isChecked = isDisabled || roleCapability !== undefined;
           if (isChecked) {
             return (

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
@@ -195,9 +195,9 @@ const RoleEditionCapabilitiesComponent: FunctionComponent<RoleEditionCapabilitie
                 && r.name.includes(capability.name)
                 && capability.name !== 'BYPASS',
             );
-            const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name.includes(capability.name));
+            const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name?.includes(capability.name));
             const isDisabled = isCapabilitiesInDraft
-              ? matchingCapabilities.length > 0 || draftCapaMatchingMainCapa.length > 0
+              ? matchingCapabilities.length > 0 || (draftCapaMatchingMainCapa.length > 0 && roleCapability === undefined)
               : matchingCapabilities.length > 0;
             const isChecked = isDisabled || roleCapability !== undefined;
             return (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- fix capa in draft disabling mechanism

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16466 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
1. enable a capa in draft
2. enable the same capa in main
3. in your devtools set the network speed at a low speed setting like GPRS
4. uncheck the capa in main
5. quickly open the capa in draft tab
6. it should be possible to disable the capa

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
