### PR TITLE
fix(import): fix import validation with xtmOne not configured (#16502)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.test.tsx
@@ -73,6 +73,12 @@ vi.mock('@components/common/files/import_files/ImportFilesContext', () => ({
   importFilesQuery: {},
 }));
 
+vi.mock('@components/chatbox/ChatbotContext', () => ({
+  useChatbot: vi.fn().mockReturnValue({
+    xtmOneConfigured: false,
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // useImportFilesData – mock the thin wrapper around usePreloadedQuery so we
 // never need to mock 'react-relay' directly (which causes worker-startup

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.test.tsx
@@ -15,6 +15,8 @@ const {
   mockEnterDraft,
   mockNotifyError,
   mockUseImportFilesContext,
+  mockUseChatbot,
+  mockUseImportFilesData,
 } = vi.hoisted(() => ({
   mockSetDraftId: vi.fn(),
   mockSetUploadStatus: vi.fn(),
@@ -23,6 +25,8 @@ const {
   mockEnterDraft: vi.fn(),
   mockNotifyError: vi.fn(),
   mockUseImportFilesContext: vi.fn(),
+  mockUseChatbot: vi.fn(),
+  mockUseImportFilesData: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -74,9 +78,7 @@ vi.mock('@components/common/files/import_files/ImportFilesContext', () => ({
 }));
 
 vi.mock('@components/chatbox/ChatbotContext', () => ({
-  useChatbot: vi.fn().mockReturnValue({
-    xtmOneConfigured: false,
-  }),
+  useChatbot: mockUseChatbot,
 }));
 
 // ---------------------------------------------------------------------------
@@ -85,10 +87,7 @@ vi.mock('@components/chatbox/ChatbotContext', () => ({
 // hangs via vite-plugin-relay intercepting the module in Vitest's forks pool).
 // ---------------------------------------------------------------------------
 vi.mock('./useImportFilesData', () => ({
-  default: vi.fn().mockReturnValue({
-    stixCoreObject: null,
-    connectorsForImport: [],
-  }),
+  default: mockUseImportFilesData,
 }));
 
 // ---------------------------------------------------------------------------
@@ -207,6 +206,11 @@ describe('ImportFilesDialog – createDraft', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseImportFilesContext.mockReturnValue(defaultContextValues);
+    mockUseChatbot.mockReturnValue({ xtmOneConfigured: false });
+    mockUseImportFilesData.mockReturnValue({
+      stixCoreObject: null,
+      connectorsForImport: [],
+    });
   });
 
   describe('when the draft mutation succeeds', () => {
@@ -308,6 +312,52 @@ describe('ImportFilesDialog – createDraft', () => {
         expect(mockBulkCommit).toHaveBeenCalled();
       });
       expect(mockCommitCreationMutation).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('ImportFilesDialog – Next button XTM One validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseImportFilesContext.mockReturnValue({
+      ...defaultContextValues,
+      activeStep: 1,
+      files: [
+        {
+          file: new File(['content'], 'test.txt', { type: 'text/plain' }),
+          connectors: [{ id: 'xtm-connector', name: 'ImportDocumentAI' }],
+        },
+      ],
+    });
+    mockUseImportFilesData.mockReturnValue({
+      stixCoreObject: null,
+      connectorsForImport: [
+        {
+          id: 'xtm-connector',
+          name: 'ImportDocumentAI',
+          xtm_one_intent: 'cti.stix_harvester',
+        },
+      ],
+    });
+  });
+
+  it('should keep Next enabled when xtmOneConfigured is false and no configuration is provided', async () => {
+    mockUseChatbot.mockReturnValue({ xtmOneConfigured: false });
+
+    testRender(<ImportFilesDialog open={true} handleClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+  });
+
+  it('should disable Next when xtmOneConfigured is true and no configuration is provided', async () => {
+    mockUseChatbot.mockReturnValue({ xtmOneConfigured: true });
+
+    testRender(<ImportFilesDialog open={true} handleClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled();
     });
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesDialog.tsx
@@ -45,6 +45,7 @@ import { useIsMandatoryAttribute } from '../../../../../utils/hooks/useEntitySet
 import useDefaultValues from '../../../../../utils/hooks/useDefaultValues';
 import useSwitchDraft from '../../../drafts/useSwitchDraft';
 import useCreateDraft from './useCreateDraft';
+import { useChatbot } from '@components/chatbox/ChatbotContext';
 
 export const CSV_MAPPER_NAME = '[FILE] CSV Mapper import';
 
@@ -147,6 +148,7 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
     queryRef,
     selectedFormId,
   } = useImportFilesContext();
+  const { xtmOneConfigured } = useChatbot();
 
   const [uploadedFiles, setUploadedFiles] = useState<{ name: string; status?: 'success' | 'error' }[]>([]);
   const { stixCoreObject: entity, connectorsForImport } = useImportFilesData(queryRef);
@@ -331,15 +333,15 @@ const ImportFiles = ({ open, handleClose }: ImportFilesDialogProps) => {
     return files.length > 0 && (importMode === 'auto' || files.every((file) => {
       const hasCsvMapperConnector = file.connectors?.some((connector) => connector.name === CSV_MAPPER_NAME);
       if (hasCsvMapperConnector) return !!file.configuration;
-      // XTM One connectors require an agent selection (stored in configuration as JSON with agent_slug)
+      // XTM One connectors require an agent selection only when XTM One is configured.
       const hasXtmOneConnector = file.connectors?.some((connector) => {
         const fullConnector = connectorsForImport?.find((c) => c?.id === connector?.id);
         return !!fullConnector?.xtm_one_intent;
       });
-      if (hasXtmOneConnector) return !!file.configuration;
+      if (hasXtmOneConnector && xtmOneConfigured) return !!file.configuration;
       return true;
     }));
-  }, [files, importMode, selectedFormId, connectorsForImport]);
+  }, [files, importMode, selectedFormId, connectorsForImport, xtmOneConfigured]);
 
   const isValidImport = useMemo(() => {
     const { values } = optionsContext;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* improve isValid function so that it does not return “false” when xtmOne is not configured

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* resolves #16502 

### How to test this PR
1- xtm-one not connected
2- Click on step by step import
3- Select a document to import
4- Select ImportDocument AI connector
5- "Next" button disable

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
