### PR TITLE
fix(frontend): fix entities distribution scoping in report and grouping details (#16633)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -76,7 +76,7 @@ const GroupingDetailsComponent = (props) => {
                 endDate: null,
               }}
               dataSelection={entitiesDistributionDataSelection}
-              parameters={{ title: 'Entities distribution' }}
+              parameters={{ title: t('Entities distribution') }}
               variant="inEntity"
             />
           </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -1,20 +1,20 @@
 import React, { useState, useRef, useEffect } from 'react';
 import * as PropTypes from 'prop-types';
-import * as R from 'ramda';
 import { graphql, createFragmentContainer } from 'react-relay';
 import Grid from '@mui/material/Grid';
 import Divider from '@mui/material/Divider';
 import Card from '@common/card/Card';
 import RelatedContainers from '../../common/containers/related_containers/RelatedContainers';
 import StixRelationshipsHorizontalBars from '../../common/stix_relationships/StixRelationshipsHorizontalBars';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import { emptyFilterGroup } from '../../../../utils/filters/filtersUtils';
 import Label from '../../../../components/common/label/Label';
 import Tag from '@common/tag/Tag';
 
 const GroupingDetailsComponent = (props) => {
-  const { t, grouping } = props;
+  const { t_i18n } = useFormatter();
+  const { grouping } = props;
   const [height, setHeight] = useState(0);
   const ref = useRef(null);
   useEffect(() => {
@@ -55,17 +55,17 @@ const GroupingDetailsComponent = (props) => {
 
   return (
     <div style={{ height: '100%' }}>
-      <Card title={t('Entity details')}>
+      <Card title={t_i18n('Entity details')}>
         <Grid container={true} spacing={3}>
           <Grid item xs={12}>
             <Label>
-              {t('Description')}
+              {t_i18n('Description')}
             </Label>
             <ExpandableMarkdown source={grouping.description} limit={400} />
           </Grid>
           <Grid item xs={6} ref={ref}>
             <Label>
-              {t('Context')}
+              {t_i18n('Context')}
             </Label>
             <Tag label={grouping.context} />
           </Grid>
@@ -76,7 +76,7 @@ const GroupingDetailsComponent = (props) => {
                 endDate: null,
               }}
               dataSelection={entitiesDistributionDataSelection}
-              parameters={{ title: t('Entities distribution') }}
+              parameters={{ title: t_i18n('Entities distribution') }}
               variant="inEntity"
             />
           </Grid>
@@ -119,4 +119,4 @@ const GroupingDetails = createFragmentContainer(GroupingDetailsComponent, {
 `,
 });
 
-export default R.compose(inject18n)(GroupingDetails);
+export default GroupingDetails;

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -32,6 +32,12 @@ const GroupingDetailsComponent = (props) => {
         mode: 'and',
         filters: [
           {
+            key: 'fromId',
+            values: [grouping.id],
+            operator: 'eq',
+            mode: 'or',
+          },
+          {
             key: 'relationship_type',
             values: [
               'object',
@@ -65,17 +71,13 @@ const GroupingDetailsComponent = (props) => {
           </Grid>
           <Grid item xs={6} style={{ minHeight: 200, maxHeight: height }}>
             <StixRelationshipsHorizontalBars
-              isWidget={false}
-              fromId={grouping.id}
               config={{
                 startDate: null,
                 endDate: null,
               }}
-              relationshipType="object"
               dataSelection={entitiesDistributionDataSelection}
               parameters={{ title: 'Entities distribution' }}
               variant="inEntity"
-              isReadOnly={true}
             />
           </Grid>
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -52,6 +52,12 @@ const ReportDetails = ({ report }) => {
         mode: 'and',
         filters: [
           {
+            key: 'fromId',
+            values: [reportData.id],
+            operator: 'eq',
+            mode: 'or',
+          },
+          {
             key: 'relationship_type',
             values: [
               'object',
@@ -96,17 +102,13 @@ const ReportDetails = ({ report }) => {
             style={{ minHeight: 200, maxHeight: height }}
           >
             <StixRelationshipsHorizontalBars
-              isWidget={false}
-              fromId={reportData.id}
               config={{
                 startDate: null,
                 endDate: null,
               }}
-              relationshipType="object"
               dataSelection={entitiesDistributionDataSelection}
               parameters={{ title: 'Entities distribution' }}
               variant="inEntity"
-              isReadOnly={true}
             />
           </Grid>
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -107,7 +107,7 @@ const ReportDetails = ({ report }) => {
                 endDate: null,
               }}
               dataSelection={entitiesDistributionDataSelection}
-              parameters={{ title: 'Entities distribution' }}
+              parameters={{ title: t_i18n('Entities distribution') }}
               variant="inEntity"
             />
           </Grid>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fixed a regression introduced by the StixRelationshipsHorizontalBars refactor.
* Relationship distribution widgets in ReportDetails and GroupingDetails are now correctly scoped to the current entity using a strict fromId filter.
* Removed legacy props that are no longer effective (fromId as component prop, relationshipType, isWidget, isReadOnly) and rely on dataSelection filtering instead.
* Result: distributions no longer show the same global values across different reports/groupings

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16633

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
