### PR TITLE
feat(form-intakes): allow users with create/update knowledge only in capabilitiesInDraft to use form intakes in forced draft mode (#16467)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/Forms.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Forms.tsx
@@ -12,7 +12,7 @@ import { usePaginationLocalStorage } from '../../../utils/hooks/useLocalStorage'
 import ListLines from '../../../components/list_lines/ListLines';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import Security from '../../../utils/Security';
-import useGranted, { INGESTION_SETINGESTIONS, KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
+import useGranted, { INGESTION_SETINGESTIONS, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE } from '../../../utils/hooks/useGranted';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 
@@ -32,7 +32,7 @@ const Forms = () => {
   setTitle(t_i18n('Form intakes | Ingestion | Data'));
   const { platformModuleHelpers } = useAuth();
   const hasIngestionCapability = useGranted([INGESTION_SETINGESTIONS]);
-  const hasKnowledgeUpdateCapability = useGranted([KNOWLEDGE_KNUPDATE]);
+  const hasKnowledgeUpdateCapability = useGranted([KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNASKIMPORT], false, { capabilitiesInDraft: [KNOWLEDGE_KNUPDATE] });
 
   const {
     viewStorage,

--- a/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/roles/RoleEditionCapabilities.tsx
@@ -196,7 +196,9 @@ const RoleEditionCapabilitiesComponent: FunctionComponent<RoleEditionCapabilitie
                 && capability.name !== 'BYPASS',
             );
             const draftCapaMatchingMainCapa = (role.capabilities ?? []).filter((r) => r?.name.includes(capability.name));
-            const isDisabled = isCapabilitiesInDraft ? matchingCapabilities.length > 0 || draftCapaMatchingMainCapa.length > 0 : matchingCapabilities.length > 0;
+            const isDisabled = isCapabilitiesInDraft
+              ? matchingCapabilities.length > 0 || draftCapaMatchingMainCapa.length > 0
+              : matchingCapabilities.length > 0;
             const isChecked = isDisabled || roleCapability !== undefined;
             return (
               <ListItem

--- a/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.ts
@@ -1,4 +1,4 @@
-import useGranted, { getCapabilitiesName, KNOWLEDGE, KNOWLEDGE_KNASKIMPORT } from './useGranted';
+import useGranted, { getCapabilitiesName, KNOWLEDGE, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE } from './useGranted';
 import useAuth from './useAuth';
 
 const useImportAccess = () => {
@@ -12,8 +12,15 @@ const useImportAccess = () => {
     capabilitiesInDraft: [KNOWLEDGE_KNASKIMPORT],
   });
 
-  // Forced to create Draft on import if they have no import capability in base but have it in draft
-  const isForcedImportToDraft = !hasImportBaseCapability && hasAnyImportCapability;
+  // Has create/update knowledge only in draft (not in main)
+  const hasKnowledgeUpdateInMain = useGranted([KNOWLEDGE_KNUPDATE]);
+  const hasKnowledgeUpdateInDraftOnly = !hasKnowledgeUpdateInMain && useGranted([], false, {
+    capabilitiesInDraft: [KNOWLEDGE_KNUPDATE],
+  });
+
+  // Forced to create Draft on import if they have no import capability in base but have it in draft,
+  // or if they only have KNOWLEDGE_KNUPDATE in draft (not in main).
+  const isForcedImportToDraft = (!hasImportBaseCapability && hasAnyImportCapability) || hasKnowledgeUpdateInDraftOnly;
 
   // Only access to Import Draft Tab
   const userCapabilities = getCapabilitiesName(me.capabilities);

--- a/opencti-platform/opencti-graphql/src/modules/form/form.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/form/form.graphql
@@ -56,7 +56,7 @@ type FormSubmissionResponse {
 
 # Queries
 type Query {
-  form(id: ID!): Form @auth(for: [KNOWLEDGE_KNUPDATE], forDraft: [KNOWLEDGE_KNASKIMPORT])
+  form(id: ID!): Form @auth(for: [KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNASKIMPORT], forDraft: [KNOWLEDGE_KNASKIMPORT])
   forms(
     search: String
     first: Int
@@ -64,7 +64,7 @@ type Query {
     orderBy: FormsOrdering
     orderMode: OrderingMode
     filters: FilterGroup
-  ): FormConnection @auth(for: [KNOWLEDGE_KNUPDATE], forDraft: [KNOWLEDGE_KNASKIMPORT])
+  ): FormConnection @auth(for: [KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNASKIMPORT], forDraft: [KNOWLEDGE_KNASKIMPORT])
 }
 
 # Mutations
@@ -72,6 +72,6 @@ type Mutation {
   formAdd(input: FormAddInput!): Form @auth(for: [INGESTION_SETINGESTIONS])
   formFieldPatch(id: ID!, input: [EditInput!]!): Form @auth(for: [INGESTION_SETINGESTIONS])
   formDelete(id: ID!): ID @auth(for: [INGESTION_SETINGESTIONS])
-  formSubmit(input: FormSubmissionInput!, isDraft: Boolean! = false): FormSubmissionResponse @auth(for: [KNOWLEDGE_KNUPDATE], forDraft: [KNOWLEDGE_KNASKIMPORT])
+  formSubmit(input: FormSubmissionInput!, isDraft: Boolean! = false): FormSubmissionResponse @auth(for: [KNOWLEDGE_KNUPDATE], forDraft: [KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE])
   formImport(file: Upload!): Form @auth(for: [INGESTION_SETINGESTIONS])
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* allow to use form intakes (in forced draft mode) if user has create/update knowledge capability in draft

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16467 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
