### PR TITLE
chore(front): bump @filigran/chatbot to 3.7.4 for completion-notice fix (#16600)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,7 +35,7 @@
     "@analytics/google-analytics": "1.1.0",
     "@cfworker/json-schema": "4.1.1",
     "@ckeditor/ckeditor5-react": "11.2.0",
-    "@filigran/chatbot": "3.7.3",
+    "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
     "@fontsource/geologica": "5.2.8",
     "@fontsource/ibm-plex-sans": "5.2.8",

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -1809,15 +1809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/chatbot@npm:3.7.3":
-  version: 3.7.3
-  resolution: "@filigran/chatbot@npm:3.7.3"
+"@filigran/chatbot@npm:3.7.4":
+  version: 3.7.4
+  resolution: "@filigran/chatbot@npm:3.7.4"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
     react-markdown: ">=10"
     remark-gfm: ">=4"
-  checksum: 10c0/dca158e21a31d5a95eed6dda2502e6a345d1d289525da77c8c118419e7b979199650973fef484fedc1c111113c07ece5092924e5377e1de87104e37dc0839bc6
+  checksum: 10c0/b29ceb727765ccd8c06eb7f482cf54eff8dcfb1b669bdbfe96ced0222a47decbd58e82bb80cbcedf29206e64c4ccc6e7dee80ef025dd182d6f5cfa497b174b9a
   languageName: node
   linkType: hard
 
@@ -13823,7 +13823,7 @@ __metadata:
     "@ckeditor/ckeditor5-react": "npm:11.2.0"
     "@eslint/js": "npm:10.0.1"
     "@faker-js/faker": "npm:10.4.0"
-    "@filigran/chatbot": "npm:3.7.3"
+    "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
     "@fontsource/geologica": "npm:5.2.8"
     "@fontsource/ibm-plex-sans": "npm:5.2.8"


### PR DESCRIPTION
## Summary

Closes #16600.

Bump `@filigran/chatbot` 3.7.3 -> 3.7.4 in `opencti-platform/opencti-front`.

3.7.4 is a patch release that fixes the "Ask Ariane" chat firing a turn-completion notification while the chat panel is already visible. The completion notice (document-title flash / browser notification / host toast) should only fire when the user is away or looking elsewhere; 3.7.4 suppresses it when the panel is on screen.

This is a dependency-only bump: the chat public API (`ChatPanel`, `ChatMode`) is unchanged, so no OpenCTI code changes are required.

Upstream fix: FiligranHQ/filigran-ui#332.

## Changes

- `opencti-platform/opencti-front`: bump `@filigran/chatbot` 3.7.3 -> 3.7.4 and regenerate `yarn.lock`. The `@filigran/chatbot-legacy` alias (1.1.2) and the chatbot resolutions are untouched.

## Test plan

- [x] `yarn install --mode=update-lockfile` regenerates `yarn.lock` against the published 3.7.4 (the only changed entry is `@filigran/chatbot`).
- [ ] CI `yarn install --immutable` succeeds against the published 3.7.4.
- [ ] Ask Ariane no longer raises a completion notification when the chat panel is open and visible.
