### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.1 for shared waiting experience (#16586)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "@filigran/chatbot": "3.7.0",
+    "@filigran/chatbot": "3.7.1",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "@filigran/chatbot": "3.6.1",
+    "@filigran/chatbot": "3.7.0",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -7,7 +7,7 @@ import { LogoXtmOneIcon } from 'filigran-icon';
 import type { Theme } from '../../../components/Theme';
 import { useFormatter } from '../../../components/i18n';
 import useAuth from '../../../utils/hooks/useAuth';
-import { APP_BASE_PATH } from '../../../relay/environment';
+import { APP_BASE_PATH, MESSAGING$ } from '../../../relay/environment';
 import { useSettingsMessagesBannerHeight } from '../settings/settings_messages/SettingsMessagesBanner';
 import useTopBanner from '../../../utils/hooks/useTopBanner';
 import FiligranIcon from '@components/common/FiligranIcon';
@@ -158,6 +158,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
       requestHeaders={requestHeaders}
       pageContext={pageContext}
       onRelativeLinkClick={handleRelativeLinkClick}
+      onTaskComplete={(_title, body) => MESSAGING$.notifySuccess(body)}
     />,
     container,
   );

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1809,15 +1809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.6.1":
-  version: 3.6.1
-  resolution: "@filigran/chatbot@npm:3.6.1"
+"@filigran/chatbot@npm:3.7.1":
+  version: 3.7.1
+  resolution: "@filigran/chatbot@npm:3.7.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/420ca59e54fe3a175d439ce1436bcd1c12d479ae0f9622539a4bb2827c9026fbc437088302b50c217af40e410d367b17c90965cb67ac6bc1301647d9443cf476
+  checksum: 10c0/b603d2d550dd5c7511764fd25b832990d545237fd0c3e057293c1ac70b3a17b32979e98e0301b8b4e8670c341f9ab6715726afb2f3bf0deb6bcaca71151de12f
   languageName: node
   linkType: hard
 
@@ -13803,7 +13803,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.2.0"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.6.1"
+    "@filigran/chatbot": "npm:3.7.1"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
## Summary

Closes #16586.

Adopt the new shared chat waiting experience from `@filigran/chatbot` 3.7.1 in the "Ask Ariane" panel, so the loading/thinking state is identical across XTM One, OpenCTI and OpenAEV (all three render the same `ChatPanel`).

3.7.1 adds, on by default:
- dynamic rotating status messages during longer waits;
- an optional Space Invader mini-game that shoots the message letters away one by one (toggle on the panel, persisted per browser; skipped under `prefers-reduced-motion`, where messages still rotate as plain text);
- a completion notification when a long turn finishes and the user is not watching the chat: document-title flash + browser notification (when granted) when away (tab hidden / another window), and a host toast when in-app but looking elsewhere.

Upstream feature: FiligranHQ/filigran-ui#326. Companion: XTM-One-Platform/xtm-one#1626.

## Changes

- `opencti-platform/opencti-front`: bump `@filigran/chatbot` 3.6.1 -> 3.7.1.
- `AskArianePanel`: wire `onTaskComplete` to `MESSAGING$.notifySuccess` so the user gets an in-app toast when an agent reply lands while they are working elsewhere in OpenCTI.

## Test plan

- [x] `yarn install --immutable` succeeds (lockfile regenerated against the published 3.7.1).
- [ ] Open Ask Ariane, send a message: the dynamic waiting messages + Space Invader appear during the wait and disappear when the answer streams.
- [ ] Send a message, click into the main app while the panel stays open -> a success toast appears when the reply lands.
- [ ] Send a message, switch to another tab/window -> document title flashes (and a browser notification fires if permission was granted).
