### PR TITLE
feat(form-intake): allow to use entity lookup with on-the-fly creation when user has only createupdate (#16469)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectsField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/StixCoreObjectsField.tsx
@@ -1,5 +1,6 @@
-import React, { useState, FunctionComponent, useCallback } from 'react';
+import React, { useState, FunctionComponent, useCallback, useRef, useMemo } from 'react';
 import * as R from 'ramda';
+import { v4 as uuidv4 } from 'uuid';
 import { Field, useFormikContext } from 'formik';
 import { graphql } from 'react-relay';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -22,6 +23,7 @@ import StixDomainObjectCreation from '../stix_domain_objects/StixDomainObjectCre
 import StixCyberObservableCreation from '../../observations/stix_cyber_observables/StixCyberObservableCreation';
 import type { Theme } from '../../../../components/Theme';
 import { FieldOption } from '../../../../utils/field';
+import { DeferredCreationContext } from '../../../../utils/hooks/useDeferredCreation';
 
 export const stixCoreObjectsFieldSearchQuery = graphql`
   query StixCoreObjectsFieldSearchQuery($search: String, $types: [String]) {
@@ -222,11 +224,18 @@ const useStyles = makeStyles<Theme>(() => ({
 
 const CREATE_OPTION_VALUE = '__create_new_entity__';
 
+/** Marker prefix used to identify pending-creation entities in the field value. */
+export const PENDING_ENTITY_PREFIX = '__pending__:';
+
 interface StixCoreObjectOption {
   label: string;
   value: string;
   type: string;
   isCreateOption?: boolean;
+  /** True when the entity has not yet been created – will be built in the draft bundle. */
+  isPendingCreation?: boolean;
+  /** Raw mutation input captured during deferred creation. Present only when isPendingCreation=true. */
+  pendingInputData?: { entityType: string; input: Record<string, unknown> };
 }
 
 interface StixCoreObjectsFieldProps {
@@ -239,6 +248,13 @@ interface StixCoreObjectsFieldProps {
   disabled?: boolean;
   types?: string[] | null;
   disableCreation?: boolean;
+  /**
+   * When true (and the user has draft-only permissions), entity creation on the fly
+   * is deferred: the creation form is shown but the mutation is intercepted and the
+   * entity data is stored locally. The entity is only created when the form intake is
+   * submitted (as part of the draft STIX bundle).
+   */
+  deferCreation?: boolean;
 }
 
 interface CreatedEntity {
@@ -261,6 +277,7 @@ const StixCoreObjectsField: FunctionComponent<StixCoreObjectsFieldProps> = ({
   disabled = false,
   types = null,
   disableCreation = false,
+  deferCreation = false,
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
@@ -279,6 +296,46 @@ const StixCoreObjectsField: FunctionComponent<StixCoreObjectsFieldProps> = ({
   const [valueBeforeCreate, setValueBeforeCreate] = useState<StixCoreObjectOption | StixCoreObjectOption[] | null>(null);
   // Ref to track if entity was successfully created (prevents handleClose from restoring old value)
   const entityCreatedSuccessfully = React.useRef(false);
+
+  /**
+   * In deferred mode, holds the raw mutation `input` captured by useApiMutation so that
+   * handleClose / handleSCOEntityCreated can build a pending-creation option from it.
+   */
+  const deferredCapturedRef = useRef<Record<string, unknown> | null>(null);
+
+  /**
+   * Context value provided to the SDO / SCO creation dialogs when deferCreation=true.
+   * useApiMutation will call captureInput() instead of dispatching the real mutation.
+   */
+  const deferredContextValue = useMemo(() => ({
+    isDeferredMode: deferCreation,
+    captureInput: (input: Record<string, unknown>) => {
+      deferredCapturedRef.current = input;
+    },
+  }), [deferCreation]);
+
+  /**
+   * Build a pending-creation option from captured deferred input data.
+   * Falls back to currentSearchTerm when the input does not carry a `name`.
+   *
+   * For SDO mutations, capturedInput.name is the entity name.
+   * For SCO mutations, capturedInput has no `name`; we use currentSearchTerm
+   * (the value typed by the user, e.g. an IP address) as the display label.
+   */
+  const buildPendingOption = useCallback((capturedInput: Record<string, unknown>): StixCoreObjectOption => {
+    const entityName = (capturedInput.name as string | undefined) || currentSearchTerm || 'New Entity';
+    const pendingId = `${PENDING_ENTITY_PREFIX}${uuidv4()}`;
+    return {
+      label: entityName,
+      value: pendingId,
+      type: createEntityType || '',
+      isPendingCreation: true,
+      pendingInputData: {
+        entityType: createEntityType || '',
+        input: capturedInput,
+      },
+    };
+  }, [createEntityType, currentSearchTerm]);
 
   const handleOpenSearchScope = (event: React.MouseEvent<HTMLElement>) => setAnchorElSearchScope(event.currentTarget);
   const handleCloseSearchScope = () => setAnchorElSearchScope(null);
@@ -417,6 +474,26 @@ const StixCoreObjectsField: FunctionComponent<StixCoreObjectsFieldProps> = ({
   }, [currentSearchTerm, getCreationType, multiple, name, searchScope, setFieldValue, shouldShowCreateOption, t_i18n, types, values]);
 
   const handleSCOEntityCreated = useCallback((createdObservable?: CreatedEntity | null) => {
+    // --- Deferred creation path ---
+    const capturedInput = deferredCapturedRef.current;
+    if (deferCreation && capturedInput) {
+      const newOption = buildPendingOption(capturedInput);
+      setStixCoreObjects((prev) => [newOption, ...prev.filter((o) => !o.isCreateOption)]);
+      const currentValue = values[name] as StixCoreObjectOption | StixCoreObjectOption[] | null;
+      if (multiple) {
+        setFieldValue(name, [...(Array.isArray(currentValue) ? currentValue : []), newOption]);
+      } else {
+        setFieldValue(name, newOption);
+      }
+      deferredCapturedRef.current = null;
+      entityCreatedSuccessfully.current = true;
+      setOpenSCOCreation(false);
+      setCreateEntityType(null);
+      setValueBeforeCreate(null);
+      return;
+    }
+
+    // --- Normal creation path ---
     entityCreatedSuccessfully.current = true;
     setOpenSCOCreation(false);
     setCreateEntityType(null);
@@ -477,7 +554,7 @@ const StixCoreObjectsField: FunctionComponent<StixCoreObjectsFieldProps> = ({
           setStixCoreObjects(finalResults);
         });
     }
-  }, [currentSearchTerm, getCreationType, multiple, name, searchScope, setFieldValue, shouldShowCreateOption, t_i18n, types, values]);
+  }, [buildPendingOption, currentSearchTerm, deferCreation, getCreationType, multiple, name, searchScope, setFieldValue, shouldShowCreateOption, t_i18n, types, values]);
 
   const searchStixCoreObjects = useCallback((event: React.SyntheticEvent | null, newInputValue?: string, reason?: string) => {
     const searchValue = newInputValue ?? '';
@@ -652,64 +729,83 @@ const StixCoreObjectsField: FunctionComponent<StixCoreObjectsFieldProps> = ({
         classes={{ clearIndicator: classes.autoCompleteIndicator }}
       />
 
-      <StixDomainObjectCreation
-        display={true}
-        open={openSDOCreation}
-        handleClose={() => {
-          if (entityCreatedSuccessfully.current) {
-            setOpenSDOCreation(false);
-            setCreateEntityType(null);
-            setValueBeforeCreate(null);
-            return;
-          }
-          setOpenSDOCreation(false);
-          setCreateEntityType(null);
-          if (valueBeforeCreate !== null) {
-            setFieldValue(name, valueBeforeCreate);
-          }
-          setValueBeforeCreate(null);
-        }}
-        speeddial={true}
-        stixDomainObjectTypes={createEntityType ? [createEntityType] : (types ?? undefined)}
-        inputValue={currentSearchTerm}
-        creationCallback={handleSDOEntityCreated}
-        confidence={undefined}
-        defaultCreatedBy={undefined}
-        defaultMarkingDefinitions={undefined}
-        paginationKey={undefined}
-        paginationOptions={undefined}
-        onCompleted={undefined}
-        isFromBulkRelation={false}
-      />
-
-      {openSCOCreation && (
-        <StixCyberObservableCreation
+      <DeferredCreationContext.Provider value={deferredContextValue}>
+        <StixDomainObjectCreation
           display={true}
-          open={openSCOCreation}
+          open={openSDOCreation}
           handleClose={() => {
-            if (entityCreatedSuccessfully.current) {
-              setOpenSCOCreation(false);
+            // Deferred path: mutation was intercepted, input was captured
+            const capturedInput = deferredCapturedRef.current;
+            if (deferCreation && capturedInput) {
+              const newOption = buildPendingOption(capturedInput);
+              setStixCoreObjects((prev) => [newOption, ...prev.filter((o) => !o.isCreateOption)]);
+              const currentValue = values[name] as StixCoreObjectOption | StixCoreObjectOption[] | null;
+              if (multiple) {
+                setFieldValue(name, [...(Array.isArray(currentValue) ? currentValue : []), newOption]);
+              } else {
+                setFieldValue(name, newOption);
+              }
+              deferredCapturedRef.current = null;
+              setOpenSDOCreation(false);
               setCreateEntityType(null);
               setValueBeforeCreate(null);
               return;
             }
-            setOpenSCOCreation(false);
+            if (entityCreatedSuccessfully.current) {
+              setOpenSDOCreation(false);
+              setCreateEntityType(null);
+              setValueBeforeCreate(null);
+              return;
+            }
+            setOpenSDOCreation(false);
             setCreateEntityType(null);
             if (valueBeforeCreate !== null) {
               setFieldValue(name, valueBeforeCreate);
             }
             setValueBeforeCreate(null);
           }}
-          contextual={true}
           speeddial={true}
-          type={createEntityType ?? undefined}
+          stixDomainObjectTypes={createEntityType ? [createEntityType] : (types ?? undefined)}
           inputValue={currentSearchTerm}
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore JSX component without proper TypeScript types
-          stixCyberObservableTypes={types || undefined}
-          onCompleted={handleSCOEntityCreated}
+          creationCallback={handleSDOEntityCreated}
+          confidence={undefined}
+          defaultCreatedBy={undefined}
+          defaultMarkingDefinitions={undefined}
+          paginationKey={undefined}
+          paginationOptions={undefined}
+          onCompleted={undefined}
+          isFromBulkRelation={false}
         />
-      )}
+
+        {openSCOCreation && (
+          <StixCyberObservableCreation
+            display={true}
+            open={openSCOCreation}
+            handleClose={() => {
+              if (entityCreatedSuccessfully.current) {
+                setOpenSCOCreation(false);
+                setCreateEntityType(null);
+                setValueBeforeCreate(null);
+                return;
+              }
+              setOpenSCOCreation(false);
+              setCreateEntityType(null);
+              if (valueBeforeCreate !== null) {
+                setFieldValue(name, valueBeforeCreate);
+              }
+              setValueBeforeCreate(null);
+            }}
+            contextual={true}
+            speeddial={true}
+            type={createEntityType ?? undefined}
+            inputValue={currentSearchTerm}
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore JSX component without proper TypeScript types
+            stixCyberObservableTypes={types || undefined}
+            onCompleted={handleSCOEntityCreated}
+          />
+        )}
+      </DeferredCreationContext.Provider>
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it, vi, expect, beforeEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
-import FormView from './FormView';
-import testRender, { createMockUserContext } from '../../../../../utils/tests/test-render';
 import { MockPayloadGenerator } from 'relay-test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as useGrantedModule from '../../../../../utils/hooks/useGranted';
+import testRender, { createMockUserContext } from '../../../../../utils/tests/test-render';
+import FormView from './FormView';
 
 vi.mock('../../../common/form/AuthorizedMembersField', () => ({
   __esModule: true,

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
@@ -618,6 +618,7 @@ const FormViewInner: FunctionComponent<FormViewInnerProps> = ({ queryRef, embedd
                           helpertext={schema.mainEntityMultiple ? t_i18n('Select one or more existing entities') : t_i18n('Select an existing entity')}
                           multiple={schema.mainEntityMultiple}
                           disableCreation={schema.mainEntityDisableCreation}
+                          deferCreation={isForcedImportToDraft}
                         />
                       );
                     }
@@ -780,6 +781,7 @@ const FormViewInner: FunctionComponent<FormViewInnerProps> = ({ queryRef, embedd
                                   helpertext={additionalEntity.multiple ? t_i18n('Select one or more existing entities') : t_i18n('Select an existing entity')}
                                   multiple={additionalEntity.multiple}
                                   disableCreation={additionalEntity.disableCreation}
+                                  deferCreation={isForcedImportToDraft}
                                 />
                               );
                             }

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormViewUtils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormViewUtils.test.ts
@@ -178,3 +178,180 @@ describe('formatFormDataForSubmission', () => {
     expect(formatted).not.toHaveProperty('draftAuthor');
   });
 });
+
+// ---------------------------------------------------------------------------
+// mainEntityLookup – deferred (pending) creation
+// ---------------------------------------------------------------------------
+
+const lookupSchema: FormSchemaDefinition = {
+  ...baseSchema,
+  mainEntityLookup: true,
+  mainEntityMultiple: false,
+};
+
+const lookupMultiSchema: FormSchemaDefinition = {
+  ...baseSchema,
+  mainEntityLookup: true,
+  mainEntityMultiple: true,
+};
+
+describe('formatFormDataForSubmission – mainEntityLookup', () => {
+  it('should map a single existing entity to mainEntityLookup', () => {
+    const values = {
+      name: 'My report',
+      mainEntityLookup: { value: 'entity-id-1', label: 'Existing Entity', type: 'Report' },
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, lookupSchema);
+
+    expect(formatted.mainEntityLookup).toBe('entity-id-1');
+    expect(formatted).not.toHaveProperty('mainEntityLookupPending');
+  });
+
+  it('should map a single pending entity to mainEntityLookupPending', () => {
+    const pendingInputData = { entityType: 'Report', input: { name: 'New Report', confidence: 50 } };
+    const values = {
+      name: 'My report',
+      mainEntityLookup: {
+        value: '__pending__:some-uuid',
+        label: 'New Report',
+        type: 'Report',
+        isPendingCreation: true,
+        pendingInputData,
+      },
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, lookupSchema);
+
+    expect(formatted).not.toHaveProperty('mainEntityLookup');
+    expect(formatted.mainEntityLookupPending).toEqual([pendingInputData]);
+  });
+
+  it('should split multiple existing entities from pending entities', () => {
+    const pendingInputData = { entityType: 'Report', input: { name: 'Pending Report' } };
+    const values = {
+      name: 'My report',
+      mainEntityLookup: [
+        { value: 'existing-id-1', label: 'Existing 1', type: 'Report' },
+        { value: '__pending__:uuid-1', label: 'Pending 1', type: 'Report', isPendingCreation: true, pendingInputData },
+        { value: 'existing-id-2', label: 'Existing 2', type: 'Report' },
+      ],
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, lookupMultiSchema);
+
+    expect(formatted.mainEntityLookup).toEqual(['existing-id-1', 'existing-id-2']);
+    expect(formatted.mainEntityLookupPending).toEqual([pendingInputData]);
+  });
+
+  it('should not produce mainEntityLookupPending when all entities are existing (multiple)', () => {
+    const values = {
+      name: 'My report',
+      mainEntityLookup: [
+        { value: 'existing-id-1', label: 'Existing 1', type: 'Report' },
+        { value: 'existing-id-2', label: 'Existing 2', type: 'Report' },
+      ],
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, lookupMultiSchema);
+
+    expect(formatted.mainEntityLookup).toEqual(['existing-id-1', 'existing-id-2']);
+    expect(formatted).not.toHaveProperty('mainEntityLookupPending');
+  });
+
+  it('should not produce mainEntityLookup when all entities are pending (multiple)', () => {
+    const pendingInputData1 = { entityType: 'Report', input: { name: 'Pending 1' } };
+    const pendingInputData2 = { entityType: 'Report', input: { name: 'Pending 2' } };
+    const values = {
+      name: 'My report',
+      mainEntityLookup: [
+        { value: '__pending__:uuid-1', label: 'Pending 1', type: 'Report', isPendingCreation: true, pendingInputData: pendingInputData1 },
+        { value: '__pending__:uuid-2', label: 'Pending 2', type: 'Report', isPendingCreation: true, pendingInputData: pendingInputData2 },
+      ],
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, lookupMultiSchema);
+
+    expect(formatted).not.toHaveProperty('mainEntityLookup');
+    expect(formatted.mainEntityLookupPending).toEqual([pendingInputData1, pendingInputData2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// additional_${id}_lookup – deferred (pending) creation
+// ---------------------------------------------------------------------------
+
+const additionalLookupSchema: FormSchemaDefinition = {
+  ...baseSchema,
+  additionalEntities: [
+    {
+      id: 'threat',
+      entityType: 'Malware',
+      label: 'Threat',
+      multiple: false,
+      lookup: true,
+    } as unknown as FormSchemaDefinition['additionalEntities'][0],
+  ],
+};
+
+const additionalLookupMultiSchema: FormSchemaDefinition = {
+  ...baseSchema,
+  additionalEntities: [
+    {
+      id: 'threat',
+      entityType: 'Malware',
+      label: 'Threat',
+      multiple: true,
+      lookup: true,
+    } as unknown as FormSchemaDefinition['additionalEntities'][0],
+  ],
+};
+
+describe('formatFormDataForSubmission – additional_${id}_lookup', () => {
+  it('should map a single existing entity to additional_threat_lookup', () => {
+    const values = {
+      name: 'My report',
+      additional_threat_lookup: { value: 'malware-id-1', label: 'Evil', type: 'Malware' },
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, additionalLookupSchema);
+
+    expect(formatted['additional_threat_lookup']).toBe('malware-id-1');
+    expect(formatted).not.toHaveProperty('additional_threat_lookup_pending');
+  });
+
+  it('should map a single pending entity to additional_threat_lookup_pending', () => {
+    const pendingInputData = { entityType: 'Malware', input: { name: 'New Malware' } };
+    const values = {
+      name: 'My report',
+      additional_threat_lookup: {
+        value: '__pending__:uuid-m',
+        label: 'New Malware',
+        type: 'Malware',
+        isPendingCreation: true,
+        pendingInputData,
+      },
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, additionalLookupSchema);
+
+    expect(formatted).not.toHaveProperty('additional_threat_lookup');
+    expect(formatted['additional_threat_lookup_pending']).toEqual([pendingInputData]);
+  });
+
+  it('should split existing and pending entities for multiple lookup', () => {
+    const pendingInputData = { entityType: 'Malware', input: { name: 'Pending Malware' } };
+    const values = {
+      name: 'My report',
+      additional_threat_lookup: [
+        { value: 'malware-id-1', label: 'Existing', type: 'Malware' },
+        { value: '__pending__:uuid-m', label: 'Pending', type: 'Malware', isPendingCreation: true, pendingInputData },
+      ],
+    };
+
+    const formatted = formatFormDataForSubmission(values as SubmissionValues, additionalLookupMultiSchema);
+
+    expect(formatted['additional_threat_lookup']).toEqual(['malware-id-1']);
+    expect(formatted['additional_threat_lookup_pending']).toEqual([pendingInputData]);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormViewUtils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormViewUtils.ts
@@ -449,9 +449,18 @@ export const formatFormDataForSubmission = (
   // If main entity lookup is enabled, include the selected entities
   if (schema.mainEntityLookup && values.mainEntityLookup) {
     if (schema.mainEntityMultiple) {
-      formattedData.mainEntityLookup = (values.mainEntityLookup as { value: string }[]).map((n) => n.value);
+      const lookupArr = values.mainEntityLookup as { value: string; isPendingCreation?: boolean; pendingInputData?: { entityType: string; input: Record<string, unknown> } }[];
+      const existingIds = lookupArr.filter((n) => !n.isPendingCreation).map((n) => n.value);
+      const pendingEntities = lookupArr.filter((n) => n.isPendingCreation && n.pendingInputData).map((n) => n.pendingInputData!);
+      if (existingIds.length > 0) formattedData.mainEntityLookup = existingIds;
+      if (pendingEntities.length > 0) formattedData.mainEntityLookupPending = pendingEntities;
     } else {
-      formattedData.mainEntityLookup = (values.mainEntityLookup as { value: string }).value;
+      const single = values.mainEntityLookup as { value: string; isPendingCreation?: boolean; pendingInputData?: { entityType: string; input: Record<string, unknown> } };
+      if (single.isPendingCreation && single.pendingInputData) {
+        formattedData.mainEntityLookupPending = [single.pendingInputData];
+      } else {
+        formattedData.mainEntityLookup = single.value;
+      }
     }
   }
 
@@ -515,13 +524,22 @@ export const formatFormDataForSubmission = (
       const entityFields = schema.fields.filter((field) => field.attributeMapping.entity === entity.id);
 
       if (entity.lookup) {
-        // Handle lookup mode
+        // Handle lookup mode – split existing entities (by ID) from pending creations.
         const lookupValue = values[`additional_${entity.id}_lookup`];
         if (lookupValue) {
           if (entity.multiple) {
-            formattedData[`additional_${entity.id}_lookup`] = (lookupValue as { value: string }[]).map((n) => n.value);
+            const lookupArr = lookupValue as { value: string; isPendingCreation?: boolean; pendingInputData?: { entityType: string; input: Record<string, unknown> } }[];
+            const existingIds = lookupArr.filter((n) => !n.isPendingCreation).map((n) => n.value);
+            const pendingEntities = lookupArr.filter((n) => n.isPendingCreation && n.pendingInputData).map((n) => n.pendingInputData!);
+            if (existingIds.length > 0) formattedData[`additional_${entity.id}_lookup`] = existingIds;
+            if (pendingEntities.length > 0) formattedData[`additional_${entity.id}_lookup_pending`] = pendingEntities;
           } else {
-            formattedData[`additional_${entity.id}_lookup`] = (lookupValue as { value: string }).value;
+            const single = lookupValue as { value: string; isPendingCreation?: boolean; pendingInputData?: { entityType: string; input: Record<string, unknown> } };
+            if (single.isPendingCreation && single.pendingInputData) {
+              formattedData[`additional_${entity.id}_lookup_pending`] = [single.pendingInputData];
+            } else {
+              formattedData[`additional_${entity.id}_lookup`] = single.value;
+            }
           }
         }
       } else if (entity.multiple && entity.fieldMode === 'parsed') {

--- a/opencti-platform/opencti-front/src/utils/hooks/useApiMutation.test.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useApiMutation.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { GraphQLTaggedNode } from 'relay-runtime';
+import useApiMutation from './useApiMutation';
+import * as useDeferredCreationModule from './useDeferredCreation';
+
+// ── Relay mocks ──────────────────────────────────────────────────────────────
+
+const mockCommit = vi.fn();
+vi.mock('react-relay', async () => {
+  const actual = await vi.importActual('react-relay');
+  return {
+    ...actual,
+    useMutation: () => [mockCommit, false],
+  };
+});
+
+// ── Silence MESSAGING$ side-effects ─────────────────────────────────────────
+
+vi.mock('../../relay/environment', () => ({
+  MESSAGING$: { notifyError: vi.fn(), notifyRelayError: vi.fn(), notifyCustomRelayError: vi.fn(), notifySuccess: vi.fn() },
+  relayErrorHandling: vi.fn(),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const fakeQuery = {} as GraphQLTaggedNode;
+
+/** Render the hook and return the commit function. */
+const renderCommit = () => {
+  const { result } = renderHook(() => useApiMutation(fakeQuery));
+  const [commit] = result.current;
+  return commit;
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useApiMutation – normal mode (isDeferredMode = false)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(useDeferredCreationModule, 'useDeferredCreation').mockReturnValue({
+      isDeferredMode: false,
+      captureInput: vi.fn(),
+    });
+  });
+
+  it('delegates to the real commit when not in deferred mode', () => {
+    const commit = renderCommit();
+    const args = { variables: { input: { name: 'Test' } }, onCompleted: vi.fn() };
+
+    commit(args as Parameters<typeof commit>[0]);
+
+    expect(mockCommit).toHaveBeenCalledOnce();
+    expect(args.onCompleted).not.toHaveBeenCalled(); // called by relay, not by us
+  });
+});
+
+describe('useApiMutation – deferred mode (isDeferredMode = true)', () => {
+  const captureInput = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(useDeferredCreationModule, 'useDeferredCreation').mockReturnValue({
+      isDeferredMode: true,
+      captureInput,
+    });
+  });
+
+  it('does NOT call the real commit', () => {
+    const commit = renderCommit();
+    commit({ variables: { input: { name: 'Intercepted' } } } as Parameters<typeof commit>[0]);
+
+    expect(mockCommit).not.toHaveBeenCalled();
+  });
+
+  it('captures variables.input for SDO-style mutations', () => {
+    const commit = renderCommit();
+    const inputData = { name: 'New Malware', is_family: true };
+
+    commit({ variables: { input: inputData } } as Parameters<typeof commit>[0]);
+
+    expect(captureInput).toHaveBeenCalledWith(inputData);
+  });
+
+  it('captures full variables for SCO-style flat mutations (no input key)', () => {
+    const commit = renderCommit();
+    const scoVariables = { type: 'IPv4-Addr', IPv4Addr: { value: '1.2.3.4' } };
+
+    commit({ variables: scoVariables } as Parameters<typeof commit>[0]);
+
+    expect(captureInput).toHaveBeenCalledWith(scoVariables);
+  });
+
+  it('calls onCompleted with an empty response to close the form', () => {
+    const commit = renderCommit();
+    const onCompleted = vi.fn();
+
+    commit({ variables: { input: { name: 'Test' } }, onCompleted } as Parameters<typeof commit>[0]);
+
+    expect(onCompleted).toHaveBeenCalledWith({}, null);
+  });
+
+  it('does not throw when onCompleted is absent', () => {
+    const commit = renderCommit();
+    expect(() => {
+      commit({ variables: { input: { name: 'Test' } } } as Parameters<typeof commit>[0]);
+    }).not.toThrow();
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/hooks/useApiMutation.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useApiMutation.ts
@@ -3,6 +3,7 @@ import { useMutation, UseMutationConfig } from 'react-relay';
 import { ReactNode, useCallback } from 'react';
 import { MESSAGING$, relayErrorHandling } from '../../relay/environment';
 import { RelayError } from '../../relay/relayTypes';
+import { useDeferredCreation } from './useDeferredCreation';
 
 export interface UsiApiMutationOptions {
   errorMessage?: string | ReactNode;
@@ -11,15 +12,36 @@ export interface UsiApiMutationOptions {
 }
 
 /**
- * Hook wrapping Relay useMutation to automatically display an error popup with a message if the mutation fails
+ * Hook wrapping Relay useMutation to automatically display an error popup with a message if the mutation fails.
+ *
+ * When `DeferredCreationContext.isDeferredMode` is active (e.g. a draft-only user is
+ * creating an entity on the fly inside a Form Intake), the mutation is NOT dispatched
+ * to the server. Instead, the raw `input` from `variables` is captured via the context
+ * so it can be bundled and created in draft when the form intake is submitted.
  */
 const useApiMutation = <T extends MutationParameters>(
   query: GraphQLTaggedNode,
   fn?: (environment: IEnvironment, config: MutationConfig<T>) => Disposable,
   options?: UsiApiMutationOptions,
 ): [(args: UseMutationConfig<T>) => void, boolean] => {
+  const { isDeferredMode, captureInput } = useDeferredCreation();
   const [commit, inFlight] = useMutation(query, fn);
   const commitWithError = useCallback((args: UseMutationConfig<T>) => {
+    if (isDeferredMode) {
+      // Intercept the mutation: capture the raw input data and fake a successful
+      // completion so the creation form closes gracefully without any server call.
+      //
+      // SDO mutations wrap the input: { input: { name, description, … } }
+      // SCO mutations use flat top-level variables: { type: 'IPv4-Addr', IPv4Addr: { value: '…' }, … }
+      const variables = args.variables as Record<string, unknown>;
+      const inputData = (variables?.input as Record<string, unknown> | undefined) ?? variables;
+      if (inputData) {
+        captureInput(inputData);
+      }
+      // Suppress the success notification – the entity hasn't been created yet.
+      args.onCompleted?.({} as T['response'], null);
+      return;
+    }
     commit({
       ...args,
       onError: (error: Error) => {
@@ -39,7 +61,7 @@ const useApiMutation = <T extends MutationParameters>(
         if (options?.successMessage) MESSAGING$.notifySuccess(options.successMessage);
       },
     });
-  }, [commit]);
+  }, [commit, isDeferredMode, captureInput]);
   return [commitWithError, inFlight];
 };
 

--- a/opencti-platform/opencti-front/src/utils/hooks/useDeferredCreation.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDeferredCreation.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext } from 'react';
+
+/**
+ * Context for deferred entity creation within Form Intake.
+ *
+ * When a user only has "create/update in draft" permissions (`isForcedImportToDraft`),
+ * creation on the fly in a lookup field must not immediately write to the main
+ * database. This context signals that mode: any mutation fired while
+ * `isDeferredMode = true` is intercepted by `useApiMutation`, the input data is
+ * captured, and the entity is only materialised when the form intake is submitted
+ * (as part of the draft bundle).
+ */
+export interface DeferredCreationContextValue {
+  isDeferredMode: boolean;
+  /**
+   * Called by `useApiMutation` when a mutation is intercepted.
+   * Receives the raw `input` from the mutation variables.
+   */
+  captureInput: (input: Record<string, unknown>) => void;
+}
+
+export const DeferredCreationContext = createContext<DeferredCreationContextValue>({
+  isDeferredMode: false,
+  captureInput: () => {},
+});
+
+export const useDeferredCreation = () => useContext(DeferredCreationContext);

--- a/opencti-platform/opencti-front/src/utils/hooks/useDeferredCreation.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useDeferredCreation.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 
 /**
  * Context for deferred entity creation within Form Intake.

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
@@ -47,7 +47,11 @@ type EntitySetting implements InternalObject & BasicObject {
   platform_hidden_type: Boolean @auth
   enforce_reference: Boolean @auth
   attributes_configuration: String @auth(for: [SETTINGS_SETCUSTOMIZATION])
-  attributesDefinitions: [TypeAttribute!]! @auth(for: [SETTINGS_SETCUSTOMIZATION])
+  # Attribute definitions (name/label/mandatory/...) are schema metadata also needed by
+  # knowledge-level read views (e.g. the draft Review diff panel) to display field labels.
+  # The underlying data is already exposed through mandatoryAttributes / scaleAttributes /
+  # defaultValuesAttributes (all plain @auth), so this only requires authentication.
+  attributesDefinitions: [TypeAttribute!]! @auth
   mandatoryAttributes: [String!]! @auth
   scaleAttributes: [ScaleAttribute!]! @auth
   defaultValuesAttributes: [DefaultValueAttribute!]! @auth

--- a/opencti-platform/opencti-graphql/src/modules/form/form-bundle-builder.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-bundle-builder.ts
@@ -17,6 +17,60 @@ import { transformSpecialFields, convertFieldType } from './form-fields-converte
 import { completeEntity } from './form-entity-builder';
 import { loadFormEntity } from './form-utils';
 
+/**
+ * Build partial StoreEntity objects from pending-creation payloads.
+ *
+ * A "pending creation" is emitted by the frontend when a draft-only user creates an
+ * entity on the fly inside a Form Intake lookup field. The mutation is intercepted
+ * client-side and the raw mutation variables (`input` for SDOs, or the flat variable
+ * object for SCOs) are forwarded here as part of the form submission so the entity
+ * can be materialised in the draft bundle.
+ *
+ * SDO mutations: variables = { input: { name, description, … } }
+ * SCO mutations: variables are flat: { type, x_opencti_description, IPv4Addr: { value }, … }
+ *
+ * Only simple scalar attributes are mapped. Complex reference fields (createdBy,
+ * objectMarking, objectLabel) carry OpenCTI internal IDs that are not guaranteed to
+ * exist in the bundle and are intentionally skipped in this minimal implementation.
+ */
+const buildPendingEntities = (
+  pendingList: Array<{ entityType: string; input: Record<string, any> }>,
+): StoreEntity[] => {
+  return pendingList.map((pending) => {
+    const entity: Record<string, any> = { entity_type: pending.entityType };
+    const { input } = pending;
+
+    // Map common scalar SDO fields
+    const scalarFields = ['name', 'description', 'confidence', 'value', 'hashes',
+      'first_seen', 'last_seen', 'first_observed', 'last_observed', 'published',
+      'pattern', 'pattern_type', 'valid_from', 'valid_until', 'source_name',
+      'url', 'external_id', 'contact_information', 'x_opencti_reliability',
+      'is_family', 'context', 'region', 'country', 'city'];
+
+    for (const field of scalarFields) {
+      if (input[field] !== undefined && input[field] !== null && input[field] !== '') {
+        entity[field] = input[field];
+      }
+    }
+
+    // Handle SCO flat-variable format: the observable data is nested under a type key
+    // e.g. { type: 'IPv4-Addr', IPv4Addr: { value: '1.2.3.4' }, x_opencti_description: '…' }
+    if (input.type && !entity.name) {
+      // Description from SCO top-level x_opencti_description
+      if (input.x_opencti_description) entity.description = input.x_opencti_description;
+      // Observable value: look for the camelCase type key (e.g. 'IPv4Addr', 'DomainName')
+      const obsTypeKey = Object.keys(input).find((k) => k !== 'type' && typeof input[k] === 'object' && input[k] !== null && 'value' in input[k]);
+      if (obsTypeKey) {
+        entity.value = input[obsTypeKey].value;
+        // Use value as name for observables so STIX converter can work
+        entity.name = input[obsTypeKey].value;
+      }
+    }
+
+    return entity as StoreEntity;
+  });
+};
+
 export const buildMainStixEntities = async (
   context: AuthContext,
   user: AuthUser,
@@ -36,6 +90,17 @@ export const buildMainStixEntities = async (
     for (let index = 0; index < mainEntities.length; index += 1) {
       mainStixEntities.push(convertStoreToStix_2_1(mainEntities[index]));
       mainEntityStixId = mainEntities[index].standard_id;
+    }
+
+    // Handle pending (deferred) entity creations for main-entity lookup
+    if (isNotEmptyField(values.mainEntityLookupPending)) {
+      const pendingEntities = buildPendingEntities(values.mainEntityLookupPending);
+      for (let index = 0; index < pendingEntities.length; index += 1) {
+        const pendingEntity = completeEntity(pendingEntities[index].entity_type, pendingEntities[index]);
+        const stixPending = convertStoreToStix_2_1(pendingEntity);
+        mainStixEntities.push(stixPending);
+        mainEntityStixId = pendingEntity.standard_id;
+      }
     }
   } else {
     const mainEntityFields = schema.fields.filter((field) => field.attributeMapping.entity === 'main_entity');
@@ -182,6 +247,22 @@ export const buildAdditionalEntities = async (
             additionalEntitiesMap[additionalEntity.id].push(stixAdditionalEntity.id);
           } else {
             additionalEntitiesMap[additionalEntity.id] = [stixAdditionalEntity.id];
+          }
+        }
+      }
+
+      // Handle pending (deferred) entity creations inside this lookup field
+      const pendingKey = `additional_${additionalEntity.id}_lookup_pending`;
+      if (isNotEmptyField(values[pendingKey])) {
+        const pendingEntities = buildPendingEntities(values[pendingKey]);
+        for (let index2 = 0; index2 < pendingEntities.length; index2 += 1) {
+          const pendingEntity = completeEntity(pendingEntities[index2].entity_type, pendingEntities[index2]);
+          const stixPending = convertStoreToStix_2_1(pendingEntity);
+          bundle.objects.push(stixPending);
+          if (additionalEntitiesMap[additionalEntity.id]) {
+            additionalEntitiesMap[additionalEntity.id].push(stixPending.id);
+          } else {
+            additionalEntitiesMap[additionalEntity.id] = [stixPending.id];
           }
         }
       }

--- a/opencti-platform/opencti-graphql/src/modules/form/form-bundle-builder.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-bundle-builder.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { AuthContext, AuthUser } from '../../types/user';
-import type { FormSchemaDefinition } from './form-types';
+import type { AdditionalEntity, FormSchemaDefinition } from './form-types';
 import type { StoreEntity, BasicStoreEntity } from '../../types/store';
 import type { StixRelation } from '../../types/stix-2-1-sro';
 import type { StixContainer } from '../../types/stix-2-1-sdo';
@@ -18,6 +18,33 @@ import { completeEntity } from './form-entity-builder';
 import { loadFormEntity } from './form-utils';
 
 /**
+ * Input fields coming from the entity-creation mutations that must NOT be copied
+ * verbatim onto the pending store entity. They are either:
+ *  - references that carry OpenCTI internal ids (createdBy, objectMarking, …) which
+ *    cannot be resolved as STIX refs inside this bundle,
+ *  - file uploads, or
+ *  - GraphQL/mutation metadata (type, update, clientMutationId, …).
+ * Everything else that is a scalar (or array of scalars) is copied so we do not
+ * silently lose attributes (aliases, x_mitre_id, goals, channel_types, …).
+ */
+const PENDING_NON_SCALAR_INPUT_FIELDS = new Set<string>([
+  'createdBy', 'objectMarking', 'objectLabel', 'objectOrganization',
+  'objectAssignee', 'objectParticipant', 'externalReferences', 'killChainPhases',
+  'objects', 'caseTemplates', 'content_mapping', 'file', 'x_opencti_files',
+  'update', 'clientMutationId', 'type',
+]);
+
+const isScalarOrScalarArray = (value: unknown): boolean => {
+  if (value === undefined || value === null || value === '') return false;
+  const valueType = typeof value;
+  if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') return true;
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every((item) => ['string', 'number', 'boolean'].includes(typeof item));
+  }
+  return false;
+};
+
+/**
  * Build partial StoreEntity objects from pending-creation payloads.
  *
  * A "pending creation" is emitted by the frontend when a draft-only user creates an
@@ -26,12 +53,13 @@ import { loadFormEntity } from './form-utils';
  * object for SCOs) are forwarded here as part of the form submission so the entity
  * can be materialised in the draft bundle.
  *
- * SDO mutations: variables = { input: { name, description, … } }
+ * SDO mutations: variables = { input: { name, description, aliases, … } }
  * SCO mutations: variables are flat: { type, x_opencti_description, IPv4Addr: { value }, … }
  *
- * Only simple scalar attributes are mapped. Complex reference fields (createdBy,
- * objectMarking, objectLabel) carry OpenCTI internal IDs that are not guaranteed to
- * exist in the bundle and are intentionally skipped in this minimal implementation.
+ * Scalar attributes are copied generically (see PENDING_NON_SCALAR_INPUT_FIELDS for the
+ * exclusions). Reference fields (createdBy, objectMarking, objectLabel) carry OpenCTI
+ * internal ids that are not guaranteed to exist in the bundle and are intentionally
+ * skipped: the entity is materialised in the draft where such links can be added later.
  */
 const buildPendingEntities = (
   pendingList: Array<{ entityType: string; input: Record<string, any> }>,
@@ -40,30 +68,31 @@ const buildPendingEntities = (
     const entity: Record<string, any> = { entity_type: pending.entityType };
     const { input } = pending;
 
-    // Map common scalar SDO fields
-    const scalarFields = ['name', 'description', 'confidence', 'value', 'hashes',
-      'first_seen', 'last_seen', 'first_observed', 'last_observed', 'published',
-      'pattern', 'pattern_type', 'valid_from', 'valid_until', 'source_name',
-      'url', 'external_id', 'contact_information', 'x_opencti_reliability',
-      'is_family', 'context', 'region', 'country', 'city'];
-
-    for (const field of scalarFields) {
-      if (input[field] !== undefined && input[field] !== null && input[field] !== '') {
-        entity[field] = input[field];
-      }
-    }
-
-    // Handle SCO flat-variable format: the observable data is nested under a type key
+    // SCO flat-variable format: the observable data is nested under a type key
     // e.g. { type: 'IPv4-Addr', IPv4Addr: { value: '1.2.3.4' }, x_opencti_description: '…' }
-    if (input.type && !entity.name) {
-      // Description from SCO top-level x_opencti_description
+    const isObservableInput = typeof input.type === 'string' && !('name' in input);
+    if (isObservableInput) {
       if (input.x_opencti_description) entity.description = input.x_opencti_description;
+      if (input.x_opencti_score !== undefined && input.x_opencti_score !== null) {
+        entity.x_opencti_score = input.x_opencti_score;
+      }
       // Observable value: look for the camelCase type key (e.g. 'IPv4Addr', 'DomainName')
-      const obsTypeKey = Object.keys(input).find((k) => k !== 'type' && typeof input[k] === 'object' && input[k] !== null && 'value' in input[k]);
+      const obsTypeKey = Object.keys(input).find((key) => key !== 'type'
+        && typeof input[key] === 'object'
+        && input[key] !== null
+        && 'value' in input[key]);
       if (obsTypeKey) {
         entity.value = input[obsTypeKey].value;
-        // Use value as name for observables so STIX converter can work
+        // Use value as name as well so the STIX converter / standard id generation can work
         entity.name = input[obsTypeKey].value;
+      }
+    } else {
+      // SDO/generic: copy every scalar (or scalar-array) attribute except references/meta
+      for (const [key, value] of Object.entries(input)) {
+        if (PENDING_NON_SCALAR_INPUT_FIELDS.has(key)) continue;
+        if (isScalarOrScalarArray(value)) {
+          entity[key] = value;
+        }
       }
     }
 
@@ -83,13 +112,17 @@ export const buildMainStixEntities = async (
   let mainEntityStixId;
 
   if (schema.mainEntityLookup) {
-    const vals = Array.isArray(values.mainEntityLookup) ? values.mainEntityLookup : [values.mainEntityLookup];
-    const mainEntities = await Promise.all(vals.map((id: string) => {
-      return loadFormEntity(context, user, id, mainEntityType);
-    }));
-    for (let index = 0; index < mainEntities.length; index += 1) {
-      mainStixEntities.push(convertStoreToStix_2_1(mainEntities[index]));
-      mainEntityStixId = mainEntities[index].standard_id;
+    // Existing entities selected through the lookup (skipped when the user only created
+    // on-the-fly entities: values.mainEntityLookup is then undefined).
+    if (isNotEmptyField(values.mainEntityLookup)) {
+      const vals = Array.isArray(values.mainEntityLookup) ? values.mainEntityLookup : [values.mainEntityLookup];
+      const mainEntities = await Promise.all(vals.map((id: string) => {
+        return loadFormEntity(context, user, id, mainEntityType);
+      }));
+      for (let index = 0; index < mainEntities.length; index += 1) {
+        mainStixEntities.push(convertStoreToStix_2_1(mainEntities[index]));
+        mainEntityStixId = mainEntities[index].standard_id;
+      }
     }
 
     // Handle pending (deferred) entity creations for main-entity lookup
@@ -232,7 +265,7 @@ export const buildAdditionalEntities = async (
   if (!schema.additionalEntities) return additionalEntitiesMap;
 
   for (let index = 0; index < schema.additionalEntities.length; index += 1) {
-    const additionalEntity = schema.additionalEntities[index];
+    const additionalEntity: AdditionalEntity = schema.additionalEntities[index];
     const additionalEntityType = additionalEntity.entityType;
     if (additionalEntity.lookup) {
       if (isNotEmptyField(values[`additional_${additionalEntity.id}_lookup`])) {

--- a/opencti-platform/opencti-graphql/src/modules/form/form-bundle-builder.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-bundle-builder.ts
@@ -30,8 +30,10 @@ import { loadFormEntity } from './form-utils';
 const PENDING_NON_SCALAR_INPUT_FIELDS = new Set<string>([
   'createdBy', 'objectMarking', 'objectLabel', 'objectOrganization',
   'objectAssignee', 'objectParticipant', 'externalReferences', 'killChainPhases',
-  'objects', 'caseTemplates', 'content_mapping', 'file', 'x_opencti_files',
-  'update', 'clientMutationId', 'type',
+  'objects', 'caseTemplates', 'content_mapping', 'file', 'files', 'x_opencti_files',
+  // `files` / `embedded` are injected by useMarkdownCreationFilesInput() for markdown
+  // image uploads; `embedded` is a boolean[] and would otherwise pass the scalar filter.
+  'embedded', 'update', 'clientMutationId', 'type',
 ]);
 
 const isScalarOrScalarArray = (value: unknown): boolean => {
@@ -72,19 +74,30 @@ const buildPendingEntities = (
     // e.g. { type: 'IPv4-Addr', IPv4Addr: { value: '1.2.3.4' }, x_opencti_description: '…' }
     const isObservableInput = typeof input.type === 'string' && !('name' in input);
     if (isObservableInput) {
-      if (input.x_opencti_description) entity.description = input.x_opencti_description;
+      // Observables use x_opencti_description (not description) in the store / STIX model.
+      if (input.x_opencti_description) entity.x_opencti_description = input.x_opencti_description;
       if (input.x_opencti_score !== undefined && input.x_opencti_score !== null) {
         entity.x_opencti_score = input.x_opencti_score;
       }
-      // Observable value: look for the camelCase type key (e.g. 'IPv4Addr', 'DomainName')
+      // The observable-specific attributes are nested under the type key (the only nested
+      // object, e.g. 'IPv4Addr', 'DomainName', 'EmailMessage'). Copy all of its scalar
+      // attributes (value, but also subject, body, dst_port, ...), still skipping refs/files.
       const obsTypeKey = Object.keys(input).find((key) => key !== 'type'
+        && !PENDING_NON_SCALAR_INPUT_FIELDS.has(key)
         && typeof input[key] === 'object'
         && input[key] !== null
-        && 'value' in input[key]);
+        && !Array.isArray(input[key]));
       if (obsTypeKey) {
-        entity.value = input[obsTypeKey].value;
-        // Use value as name as well so the STIX converter / standard id generation can work
-        entity.name = input[obsTypeKey].value;
+        const observableData = input[obsTypeKey] as Record<string, any>;
+        for (const [key, value] of Object.entries(observableData)) {
+          if (isScalarOrScalarArray(value)) {
+            entity[key] = value;
+          }
+        }
+        // Use the observable value as a display name so standard id generation / STIX conversion can work.
+        if (entity.value !== undefined && entity.name === undefined) {
+          entity.name = entity.value;
+        }
       }
     } else {
       // SDO/generic: copy every scalar (or scalar-array) attribute except references/meta

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-bundle-builder-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-bundle-builder-test.ts
@@ -194,6 +194,9 @@ describe('buildMainStixEntities', () => {
               objectLabel: ['label-id-1'],
               externalReferences: ['ref-1'],
               file: null,
+              // injected by useMarkdownCreationFilesInput(): not real entity attributes
+              files: [{ name: 'img.png' }],
+              embedded: [true, false],
             },
           },
         ],
@@ -209,6 +212,9 @@ describe('buildMainStixEntities', () => {
       expect(entityPassedToComplete.objectLabel).toBeUndefined();
       expect(entityPassedToComplete.externalReferences).toBeUndefined();
       expect(entityPassedToComplete.file).toBeUndefined();
+      // markdown file-upload helper fields must not pollute the bundle
+      expect(entityPassedToComplete.files).toBeUndefined();
+      expect(entityPassedToComplete.embedded).toBeUndefined();
     });
 
     it('should combine existing lookup entities with pending creations', async () => {
@@ -244,7 +250,9 @@ describe('buildMainStixEntities', () => {
       expect(mainStixEntities).toHaveLength(1);
       expect(mainStixEntities[0].value).toBe('1.2.3.4');
       expect(mainStixEntities[0].name).toBe('1.2.3.4');
-      expect(mainStixEntities[0].description).toBe('malicious ip');
+      // observables use x_opencti_description, not description
+      expect(mainStixEntities[0].x_opencti_description).toBe('malicious ip');
+      expect(mainStixEntities[0].description).toBeUndefined();
       expect(mainStixEntities[0].x_opencti_score).toBe(50);
     });
   });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-bundle-builder-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-bundle-builder-test.ts
@@ -162,6 +162,93 @@ describe('buildMainStixEntities', () => {
     });
   });
 
+  describe('mainEntityLookup - pending (deferred) creation', () => {
+    it('should materialise a pending entity without calling loadFormEntity when no existing id is selected', async () => {
+      const schema = makeSchema({ mainEntityLookup: true });
+      const values = {
+        mainEntityLookupPending: [
+          { entityType: 'Intrusion-Set', input: { name: 'APT-Pending', description: 'desc', aliases: ['a1', 'a2'] } },
+        ],
+      };
+
+      const { mainStixEntities, mainEntityStixId } = await buildMainStixEntities(context, user, schema, values, 'Intrusion-Set');
+
+      expect(loadFormEntity).not.toHaveBeenCalled();
+      expect(mainStixEntities).toHaveLength(1);
+      expect(mainStixEntities[0].name).toBe('APT-Pending');
+      expect(mainStixEntities[0].aliases).toEqual(['a1', 'a2']);
+      expect(mainEntityStixId).toBe('intrusion-set--completed-id');
+    });
+
+    it('should copy scalar attributes but drop reference fields (createdBy, objectMarking, objectLabel)', async () => {
+      const schema = makeSchema({ mainEntityLookup: true });
+      const values = {
+        mainEntityLookupPending: [
+          {
+            entityType: 'Intrusion-Set',
+            input: {
+              name: 'APT-Pending',
+              confidence: 80,
+              createdBy: 'identity-id-1',
+              objectMarking: ['marking-id-1'],
+              objectLabel: ['label-id-1'],
+              externalReferences: ['ref-1'],
+              file: null,
+            },
+          },
+        ],
+      };
+
+      await buildMainStixEntities(context, user, schema, values, 'Intrusion-Set');
+
+      const entityPassedToComplete = vi.mocked(completeEntity).mock.calls[0][1] as any;
+      expect(entityPassedToComplete.name).toBe('APT-Pending');
+      expect(entityPassedToComplete.confidence).toBe(80);
+      expect(entityPassedToComplete.createdBy).toBeUndefined();
+      expect(entityPassedToComplete.objectMarking).toBeUndefined();
+      expect(entityPassedToComplete.objectLabel).toBeUndefined();
+      expect(entityPassedToComplete.externalReferences).toBeUndefined();
+      expect(entityPassedToComplete.file).toBeUndefined();
+    });
+
+    it('should combine existing lookup entities with pending creations', async () => {
+      vi.mocked(loadFormEntity).mockResolvedValue({ standard_id: 'intrusion-set--existing' } as any);
+
+      const schema = makeSchema({ mainEntityLookup: true });
+      const values = {
+        mainEntityLookup: ['existing-id-1'],
+        mainEntityLookupPending: [
+          { entityType: 'Intrusion-Set', input: { name: 'APT-Pending' } },
+        ],
+      };
+
+      const { mainStixEntities } = await buildMainStixEntities(context, user, schema, values, 'Intrusion-Set');
+
+      expect(loadFormEntity).toHaveBeenCalledTimes(1);
+      expect(mainStixEntities).toHaveLength(2);
+    });
+
+    it('should map an observable pending creation from its flat variable format', async () => {
+      const schema = makeSchema({ mainEntityLookup: true });
+      const values = {
+        mainEntityLookupPending: [
+          {
+            entityType: 'IPv4-Addr',
+            input: { type: 'IPv4-Addr', IPv4Addr: { value: '1.2.3.4' }, x_opencti_description: 'malicious ip', x_opencti_score: 50 },
+          },
+        ],
+      };
+
+      const { mainStixEntities } = await buildMainStixEntities(context, user, schema, values, 'IPv4-Addr');
+
+      expect(mainStixEntities).toHaveLength(1);
+      expect(mainStixEntities[0].value).toBe('1.2.3.4');
+      expect(mainStixEntities[0].name).toBe('1.2.3.4');
+      expect(mainStixEntities[0].description).toBe('malicious ip');
+      expect(mainStixEntities[0].x_opencti_score).toBe(50);
+    });
+  });
+
   describe('fieldMode: multiple', () => {
     it('should build one entity per group', async () => {
       const schema = makeSchema({
@@ -481,6 +568,52 @@ describe('buildAdditionalEntities', () => {
 
       expect(bundle.objects).toHaveLength(0);
       expect(result.victim).toBeUndefined();
+    });
+
+    it('should materialise a pending (deferred) creation and add it to the bundle and map', async () => {
+      const schema = makeSchema({
+        additionalEntities: [{ id: 'threat', lookup: true, entityType: 'Malware' }],
+      });
+      const bundle = makeBundle();
+      const values = {
+        additional_threat_lookup_pending: [
+          { entityType: 'Malware', input: { name: 'EvilBot', is_family: true, objectMarking: ['marking-1'] } },
+        ],
+      };
+
+      const result = await buildAdditionalEntities(context, user, schema, values, bundle);
+
+      expect(loadFormEntity).not.toHaveBeenCalled();
+      expect(bundle.objects).toHaveLength(1);
+      expect(result.threat).toHaveLength(1);
+      const entityPassedToComplete = vi.mocked(completeEntity).mock.calls[0][1] as any;
+      expect(entityPassedToComplete.entity_type).toBe('Malware');
+      expect(entityPassedToComplete.name).toBe('EvilBot');
+      expect(entityPassedToComplete.is_family).toBe(true);
+      // reference fields are dropped from the pending payload
+      expect(entityPassedToComplete.objectMarking).toBeUndefined();
+    });
+
+    it('should combine existing lookup entities with pending creations in the same field', async () => {
+      vi.mocked(loadFormEntity).mockResolvedValue({ standard_id: 'malware--existing' } as any);
+      vi.mocked(convertStoreToStix_2_1).mockReturnValueOnce({ id: 'malware--existing' } as any);
+
+      const schema = makeSchema({
+        additionalEntities: [{ id: 'threat', lookup: true, entityType: 'Malware' }],
+      });
+      const bundle = makeBundle();
+      const values = {
+        additional_threat_lookup: 'malware-id-1',
+        additional_threat_lookup_pending: [
+          { entityType: 'Malware', input: { name: 'NewBot' } },
+        ],
+      };
+
+      const result = await buildAdditionalEntities(context, user, schema, values, bundle);
+
+      expect(loadFormEntity).toHaveBeenCalledTimes(1);
+      expect(bundle.objects).toHaveLength(2);
+      expect(result.threat).toHaveLength(2);
     });
   });
 


### PR DESCRIPTION
### Proposed changes

Let a user who only has *create/update knowledge in draft* (capabilitiesInDraft, without direct create/update) create entities on the fly from a Form Intake entity-lookup field. Previously the lookup creation dialog fired the real creation mutation against the main database and failed with "You are not allowed to do this", which blocked the SAMA workflow: org analysts (create/update in draft only) could not create intrusion sets, campaigns, vulnerabilities, channels, TTPs, etc.

How it works:

- Frontend: when the form intake is forced to draft (`isForcedImportToDraft`), the entity-lookup field opens the normal creation dialog inside a `DeferredCreationContext`. `useApiMutation` intercepts the creation mutation instead of sending it to the server, captures the raw input, and the field shows the entity as a local "pending" option (prefix `__pending__:`).
- On submit, pending entities are sent alongside the existing selections (`mainEntityLookupPending` / `additional_<id>_lookup_pending`).
- Backend: `form-bundle-builder` materialises the pending entities into the STIX bundle, which is imported into the draft. They are only persisted when the draft is validated; if the draft is discarded, nothing is created.

Hardening and fixes included in this PR:

- `buildPendingEntities` copies every scalar / scalar-array attribute from the captured input (no more silently dropped fields such as aliases, x_mitre_id, goals, channel_types) and skips reference fields (createdBy, objectMarking, objectLabel, ...) plus markdown upload helper fields (files, embedded) and other mutation metadata that are not real entity attributes.
- Observables: write `x_opencti_description` (not `description`) per the store/STIX model and copy the scalar attributes nested under the observable type key.
- Guard the main-entity lookup existing-load so a draft-only user creating ONLY on-the-fly main entities (mainEntityLookup undefined) no longer triggers `loadFormEntity(undefined)`.
- Fix a `TS7022` build failure in `form-bundle-builder.ts` and remove an unused `React` import flagged by lint.
- Ungate `EntitySetting.attributesDefinitions` (now plain `@auth`, consistent with its siblings `mandatoryAttributes` / `scaleAttributes` / `defaultValuesAttributes`). The draft Review diff panel reads this field only to build attribute labels; it previously required `SETTINGS_SETCUSTOMIZATION`, so a draft-only reviewer got `FORBIDDEN_ACCESS` rendered as "page not found" when opening an entity in the review.
- Backend unit tests added for the pending (deferred) creation paths.

Behind feature flags: `DRAFT_WORKFLOW`, `FORM_INTAKE_DEFAULT_VALUES`.

### Related issues

- closes #16469

### How to test this PR

1. Create a role with *Create/Update knowledge* ONLY under "Capabilities in draft" (not in the main capabilities), like the `[Member Organization] [Analysts]` role, and assign a user to it.
2. Create a Form Intake whose main entity and/or additional entities use entity lookup (e.g. an Intrusion-Set / Malware / Channel lookup). Enable the draft workflow (`DRAFT_WORKFLOW`, `FORM_INTAKE_DEFAULT_VALUES`).
3. Log in as the draft-only user and open the form intake.
4. In an entity lookup field, type a new name and use "Create ...". Before this PR the creation failed with "You are not allowed to do this"; now the dialog closes and the new entity appears as a pending option, with no error and no server-side creation yet.
5. Submit the form -> a draft is created containing the pending entities; open the draft Review tab and click an entity (this now works for draft-only users too).
6. Validate the draft -> the entities are created in the platform.
7. Repeat but discard/cancel the draft instead of validating -> the on-the-fly entities are NOT created.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Known limitations / follow-ups

- Bulk on-the-fly creation (multiple names entered at once) in a single lookup keeps only the last entity, because the deferred capture is single-slot.
- Pending entities are materialised in the draft without markings/labels/author: those reference OpenCTI internal ids that cannot be resolved as STIX refs inside the submitted bundle. They can be set inside the draft before validation.
- The pending-option construction is duplicated across the SDO (`handleClose`) and SCO (`handleSCOEntityCreated`) completion handlers in `StixCoreObjectsField`; it could be factored into a shared helper in a follow-up.
