### PR TITLE
fix(draft-workflow): run onEnter after async transition (#16513)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
@@ -115,6 +115,30 @@ export const reportWorkflowAsyncActionResult = async (
     }
   }
 
+  // Run onEnter actions of the target state (phase 2 equivalent of engine's onEnter block)
+  for (const actionConfig of (pendingTransition.onEnterActions ?? [])) {
+    const actionFn = ActionRegistry[actionConfig.type];
+    if (!actionFn) {
+      logApp.error('[workflow-async-completion] Unknown onEnter action type', { type: actionConfig.type });
+      await updateAttribute(executionContext, executionUser, workflowInstanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [
+        { key: 'pendingStatus', value: ['error'] },
+        { key: 'pendingError', value: [`Unknown onEnter action type: ${actionConfig.type}`] },
+      ]);
+      return;
+    }
+    try {
+      await actionFn(workflowContext, actionConfig.params);
+    } catch (onEnterError) {
+      const onEnterErrorMsg = onEnterError instanceof Error ? onEnterError.message : String(onEnterError);
+      logApp.error('[workflow-async-completion] onEnter action failed', { type: actionConfig.type, error: onEnterErrorMsg });
+      await updateAttribute(executionContext, executionUser, workflowInstanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [
+        { key: 'pendingStatus', value: ['error'] },
+        { key: 'pendingError', value: [`onEnter action '${actionConfig.type}' failed: ${onEnterErrorMsg}`] },
+      ]);
+      return;
+    }
+  }
+
   // All phases complete — advance state and clear pending
   const history = (() => {
     try {

--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
@@ -97,6 +97,7 @@ export const reportWorkflowAsyncActionResult = async (
     if (!actionFn) {
       logApp.error('[workflow-async-completion] Unknown syncAction type', { type: actionConfig.type });
       await updateAttribute(executionContext, executionUser, workflowInstanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [
+        { key: 'pendingTransition', value: [JSON.stringify(pendingTransition)] },
         { key: 'pendingStatus', value: ['error'] },
         { key: 'pendingError', value: [`Unknown syncAction type: ${actionConfig.type}`] },
       ]);
@@ -108,6 +109,7 @@ export const reportWorkflowAsyncActionResult = async (
       const syncErrorMsg = syncError instanceof Error ? syncError.message : String(syncError);
       logApp.error('[workflow-async-completion] syncAction failed', { type: actionConfig.type, error: syncErrorMsg });
       await updateAttribute(executionContext, executionUser, workflowInstanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [
+        { key: 'pendingTransition', value: [JSON.stringify(pendingTransition)] },
         { key: 'pendingStatus', value: ['error'] },
         { key: 'pendingError', value: [`syncAction '${actionConfig.type}' failed: ${syncErrorMsg}`] },
       ]);
@@ -121,6 +123,7 @@ export const reportWorkflowAsyncActionResult = async (
     if (!actionFn) {
       logApp.error('[workflow-async-completion] Unknown onEnter action type', { type: actionConfig.type });
       await updateAttribute(executionContext, executionUser, workflowInstanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [
+        { key: 'pendingTransition', value: [JSON.stringify(pendingTransition)] },
         { key: 'pendingStatus', value: ['error'] },
         { key: 'pendingError', value: [`Unknown onEnter action type: ${actionConfig.type}`] },
       ]);
@@ -132,6 +135,7 @@ export const reportWorkflowAsyncActionResult = async (
       const onEnterErrorMsg = onEnterError instanceof Error ? onEnterError.message : String(onEnterError);
       logApp.error('[workflow-async-completion] onEnter action failed', { type: actionConfig.type, error: onEnterErrorMsg });
       await updateAttribute(executionContext, executionUser, workflowInstanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [
+        { key: 'pendingTransition', value: [JSON.stringify(pendingTransition)] },
         { key: 'pendingStatus', value: ['error'] },
         { key: 'pendingError', value: [`onEnter action '${actionConfig.type}' failed: ${onEnterErrorMsg}`] },
       ]);

--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
@@ -757,15 +757,21 @@ export const triggerWorkflowEvent = async (
       // fallback on actions if syncActions not explicitly defined on transition (legacy support)
       const serializedTransitions: WorkflowActionConfig[] = targetTransitionForSync?.syncActions ?? [];
 
+      // Collect the onEnter actions of the target state so phase 2 can replay them.
+      const toStateId = targetTransitionForSync?.to ?? instance.getCurrentState();
+      const targetStateDef = definitionData.states?.find((s: any) => s.statusId === toStateId);
+      const serializedOnEnterActions: WorkflowActionConfig[] = targetStateDef?.onEnter ?? [];
+
       const pendingTransition: WorkflowPendingTransition = {
         event: eventName,
-        toState: targetTransitionForSync?.to ?? instance.getCurrentState(),
+        toState: toStateId,
         triggeredBy: user.id,
         triggeredAt: new Date().toISOString(),
         runtimeParams,
         ...(comment ? { comment } : {}),
         asyncActions: rawSlots,
         syncActions: serializedTransitions,
+        ...(serializedOnEnterActions.length > 0 ? { onEnterActions: serializedOnEnterActions } : {}),
       };
 
       await updateAttribute(executionContext, executionUser, instanceId, ENTITY_TYPE_WORKFLOW_INSTANCE, [

--- a/opencti-platform/opencti-graphql/src/modules/workflow/types/workflow-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/types/workflow-types.ts
@@ -47,6 +47,7 @@ export interface WorkflowPendingTransition {
   comment?: string;
   asyncActions: AsyncActionSlot[];
   syncActions: WorkflowActionConfig[];
+  onEnterActions?: WorkflowActionConfig[]; // onEnter actions of the target state, serialized so phase 2 can replay them.
 }
 
 /**

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-async-completion-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-async-completion-test.ts
@@ -280,6 +280,108 @@ describe('reportWorkflowAsyncActionResult', () => {
     expect(history[history.length - 1].state).toBe('reviewing');
   });
 
+  it('sets pendingStatus=error and persists pendingTransition when an unknown onEnter action type is encountered', async () => {
+    const pt = makePendingTransition({
+      asyncActions: [
+        { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+      ],
+      syncActions: [],
+      onEnterActions: [{ type: 'unknownOnEnterType', params: {} }],
+    });
+    (storeLoadById as any).mockResolvedValue(
+      makeInstance({ pendingTransition: JSON.stringify(pt) }),
+    );
+    (ActionRegistry as any).unknownOnEnterType = undefined;
+    (updateAttribute as any).mockResolvedValue({});
+
+    await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+    const calls = (updateAttribute as any).mock.calls;
+    const lastPatches = calls[calls.length - 1][4];
+    expect(lastPatches.find((p: any) => p.key === 'pendingStatus')?.value[0]).toBe('error');
+    expect(lastPatches.find((p: any) => p.key === 'pendingError')?.value[0]).toContain('Unknown onEnter action type');
+    // pendingTransition must be persisted so the UI shows the correct slot statuses
+    const ptPatch = lastPatches.find((p: any) => p.key === 'pendingTransition');
+    expect(ptPatch).toBeDefined();
+    const ptPersisted = JSON.parse(ptPatch.value[0]);
+    expect(ptPersisted.asyncActions[0].status).toBe('success');
+  });
+
+  it('sets pendingStatus=error and persists pendingTransition when an onEnter action throws', async () => {
+    const pt = makePendingTransition({
+      asyncActions: [
+        { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+      ],
+      syncActions: [],
+      onEnterActions: [{ type: 'throwingOnEnter', params: {} }],
+    });
+    (storeLoadById as any).mockResolvedValue(
+      makeInstance({ pendingTransition: JSON.stringify(pt) }),
+    );
+    (ActionRegistry as any).throwingOnEnter = vi.fn().mockRejectedValue(new Error('onEnter blew up'));
+    (updateAttribute as any).mockResolvedValue({});
+
+    await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+    const calls = (updateAttribute as any).mock.calls;
+    const lastPatches = calls[calls.length - 1][4];
+    expect(lastPatches.find((p: any) => p.key === 'pendingStatus')?.value[0]).toBe('error');
+    expect(lastPatches.find((p: any) => p.key === 'pendingError')?.value[0]).toContain('onEnter blew up');
+    const ptPatch = lastPatches.find((p: any) => p.key === 'pendingTransition');
+    expect(ptPatch).toBeDefined();
+    const ptPersisted = JSON.parse(ptPatch.value[0]);
+    expect(ptPersisted.asyncActions[0].status).toBe('success');
+  });
+
+  it('runs onEnterActions after syncActions and then advances state', async () => {
+    const executionOrder: string[] = [];
+    const pt = makePendingTransition({
+      asyncActions: [
+        { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+      ],
+      syncActions: [{ type: 'syncFirst', params: {} }],
+      onEnterActions: [{ type: 'onEnterSecond', params: {} }],
+    });
+    (storeLoadById as any).mockResolvedValue(
+      makeInstance({ pendingTransition: JSON.stringify(pt) }),
+    );
+    (ActionRegistry as any).syncFirst = vi.fn().mockImplementation(() => { executionOrder.push('sync'); });
+    (ActionRegistry as any).onEnterSecond = vi.fn().mockImplementation(() => { executionOrder.push('onEnter'); });
+    (updateAttribute as any).mockResolvedValue({});
+
+    await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+    // syncActions must run before onEnterActions
+    expect(executionOrder).toEqual(['sync', 'onEnter']);
+    const [, , , , patches] = (updateAttribute as any).mock.calls[0];
+    expect(patches.find((p: any) => p.key === 'currentState')?.value[0]).toBe('reviewing');
+    expect(patches.find((p: any) => p.key === 'pendingTransition')?.value[0]).toBeNull();
+    expect(patches.find((p: any) => p.key === 'pendingStatus')?.value[0]).toBeNull();
+  });
+
+  it('advances state when all slots succeed and onEnterActions all succeed', async () => {
+    const pt = makePendingTransition({
+      asyncActions: [
+        { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+      ],
+      syncActions: [],
+      onEnterActions: [{ type: 'onEnterOk', params: { flag: true } }],
+    });
+    (storeLoadById as any).mockResolvedValue(
+      makeInstance({ pendingTransition: JSON.stringify(pt) }),
+    );
+    (ActionRegistry as any).onEnterOk = vi.fn().mockResolvedValue(undefined);
+    (updateAttribute as any).mockResolvedValue({});
+
+    await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+    expect((ActionRegistry as any).onEnterOk).toHaveBeenCalledTimes(1);
+    expect(updateAttribute).toHaveBeenCalledTimes(1);
+    const [, , , , patches] = (updateAttribute as any).mock.calls[0];
+    expect(patches.find((p: any) => p.key === 'currentState')?.value[0]).toBe('reviewing');
+    expect(patches.find((p: any) => p.key === 'pendingTransition')?.value[0]).toBeNull();
+  });
+
   it('accepts a pendingTransition stored as a JSON object (not a string)', async () => {
     const pt = makePendingTransition({
       asyncActions: [

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-domain-test.ts
@@ -1226,6 +1226,88 @@ describe('triggerWorkflowEvent – async / pending / lock', () => {
     expect(result.success).toBe(false);
     expect(result.reason).toContain('DB connection error');
   });
+
+  // Helper shared by the three tests below
+  const setupAsyncPendingMocks = (definitionContent: string) => {
+    (storeLoadById as any).mockImplementation((_ctx: any, _user: any, id: string) => {
+      if (id === 'entity-id') return Promise.resolve({ id: 'entity-id', internal_id: 'entity-id', entity_type: 'Incident' });
+      if (id === 'workflow-def-id') return Promise.resolve({ id: 'workflow-def-id', name: 'Test Workflow', published_version: { id: 'v1', content: definitionContent, validation_errors: [] } });
+      return Promise.resolve(null);
+    });
+    (findByType as any).mockResolvedValue({ id: 'setting-id', workflow_id: 'workflow-def-id' });
+    (loadEntity as any).mockResolvedValue({ id: 'inst-id', internal_id: 'inst-id', currentState: 'draft', history: '[]' });
+    (WorkflowFactory.getInstance as any).mockReturnValue({
+      start: vi.fn(),
+      trigger: vi.fn().mockResolvedValue({
+        success: true,
+        executionStatus: 'pending',
+        asyncActionSlots: [{ id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction' }],
+      }),
+      getCurrentState: vi.fn().mockReturnValue('reviewing'),
+    });
+    (updateAttribute as any).mockResolvedValue({ element: {} });
+  };
+
+  const getPendingTransitionArg = (): any => {
+    const patches: Array<{ key: string; value: any[] }> = (updateAttribute as any).mock.calls[0][4];
+    return JSON.parse(patches.find((p) => p.key === 'pendingTransition')!.value[0]);
+  };
+
+  // lines 761-763 (toStateId from transition.to) + line 774 (onEnterActions present)
+  it('stores onEnterActions in pendingTransition when the target state defines onEnter actions', async () => {
+    const definitionContent = JSON.stringify({
+      initialState: 'draft',
+      states: [
+        { statusId: 'draft' },
+        { statusId: 'reviewing', onEnter: [{ type: 'validateDraft' }] },
+      ],
+      transitions: [{ from: 'draft', to: 'reviewing', event: 'submit', syncActions: [{ type: 'validateDraft' }] }],
+    });
+    setupAsyncPendingMocks(definitionContent);
+
+    await triggerWorkflowEvent(mockContext, mockUser, 'entity-id', 'submit');
+
+    const stored = getPendingTransitionArg();
+    expect(stored.toState).toBe('reviewing');
+    expect(stored.onEnterActions).toEqual([{ type: 'validateDraft' }]);
+  });
+
+  // line 774 (onEnterActions absent when serializedOnEnterActions is empty)
+  it('omits onEnterActions from pendingTransition when the target state has no onEnter actions', async () => {
+    const definitionContent = JSON.stringify({
+      initialState: 'draft',
+      states: [
+        { statusId: 'draft' },
+        { statusId: 'reviewing' }, // no onEnter
+      ],
+      transitions: [{ from: 'draft', to: 'reviewing', event: 'submit' }],
+    });
+    setupAsyncPendingMocks(definitionContent);
+
+    await triggerWorkflowEvent(mockContext, mockUser, 'entity-id', 'submit');
+
+    const stored = getPendingTransitionArg();
+    expect(stored).not.toHaveProperty('onEnterActions');
+  });
+
+  // line 761 — toStateId falls back to instance.getCurrentState() when transition has no "to"
+  it('uses instance.getCurrentState() as toState when the matched transition has no "to" field', async () => {
+    const definitionContent = JSON.stringify({
+      initialState: 'draft',
+      states: [
+        { statusId: 'draft' },
+        { statusId: 'reviewing' },
+      ],
+      transitions: [{ from: 'draft', event: 'submit' }], // no "to" — forces the ?? fallback
+    });
+    setupAsyncPendingMocks(definitionContent);
+
+    await triggerWorkflowEvent(mockContext, mockUser, 'entity-id', 'submit');
+
+    const stored = getPendingTransitionArg();
+    // getCurrentState() mock returns 'reviewing', so toState must equal that value
+    expect(stored.toState).toBe('reviewing');
+  });
 });
 
 // ===========================================================================


### PR DESCRIPTION
### Proposed changes

* get onEnter actions during an async transition
* run theses actions after completing the async transition actions, and after sync transition actions

### Related issues

* closes #16513 

### How to test this PR

- Launch the worker
- Create a draft workflow (Settings / customization / draft)
- Add a status (have a transition between these status)
- On the transition, enable "share organisation" and select an org. (This is the async action)
- On the next status, enable "authorized members" and add members.
- Go to a draft, run the transition

Expected :
- Pending during async actions (share orga)
- Status updated after async action completed
- authorized members updated (UI refresh authorized members with delay, please wait 5s)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality