### PR TITLE
fix(nav): redirect to filigran.io when no OpenAEV instance is connected (#14817)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
@@ -21,6 +21,9 @@ interface PopoverListItemProps {
   onClick?: () => void;
 }
 
+const OPENAEV_FALLBACK_URL = 'https://filigran.io/platform/openaev/';
+const XTMHUB_FALLBACK_URL = 'https://hub.filigran.io';
+
 export const PopoverListItem: React.FC<PopoverListItemProps> = ({
   logoSrc,
   href,
@@ -204,7 +207,7 @@ export const LeftBarHeader: React.FC<LeftBarHeaderProps> = ({
             <span>
               <PopoverListItem
                 logoSrc={theme.palette.mode === 'dark' ? logoOpenAEVDark : logoOpenAEVLight}
-                href={openAEVUrl}
+                href={isNotEmptyField(openAEVUrl) ? openAEVUrl : OPENAEV_FALLBACK_URL}
                 external
                 onClick={handleMouseLeave}
               />
@@ -216,7 +219,7 @@ export const LeftBarHeader: React.FC<LeftBarHeaderProps> = ({
           {(xtmhubStatus === 'registered' || !hasXtmHubAccess) ? (
             <PopoverListItem
               logoSrc={theme.palette.mode === 'dark' ? logoXTMHubDark : logoXTMHubLight}
-              href={isNotEmptyField(xtmhubUrl) ? xtmhubUrl : 'https://hub.filigran.io'}
+              href={isNotEmptyField(xtmhubUrl) ? xtmhubUrl : XTMHUB_FALLBACK_URL}
               external
               onClick={handleMouseLeave}
             />


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* redirect to filigran.io when no OpenAEV instance is connected

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #14817 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
