### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.3 for waiting mini-game autoscroll (#16598)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "@filigran/chatbot": "3.7.2",
+    "@filigran/chatbot": "3.7.3",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1809,15 +1809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.7.2":
-  version: 3.7.2
-  resolution: "@filigran/chatbot@npm:3.7.2"
+"@filigran/chatbot@npm:3.7.3":
+  version: 3.7.3
+  resolution: "@filigran/chatbot@npm:3.7.3"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/4c014714631627623acac2d6671708e32bb0db21bf4e372f1c1456c7f0d7b58adee679765b93162747f95f9b10ba52d5e0e4bf7ce45207a0bab798a5aeec56de
+  checksum: 10c0/dca158e21a31d5a95eed6dda2502e6a345d1d289525da77c8c118419e7b979199650973fef484fedc1c111113c07ece5092924e5377e1de87104e37dc0839bc6
   languageName: node
   linkType: hard
 
@@ -13823,7 +13823,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.2.0"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.7.2"
+    "@filigran/chatbot": "npm:3.7.3"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
## Summary

Bumps `@filigran/chatbot` from 3.7.2 to 3.7.3 in `opencti-front`.

3.7.3 brings the waiting mini-game auto-scroll fix (FiligranHQ/filigran-ui#330): when the waiting mini-game appears at the bottom of the chat while the user is following the conversation, it now scrolls into view automatically instead of sitting under the fold. Users who scrolled up to read history are left untouched.

Parity with OpenAEV and XTM One, which track the same `@filigran/chatbot` release.

## Changes

- `opencti-platform/opencti-front/package.json`: `@filigran/chatbot` 3.7.2 -> 3.7.3
- `opencti-platform/opencti-front/yarn.lock`: updated to resolve `@filigran/chatbot@npm:3.7.3`

Closes #16598
