### PR TITLE
fix(banners): fix banners display (#16559)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesBanner.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesBanner.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { act } from '@testing-library/react';
 import ReactDOM from 'react-dom/client';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
@@ -9,10 +9,28 @@ import { RelayMockEnvironment } from 'relay-test-utils/lib/RelayModernMockEnviro
 import SettingsMessagesBanner, { settingsMessagesQuery } from './SettingsMessagesBanner';
 import AppIntlProvider from '../../../../components/AppIntlProvider';
 import ThemeDark from '../../../../components/ThemeDark';
+import useAuth from '../../../../utils/hooks/useAuth';
+import useTopBanner from '../../../../utils/hooks/useTopBanner';
+
+vi.mock('../../../../utils/hooks/useAuth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../utils/hooks/useAuth')>();
+  return {
+    ...actual,
+    default: vi.fn(),
+  };
+});
+vi.mock('../../../../utils/hooks/useTopBanner', () => ({ default: vi.fn() }));
 
 let container: HTMLDivElement | null;
 
 beforeEach(() => {
+  localStorage.clear();
+  (useAuth as Mock).mockReturnValue({
+    bannerSettings: { bannerHeightNumber: 0 },
+  });
+  (useTopBanner as Mock).mockReturnValue({
+    height: 0,
+  });
   container = document.createElement('div');
   document.body.appendChild(container);
 });

--- a/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/settings_messages/SettingsMessagesBanner.tsx
@@ -12,6 +12,8 @@ import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { SettingsMessagesBannerQuery } from './__generated__/SettingsMessagesBannerQuery.graphql';
 import { MessageFromLocalStorage } from '../../../../utils/hooks/useLocalStorageModel';
 import { isEmptyField } from '../../../../utils/utils';
+import useAuth from '../../../../utils/hooks/useAuth';
+import useTopBanner from '../../../../utils/hooks/useTopBanner';
 import { extractUrlsFromText } from '../../../../utils/String';
 
 export const settingsMessagesQuery = graphql`
@@ -131,6 +133,9 @@ const SettingsMessagesBannerComponent = ({
   queryRef: PreloadedQuery<SettingsMessagesBannerQuery>;
 }) => {
   const classes = useStyles();
+  const { bannerSettings } = useAuth();
+  const { height: topBannerHeight } = useTopBanner();
+  const topOffset = topBannerHeight + bannerSettings.bannerHeightNumber;
   const { settings } = usePreloadedQuery<SettingsMessagesBannerQuery>(
     settingsMessagesQuery,
     queryRef,
@@ -208,6 +213,7 @@ const SettingsMessagesBannerComponent = ({
       id={BANNER_DIV}
       className={classes.container}
       style={{
+        top: `${topOffset}px`,
         backgroundColor,
         borderLeft,
       }}


### PR DESCRIPTION
### Proposed changes

* Adapt the banners display if there is multiple banners 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* close #16559 
* On the XTM hub: 2537

### How to test this PR
Make sure the XTM hub is accessible: you should see the Registration Banner
Add a Platform announcement in Settings > Parameters

You should see both banners properly. 

### Checklist

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant use cases (coverage and e2e)
- [X] I added/updated the relevant documentation (either on GitHub or on Notion)
- [X] Where necessary, I refactored code to improve the overall quality

### Further comments
<img width="1852" height="221" alt="Capture d’écran du 2026-06-12 10-27-18" src="https://github.com/user-attachments/assets/caec33dd-71ea-45a4-9286-f064c6de05c0" />
<img width="1852" height="221" alt="Capture d’écran du 2026-06-12 10-24-47" src="https://github.com/user-attachments/assets/28c94b11-7e42-4173-87e8-e0444974a7ed" />


Before was:
<img width="1852" height="221" alt="Capture d’écran du 2026-06-12 10-23-30" src="https://github.com/user-attachments/assets/9a1aa09f-1864-4617-a9a8-13723a30cfc1" />


