### PR TITLE
fix(login): Scrollbar for long login messages (#16537)

### DIFF
--- a/opencti-platform/opencti-front/src/public/components/login/LoginPage.tsx
+++ b/opencti-platform/opencti-front/src/public/components/login/LoginPage.tsx
@@ -68,7 +68,14 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({ settings }) => {
         )}
 
         {!!loginMessage && (
-          <Typography textAlign="center" variant="body2">
+          <Typography
+            textAlign="center"
+            variant="body2"
+            sx={{
+              maxHeight: '25vh',
+              overflowY: loginMessage.length > 500 ? 'auto' : undefined,
+            }}
+          >
             <LoginMarkdown sx={{ mb: 2 }}>
               {loginMessage}
             </LoginMarkdown>

--- a/opencti-platform/opencti-front/src/public/components/login/LoginPage.tsx
+++ b/opencti-platform/opencti-front/src/public/components/login/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from 'react';
+import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import LoginForm from './LoginForm';
 import { LoginRootPublicQuery$data } from '../../__generated__/LoginRootPublicQuery.graphql';
 import { isNotEmptyField } from '../../../utils/utils';
@@ -26,11 +26,21 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({ settings }) => {
   const { resetPwdStep } = useLoginContext();
   const [checked, setChecked] = useState(false);
 
+  const loginMessageRef = useRef<HTMLElement>(null);
+  const [isLoginMessageOverflowing, setIsLoginMessageOverflowing] = useState(false);
+  const loginMessageMaxHeight = window.innerHeight * 0.25;
+
   const consentMessage = settings.platform_consent_message;
   const loginMessage = settings.platform_login_message;
   const providers = settings.platform_providers;
   const hasAuthForm = providers.filter((p) => p?.type === 'FORM').length > 0;
   const hasConsentMessage = isNotEmptyField(consentMessage);
+
+  useEffect(() => {
+    if (loginMessageRef.current) {
+      setIsLoginMessageOverflowing(loginMessageRef.current.scrollHeight > loginMessageMaxHeight);
+    }
+  }, [loginMessage]);
 
   const handleChange = () => {
     setChecked(!checked);
@@ -69,11 +79,12 @@ const LoginPage: FunctionComponent<LoginPageProps> = ({ settings }) => {
 
         {!!loginMessage && (
           <Typography
+            ref={loginMessageRef}
             textAlign="center"
             variant="body2"
             sx={{
-              maxHeight: '25vh',
-              overflowY: loginMessage.length > 500 ? 'auto' : undefined,
+              maxHeight: loginMessageMaxHeight,
+              overflowY: isLoginMessageOverflowing ? 'auto' : undefined,
             }}
           >
             <LoginMarkdown sx={{ mb: 2 }}>


### PR DESCRIPTION
### Proposed changes
Add a scrollbar for long login message, so the login form and external-auth buttons remain visible and usable regardless of configured message length.

- short message
<img width="1899" height="991" alt="image" src="https://github.com/user-attachments/assets/a8a12385-3e6e-46d6-bfa6-5a4709f675c6" />


- long message
<img width="1883" height="974" alt="image" src="https://github.com/user-attachments/assets/39b59cac-22cd-445e-8fa1-11eccd90987d" />


### Related issues
fixes #16537