### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.2 for markdown table fix (#16596)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "@filigran/chatbot": "3.7.1",
+    "@filigran/chatbot": "3.7.2",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1809,15 +1809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.7.1":
-  version: 3.7.1
-  resolution: "@filigran/chatbot@npm:3.7.1"
+"@filigran/chatbot@npm:3.7.2":
+  version: 3.7.2
+  resolution: "@filigran/chatbot@npm:3.7.2"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/b603d2d550dd5c7511764fd25b832990d545237fd0c3e057293c1ac70b3a17b32979e98e0301b8b4e8670c341f9ab6715726afb2f3bf0deb6bcaca71151de12f
+  checksum: 10c0/4c014714631627623acac2d6671708e32bb0db21bf4e372f1c1456c7f0d7b58adee679765b93162747f95f9b10ba52d5e0e4bf7ce45207a0bab798a5aeec56de
   languageName: node
   linkType: hard
 
@@ -13823,7 +13823,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.2.0"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.7.1"
+    "@filigran/chatbot": "npm:3.7.2"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
## Summary

Closes #16596.

Bump `@filigran/chatbot` 3.7.1 -> 3.7.2 in `opencti-platform/opencti-front`.

3.7.2 is a patch release that fixes GFM markdown table rendering in the "Ask Ariane" chat panel: a pipe table whose delimiter row had a different column count than its header (a frequent LLM miscount, or upstream delimiter corruption) degraded to raw `| ... |` text instead of rendering as a table. The chat preprocessor now repairs the mismatched delimiter to the header's column count before rendering - including a table whose header shares a list-item line - while leaving already-valid tables, fenced code blocks and escaped pipes untouched.

This is a dependency-only bump: the chat public API (`ChatPanel`, `ChatMode`) is unchanged, so no OpenCTI code changes are required.

Upstream fix: FiligranHQ/filigran-ui#328 (closes FiligranHQ/filigran-ui#327).

## Changes

- `opencti-platform/opencti-front`: bump `@filigran/chatbot` 3.7.1 -> 3.7.2 and regenerate `yarn.lock`. The `@filigran/chatbot-legacy` alias (1.1.2) and the chatbot resolutions are untouched.

## Test plan

- [x] `yarn install --mode=update-lockfile` regenerates `yarn.lock` against the published 3.7.2 (the only changed entry is `@filigran/chatbot`).
- [ ] CI `yarn install --immutable` succeeds against the published 3.7.2.
- [ ] Ask Ariane renders an agent answer containing a column-mismatched markdown table as a table instead of raw pipes.
