### PR TITLE
feat(playbook): add a "run as" user on AI agent playbook components (#16636)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import Button from '@common/button/Button';
 import OpenVocabField from '@components/common/form/OpenVocabField';
+import ObjectMembersField from '@components/common/form/ObjectMembersField';
 import MenuItem from '@mui/material/MenuItem';
 import { Field, Form, Formik, FormikConfig } from 'formik';
 import * as Yup from 'yup';
@@ -231,6 +232,17 @@ const PlaybookFlowForm = ({
                   }
                   if (propName === 'authorized_members') {
                     return <PlaybookFlowFieldAuthorizedMembers key={propName} />;
+                  }
+                  if (propName === 'run_as') {
+                    return (
+                      <ObjectMembersField
+                        key={propName}
+                        name={propName}
+                        label={t_i18n(property.$ref ?? 'Run as')}
+                        entityTypes={['User']}
+                        style={fieldSpacingContainerStyle}
+                      />
+                    );
                   }
                   if (propName === 'periodicity' || propName === 'duration') {
                     return (

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -18,7 +18,7 @@ import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveRunAsUserId } from './ai-agent-shared';
 
 // Canonical STIX 2.1 ID shape: `<type>--<uuid>` where the UUID is the
 // 8-4-4-4-12 hex layout. Stricter than the loose `[\w-]{36}` pattern in
@@ -31,6 +31,10 @@ const STIX_UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-
 
 interface AiAgentTransformConfiguration {
   agent_slug: string;
+  // User the agent call runs as: the cross-platform JWT carries this
+  // user's email so XTM One (and any write-back to OpenCTI) attributes the
+  // work to a real account. Stored as the member-picker option.
+  run_as?: { label: string; value: string };
   prompt?: string;
 }
 
@@ -43,6 +47,16 @@ const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT_SCHEMA: JSONSchemaType<AiAgentTransf
       type: 'string',
       $ref: 'AI agent',
       // Populated dynamically from the XTM One intent catalog at schema() time.
+      oneOf: [],
+    },
+    run_as: {
+      type: 'object',
+      $ref: 'Run as',
+      nullable: true,
+      default: null,
+      // Stored as the member-picker option ({ label, value }). The empty
+      // oneOf keeps AJV's JSONSchemaType satisfied without enumerating the
+      // option shape (same escape as the access-restrictions component).
       oneOf: [],
     },
     prompt: {
@@ -153,7 +167,7 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
     );
   },
   executor: async ({ playbookNode, bundle }) => {
-    const { agent_slug, prompt } = playbookNode.configuration;
+    const { agent_slug, prompt, run_as } = playbookNode.configuration;
     if (!agent_slug) {
       logApp.warn('[PLAYBOOK AI AGENT] No agent configured, returning bundle unmodified');
       return { output_port: 'unmodified', bundle };
@@ -172,7 +186,7 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
       return { output_port: 'unmodified', bundle };
     }
     const content = buildAgentMessageContent(bundle, prompt);
-    const rawResponse = await callXtmAgent(agent_slug, content);
+    const rawResponse = await callXtmAgent(agent_slug, content, resolveRunAsUserId(run_as));
     if (rawResponse === null) {
       return { output_port: 'unmodified', bundle };
     }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -17,10 +17,14 @@ import * as R from 'ramda';
 import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveRunAsUserId } from './ai-agent-shared';
 
 interface AiAgentSendConfiguration {
   agent_slug: string;
+  // User the agent call runs as: the cross-platform JWT carries this
+  // user's email so XTM One (and any write-back to OpenCTI) attributes the
+  // work to a real account. Stored as the member-picker option.
+  run_as?: { label: string; value: string };
   prompt?: string;
 }
 
@@ -33,6 +37,16 @@ const PLAYBOOK_AI_AGENT_SEND_COMPONENT_SCHEMA: JSONSchemaType<AiAgentSendConfigu
       type: 'string',
       $ref: 'AI agent',
       // Populated dynamically from the XTM One intent catalog at schema() time.
+      oneOf: [],
+    },
+    run_as: {
+      type: 'object',
+      $ref: 'Run as',
+      nullable: true,
+      default: null,
+      // Stored as the member-picker option ({ label, value }). The empty
+      // oneOf keeps AJV's JSONSchemaType satisfied without enumerating the
+      // option shape (same escape as the access-restrictions component).
       oneOf: [],
     },
     prompt: {
@@ -79,7 +93,7 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
     );
   },
   executor: async ({ playbookNode, bundle, playbookId }) => {
-    const { agent_slug, prompt } = playbookNode.configuration;
+    const { agent_slug, prompt, run_as } = playbookNode.configuration;
     if (!agent_slug) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] No agent configured, dropping playbook step', { playbookId });
       return { output_port: undefined, bundle, forceBundleTracking: true };
