### PR TITLE
feat(rich-text-editor): use rich-text-editor component by default (#16653)

### DIFF
--- a/opencti-platform/opencti-front/src/components/HtmlDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/HtmlDisplay.tsx
@@ -17,8 +17,8 @@ const SANITIZE_CONFIG = {
 };
 
 const HtmlDisplay: FunctionComponent<HtmlDisplayProps> = ({ content, limit }) => {
-  const { isTiptapEditorEnable } = useHelper();
-  const tiptapEnabled = isTiptapEditorEnable();
+  const { isOldEditorEnable } = useHelper();
+  const oldEditorEnabled = isOldEditorEnable();
 
   if (isEmptyField(content)) {
     return (
@@ -26,7 +26,7 @@ const HtmlDisplay: FunctionComponent<HtmlDisplayProps> = ({ content, limit }) =>
     );
   }
 
-  if (!tiptapEnabled) {
+  if (oldEditorEnabled) {
     return (
       <div className="ck-content">
         {limit ? parse(purify.sanitize(truncate(content, limit))) : parse(purify.sanitize(content))}

--- a/opencti-platform/opencti-front/src/components/fields/RichTextField.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/RichTextField.tsx
@@ -48,7 +48,7 @@ const RichTextField = ({
 }: RichTextFieldProps) => {
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
-  const { isTiptapEditorEnable } = useHelper();
+  const { isOldEditorEnable } = useHelper();
   const ckEditorRef = useRef<ClassicEditor>(undefined);
   const [fullScreen, setFullScreen] = useState(false);
   const [, meta] = useField(name);
@@ -56,7 +56,7 @@ const RichTextField = ({
 
   const fieldErrors = errors[name] as string;
   const showError = !isNil(meta.error) && (meta.touched || submitCount > 0);
-  const RichTextEditorInstance = isTiptapEditorEnable() ? (
+  const RichTextEditorInstance = !isOldEditorEnable() ? (
     <RichTextEditor
       onTextSelection={(text) => {
         if (onTextSelection && disabled && !fullScreen && text.length > 2) {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
@@ -463,7 +463,7 @@ class StixCoreObjectContentComponent extends Component {
       .replaceAll(regex, '');
     const fragment = stixCoreObject.name.split('/');
     const currentName = R.last(fragment);
-    await htmlToPdf('content', htmlData, this.props.isTiptapEditorEnable).download(`${currentName}.pdf`);
+    await htmlToPdf('content', htmlData, !this.props.isOldEditorEnable).download(`${currentName}.pdf`);
   }
 
   render() {
@@ -592,7 +592,7 @@ class StixCoreObjectContentComponent extends Component {
                   className={classes.editorContainer}
                   style={{ minHeight: height, height }}
                 >
-                  {this.props.isTiptapEditorEnable ? (
+                  {!this.props.isOldEditorEnable ? (
                     <RichTextEditor
                       data={currentContent ?? ''}
                       onChange={(_, adapter) => {
@@ -960,8 +960,8 @@ const withAttributes = (Component) => {
 
 const withHelperFF = (Component) => {
   const WithHelperFF = (props) => {
-    const { isTiptapEditorEnable } = useHelper();
-    return <Component {...props} isTiptapEditorEnable={isTiptapEditorEnable()} />;
+    const { isOldEditorEnable } = useHelper();
+    return <Component {...props} isOldEditorEnable={isOldEditorEnable()} />;
   };
   WithHelperFF.displayName = `WithHelperFF(${Component.displayName || Component.name || 'Component'})`;
   return WithHelperFF;

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectFileExport.tsx
@@ -178,8 +178,8 @@ const StixCoreObjectFileExportComponent = ({
   };
   const { buildFileFromTemplate } = useFileFromTemplate();
   const hasUploadAndExportCapabilities = useGranted([KNOWLEDGE_KNUPLOAD, KNOWLEDGE_KNGETEXPORT], true);
-  const { isTiptapEditorEnable } = useHelper();
-  const tiptapEnabled = isTiptapEditorEnable();
+  const { isOldEditorEnable } = useHelper();
+  const oldEditorEnabled = isOldEditorEnable();
 
   const {
     connectorsForExport,
@@ -316,7 +316,7 @@ const StixCoreObjectFileExportComponent = ({
           const templateName = values.template.label;
           const fileName = `${values.exportFileName}.pdf`;
           const fileMarkingNames = values.fileMarkings.map(({ label }) => label);
-          const PDF = await htmlToPdfReport(scoName ?? '', templateContent, templateName, fileMarkingNames, values.fintelDesign?.value, tiptapEnabled);
+          const PDF = await htmlToPdfReport(scoName ?? '', templateContent, templateName, fileMarkingNames, values.fintelDesign?.value, !oldEditorEnabled);
           const blob = await PDF.getBlob();
           uploadFile({
             id: scoId,
@@ -341,8 +341,8 @@ const StixCoreObjectFileExportComponent = ({
         const fileName = `${values.exportFileName}.pdf`;
         const isFromTemplate = fileId.startsWith('fromTemplate');
         const PDF = isFromTemplate
-          ? await htmlToPdfReport(scoName ?? '', fileData, name, fileMarkingNames, values.fintelDesign?.value, tiptapEnabled)
-          : htmlToPdf(fileId, fileData, tiptapEnabled);
+          ? await htmlToPdfReport(scoName ?? '', fileData, name, fileMarkingNames, values.fintelDesign?.value, !oldEditorEnabled)
+          : htmlToPdf(fileId, fileData, !oldEditorEnabled);
         const blob = await PDF.getBlob();
         uploadFile({
           id: scoId,

--- a/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesign.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/fintel_design/FintelDesign.tsx
@@ -56,8 +56,8 @@ const FintelDesignComponent: FunctionComponent<FintelDesignComponentProps> = ({
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const canDelete = useGranted([KNOWLEDGE_KNUPDATE_KNDELETE]);
-  const { isTiptapEditorEnable } = useHelper();
-  const tiptapEnabled = isTiptapEditorEnable();
+  const { isOldEditorEnable } = useHelper();
+  const tiptapEnabled = !isOldEditorEnable();
   const [openDelete, setOpenDelete] = useState(false);
 
   const [pdf, setPdf] = useState<File>();

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/fintel_templates/FintelTemplatePreview.tsx
@@ -57,8 +57,8 @@ const FintelTemplatePreview = ({
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
   const { buildFileFromTemplate } = useFileFromTemplate();
-  const { isTiptapEditorEnable } = useHelper();
-  const tiptapEnabled = isTiptapEditorEnable();
+  const { isOldEditorEnable } = useHelper();
+  const tiptapEnabled = !isOldEditorEnable();
   const { editorValue } = useFintelTemplateContext();
 
   const [pdf, setPdf] = useState<File>();

--- a/opencti-platform/opencti-front/src/utils/ai/ResponseDialog.tsx
+++ b/opencti-platform/opencti-front/src/utils/ai/ResponseDialog.tsx
@@ -107,8 +107,8 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
   const { t_i18n } = useFormatter();
   const [markdownSelectedTab, setMarkdownSelectedTab] = useState<'write' | 'preview' | undefined>('write');
   const { fullyActive } = useAI();
-  const { isTiptapEditorEnable } = useHelper();
-  const tiptapEnabled = isTiptapEditorEnable();
+  const { isOldEditorEnable } = useHelper();
+  const oldEditorEnabled = isOldEditorEnable();
   const isLegacyMode = !agentMode;
 
   // Agent mode state (XTM One path)
@@ -200,7 +200,7 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
         markdownFieldRef.current.scrollTop = markdownFieldRef.current.scrollHeight;
       }
     } else if (format === 'html') {
-      const selector = tiptapEnabled
+      const selector = !oldEditorEnabled
         ? '.tiptap-editor-content.ProseMirror'
         : '.ck-content.ck-editor__editable.ck-editor__editable_inline';
       const elementEditor = document.querySelector(selector);
@@ -305,7 +305,7 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
           } : undefined}
         />
       )}
-      {format === 'html' && tiptapEnabled && (
+      {format === 'html' && !oldEditorEnabled && (
         <RichTextEditor
           id="response-dialog-editor"
           data={content}
@@ -315,7 +315,7 @@ const ResponseDialog: FunctionComponent<ResponseDialogProps> = ({
           disabled={effectiveDisabled}
         />
       )}
-      {format === 'html' && !tiptapEnabled && (
+      {format === 'html' && oldEditorEnabled && (
         <CKEditor
           id="response-dialog-editor"
           data={content}

--- a/opencti-platform/opencti-front/src/utils/platformModulesHelper.ts
+++ b/opencti-platform/opencti-front/src/utils/platformModulesHelper.ts
@@ -18,6 +18,7 @@ export const INDICATOR_DECAY_MANAGER = 'INDICATOR_DECAY_MANAGER';
 export const TELEMETRY_MANAGER = 'TELEMETRY_MANAGER';
 export const GARBAGE_COLLECTION_MANAGER = 'GARBAGE_COLLECTION_MANAGER';
 export const TIPTAP_EDITOR = 'TIPTAP_EDITOR';
+export const OLD_EDITOR = 'OLD_EDITOR';
 
 export interface ModuleHelper {
   isModuleEnable: (id: string) => boolean;
@@ -39,6 +40,7 @@ export interface ModuleHelper {
   isRequestAccessEnabled: () => boolean;
   isChatbotAiEnabled: () => boolean;
   isTiptapEditorEnable: () => boolean;
+  isOldEditorEnable: () => boolean;
 }
 
 export const isFeatureEnable = (
@@ -91,6 +93,7 @@ const platformModuleHelper = (
   isRequestAccessEnabled: () => settings.request_access_enabled,
   isChatbotAiEnabled: () => settings.filigran_chatbot_ai_cgu_status === 'enabled',
   isTiptapEditorEnable: () => isFeatureEnable(settings, TIPTAP_EDITOR),
+  isOldEditorEnable: () => isFeatureEnable(settings, OLD_EDITOR),
 });
 
 export default platformModuleHelper;


### PR DESCRIPTION
### Proposed changes

* Add a new `OLD_EDITOR` feature flag to explicitly opt-in to the old editor
* Default editor is now the rich-text-editor  — no flag required
* Remove usage of `TIPTAP_EDITOR` FF from all components, replaced by `isOldEditorEnable()` helper with inverted logic

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16653 

### How to test this PR

1. Without any feature flag enabled: the rich-text-editor  should be used everywhere (rich text fields, HTML display, content editor, AI response dialog, Fintel templates…)
2. Add `OLD_EDITOR` to `app.enabled_dev_features` in your config: the old editor should be used instead across all the same components

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Previously, the `TIPTAP_EDITOR` flag had to be explicitly enabled to use the rich-text-editor, making the old editor the implicit default. This PR inverts that behaviour: the rich-text-editor is now the default, and enabling the `OLD_EDITOR` feature flag switches back to the old editor. The old `TIPTAP_EDITOR` constant and helper are kept in `platformModulesHelper.ts` for backward compatibility but are no longer used by any component.