### PR TITLE
fix(migrations): rewrite attack pattern standard_id without patchAttribute

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1779435787999-attack_pattern_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1779435787999-attack_pattern_case_insensitive_standard_id.js
@@ -5,11 +5,24 @@ import { generateStandardId } from '../schema/identifier';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION } from '../schema/stixDomainObject';
 import { READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { fullEntitiesList } from '../database/middleware-loader';
-import { mergeEntities, patchAttribute } from '../database/middleware';
+import { mergeEntities } from '../database/middleware';
 import { BULK_TIMEOUT, elBatchIdsWithRelCount, elBulk, ES_MAX_CONCURRENCY, MAX_BULK_OPERATIONS } from '../database/engine';
 import { logApp, logMigration } from '../config/conf';
 
 const message = '[MIGRATION] Attack Pattern / Course of Action standard_id case-insensitive rewrite';
+
+const rewriteStandardId = async (context, entity, newId) => {
+  const existingStixIds = entity.x_opencti_stix_ids ?? [];
+  const updatedStixIds = R.uniq([...existingStixIds, entity.standard_id]);
+  await elBulk(context, {
+    refresh: true,
+    timeout: BULK_TIMEOUT,
+    body: [
+      { update: { _index: entity._index, _id: entity._id } },
+      { doc: { standard_id: newId, x_opencti_stix_ids: updatedStixIds } },
+    ],
+  });
+};
 
 // Recompute and rewrite the standard_id of all entities of a given STIX domain entity type,
 // merging duplicates that collide after the new (case-insensitive) x_mitre_id normalization.
@@ -76,7 +89,10 @@ const migrateEntityType = async (context, entityType) => {
     const sources = sorted.slice(1).map((e) => e.entity);
     try {
       if (target.standard_id !== newId) {
-        await patchAttribute(context, SYSTEM_USER, target.internal_id, target.entity_type, { standard_id: newId });
+        // `standard_id` is not updatable through middleware patching (update: false).
+        // For this migration we must still rewrite it, while preserving the previous value in
+        // `x_opencti_stix_ids` so old IDs continue resolving.
+        await rewriteStandardId(context, target, newId);
       }
       await mergeEntities(context, SYSTEM_USER, target.internal_id, sources.map((s) => s.internal_id));
       mergedEntities += sources.length;


### PR DESCRIPTION
### Proposed changes

- Fix migration [1779435787999-attack_pattern_case_insensitive_standard_id.js](cci:7://file:///c:/Users/PAILFAC/Downloads/Clients/amiraifori-opencti/opencti-platform/opencti-graphql/src/migrations/1779435787999-attack_pattern_case_insensitive_standard_id.js:0:0-0:0) failing with `VALIDATION_ERROR: You cannot update incompatible attribute` when handling collision groups.
- Avoid updating `standard_id` via `patchAttribute` (not updatable through middleware); instead rewrite `standard_id` via a direct Elasticsearch update (`elBulk`) while archiving the previous value into `x_opencti_stix_ids`, then proceed with `mergeEntities`.

### Related issues
- closes #16485

### How to test this PR

1. Run OpenCTI backend on a dataset where duplicate `Attack-Pattern` / `Course-Of-Action` entities collide after the new case-insensitive `x_mitre_id` normalization.
2. Run migrations (or specifically execute migration 1779435787999-attack_pattern_case_insensitive_standard_id.js.
3. Verify the migration no longer errors with `You cannot update incompatible attribute`.
4. Verify for merged collision groups:
   - the merge target has `standard_id` rewritten to the recomputed value
   - the previous `standard_id` is preserved in `x_opencti_stix_ids`
   - merge completes and relationships are retained.

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

- This change is intentionally scoped to the migration code path. The bulk rewrite approach is already used later in the same migration for singleton entities; this extends the same strategy to collision groups to avoid middleware validation on `standard_id`.