### PR TITLE
feat: support Ask Ariane conversation history and mid-run steering (#16511)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.1.2",
-    "@filigran/chatbot": "3.5.2",
+    "@filigran/chatbot": "3.6.0",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -135,6 +135,10 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
       apiEndpoints={{
         agents: '/agents',
         messages: '/messages',
+        // Mid-run steering — must be set explicitly because the chatbot
+        // default ('/chat/messages/steer') assumes XTM One-style paths,
+        // while the OpenCTI proxy exposes '/messages/steer'.
+        steer: '/messages/steer',
         sessions: '/sessions',
         upload: '/upload',
         download: '/files',

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1781,15 +1781,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.5.2":
-  version: 3.5.2
-  resolution: "@filigran/chatbot@npm:3.5.2"
+"@filigran/chatbot@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@filigran/chatbot@npm:3.6.0"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/54eb2d82a33c3e93bb697dbe26b7550fc65a0322aa624cc467c35935062f186bd1534648602466ebc82002487a94f65c3160e08ab0b488302c924bcb8fdf0acb
+  checksum: 10c0/50715d5ce0a1ef1dddf8477054d9ade23c73ebcbd8ab9cbf6992e3cd83090268339ed4abf11963851bc6a8959590168eb4bf0d39f8ae9867da3c4885f852d4da
   languageName: node
   linkType: hard
 
@@ -13662,7 +13662,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.1.2"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.5.2"
+    "@filigran/chatbot": "npm:3.6.0"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -46,6 +46,11 @@ const AI_AGENTS_REFRESH_TIMEOUT_MINUTES = Number.isFinite(parsedAgentsRefreshTim
   : AI_AGENTS_REFRESH_TIMEOUT_DEFAULT_MINUTES;
 const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = Math.floor(AI_AGENTS_REFRESH_TIMEOUT_MINUTES * 60);
 
+// Strict UUID shape check for path parameters forwarded to XTM One
+// (conversation ids, file ids). Rejecting anything else up-front keeps
+// arbitrary strings out of the upstream URL path.
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 // ── HTTP client (proxy-aware) ────────────────────────────────────────────
 const getXtmClient = (responseType: 'json' | 'stream', headers?: Record<string, string>) => {
   return getHttpClient({
@@ -220,25 +225,27 @@ export const getChatbotSessions = async (req: Express.Request, res: Express.Resp
     const response = await httpClient.get('/api/v1/platform/chat/sessions', {
       timeout: DEFAULT_XTM_TIMEOUT,
     });
-    res.json(response.data);
+    res.status(response.status).json(response.data);
   } catch (e: unknown) {
     logApp.error('Error in chatbot sessions list', { cause: e });
     const { message } = e as Error;
     const httpErr = getResponseError(e);
-    res.status(httpErr ? httpErr.status : 503).send({ status: 'error', error: message });
+    // Surface the upstream `detail` / `message` (e.g. FastAPI validation
+    // errors) instead of the generic axios "Request failed with status
+    // code N", so failures are actionable in the UI and logs.
+    const detail = httpErr?.data?.detail ?? httpErr?.data?.message ?? message;
+    res.status(httpErr ? httpErr.status : 503).send({ status: 'error', error: detail });
   }
 };
 
 // ── DELETE /chatbot/sessions/:conversationId ────────────────────────────
 // Removes a conversation from the chatbot history menu (archived upstream).
-const CONVERSATION_ID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
 export const deleteChatbotSession = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);
     if (!context?.user) return;
     const conversationId = String(req.params.conversationId ?? '');
-    if (!conversationId || !CONVERSATION_ID_RE.test(conversationId)) {
+    if (!conversationId || !UUID_RE.test(conversationId)) {
       res.status(400).json({ error: 'Invalid conversation id' });
       return;
     }
@@ -247,15 +254,18 @@ export const deleteChatbotSession = async (req: Express.Request, res: Express.Re
       Authorization: `Bearer ${jwt}`,
       'Content-Type': 'application/json',
     });
-    await httpClient.delete(`/api/v1/platform/chat/sessions/${conversationId}`, {
+    const response = await httpClient.delete(`/api/v1/platform/chat/sessions/${conversationId}`, {
       timeout: DEFAULT_XTM_TIMEOUT,
     });
-    res.sendStatus(204);
+    // Forward the upstream success status (200 or 204 depending on whether
+    // XTM One returns a body); the chatbot only checks for a 2xx.
+    res.sendStatus(response.status);
   } catch (e: unknown) {
     logApp.error('Error in chatbot session delete', { cause: e });
     const { message } = e as Error;
     const httpErr = getResponseError(e);
-    res.status(httpErr ? httpErr.status : 503).send({ status: 'error', error: message });
+    const detail = httpErr?.data?.detail ?? httpErr?.data?.message ?? message;
+    res.status(httpErr ? httpErr.status : 503).send({ status: 'error', error: detail });
   }
 };
 
@@ -280,13 +290,13 @@ export const postChatbotMessageSteer = async (req: Express.Request, res: Express
     const response = await httpClient.post('/api/v1/platform/chat/messages/steer', req.body, {
       timeout: DEFAULT_XTM_TIMEOUT,
     });
-    res.json(response.data);
+    res.status(response.status).json(response.data);
   } catch (e: unknown) {
     logApp.error('Error in chatbot steer', { cause: e });
     const { message } = e as Error;
     const httpErr = getResponseError(e);
     if (httpErr) {
-      const detail = httpErr.data?.detail ?? message;
+      const detail = httpErr.data?.detail ?? httpErr.data?.message ?? message;
       res.status(httpErr.status).send({ status: 'error', error: detail });
     } else {
       res.status(503).send({ status: 'error', error: message });
@@ -453,8 +463,6 @@ export const postChatbotUpload = async (req: Express.Request, res: Express.Respo
 // user therefore never authenticates to XTM One directly: the embedded
 // chatbot points its download URL at this proxy (relative to its
 // `apiBaseUrl` of `${APP_BASE_PATH}/chatbot`), not at XTM One.
-const FILE_ID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
 export const getChatbotFileDownload = async (req: Express.Request, res: Express.Response) => {
   try {
     const context = await authenticateAndVerify(req, res);
@@ -464,7 +472,7 @@ export const getChatbotFileDownload = async (req: Express.Request, res: Express.
     // single route segment is always a string at runtime, but coerce
     // defensively so a malformed value simply fails the UUID check below.
     const fileId = String(req.params.fileId ?? '');
-    if (!fileId || !FILE_ID_RE.test(fileId)) {
+    if (!fileId || !UUID_RE.test(fileId)) {
       res.status(400).json({ error: 'Invalid file id' });
       return;
     }

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -205,6 +205,95 @@ export const postChatbotSession = async (req: Express.Request, res: Express.Resp
   }
 };
 
+// ── GET /chatbot/sessions ───────────────────────────────────────────────
+// Lists the user's past conversations for the chatbot history menu.
+// Proxies to XTM One Platform Chat API.
+export const getChatbotSessions = async (req: Express.Request, res: Express.Response) => {
+  try {
+    const context = await authenticateAndVerify(req, res);
+    if (!context?.user) return;
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
+    const httpClient = getXtmClient('json', {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    });
+    const response = await httpClient.get('/api/v1/platform/chat/sessions', {
+      timeout: DEFAULT_XTM_TIMEOUT,
+    });
+    res.json(response.data);
+  } catch (e: unknown) {
+    logApp.error('Error in chatbot sessions list', { cause: e });
+    const { message } = e as Error;
+    const httpErr = getResponseError(e);
+    res.status(httpErr ? httpErr.status : 503).send({ status: 'error', error: message });
+  }
+};
+
+// ── DELETE /chatbot/sessions/:conversationId ────────────────────────────
+// Removes a conversation from the chatbot history menu (archived upstream).
+const CONVERSATION_ID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export const deleteChatbotSession = async (req: Express.Request, res: Express.Response) => {
+  try {
+    const context = await authenticateAndVerify(req, res);
+    if (!context?.user) return;
+    const conversationId = String(req.params.conversationId ?? '');
+    if (!conversationId || !CONVERSATION_ID_RE.test(conversationId)) {
+      res.status(400).json({ error: 'Invalid conversation id' });
+      return;
+    }
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
+    const httpClient = getXtmClient('json', {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    });
+    await httpClient.delete(`/api/v1/platform/chat/sessions/${conversationId}`, {
+      timeout: DEFAULT_XTM_TIMEOUT,
+    });
+    res.sendStatus(204);
+  } catch (e: unknown) {
+    logApp.error('Error in chatbot session delete', { cause: e });
+    const { message } = e as Error;
+    const httpErr = getResponseError(e);
+    res.status(httpErr ? httpErr.status : 503).send({ status: 'error', error: message });
+  }
+};
+
+// ── POST /chatbot/messages/steer ────────────────────────────────────────
+// Mid-run steering: injects a user message into the running agent loop of
+// the conversation. Upstream status codes are forwarded as-is — the
+// chatbot rolls back its optimistic bubble on any non-2xx (e.g. 409 when
+// no response is currently being generated).
+export const postChatbotMessageSteer = async (req: Express.Request, res: Express.Response) => {
+  try {
+    const context = await authenticateAndVerify(req, res);
+    if (!context?.user) return;
+    if (!req.body) {
+      res.status(400).json({ error: 'Request body is missing' });
+      return;
+    }
+    const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
+    const httpClient = getXtmClient('json', {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    });
+    const response = await httpClient.post('/api/v1/platform/chat/messages/steer', req.body, {
+      timeout: DEFAULT_XTM_TIMEOUT,
+    });
+    res.json(response.data);
+  } catch (e: unknown) {
+    logApp.error('Error in chatbot steer', { cause: e });
+    const { message } = e as Error;
+    const httpErr = getResponseError(e);
+    if (httpErr) {
+      const detail = httpErr.data?.detail ?? message;
+      res.status(httpErr.status).send({ status: 'error', error: detail });
+    } else {
+      res.status(503).send({ status: 'error', error: message });
+    }
+  }
+};
+
 // ── POST /chatbot/messages ──────────────────────────────────────────────
 // Proxies to XTM One Platform Chat API (streaming SSE).
 // When file_ids are present in the body, routes to the conversation-level

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -258,8 +258,15 @@ export const deleteChatbotSession = async (req: Express.Request, res: Express.Re
       timeout: DEFAULT_XTM_TIMEOUT,
     });
     // Forward the upstream success status (200 or 204 depending on whether
-    // XTM One returns a body); the chatbot only checks for a 2xx.
-    res.sendStatus(response.status);
+    // XTM One returns a body); the chatbot only checks for a 2xx. When the
+    // upstream replies with a body, forward it as JSON; otherwise end the
+    // response empty (`sendStatus` would inject a textual "OK"/"No Content"
+    // body, breaking clients that expect empty or JSON content).
+    if (response.data !== undefined && response.data !== null && response.data !== '') {
+      res.status(response.status).json(response.data);
+    } else {
+      res.status(response.status).end();
+    }
   } catch (e: unknown) {
     logApp.error('Error in chatbot session delete', { cause: e });
     const { message } = e as Error;

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -36,7 +36,10 @@ import {
   getChatbotConfig,
   getChatbotAgents,
   postChatbotSession,
+  getChatbotSessions,
+  deleteChatbotSession,
   postChatbotMessage,
+  postChatbotMessageSteer,
   postChatbotUpload,
   getChatbotFileDownload,
   postAgentMessage,
@@ -543,7 +546,10 @@ const createApp = async (app, schema) => {
   // XTM One Platform Chat API routes (used when xtm_one_token is set)
   app.get(`${basePath}/chatbot/agents`, getChatbotAgents);
   app.post(`${basePath}/chatbot/sessions`, postChatbotSession);
+  app.get(`${basePath}/chatbot/sessions`, getChatbotSessions);
+  app.delete(`${basePath}/chatbot/sessions/:conversationId`, deleteChatbotSession);
   app.post(`${basePath}/chatbot/messages`, postChatbotMessage);
+  app.post(`${basePath}/chatbot/messages/steer`, postChatbotMessageSteer);
   app.post(`${basePath}/chatbot/upload`, postChatbotUpload);
   app.get(`${basePath}/chatbot/files/:fileId/download`, getChatbotFileDownload);
   app.post(`${basePath}/chatbot/agent`, postAgentMessage);

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -114,11 +114,12 @@ vi.mock('../../../src/modules/xtm/one/xtm-one-client', () => ({
 // Mock getHttpClient — the core HTTP abstraction
 const mockPost = vi.fn();
 const mockGet = vi.fn();
+const mockDelete = vi.fn();
 vi.mock('../../../src/utils/http-client', () => ({
   getHttpClient: vi.fn(() => ({
     get: mockGet,
     post: mockPost,
-    delete: vi.fn(),
+    delete: mockDelete,
     head: vi.fn(),
     call: vi.fn(),
   })),
@@ -138,7 +139,7 @@ vi.mock('../../../src/utils/http-client', () => ({
 import { createAuthenticatedContext } from '../../../src/http/httpAuthenticatedContext';
 import { getEntityFromCache } from '../../../src/database/cache';
 import { getEnterpriseEditionActivePem, getEnterpriseEditionInfo } from '../../../src/modules/settings/licensing';
-import { getChatbotFileDownload, postAgentMessageStream } from '../../../src/http/httpChatbotProxy';
+import { deleteChatbotSession, getChatbotFileDownload, getChatbotSessions, postAgentMessageStream, postChatbotMessageSteer } from '../../../src/http/httpChatbotProxy';
 import { checkDraftInContext } from '../../../src/http/httpServer-draft';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -806,5 +807,206 @@ describe('httpChatbotProxy: getChatbotFileDownload', () => {
 
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.json).toHaveBeenCalledWith({ error: 'XTM One is unreachable' });
+  });
+});
+
+describe('httpChatbotProxy: getChatbotSessions', () => {
+  let res: ReturnType<typeof buildRes>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupAuthenticatedContext();
+    res = buildRes();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return 403 when user is not authenticated', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({ user: null } as any);
+
+    await getChatbotSessions(buildReq(), res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it('should forward the upstream status and body on success', async () => {
+    const sessions = [{ conversation_id: '11111111-1111-1111-1111-111111111111', title: 'Threat recap' }];
+    mockGet.mockResolvedValue({ status: 200, data: sessions });
+
+    await getChatbotSessions(buildReq(), res);
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    const [url, opts] = mockGet.mock.calls[0];
+    expect(url).toBe('/api/v1/platform/chat/sessions');
+    expect(opts.timeout).toBeGreaterThan(0);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(sessions);
+  });
+
+  it('should surface the upstream detail and status on HTTP error', async () => {
+    const httpError = new Error('Request failed with status code 502') as any;
+    httpError.response = { status: 502, data: { detail: 'Chat history unavailable' } };
+    mockGet.mockRejectedValue(httpError);
+
+    await getChatbotSessions(buildReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.send).toHaveBeenCalledWith({ status: 'error', error: 'Chat history unavailable' });
+  });
+
+  it('should fall back to the error message and 503 when no HTTP response is available', async () => {
+    mockGet.mockRejectedValue(new Error('Network failure'));
+
+    await getChatbotSessions(buildReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.send).toHaveBeenCalledWith({ status: 'error', error: 'Network failure' });
+  });
+});
+
+describe('httpChatbotProxy: deleteChatbotSession', () => {
+  const VALID_CONVERSATION_ID = '22222222-2222-2222-2222-222222222222';
+  let res: ReturnType<typeof buildRes>;
+
+  const buildDeleteReq = (conversationId: string) => ({ params: { conversationId }, headers: {} } as any);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupAuthenticatedContext();
+    res = buildRes();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return 403 when user is not authenticated', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({ user: null } as any);
+
+    await deleteChatbotSession(buildDeleteReq(VALID_CONVERSATION_ID), res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for a non-UUID conversation id without calling XTM One', async () => {
+    await deleteChatbotSession(buildDeleteReq('../other-tenant/conversations'), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid conversation id' });
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('should forward an upstream 204 with an empty body', async () => {
+    mockDelete.mockResolvedValue({ status: 204, data: '' });
+
+    await deleteChatbotSession(buildDeleteReq(VALID_CONVERSATION_ID), res);
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const [url] = mockDelete.mock.calls[0];
+    expect(url).toBe(`/api/v1/platform/chat/sessions/${VALID_CONVERSATION_ID}`);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.end).toHaveBeenCalled();
+    // Must not inject a textual ("No Content") or JSON body on empty upstream responses.
+    expect(res.json).not.toHaveBeenCalled();
+    expect(res.sendStatus).not.toHaveBeenCalled();
+  });
+
+  it('should forward an upstream 200 with its JSON body', async () => {
+    mockDelete.mockResolvedValue({ status: 200, data: { archived: true } });
+
+    await deleteChatbotSession(buildDeleteReq(VALID_CONVERSATION_ID), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ archived: true });
+  });
+
+  it('should surface the upstream detail and status on HTTP error', async () => {
+    const httpError = new Error('Request failed with status code 404') as any;
+    httpError.response = { status: 404, data: { detail: 'Conversation not found' } };
+    mockDelete.mockRejectedValue(httpError);
+
+    await deleteChatbotSession(buildDeleteReq(VALID_CONVERSATION_ID), res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith({ status: 'error', error: 'Conversation not found' });
+  });
+
+  it('should fall back to the error message and 503 when no HTTP response is available', async () => {
+    mockDelete.mockRejectedValue(new Error('Network failure'));
+
+    await deleteChatbotSession(buildDeleteReq(VALID_CONVERSATION_ID), res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.send).toHaveBeenCalledWith({ status: 'error', error: 'Network failure' });
+  });
+});
+
+describe('httpChatbotProxy: postChatbotMessageSteer', () => {
+  let res: ReturnType<typeof buildRes>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupAuthenticatedContext();
+    res = buildRes();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return 403 when user is not authenticated', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({ user: null } as any);
+
+    await postChatbotMessageSteer(buildReq({ conversation_id: 'c-1', content: 'steer this' }), res);
+
+    expect(res.sendStatus).toHaveBeenCalledWith(403);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 when the body is missing', async () => {
+    await postChatbotMessageSteer(buildReq(undefined), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Request body is missing' });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('should forward the body and the upstream status on success', async () => {
+    mockPost.mockResolvedValue({ status: 202, data: { message_id: 'm-1' } });
+    const body = { conversation_id: 'c-1', content: 'focus on the APT41 angle', agent_slug: 'global.assistant' };
+
+    await postChatbotMessageSteer(buildReq(body), res);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    const [url, sentBody, opts] = mockPost.mock.calls[0];
+    expect(url).toBe('/api/v1/platform/chat/messages/steer');
+    expect(sentBody).toEqual(body);
+    expect(opts.timeout).toBeGreaterThan(0);
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith({ message_id: 'm-1' });
+  });
+
+  it('should forward an upstream 409 with its detail so the widget rolls back the optimistic bubble', async () => {
+    const httpError = new Error('Request failed with status code 409') as any;
+    httpError.response = { status: 409, data: { detail: 'No response is currently being generated' } };
+    mockPost.mockRejectedValue(httpError);
+
+    await postChatbotMessageSteer(buildReq({ conversation_id: 'c-1', content: 'steer' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.send).toHaveBeenCalledWith({ status: 'error', error: 'No response is currently being generated' });
+  });
+
+  it('should fall back to the error message and 503 when no HTTP response is available', async () => {
+    mockPost.mockRejectedValue(new Error('Network failure'));
+
+    await postChatbotMessageSteer(buildReq({ conversation_id: 'c-1', content: 'steer' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.send).toHaveBeenCalledWith({ status: 'error', error: 'Network failure' });
   });
 });


### PR DESCRIPTION
Closes #16511

## Summary

Wires the OpenCTI side of the @filigran/chatbot v3.6.0 multi-conversation + mid-run steering contract (FiligranHQ/filigran-ui#317, XTM One platform endpoints in XTM-One-Platform/xtm-one#1557):

- httpChatbotProxy: new handlers getChatbotSessions (GET /chatbot/sessions -> XTM One history listing), deleteChatbotSession (DELETE /chatbot/sessions/:conversationId, UUID-validated) and postChatbotMessageSteer (POST /chatbot/messages/steer)
- All three handlers forward the upstream status code as-is (success and error) and surface the upstream detail/message in error responses, so the chatbot rolls back its optimistic bubble on 409 "no run active" with an actionable message
- The UUID path-parameter regex is shared (UUID_RE) between the conversation-id and file-id validations
- httpPlatform: route registrations for the three endpoints
- AskArianePanel: configure apiEndpoints.steer = '/messages/steer' (the chatbot default assumes XTM One-style paths); the history menu uses the existing sessions path (GET to list, DELETE to remove)
- bump @filigran/chatbot to 3.6.0 (published on npm, lockfile refreshed)

## Notes

- Branch rebased onto master to resolve the @filigran/chatbot 3.5.2 bump (#16495) conflict in package.json / yarn.lock; the dependency lands at 3.6.0.
- All backend proxy changes degrade gracefully against an older XTM One: non-2xx upstream responses are forwarded and the widget rolls back / hides the corresponding UI affordances.

## Test plan

- [x] opencti-graphql: tsc --noEmit clean, eslint clean on the changed files
- [x] Unit tests: 15 new Vitest cases for the three handlers (auth rejection, UUID/body validation, upstream status forwarding incl. 204-no-body vs 200-with-body on delete, upstream detail surfacing on 404/409/502, 503 fallback) - 45/45 passing in tests/01-unit/http/httpChatbotProxy-test.ts
- [x] opencti-front: yarn install with @filigran/chatbot 3.6.0 and typecheck (no errors in chatbot-related files)
- [ ] Manual: history menu lists/switches/deletes conversations; steering mid-generation injects the message (409 rollback when idle)