@@ -99,7 +113,7 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
       return { output_port: undefined, bundle, forceBundleTracking: true };
     }
     const content = buildAgentMessageContent(bundle, prompt);
-    const rawResponse = await callXtmAgent(agent_slug, content);
+    const rawResponse = await callXtmAgent(agent_slug, content, resolveRunAsUserId(run_as));
     if (rawResponse === null) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] Agent call did not complete', {
         playbookId,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -120,7 +120,7 @@ export const isAgentBoundToIntent = async (
  * user is configured.
  */
 export const resolveRunAsUserId = (
-  runAs?: string | { value?: string } | null,
+  runAs?: string | { label?: string; value?: string } | null,
 ): string | undefined => {
   if (!runAs) return undefined;
   if (typeof runAs === 'string') return runAs.trim() || undefined;

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -21,6 +21,7 @@ import { logApp, PLATFORM_VERSION } from '../../../config/conf';
 import { AUTOMATION_MANAGER_USER, executionContext, SYSTEM_USER } from '../../../utils/access';
 import { internalLoadById } from '../../../database/middleware-loader';
 import { ENTITY_TYPE_USER } from '../../../schema/internalObject';
+import { OPENCTI_ADMIN_UUID } from '../../../schema/general';
 import type { AuthContext } from '../../../types/user';
 import type { BasicStoreEntity } from '../../../types/store';
 import type { StixBundle } from '../../../types/stix-2-1-common';
@@ -131,32 +132,36 @@ export const resolveRunAsUserId = (
  * sent to XTM One. When the component is configured with an explicit
  * ``run_as`` user, the JWT is minted for that user so XTM One resolves a
  * matching local account and any write-back to OpenCTI is attributed to
- * a real, well-known user instead of the platform-internal automation
- * user (which has no resolvable email on the other side).
+ * a real, well-known user.
  *
- * Falls back to ``AUTOMATION_MANAGER_USER`` when no run-as user is set or
- * the configured one can no longer be resolved, so an unconfigured (or
- * stale) component degrades to the previous behaviour instead of failing.
+ * When no run-as user is configured, it defaults to the seeded platform
+ * admin (``OPENCTI_ADMIN_UUID``) - a real, indexed account with a
+ * resolvable email - rather than the in-memory ``AUTOMATION_MANAGER_USER``,
+ * whose placeholder email cannot be resolved on the XTM One side.
+ *
+ * ``AUTOMATION_MANAGER_USER`` remains the last-resort fallback when the
+ * target user (explicit run-as or seeded admin) cannot be loaded, so the
+ * component degrades gracefully instead of failing.
  */
 const resolveAgentJwtUser = async (
   runAsUserId?: string,
 ): Promise<{ id: string; user_email: string }> => {
-  if (!runAsUserId) return AUTOMATION_MANAGER_USER;
+  const targetUserId = runAsUserId || OPENCTI_ADMIN_UUID;
   try {
     const context = executionContext('playbook_components');
     const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
       context,
       SYSTEM_USER,
-      runAsUserId,
+      targetUserId,
       { type: ENTITY_TYPE_USER },
     );
     if (user?.user_email) {
       return { id: user.id, user_email: user.user_email };
     }
-    logApp.warn('[PLAYBOOK AI AGENT] Configured run-as user not found, falling back to automation user', { runAsUserId });
+    logApp.warn('[PLAYBOOK AI AGENT] Run-as user not found, falling back to automation user', { runAsUserId: targetUserId });
   } catch (e: unknown) {
     logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve run-as user, falling back to automation user', {
-      runAsUserId,
+      runAsUserId: targetUserId,
       cause: (e as Error).message,
     });
   }
@@ -172,11 +177,9 @@ const resolveAgentJwtUser = async (
  * of a chain, etc.) instead of crashing the whole run.
  *
  * The JWT is minted on behalf of the configured ``run_as`` user (see
- * ``resolveAgentJwtUser``) so XTM One — and any subsequent write-back to
- * OpenCTI — sees the agent call as coming from that real account. When no
- * run-as user is configured it falls back to the platform-internal
- * ``AUTOMATION_MANAGER_USER`` (the identity that drives every other
- * playbook side effect).
+ * ``resolveAgentJwtUser``) so XTM One - and any subsequent write-back to
+ * OpenCTI - sees the agent call as coming from that real account. When no
+ * run-as user is configured it defaults to the seeded platform admin.
  */
 export const callXtmAgent = async (
   agentSlug: string,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -18,8 +18,11 @@ import xtmOneClient from '../../xtm/one/xtm-one-client';
 import { issueXtmJwt } from '../../../domain/xtm-auth';
 import { getHttpClient, getResponseError } from '../../../utils/http-client';
 import { logApp, PLATFORM_VERSION } from '../../../config/conf';
-import { AUTOMATION_MANAGER_USER, executionContext } from '../../../utils/access';
+import { AUTOMATION_MANAGER_USER, executionContext, SYSTEM_USER } from '../../../utils/access';
+import { internalLoadById } from '../../../database/middleware-loader';
+import { ENTITY_TYPE_USER } from '../../../schema/internalObject';
 import type { AuthContext } from '../../../types/user';
+import type { BasicStoreEntity } from '../../../types/store';
 import type { StixBundle } from '../../../types/stix-2-1-common';
 
 // 5 minutes — agent runs may take a while when the LLM has to materialise
@@ -109,6 +112,58 @@ export const isAgentBoundToIntent = async (
 };
 
 /**
+ * Normalize the component ``run_as`` configuration into a plain user id.
+ * The playbook form stores the member-picker selection as a
+ * ``{ label, value }`` option object, while hand-written / imported
+ * configs may carry a raw id string. Returns undefined when no run-as
+ * user is configured.
+ */
+export const resolveRunAsUserId = (
+  runAs?: string | { value?: string } | null,
+): string | undefined => {
+  if (!runAs) return undefined;
+  if (typeof runAs === 'string') return runAs.trim() || undefined;
+  return runAs.value?.trim() || undefined;
+};
+
+/**
+ * Resolve the identity whose email is embedded in the cross-platform JWT
+ * sent to XTM One. When the component is configured with an explicit
+ * ``run_as`` user, the JWT is minted for that user so XTM One resolves a
+ * matching local account and any write-back to OpenCTI is attributed to
+ * a real, well-known user instead of the platform-internal automation
+ * user (which has no resolvable email on the other side).
+ *
+ * Falls back to ``AUTOMATION_MANAGER_USER`` when no run-as user is set or
+ * the configured one can no longer be resolved, so an unconfigured (or
+ * stale) component degrades to the previous behaviour instead of failing.
+ */
+const resolveAgentJwtUser = async (
+  runAsUserId?: string,
+): Promise<{ id: string; user_email: string }> => {
+  if (!runAsUserId) return AUTOMATION_MANAGER_USER;
+  try {
+    const context = executionContext('playbook_components');
+    const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
+      context,
+      SYSTEM_USER,
+      runAsUserId,
+      { type: ENTITY_TYPE_USER },
+    );
+    if (user?.user_email) {
+      return { id: user.id, user_email: user.user_email };
+    }
+    logApp.warn('[PLAYBOOK AI AGENT] Configured run-as user not found, falling back to automation user', { runAsUserId });
+  } catch (e: unknown) {
+    logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve run-as user, falling back to automation user', {
+      runAsUserId,
+      cause: (e as Error).message,
+    });
+  }
+  return AUTOMATION_MANAGER_USER;
+};
+
+/**
  * Synchronous, non-streaming call to XTM One Platform Chat. Returns the
  * raw assistant content or null when the call cannot complete (XTM One
  * not configured, network failure, non-success status). Errors are
@@ -116,15 +171,17 @@ export const isAgentBoundToIntent = async (
  * deciding how to react (route to ``unmodified``, swallow at the end
  * of a chain, etc.) instead of crashing the whole run.
  *
- * The JWT is minted on behalf of the platform-internal
- * ``AUTOMATION_MANAGER_USER`` (the user that already drives every other
- * playbook side effect: stream events, RabbitMQ work, knowledge
- * mutations, ...), so XTM One sees the playbook agent calls as coming
- * from the same identity as the rest of the playbook engine.
+ * The JWT is minted on behalf of the configured ``run_as`` user (see
+ * ``resolveAgentJwtUser``) so XTM One — and any subsequent write-back to
+ * OpenCTI — sees the agent call as coming from that real account. When no
+ * run-as user is configured it falls back to the platform-internal
+ * ``AUTOMATION_MANAGER_USER`` (the identity that drives every other
+ * playbook side effect).
  */
 export const callXtmAgent = async (
   agentSlug: string,
   content: string,
+  runAsUserId?: string,
 ): Promise<string | null> => {
   const xtmOneUrl = nconf.get('xtm:xtm_one_url');
   if (!xtmOneUrl || !xtmOneClient.isConfigured()) {
@@ -132,7 +189,8 @@ export const callXtmAgent = async (
     return null;
   }
   try {
-    const jwt = await issueXtmJwt(AUTOMATION_MANAGER_USER, xtmOneUrl);
+    const jwtUser = await resolveAgentJwtUser(runAsUserId);
+    const jwt = await issueXtmJwt(jwtUser, xtmOneUrl);
     const httpClient = getHttpClient({
       baseURL: xtmOneUrl,
       responseType: 'json',

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -7,6 +7,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
   isAgentBoundToIntent: vi.fn(),
+  resolveRunAsUserId: vi.fn(),
 }));
 
 vi.mock('../../../../../src/config/conf', () => ({
@@ -16,7 +17,13 @@ vi.mock('../../../../../src/config/conf', () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import { PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT } from '../../../../../src/modules/playbook/components/ai-agent-component';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import {
+  buildAgentMessageContent,
+  buildAgentSlugOneOf,
+  callXtmAgent,
+  isAgentBoundToIntent,
+  resolveRunAsUserId,
+} from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 import type { ExecutorParameters } from '../../../../../src/modules/playbook/playbook-types';
 
@@ -64,6 +71,8 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+    // No run-as user configured by default; tests that need it override this.
+    vi.mocked(resolveRunAsUserId).mockReturnValue(undefined);
     // Default to "agent slug is bound to the right intent" so existing
     // tests exercise the live agent-call path; tests that need the
     // negative branch override this explicitly.
@@ -151,9 +160,20 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content');
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', undefined);
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should resolve the configured run-as user and forward it to the agent call', async () => {
+      vi.mocked(resolveRunAsUserId).mockReturnValue('run-as-user-id');
+      vi.mocked(callXtmAgent).mockResolvedValue(null);
+
+      await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', 'run-as-user-id');
     });
 
     it('should accept a raw JSON STIX bundle response and emit a new bundle preserving the original envelope', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -7,6 +7,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
   isAgentBoundToIntent: vi.fn(),
+  resolveRunAsUserId: vi.fn(),
 }));
 
 vi.mock('../../../../../src/config/conf', () => ({
@@ -16,7 +17,13 @@ vi.mock('../../../../../src/config/conf', () => ({
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import { PLAYBOOK_AI_AGENT_SEND_COMPONENT } from '../../../../../src/modules/playbook/components/ai-agent-send-component';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent } from '../../../../../src/modules/playbook/components/ai-agent-shared';
+import {
+  buildAgentMessageContent,
+  buildAgentSlugOneOf,
+  callXtmAgent,
+  isAgentBoundToIntent,
+  resolveRunAsUserId,
+} from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 import type { ExecutorParameters } from '../../../../../src/modules/playbook/playbook-types';
 
@@ -51,6 +58,8 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+    // No run-as user configured by default; tests that need it override this.
+    vi.mocked(resolveRunAsUserId).mockReturnValue(undefined);
     // Default to "agent slug is bound to the consumer intent" so the
     // existing tests exercise the live path; tests that need the
     // negative branch override this explicitly.
@@ -129,7 +138,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
       );
 
       expect(buildAgentMessageContent).toHaveBeenCalledWith(BUNDLE, 'do something');
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content');
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', undefined);
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
       expect(result.forceBundleTracking).toBe(true);
@@ -142,10 +151,21 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content');
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', undefined);
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
       expect(result.forceBundleTracking).toBe(true);
+    });
+
+    it('should resolve the configured run-as user and forward it to the agent call', async () => {
+      vi.mocked(resolveRunAsUserId).mockReturnValue('run-as-user-id');
+      vi.mocked(callXtmAgent).mockResolvedValue('reply');
+
+      await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', 'run-as-user-id');
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -29,7 +29,20 @@ vi.mock('../../../../../src/config/conf', () => ({
 
 vi.mock('../../../../../src/utils/access', () => ({
   AUTOMATION_MANAGER_USER: { id: 'automation-manager', user_email: 'AUTOMATION MANAGER' },
+  SYSTEM_USER: { id: 'system', user_email: 'SYSTEM' },
   executionContext: vi.fn((source: string) => ({ source })),
+}));
+
+vi.mock('../../../../../src/database/middleware-loader', () => ({
+  internalLoadById: vi.fn(),
+}));
+
+vi.mock('../../../../../src/schema/internalObject', () => ({
+  ENTITY_TYPE_USER: 'User',
+}));
+
+vi.mock('../../../../../src/schema/general', () => ({
+  OPENCTI_ADMIN_UUID: 'admin-uuid',
 }));
 
 // ── Imports (after mocks) ───────────────────────────────────────────────
@@ -38,7 +51,10 @@ import nconf from 'nconf';
 import xtmOneClient from '../../../../../src/modules/xtm/one/xtm-one-client';
 import { issueXtmJwt } from '../../../../../src/domain/xtm-auth';
 import { getHttpClient } from '../../../../../src/utils/http-client';
-import { AUTOMATION_MANAGER_USER } from '../../../../../src/utils/access';
+import { AUTOMATION_MANAGER_USER, SYSTEM_USER } from '../../../../../src/utils/access';
+import { internalLoadById } from '../../../../../src/database/middleware-loader';
+import { ENTITY_TYPE_USER } from '../../../../../src/schema/internalObject';
+import { OPENCTI_ADMIN_UUID } from '../../../../../src/schema/general';
 import {
   AGENT_CALL_TIMEOUT_MS,
   buildAgentMessageContent,
@@ -46,6 +62,7 @@ import {
   buildPlaybookAutomationContext,
   callXtmAgent,
   isAgentBoundToIntent,
+  resolveRunAsUserId,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 
@@ -181,11 +198,34 @@ describe('ai-agent-shared', () => {
     });
   });
 
+  describe('resolveRunAsUserId', () => {
+    it('should return undefined when no run-as value is set', () => {
+      expect(resolveRunAsUserId(undefined)).toBeUndefined();
+      expect(resolveRunAsUserId(null)).toBeUndefined();
+      expect(resolveRunAsUserId('')).toBeUndefined();
+      expect(resolveRunAsUserId('   ')).toBeUndefined();
+      expect(resolveRunAsUserId({})).toBeUndefined();
+      expect(resolveRunAsUserId({ value: '   ' })).toBeUndefined();
+    });
+
+    it('should return the trimmed id from a raw string value', () => {
+      expect(resolveRunAsUserId('  user-1  ')).toBe('user-1');
+    });
+
+    it('should return the trimmed value from a member-picker option object', () => {
+      expect(resolveRunAsUserId({ label: 'Alice', value: '  user-2 ' })).toBe('user-2');
+    });
+  });
+
   describe('callXtmAgent', () => {
+    const ADMIN_JWT_USER = { id: OPENCTI_ADMIN_UUID, user_email: 'admin@opencti.io' };
+
     beforeEach(() => {
       vi.mocked(issueXtmJwt).mockResolvedValue('signed.jwt');
       vi.mocked(xtmOneClient.isConfigured).mockReturnValue(true);
       vi.mocked(nconf.get).mockReturnValue('https://xtm-one.test');
+      // No run-as user configured by default -> the seeded admin is resolved.
+      vi.mocked(internalLoadById).mockResolvedValue(ADMIN_JWT_USER as any);
     });
 
     it('should return null and not call the HTTP client when XTM One is not configured', async () => {
@@ -198,14 +238,21 @@ describe('ai-agent-shared', () => {
       expect(getHttpClient).not.toHaveBeenCalled();
     });
 
-    it('should mint the JWT as AUTOMATION_MANAGER_USER and POST a non-streaming chat message', async () => {
+    it('should default to the seeded admin and POST a non-streaming chat message', async () => {
       const post = vi.fn().mockResolvedValue({ data: { content: 'agent reply' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
       const result = await callXtmAgent('agent-slug', 'hello world');
 
       expect(result).toBe('agent reply');
-      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+      // No run-as user -> resolve the seeded admin by its fixed UUID.
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        OPENCTI_ADMIN_UUID,
+        { type: ENTITY_TYPE_USER },
+      );
+      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
       expect(getHttpClient).toHaveBeenCalledTimes(1);
       const headers = vi.mocked(getHttpClient).mock.calls[0][0].headers as Record<string, string>;
       expect(headers.Authorization).toBe('Bearer signed.jwt');
@@ -215,6 +262,53 @@ describe('ai-agent-shared', () => {
         { agent_slug: 'agent-slug', content: 'hello world', stream: false },
         { timeout: AGENT_CALL_TIMEOUT_MS },
       );
+    });
+
+    it('should mint the JWT for the resolved run-as user when a runAsUserId is provided', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-7', user_email: 'analyst@org.test' } as any);
+      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      const result = await callXtmAgent('agent-slug', 'content', 'user-7');
+
+      expect(result).toBe('ok');
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        'user-7',
+        { type: ENTITY_TYPE_USER },
+      );
+      expect(issueXtmJwt).toHaveBeenCalledWith({ id: 'user-7', user_email: 'analyst@org.test' }, 'https://xtm-one.test');
+    });
+
+    it('should fall back to AUTOMATION_MANAGER_USER when the run-as user cannot be loaded', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      await callXtmAgent('agent-slug', 'content', 'missing-user');
+
+      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+    });
+
+    it('should fall back to AUTOMATION_MANAGER_USER when the resolved user has no email', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-9' } as any);
+      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      await callXtmAgent('agent-slug', 'content', 'user-9');
+
+      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+    });
+
+    it('should fall back to AUTOMATION_MANAGER_USER when resolving the run-as user throws', async () => {
+      vi.mocked(internalLoadById).mockRejectedValue(new Error('ES down'));
+      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      await callXtmAgent('agent-slug', 'content', 'user-x');
+
+      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
     });
 
     it('should return null when the assistant content field is missing', async () => {


### PR DESCRIPTION
### Proposed changes

* Add an optional `run_as` user on the two AI agent playbook components ("Transform with AI agent" and "Send to AI agent"). When set, the cross-platform JWT sent to XTM One is minted for that user, so XTM One resolves a matching account and any write-back to OpenCTI is attributed to it.
* When no `run_as` is set, default to the seeded platform admin (`OPENCTI_ADMIN_UUID`) - a real, indexed account with a resolvable email - instead of the in-memory `AUTOMATION_MANAGER_USER`. `AUTOMATION_MANAGER_USER` remains the last-resort fallback when the target user cannot be loaded, so existing playbooks keep working.
* `callXtmAgent()` resolves the run-as user via `internalLoadById` and mints the XTM JWT for the resolved user.
* The playbook component configuration form renders the new field with the existing `ObjectMembersField` selector, restricted to `User`.
* Unit tests cover `resolveRunAsUserId` normalization, the seeded-admin default, run-as resolution, the fallbacks, and run-as forwarding from both components.

### Related issues

* closes #16636

### How to test this PR

1. Configure XTM One in OpenCTI and create an OpenCTI user that also exists (same email) on the XTM One side.
2. Build a playbook with a "Transform with AI agent" or "Send to AI agent" step and set "Run as" to that user.
3. Run the playbook and confirm the agent can read/write back to OpenCTI and that the resulting changes are attributed to the selected user.
4. Leave "Run as" empty and confirm the call now runs as the seeded admin (and still degrades to the automation user if the admin cannot be loaded).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

`run_as` is stored inside the playbook component configuration JSON, the same way other member-picker fields (organizations, targets) are stored and normalized in the executor, so there is no DB migration or GraphQL schema change. The `run_as` option type was widened to the `{ label, value }` member-picker shape to keep the type-check green. All backend unit/integration tests, frontend unit/e2e, and the codecov patch gates pass.
