### PR TITLE
fix(client-python): prevent stale ping echo from overwriting connector state (#16612)

### DIFF
--- a/client-python/pycti/api/opencti_api_connector.py
+++ b/client-python/pycti/api/opencti_api_connector.py
@@ -124,6 +124,7 @@ class OpenCTIApiConnector:
                 pingConnector(id: $id, state: $state, connectorInfo: $connectorInfo) {
                     id
                     connector_state
+                    connector_state_timestamp
                     connector_info {
                         run_and_terminate
                         buffering

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -946,7 +946,7 @@ class PingAlive(threading.Thread):
     :param get_state: Function to retrieve current connector state
     :type get_state: Callable[[], Optional[Dict]]
     :param set_state: Function to update connector state
-    :type set_state: Callable[[str], None]
+    :type set_state: Callable[[Optional[Dict]], None]
     :param metric: Metric handler for recording ping statistics
     :type metric: OpenCTIMetricHandler
     :param connector_info: ConnectorInfo instance with runtime details
@@ -959,10 +959,12 @@ class PingAlive(threading.Thread):
         connector_id: str,
         api,
         get_state: Callable[[], Optional[Dict]],
-        set_state: Callable[[str], None],
+        set_state: Callable[[Optional[Dict]], None],
         metric,
         connector_info,
-        get_state_last_write=None,
+        get_state_last_write: Optional[
+            Callable[[], Optional[datetime.datetime]]
+        ] = None,
     ) -> None:
         """Initialize the PingAlive daemon thread.
 
@@ -975,11 +977,14 @@ class PingAlive(threading.Thread):
         :param get_state: Function to retrieve current connector state
         :type get_state: Callable[[], Optional[Dict]]
         :param set_state: Function to update connector state
-        :type set_state: Callable[[str], None]
+        :type set_state: Callable[[Optional[Dict]], None]
         :param metric: Metric handler for recording ping statistics
         :type metric: OpenCTIMetricHandler
         :param connector_info: ConnectorInfo instance with runtime details
         :type connector_info: ConnectorInfo
+        :param get_state_last_write: Returns the connector's last local state
+            write as a timezone-aware UTC datetime (or None)
+        :type get_state_last_write: Callable[[], Optional[datetime.datetime]]
         """
         threading.Thread.__init__(self, daemon=True)
         self.connector_logger = connector_logger

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -1029,13 +1029,24 @@ class PingAlive(threading.Thread):
                 # (frequent under high platform latency) from overwriting the
                 # connector's own freshly written state.
                 raw_timestamp = result.get("connector_state_timestamp")
-                reset_timestamp = (
-                    datetime.datetime.fromisoformat(
-                        raw_timestamp.replace("Z", "+00:00")
-                    )
-                    if raw_timestamp
-                    else None
-                )
+                reset_timestamp = None
+                if raw_timestamp:
+                    try:
+                        reset_timestamp = datetime.datetime.fromisoformat(
+                            raw_timestamp.replace("Z", "+00:00")
+                        )
+                        if reset_timestamp.tzinfo is None:
+                            reset_timestamp = reset_timestamp.replace(
+                                tzinfo=datetime.timezone.utc
+                            )
+                    except (TypeError, ValueError):
+                        self.connector_logger.debug(
+                            "Invalid connector_state_timestamp received from platform; ignoring reset timestamp",
+                            {"connector_state_timestamp": raw_timestamp},
+                        )
+                        reset_timestamp = datetime.datetime.min.replace(
+                            tzinfo=datetime.timezone.utc
+                        )
                 last_local_write = self.get_state_last_write()
                 is_genuine_reset = remote_state is None and (
                     reset_timestamp is None

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3626,9 +3626,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                             )
                         )
                     else:
-                        octi_extensions[
-                            "granted_refs"
-                        ] = self.enrichment_shared_organizations
+                        octi_extensions["granted_refs"] = (
+                            self.enrichment_shared_organizations
+                        )
                 else:
                     if item.get("x_opencti_granted_refs") is not None:
                         item["x_opencti_granted_refs"] = list(
@@ -3638,9 +3638,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                             )
                         )
                     else:
-                        item[
-                            "x_opencti_granted_refs"
-                        ] = self.enrichment_shared_organizations
+                        item["x_opencti_granted_refs"] = (
+                            self.enrichment_shared_organizations
+                        )
             bundle = json.dumps(bundle_data)
 
         # If execution in playbook, callback the api

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -962,6 +962,7 @@ class PingAlive(threading.Thread):
         set_state: Callable[[str], None],
         metric,
         connector_info,
