### PR TITLE
feat(filters): fix refresh saved filters after renaming (#11624)

### DIFF
--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
@@ -6,15 +6,12 @@ import { Form, Formik } from 'formik';
 import { graphql } from 'react-relay';
 import { useFormatter } from 'src/components/i18n';
 import { type SavedFiltersSelectionData } from 'src/components/saved_filters/SavedFilterSelection';
-import { invalidateConnection } from 'src/utils/store';
 import useApiMutation from '../../utils/hooks/useApiMutation';
 import useAuth from '../../utils/hooks/useAuth';
 import useGranted, { KNOWLEDGE_KNSHAREFILTERS } from '../../utils/hooks/useGranted';
 import { AccessRight, type AuthorizedMemberOption } from '../../utils/authorizedMembers';
 import { type AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
-import getSavedFilterScopeFilter from './getSavedFilterScopeFilter';
 import SavedFilterSharingSection from './SavedFilterSharingSection';
-import { RecordSourceSelectorProxy } from 'relay-runtime';
 import Security from '../../utils/Security';
 import useHelper from '../../utils/hooks/useHelper';
 
@@ -62,7 +59,7 @@ type SavedFilterEditDialogProps = {
   onClose: () => void;
   isOpen: boolean;
   savedFilter: SavedFiltersSelectionData;
-  localStorageKey: string;
+  onSaved?: () => void;
 };
 
 interface SavedFilterEditFormValues {
@@ -74,7 +71,7 @@ const SavedFilterEditDialog = ({
   isOpen,
   onClose,
   savedFilter,
-  localStorageKey,
+  onSaved,
 }: SavedFilterEditDialogProps) => {
   const { t_i18n } = useFormatter();
   const { me } = useAuth();
@@ -96,12 +93,6 @@ const SavedFilterEditDialog = ({
   );
 
   const handleSubmit = (values: SavedFilterEditFormValues) => {
-    const filters = getSavedFilterScopeFilter(localStorageKey);
-
-    const updater = (store: RecordSourceSelectorProxy) => {
-      invalidateConnection(store, 'SavedFilters_savedFilters', { filters });
-    };
-
     // Update name
     if (values.name !== savedFilter.name) {
       commitFieldPatch({
@@ -109,7 +100,7 @@ const SavedFilterEditDialog = ({
           id: savedFilter.id,
           input: [{ key: 'name', value: [values.name] }],
         },
-        updater,
+        onCompleted: () => onSaved?.(),
       });
     }
 
@@ -124,7 +115,7 @@ const SavedFilterEditDialog = ({
           id: savedFilter.id,
           input: memberAccessInput,
         },
-        updater,
+        onCompleted: () => onSaved?.(),
       });
     }
 

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterSelection.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterSelection.tsx
@@ -13,6 +13,7 @@ type SavedFilterSelectionProps = {
   data: SavedFiltersSelectionData[];
   currentSavedFilter?: SavedFiltersSelectionData;
   setCurrentSavedFilter: (savedFilter: SavedFiltersSelectionData | undefined) => void;
+  onRefetch: () => void;
 };
 
 export type SavedFiltersAutocompleteOptionType = {
@@ -28,6 +29,7 @@ const SavedFilterSelection = ({
   data,
   currentSavedFilter,
   setCurrentSavedFilter,
+  onRefetch,
 }: SavedFilterSelectionProps) => {
   const { me } = useAuth();
   const {
@@ -97,6 +99,18 @@ const SavedFilterSelection = ({
     }
   }, [currentSavedFilter]);
 
+  // Sync local state when the underlying data changes (e.g. after a name edit)
+  useEffect(() => {
+    if (selectedSavedFilter) {
+      const updated = sortedOptions.find((o) => o.value.id === selectedSavedFilter.value.id);
+      if (updated && updated.label !== selectedSavedFilter.label) {
+        setSelectedSavedFilter(updated);
+        setInputValue(updated.label);
+        setCurrentSavedFilter(updated.value);
+      }
+    }
+  }, [data]);
+
   useEffect(() => {
     if (isDisabled && !!selectedSavedFilter) {
       handleReset();
@@ -129,6 +143,7 @@ const SavedFilterSelection = ({
         value={selectedSavedFilter}
         inputValue={inputValue}
         localStorageKey={localStorageKey}
+        onRefetch={onRefetch}
       />
       {!!savedFilterToDelete && (
         <SavedFilterDeleteDialog

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterSharingSection.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterSharingSection.tsx
@@ -30,6 +30,7 @@ const SavedFilterSharingSection = ({
             component={AuthorizedMembersField}
             owner={owner}
             enableAccesses
+            showAllMembersLine
             addMeUserWithAdminRights={!isEditMode}
             hideInfo
             customAccessRights={['view', 'admin']}

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilters.tsx
@@ -1,6 +1,6 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useCallback } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import useQueryLoading from 'src/utils/hooks/useQueryLoading';
+import { useQueryLoadingWithLoadQuery } from 'src/utils/hooks/useQueryLoading';
 import { SavedFiltersQuery, SavedFiltersQuery$variables } from 'src/components/saved_filters/__generated__/SavedFiltersQuery.graphql';
 import { useDataTableContext } from 'src/components/dataGrid/components/DataTableContext';
 import useHelper from '../../utils/hooks/useHelper';
@@ -36,9 +36,10 @@ type SavedFiltersComponentProps = {
   queryRef: PreloadedQuery<SavedFiltersQuery>;
   currentSavedFilter?: SavedFiltersSelectionData;
   setCurrentSavedFilter: (savedFilter: SavedFiltersSelectionData | undefined) => void;
+  onRefetch: () => void;
 };
 
-const SavedFiltersComponent = ({ queryRef, currentSavedFilter, setCurrentSavedFilter }: SavedFiltersComponentProps) => {
+const SavedFiltersComponent = ({ queryRef, currentSavedFilter, setCurrentSavedFilter, onRefetch }: SavedFiltersComponentProps) => {
   const { savedFilters } = usePreloadedQuery(savedFiltersQuery, queryRef);
 
   return (
@@ -47,6 +48,7 @@ const SavedFiltersComponent = ({ queryRef, currentSavedFilter, setCurrentSavedFi
       data={savedFilters?.edges?.map(({ node }) => node) ?? []}
       currentSavedFilter={currentSavedFilter}
       setCurrentSavedFilter={setCurrentSavedFilter}
+      onRefetch={onRefetch}
     />
   );
 };
@@ -69,7 +71,11 @@ const SavedFilters = ({ currentSavedFilter, setCurrentSavedFilter }: SavedFilter
   const filters = getSavedFilterScopeFilter(localStorageKey);
   const queryOptions = { filters, skipSharedFilters: !isSharedFiltersEnabled } as unknown as SavedFiltersQuery$variables;
 
-  const queryRef = useQueryLoading<SavedFiltersQuery>(savedFiltersQuery, queryOptions);
+  const [queryRef, loadQuery] = useQueryLoadingWithLoadQuery<SavedFiltersQuery>(savedFiltersQuery, queryOptions);
+
+  const handleRefetch = useCallback(() => {
+    loadQuery(queryOptions, { fetchPolicy: 'network-only' });
+  }, [loadQuery, localStorageKey, isSharedFiltersEnabled]);
 
   const isRestrictedStorageKey = localStorageKey.includes('_stixCoreRelationshipCreationFromEntity');
   if (isRestrictedStorageKey) return null;
@@ -83,6 +89,7 @@ const SavedFilters = ({ currentSavedFilter, setCurrentSavedFilter }: SavedFilter
                 queryRef={queryRef}
                 currentSavedFilter={currentSavedFilter}
                 setCurrentSavedFilter={setCurrentSavedFilter}
+                onRefetch={handleRefetch}
               />
             </Suspense>
           )

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFiltersAutocomplete.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFiltersAutocomplete.tsx
@@ -22,6 +22,7 @@ type SavedFiltersAutocompleteProps = {
   onDelete?: (value: SavedFiltersSelectionData) => void;
   options?: SavedFiltersAutocompleteOptionType[];
   localStorageKey?: string;
+  onRefetch?: () => void;
 };
 const SavedFiltersAutocomplete = ({
   isDisabled,
@@ -32,6 +33,7 @@ const SavedFiltersAutocomplete = ({
   onDelete,
   options,
   localStorageKey,
+  onRefetch,
 }: SavedFiltersAutocompleteProps) => {
   const { isFeatureEnable } = useHelper();
   const isSharingSavedFilterFeatureEnabled = isFeatureEnable('SHARE_FILTERS');
@@ -148,7 +150,7 @@ const SavedFiltersAutocomplete = ({
           isOpen={!!savedFilterToEdit}
           onClose={() => setSavedFilterToEdit(undefined)}
           savedFilter={savedFilterToEdit}
-          localStorageKey={localStorageKey}
+          onSaved={onRefetch}
         />
       )}
     </>

--- a/opencti-platform/opencti-front/src/utils/store.js
+++ b/opencti-platform/opencti-front/src/utils/store.js
@@ -115,7 +115,7 @@ export const deleteNodeFromContainer = (store, containerId, key, filters, id) =>
 export const deleteNodeFromEdge = (store, path, rootId, deleteId, params) => {
   const node = store.get(rootId);
   const records = node.getLinkedRecord(path, params);
-  const edges = records.getLinkedRecords('edges');
+  const edges = records.getLinkedRecords('edges') || [];
   const newEdges = edges.filter((n) => n.getLinkedRecord('node').getValue('id') !== deleteId);
   records.setLinkedRecords(newEdges, 'edges');
 };

--- a/opencti-platform/opencti-front/src/utils/store.js
+++ b/opencti-platform/opencti-front/src/utils/store.js
@@ -1,12 +1,10 @@
-import * as R from 'ramda';
-import { filter } from 'ramda';
 import { ConnectionHandler } from 'relay-runtime';
 
 export const isNodeInConnection = (payload, conn) => {
   const records = conn.getLinkedRecords('edges');
   const recordsIds = records.map((n) => n.getLinkedRecord('node').getValue('id'));
   const payloadId = payload.getValue('id');
-  return R.includes(payloadId, recordsIds);
+  return recordsIds.includes(payloadId);
 };
 
 export const insertNode = (
@@ -118,10 +116,7 @@ export const deleteNodeFromEdge = (store, path, rootId, deleteId, params) => {
   const node = store.get(rootId);
   const records = node.getLinkedRecord(path, params);
   const edges = records.getLinkedRecords('edges');
-  const newEdges = filter(
-    (n) => n.getLinkedRecord('node').getValue('id') !== deleteId,
-    edges,
-  );
+  const newEdges = edges.filter((n) => n.getLinkedRecord('node').getValue('id') !== deleteId);
   records.setLinkedRecords(newEdges, 'edges');
 };
 
@@ -131,26 +126,4 @@ export const insertNodeFromEdge = (store, parentId, edgesPath, dataPath, params)
   const payload = store.getRootField(dataPath);
   const newEdge = payload.setLinkedRecord(payload, 'node');
   ConnectionHandler.insertEdgeBefore(records, newEdge);
-};
-
-/**
- * Invalidates a connection record in the Relay store, forcing subscribed
- * components to refetch the data on next render.
- * Useful after updating a node within a connection when usePreloadedQuery
- * does not automatically detect field changes.
- */
-export const invalidateConnection = (store, key, filters = {}) => {
-  const root = store.getRoot();
-  const params = { ...filters };
-  delete params.count;
-  delete params.id;
-  let conn;
-  if (Object.keys(params).length === 0) {
-    conn = ConnectionHandler.getConnection(root, key);
-  } else {
-    conn = ConnectionHandler.getConnection(root, key, params);
-  }
-  if (conn) {
-    conn.invalidateRecord();
-  }
 };

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -39,12 +39,10 @@ export const addSavedFilter = (context: AuthContext, user: AuthUser, input: Save
   // construct final creation input
   const canShare = isFeatureEnabled('SHARE_FILTERS')
     && isUserHasCapability(user, KNOWLEDGE_KNSHAREFILTERS);
-  const savedFiltersToCreate = canShare
-    ? {
-        ...input,
-        restricted_members: initializeAuthorizedMembers(input.authorized_members, user),
-      }
-    : input;
+  const savedFiltersToCreate = {
+    ...input,
+    restricted_members: initializeAuthorizedMembers(canShare ? input.authorized_members : undefined, user),
+  };
   return createInternalObject<StoreEntitySavedFilter>(contextOutOfDraft, user, savedFiltersToCreate, ENTITY_TYPE_SAVED_FILTER);
 };
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/savedFilter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/savedFilter-test.ts
@@ -122,6 +122,35 @@ describe('Saved Filter Resolver', () => {
       expect(authorizedMembers.length).toEqual(1);
       expect(authorizedMembers[0].access_right).toEqual('admin');
     });
+
+    it('should create a filter with creator as admin in authorized members even without KNOWLEDGE_KNSHAREFILTERS capability', async () => {
+      const input = {
+        name: 'filter without share capability',
+        filters: JSON.stringify(newFilter),
+        scope: 'Incident',
+      };
+
+      const result = await queryAsUserWithSuccess(USER_PARTICIPATE, {
+        query: CREATE_SAVED_FILTER_MUTATION,
+        variables: {
+          input: { ...input },
+        },
+      });
+
+      expect(result?.data?.savedFilterAdd).toBeDefined();
+      expect(result?.data?.savedFilterAdd.name).toEqual('filter without share capability');
+
+      const { authorizedMembers } = result.data.savedFilterAdd;
+      expect(authorizedMembers.length).toEqual(1);
+      expect(authorizedMembers[0].name).toEqual(USER_PARTICIPATE.name);
+      expect(authorizedMembers[0].access_right).toEqual('admin');
+
+      // Cleanup: delete the filter as the creator
+      await queryAsUserWithSuccess(USER_PARTICIPATE, {
+        query: DELETE_SAVED_FILTER_MUTATION,
+        variables: { id: result.data.savedFilterAdd.id },
+      });
+    });
   });
 
   describe('savedFilters', () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/savedFilter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/savedFilter-test.ts
@@ -142,7 +142,7 @@ describe('Saved Filter Resolver', () => {
 
       const { authorizedMembers } = result.data.savedFilterAdd;
       expect(authorizedMembers.length).toEqual(1);
-      expect(authorizedMembers[0].name).toEqual(USER_PARTICIPATE.name);
+      expect(authorizedMembers[0].name).toEqual(USER_PARTICIPATE.email);
       expect(authorizedMembers[0].access_right).toEqual('admin');
 
       // Cleanup: delete the filter as the creator


### PR DESCRIPTION
### Proposed changes
Some fixes about Sharing saved filters:
- When a saved filter is renamed, the name of the filter should be updated in the saved filters selection dropdown
- 'everyone on the platform' displayed in the Access rights edition form of saved filters
- the saved filters of a user without the 'share filters' capability should only be in the saved filters selection list for the user who created them

### Related issues
fixes #11624