### PR TITLE
fix(frontend): prevent react-draggable@4.6.0 from crashing due to process.env.DRAGGABLE_DEBUG (#16607)

### DIFF
--- a/opencti-platform/opencti-front/vite.config.mts
+++ b/opencti-platform/opencti-front/vite.config.mts
@@ -213,7 +213,7 @@ export default defineConfig({
   define: {
     // Workaround to circumvent usage of process.env in react-draggable.
     // To remove once https://github.com/react-grid-layout/react-draggable/issues/806 is addressed.
-    'process.env.DRAGGABLE_DEBUG': JSON.stringify(process.env.DRAGGABLE_DEBUG ?? false),
+    'process.env.DRAGGABLE_DEBUG': JSON.stringify(process.env.DRAGGABLE_DEBUG === 'true'),
   },
 
   resolve: {

--- a/opencti-platform/opencti-front/vite.config.mts
+++ b/opencti-platform/opencti-front/vite.config.mts
@@ -210,6 +210,12 @@ export default defineConfig({
     target: ['chrome58'],
   },
 
+  define: {
+    // Workaround to circumvent usage of process.env in react-draggable.
+    // To remove once https://github.com/react-grid-layout/react-draggable/issues/806 is addressed.
+    'process.env.DRAGGABLE_DEBUG': JSON.stringify(process.env.DRAGGABLE_DEBUG ?? false),
+  },
+
   resolve: {
     alias: {
       '@components': path.resolve(__dirname, './src/private/components'),


### PR DESCRIPTION
### Proposed changes

* Apply workaroud described in https://github.com/react-grid-layout/react-draggable/issues/806 to manage bump to `react-draggable@4.6.0` 

### Related issues

* closes #16607 

### How to test this PR

Check Custom dashboards work as intended (widgets are draggable/resizable.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