+        get_state_last_write=None,
     ) -> None:
         """Initialize the PingAlive daemon thread.
 
@@ -990,6 +991,7 @@ class PingAlive(threading.Thread):
         self.exit_event = threading.Event()
         self.metric = metric
         self.connector_info = connector_info
+        self.get_state_last_write = get_state_last_write or (lambda: None)
 
     def ping(self) -> None:
         """Execute the ping loop to maintain connector heartbeat.
@@ -1021,12 +1023,41 @@ class PingAlive(threading.Thread):
                     and len(result["connector_state"]) > 0
                     else None
                 )
-                if initial_state != remote_state:
-                    self.set_state(result["connector_state"])
-                    self.connector_logger.info(
-                        "Connector state has been remotely reset",
-                        {"state": self.get_state()},
+                # A divergent platform state is only adopted when it is a genuine
+                # reset: an empty state whose reset timestamp is newer than our
+                # last local write. This prevents a delayed/stale ping echo
+                # (frequent under high platform latency) from overwriting the
+                # connector's own freshly written state.
+                raw_timestamp = result.get("connector_state_timestamp")
+                reset_timestamp = (
+                    datetime.datetime.fromisoformat(
+                        raw_timestamp.replace("Z", "+00:00")
                     )
+                    if raw_timestamp
+                    else None
+                )
+                last_local_write = self.get_state_last_write()
+                is_genuine_reset = remote_state is None and (
+                    reset_timestamp is None
+                    or last_local_write is None
+                    or reset_timestamp > last_local_write
+                )
+                if initial_state != remote_state:
+                    if is_genuine_reset:
+                        self.set_state(None)
+                        self.connector_logger.info(
+                            "Connector state has been remotely reset",
+                            {"state": self.get_state()},
+                        )
+                    else:
+                        self.connector_logger.debug(
+                            "Ignoring divergent platform state (stale echo), "
+                            "keeping local state",
+                            {
+                                "local_state": initial_state,
+                                "remote_state": remote_state,
+                            },
+                        )
 
                 if self.in_error:
                     self.in_error = False
@@ -2503,6 +2534,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                     self.set_state,
                     self.metric,
                     self.connector_info,
+                    self.get_state_last_write,
                 )
                 self.ping.start()
 
@@ -2835,6 +2867,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.connector_state = json.dumps(state)
         else:
             self.connector_state = None
