### PR TITLE
feat(playbook): smart playbook filtering for bulk enrollment (#10039)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "Wissensereignisse abhören",
   "Listen queue": "Warteschlange abhören",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "Auflistung der Playbooks mit manuellen Einstiegspunkten oder Live-Triggern (Ereignissen) und passenden Filtern.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "Auflistung von Playbooks mit manuellen oder durch Live-Trigger (Ereignisse) ausgelösten Einstiegspunkten und entsprechenden Filtern. Es wurden nur die ersten 5000 Entitäten auf Kompatibilität geprüft; nicht kompatible Entitäten werden vom ausgewählten Playbook nicht verarbeitet.",
   "Live streams": "Live-Streams",
   "Live Streams | Data Sharing | Data": "Live-Streams | Gemeinsame Nutzung von Daten | Daten",
   "Live trigger": "Live-Trigger",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "Listen knowledge events",
   "Listen queue": "Listen queue",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "Listing playbooks with entry points manual or live trigger (events) and matching filters.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.",
   "Live streams": "Live streams",
   "Live Streams | Data Sharing | Data": "Live Streams | Data Sharing | Data",
   "Live trigger": "Live trigger",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "Escuchar eventos de conocimiento",
   "Listen queue": "Cola de escucha",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "Listado de playbooks con puntos de entrada manual o live trigger (eventos) y filtros coincidentes.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "Lista de guiones con puntos de entrada manuales o activados en tiempo real (eventos) y filtros correspondientes. Solo se ha comprobado la compatibilidad de las primeras 5000 entidades; el guión seleccionado no procesará ninguna entidad incompatible.",
   "Live streams": "Publicación en vivo",
   "Live Streams | Data Sharing | Data": "Transmisiones en directo | Intercambio de datos | Datos",
   "Live trigger": "Disparador en vivo",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "Écouter les événements de connaissance",
   "Listen queue": "File d'attente d'écoute",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "Liste des playbooks avec points d'entrée manuels ou déclencheurs en direct (événements) et filtres correspondants.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "Liste des playbooks avec des points d'entrée manuels ou déclenchés en temps réel (événements) et des filtres correspondants. Seules les 5 000 premières entités ont fait l'objet d'un contrôle de compatibilité ; les entités incompatibles ne seront pas traitées par le playbook sélectionné.",
   "Live streams": "Streams live",
   "Live Streams | Data Sharing | Data": "Flux en direct | Partage de données | Données",
   "Live trigger": "Déclencheur live",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "Ascoltare gli eventi di conoscenza",
   "Listen queue": "Coda di ascolto",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "Elenco dei playbook con punti di ingresso manuali o trigger live (eventi) e filtri corrispondenti.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "Elenco dei playbook con punti di ingresso manuali o attivati in tempo reale (eventi) e relativi filtri. È stata verificata la compatibilità solo delle prime 5000 entità; le entità incompatibili non saranno elaborate dal playbook selezionato.",
   "Live streams": "Flussi in diretta",
   "Live Streams | Data Sharing | Data": "Streaming dal vivo | Condivisione dati | Dati",
   "Live trigger": "Trigger live",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "ナレッジイベントをリッスン",
   "Listen queue": "キューを聞く",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "手動またはライブトリガー(イベント)をエントリーポイントとするプレイブックと、それにマッチするフィルタをリストアップする。",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "エントリポイント（手動またはライブトリガー（イベント））と一致するフィルターを持つプレイブックを一覧表示します。互換性の確認は最初の5000件のエンティティに対してのみ行われており、互換性のないエンティティは、選択されたプレイブックによって処理されません。",
   "Live streams": "ライブストリーム",
   "Live Streams | Data Sharing | Data": "ライブストリーム｜データ共有｜データ",
   "Live trigger": "ライブトリガー",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "지식 이벤트 듣기",
   "Listen queue": "대기열 듣기",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "진입점 수동 또는 실시간 트리거(이벤트) 및 일치하는 필터가 있는 플레이북을 나열합니다.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "시작점(수동 또는 실시간 트리거(이벤트))과 일치하는 필터를 가진 플레이북 목록입니다. 호환성 검사는 처음 5,000개의 엔티티에 대해서만 수행되었으며, 호환되지 않는 엔티티는 선택한 플레이북에서 처리되지 않습니다.",
   "Live streams": "실시간 스트림",
   "Live Streams | Data Sharing | Data": "실시간 스트림 | 데이터 공유 | 데이터",
   "Live trigger": "실시간 트리거",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "Прослушать события знаний",
   "Listen queue": "Очередь на прослушивание",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "Листинг плейбуков с точками входа, ручными или живыми триггерами (событиями) и соответствующими фильтрами.",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "Список сценариев с точками входа (ручным вводом или триггерами в реальном времени) и соответствующими фильтрами. На совместимость проверены только первые 5000 объектов; любые несовместимые объекты не будут обрабатываться выбранным сценарием.",
   "Live streams": "Прямые трансляции",
   "Live Streams | Data Sharing | Data": "Прямые трансляции | Обмен данными | Данные",
   "Live trigger": "Живой триггер",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2621,6 +2621,7 @@
   "Listen knowledge events": "监听知识事件",
   "Listen queue": "监听队列",
   "Listing playbooks with entry points manual or live trigger (events) and matching filters.": "列出具有入口点手动或实时触发器（事件）和匹配过滤器的播放列表。",
+  "Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.": "列出具有手动或实时触发（事件）入口点及匹配过滤器的操作指南。目前仅对前 5000 个实体进行了兼容性检查，任何不兼容的实体都不会被所选操作指南处理。",
   "Live streams": "实时流",
   "Live Streams | Data Sharing | Data": "实时流 | 数据共享 | 数据",
   "Live trigger": "实时触发器",

--- a/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/DataTable.tsx
@@ -121,6 +121,7 @@ type DataTableInternalToolbarProps = Pick<DataTableProps,
   | 'markAsReadEnabled'
   | 'entityTypes'
   | 'trashOperationsEnabled'
+  | 'disableBulkEnroll'
   | 'deleteDisable'
   | 'container'
 > & {
@@ -140,6 +141,7 @@ const DataTableInternalToolbar = ({
   entityTypes,
   displayEditButtons,
   trashOperationsEnabled,
+  disableBulkEnroll,
   deleteDisable,
   container,
 }: DataTableInternalToolbarProps) => {
@@ -182,6 +184,7 @@ const DataTableInternalToolbar = ({
         markAsReadEnabled={markAsReadEnabled}
         displayEditButtons={displayEditButtons}
         trashOperationsEnabled={trashOperationsEnabled}
+        disableBulkEnroll={disableBulkEnroll}
         deleteDisable={deleteDisable}
         container={container}
       />
@@ -250,6 +253,7 @@ const DataTable = (props: OCTIDataTableProps) => {
     removeFromDraftEnabled,
     markAsReadEnabled,
     trashOperationsEnabled,
+    disableBulkEnroll,
     deleteDisable,
     container,
   } = props;
@@ -311,6 +315,7 @@ const DataTable = (props: OCTIDataTableProps) => {
             markAsReadEnabled={markAsReadEnabled}
             displayEditButtons={hasAuthorizedMembersCanEdit}
             trashOperationsEnabled={trashOperationsEnabled}
+            disableBulkEnroll={disableBulkEnroll}
             deleteDisable={deleteDisable}
           />
         )}

--- a/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
+++ b/opencti-platform/opencti-front/src/components/dataGrid/dataTableTypes.ts
@@ -161,6 +161,7 @@ export interface DataTableProps {
   isLocalStorageEnabled?: boolean;
   emptyStateMessage?: string;
   trashOperationsEnabled?: boolean;
+  disableBulkEnroll?: boolean;
   deleteDisable?: boolean;
 }
 

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -518,7 +518,8 @@ class DataTableToolBar extends Component {
       type: 'ENROLL_PLAYBOOK',
       context: { values: [{ id: playbookId, name: playbookName }] },
     }];
-    this.setState({ actions }, () => {
+    const description = `ENROLL IN PLAYBOOK ${playbookName}`;
+    this.setState({ description, actions }, () => {
       this.handleCloseEnrollPlaybook();
       this.handleOpenTask();
     });
@@ -2559,22 +2560,27 @@ class DataTableToolBar extends Component {
                         </Security>
                       </>
                     )}
-                    {isBulkEnrollEnabled && (
-                      <Security needs={[AUTOMATION]}>
-                        <Tooltip title={t('Enroll in playbook')}>
-                          <span>
-                            <IconButton
-                              aria-label="enroll-playbook"
-                              disabled={numberOfSelectedElements === 0 || this.state.processing}
-                              onClick={this.handleOpenEnrollPlaybook.bind(this)}
-                              size="small"
-                            >
-                              <PrecisionManufacturingOutlined fontSize="small" />
-                            </IconButton>
-                          </span>
-                        </Tooltip>
-                      </Security>
-                    )}
+                    {isBulkEnrollEnabled && !isInDraft && !isUserDatatable
+                      && taskScope !== 'SETTINGS'
+                      && taskScope !== 'INVESTIGATION'
+                      && taskScope !== 'DASHBOARD'
+                      && taskScope !== 'PUBLIC_DASHBOARD'
+                      && (
+                        <Security needs={[AUTOMATION]}>
+                          <Tooltip title={t('Enroll in playbook')}>
+                            <span>
+                              <IconButton
+                                aria-label="enroll-playbook"
+                                disabled={numberOfSelectedElements === 0 || this.state.processing}
+                                onClick={this.handleOpenEnrollPlaybook.bind(this)}
+                                size="small"
+                              >
+                                <PrecisionManufacturingOutlined fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                        </Security>
+                      )}
                     {deleteDisable !== true && !removeAuthMembersEnabled && !removeFromDraftEnabled && !isUserDatatable && (
                       <Security needs={[deleteCapability]}>
                         <Tooltip title={warningMessage || t('Delete')}>
@@ -3383,6 +3389,11 @@ class DataTableToolBar extends Component {
                 open={this.state.displayEnrollPlaybook}
                 onClose={this.handleCloseEnrollPlaybook.bind(this)}
                 onLaunch={this.handleLaunchEnrollPlaybook.bind(this)}
+                entityIds={this.props.selectAll ? undefined : Object.keys(this.props.selectedElements || {})}
+                isSelectAll={this.props.selectAll}
+                filters={this.props.selectAll ? this.props.filters : undefined}
+                search={this.props.selectAll ? this.props.search : undefined}
+                excludedIds={this.props.selectAll ? Object.keys(this.props.deSelectedElements || {}) : undefined}
               />
             </>
           );

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -2171,6 +2171,7 @@ class DataTableToolBar extends Component {
       deleteDisable,
       mergeDisable,
       trashOperationsEnabled,
+      disableBulkEnroll,
       removeAuthMembersEnabled,
       removeFromDraftEnabled,
       markAsReadEnabled,
@@ -2560,11 +2561,9 @@ class DataTableToolBar extends Component {
                         </Security>
                       </>
                     )}
-                    {isBulkEnrollEnabled && !isInDraft && !isUserDatatable
-                      && taskScope !== 'SETTINGS'
-                      && taskScope !== 'INVESTIGATION'
-                      && taskScope !== 'DASHBOARD'
-                      && taskScope !== 'PUBLIC_DASHBOARD'
+                    {isBulkEnrollEnabled && !isInDraft
+                      && (!taskScope || taskScope === 'KNOWLEDGE')
+                      && !disableBulkEnroll
                       && (
                         <Security needs={[AUTOMATION]}>
                           <Tooltip title={t('Enroll in playbook')}>
@@ -3423,6 +3422,7 @@ DataTableToolBar.propTypes = {
   rightOffset: PropTypes.number,
   mergeDisable: PropTypes.bool,
   trashOperationsEnabled: PropTypes.bool,
+  disableBulkEnroll: PropTypes.bool,
   removeAuthMembersEnabled: PropTypes.bool,
   removeFromDraft: PropTypes.bool,
   markAsReadEnabled: PropTypes.bool,

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -99,7 +99,7 @@ import { killChainPhasesSearchQuery } from '../settings/KillChainPhases';
 import { labelsSearchQuery } from '../settings/LabelsQuery';
 import UserEmailSend from '../settings/users/UserEmailSend';
 import PromoteDrawer from './drawers/PromoteDrawer';
-import { isFeatureEnable } from '../../../utils/platformModulesHelper';
+
 import EnrollPlaybookDrawer from '@components/data/drawers/EnrollPlaybookDrawer';
 
 const styles = (theme) => ({
@@ -2199,7 +2199,7 @@ class DataTableToolBar extends Component {
         {({ schema, settings, me }) => {
           const isAdmin = me.capabilities.map((o) => o.name).filter((o) => [SETTINGS_SETACCESSES, BYPASS].includes(o)).length > 0;
           const isInDraft = me.draftContext;
-          const isBulkEnrollEnabled = isFeatureEnable(settings, 'BULK_ENROLLMENT');
+
           const stixCyberObservableSubTypes = schema.scos.map((sco) => sco.id);
           const stixDomainObjectSubTypes = schema.sdos.map((sdo) => sdo.id);
           const { entityTypeFilterValues, selectedElementsList, selectedTypes } = this.getSelectedTypes(stixCyberObservableSubTypes, stixDomainObjectSubTypes);
@@ -2561,7 +2561,7 @@ class DataTableToolBar extends Component {
                         </Security>
                       </>
                     )}
-                    {isBulkEnrollEnabled && !isInDraft
+                    {!isInDraft
                       && (!taskScope || taskScope === 'KNOWLEDGE')
                       && !disableBulkEnroll
                       && (

--- a/opencti-platform/opencti-front/src/private/components/data/drawers/EnrollPlaybookDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/drawers/EnrollPlaybookDrawer.tsx
@@ -1,60 +1,30 @@
 import { PlayCircleOutlined } from '@mui/icons-material';
-import { Alert, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
-import { graphql } from 'react-relay';
-import React, { useEffect, useState } from 'react';
+import { Alert, CircularProgress, List, ListItem, ListItemIcon, ListItemText } from '@mui/material';
+import React from 'react';
 import Drawer from '@components/common/drawer/Drawer';
 import ItemIcon from '../../../../components/ItemIcon';
-import { fetchQuery } from '../../../../relay/environment';
 import Security from '../../../../utils/Security';
 import { AUTOMATION } from '../../../../utils/hooks/useGranted';
 import IconButton from '@common/button/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import { useFormatter } from '../../../../components/i18n';
-import { EnrollPlaybookDrawerQuery$data } from '@components/data/drawers/__generated__/EnrollPlaybookDrawerQuery.graphql';
-
-const toolBarPlaybooksQuery = graphql`
-  query EnrollPlaybookDrawerQuery {
-    playbooksForEnrollment {
-      id
-      name
-      description
-    }
-  }
-`;
-
-interface Playbook {
-  label: string;
-  value: string;
-  description: string | null | undefined;
-}
+import type { FilterGroup } from '../../../../utils/filters/filtersHelpers-types';
+import useEnrollPlaybooks from './hooks/useEnrollPlaybooks';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   onLaunch: (playbookId: string, playbookName: string) => void;
+  entityIds?: string[];
+  isSelectAll?: boolean;
+  filters?: FilterGroup | null;
+  search?: string | null;
+  excludedIds?: string[];
 }
 
-const EnrollPlaybookDrawer = ({ open, onClose, onLaunch }: Props) => {
+const EnrollPlaybookDrawer = ({ open, onClose, onLaunch, entityIds, isSelectAll, filters, search, excludedIds }: Props) => {
   const { t_i18n } = useFormatter();
-  const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
-
-  useEffect(() => {
-    if (!open) return;
-    fetchQuery(toolBarPlaybooksQuery)
-      .toPromise()
-      .then((playbooks) => {
-        const data = playbooks as EnrollPlaybookDrawerQuery$data;
-        const fetched = (data?.playbooksForEnrollment ?? [])
-          .filter((p): p is NonNullable<typeof p> => Boolean(p))
-          .map((p) => ({
-            label: p.name,
-            value: p.id,
-            description: p.description,
-          }))
-          .sort((a, b) => a.label.localeCompare(b.label));
-        setPlaybooks(fetched);
-      });
-  }, [open]);
+  const { playbooks, loading } = useEnrollPlaybooks({ open, entityIds, isSelectAll, filters, search, excludedIds });
 
   return (
     <Drawer
@@ -64,41 +34,47 @@ const EnrollPlaybookDrawer = ({ open, onClose, onLaunch }: Props) => {
     >
       <>
         <Alert severity="info" variant="outlined">
-          {t_i18n('Select a playbook to enroll the selected entities.')}
+          {t_i18n('Listing playbooks with entry points manual or live trigger (events) and matching filters. Only the first 5000 entities have been checked for compatibility, any incompatible entities will not be processed by the selected playbook.')}
         </Alert>
-        <List>
-          {playbooks.length > 0 ? (
-            playbooks.map((playbook) => (
-              <ListItem
-                key={playbook.value}
-                divider
-                secondaryAction={(
-                  <Security needs={[AUTOMATION]}>
-                    <Tooltip title={t_i18n('Enroll in this playbook')}>
-                      <IconButton
-                        onClick={() => onLaunch(playbook.value, playbook.label)}
-                      >
-                        <PlayCircleOutlined />
-                      </IconButton>
-                    </Tooltip>
-                  </Security>
-                )}
-              >
-                <ListItemIcon>
-                  <ItemIcon type="Playbook" />
-                </ListItemIcon>
-                <ListItemText
-                  primary={playbook.label}
-                  secondary={playbook.description ?? ''}
-                />
-              </ListItem>
-            ))
-          ) : (
-            <div style={{ color: 'text.primary', fontSize: 15, textAlign: 'center', marginTop: 20 }}>
-              {t_i18n('No playbook available')}
-            </div>
-          )}
-        </List>
+        {loading ? (
+          <div style={{ display: 'flex', justifyContent: 'center', marginTop: 20 }}>
+            <CircularProgress />
+          </div>
+        ) : (
+          <List>
+            {playbooks.length > 0 ? (
+              playbooks.map((playbook) => (
+                <ListItem
+                  key={playbook.value}
+                  divider
+                  secondaryAction={(
+                    <Security needs={[AUTOMATION]}>
+                      <Tooltip title={t_i18n('Enroll in this playbook')}>
+                        <IconButton
+                          onClick={() => onLaunch(playbook.value, playbook.label)}
+                        >
+                          <PlayCircleOutlined />
+                        </IconButton>
+                      </Tooltip>
+                    </Security>
+                  )}
+                >
+                  <ListItemIcon>
+                    <ItemIcon type="Playbook" />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={playbook.label}
+                    secondary={playbook.description ?? ''}
+                  />
+                </ListItem>
+              ))
+            ) : (
+              <div style={{ color: 'text.primary', fontSize: 15, textAlign: 'center', marginTop: 20 }}>
+                {t_i18n('No playbook available')}
+              </div>
+            )}
+          </List>
+        )}
       </>
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mapIdsResponse, mapFiltersResponse, sortPlaybooks, fetchPlaybooks } from './enrollPlaybookDrawer.utils';
+import type { IdsResponseData, FiltersResponseData, Playbook } from './enrollPlaybookDrawer.utils';
+
+const ENRICH_OBSERVABLE = {
+  id: 'playbook-enrich-observable',
+  name: 'Enrich observable',
+  description: 'Fetches enrichment data for observables matching the trigger.',
+};
+
+const NOTIFY_ON_MALWARE = {
+  id: 'playbook-notify-malware',
+  name: 'Notify on malware',
+  description: null,
+};
+
+const TAG_AND_SCORE = {
+  id: 'playbook-tag-score',
+  name: 'Tag and score indicator',
+  description: 'Applies tags and confidence scores to matched indicators.',
+};
+
+describe('mapIdsResponse', () => {
+  it('maps valid playbooks to label/value/description', () => {
+    const data: IdsResponseData = {
+      playbooksForEnrollment: [ENRICH_OBSERVABLE, NOTIFY_ON_MALWARE],
+    };
+    expect(mapIdsResponse(data)).toEqual([
+      { label: ENRICH_OBSERVABLE.name, value: ENRICH_OBSERVABLE.id, description: ENRICH_OBSERVABLE.description },
+      { label: NOTIFY_ON_MALWARE.name, value: NOTIFY_ON_MALWARE.id, description: NOTIFY_ON_MALWARE.description },
+    ]);
+  });
+
+  it('filters out null/undefined entries while preserving valid ones', () => {
+    const data: IdsResponseData = {
+      playbooksForEnrollment: [null, ENRICH_OBSERVABLE, undefined, NOTIFY_ON_MALWARE],
+    };
+    const result = mapIdsResponse(data);
+    expect(result).toHaveLength(2);
+    expect(result[0].value).toBe(ENRICH_OBSERVABLE.id);
+    expect(result[1].value).toBe(NOTIFY_ON_MALWARE.id);
+  });
+
+  it('returns empty array when playbooksForEnrollment is null', () => {
+    expect(mapIdsResponse({ playbooksForEnrollment: null })).toEqual([]);
+  });
+
+  it('returns empty array when playbooksForEnrollment is undefined', () => {
+    expect(mapIdsResponse({ playbooksForEnrollment: undefined })).toEqual([]);
+  });
+
+  it('returns empty array when playbooksForEnrollment is an empty array', () => {
+    expect(mapIdsResponse({ playbooksForEnrollment: [] })).toEqual([]);
+  });
+});
+
+describe('mapFiltersResponse', () => {
+  it('maps a single playbook from filter response', () => {
+    const data: FiltersResponseData = {
+      playbooksForEnrollmentByFilters: { playbooks: [TAG_AND_SCORE] },
+    };
+    expect(mapFiltersResponse(data)).toEqual([
+      { label: TAG_AND_SCORE.name, value: TAG_AND_SCORE.id, description: TAG_AND_SCORE.description },
+    ]);
+  });
+
+  it('returns empty array when result is null', () => {
+    expect(mapFiltersResponse({ playbooksForEnrollmentByFilters: null })).toEqual([]);
+  });
+
+  it('returns empty array when result is undefined', () => {
+    expect(mapFiltersResponse({ playbooksForEnrollmentByFilters: undefined })).toEqual([]);
+  });
+});
+
+describe('sortPlaybooks', () => {
+  it('sorts alphabetically by label', () => {
+    const input: Playbook[] = [
+      { label: TAG_AND_SCORE.name, value: TAG_AND_SCORE.id, description: null },
+      { label: NOTIFY_ON_MALWARE.name, value: NOTIFY_ON_MALWARE.id, description: null },
+      { label: ENRICH_OBSERVABLE.name, value: ENRICH_OBSERVABLE.id, description: null },
+    ];
+    expect(sortPlaybooks(input).map((p) => p.value)).toEqual([
+      ENRICH_OBSERVABLE.id,
+      NOTIFY_ON_MALWARE.id,
+      TAG_AND_SCORE.id,
+    ]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(sortPlaybooks([])).toEqual([]);
+  });
+
+  it('returns single-item array unchanged', () => {
+    const input: Playbook[] = [
+      { label: NOTIFY_ON_MALWARE.name, value: NOTIFY_ON_MALWARE.id, description: null },
+    ];
+    expect(sortPlaybooks(input)).toEqual(input);
+  });
+});
+
+describe('fetchPlaybooks', () => {
+  const idsResponseFixture: IdsResponseData = {
+    playbooksForEnrollment: [TAG_AND_SCORE, ENRICH_OBSERVABLE],
+  };
+
+  const filtersResponseFixture: FiltersResponseData = {
+    playbooksForEnrollmentByFilters: {
+      playbooks: [TAG_AND_SCORE, NOTIFY_ON_MALWARE, ENRICH_OBSERVABLE],
+    },
+  };
+
+  it('calls fetcher with the provided entityIds when isSelectAll is false', async () => {
+    const fetcher = vi.fn().mockResolvedValue(idsResponseFixture);
+    await fetchPlaybooks({ isSelectAll: false, entityIds: [ENRICH_OBSERVABLE.id, TAG_AND_SCORE.id] }, fetcher);
+    expect(fetcher).toHaveBeenCalledWith(expect.anything(), { ids: [ENRICH_OBSERVABLE.id, TAG_AND_SCORE.id] });
+  });
+
+  it('returns playbooks sorted by name when isSelectAll is false', async () => {
+    const fetcher = vi.fn().mockResolvedValue(idsResponseFixture);
+    const result = await fetchPlaybooks({ isSelectAll: false, entityIds: [ENRICH_OBSERVABLE.id, TAG_AND_SCORE.id] }, fetcher);
+    expect(result.map((p) => p.value)).toEqual([ENRICH_OBSERVABLE.id, TAG_AND_SCORE.id]);
+  });
+
+  it('defaults entityIds to [] when not provided on the ids path', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ playbooksForEnrollment: [] });
+    await fetchPlaybooks({ isSelectAll: false }, fetcher);
+    expect(fetcher).toHaveBeenCalledWith(expect.anything(), { ids: [] });
+  });
+
+  it('returns empty array when ids response has no playbooks', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ playbooksForEnrollment: null });
+    expect(await fetchPlaybooks({ isSelectAll: false }, fetcher)).toEqual([]);
+  });
+
+  it('calls fetcher with filters, search and excludedIds when isSelectAll is true', async () => {
+    const fetcher = vi.fn().mockResolvedValue(filtersResponseFixture);
+    const filters = { mode: 'and' as const, filters: [], filterGroups: [] };
+    await fetchPlaybooks({ isSelectAll: true, filters, search: 'malware', excludedIds: [NOTIFY_ON_MALWARE.id] }, fetcher);
+    expect(fetcher).toHaveBeenCalledWith(expect.anything(), {
+      filters,
+      search: 'malware',
+      excludedIds: [NOTIFY_ON_MALWARE.id],
+    });
+  });
+
+  it('returns playbooks sorted by name when isSelectAll is true', async () => {
+    const fetcher = vi.fn().mockResolvedValue(filtersResponseFixture);
+    const result = await fetchPlaybooks({ isSelectAll: true }, fetcher);
+    expect(result.map((p) => p.value)).toEqual([ENRICH_OBSERVABLE.id, NOTIFY_ON_MALWARE.id, TAG_AND_SCORE.id]);
+  });
+
+  it('returns empty array when filters response has no playbooks', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ playbooksForEnrollmentByFilters: null });
+    expect(await fetchPlaybooks({ isSelectAll: true }, fetcher)).toEqual([]);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.test.ts
@@ -57,19 +57,11 @@ describe('mapIdsResponse', () => {
 describe('mapFiltersResponse', () => {
   it('maps a single playbook from filter response', () => {
     const data: FiltersResponseData = {
-      playbooksForEnrollmentByFilters: { playbooks: [TAG_AND_SCORE] },
+      playbooksForEnrollmentByFilters: [TAG_AND_SCORE],
     };
     expect(mapFiltersResponse(data)).toEqual([
       { label: TAG_AND_SCORE.name, value: TAG_AND_SCORE.id, description: TAG_AND_SCORE.description },
     ]);
-  });
-
-  it('returns empty array when result is null', () => {
-    expect(mapFiltersResponse({ playbooksForEnrollmentByFilters: null })).toEqual([]);
-  });
-
-  it('returns empty array when result is undefined', () => {
-    expect(mapFiltersResponse({ playbooksForEnrollmentByFilters: undefined })).toEqual([]);
   });
 });
 
@@ -105,9 +97,7 @@ describe('fetchPlaybooks', () => {
   };
 
   const filtersResponseFixture: FiltersResponseData = {
-    playbooksForEnrollmentByFilters: {
-      playbooks: [TAG_AND_SCORE, NOTIFY_ON_MALWARE, ENRICH_OBSERVABLE],
-    },
+    playbooksForEnrollmentByFilters: [TAG_AND_SCORE, NOTIFY_ON_MALWARE, ENRICH_OBSERVABLE],
   };
 
   it('calls fetcher with the provided entityIds when isSelectAll is false', async () => {
@@ -151,7 +141,7 @@ describe('fetchPlaybooks', () => {
   });
 
   it('returns empty array when filters response has no playbooks', async () => {
-    const fetcher = vi.fn().mockResolvedValue({ playbooksForEnrollmentByFilters: null });
+    const fetcher = vi.fn().mockResolvedValue({ playbooksForEnrollmentByFilters: [] });
     expect(await fetchPlaybooks({ isSelectAll: true }, fetcher)).toEqual([]);
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.ts
@@ -16,11 +16,9 @@ export const playbooksForEnrollmentIdsQuery = graphql`
 export const playbooksForEnrollmentByFiltersQuery = graphql`
   query enrollPlaybookDrawerFiltersQuery($filters: FilterGroup, $search: String, $excludedIds: [String!]) {
     playbooksForEnrollmentByFilters(filters: $filters, search: $search, excludedIds: $excludedIds) {
-      playbooks {
-        id
-        name
-        description
-      }
+      id
+      name
+      description
     }
   }
 `;
@@ -55,15 +53,13 @@ export function mapIdsResponse(data: IdsResponseData): Playbook[] {
 }
 
 export function mapFiltersResponse(data: FiltersResponseData): Playbook[] {
-  const result = data.playbooksForEnrollmentByFilters;
-  if (!result) {
-    return [];
-  }
-  return (result.playbooks ?? []).map((p) => ({
-    label: p.name,
-    value: p.id,
-    description: p.description,
-  }));
+  return data.playbooksForEnrollmentByFilters
+    .filter((p): p is NonNullable<typeof p> => Boolean(p))
+    .map((p) => ({
+      label: p.name,
+      value: p.id,
+      description: p.description,
+    }));
 }
 
 export function sortPlaybooks(playbooks: Playbook[]): Playbook[] {

--- a/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/drawers/enrollPlaybookDrawer.utils.ts
@@ -1,0 +1,87 @@
+import { graphql } from 'react-relay';
+import type { FilterGroup } from '../../../../utils/filters/filtersHelpers-types';
+import type { enrollPlaybookDrawerIdsQuery$data } from './__generated__/enrollPlaybookDrawerIdsQuery.graphql';
+import type { enrollPlaybookDrawerFiltersQuery$data } from './__generated__/enrollPlaybookDrawerFiltersQuery.graphql';
+
+export const playbooksForEnrollmentIdsQuery = graphql`
+  query enrollPlaybookDrawerIdsQuery($ids: [String!]!) {
+    playbooksForEnrollment(ids: $ids) {
+      id
+      name
+      description
+    }
+  }
+`;
+
+export const playbooksForEnrollmentByFiltersQuery = graphql`
+  query enrollPlaybookDrawerFiltersQuery($filters: FilterGroup, $search: String, $excludedIds: [String!]) {
+    playbooksForEnrollmentByFilters(filters: $filters, search: $search, excludedIds: $excludedIds) {
+      playbooks {
+        id
+        name
+        description
+      }
+    }
+  }
+`;
+
+export interface Playbook {
+  label: string;
+  value: string;
+  description: string | null | undefined;
+}
+
+export type IdsResponseData = enrollPlaybookDrawerIdsQuery$data;
+export type FiltersResponseData = enrollPlaybookDrawerFiltersQuery$data;
+
+export interface FetchPlaybooksParams {
+  isSelectAll?: boolean;
+  filters?: FilterGroup | null;
+  search?: string | null;
+  excludedIds?: string[];
+  entityIds?: string[];
+}
+
+export type Fetcher = (query: unknown, variables: Record<string, unknown>) => Promise<unknown>;
+
+export function mapIdsResponse(data: IdsResponseData): Playbook[] {
+  return (data.playbooksForEnrollment ?? [])
+    .filter((p): p is NonNullable<typeof p> => Boolean(p))
+    .map((p) => ({
+      label: p.name,
+      value: p.id,
+      description: p.description,
+    }));
+}
+
+export function mapFiltersResponse(data: FiltersResponseData): Playbook[] {
+  const result = data.playbooksForEnrollmentByFilters;
+  if (!result) {
+    return [];
+  }
+  return (result.playbooks ?? []).map((p) => ({
+    label: p.name,
+    value: p.id,
+    description: p.description,
+  }));
+}
+
+export function sortPlaybooks(playbooks: Playbook[]): Playbook[] {
+  return [...playbooks].sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export async function fetchPlaybooks(params: FetchPlaybooksParams, fetcher: Fetcher): Promise<Playbook[]> {
+  if (params.isSelectAll) {
+    const response = await fetcher(playbooksForEnrollmentByFiltersQuery, {
+      filters: params.filters ?? undefined,
+      search: params.search ?? undefined,
+      excludedIds: params.excludedIds ?? [],
+    });
+    return sortPlaybooks(mapFiltersResponse(response as FiltersResponseData));
+  }
+
+  const response = await fetcher(playbooksForEnrollmentIdsQuery, {
+    ids: params.entityIds ?? [],
+  });
+  return sortPlaybooks(mapIdsResponse(response as IdsResponseData));
+}

--- a/opencti-platform/opencti-front/src/private/components/data/drawers/hooks/useEnrollPlaybooks.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/drawers/hooks/useEnrollPlaybooks.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { fetchQuery } from '../../../../../relay/environment';
+import { fetchPlaybooks } from '../enrollPlaybookDrawer.utils';
+import type { Playbook, FetchPlaybooksParams } from '../enrollPlaybookDrawer.utils';
+
+export interface UseEnrollPlaybooksParams extends FetchPlaybooksParams {
+  open: boolean;
+}
+
+const fetcher = (query: unknown, variables: Record<string, unknown>) => {
+  return fetchQuery(query, variables).toPromise() as Promise<unknown>;
+};
+
+const useEnrollPlaybooks = ({ open, ...params }: UseEnrollPlaybooksParams) => {
+  const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setPlaybooks([]);
+    fetchPlaybooks(params, fetcher).then((result) => {
+      setPlaybooks(result);
+      setLoading(false);
+    });
+  }, [open]);
+
+  return { playbooks, loading };
+};
+
+export default useEnrollPlaybooks;

--- a/opencti-platform/opencti-front/src/private/components/data/restriction/RestrictedDrafts.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/restriction/RestrictedDrafts.tsx
@@ -228,6 +228,7 @@ const RestrictedDrafts = () => {
             contextFilters={contextFilters}
             preloadedPaginationProps={preloadedPaginationProps}
             lineFragment={RestrictedDraftLineFragment}
+            disableBulkEnroll
             removeAuthMembersEnabled
           />
         </div>

--- a/opencti-platform/opencti-front/src/private/components/settings/KillChainPhases.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/KillChainPhases.jsx
@@ -156,6 +156,7 @@ const KillChainPhases = () => {
           contextFilters={contextFilters}
           lineFragment={lineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
+          taskScope="SETTINGS"
           actions={(killChainPhase) => <KillChainPhasePopover killChainPhase={killChainPhase} paginationOptions={queryPaginationOptions} />}
           searchContextFinal={{ entityTypes: ['Kill-Chain-Phase'] }}
           disableNavigation

--- a/opencti-platform/opencti-front/src/private/components/settings/Labels.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Labels.jsx
@@ -166,6 +166,7 @@ const Labels = () => {
           contextFilters={contextFilters}
           lineFragment={lineFragment}
           preloadedPaginationProps={preloadedPaginationProps}
+          taskScope="SETTINGS"
           actions={(label) => <LabelPopover label={label} paginationOptions={queryPaginationOptions} />}
           searchContextFinal={{ entityTypes: ['Label'] }}
           disableNavigation

--- a/opencti-platform/opencti-front/src/private/components/trash/Trash.tsx
+++ b/opencti-platform/opencti-front/src/private/components/trash/Trash.tsx
@@ -190,6 +190,7 @@ const Trash: React.FC = () => {
             exportContext={{ entity_type: 'DeleteOperation' }}
             disableNavigation
             trashOperationsEnabled
+            disableBulkEnroll
             deleteDisable
             actions={(row: TrashDeleteOperationLine_node$data) => (
               <DeleteOperationPopover

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9694,7 +9694,7 @@ type Query {
   playbookComponents: [PlaybookComponent]!
   playbooksForEntity(id: String!): [Playbook]
   playbooksForEnrollment(ids: [String!]!): [Playbook]
-  playbooksForEnrollmentByFilters(filters: FilterGroup, search: String, excludedIds: [String!]): PlaybooksForEnrollmentResult
+  playbooksForEnrollmentByFilters(filters: FilterGroup, search: String, excludedIds: [String!]): [Playbook!]!
   playbookManagerInfo: PlaybookManager
   ingestionRss(id: String!): IngestionRss
   ingestionRsss(first: Int, after: ID, orderBy: IngestionRssOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionRssConnection
@@ -13693,10 +13693,6 @@ type PlaybookManager {
   firstStreamEventId: String
   firstStreamEventDate: DateTime
   managerInGoodHealth: Boolean
-}
-
-type PlaybooksForEnrollmentResult {
-  playbooks: [Playbook!]!
 }
 
 input PlaybookAddInput {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9693,7 +9693,8 @@ type Query {
   playbooks(first: Int, after: ID, orderBy: PlaybooksOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): PlaybookConnection
   playbookComponents: [PlaybookComponent]!
   playbooksForEntity(id: String!): [Playbook]
-  playbooksForEnrollment: [Playbook]
+  playbooksForEnrollment(ids: [String!]!): [Playbook]
+  playbooksForEnrollmentByFilters(filters: FilterGroup, search: String, excludedIds: [String!]): PlaybooksForEnrollmentResult
   playbookManagerInfo: PlaybookManager
   ingestionRss(id: String!): IngestionRss
   ingestionRsss(first: Int, after: ID, orderBy: IngestionRssOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionRssConnection
@@ -13692,6 +13693,10 @@ type PlaybookManager {
   firstStreamEventId: String
   firstStreamEventDate: DateTime
   managerInGoodHealth: Boolean
+}
+
+type PlaybooksForEnrollmentResult {
+  playbooks: [Playbook!]!
 }
 
 input PlaybookAddInput {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23593,11 +23593,6 @@ export type PlaybookManager = {
   managerInGoodHealth?: Maybe<Scalars['Boolean']['output']>;
 };
 
-export type PlaybooksForEnrollmentResult = {
-  __typename?: 'PlaybooksForEnrollmentResult';
-  playbooks: Array<Playbook>;
-};
-
 export enum PlaybooksOrdering {
   Score = '_score',
   CreatedAt = 'created_at',
@@ -24540,7 +24535,7 @@ export type Query = {
   playbookManagerInfo?: Maybe<PlaybookManager>;
   playbooks?: Maybe<PlaybookConnection>;
   playbooksForEnrollment?: Maybe<Array<Maybe<Playbook>>>;
-  playbooksForEnrollmentByFilters?: Maybe<PlaybooksForEnrollmentResult>;
+  playbooksForEnrollmentByFilters: Array<Playbook>;
   playbooksForEntity?: Maybe<Array<Maybe<Playbook>>>;
   position?: Maybe<Position>;
   positions?: Maybe<PositionConnection>;
@@ -40062,7 +40057,6 @@ export type ResolversTypes = ResolversObject<{
   PlaybookEdge: ResolverTypeWrapper<Omit<PlaybookEdge, 'node'> & { node: ResolversTypes['Playbook'] }>;
   PlaybookInsertResult: ResolverTypeWrapper<PlaybookInsertResult>;
   PlaybookManager: ResolverTypeWrapper<PlaybookManager>;
-  PlaybooksForEnrollmentResult: ResolverTypeWrapper<Omit<PlaybooksForEnrollmentResult, 'playbooks'> & { playbooks: Array<ResolversTypes['Playbook']> }>;
   PlaybooksOrdering: PlaybooksOrdering;
   Position: ResolverTypeWrapper<Omit<Position, 'avatar' | 'cases' | 'city' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversTypes['OpenCtiFile']>, cases?: Maybe<ResolversTypes['CaseConnection']>, city?: Maybe<ResolversTypes['City']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<ResolversTypes['FileConnection']>, fintelTemplates?: Maybe<Array<ResolversTypes['FintelTemplate']>>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, status?: Maybe<ResolversTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   PositionAddInput: PositionAddInput;
@@ -41102,7 +41096,6 @@ export type ResolversParentTypes = ResolversObject<{
   PlaybookEdge: Omit<PlaybookEdge, 'node'> & { node: ResolversParentTypes['Playbook'] };
   PlaybookInsertResult: PlaybookInsertResult;
   PlaybookManager: PlaybookManager;
-  PlaybooksForEnrollmentResult: Omit<PlaybooksForEnrollmentResult, 'playbooks'> & { playbooks: Array<ResolversParentTypes['Playbook']> };
   Position: Omit<Position, 'avatar' | 'cases' | 'city' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversParentTypes['OpenCtiFile']>, cases?: Maybe<ResolversParentTypes['CaseConnection']>, city?: Maybe<ResolversParentTypes['City']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<ResolversParentTypes['FileConnection']>, fintelTemplates?: Maybe<Array<ResolversParentTypes['FintelTemplate']>>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, status?: Maybe<ResolversParentTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
   PositionAddInput: PositionAddInput;
   PositionConnection: Omit<PositionConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['PositionEdge']>>> };
@@ -48811,10 +48804,6 @@ export type PlaybookManagerResolvers<ContextType = any, ParentType extends Resol
   managerInGoodHealth?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
-export type PlaybooksForEnrollmentResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['PlaybooksForEnrollmentResult'] = ResolversParentTypes['PlaybooksForEnrollmentResult']> = ResolversObject<{
-  playbooks?: Resolver<Array<ResolversTypes['Playbook']>, ParentType, ContextType>;
-}>;
-
 export type PositionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Position'] = ResolversParentTypes['Position']> = ResolversObject<{
   avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<PositionCasesArgs>>;
@@ -49302,7 +49291,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   playbookManagerInfo?: Resolver<Maybe<ResolversTypes['PlaybookManager']>, ParentType, ContextType>;
   playbooks?: Resolver<Maybe<ResolversTypes['PlaybookConnection']>, ParentType, ContextType, Partial<QueryPlaybooksArgs>>;
   playbooksForEnrollment?: Resolver<Maybe<Array<Maybe<ResolversTypes['Playbook']>>>, ParentType, ContextType, RequireFields<QueryPlaybooksForEnrollmentArgs, 'ids'>>;
-  playbooksForEnrollmentByFilters?: Resolver<Maybe<ResolversTypes['PlaybooksForEnrollmentResult']>, ParentType, ContextType, Partial<QueryPlaybooksForEnrollmentByFiltersArgs>>;
+  playbooksForEnrollmentByFilters?: Resolver<Array<ResolversTypes['Playbook']>, ParentType, ContextType, Partial<QueryPlaybooksForEnrollmentByFiltersArgs>>;
   playbooksForEntity?: Resolver<Maybe<Array<Maybe<ResolversTypes['Playbook']>>>, ParentType, ContextType, RequireFields<QueryPlaybooksForEntityArgs, 'id'>>;
   position?: Resolver<Maybe<ResolversTypes['Position']>, ParentType, ContextType, RequireFields<QueryPositionArgs, 'id'>>;
   positions?: Resolver<Maybe<ResolversTypes['PositionConnection']>, ParentType, ContextType, Partial<QueryPositionsArgs>>;
@@ -53517,7 +53506,6 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   PlaybookEdge?: PlaybookEdgeResolvers<ContextType>;
   PlaybookInsertResult?: PlaybookInsertResultResolvers<ContextType>;
   PlaybookManager?: PlaybookManagerResolvers<ContextType>;
-  PlaybooksForEnrollmentResult?: PlaybooksForEnrollmentResultResolvers<ContextType>;
   Position?: PositionResolvers<ContextType>;
   PositionConnection?: PositionConnectionResolvers<ContextType>;
   PositionEdge?: PositionEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -23593,6 +23593,11 @@ export type PlaybookManager = {
   managerInGoodHealth?: Maybe<Scalars['Boolean']['output']>;
 };
 
+export type PlaybooksForEnrollmentResult = {
+  __typename?: 'PlaybooksForEnrollmentResult';
+  playbooks: Array<Playbook>;
+};
+
 export enum PlaybooksOrdering {
   Score = '_score',
   CreatedAt = 'created_at',
@@ -24535,6 +24540,7 @@ export type Query = {
   playbookManagerInfo?: Maybe<PlaybookManager>;
   playbooks?: Maybe<PlaybookConnection>;
   playbooksForEnrollment?: Maybe<Array<Maybe<Playbook>>>;
+  playbooksForEnrollmentByFilters?: Maybe<PlaybooksForEnrollmentResult>;
   playbooksForEntity?: Maybe<Array<Maybe<Playbook>>>;
   position?: Maybe<Position>;
   positions?: Maybe<PositionConnection>;
@@ -26395,6 +26401,18 @@ export type QueryPlaybooksArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<PlaybooksOrdering>;
   orderMode?: InputMaybe<OrderingMode>;
+  search?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryPlaybooksForEnrollmentArgs = {
+  ids: Array<Scalars['String']['input']>;
+};
+
+
+export type QueryPlaybooksForEnrollmentByFiltersArgs = {
+  excludedIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  filters?: InputMaybe<FilterGroup>;
   search?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -40044,6 +40062,7 @@ export type ResolversTypes = ResolversObject<{
   PlaybookEdge: ResolverTypeWrapper<Omit<PlaybookEdge, 'node'> & { node: ResolversTypes['Playbook'] }>;
   PlaybookInsertResult: ResolverTypeWrapper<PlaybookInsertResult>;
   PlaybookManager: ResolverTypeWrapper<PlaybookManager>;
+  PlaybooksForEnrollmentResult: ResolverTypeWrapper<Omit<PlaybooksForEnrollmentResult, 'playbooks'> & { playbooks: Array<ResolversTypes['Playbook']> }>;
   PlaybooksOrdering: PlaybooksOrdering;
   Position: ResolverTypeWrapper<Omit<Position, 'avatar' | 'cases' | 'city' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversTypes['OpenCtiFile']>, cases?: Maybe<ResolversTypes['CaseConnection']>, city?: Maybe<ResolversTypes['City']>, connectors?: Maybe<Array<Maybe<ResolversTypes['Connector']>>>, containers?: Maybe<ResolversTypes['ContainerConnection']>, createdBy?: Maybe<ResolversTypes['Identity']>, editContext?: Maybe<Array<ResolversTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversTypes['FileConnection']>, externalReferences?: Maybe<ResolversTypes['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<ResolversTypes['FileConnection']>, fintelTemplates?: Maybe<Array<ResolversTypes['FintelTemplate']>>, groupings?: Maybe<ResolversTypes['GroupingConnection']>, importFiles?: Maybe<ResolversTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversTypes['Work']>>>, notes?: Maybe<ResolversTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversTypes['Label']>>, objectMarking?: Maybe<Array<ResolversTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversTypes['Organization']>>, observedData?: Maybe<ResolversTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversTypes['FileConnection']>, reports?: Maybe<ResolversTypes['ReportConnection']>, status?: Maybe<ResolversTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversTypes['Inference']>>> }>;
   PositionAddInput: PositionAddInput;
@@ -41083,6 +41102,7 @@ export type ResolversParentTypes = ResolversObject<{
   PlaybookEdge: Omit<PlaybookEdge, 'node'> & { node: ResolversParentTypes['Playbook'] };
   PlaybookInsertResult: PlaybookInsertResult;
   PlaybookManager: PlaybookManager;
+  PlaybooksForEnrollmentResult: Omit<PlaybooksForEnrollmentResult, 'playbooks'> & { playbooks: Array<ResolversParentTypes['Playbook']> };
   Position: Omit<Position, 'avatar' | 'cases' | 'city' | 'connectors' | 'containers' | 'createdBy' | 'editContext' | 'exportFiles' | 'externalReferences' | 'filesFromTemplate' | 'fintelTemplates' | 'groupings' | 'importFiles' | 'jobs' | 'notes' | 'objectLabel' | 'objectMarking' | 'objectOrganization' | 'observedData' | 'opinions' | 'pendingFiles' | 'reports' | 'status' | 'stixCoreObjectsDistribution' | 'stixCoreRelationships' | 'stixCoreRelationshipsDistribution' | 'x_opencti_inferences'> & { avatar?: Maybe<ResolversParentTypes['OpenCtiFile']>, cases?: Maybe<ResolversParentTypes['CaseConnection']>, city?: Maybe<ResolversParentTypes['City']>, connectors?: Maybe<Array<Maybe<ResolversParentTypes['Connector']>>>, containers?: Maybe<ResolversParentTypes['ContainerConnection']>, createdBy?: Maybe<ResolversParentTypes['Identity']>, editContext?: Maybe<Array<ResolversParentTypes['EditUserContext']>>, exportFiles?: Maybe<ResolversParentTypes['FileConnection']>, externalReferences?: Maybe<ResolversParentTypes['ExternalReferenceConnection']>, filesFromTemplate?: Maybe<ResolversParentTypes['FileConnection']>, fintelTemplates?: Maybe<Array<ResolversParentTypes['FintelTemplate']>>, groupings?: Maybe<ResolversParentTypes['GroupingConnection']>, importFiles?: Maybe<ResolversParentTypes['FileConnection']>, jobs?: Maybe<Array<Maybe<ResolversParentTypes['Work']>>>, notes?: Maybe<ResolversParentTypes['NoteConnection']>, objectLabel?: Maybe<Array<ResolversParentTypes['Label']>>, objectMarking?: Maybe<Array<ResolversParentTypes['MarkingDefinition']>>, objectOrganization?: Maybe<Array<ResolversParentTypes['Organization']>>, observedData?: Maybe<ResolversParentTypes['ObservedDataConnection']>, opinions?: Maybe<ResolversParentTypes['OpinionConnection']>, pendingFiles?: Maybe<ResolversParentTypes['FileConnection']>, reports?: Maybe<ResolversParentTypes['ReportConnection']>, status?: Maybe<ResolversParentTypes['Status']>, stixCoreObjectsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, stixCoreRelationships?: Maybe<ResolversParentTypes['StixCoreRelationshipConnection']>, stixCoreRelationshipsDistribution?: Maybe<Array<Maybe<ResolversParentTypes['Distribution']>>>, x_opencti_inferences?: Maybe<Array<Maybe<ResolversParentTypes['Inference']>>> };
   PositionAddInput: PositionAddInput;
   PositionConnection: Omit<PositionConnection, 'edges'> & { edges?: Maybe<Array<Maybe<ResolversParentTypes['PositionEdge']>>> };
@@ -48791,6 +48811,10 @@ export type PlaybookManagerResolvers<ContextType = any, ParentType extends Resol
   managerInGoodHealth?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
+export type PlaybooksForEnrollmentResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['PlaybooksForEnrollmentResult'] = ResolversParentTypes['PlaybooksForEnrollmentResult']> = ResolversObject<{
+  playbooks?: Resolver<Array<ResolversTypes['Playbook']>, ParentType, ContextType>;
+}>;
+
 export type PositionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Position'] = ResolversParentTypes['Position']> = ResolversObject<{
   avatar?: Resolver<Maybe<ResolversTypes['OpenCtiFile']>, ParentType, ContextType>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<PositionCasesArgs>>;
@@ -49277,7 +49301,8 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   playbookComponents?: Resolver<Array<Maybe<ResolversTypes['PlaybookComponent']>>, ParentType, ContextType>;
   playbookManagerInfo?: Resolver<Maybe<ResolversTypes['PlaybookManager']>, ParentType, ContextType>;
   playbooks?: Resolver<Maybe<ResolversTypes['PlaybookConnection']>, ParentType, ContextType, Partial<QueryPlaybooksArgs>>;
-  playbooksForEnrollment?: Resolver<Maybe<Array<Maybe<ResolversTypes['Playbook']>>>, ParentType, ContextType>;
+  playbooksForEnrollment?: Resolver<Maybe<Array<Maybe<ResolversTypes['Playbook']>>>, ParentType, ContextType, RequireFields<QueryPlaybooksForEnrollmentArgs, 'ids'>>;
+  playbooksForEnrollmentByFilters?: Resolver<Maybe<ResolversTypes['PlaybooksForEnrollmentResult']>, ParentType, ContextType, Partial<QueryPlaybooksForEnrollmentByFiltersArgs>>;
   playbooksForEntity?: Resolver<Maybe<Array<Maybe<ResolversTypes['Playbook']>>>, ParentType, ContextType, RequireFields<QueryPlaybooksForEntityArgs, 'id'>>;
   position?: Resolver<Maybe<ResolversTypes['Position']>, ParentType, ContextType, RequireFields<QueryPositionArgs, 'id'>>;
   positions?: Resolver<Maybe<ResolversTypes['PositionConnection']>, ParentType, ContextType, Partial<QueryPositionsArgs>>;
@@ -53492,6 +53517,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   PlaybookEdge?: PlaybookEdgeResolvers<ContextType>;
   PlaybookInsertResult?: PlaybookInsertResultResolvers<ContextType>;
   PlaybookManager?: PlaybookManagerResolvers<ContextType>;
+  PlaybooksForEnrollmentResult?: PlaybooksForEnrollmentResultResolvers<ContextType>;
   Position?: PositionResolvers<ContextType>;
   PositionConnection?: PositionConnectionResolvers<ContextType>;
   PositionEdge?: PositionEdgeResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -4,7 +4,7 @@ import * as R from 'ramda';
 import { Promise as BluePromise } from 'bluebird';
 import { lockResources } from '../lock/master-lock';
 import { buildQueryFilters, findBackgroundTask, updateTask } from '../domain/backgroundTask';
-import conf, { booleanConf, isFeatureEnabled, logApp } from '../config/conf';
+import conf, { booleanConf, logApp } from '../config/conf';
 import { resolveUserByIdFromCache } from '../domain/user';
 import { storeLoadByIdsWithRefs } from '../database/middleware';
 import { now } from '../utils/format';
@@ -244,7 +244,7 @@ export const baseOperationBuilder = (actionType, operations, element) => {
     baseOperationObject.template_id = operations[0].context.values;
   }
   // Playbook enrollment
-  if (isFeatureEnabled('BULK_ENROLLMENT') && actionType === ACTION_TYPE_ENROLL_PLAYBOOK) {
+  if (actionType === ACTION_TYPE_ENROLL_PLAYBOOK) {
     baseOperationObject.opencti_operation = 'enroll_playbook';
     const playbookRef = operations[0].context.values[0];
     baseOperationObject.playbook_id = playbookRef?.id ?? playbookRef;

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -246,7 +246,8 @@ export const baseOperationBuilder = (actionType, operations, element) => {
   // Playbook enrollment
   if (isFeatureEnabled('BULK_ENROLLMENT') && actionType === ACTION_TYPE_ENROLL_PLAYBOOK) {
     baseOperationObject.opencti_operation = 'enroll_playbook';
-    baseOperationObject.playbook_id = operations[0].context.values[0];
+    const playbookRef = operations[0].context.values[0];
+    baseOperationObject.playbook_id = playbookRef?.id ?? playbookRef;
   }
   return baseOperationObject;
 };

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -119,7 +119,7 @@ export const findPlaybooksForEnrollmentByFilters = async (
   const stixEntities = await stixLoadByFilters(context, user, [ABSTRACT_STIX_CORE_OBJECT], {
     filters: filters ?? undefined,
     search: search ?? undefined,
-    first: ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT,
+    maxSize: ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT,
   });
   const filteredEntities = excludeEntitiesByIds(stixEntities, excludedIds);
   if (filteredEntities.length === 0) return [];

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -87,7 +87,7 @@ export const findPlaybooksForEntity = async (context: AuthContext, user: AuthUse
   return filteredPlaybooks;
 };
 
-const getEligiblePlaybooks = async (context: AuthContext) => {
+const getEligiblePlaybooksForEnrollment = async (context: AuthContext) => {
   const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
   return playbooks.map(getEnrollmentEligibility).filter((e): e is NonNullable<typeof e> => e !== null);
 };
@@ -98,7 +98,7 @@ export const findPlaybooksForEnrollment = async (
   ids: string[],
 ) => {
   await checkEnterpriseEdition(context);
-  const eligible = await getEligiblePlaybooks(context);
+  const eligible = await getEligiblePlaybooksForEnrollment(context);
   if (eligible.length === 0) return [];
   const cappedIds = ids.slice(0, ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT);
   const stixEntities = await stixLoadByIds(context, user, cappedIds);
@@ -106,30 +106,25 @@ export const findPlaybooksForEnrollment = async (
   return matchPlaybooksToEntities(eligible, stixEntities, isEntityMatchingFilterGroup);
 };
 
-export interface PlaybooksForEnrollmentResult {
-  playbooks: BasicStoreEntityPlaybook[];
-}
-
 export const findPlaybooksForEnrollmentByFilters = async (
   context: AuthContext,
   user: AuthUser,
   filters: FilterGroup | null,
   search: string | null,
   excludedIds: string[],
-): Promise<PlaybooksForEnrollmentResult> => {
+): Promise<BasicStoreEntityPlaybook[]> => {
   await checkEnterpriseEdition(context);
-  const eligible = await getEligiblePlaybooks(context);
-  if (eligible.length === 0) return { playbooks: [] };
+  const eligible = await getEligiblePlaybooksForEnrollment(context);
+  if (eligible.length === 0) return [];
   const stixEntities = await stixLoadByFilters(context, user, [ABSTRACT_STIX_CORE_OBJECT], {
     filters: filters ?? undefined,
     search: search ?? undefined,
     first: ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT,
   });
   const filteredEntities = excludeEntitiesByIds(stixEntities, excludedIds);
-  if (filteredEntities.length === 0) return { playbooks: [] };
+  if (filteredEntities.length === 0) return [];
   const isEntityMatchingFilterGroup: StixFilterMatchFn = (entity, filterGroup) => isStixMatchFilterGroup(context, SYSTEM_USER, entity, filterGroup);
-  const matchingPlaybooks = await matchPlaybooksToEntities(eligible, filteredEntities, isEntityMatchingFilterGroup);
-  return { playbooks: matchingPlaybooks };
+  return matchPlaybooksToEntities(eligible, filteredEntities, isEntityMatchingFilterGroup);
 };
 
 // IDs of playbook components that delegate their work to an XTM One agent

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -16,17 +16,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import { v4 as uuidv4 } from 'uuid';
 import type { FileHandle } from 'fs/promises';
 import { BUS_TOPICS } from '../../config/conf';
-import { createEntity, deleteElementById, patchAttribute, stixLoadById, updateAttribute } from '../../database/middleware';
+import { createEntity, deleteElementById, patchAttribute, stixLoadById, stixLoadByIds, stixLoadByFilters, updateAttribute } from '../../database/middleware';
 import { type EntityOptions, internalFindByIds, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import { deleteAllPlaybookExecutions, notify } from '../../database/redis';
 import type { DomainFindById } from '../../domain/domainTypes';
-import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
+import { ABSTRACT_INTERNAL_OBJECT, ABSTRACT_STIX_CORE_OBJECT } from '../../schema/general';
 import type { AuthContext, AuthUser } from '../../types/user';
-import { type EditInput, type PlaybookAddInput, type PlaybookAddLinkInput, type PlaybookAddNodeInput, type PositionInput } from '../../generated/graphql';
+import { type EditInput, type FilterGroup, type PlaybookAddInput, type PlaybookAddLinkInput, type PlaybookAddNodeInput, type PositionInput } from '../../generated/graphql';
 import type { BasicStoreEntityPlaybook, ComponentDefinition } from './playbook-types';
 import { ENTITY_TYPE_PLAYBOOK } from './playbook-types';
 import { PLAYBOOK_COMPONENTS, type StreamConfiguration } from './playbook-components';
 import xtmOneClient from '../xtm/one/xtm-one-client';
+import { getEnrollmentEligibility, excludeEntitiesByIds, matchPlaybooksToEntities, type StixFilterMatchFn, ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT } from './playbook-enrollment';
 import { FunctionalError, UnsupportedError } from '../../config/errors';
 import { type BasicStoreEntityOrganization, ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../organization/organization-types';
 import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/stix-filtering';
@@ -86,25 +87,49 @@ export const findPlaybooksForEntity = async (context: AuthContext, user: AuthUse
   return filteredPlaybooks;
 };
 
+const getEligiblePlaybooks = async (context: AuthContext) => {
+  const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
+  return playbooks.map(getEnrollmentEligibility).filter((e): e is NonNullable<typeof e> => e !== null);
+};
+
 export const findPlaybooksForEnrollment = async (
   context: AuthContext,
+  user: AuthUser,
+  ids: string[],
 ) => {
   await checkEnterpriseEdition(context);
-  const playbooks = await getEntitiesListFromCache<BasicStoreEntityPlaybook>(context, SYSTEM_USER, ENTITY_TYPE_PLAYBOOK);
-  const filteredPlaybooks: BasicStoreEntityPlaybook[] = [];
-  for (const playbook of playbooks) {
-    if (playbook.playbook_definition) {
-      const def = JSON.parse(playbook.playbook_definition) as ComponentDefinition;
-      const instance = def.nodes.find((n) => n.id === playbook.playbook_start);
-      if (instance && (instance.component_id === 'PLAYBOOK_INTERNAL_DATA_STREAM' || instance.component_id === 'PLAYBOOK_INTERNAL_MANUAL_TRIGGER')) {
-        const { canEnrollManually } = JSON.parse(instance.configuration ?? '{}') as StreamConfiguration;
-        const isAvailableForManualEnrollment = canEnrollManually ?? true;
-        if (!isAvailableForManualEnrollment) continue;
-        filteredPlaybooks.push(playbook);
-      }
-    }
-  }
-  return filteredPlaybooks;
+  const eligible = await getEligiblePlaybooks(context);
+  if (eligible.length === 0) return [];
+  const cappedIds = ids.slice(0, ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT);
+  const stixEntities = await stixLoadByIds(context, user, cappedIds);
+  const isEntityMatchingFilterGroup: StixFilterMatchFn = (entity, filters) => isStixMatchFilterGroup(context, SYSTEM_USER, entity, filters);
+  return matchPlaybooksToEntities(eligible, stixEntities, isEntityMatchingFilterGroup);
+};
+
+export interface PlaybooksForEnrollmentResult {
+  playbooks: BasicStoreEntityPlaybook[];
+}
+
+export const findPlaybooksForEnrollmentByFilters = async (
+  context: AuthContext,
+  user: AuthUser,
+  filters: FilterGroup | null,
+  search: string | null,
+  excludedIds: string[],
+): Promise<PlaybooksForEnrollmentResult> => {
+  await checkEnterpriseEdition(context);
+  const eligible = await getEligiblePlaybooks(context);
+  if (eligible.length === 0) return { playbooks: [] };
+  const stixEntities = await stixLoadByFilters(context, user, [ABSTRACT_STIX_CORE_OBJECT], {
+    filters: filters ?? undefined,
+    search: search ?? undefined,
+    first: ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT,
+  });
+  const filteredEntities = excludeEntitiesByIds(stixEntities, excludedIds);
+  if (filteredEntities.length === 0) return { playbooks: [] };
+  const isEntityMatchingFilterGroup: StixFilterMatchFn = (entity, filterGroup) => isStixMatchFilterGroup(context, SYSTEM_USER, entity, filterGroup);
+  const matchingPlaybooks = await matchPlaybooksToEntities(eligible, filteredEntities, isEntityMatchingFilterGroup);
+  return { playbooks: matchingPlaybooks };
 };
 
 // IDs of playbook components that delegate their work to an XTM One agent

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-enrollment.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-enrollment.ts
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2021-2025 Filigran SAS
+
+This file is part of the OpenCTI Enterprise Edition ("EE") and is
+licensed under the OpenCTI Enterprise Edition License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://github.com/OpenCTI-Platform/opencti/blob/master/LICENSE
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+import type { FilterGroup } from '../../generated/graphql';
+import type { StixObject as Stix21Object } from '../../types/stix-2-1-common';
+import type { StixObject as Stix20Object } from '../../types/stix-2-0-common';
+import type { BasicStoreEntityPlaybook, ComponentDefinition } from './playbook-types';
+import type { StreamConfiguration } from './playbook-components';
+import { STIX_EXT_OCTI } from '../../types/stix-2-1-extensions';
+
+export type StixEntity = Stix21Object | Stix20Object;
+
+export const ENROLLMENT_PLAYBOOK_EVALUATION_LIMIT = 5000;
+
+export interface EligiblePlaybook {
+  playbook: BasicStoreEntityPlaybook;
+  jsonFilters: FilterGroup | null;
+}
+
+export type StixFilterMatchFn = (
+  stixEntity: StixEntity,
+  filters: FilterGroup,
+) => Promise<boolean>;
+
+const MANUAL_ENROLLMENT_TRIGGERS = new Set([
+  'PLAYBOOK_INTERNAL_DATA_STREAM',
+  'PLAYBOOK_INTERNAL_MANUAL_TRIGGER',
+]);
+
+export const getEnrollmentEligibility = (
+  playbook: BasicStoreEntityPlaybook,
+): EligiblePlaybook | null => {
+  if (!playbook.playbook_definition) return null;
+
+  const def = JSON.parse(playbook.playbook_definition) as ComponentDefinition;
+  const startNode = def.nodes.find((n) => n.id === playbook.playbook_start);
+  if (!startNode) return null;
+
+  if (!MANUAL_ENROLLMENT_TRIGGERS.has(startNode.component_id)) return null;
+
+  const config = JSON.parse(startNode.configuration ?? '{}') as StreamConfiguration;
+  if (!(config.canEnrollManually ?? true)) return null;
+
+  const jsonFilters: FilterGroup | null = config.filters
+    ? JSON.parse(config.filters) as FilterGroup
+    : null;
+
+  if (jsonFilters === null) return { playbook, jsonFilters: null };
+  return { playbook, jsonFilters };
+};
+
+export const allEntitiesMatchFilters = async (
+  stixEntities: StixEntity[],
+  filters: FilterGroup,
+  isEntityMatchingFilterGroup: StixFilterMatchFn,
+): Promise<boolean> => {
+  for (const entity of stixEntities) {
+    const matches = await isEntityMatchingFilterGroup(entity, filters);
+    if (!matches) return false;
+  }
+  return true;
+};
+
+export const matchPlaybooksToEntities = async (
+  eligiblePlaybooks: EligiblePlaybook[],
+  stixEntities: StixEntity[],
+  isEntityMatchingFilterGroup: StixFilterMatchFn,
+): Promise<BasicStoreEntityPlaybook[]> => {
+  const result: BasicStoreEntityPlaybook[] = [];
+  for (const { playbook, jsonFilters } of eligiblePlaybooks) {
+    if (jsonFilters === null) {
+      result.push(playbook);
+      continue;
+    }
+    const allMatch = await allEntitiesMatchFilters(stixEntities, jsonFilters, isEntityMatchingFilterGroup);
+    if (allMatch) result.push(playbook);
+  }
+  return result;
+};
+
+export const excludeEntitiesByIds = (entities: Stix21Object[], excludedIds: string[]): Stix21Object[] => {
+  if (excludedIds.length === 0) return entities;
+  return entities.filter((entity) => {
+    const internalId = entity.extensions[STIX_EXT_OCTI]?.id;
+    return internalId ? !excludedIds.includes(internalId) : true;
+  });
+};

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-resolvers.ts
@@ -34,6 +34,7 @@ import {
   playbookImport,
   playbookDuplicate,
   findPlaybooksForEnrollment,
+  findPlaybooksForEnrollmentByFilters,
 } from './playbook-domain';
 import { executePlaybookOnEntity, playbookStepExecution, getManagerInfo } from '../../manager/playbookManager/playbookManager';
 import { getLastPlaybookExecutions } from '../../database/redis';
@@ -45,7 +46,10 @@ const playbookResolvers: Resolvers = {
     playbook: (_, { id }, context) => findById(context, context.user, id),
     playbooks: (_, args, context) => findPlaybookPaginated(context, context.user, args),
     playbooksForEntity: (_, { id }, context) => findPlaybooksForEntity(context, context.user, id),
-    playbooksForEnrollment: (_, __, context) => findPlaybooksForEnrollment(context),
+    playbooksForEnrollment: (_, { ids }, context) => findPlaybooksForEnrollment(context, context.user, ids),
+    playbooksForEnrollmentByFilters: (_, { filters, search, excludedIds }, context) => {
+      return findPlaybooksForEnrollmentByFilters(context, context.user, filters ?? null, search ?? null, excludedIds ?? []);
+    },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     playbookComponents: (_, __, context) => availableComponents(context),

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -105,12 +105,12 @@ type Query {
     ): PlaybookConnection @auth(for: [AUTOMATION])
     playbookComponents: [PlaybookComponent]! @auth(for: [AUTOMATION])
     playbooksForEntity(id: String!): [Playbook] @auth(for: [AUTOMATION])
-    playbooksForEnrollment(ids: [String!]!): [Playbook] @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
+    playbooksForEnrollment(ids: [String!]!): [Playbook] @auth(for: [AUTOMATION])
     playbooksForEnrollmentByFilters(
         filters: FilterGroup
         search: String
         excludedIds: [String!]
-    ): [Playbook!]! @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
+    ): [Playbook!]! @auth(for: [AUTOMATION])
     playbookManagerInfo: PlaybookManager @auth(for: [AUTOMATION])
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -92,10 +92,6 @@ type PlaybookManager {
     managerInGoodHealth: Boolean
 }
 
-type PlaybooksForEnrollmentResult {
-    playbooks: [Playbook!]!
-}
-
 # Queries
 type Query {
     playbook(id: String!): Playbook @auth(for: [AUTOMATION])
@@ -114,7 +110,7 @@ type Query {
         filters: FilterGroup
         search: String
         excludedIds: [String!]
-    ): PlaybooksForEnrollmentResult @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
+    ): [Playbook!]! @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
     playbookManagerInfo: PlaybookManager @auth(for: [AUTOMATION])
 }
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook.graphql
@@ -92,6 +92,10 @@ type PlaybookManager {
     managerInGoodHealth: Boolean
 }
 
+type PlaybooksForEnrollmentResult {
+    playbooks: [Playbook!]!
+}
+
 # Queries
 type Query {
     playbook(id: String!): Playbook @auth(for: [AUTOMATION])
@@ -105,7 +109,12 @@ type Query {
     ): PlaybookConnection @auth(for: [AUTOMATION])
     playbookComponents: [PlaybookComponent]! @auth(for: [AUTOMATION])
     playbooksForEntity(id: String!): [Playbook] @auth(for: [AUTOMATION])
-    playbooksForEnrollment: [Playbook] @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
+    playbooksForEnrollment(ids: [String!]!): [Playbook] @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
+    playbooksForEnrollmentByFilters(
+        filters: FilterGroup
+        search: String
+        excludedIds: [String!]
+    ): PlaybooksForEnrollmentResult @auth(for: [AUTOMATION]) @ff(flags: ["BULK_ENROLLMENT"])
     playbookManagerInfo: PlaybookManager @auth(for: [AUTOMATION])
 }
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/listen-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/listen-knowledge-component-test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { findPlaybooksForEnrollment, findPlaybooksForEntity } from '../../../../src/modules/playbook/playbook-domain';
+import { findPlaybooksForEnrollment, findPlaybooksForEnrollmentByFilters, findPlaybooksForEntity } from '../../../../src/modules/playbook/playbook-domain';
 import type { BasicStoreEntityPlaybook } from '../../../../src/modules/playbook/playbook-types';
 import * as cache from '../../../../src/database/cache';
 import * as middleware from '../../../../src/database/middleware';
 import * as stixFiltering from '../../../../src/utils/filtering/filtering-stix/stix-filtering';
 import * as ee from '../../../../src/enterprise-edition/ee';
+import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
 import { testContext } from '../../../utils/testQuery';
 import { SYSTEM_USER } from '../../../../src/utils/access';
 
@@ -18,6 +19,13 @@ const buildPlaybook = (componentId: string, configuration: object, playbookStart
     }],
   }),
 } as unknown as BasicStoreEntityPlaybook);
+
+const buildStixEntity = (internalId: string) => ({
+  id: `malware--${internalId}`,
+  type: 'malware',
+  spec_version: '2.1',
+  extensions: { [STIX_EXT_OCTI]: { id: internalId } },
+});
 
 describe('findPlaybooksForEntity', () => {
   beforeEach(() => {
@@ -148,6 +156,7 @@ describe('findPlaybooksForEnrollment', () => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
     vi.spyOn(ee, 'checkEnterpriseEdition').mockResolvedValue(undefined);
+    vi.spyOn(middleware, 'stixLoadByIds').mockResolvedValue([]);
   });
 
   // -- Enterprise Edition --
@@ -156,7 +165,7 @@ describe('findPlaybooksForEnrollment', () => {
     vi.spyOn(ee, 'checkEnterpriseEdition').mockRejectedValue(new Error('Enterprise edition required'));
     const cacheSpy = vi.spyOn(cache, 'getEntitiesListFromCache');
 
-    await expect(findPlaybooksForEnrollment(testContext)).rejects.toThrow('Enterprise edition required');
+    await expect(findPlaybooksForEnrollment(testContext, SYSTEM_USER, [])).rejects.toThrow('Enterprise edition required');
     expect(cacheSpy).not.toHaveBeenCalled();
   });
 
@@ -167,7 +176,7 @@ describe('findPlaybooksForEnrollment', () => {
       { playbook_start: 'node-1', playbook_definition: null } as unknown as BasicStoreEntityPlaybook,
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(0);
   });
 
@@ -178,7 +187,7 @@ describe('findPlaybooksForEnrollment', () => {
       buildPlaybook('PLAYBOOK_OTHER_COMPONENT', {}),
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(0);
   });
 
@@ -187,7 +196,7 @@ describe('findPlaybooksForEnrollment', () => {
       buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true }),
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(1);
   });
 
@@ -196,7 +205,7 @@ describe('findPlaybooksForEnrollment', () => {
       buildPlaybook('PLAYBOOK_INTERNAL_MANUAL_TRIGGER', { canEnrollManually: true }),
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(1);
   });
 
@@ -207,7 +216,7 @@ describe('findPlaybooksForEnrollment', () => {
       buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: false }),
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(0);
   });
 
@@ -216,7 +225,7 @@ describe('findPlaybooksForEnrollment', () => {
       buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', {}),
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(1);
   });
 
@@ -230,14 +239,128 @@ describe('findPlaybooksForEnrollment', () => {
       buildPlaybook('PLAYBOOK_OTHER_COMPONENT', { canEnrollManually: true }),
     ]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(2);
   });
 
   it('should return empty array when no playbooks exist', async () => {
     vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([]);
 
-    const result = await findPlaybooksForEnrollment(testContext);
+    const result = await findPlaybooksForEnrollment(testContext, SYSTEM_USER, []);
     expect(result).toHaveLength(0);
+  });
+
+  it('should not load entities when no eligible playbooks', async () => {
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([]);
+    const stixLoadSpy = vi.spyOn(middleware, 'stixLoadByIds');
+
+    await findPlaybooksForEnrollment(testContext, SYSTEM_USER, ['some-id']);
+
+    expect(stixLoadSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('findPlaybooksForEnrollmentByFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.spyOn(ee, 'checkEnterpriseEdition').mockResolvedValue(undefined);
+  });
+
+  it('should throw when not EE', async () => {
+    vi.spyOn(ee, 'checkEnterpriseEdition').mockRejectedValue(new Error('Enterprise edition required'));
+
+    await expect(findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []))
+      .rejects.toThrow('Enterprise edition required');
+  });
+
+  it('should return empty and skip DB load when there are no eligible playbooks', async () => {
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([]);
+    const stixLoadByFiltersSpy = vi.spyOn(middleware, 'stixLoadByFilters');
+
+    const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
+
+    expect(result.playbooks).toHaveLength(0);
+    expect(stixLoadByFiltersSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return empty and skip DB load when no playbook has canEnrollManually enabled', async () => {
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([
+      buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: false }),
+    ]);
+    const stixLoadByFiltersSpy = vi.spyOn(middleware, 'stixLoadByFilters');
+
+    const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
+
+    expect(result.playbooks).toHaveLength(0);
+    expect(stixLoadByFiltersSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return empty when all entities are excluded', async () => {
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([
+      buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true }),
+    ]);
+    vi.spyOn(middleware, 'stixLoadByFilters').mockResolvedValue([
+      buildStixEntity('id-1'),
+      buildStixEntity('id-2'),
+    ] as never);
+
+    const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, ['id-1', 'id-2']);
+
+    expect(result.playbooks).toHaveLength(0);
+  });
+
+  it('should return playbook when it has no filters and entity is not excluded', async () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true });
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([playbook]);
+    vi.spyOn(middleware, 'stixLoadByFilters').mockResolvedValue([buildStixEntity('id-1')] as never);
+    const isStixMatchFilterGroupSpy = vi.spyOn(stixFiltering, 'isStixMatchFilterGroup');
+
+    const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
+
+    expect(result.playbooks).toEqual([playbook]);
+    expect(isStixMatchFilterGroupSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return matching playbooks when entity passes playbook filters', async () => {
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([
+      buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true }),
+    ]);
+    vi.spyOn(middleware, 'stixLoadByFilters').mockResolvedValue([buildStixEntity('id-1')] as never);
+    vi.spyOn(stixFiltering, 'isStixMatchFilterGroup').mockResolvedValue(true);
+
+    const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
+
+    expect(result.playbooks).toHaveLength(1);
+  });
+
+  it('should return empty when entity does not pass playbook filters', async () => {
+    const filters = JSON.stringify({ mode: 'and', filters: [], filterGroups: [] });
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([
+      buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true, filters }),
+    ]);
+    vi.spyOn(middleware, 'stixLoadByFilters').mockResolvedValue([buildStixEntity('id-1')] as never);
+    vi.spyOn(stixFiltering, 'isStixMatchFilterGroup').mockResolvedValue(false);
+
+    const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
+
+    expect(result.playbooks).toHaveLength(0);
+  });
+
+  it('should pass filters and search to stixLoadByFilters', async () => {
+    const filters = { mode: 'and', filters: [], filterGroups: [] };
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([
+      buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true }),
+    ]);
+    const stixLoadByFiltersSpy = vi.spyOn(middleware, 'stixLoadByFilters').mockResolvedValue([]);
+
+    await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, filters as never, 'my-search', []);
+
+    expect(stixLoadByFiltersSpy).toHaveBeenCalledWith(
+      testContext,
+      SYSTEM_USER,
+      expect.any(Array),
+      expect.objectContaining({ filters, search: 'my-search' }),
+    );
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/listen-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/listen-knowledge-component-test.ts
@@ -280,7 +280,7 @@ describe('findPlaybooksForEnrollmentByFilters', () => {
 
     const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
 
-    expect(result.playbooks).toHaveLength(0);
+    expect(result).toHaveLength(0);
     expect(stixLoadByFiltersSpy).not.toHaveBeenCalled();
   });
 
@@ -292,7 +292,7 @@ describe('findPlaybooksForEnrollmentByFilters', () => {
 
     const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
 
-    expect(result.playbooks).toHaveLength(0);
+    expect(result).toHaveLength(0);
     expect(stixLoadByFiltersSpy).not.toHaveBeenCalled();
   });
 
@@ -307,7 +307,7 @@ describe('findPlaybooksForEnrollmentByFilters', () => {
 
     const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, ['id-1', 'id-2']);
 
-    expect(result.playbooks).toHaveLength(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should return playbook when it has no filters and entity is not excluded', async () => {
@@ -318,7 +318,7 @@ describe('findPlaybooksForEnrollmentByFilters', () => {
 
     const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
 
-    expect(result.playbooks).toEqual([playbook]);
+    expect(result).toEqual([playbook]);
     expect(isStixMatchFilterGroupSpy).not.toHaveBeenCalled();
   });
 
@@ -331,7 +331,7 @@ describe('findPlaybooksForEnrollmentByFilters', () => {
 
     const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
 
-    expect(result.playbooks).toHaveLength(1);
+    expect(result).toHaveLength(1);
   });
 
   it('should return empty when entity does not pass playbook filters', async () => {
@@ -344,7 +344,7 @@ describe('findPlaybooksForEnrollmentByFilters', () => {
 
     const result = await findPlaybooksForEnrollmentByFilters(testContext, SYSTEM_USER, null, null, []);
 
-    expect(result.playbooks).toHaveLength(0);
+    expect(result).toHaveLength(0);
   });
 
   it('should pass filters and search to stixLoadByFilters', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/playbook-enrollment-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/playbook-enrollment-test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import type { BasicStoreEntityPlaybook } from '../../../../src/modules/playbook/playbook-types';
+import type { FilterGroup } from '../../../../src/generated/graphql';
+import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+import type { StixObject as Stix21Object } from '../../../../src/types/stix-2-1-common';
+import {
+  allEntitiesMatchFilters,
+  excludeEntitiesByIds,
+  getEnrollmentEligibility,
+  matchPlaybooksToEntities,
+  type StixEntity,
+  type StixFilterMatchFn,
+} from '../../../../src/modules/playbook/playbook-enrollment';
+
+const buildPlaybook = (
+  componentId: string,
+  configuration: object,
+  playbookStart = 'node-1',
+): BasicStoreEntityPlaybook => ({
+  playbook_start: playbookStart,
+  playbook_definition: JSON.stringify({
+    nodes: [{
+      id: playbookStart,
+      component_id: componentId,
+      configuration: JSON.stringify(configuration),
+    }],
+  }),
+} as unknown as BasicStoreEntityPlaybook);
+
+const VALID_FILTERS: FilterGroup = { mode: 'and', filters: [], filterGroups: [] } as unknown as FilterGroup;
+
+const buildPlaybookWithFilters = (filters: FilterGroup): BasicStoreEntityPlaybook => buildPlaybook(
+  'PLAYBOOK_INTERNAL_DATA_STREAM',
+  { canEnrollManually: true, filters: JSON.stringify(filters) },
+);
+
+const fakeEntity = (id: string): StixEntity => ({ id, type: 'malware', spec_version: '2.1' }) as unknown as StixEntity;
+
+const fakeStixEntityWithInternalId = (internalId: string): Stix21Object => ({
+  id: `malware--${internalId}`,
+  type: 'malware',
+  spec_version: '2.1',
+  extensions: { [STIX_EXT_OCTI]: { id: internalId } },
+} as unknown as Stix21Object);
+
+describe('getEnrollmentEligibility', () => {
+  it('returns null when playbook_definition is missing', () => {
+    const playbook = { playbook_start: 'x', playbook_definition: null } as unknown as BasicStoreEntityPlaybook;
+    expect(getEnrollmentEligibility(playbook)).toBeNull();
+  });
+
+  it('returns null when start node is not found in definition', () => {
+    const playbook = {
+      playbook_start: 'missing-node',
+      playbook_definition: JSON.stringify({ nodes: [{ id: 'other', component_id: 'X', configuration: '{}' }] }),
+    } as unknown as BasicStoreEntityPlaybook;
+    expect(getEnrollmentEligibility(playbook)).toBeNull();
+  });
+
+  it('returns null when component_id is not a valid manual trigger', () => {
+    const playbook = buildPlaybook('PLAYBOOK_SOME_OTHER', { canEnrollManually: true });
+    expect(getEnrollmentEligibility(playbook)).toBeNull();
+  });
+
+  it('returns null when canEnrollManually is false', () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: false });
+    expect(getEnrollmentEligibility(playbook)).toBeNull();
+  });
+
+  it('returns eligible with null filters when no filters configured', () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', { canEnrollManually: true });
+    const result = getEnrollmentEligibility(playbook);
+    expect(result).not.toBeNull();
+    expect(result!.playbook).toBe(playbook);
+    expect(result!.jsonFilters).toBeNull();
+  });
+
+  it('returns eligible with parsed filters', () => {
+    const playbook = buildPlaybookWithFilters(VALID_FILTERS);
+    const result = getEnrollmentEligibility(playbook);
+    expect(result).not.toBeNull();
+    expect(result!.jsonFilters).toEqual(VALID_FILTERS);
+  });
+
+  it('treats canEnrollManually as true when undefined', () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_MANUAL_TRIGGER', {});
+    const result = getEnrollmentEligibility(playbook);
+    expect(result).not.toBeNull();
+  });
+
+  it('accepts PLAYBOOK_INTERNAL_DATA_STREAM', () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', {});
+    expect(getEnrollmentEligibility(playbook)).not.toBeNull();
+  });
+
+  it('accepts PLAYBOOK_INTERNAL_MANUAL_TRIGGER', () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_MANUAL_TRIGGER', {});
+    expect(getEnrollmentEligibility(playbook)).not.toBeNull();
+  });
+});
+
+describe('allEntitiesMatchFilters', () => {
+  const alwaysMatch: StixFilterMatchFn = async () => true;
+  const neverMatch: StixFilterMatchFn = async () => false;
+
+  it('returns true when all entities match', async () => {
+    const entities = [fakeEntity('a'), fakeEntity('b')];
+    const result = await allEntitiesMatchFilters(entities, VALID_FILTERS, alwaysMatch);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when any entity does not match', async () => {
+    let callCount = 0;
+    const matchSecondFails: StixFilterMatchFn = async () => {
+      callCount += 1;
+      return callCount !== 2;
+    };
+    const entities = [fakeEntity('a'), fakeEntity('b'), fakeEntity('c')];
+    const result = await allEntitiesMatchFilters(entities, VALID_FILTERS, matchSecondFails);
+    expect(result).toBe(false);
+  });
+
+  it('short-circuits on first non-match', async () => {
+    let callCount = 0;
+    const matchFn: StixFilterMatchFn = async () => {
+      callCount += 1;
+      return false;
+    };
+    const entities = [fakeEntity('a'), fakeEntity('b'), fakeEntity('c')];
+    await allEntitiesMatchFilters(entities, VALID_FILTERS, matchFn);
+    expect(callCount).toBe(1);
+  });
+
+  it('returns true for empty entity list', async () => {
+    const result = await allEntitiesMatchFilters([], VALID_FILTERS, neverMatch);
+    expect(result).toBe(true);
+  });
+});
+
+describe('matchPlaybooksToEntities', () => {
+  const alwaysMatch: StixFilterMatchFn = async () => true;
+  const neverMatch: StixFilterMatchFn = async () => false;
+
+  it('includes playbooks with null filters unconditionally', async () => {
+    const playbook = buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', {});
+    const eligible = [{ playbook, jsonFilters: null }];
+    const result = await matchPlaybooksToEntities(eligible, [fakeEntity('x')], neverMatch);
+    expect(result).toEqual([playbook]);
+  });
+
+  it('includes playbooks when all entities match filters', async () => {
+    const playbook = buildPlaybookWithFilters(VALID_FILTERS);
+    const eligible = [{ playbook, jsonFilters: VALID_FILTERS }];
+    const result = await matchPlaybooksToEntities(eligible, [fakeEntity('x')], alwaysMatch);
+    expect(result).toEqual([playbook]);
+  });
+
+  it('excludes playbooks when any entity does not match', async () => {
+    const playbook = buildPlaybookWithFilters(VALID_FILTERS);
+    const eligible = [{ playbook, jsonFilters: VALID_FILTERS }];
+    const result = await matchPlaybooksToEntities(eligible, [fakeEntity('x')], neverMatch);
+    expect(result).toEqual([]);
+  });
+
+  it('handles mixed eligible playbooks correctly', async () => {
+    const noFilterPlaybook = buildPlaybook('PLAYBOOK_INTERNAL_DATA_STREAM', {});
+    const withFilterPlaybook = buildPlaybookWithFilters(VALID_FILTERS);
+    const eligible = [
+      { playbook: noFilterPlaybook, jsonFilters: null },
+      { playbook: withFilterPlaybook, jsonFilters: VALID_FILTERS },
+    ];
+    const result = await matchPlaybooksToEntities(eligible, [fakeEntity('x')], neverMatch);
+    expect(result).toEqual([noFilterPlaybook]);
+  });
+
+  it('returns empty array when no playbooks are eligible', async () => {
+    const result = await matchPlaybooksToEntities([], [fakeEntity('x')], alwaysMatch);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('excludeEntitiesByIds', () => {
+  it('returns all entities when excludedIds is empty', () => {
+    const entities = [fakeStixEntityWithInternalId('internal-a')];
+    expect(excludeEntitiesByIds(entities, [])).toEqual(entities);
+  });
+
+  it('removes entities whose internal id is in excludedIds', () => {
+    const keep = fakeStixEntityWithInternalId('internal-a');
+    const remove = fakeStixEntityWithInternalId('internal-b');
+    const result = excludeEntitiesByIds([keep, remove], ['internal-b']);
+    expect(result).toEqual([keep]);
+  });
+
+  it('keeps entities when none match the excluded ids', () => {
+    const firstEntity = fakeStixEntityWithInternalId('internal-a');
+    const secondEntity = fakeStixEntityWithInternalId('internal-b');
+    const result = excludeEntitiesByIds([firstEntity, secondEntity], ['internal-c']);
+    expect(result).toEqual([firstEntity, secondEntity]);
+  });
+
+  it('keeps entities whose extension id is undefined', () => {
+    const entity = {
+      id: 'malware--x',
+      type: 'malware',
+      spec_version: '2.1',
+      extensions: { [STIX_EXT_OCTI]: {} },
+    } as unknown as Stix21Object;
+    const result = excludeEntitiesByIds([entity], ['some-id']);
+    expect(result).toEqual([entity]);
+  });
+
+  it('removes all entities when all are excluded', () => {
+    const firstEntity = fakeStixEntityWithInternalId('internal-a');
+    const secondEntity = fakeStixEntityWithInternalId('internal-b');
+    const result = excludeEntitiesByIds([firstEntity, secondEntity], ['internal-a', 'internal-b']);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The bulk-enroll drawer now lists only playbooks compatible with the selected entities. A loading state is shown while fetching
* Compatibility is checked against the first 5,000 entities — beyond that threshold, incompatible entities are silently skipped
* The "Enroll in playbook" button is hidden in irrelevant contexts (draft, dashboard, settings…)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #10039 

### How to test this PR
 1. Select entities in any knowledge list → click Enroll in playbook
 2. Verify only compatible playbooks are listed (with a loading spinner)
 3. Enroll and confirm the task in Data > Processing > Tasks.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->
