### PR TITLE
fix(styles): restore index.css import in front.tsx (#16568)

### DIFF
--- a/opencti-platform/opencti-front/index.html
+++ b/opencti-platform/opencti-front/index.html
@@ -12,7 +12,6 @@
         <meta name="dеѕсrірtіоn" content="%APP_DESCRIPTION%">
         <link id="favicon" rel="shortcut icon" href="%APP_FAVICON%">
         <link id="manifest" rel="manifest" href="%APP_MANIFEST%">
-        <link rel="stylesheet" href="/src/static/css/index.css" />
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/opencti-platform/opencti-front/src/front.tsx
+++ b/opencti-platform/opencti-front/src/front.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
+import './static/css/index.css';
 import makeStyles from '@mui/styles/makeStyles';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import App from './app';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* **Restore `index.css` import in `front.tsx`**: Reintroduced the `index.css` import in `src/front.tsx` and removed the `<link>` tag from `index.html`. This ensures that **Esbuild** (which uses `front.tsx` as its entrypoint for production builds) compiles and bundles `index.css` (along with its `@import` statements like `@filigran/chatbot/styles.css`).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16568 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

1. **Verify build output**:
   * Run `yarn build` in `opencti-platform/opencti-front`.
   * Check that a bundle CSS file (e.g. `front-[hash].css`) is generated under the build directory with a size of ~1.4MB (meaning `index.css` and its imports were successfully bundled).
2. **Verify TypeScript check**:
   * Run `yarn check-ts`. It should compile successfully without Tiptap-related errors.
3. **Verify visual bugs in production build**:
   * Deploy the build and verify that:
     * The login page takes the full height of the browser viewport.
     * Links/labels in the Datatable rows (e.g., entity lines) are no longer underlined.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
Moving `index.css` to `index.html` as a `<link>` stylesheet worked fine under Vite's native HTML entrypoint resolution but caused Esbuild to bypass it entirely during production bundling since Esbuild only resolved from `front.tsx`. Restoring the import in `front.tsx` fixes this seamlessly for both Vite dev and production bundles.