### PR TITLE
fix: Support meta key and middle-click to open in new tab (#15468)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -142,6 +142,8 @@ const DataTableLine = ({
 
   const handleNavigate = (event: React.MouseEvent) => {
     if (!navigable || !link) return;
+    event.preventDefault();
+    event.stopPropagation();
 
     if (shouldOpenInNewTabMouseEvent(event)) {
       window.open(link, '_blank');
@@ -189,8 +191,9 @@ const DataTableLine = ({
         style={linkStyle}
         href={navigable ? link : undefined}
         // We need both to handle accessibility and widget.
-        onMouseDown={variant === DataTableVariant.widget ? handleNavigate : undefined}
-        onClick={variant !== DataTableVariant.widget ? handleRowClick : undefined}
+        onClick={variant !== DataTableVariant.widget
+          ? handleRowClick
+          : (variant === DataTableVariant.widget ? handleNavigate : undefined)}
         data-testid={getMainRepresentative(data)}
       >
         {(startsWithAction || startsWithIcon) && (

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableLine.tsx
@@ -9,6 +9,7 @@ import type { Theme } from '../../Theme';
 import { getMainRepresentative } from '../../../utils/defaultRepresentatives';
 import { SELECT_COLUMN_SIZE } from './DataTableHeader';
 import { useDataTableContext } from './DataTableContext';
+import { shouldOpenInNewTabMouseEvent } from 'src/utils/domEvent';
 
 const cellContainerStyle = (theme: Theme) => ({
   display: 'flex',
@@ -142,7 +143,7 @@ const DataTableLine = ({
   const handleNavigate = (event: React.MouseEvent) => {
     if (!navigable || !link) return;
 
-    if (event.ctrlKey) {
+    if (shouldOpenInNewTabMouseEvent(event)) {
       window.open(link, '_blank');
     } else {
       navigate(link);
@@ -200,7 +201,7 @@ const DataTableLine = ({
               width: startColumnWidth,
             }}
           >
-            { startsWithAction && (
+            {startsWithAction && (
               <Checkbox
                 onClick={handleSelectLine}
                 sx={{

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -120,6 +120,7 @@ import { LeftBarHeader } from './LeftBarHeader';
 import LeftBarItem from './LeftBarItem';
 import LogoTextOrange from '../../../static/images/logo_text_orange.svg';
 import LogoCollapsedOrange from '../../../static/images/logo_orange.svg';
+import { shouldOpenInNewTabMouseEvent } from 'src/utils/domEvent';
 
 export const SMALL_BAR_WIDTH = 55;
 export const OPEN_BAR_WIDTH = 180;
@@ -302,7 +303,7 @@ const LeftBarComponent = ({ queryRef }) => {
     localStorage.setItem('selectedMenu', JSON.stringify(updatedMenu));
   };
   const handleGoToPage = (event, link) => {
-    if (event.ctrlKey) {
+    if (shouldOpenInNewTabMouseEvent(event)) {
       window.open(link, '_blank');
     } else {
       navigate(link);

--- a/opencti-platform/opencti-front/src/utils/Charts.jsx
+++ b/opencti-platform/opencti-front/src/utils/Charts.jsx
@@ -3,6 +3,7 @@ import { resolveLink } from './Entity';
 import { truncate } from './String';
 import { isColorCloseToWhite } from './Colors';
 import { alpha } from '@mui/material/styles';
+import { shouldOpenInNewTabMouseEvent } from './domEvent';
 
 export const colors = (temp) => [
   C.red[temp],
@@ -39,6 +40,18 @@ const toolbarOptions = {
       },
     },
   },
+};
+
+const handleNavigate = (event, navigate, link) => {
+  if (!link) return;
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (shouldOpenInNewTabMouseEvent(event)) {
+    window.open(link, '_blank');
+  } else {
+    navigate(link);
+  }
 };
 
 /**
@@ -409,7 +422,7 @@ export const horizontalBarsChartOptions = (
           const link = resolveLink(entityType);
           if (link) {
             const entityId = redirectionUtils[labelIndex].id;
-            navigate(`${link}/${entityId}`);
+            handleNavigate(event, navigate, `${link}/${entityId}`);
           }
         }
       },
@@ -455,7 +468,7 @@ export const horizontalBarsChartOptions = (
                 const link = resolveLink(redirectionUtils[dataPointIndex].series[seriesIndex].entity_type);
                 if (link) {
                   const entityId = redirectionUtils[dataPointIndex].series[seriesIndex].id;
-                  navigate(`${link}/${entityId}`);
+                  handleNavigate(event, navigate, `${link}/${entityId}`);
                 }
               }
             } else {
@@ -465,7 +478,7 @@ export const horizontalBarsChartOptions = (
               const link = resolveLink(redirectionUtils[dataPointIndex].entity_type);
               if (link) {
                 const entityId = redirectionUtils[dataPointIndex].id;
-                navigate(`${link}/${entityId}`);
+                handleNavigate(event, navigate, `${link}/${entityId}`);
               }
             }
           }

--- a/opencti-platform/opencti-front/src/utils/domEvent.ts
+++ b/opencti-platform/opencti-front/src/utils/domEvent.ts
@@ -1,8 +1,11 @@
-import { UIEvent } from 'react';
+import { MouseEvent, UIEvent } from 'react';
 
 const stopEvent = (event: UIEvent) => {
   event.stopPropagation();
   event.preventDefault();
 };
+
+// event.button 1 handles middleButton mouse click
+export const shouldOpenInNewTabMouseEvent = (event: MouseEvent) => event.ctrlKey || event.metaKey || event.button === 1;
 
 export default stopEvent;


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Extract "openInNewTab" check to handle once the multi OS checks
  * It is not possible to handle ctrl-click with MacOS since the event is intercepted by the OS before reaching our code, in addition it would not follow MacOS conventions
* Add support for metaKey and middle click on DataGrid lines and LeftMenu

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #15468 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
- Use the search bar to display the data Grid with results
- ctrl-click (on windows/linux) on a line and ensure the link opens in another tab
- middle-click with the mouse on a line and ensure the link opens in another tab
- Also test left click menu, the piece of code I changed Is only called on collapsed menu

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
