### PR TITLE
refactor(frontend): migrate BrowserLanguage.js to TypeScript (#16619)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/BrowserLanguage.test.ts
+++ b/opencti-platform/opencti-front/src/utils/BrowserLanguage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { LANGUAGES, DEFAULT_LANG, detectedLocale } from './BrowserLanguage';
+
+describe('BrowserLanguage utils', () => {
+  describe('LANGUAGES constant', () => {
+    it('should define languages correctly', () => {
+      expect(LANGUAGES.CHINESE).toBe('zh-cn');
+      expect(LANGUAGES.ENGLISH).toBe('en-us');
+      expect(LANGUAGES.FRENCH).toBe('fr-fr');
+    });
+  });
+
+  describe('DEFAULT_LANG constant', () => {
+    it('should fall back to English by default', () => {
+      expect(DEFAULT_LANG).toBe('en-us');
+    });
+  });
+
+  describe('Function: detectedLocale', () => {
+    it('should return undefined if navigator is null or undefined', () => {
+      expect(detectedLocale(null)).toBeUndefined();
+      expect(detectedLocale(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined if navigator has no language keys', () => {
+      expect(detectedLocale({})).toBeUndefined();
+    });
+
+    it('should match language from languages array', () => {
+      const mockNav = {
+        languages: ['fr-FR', 'en-US'],
+      };
+      expect(detectedLocale(mockNav)).toBe('fr-fr');
+    });
+
+    it('should match language from language property', () => {
+      const mockNav = {
+        language: 'zh-CN',
+      };
+      expect(detectedLocale(mockNav)).toBe('zh-cn');
+    });
+
+    it('should match language from browserLanguage property', () => {
+      const mockNav = {
+        browserLanguage: 'DE-DE',
+      } as unknown as Navigator;
+      expect(detectedLocale(mockNav)).toBe('de-de');
+    });
+
+    it('should match language from userLanguage property', () => {
+      const mockNav = {
+        userLanguage: 'ES-ES',
+      } as unknown as Navigator;
+      expect(detectedLocale(mockNav)).toBe('es-es');
+    });
+
+    it('should match language from systemLanguage property', () => {
+      const mockNav = {
+        systemLanguage: 'IT-IT',
+      } as unknown as Navigator;
+      expect(detectedLocale(mockNav)).toBe('it-it');
+    });
+
+    it('should return undefined if none of the languages are supported', () => {
+      const mockNav = {
+        languages: ['ru-RU', 'pl-PL'],
+      };
+      expect(detectedLocale(mockNav)).toBeUndefined();
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/BrowserLanguage.test.ts
+++ b/opencti-platform/opencti-front/src/utils/BrowserLanguage.test.ts
@@ -43,21 +43,21 @@ describe('BrowserLanguage utils', () => {
     it('should match language from browserLanguage property', () => {
       const mockNav = {
         browserLanguage: 'DE-DE',
-      } as unknown as Navigator;
+      };
       expect(detectedLocale(mockNav)).toBe('de-de');
     });
 
     it('should match language from userLanguage property', () => {
       const mockNav = {
         userLanguage: 'ES-ES',
-      } as unknown as Navigator;
+      };
       expect(detectedLocale(mockNav)).toBe('es-es');
     });
 
     it('should match language from systemLanguage property', () => {
       const mockNav = {
         systemLanguage: 'IT-IT',
-      } as unknown as Navigator;
+      };
       expect(detectedLocale(mockNav)).toBe('it-it');
     });
 

--- a/opencti-platform/opencti-front/src/utils/BrowserLanguage.ts
+++ b/opencti-platform/opencti-front/src/utils/BrowserLanguage.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 
-export const LANGUAGES = {
+export const LANGUAGES: Record<string, string> = {
   AUTO: 'auto',
   CHINESE: 'zh-cn',
   ENGLISH: 'en-us',
@@ -12,7 +12,7 @@ export const LANGUAGES = {
   SPANISH: 'es-es',
 };
 
-export const DEFAULT_LANG = LANGUAGES.ENGLISH;
+export const DEFAULT_LANG: string = LANGUAGES.ENGLISH;
 // These window.navigator contain language information
 // 1. languages -> [] of preferred languages (eg ["en-US", "zh-CN", "ja-JP"]) Firefox^32, Chrome^32
 // 2. language  -> Preferred language as String (eg "en-US") Firefox^5, IE^11, Safari,
@@ -28,7 +28,7 @@ const browserLanguagePropertyKeys = [
   'systemLanguage',
 ];
 
-const availableLanguages = [
+const availableLanguages: string[] = [
   LANGUAGES.CHINESE,
   LANGUAGES.ENGLISH,
   LANGUAGES.FRENCH,
@@ -39,13 +39,25 @@ const availableLanguages = [
   LANGUAGES.SPANISH,
 ];
 
-const detectedLocale = R.pipe(
-  R.pick(browserLanguagePropertyKeys), // Get only language properties
-  R.values(), // Get values of the properties
-  R.flatten(), // flatten all arrays
-  R.reject(R.isNil), // Remove undefined values
-  R.map((x) => x.toLowerCase()),
-  R.find((x) => R.includes(x, availableLanguages)), // Returns first language matched in languages
-);
+interface NonStandardNavigator {
+  browserLanguage?: string;
+  userLanguage?: string;
+  systemLanguage?: string;
+}
+
+export const detectedLocale = (navigatorInstance: (Partial<Navigator> & NonStandardNavigator) | null | undefined): string | undefined => {
+  if (!navigatorInstance) return undefined;
+
+  const pickLanguages = R.pick(browserLanguagePropertyKeys) as (nav: Partial<Navigator> & NonStandardNavigator) => Record<string, string | readonly string[] | undefined>;
+  const properties = pickLanguages(navigatorInstance);
+
+  const values = R.values(properties);
+  const flatValues = R.flatten(values) as (string | undefined)[];
+  const activeLanguages = R.reject(R.isNil, flatValues) as string[];
+
+  const lowercaseLanguages = R.map((x) => x.toLowerCase(), activeLanguages);
+
+  return R.find((x) => R.includes(x, availableLanguages), lowercaseLanguages);
+};
 
 export default detectedLocale(window.navigator) || DEFAULT_LANG; // If no locale is detected, fallback to 'en'

--- a/opencti-platform/opencti-front/src/utils/BrowserLanguage.ts
+++ b/opencti-platform/opencti-front/src/utils/BrowserLanguage.ts
@@ -1,5 +1,3 @@
-import * as R from 'ramda';
-
 export const LANGUAGES: Record<string, string> = {
   AUTO: 'auto',
   CHINESE: 'zh-cn',
@@ -48,16 +46,12 @@ interface NonStandardNavigator {
 export const detectedLocale = (navigatorInstance: (Partial<Navigator> & NonStandardNavigator) | null | undefined): string | undefined => {
   if (!navigatorInstance) return undefined;
 
-  const pickLanguages = R.pick(browserLanguagePropertyKeys) as (nav: Partial<Navigator> & NonStandardNavigator) => Record<string, string | readonly string[] | undefined>;
-  const properties = pickLanguages(navigatorInstance);
+  const nav = navigatorInstance as Record<string, string | string[] | undefined>;
+  const languages = browserLanguagePropertyKeys
+    .flatMap((key) => nav[key] ?? [])
+    .map((x) => x.toLowerCase());
 
-  const values = R.values(properties);
-  const flatValues = R.flatten(values) as (string | undefined)[];
-  const activeLanguages = R.reject(R.isNil, flatValues) as string[];
-
-  const lowercaseLanguages = R.map((x) => x.toLowerCase(), activeLanguages);
-
-  return R.find((x) => R.includes(x, availableLanguages), lowercaseLanguages);
+  return languages.find((x) => availableLanguages.includes(x));
 };
 
 export default detectedLocale(window.navigator) || DEFAULT_LANG; // If no locale is detected, fallback to 'en'


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* **JS to TS Migration**: Migrated `BrowserLanguage.js` to `BrowserLanguage.ts`.
* **Unit Tests Addition**: Created a comprehensive test suite in `BrowserLanguage.test.ts` to cover all locale detection cases.
* **Strict Type Safety**: Refactored the collection transformations step-by-step using Ramda functions with strict type parameters, ensuring 0 `any` types remain in the utility.
* **Non-Standard Navigator Typings**: Added a `NonStandardNavigator` interface to safely type IE/Windows-specific navigator properties without casting to `any`.
* **Cascading Compiler Fixes**: Typed `LANGUAGES` and `DEFAULT_LANG` to prevent downstream TS compilation errors in importing modules (such as `useUserMetric.tsx`).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16619 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

Run the dedicated unit test suite:
```bash
yarn test src/utils/BrowserLanguage.test.ts
```

Run the compiler check to ensure type correctness across the platform:
```bash
yarn check-ts
```
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->