### PR TITLE
feat(filters): Sharing saved filters: remove FF and migration to add share filters capability (#11624)

### DIFF
--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterCreateDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterCreateDialog.tsx
@@ -13,7 +13,6 @@ import { insertNode } from 'src/utils/store';
 import useApiMutation from '../../utils/hooks/useApiMutation';
 import useAuth from '../../utils/hooks/useAuth';
 import { KNOWLEDGE_KNSHAREFILTERS } from '../../utils/hooks/useGranted';
-import useHelper from '../../utils/hooks/useHelper';
 import { type AuthorizedMemberOption } from '../../utils/authorizedMembers';
 import { type AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import getSavedFilterScopeFilter from './getSavedFilterScopeFilter';

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterCreateDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterCreateDialog.tsx
@@ -54,9 +54,6 @@ const SavedFilterCreateDialog = ({ isOpen, onClose, setCurrentSavedFilter }: Sav
   const { t_i18n } = useFormatter();
   const { me } = useAuth();
 
-  const { isFeatureEnable } = useHelper();
-  const isSharingSavedFiltersFeatureEnabled = isFeatureEnable('SHARE_FILTERS');
-
   const owner = { id: me.id, name: me.name, entity_type: 'User' };
 
   const {
@@ -136,15 +133,11 @@ const SavedFilterCreateDialog = ({ isOpen, onClose, setCurrentSavedFilter }: Sav
               value={filterName}
               onChange={handleChange}
             />
-            {isSharingSavedFiltersFeatureEnabled
-              && (
-                <Security needs={[KNOWLEDGE_KNSHAREFILTERS]}>
-                  <SavedFilterSharingSection
-                    owner={owner}
-                  />
-                </Security>
-              )
-            }
+            <Security needs={[KNOWLEDGE_KNSHAREFILTERS]}>
+              <SavedFilterSharingSection
+                owner={owner}
+              />
+            </Security>
             <DialogActions>
               <Button variant="secondary" onClick={onClose}>{t_i18n('Cancel')}</Button>
               <Button onClick={submitForm} disabled={!filterName}>{t_i18n('Save')}</Button>

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterDeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterDeleteDialog.tsx
@@ -28,9 +28,6 @@ const SavedFilterDeleteDialog = ({ savedFilterToDelete, onClose, onReset, should
   const { t_i18n } = useFormatter();
   const { me } = useAuth();
 
-  const { isFeatureEnable } = useHelper();
-  const isShareFiltersFeatureEnabled = isFeatureEnable('SHARE_FILTERS');
-
   const {
     useDataTablePaginationLocalStorage: {
       localStorageKey,
@@ -68,7 +65,7 @@ const SavedFilterDeleteDialog = ({ savedFilterToDelete, onClose, onReset, should
   const sharedMembersCount = (savedFilterToDelete.authorizedMembers ?? [])
     .filter((m) => m.member_id !== me.id).length;
 
-  const message = isShareFiltersFeatureEnabled && sharedMembersCount > 0
+  const message = sharedMembersCount > 0
     ? t_i18n('This saved filter is shared with other members. Are you sure you want to delete it?')
     : t_i18n('Do you want to delete this saved filter?');
 

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterDeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterDeleteDialog.tsx
@@ -9,7 +9,6 @@ import useDeletion from 'src/utils/hooks/useDeletion';
 import { type SavedFiltersSelectionData } from './SavedFilterSelection';
 import useApiMutation from '../../utils/hooks/useApiMutation';
 import useAuth from '../../utils/hooks/useAuth';
-import useHelper from '../../utils/hooks/useHelper';
 
 const savedFilterDeleteDialogMutation = graphql`
   mutation SavedFilterDeleteDialogMutation($id: ID!) {

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
@@ -13,7 +13,6 @@ import { AccessRight, type AuthorizedMemberOption } from '../../utils/authorized
 import { type AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import SavedFilterSharingSection from './SavedFilterSharingSection';
 import Security from '../../utils/Security';
-import useHelper from '../../utils/hooks/useHelper';
 
 const savedFilterFieldPatchMutation = graphql`
   mutation SavedFilterEditDialogFieldPatchMutation($id: ID!, $input: [EditInput!]!) {

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
@@ -77,9 +77,6 @@ const SavedFilterEditDialog = ({
   const { me } = useAuth();
   const hasShareFilterCapability = useGranted([KNOWLEDGE_KNSHAREFILTERS]);
 
-  const { isFeatureEnable } = useHelper();
-  const isSharingSavedFiltersFeatureEnabled = isFeatureEnable('SHARE_FILTERS');
-
   const owner = { id: me.id, name: me.name, entity_type: 'User' };
 
   const [commitFieldPatch] = useApiMutation(
@@ -105,7 +102,7 @@ const SavedFilterEditDialog = ({
     }
 
     // Update authorized members
-    if (isSharingSavedFiltersFeatureEnabled && hasShareFilterCapability && values.authorized_members) {
+    if (hasShareFilterCapability && values.authorized_members) {
       const memberAccessInput = values.authorized_members.map((m: AuthorizedMemberOption) => ({
         id: m.value,
         access_right: m.accessRight,
@@ -158,16 +155,12 @@ const SavedFilterEditDialog = ({
               value={values.name}
               onChange={(e) => setFieldValue('name', e.target.value)}
             />
-            {isSharingSavedFiltersFeatureEnabled
-              && (
-                <Security needs={[KNOWLEDGE_KNSHAREFILTERS]}>
-                  <SavedFilterSharingSection
-                    owner={owner}
-                    isEditMode
-                  />
-                </Security>
-              )
-            }
+            <Security needs={[KNOWLEDGE_KNSHAREFILTERS]}>
+              <SavedFilterSharingSection
+                owner={owner}
+                isEditMode
+              />
+            </Security>
             <DialogActions>
               <Button variant="secondary" onClick={onClose}>{t_i18n('Cancel')}</Button>
               <Button onClick={submitForm} disabled={!values.name}>{t_i18n('Save')}</Button>

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
@@ -71,7 +71,7 @@ const SavedFilters = ({ currentSavedFilter, setCurrentSavedFilter }: SavedFilter
 
   const handleRefetch = useCallback(() => {
     loadQuery(queryOptions, { fetchPolicy: 'network-only' });
-  }, [loadQuery, localStorageKey, isSharedFiltersEnabled]);
+  }, [loadQuery, localStorageKey]);
 
   const isRestrictedStorageKey = localStorageKey.includes('_stixCoreRelationshipCreationFromEntity');
   if (isRestrictedStorageKey) return null;

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
@@ -9,7 +9,7 @@ import SavedFilterSelection, { type SavedFiltersSelectionData } from './SavedFil
 import SavedFiltersAutocomplete from './SavedFiltersAutocomplete';
 
 const savedFiltersQuery = graphql`
-  query SavedFiltersQuery($filters: FilterGroup, $skipSharedFilters: Boolean!) {
+  query SavedFiltersQuery($filters: FilterGroup) {
     savedFilters(first: 100, filters: $filters) @connection(key: "SavedFilters_savedFilters") {
       edges {
         node {
@@ -18,8 +18,8 @@ const savedFiltersQuery = graphql`
           filters
           scope
           creator_id
-          currentUserAccessRight @skip(if: $skipSharedFilters)
-          authorizedMembers @skip(if: $skipSharedFilters) {
+          currentUserAccessRight
+          authorizedMembers {
             id
             name
             entity_type
@@ -65,11 +65,8 @@ const SavedFilters = ({ currentSavedFilter, setCurrentSavedFilter }: SavedFilter
     },
   } = useDataTableContext();
 
-  const { isFeatureEnable } = useHelper();
-  const isSharedFiltersEnabled = isFeatureEnable('SHARE_FILTERS');
-
   const filters = getSavedFilterScopeFilter(localStorageKey);
-  const queryOptions = { filters, skipSharedFilters: !isSharedFiltersEnabled } as unknown as SavedFiltersQuery$variables;
+  const queryOptions = { filters } as unknown as SavedFiltersQuery$variables;
 
   const [queryRef, loadQuery] = useQueryLoadingWithLoadQuery<SavedFiltersQuery>(savedFiltersQuery, queryOptions);
 

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
@@ -3,7 +3,6 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useQueryLoadingWithLoadQuery } from 'src/utils/hooks/useQueryLoading';
 import { SavedFiltersQuery, SavedFiltersQuery$variables } from 'src/components/saved_filters/__generated__/SavedFiltersQuery.graphql';
 import { useDataTableContext } from 'src/components/dataGrid/components/DataTableContext';
-import useHelper from '../../utils/hooks/useHelper';
 import getSavedFilterScopeFilter from './getSavedFilterScopeFilter';
 import SavedFilterSelection, { type SavedFiltersSelectionData } from './SavedFilterSelection';
 import SavedFiltersAutocomplete from './SavedFiltersAutocomplete';

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFiltersAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFiltersAutocomplete.tsx
@@ -35,9 +35,6 @@ const SavedFiltersAutocomplete = ({
   localStorageKey,
   onRefetch,
 }: SavedFiltersAutocompleteProps) => {
-  const { isFeatureEnable } = useHelper();
-  const isSharingSavedFilterFeatureEnabled = isFeatureEnable('SHARE_FILTERS');
-
   const hasSharingSavedFiltersCapability = useGranted(['KNOWLEDGE_KNSHAREFILTERS']);
 
   const theme = useTheme<Theme>();
@@ -71,18 +68,16 @@ const SavedFiltersAutocomplete = ({
           </Tooltip>
           {canManage && (
             <div style={{ display: 'flex', flexShrink: 0, alignItems: 'center' }}>
-              {isSharingSavedFilterFeatureEnabled && (
-                <Tooltip title={t_i18n('Edit this saved filter')}>
-                  <IconButton
-                    color="primary"
-                    onClick={handleEdit(option.value)}
-                    size="small"
-                    sx={{ padding: '4px' }}
-                  >
-                    <EditOutlined sx={{ fontSize: 18 }} />
-                  </IconButton>
-                </Tooltip>
-              )}
+              <Tooltip title={t_i18n('Edit this saved filter')}>
+                <IconButton
+                  color="primary"
+                  onClick={handleEdit(option.value)}
+                  size="small"
+                  sx={{ padding: '4px' }}
+                >
+                  <EditOutlined sx={{ fontSize: 18 }} />
+                </IconButton>
+              </Tooltip>
               <Tooltip title={t_i18n('Delete this saved filter')}>
                 <IconButton
                   color="primary"
@@ -114,10 +109,7 @@ const SavedFiltersAutocomplete = ({
         isOptionEqualToValue={(option, v) => option?.value.id === v.value.id}
         inputValue={inputValue}
         options={options ?? []}
-        groupBy={isSharingSavedFilterFeatureEnabled
-          ? (option) => handleFiltersGroupBy(option.isOwner)
-          : undefined
-        }
+        groupBy={(option) => handleFiltersGroupBy(option.isOwner)}
         sx={{ width: 200 }}
         slotProps={{
           listbox: {

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFiltersAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFiltersAutocomplete.tsx
@@ -10,7 +10,6 @@ import { useFormatter } from 'src/components/i18n';
 import { AutocompleteInputChangeReason } from '@mui/material/useAutocomplete/useAutocomplete';
 import SavedFilterEditDialog from './SavedFilterEditDialog';
 import type { Theme } from '../Theme';
-import useHelper from '../../utils/hooks/useHelper';
 import useGranted from '../../utils/hooks/useGranted';
 
 type SavedFiltersAutocompleteProps = {

--- a/opencti-platform/opencti-graphql/src/database/data-initialization.js
+++ b/opencti-platform/opencti-graphql/src/database/data-initialization.js
@@ -1,6 +1,6 @@
 import validator from 'validator';
 import { addSettings } from '../domain/settings';
-import { BYPASS, AUTOMATION, ROLE_ADMINISTRATOR, ROLE_DEFAULT, SYSTEM_USER } from '../utils/access';
+import { AUTOMATION, BYPASS, ROLE_ADMINISTRATOR, ROLE_DEFAULT, SYSTEM_USER } from '../utils/access';
 import { findByType as findEntitySettingsByType, initCreateEntitySettings } from '../modules/entitySetting/entitySetting-domain';
 import { initDecayRules } from '../modules/decayRule/decayRule-domain';
 import { initManagerConfigurations } from '../modules/managerConfiguration/managerConfiguration-domain';
@@ -17,7 +17,7 @@ import { KNOWLEDGE_COLLABORATION, KNOWLEDGE_FRONTEND_EXPORT, KNOWLEDGE_SHARE_FIL
 import { ENTITY_TYPE_CONTAINER_CASE_RFI } from '../modules/case/case-rfi/case-rfi-types';
 import { loadEntity, updateAttribute } from './middleware';
 import { ENTITY_TYPE_ENTITY_SETTING } from '../modules/entitySetting/entitySetting-types';
-import conf, { isFeatureEnabled, logApp } from '../config/conf';
+import conf, { logApp } from '../config/conf';
 import { isNotEmptyField } from './utils';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { elRawDelete, elRawGet, elRawIndex } from './engine';
@@ -69,7 +69,7 @@ const KNOWLEDGE_CAPABILITIES = {
     },
     { name: 'KNENRICHMENT', description: 'Ask for knowledge enrichment', attribute_order: 800 },
     { name: 'KNDISSEMINATION', description: 'Disseminate files by email', attribute_order: 900 },
-    ...(isFeatureEnabled('SHARE_FILTERS') ? [SHARE_FILTERS_CAPABILITY] : []),
+    SHARE_FILTERS_CAPABILITY,
   ],
 };
 export const SETTINGS_CAPABILITIES = {

--- a/opencti-platform/opencti-graphql/src/migrations/1781190202247-add-share-filters-capability.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1781190202247-add-share-filters-capability.ts
@@ -1,0 +1,42 @@
+import { logMigration } from '../config/conf';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { fullEntitiesList } from '../database/middleware-loader';
+import { createRelation } from '../database/middleware';
+import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_ROLE } from '../schema/internalObject';
+import { roleCapabilities } from '../domain/user';
+import { generateStandardId } from '../schema/identifier';
+import { createCapabilities, SHARE_FILTERS_CAPABILITY } from '../database/data-initialization';
+import type { BasicCapabilityEntity } from '../types/store';
+
+const message = '[MIGRATION] Add KNOWLEDGE_KNSHAREFILTERS capability and grant to roles with KNOWLEDGE';
+
+export const up = async (next: (error?: Error) => void) => {
+  logMigration.info(`${message} > started`);
+
+  const context = executionContext('migration');
+
+  // 1. Create Capability
+  await createCapabilities(context, [SHARE_FILTERS_CAPABILITY], 'KNOWLEDGE_');
+
+  // 2. Grant to every existing role that already has the KNOWLEDGE capability
+  const roles = await fullEntitiesList(context, SYSTEM_USER, [ENTITY_TYPE_ROLE], {});
+  const capabilityId = generateStandardId(ENTITY_TYPE_CAPABILITY, { name: 'KNOWLEDGE_KNSHAREFILTERS' });
+  const createRelationPromises = roles.map(async (role) => {
+    const roleId = role.id;
+    const capabilities = await roleCapabilities(context, SYSTEM_USER, roleId) as BasicCapabilityEntity[];
+    const hasKnowledgeCapability = capabilities.some((capability) => capability.name === 'KNOWLEDGE');
+    if (hasKnowledgeCapability) {
+      const input = { fromId: roleId, toId: capabilityId, relationship_type: 'has-capability' };
+      return createRelation(context, SYSTEM_USER, input);
+    }
+    return undefined;
+  });
+  await Promise.all(createRelationPromises);
+
+  logMigration.info(`${message} > done`);
+  next();
+};
+
+export const down = async (next: (error?: Error) => void) => {
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -37,8 +37,7 @@ export const addSavedFilter = (context: AuthContext, user: AuthUser, input: Save
   // Force context out of draft to force creation in live index
   const contextOutOfDraft = { ...context, draft_context: '' };
   // construct final creation input
-  const canShare = isFeatureEnabled('SHARE_FILTERS')
-    && isUserHasCapability(user, KNOWLEDGE_KNSHAREFILTERS);
+  const canShare = isUserHasCapability(user, KNOWLEDGE_KNSHAREFILTERS);
   const savedFiltersToCreate = {
     ...input,
     restricted_members: initializeAuthorizedMembers(canShare ? input.authorized_members : undefined, user),
@@ -92,9 +91,6 @@ export const savedFilterEditAuthorizedMembers = async (
   savedFilterId: string,
   input: MemberAccessInput[],
 ) => {
-  if (!isFeatureEnabled('SHARE_FILTERS')) {
-    throw ForbiddenAccess('Sharing saved filters is disabled');
-  }
   const args = {
     entityId: savedFilterId,
     input,

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -8,7 +8,6 @@ import type { InputMaybe, MemberAccessInput, MutationSavedFilterFieldPatchArgs, 
 import { createInternalObject, deleteInternalObject } from '../../domain/internalObject';
 import { getUserAccessRight, isUserHasCapability, KNOWLEDGE_KNSHAREFILTERS, MEMBER_ACCESS_RIGHT_ADMIN } from '../../utils/access';
 import { editAuthorizedMembers } from '../../utils/authorizedMembers';
-import { isFeatureEnabled } from '../../config/conf';
 
 const findById = (context: AuthContext, user: AuthUser, id: string) => {
   return storeLoadById<BasicStoreEntitySavedFilter>(context, user, id, ENTITY_TYPE_SAVED_FILTER);

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter.graphql
@@ -10,8 +10,8 @@ type SavedFilter implements InternalObject & BasicObject {
     scope: String!
     creator_id: String
     # Sharing
-    authorizedMembers: [MemberAccess!]! @ff(flags: ["SHARE_FILTERS"], softFail: true, defaultValue: "[]")
-    currentUserAccessRight: String @ff(flags: ["SHARE_FILTERS"], softFail: true)
+    authorizedMembers: [MemberAccess!]!
+    currentUserAccessRight: String
 }
 
 type SavedFilterEdge {
@@ -52,5 +52,5 @@ type Mutation {
     savedFilterAdd(input: SavedFilterAddInput!): SavedFilter @auth
     savedFilterDelete(id: ID!): ID @auth
     savedFilterFieldPatch(id: ID!, input: [EditInput!]): SavedFilter @auth
-    savedFilterEditAuthorizedMembers(id: ID!, input: [MemberAccessInput!]!): SavedFilter @auth(for: [KNOWLEDGE_KNSHAREFILTERS]) @ff(flags: ["SHARE_FILTERS"])
+    savedFilterEditAuthorizedMembers(id: ID!, input: [MemberAccessInput!]!): SavedFilter @auth(for: [KNOWLEDGE_KNSHAREFILTERS])
 }

--- a/opencti-platform/opencti-graphql/src/types/store.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/store.d.ts
@@ -734,6 +734,12 @@ interface BasicGroupEntity extends BasicStoreEntity {
   auto_integration_assignation: string[];
 }
 
+interface BasicCapabilityEntity extends BasicStoreCommon {
+  name: string;
+  description?: string;
+  attribute_order?: number;
+}
+
 interface BasicOrganizationEntity extends BasicStoreEntity {
   [RELATION_PARTICIPATE_TO]: string[];
 }


### PR DESCRIPTION
### Proposed changes
- Remove the Feature Flag 'SHARE_FILTERS'
- Migration to add the 'Share filters' capability

### Related issues
closes #11624