### PR TITLE
fix(frontend): Dashboard widgets partially rendered in PDF export when changing theme (#16498)

### DIFF
--- a/opencti-platform/opencti-front/src/components/AppThemeProvider.tsx
+++ b/opencti-platform/opencti-front/src/components/AppThemeProvider.tsx
@@ -112,10 +112,11 @@ const AppThemeProvider: FunctionComponent<AppThemeProviderProps> = ({
       theme_secondary: themeToUse?.theme_secondary ?? defaultTheme.theme_secondary,
       theme_text_color: themeToUse?.theme_text_color ?? defaultTheme.theme_text_color,
     };
-    const theme = createTheme(themeBuilder(appTheme) as ThemeOptions);
-    theme.isExportTheme = !!exportTheme;
-    return theme;
-  }, [themeToUse, !!exportTheme]);
+    return createTheme({
+      ...(themeBuilder(appTheme) as ThemeOptions),
+      isExportTheme: !!exportTheme,
+    });
+  }, [themeToUse, exportTheme]);
 
   // Compute the lowercase palette mode used by the body `data-theme`
   // attribute. This must match `theme.palette.mode` so that CSS files

--- a/opencti-platform/opencti-front/src/components/AppThemeProvider.tsx
+++ b/opencti-platform/opencti-front/src/components/AppThemeProvider.tsx
@@ -112,8 +112,10 @@ const AppThemeProvider: FunctionComponent<AppThemeProviderProps> = ({
       theme_secondary: themeToUse?.theme_secondary ?? defaultTheme.theme_secondary,
       theme_text_color: themeToUse?.theme_text_color ?? defaultTheme.theme_text_color,
     };
-    return createTheme(themeBuilder(appTheme) as ThemeOptions);
-  }, [themeToUse]);
+    const theme = createTheme(themeBuilder(appTheme) as ThemeOptions);
+    theme.isExportTheme = !!exportTheme;
+    return theme;
+  }, [themeToUse, !!exportTheme]);
 
   // Compute the lowercase palette mode used by the body `data-theme`
   // attribute. This must match `theme.palette.mode` so that CSS files

--- a/opencti-platform/opencti-front/src/components/Theme.d.ts
+++ b/opencti-platform/opencti-front/src/components/Theme.d.ts
@@ -129,6 +129,7 @@ declare module '@mui/material/styles' {
     tag: {
       overflowColor: string;
     };
+    isExportTheme?: boolean;
   }
 
   interface ThemeOptions {
@@ -144,6 +145,7 @@ declare module '@mui/material/styles' {
     tag?: {
       overflowColor?: string;
     };
+    isExportTheme?: boolean;
   }
 }
 
@@ -324,4 +326,5 @@ export interface Theme extends MuiTheme {
       small: SizeConfig;
     };
   };
+  isExportTheme?: boolean;
 }

--- a/opencti-platform/opencti-front/src/utils/Charts.jsx
+++ b/opencti-platform/opencti-front/src/utils/Charts.jsx
@@ -81,6 +81,9 @@ export const lineChartOptions = (
     foreColor: theme.palette.text.secondary,
     width: '100%',
     height: '100%',
+    animations: {
+      enabled: !theme.isExportTheme,
+    },
   },
   theme: {
     mode: theme.palette.mode,
@@ -176,6 +179,9 @@ export const areaChartOptions = (
     stacked: isStacked,
     width: '100%',
     height: '100%',
+    animations: {
+      enabled: !theme.isExportTheme,
+    },
   },
   theme: {
     mode: theme.palette.mode,
@@ -286,6 +292,9 @@ export const verticalBarsChartOptions = (
     stacked: isStacked,
     width: '100%',
     height: '100%',
+    animations: {
+      enabled: !theme.isExportTheme,
+    },
   },
   theme: {
     mode: theme.palette.mode,
@@ -398,6 +407,9 @@ export const horizontalBarsChartOptions = (
     stackType,
     width: '100%',
     height: '100%',
+    animations: {
+      enabled: !theme.isExportTheme,
+    },
     events: {
       xAxisLabelClick: (event, chartContext, config) => {
         if (redirectionUtils) {
@@ -594,6 +606,9 @@ export const radarChartOptions = (
     toolbar: toolbarOptions,
     width: '100%',
     height: '100%',
+    animations: {
+      enabled: !theme.isExportTheme,
+    },
     events: {
       click: () => handleClick(),
       markerClick: () => handleClick(),
@@ -708,6 +723,9 @@ export const polarAreaChartOptions = (
       foreColor: theme.palette.text.secondary,
       width: '100%',
       height: '100%',
+      animations: {
+        enabled: !theme.isExportTheme,
+      },
     },
     theme: {
       mode: theme.palette.mode,
@@ -825,6 +843,9 @@ export const donutChartOptions = (
       foreColor: theme.palette.text.secondary,
       width: '100%',
       height: '100%',
+      animations: {
+        enabled: !theme.isExportTheme,
+      },
     },
     theme: {
       mode: theme.palette.mode,
@@ -907,6 +928,9 @@ export const treeMapOptions = (
       foreColor: theme.palette.text.secondary,
       width: '100%',
       height: '100%',
+      animations: {
+        enabled: !theme.isExportTheme,
+      },
     },
     theme: {
       mode: theme.palette.mode,
@@ -988,6 +1012,9 @@ export const heatMapOptions = (
     toolbar: toolbarOptions,
     foreColor: theme.palette.text.secondary,
     stacked: isStacked,
+    animations: {
+      enabled: !theme.isExportTheme,
+    },
   },
   theme: {
     mode: theme.palette.mode,


### PR DESCRIPTION
### Proposed changes

* Add `isExportTheme` flag to the MUI theme type declarations (`Theme.d.ts`) and set it in `AppThemeProvider.tsx` when an export theme is active
* Disable ApexCharts animations for all chart types (line, area, vertical/horizontal bars, radar, polar area, donut, treemap, heatmap) when `theme.isExportTheme` is `true`, preventing mid-transition screenshots during PDF/image export

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16498

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
1. Set the application theme to **Dark** in user profile settings
2. Open a dashboard with multiple widgets (Donut, Area, Vertical Bars, etc.)
3. Click **Export to PDF** and select the **Light** theme
4. Verify the generated PDF contains all charts fully rendered with no missing/cropped content
5. Repeat with matching themes (Dark → Dark) to confirm no regression

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

The root cause is that switching the export theme triggers ApexCharts update animations (up to ~800ms). Since `htmlToImage` captures the DOM before these async animations complete, charts appear mid-transition in the export. Rather than increasing the arbitrary `wait(1000)` delay, this fix adds an `isExportTheme` boolean to the MUI theme object and uses it to disable chart animations entirely during export. This ensures charts render to their final static state immediately upon theme switch, making the approach robust regardless of system speed or dashboard complexity.