### PR TITLE
fix(backend): guard subscription filters against null payload to prevent redis sub leak (#16402)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/subscriptionWrapper.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/subscriptionWrapper.ts
@@ -27,8 +27,8 @@ const withCancel = (asyncIterator: AsyncIterableIterator<any>, onCancel: () => v
 export const subscribeToUserEvents = async (context: any, topics: string | string[]): Promise<AsyncIterable<any>> => {
   const asyncIterator = pubSubAsyncIterator(topics);
   const filtering = await withFilter(() => asyncIterator, (payload) => {
-    if (!payload) {
-      // When disconnected, an empty payload is dispatched.
+    // A throw here closes the socket (4500) and orphans the redis sub; guard all fields.
+    if (!payload || !payload.instance) {
       return false;
     }
     return [payload.instance.user_id, payload.instance.id].includes(context.user.id);
@@ -41,8 +41,8 @@ export const subscribeToUserEvents = async (context: any, topics: string | strin
 export const subscribeToAiEvents = async (context: any, id: string, topics: string | string[]): Promise<AsyncIterable<any>> => {
   const asyncIterator = pubSubAsyncIterator(topics);
   const filtering = await withFilter(() => asyncIterator, (payload) => {
-    if (!payload) {
-      // When disconnected, an empty payload is dispatched.
+    // A throw here closes the socket (4500) and orphans the redis sub; guard all fields.
+    if (!payload || !payload.user || !payload.instance) {
       return false;
     }
     return payload.user.id === context.user.id && payload.instance.bus_id === id;
@@ -71,11 +71,15 @@ export const subscribeToInstanceEvents = async (
   const filtering = await withFilter(
     () => pubSubAsyncIterator(topics),
     (payload) => {
-      if (!payload) {
-        // When disconnected, an empty payload is dispatched.
+      // A throw here closes the socket (4500) and orphans the redis sub; guard before deref.
+      if (!payload || !payload.instance) {
         return false;
       }
       if (!notifySelf) {
+        // Only this branch needs the event user; a user-less (system) event must still reach notifySelf subs.
+        if (!payload.user) {
+          return false;
+        }
         return payload.user.id !== context.user.id && payload.instance.id === id;
       }
       return payload.instance.id === id;
@@ -95,6 +99,10 @@ export const subscribeToPlatformSettingsEvents = async (context: any): Promise<A
   const asyncIterator = pubSubAsyncIterator(BUS_TOPICS[ENTITY_TYPE_SETTINGS].EDIT_TOPIC);
   const settings = await getEntityFromCache(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   const filtering = await withFilter(() => asyncIterator, (payload) => {
+    // A throw here closes the socket (4500) and orphans the redis sub; guard all fields.
+    if (!payload || !payload.instance) {
+      return false;
+    }
     const oldMessages: BasicStoreSettingsMessage[] = getMessagesFilteredByRecipients(context.user, settings);
     const newMessages: BasicStoreSettingsMessage[] = getMessagesFilteredByRecipients(context.user, payload.instance);
     // If removed and was activated


### PR DESCRIPTION
### Proposed changes

  Null-guard every GraphQL subscription filter so dereferencing `payload.user` / `payload.instance` can never throw
  synchronously inside the filter:

  * `subscribeToUserEvents` — guard `payload` + `payload.instance`.
  * `subscribeToAiEvents` — guard `payload` + `payload.user` + `payload.instance`.
  * `subscribeToInstanceEvents` — guard `payload` + `payload.instance` up front; the `payload.user` check is scoped to
  the `!notifySelf` branch (the only branch that dereferences it), so a user-less / system-originated event still
  reaches `notifySelf` subscribers instead of being dropped at the top.
  * `subscribeToPlatformSettingsEvents` — add the previously-missing `payload` + `payload.instance` guard.

  Root cause: a synchronous throw inside a `withFilter` callback is surfaced by graphql-ws as a `4500` socket close
  that bypasses normal teardown, leaving the underlying redis subscription orphaned — connections accumulate over time
  (memory/connection leak).

  ### Related issues
  * fixes https://github.com/OpenCTI-Platform/opencti/issues/16402

  ### How to test this PR

  1. Open a GraphQL subscription (instance / user / AI / platform-settings events) over websocket.
  2. Publish an event whose payload has a missing/undefined `user` or `instance` (e.g. a system-originated edit).
  3. Before the fix: the websocket is force-closed with code `4500` and the redis subscription is orphaned
  (subscription/connection count keeps growing).
  4. After the fix: the filter returns `false`, the socket stays open, and the redis subscription count stays stable.
  For `subscribeToInstanceEvents` with `notifySelf=true`, a user-less system event is still delivered.

  ### Checklist

  - [x] I consider the submitted work as finished
  - [x] I tested the code for its functionality
  - [ ] I wrote test cases for the relevant use cases (coverage and e2e)
  - [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
  - [ ] Where necessary, I refactored code to improve the overall quality

  ### Further comments

  This PR is the defensive guard on the consumer side. The producer-side contract (ensuring system-originated events
  carry a valid user / `SYSTEM_USER`) can be addressed separately. Rebased onto latest `master`.