+        self.connector_state_last_write = datetime.datetime.now(datetime.timezone.utc)
+
+    def get_state_last_write(self) -> Optional[datetime.datetime]:
+        """returns the timestamp of the last local state write, or None"""
+        return getattr(self, "connector_state_last_write", None)
 
     def get_state(self) -> Optional[Dict]:
         """Get the connector state.
@@ -3589,9 +3626,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                             )
                         )
                     else:
-                        octi_extensions["granted_refs"] = (
-                            self.enrichment_shared_organizations
-                        )
+                        octi_extensions[
+                            "granted_refs"
+                        ] = self.enrichment_shared_organizations
                 else:
                     if item.get("x_opencti_granted_refs") is not None:
                         item["x_opencti_granted_refs"] = list(
@@ -3601,9 +3638,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                             )
                         )
                     else:
-                        item["x_opencti_granted_refs"] = (
-                            self.enrichment_shared_organizations
-                        )
+                        item[
+                            "x_opencti_granted_refs"
+                        ] = self.enrichment_shared_organizations
             bundle = json.dumps(bundle_data)
 
         # If execution in playbook, callback the api
@@ -3703,13 +3740,15 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             expectations_number = 1
         else:
             stix2_splitter = OpenCTIStix2Splitter()
-            expectations_number, _, bundles = (
-                stix2_splitter.split_bundle_with_expectations(
-                    bundle=bundle,
-                    use_json=True,
-                    event_version=event_version,
-                    cleanup_inconsistent_bundle=cleanup_inconsistent_bundle,
-                )
+            (
+                expectations_number,
+                _,
+                bundles,
+            ) = stix2_splitter.split_bundle_with_expectations(
+                bundle=bundle,
+                use_json=True,
+                event_version=event_version,
+                cleanup_inconsistent_bundle=cleanup_inconsistent_bundle,
             )
 
         if len(bundles) == 0:

--- a/client-python/tests/01-unit/connector_helper/test_ping_state_adoption.py
+++ b/client-python/tests/01-unit/connector_helper/test_ping_state_adoption.py
@@ -1,0 +1,83 @@
+import datetime
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from pycti.connector.opencti_connector_helper import PingAlive
+
+
+class DummyLogger:
+    def info(self, message, data=None):
+        pass
+
+    def debug(self, message, data=None):
+        pass
+
+    def error(self, message, data=None):
+        pass
+
+
+def _run_one_ping(local_state, last_write, ping_response):
+    """Construct PingAlive with stubs, run exactly one loop iteration,
+    and return the resulting local state."""
+    holder = {"state": local_state}
+    api = MagicMock()
+    api.connector.ping.return_value = ping_response
+
+    ping = PingAlive(
+        DummyLogger(),
+        "connector-test",
+        api,
+        lambda: holder["state"],
+        lambda s: holder.__setitem__("state", s),
+        MagicMock(),
+        MagicMock(all_details={}),
+        lambda: last_write,
+    )
+    # Stop the loop after a single iteration.
+    ping.exit_event.wait = lambda *args, **kwargs: ping.exit_event.set()
+    ping.ping()
+    return holder["state"]
+
+
+class TestPingStateAdoption(TestCase):
+    def test_stale_value_echo_is_ignored(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old = (now - datetime.timedelta(hours=1)).isoformat()
+        result = _run_one_ping(
+            {"last_run": 2},
+            now,
+            {
+                "connector_state": '{"last_run": 1}',
+                "connector_state_timestamp": old,
+            },
+        )
+        # Local state must be preserved; the stale value echo is ignored.
+        self.assertEqual(result, {"last_run": 2})
+
+    def test_stale_empty_echo_is_ignored(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old = (now - datetime.timedelta(hours=1)).isoformat()
+        result = _run_one_ping(
+            {"last_run": 2},
+            now,
+            {
+                "connector_state": None,
+                "connector_state_timestamp": old,
+            },
+        )
+        # Empty echo with an old reset timestamp is not a genuine reset.
+        self.assertEqual(result, {"last_run": 2})
+
+    def test_genuine_reset_is_adopted(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        fresh = (now + datetime.timedelta(seconds=5)).isoformat()
+        result = _run_one_ping(
+            {"last_run": 2},
+            now,
+            {
+                "connector_state": None,
+                "connector_state_timestamp": fresh,
+            },
+        )
+        # Empty state with a fresh reset timestamp is a genuine reset.
+        self.assertIsNone(result)


### PR DESCRIPTION
### Proposed changes

* PingAlive no longer blindly takes the state the platform sends back. It only
  clears the local state on a real reset, meaning an empty state whose
  connector_state_timestamp is newer than the last time the connector wrote its
  own state. A stale or delayed echo (which happens a lot under load) is left
  alone.
* Fixes the actual type bug as well: set_state was getting the raw
  connector_state string instead of the parsed dict, so it always turned into
  None and wiped the state.
* set_state now remembers when it last wrote, and PingAlive uses that timestamp
  to tell a real reset apart from an old echo.
* The ping mutation now requests connector_state_timestamp so the connector has
  something to compare against.

### Related issues
* closes #16612

### How to test this PR
* `cd client-python && pip install -e ".[dev]"`
* `pytest tests/01-unit/connector_helper/test_ping_state_adoption.py -v`
* Three cases are covered: a stale value echo and a stale empty echo are both
  ignored (local state kept), and a genuine reset (empty state with a fresh
  connector_state_timestamp) clears the state.

### Checklist
- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [X] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [X] Where necessary, I refactored code to improve the overall quality

### Further comments

Just swapping in set_state(remote_state) on its own is not enough. Under latency
the connector would still pick up a stale value, so the flipping continues. The
point of the change is that the connector owns its state, and the platform only
gets to clear it through an explicit, timestamped reset.

It should be safe for older setups: if the platform does not send
connector_state_timestamp, or the connector has not written any state yet in
this process, it falls back to the previous behavior. The existing "Connector
state has been remotely reset" log stays as it was, and the ignored echoes only
log at debug level.

One assumption worth pointing out: as far as I can tell the only case where the
platform pushes a state back to the connector is the UI reset (which empties it).
If there is another flow where a non-empty state from the platform should win,
let me know, since the change deliberately ignores non-empty differences.
