### PR TITLE
fix(workflow): only fetch filtered members from definition (#16515)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.graphql.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.graphql.ts
@@ -4,7 +4,7 @@ import { graphql } from 'react-relay';
 export const COMMENT_MAX_LENGTH = 1000;
 
 export const workflowStatusFragment = graphql`
-  fragment workflowStatus_data on DraftWorkspace {
+  fragment WorkflowStatus_data on DraftWorkspace {
     id
     entity_id
     processingCount
@@ -61,7 +61,7 @@ export const workflowStatusFragment = graphql`
 `;
 
 export const workflowStatusTriggerMutation = graphql`
-  mutation workflowStatusTriggerMutation($entityId: String!, $eventName: String!, $comment: String, $runtimeParams: JSON) {
+  mutation WorkflowStatusTriggerMutation($entityId: String!, $eventName: String!, $comment: String, $runtimeParams: JSON) {
     triggerWorkflowEvent(entityId: $entityId, eventName: $eventName, comment: $comment, runtimeParams: $runtimeParams) {
       success
       reason
@@ -112,7 +112,7 @@ export const workflowStatusTriggerMutation = graphql`
       }
       entity {
         ... on DraftWorkspace {
-          ...workflowStatus_data
+          ...WorkflowStatus_data
         }
       }
     }
@@ -120,7 +120,7 @@ export const workflowStatusTriggerMutation = graphql`
 `;
 
 export const workflowStatusClearMutation = graphql`
-  mutation workflowStatusClearMutation($entityId: String!) {
+  mutation WorkflowStatusClearMutation($entityId: String!) {
     clearWorkflowPendingState(entityId: $entityId) {
       id
       pendingStatus

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import WorkflowStatus, { WorkflowTransitions } from './WorkflowStatus';
 import testRender from '../../../../utils/tests/test-render';
-import type { workflowStatus_data$key } from './__generated__/workflowStatus_data.graphql';
+import type { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 import { CommentMode } from '../../settings/sub_types/workflow/utils';
 
 // ---------------------------------------------------------------------------

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
-import WorkflowStatus, { WorkflowTransitions } from './WorkflowStatus';
+import WorkflowStatus from './WorkflowStatus';
+import WorkflowTransitions from './WorkflowTransitions';
 import testRender from '../../../../utils/tests/test-render';
-import type { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
+import type { WorkflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 import { CommentMode } from '../../settings/sub_types/workflow/utils';
 
 // ---------------------------------------------------------------------------
@@ -55,7 +56,7 @@ const makeStatus = (color = '#ff0000', name = 'In review') => ({
   template: { name, color },
 });
 
-const makeDraft = (overrides: Record<string, unknown> = {}): workflowStatus_data$key => ({
+const makeDraft = (overrides: Record<string, unknown> = {}): WorkflowStatus_data$key => ({
   id: 'draft-1',
   entity_id: 'entity-1',
   processingCount: 0,
@@ -67,7 +68,7 @@ const makeDraft = (overrides: Record<string, unknown> = {}): workflowStatus_data
     allowedTransitions: [],
   },
   ...overrides,
-} as unknown as workflowStatus_data$key);
+} as unknown as WorkflowStatus_data$key);
 
 const makeTransition = (overrides: Record<string, unknown> = {}) => ({
   event: 'approve',

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from '@mui/material';
 import { CommentOutlined } from '@mui/icons-material';
 import ItemStatus from '../../../../components/ItemStatus';
 import { workflowStatusFragment } from './workflowStatus.graphql';
-import { workflowStatus_data$key } from './__generated__/workflowStatus_data.graphql';
+import { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 
 export { workflowStatusFragment } from './workflowStatus.graphql';
 export { WorkflowTransitions } from './WorkflowTransitions';

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowStatus.tsx
@@ -3,14 +3,11 @@ import { useFragment } from 'react-relay';
 import { Tooltip } from '@mui/material';
 import { CommentOutlined } from '@mui/icons-material';
 import ItemStatus from '../../../../components/ItemStatus';
-import { workflowStatusFragment } from './workflowStatus.graphql';
-import { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
-
-export { workflowStatusFragment } from './workflowStatus.graphql';
-export { WorkflowTransitions } from './WorkflowTransitions';
+import { workflowStatusFragment } from './WorkflowStatus.graphql';
+import { WorkflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 
 interface WorkflowStatusProps {
-  data: workflowStatus_data$key;
+  data: WorkflowStatus_data$key;
 }
 
 const WorkflowStatus: FunctionComponent<WorkflowStatusProps> = ({ data }) => {

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { WorkflowTransitions } from './WorkflowTransitions';
 import testRender from '../../../../utils/tests/test-render';
-import type { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
+import type { WorkflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 
 // ---------------------------------------------------------------------------
 // Relay + router mocks (same pattern as WorkflowStatus.test.tsx)
@@ -59,7 +59,7 @@ const makeStatus = () => ({
   template: { name: 'In review', color: '#ff0000' },
 });
 
-const makeDraft = (overrides: Record<string, unknown> = {}): workflowStatus_data$key => ({
+const makeDraft = (overrides: Record<string, unknown> = {}): WorkflowStatus_data$key => ({
   id: 'draft-1',
   entity_id: 'entity-1',
   processingCount: 0,
@@ -74,7 +74,7 @@ const makeDraft = (overrides: Record<string, unknown> = {}): workflowStatus_data
     pendingError: null,
   },
   ...overrides,
-} as unknown as workflowStatus_data$key);
+} as unknown as WorkflowStatus_data$key);
 
 const makePendingDraft = (asyncActions = [{ id: 's1', workId: 'w1', type: 'asyncBulkAction', status: 'pending', expectedCount: 20, processedCount: 5 }]) =>
   makeDraft({

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.test.tsx
@@ -7,7 +7,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { WorkflowTransitions } from './WorkflowTransitions';
 import testRender from '../../../../utils/tests/test-render';
-import type { workflowStatus_data$key } from './__generated__/workflowStatus_data.graphql';
+import type { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 
 // ---------------------------------------------------------------------------
 // Relay + router mocks (same pattern as WorkflowStatus.test.tsx)

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
@@ -6,7 +6,7 @@ import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import ObjectOrganizationField from '../../common/form/ObjectOrganizationField';
 import Button from '../../../../components/common/button/Button';
-import { workflowStatus_data$key } from './__generated__/workflowStatus_data.graphql';
+import { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import Transition from '../../../../components/Transition';
 import Dialog from '@common/dialog/Dialog';

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
@@ -6,19 +6,19 @@ import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import ObjectOrganizationField from '../../common/form/ObjectOrganizationField';
 import Button from '../../../../components/common/button/Button';
-import { workflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
+import { WorkflowStatus_data$key } from './__generated__/WorkflowStatus_data.graphql';
 import { useFormatter } from '../../../../components/i18n';
 import Transition from '../../../../components/Transition';
 import Dialog from '@common/dialog/Dialog';
 import { CommentMode } from '../../settings/sub_types/workflow/utils';
-import { workflowStatusFragment, COMMENT_MAX_LENGTH } from './workflowStatus.graphql';
+import { workflowStatusFragment, COMMENT_MAX_LENGTH } from './WorkflowStatus.graphql';
 import { useTransitionWizard } from './useTransitionWizard';
 import { isBypassUser } from '../../../../utils/hooks/useGranted';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { Close } from 'mdi-material-ui';
 
 interface WorkflowTransitionsProps {
-  data: workflowStatus_data$key;
+  data: WorkflowStatus_data$key;
 }
 
 export const WorkflowTransitions: FunctionComponent<WorkflowTransitionsProps> = ({ data }) => {

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.test.ts
@@ -26,7 +26,7 @@ const {
 
 // Distinguish mutations by identity so useMutation can return the right commit fn
 // in every test, without relying on a fragile mockImplementationOnce queue.
-vi.mock('./workflowStatus.graphql', () => ({
+vi.mock('./WorkflowStatus.graphql', () => ({
   workflowStatusTriggerMutation: { __id: 'trigger' },
   workflowStatusClearMutation: { __id: 'clear' },
   workflowStatusFragment: {},

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.ts
@@ -7,8 +7,8 @@ import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSFIELDS } from '../../../../utils
 import { MESSAGING$ } from '../../../../relay/environment';
 import { CommentMode } from '../../settings/sub_types/workflow/utils';
 import { workflowStatusTriggerMutation, workflowStatusClearMutation } from './workflowStatus.graphql';
-import type { workflowStatusTriggerMutation as workflowStatusTriggerMutationType } from './__generated__/workflowStatusTriggerMutation.graphql';
-import type { workflowStatusClearMutation as workflowStatusClearMutationType } from './__generated__/workflowStatusClearMutation.graphql';
+import type { workflowStatusTriggerMutation as WorkflowStatusTriggerMutationType } from './__generated__/WorkflowStatusTriggerMutation.graphql';
+import type { workflowStatusClearMutation as WorkflowStatusClearMutationType } from './__generated__/WorkflowStatusClearMutation.graphql';
 
 export type WizardStep = 'org-picker' | 'comment' | 'validate';
 
@@ -37,8 +37,8 @@ export const useTransitionWizard = ({ entityId, entityNavigationId }: UseTransit
   const [wizard, setWizard] = useState<TransitionWizard | null>(null);
   const [commentValue, setCommentValue] = useState('');
 
-  const [commit, approving] = useMutation<workflowStatusTriggerMutationType>(workflowStatusTriggerMutation);
-  const [commitClear, clearing] = useMutation<workflowStatusClearMutationType>(workflowStatusClearMutation);
+  const [commit, approving] = useMutation<WorkflowStatusTriggerMutationType>(workflowStatusTriggerMutation);
+  const [commitClear, clearing] = useMutation<WorkflowStatusClearMutationType>(workflowStatusClearMutation);
 
   const exitDraftAfterValidation = () => {
     exitDraft({

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/useTransitionWizard.ts
@@ -6,9 +6,9 @@ import useSwitchDraft from '../../drafts/useSwitchDraft';
 import useGranted, { KNOWLEDGE_KNUPDATE_KNBYPASSFIELDS } from '../../../../utils/hooks/useGranted';
 import { MESSAGING$ } from '../../../../relay/environment';
 import { CommentMode } from '../../settings/sub_types/workflow/utils';
-import { workflowStatusTriggerMutation, workflowStatusClearMutation } from './workflowStatus.graphql';
-import type { workflowStatusTriggerMutation as WorkflowStatusTriggerMutationType } from './__generated__/WorkflowStatusTriggerMutation.graphql';
-import type { workflowStatusClearMutation as WorkflowStatusClearMutationType } from './__generated__/WorkflowStatusClearMutation.graphql';
+import { workflowStatusTriggerMutation, workflowStatusClearMutation } from './WorkflowStatus.graphql';
+import type { WorkflowStatusTriggerMutation as WorkflowStatusTriggerMutationType } from './__generated__/WorkflowStatusTriggerMutation.graphql';
+import type { WorkflowStatusClearMutation as WorkflowStatusClearMutationType } from './__generated__/WorkflowStatusClearMutation.graphql';
 
 export type WizardStep = 'org-picker' | 'comment' | 'validate';
 

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftToolbar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftToolbar.tsx
@@ -13,7 +13,8 @@ import DraftExit from './DraftExit';
 import { FIVE_SECONDS, THIRTY_SECONDS } from '../../../utils/Time';
 import useInterval from '../../../utils/hooks/useInterval';
 import DraftAuthorizedMembers from './DraftAuthorizedMembers';
-import WorkflowStatus, { WorkflowTransitions } from '../common/workflow/WorkflowStatus';
+import WorkflowStatus from '../common/workflow/WorkflowStatus';
+import WorkflowTransitions from '../common/workflow/WorkflowTransitions';
 import { DraftToolbarQuery } from '@components/drafts/__generated__/DraftToolbarQuery.graphql';
 import { DraftToolbarFragment$key } from '@components/drafts/__generated__/DraftToolbarFragment.graphql';
 import DraftApprove from './DraftApprove';
@@ -28,7 +29,7 @@ const draftFragment = graphql`
     ...DraftApproveFragment
     ...DraftExitFragment
     ...DraftAuthorizedMembersFragment
-    ...workflowStatus_data
+    ...WorkflowStatus_data
   }
 `;
 

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflow.tsx
@@ -63,11 +63,8 @@ export const workflowQuery = graphql`
 `;
 
 export const workflowDependenciesQuery = graphql`
-  query SubTypeWorkflowDependenciesQuery(
-    $memberFilters: FilterGroup
-    $memberFirst: Int
-  ) {
-    members(filters: $memberFilters, first: $memberFirst) {
+  query SubTypeWorkflowDependenciesQuery($memberFilters: FilterGroup) {
+    members(filters: $memberFilters) {
       edges {
         node {
           id
@@ -130,11 +127,7 @@ const WorkflowWithDependencies = ({ queryRef }: WorkflowWithDependenciesProps) =
   const depsQueryRef = useQueryLoading<SubTypeWorkflowDependenciesQuery>(workflowDependenciesQuery,
     {
       memberFilters: memberIds.length
-        ? ({
-            mode: 'and' as const,
-            filters: [{ key: ['id'], values: memberIds }],
-            filterGroups: [],
-          })
+        ? ({ mode: 'and' as const, filters: [{ key: ['id'], values: memberIds }], filterGroups: [] })
         : null,
     },
   );

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypeWorkflow.tsx
@@ -1,9 +1,10 @@
 import Workflow from './workflow/Workflow';
 import { ReactFlowProvider } from 'reactflow';
 import { ErrorBoundary } from '../../Error';
-import { graphql } from 'react-relay';
+import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import { SubTypeWorkflowQuery } from './__generated__/SubTypeWorkflowQuery.graphql';
+import { SubTypeWorkflowQuery, SubTypeWorkflowQuery$data } from './__generated__/SubTypeWorkflowQuery.graphql';
+import { SubTypeWorkflowDependenciesQuery } from './__generated__/SubTypeWorkflowDependenciesQuery.graphql';
 import Loader from '../../../../components/Loader';
 import { Suspense } from 'react';
 
@@ -49,31 +50,6 @@ export const workflowQuery = graphql`
         comment
       }
     }
-    members(search: "", first: 100) {
-      edges {
-        node {
-          id
-          entity_type
-          name
-        }
-      }
-    }
-    organizations(search: "", first: 200) {
-      edges {
-        node {
-          id
-          name
-        }
-      }
-    }
-    groups(search: "", first: 500) {
-      edges {
-        node {
-          id
-          name
-        }
-      }
-    }
     statusTemplates(search: "") {
       edges {
         node {
@@ -85,6 +61,92 @@ export const workflowQuery = graphql`
     }
   }
 `;
+
+export const workflowDependenciesQuery = graphql`
+  query SubTypeWorkflowDependenciesQuery(
+    $memberFilters: FilterGroup
+    $memberFirst: Int
+  ) {
+    members(filters: $memberFilters, first: $memberFirst) {
+      edges {
+        node {
+          id
+          entity_type
+          name
+        }
+      }
+    }
+  }
+`;
+
+type ActionParams = {
+  authorized_members?: { id: string; groups_restriction_ids?: string[] }[];
+  actions?: { context?: { values?: string[] } }[];
+};
+
+type ActionList = { type: string; params: unknown }[];
+
+/**
+ * Extracts the unique entity IDs referenced by a workflow definition's actions,
+ * so that only the relevant members are fetched.
+ */
+export const extractWorkflowMembersIds = (
+  workflowDefinition: SubTypeWorkflowQuery$data['workflowDefinition'],
+): string[] => {
+  if (!workflowDefinition) return [];
+
+  const allActionLists = [
+    ...workflowDefinition.states.flatMap((s) => [s.onEnter, s.onExit]),
+    ...workflowDefinition.transitions.flatMap((t) => [t.asyncActions, t.syncActions]),
+  ];
+
+  const collected = allActionLists.flatMap((actions) => {
+    // Get member IDs from updateAuthorizedMembers actions
+    const memberIds = (actions ?? [] as ActionList)
+      ?.filter((action) => action.type === 'updateAuthorizedMembers')
+      .flatMap((action) => (action.params as ActionParams).authorized_members ?? [])
+      .flatMap((authorizedMember) => [authorizedMember.id, ...(authorizedMember.groups_restriction_ids ?? [])]);
+
+    // Get organization IDs from asyncBulkAction actions
+    const orgIds = (actions ?? [] as ActionList)
+      ?.filter((action) => action.type === 'asyncBulkAction')
+      .flatMap((action) => (action.params as ActionParams).actions?.[0]?.context?.values ?? []);
+
+    return [...memberIds, ...orgIds];
+  });
+
+  // Remove duplicates and falsy values
+  return Array.from(new Set(collected)).filter(Boolean) as string[];
+};
+
+interface WorkflowWithDependenciesProps {
+  queryRef: PreloadedQuery<SubTypeWorkflowQuery>;
+}
+
+const WorkflowWithDependencies = ({ queryRef }: WorkflowWithDependenciesProps) => {
+  const { workflowDefinition } = usePreloadedQuery<SubTypeWorkflowQuery>(workflowQuery, queryRef);
+  const memberIds = extractWorkflowMembersIds(workflowDefinition);
+
+  const depsQueryRef = useQueryLoading<SubTypeWorkflowDependenciesQuery>(workflowDependenciesQuery,
+    {
+      memberFilters: memberIds.length
+        ? ({
+            mode: 'and' as const,
+            filters: [{ key: ['id'], values: memberIds }],
+            filterGroups: [],
+          })
+        : null,
+    },
+  );
+
+  if (!depsQueryRef) return <Loader />;
+
+  return (
+    <Suspense fallback={<Loader />}>
+      <Workflow queryRef={queryRef} depsQueryRef={depsQueryRef} />
+    </Suspense>
+  );
+};
 
 const SubTypeWorkflow = () => {
   const workflowQueryRef = useQueryLoading<SubTypeWorkflowQuery>(
@@ -101,9 +163,7 @@ const SubTypeWorkflow = () => {
       <ErrorBoundary>
         <div style={{ width: '100%', height: 'calc(100vh - 250px)', marginBottom: '-50px' }}>
           <ReactFlowProvider>
-            <Workflow
-              queryRef={workflowQueryRef}
-            />
+            <WorkflowWithDependencies queryRef={workflowQueryRef} />
           </ReactFlowProvider>
         </div>
       </ErrorBoundary>

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/__tests__/extractWorkflowMembersIds.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/__tests__/extractWorkflowMembersIds.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import { SubTypeWorkflowQuery$data } from '../__generated__/SubTypeWorkflowQuery.graphql';
+import { extractWorkflowMembersIds } from '../SubTypeWorkflow';
+
+type WorkflowDef = SubTypeWorkflowQuery$data['workflowDefinition'];
+
+const emptyDef = (overrides: Partial<NonNullable<WorkflowDef>> = {}): NonNullable<WorkflowDef> => ({
+  id: 'wf-1',
+  name: 'Test',
+  published: false,
+  errors: [],
+  initialState: '',
+  states: [],
+  transitions: [],
+  ...overrides,
+});
+
+describe('extractWorkflowMembersIds', () => {
+  it('returns empty array for null workflowDefinition', () => {
+    expect(extractWorkflowMembersIds(null)).toEqual([]);
+  });
+
+  it('returns empty array for undefined workflowDefinition', () => {
+    expect(extractWorkflowMembersIds(undefined as never)).toEqual([]);
+  });
+
+  it('returns empty array when there are no actions', () => {
+    expect(extractWorkflowMembersIds(emptyDef())).toEqual([]);
+  });
+
+  describe('updateAuthorizedMembers', () => {
+    it('extracts member ids from state onEnter actions', () => {
+      const def = emptyDef({
+        states: [{
+          statusId: 's1',
+          onEnter: [{
+            type: 'updateAuthorizedMembers',
+            params: { authorized_members: [{ id: 'user-1', access_right: 'view' }] },
+          }],
+          onExit: [],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['user-1']);
+    });
+
+    it('extracts member ids from state onExit actions', () => {
+      const def = emptyDef({
+        states: [{
+          statusId: 's1',
+          onEnter: [],
+          onExit: [{
+            type: 'updateAuthorizedMembers',
+            params: { authorized_members: [{ id: 'user-2', access_right: 'admin' }] },
+          }],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['user-2']);
+    });
+
+    it('extracts groups_restriction_ids alongside member ids', () => {
+      const def = emptyDef({
+        states: [{
+          statusId: 's1',
+          onEnter: [{
+            type: 'updateAuthorizedMembers',
+            params: {
+              authorized_members: [{
+                id: 'user-1',
+                access_right: 'view',
+                groups_restriction_ids: ['group-1', 'group-2'],
+              }],
+            },
+          }],
+          onExit: [],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['user-1', 'group-1', 'group-2']);
+    });
+
+    it('extracts member ids from transition syncActions', () => {
+      const def = emptyDef({
+        transitions: [{
+          from: ['s1'],
+          to: 's2',
+          event: 'go',
+          conditions: {},
+          comment: null,
+          asyncActions: [],
+          syncActions: [{
+            type: 'updateAuthorizedMembers',
+            params: { authorized_members: [{ id: 'user-3', access_right: 'edit' }] },
+          }],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['user-3']);
+    });
+  });
+
+  describe('asyncBulkAction', () => {
+    it('extracts org ids from SHARE asyncBulkAction in transition asyncActions', () => {
+      const def = emptyDef({
+        transitions: [{
+          from: ['s1'],
+          to: 's2',
+          event: 'share',
+          conditions: {},
+          comment: null,
+          asyncActions: [{
+            type: 'asyncBulkAction',
+            params: {
+              actions: [{ type: 'SHARE', context: { values: ['org-1', 'org-2'] } }],
+            },
+          }],
+          syncActions: [],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['org-1', 'org-2']);
+    });
+
+    it('extracts org ids from UNSHARE asyncBulkAction', () => {
+      const def = emptyDef({
+        transitions: [{
+          from: ['s1'],
+          to: 's2',
+          event: 'unshare',
+          conditions: {},
+          comment: null,
+          asyncActions: [{
+            type: 'asyncBulkAction',
+            params: {
+              actions: [{ type: 'UNSHARE', context: { values: ['org-3'] } }],
+            },
+          }],
+          syncActions: [],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['org-3']);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('deduplicates ids appearing in multiple states', () => {
+      const def = emptyDef({
+        states: [
+          {
+            statusId: 's1',
+            onEnter: [{
+              type: 'updateAuthorizedMembers',
+              params: { authorized_members: [{ id: 'user-1', access_right: 'view' }] },
+            }],
+            onExit: [],
+          },
+          {
+            statusId: 's2',
+            onEnter: [{
+              type: 'updateAuthorizedMembers',
+              params: { authorized_members: [{ id: 'user-1', access_right: 'admin' }] },
+            }],
+            onExit: [],
+          },
+        ],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['user-1']);
+    });
+
+    it('deduplicates ids shared between members and group restrictions', () => {
+      const def = emptyDef({
+        states: [{
+          statusId: 's1',
+          onEnter: [{
+            type: 'updateAuthorizedMembers',
+            params: {
+              authorized_members: [
+                { id: 'group-1', access_right: 'view' },
+                { id: 'user-1', access_right: 'admin', groups_restriction_ids: ['group-1'] },
+              ],
+            },
+          }],
+          onExit: [],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['group-1', 'user-1']);
+    });
+
+    it('collects ids from both states and transitions without duplicates', () => {
+      const def = emptyDef({
+        states: [{
+          statusId: 's1',
+          onEnter: [{
+            type: 'updateAuthorizedMembers',
+            params: { authorized_members: [{ id: 'user-1', access_right: 'view' }] },
+          }],
+          onExit: [],
+        }],
+        transitions: [{
+          from: ['s1'],
+          to: 's2',
+          event: 'go',
+          conditions: {},
+          comment: null,
+          asyncActions: [{
+            type: 'asyncBulkAction',
+            params: { actions: [{ type: 'SHARE', context: { values: ['user-1', 'org-1'] } }] },
+          }],
+          syncActions: [],
+        }],
+      });
+
+      expect(extractWorkflowMembersIds(def)).toEqual(['user-1', 'org-1']);
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/Workflow.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/Workflow.test.tsx
@@ -7,6 +7,7 @@ import { WorkflowNodeType } from './utils';
 import ThemeDark from '../../../../../components/ThemeDark';
 import { PreloadedQuery } from 'react-relay/relay-hooks/EntryPointTypes';
 import { SubTypeWorkflowQuery } from '../__generated__/SubTypeWorkflowQuery.graphql';
+import { SubTypeWorkflowDependenciesQuery } from '../__generated__/SubTypeWorkflowDependenciesQuery.graphql';
 
 // Mock ResizeObserver
 global.ResizeObserver = class ResizeObserver {
@@ -188,6 +189,7 @@ vi.mock('./EdgeTypes', () => ({
 
 describe('Workflow Component', () => {
   const mockQueryRef = {} as PreloadedQuery<SubTypeWorkflowQuery, Record<string, unknown>>;
+  const mockDepsQueryRef = {} as PreloadedQuery<SubTypeWorkflowDependenciesQuery, Record<string, unknown>>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -215,22 +217,22 @@ describe('Workflow Component', () => {
 
   describe('Component rendering', () => {
     it('should render ReactFlow component', () => {
-      const { container } = renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      const { container } = renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
       expect(container.querySelector('.react-flow')).toBeInTheDocument();
     });
 
     it('should render PublishButton', () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
       expect(screen.getByTestId('publish-button')).toBeInTheDocument();
     });
 
     it('should render Add Status button', () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
       expect(screen.getByText('Add Status')).toBeInTheDocument();
     });
 
     it('should call fitView on mount', () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
       expect(mockFitView).toHaveBeenCalled();
     });
   });
@@ -238,7 +240,7 @@ describe('Workflow Component', () => {
   describe('User interactions', () => {
     it('should open drawer when Add Status button is clicked', async () => {
       const user = userEvent.setup();
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       const addButton = screen.getByText('Add Status');
       await user.click(addButton);
@@ -248,7 +250,7 @@ describe('Workflow Component', () => {
 
     it('should close drawer when close button is clicked', async () => {
       const user = userEvent.setup();
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       // Open drawer
       const addButton = screen.getByText('Add Status');
@@ -267,7 +269,7 @@ describe('Workflow Component', () => {
 
   describe('Autosave functionality', () => {
     it('should call saveWorkflowDefinition with correct entity type', async () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       await waitFor(() => {
         const calls = mockSaveWorkflowDefinition.mock.calls;
@@ -282,7 +284,7 @@ describe('Workflow Component', () => {
     });
 
     it('should provide onCompleted callback to save mutation', async () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       await waitFor(() => {
         const calls = mockSaveWorkflowDefinition.mock.calls;
@@ -296,7 +298,7 @@ describe('Workflow Component', () => {
 
   describe('Initial state', () => {
     it('should display publish button with correct initial state', () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       const publishButton = screen.getByTestId('publish-button');
       expect(publishButton).toBeInTheDocument();
@@ -304,7 +306,7 @@ describe('Workflow Component', () => {
     });
 
     it('should handle workflow definition with no errors', () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       const publishButton = screen.getByTestId('publish-button');
       expect(publishButton).not.toBeDisabled();
@@ -314,7 +316,7 @@ describe('Workflow Component', () => {
   describe('Drawer interactions', () => {
     it('should set selectedElement when opening drawer for new status', async () => {
       const user = userEvent.setup();
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       const addButton = screen.getByText('Add Status');
       await user.click(addButton);
@@ -324,7 +326,7 @@ describe('Workflow Component', () => {
 
     it('should reset selectedElement when closing drawer', async () => {
       const user = userEvent.setup();
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       const addButton = screen.getByText('Add Status');
       await user.click(addButton);
@@ -340,14 +342,14 @@ describe('Workflow Component', () => {
 
   describe('ReactFlow integration', () => {
     it('should pass nodes and edges to ReactFlow', () => {
-      const { container } = renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      const { container } = renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
       const reactFlow = container.querySelector('.react-flow');
 
       expect(reactFlow).toBeInTheDocument();
     });
 
     it('should call fitView with correct options', () => {
-      renderWithTheme(<Workflow queryRef={mockQueryRef} />);
+      renderWithTheme(<Workflow queryRef={mockQueryRef} depsQueryRef={mockDepsQueryRef} />);
 
       expect(mockFitView).toHaveBeenCalled();
     });

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/Workflow.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/Workflow.tsx
@@ -9,8 +9,9 @@ import Button from '@common/button/Button';
 import { Typography } from '@mui/material';
 import { NEW_STATUS_NAME, transformToWorkflowDefinition, WorkflowNodeType } from './utils';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { workflowQuery } from '../SubTypeWorkflow';
+import { workflowDependenciesQuery, workflowQuery } from '../SubTypeWorkflow';
 import { SubTypeWorkflowQuery } from '../__generated__/SubTypeWorkflowQuery.graphql';
+import { SubTypeWorkflowDependenciesQuery } from '../__generated__/SubTypeWorkflowDependenciesQuery.graphql';
 import useApiMutation from '../../../../../utils/hooks/useApiMutation';
 import { useFormatter } from '../../../../../components/i18n';
 import { WorkflowDefinitionMutation } from './__generated__/WorkflowDefinitionMutation.graphql';
@@ -65,18 +66,22 @@ const emptyElement = {
   position: { x: 0, y: 0 },
 };
 
-const Workflow = ({ queryRef }: { queryRef: PreloadedQuery<SubTypeWorkflowQuery> }) => {
+const Workflow = ({ queryRef, depsQueryRef }: { queryRef: PreloadedQuery<SubTypeWorkflowQuery>; depsQueryRef: PreloadedQuery<SubTypeWorkflowDependenciesQuery> }) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const { fitView, getNode } = useReactFlow();
 
-  const { workflowDefinition, statusTemplates, members, organizations, groups } = usePreloadedQuery<SubTypeWorkflowQuery>(
+  const { workflowDefinition, statusTemplates } = usePreloadedQuery<SubTypeWorkflowQuery>(
     workflowQuery,
     queryRef,
   );
+  const { members } = usePreloadedQuery<SubTypeWorkflowDependenciesQuery>(
+    workflowDependenciesQuery,
+    depsQueryRef,
+  );
 
   // 1. Get initial edges and nodes from workflow definition
-  const { initialNodes, initialEdges } = useWorkflowInitialElements(workflowDefinition, statusTemplates, members, organizations, groups);
+  const { initialNodes, initialEdges } = useWorkflowInitialElements(workflowDefinition, statusTemplates, members);
 
   const [nodes, _dispatchNodes, onNodesChange] = useNodesState<Node>(initialNodes);
   const [edges, _dispatchEdges, onEdgesChange] = useEdgesState<Edge>(initialEdges);

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/hooks/useWorkflowInitialElements.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/hooks/useWorkflowInitialElements.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { MarkerType, Node } from 'reactflow';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SubTypeWorkflowQuery$data } from '../../__generated__/SubTypeWorkflowQuery.graphql';
+import { SubTypeWorkflowDependenciesQuery$data } from '../../__generated__/SubTypeWorkflowDependenciesQuery.graphql';
 import { WorkflowNodeType } from '../utils';
 import { useWorkflowInitialElements } from './useWorkflowInitialElements';
 
@@ -34,15 +35,10 @@ describe('useWorkflowInitialElements', () => {
     ],
   };
 
-  const mockMembers: SubTypeWorkflowQuery$data['members'] = {
+  const mockMembers: SubTypeWorkflowDependenciesQuery$data['members'] = {
     edges: [
       { node: { id: 'user-1', name: 'John Doe', entity_type: 'User' } },
-    ],
-  };
-
-  const mockGroups: SubTypeWorkflowQuery$data['groups'] = {
-    edges: [
-      { node: { id: 'group-1', name: 'Analysts' } },
+      { node: { id: 'group-1', name: 'Analysts', entity_type: 'Group' } },
     ],
   };
 
@@ -87,7 +83,7 @@ describe('useWorkflowInitialElements', () => {
 
   it('should return empty arrays if workflowDefinition is null', () => {
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(null, null, null, null, null),
+      useWorkflowInitialElements(null, null, null),
     );
 
     expect(result.current.initialNodes).toEqual([]);
@@ -96,7 +92,7 @@ describe('useWorkflowInitialElements', () => {
 
   it('should transform states into status nodes', () => {
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(mockWorkflowDefinition, mockStatusTemplates, mockMembers, null, null),
+      useWorkflowInitialElements(mockWorkflowDefinition, mockStatusTemplates, mockMembers),
     );
 
     const statusNodes = result.current.initialNodes.filter(
@@ -118,7 +114,7 @@ describe('useWorkflowInitialElements', () => {
 
   it('should transform transitions into one node and two edges', () => {
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(mockWorkflowDefinition, mockStatusTemplates, mockMembers, null, null),
+      useWorkflowInitialElements(mockWorkflowDefinition, mockStatusTemplates, mockMembers),
     );
 
     const transitionNodes = result.current.initialNodes.filter(
@@ -139,7 +135,7 @@ describe('useWorkflowInitialElements', () => {
 
   it('should enrich authorized members actions with member data', () => {
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(mockWorkflowDefinition, mockStatusTemplates, mockMembers, null, null),
+      useWorkflowInitialElements(mockWorkflowDefinition, mockStatusTemplates, mockMembers),
     );
 
     const node = result.current.initialNodes.find((n: Node) => n.id === 'status-open');
@@ -175,7 +171,7 @@ describe('useWorkflowInitialElements', () => {
     };
 
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(defWithGroupRestriction, mockStatusTemplates, mockMembers, null, mockGroups),
+      useWorkflowInitialElements(defWithGroupRestriction, mockStatusTemplates, mockMembers),
     );
 
     const node = result.current.initialNodes.find((n: Node) => n.id === 'status-open');
@@ -196,7 +192,7 @@ describe('useWorkflowInitialElements', () => {
 
     const { result, rerender } = renderHook(
       ({ def }: HookProps) =>
-        useWorkflowInitialElements(def, mockStatusTemplates, mockMembers, null, null),
+        useWorkflowInitialElements(def, mockStatusTemplates, mockMembers),
       { initialProps: { def: mockWorkflowDefinition } },
     );
 
@@ -240,12 +236,15 @@ describe('useWorkflowInitialElements', () => {
       ],
     };
 
-    const mockOrgs: SubTypeWorkflowQuery$data['organizations'] = {
-      edges: [{ node: { id: orgId, name: 'Org Alpha' } }],
+    const membersWithOrg: SubTypeWorkflowDependenciesQuery$data['members'] = {
+      edges: [
+        ...mockMembers.edges ?? [],
+        { node: { id: orgId, name: 'Org Alpha', entity_type: 'Organization' } },
+      ],
     };
 
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(defWithShare, mockStatusTemplates, mockMembers, mockOrgs, null),
+      useWorkflowInitialElements(defWithShare, mockStatusTemplates, membersWithOrg),
     );
 
     const transitionNode = result.current.initialNodes.find((n: Node) => n.type === WorkflowNodeType.transition);
@@ -280,7 +279,7 @@ describe('useWorkflowInitialElements', () => {
     };
 
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(defWithUnshare, mockStatusTemplates, mockMembers, null, null),
+      useWorkflowInitialElements(defWithUnshare, mockStatusTemplates, mockMembers),
     );
 
     const transitionNode = result.current.initialNodes.find((n: Node) => n.type === WorkflowNodeType.transition);
@@ -290,7 +289,7 @@ describe('useWorkflowInitialElements', () => {
 
   it('should return empty arrays when workflowDefinition is undefined', () => {
     const { result } = renderHook(() =>
-      useWorkflowInitialElements(undefined as never, mockStatusTemplates, mockMembers, null, null),
+      useWorkflowInitialElements(undefined as never, mockStatusTemplates, mockMembers),
     );
     expect(result.current.initialNodes).toEqual([]);
     expect(result.current.initialEdges).toEqual([]);

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/hooks/useWorkflowInitialElements.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/hooks/useWorkflowInitialElements.ts
@@ -134,5 +134,5 @@ export const useWorkflowInitialElements = (
       initialNodes: [...stateNodes, ...transitionNodes],
       initialEdges: [...transitionEdges],
     };
-  }, [workflowDefinition]);
+  }, [workflowDefinition, statusTemplatesEdges, membersEdges]);
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/hooks/useWorkflowInitialElements.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/hooks/useWorkflowInitialElements.ts
@@ -5,6 +5,7 @@ import type { Theme } from '../../../../../../components/Theme';
 import { authorizedMembersToOptions } from '../../../../../../utils/authorizedMembers';
 import { Connection, getNodes } from '../../../../../../utils/connection';
 import { SubTypeWorkflowQuery$data } from '../../__generated__/SubTypeWorkflowQuery.graphql';
+import { SubTypeWorkflowDependenciesQuery$data } from '../../__generated__/SubTypeWorkflowDependenciesQuery.graphql';
 import { Action, CommentMode, CommentModeType, WorkflowNodeType } from '../utils';
 
 type ReadOnlyAction = NonNullable<NonNullable<SubTypeWorkflowQuery$data['workflowDefinition']>['states'][0]['onEnter']>[0]
@@ -25,9 +26,7 @@ const convertEdgesToObject = <T extends { id: string }>(
 export const useWorkflowInitialElements = (
   workflowDefinition: SubTypeWorkflowQuery$data['workflowDefinition'],
   statusTemplatesEdges: SubTypeWorkflowQuery$data['statusTemplates'],
-  membersEdges: SubTypeWorkflowQuery$data['members'],
-  organizationsEdges: SubTypeWorkflowQuery$data['organizations'] | null,
-  groupsEdges: SubTypeWorkflowQuery$data['groups'] | null,
+  membersEdges: SubTypeWorkflowDependenciesQuery$data['members'],
 ) => {
   const theme = useTheme<Theme>();
 
@@ -35,9 +34,8 @@ export const useWorkflowInitialElements = (
     if (!workflowDefinition) return { initialNodes: [], initialEdges: [] };
 
     const statusTemplates: StatusTemplate = convertEdgesToObject(statusTemplatesEdges);
+    // Members contains both users, groups and organizations
     const members = convertEdgesToObject(membersEdges);
-    const organizations = convertEdgesToObject(organizationsEdges);
-    const groups = convertEdgesToObject(groupsEdges);
 
     // Populate authorized members
     const parseActions = (actions?: ReadonlyArray<ReadOnlyAction> | null): Action[] => {
@@ -59,7 +57,7 @@ export const useWorkflowInitialElements = (
                   access_right: am.access_right,
                   groups_restriction: (am.groups_restriction_ids ?? []).map((gid) => ({
                     id: gid,
-                    name: groups[gid]?.name ?? gid,
+                    name: members[gid]?.name ?? gid,
                   })),
                 })),
               ),
@@ -73,7 +71,7 @@ export const useWorkflowInitialElements = (
           const frontendType = innerType === 'UNSHARE' ? 'unshareFromOrganizations' : 'shareWithOrganizations';
           return {
             type: frontendType,
-            params: { organizations: orgIds.map((id) => ({ value: id, label: organizations[id]?.name ?? id })) },
+            params: { organizations: orgIds.map((id) => ({ value: id, label: members[id]?.name ?? id })) },
           } as Action;
         }
         return { ...action } as Action;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Only fetch filters members (user, org, group)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16515

### How to test this PR
* Go to workflow edition, add share organization and authorized member
* Refresh, every organization, users, group should load
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
