### PR TITLE
feat(build): add workaround for process.env usage in react-draggable (#16658)

### DIFF
--- a/opencti-platform/opencti-front/builder/prod/prod.js
+++ b/opencti-platform/opencti-front/builder/prod/prod.js
@@ -58,6 +58,11 @@ const buildPath = "./builder/prod/build";
       keepNames: true,
       sourcemap: keep,
       outdir: "builder/prod/build",
+      // Workaround to circumvent usage of process.env in react-draggable.
+      // To remove once https://github.com/react-grid-layout/react-draggable/issues/806 is addressed.
+      define: {
+        'process.env.DRAGGABLE_DEBUG': JSON.stringify(process.env.DRAGGABLE_DEBUG === 'true'),
+      },
     });
   // Copy public files to build
   await cp("./src/static/ext",  `${buildPath}/static/ext`, { recursive: true, overwrite: true });


### PR DESCRIPTION
### Proposed changes

* Extend the `react-draggable` `process.env.DRAGGABLE_DEBUG` workaround to the esbuild production build (`builder/prod/prod.js`)
* The previous fix (#16607 / cb95c20) only patched `vite.config.mts` (dev mode), leaving the prod bundle broken

### Related issues
* closes #16658 

### How to test this PR
1. Run `yarn build` (esbuild prod path) and verify the output bundle does **not** contain a bare `process.env` reference
2. Load the app from the prod build, drag any draggable element (e.g. a dashboard widget) and confirm no `ReferenceError: process is not defined` is thrown in the browser console

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

`react-draggable@4.6.0` introduced a `process.env.DRAGGABLE_DEBUG` check that crashes in browsers where `process` is not defined (see [react-grid-layout/react-draggable#806](https://github.com/react-grid-layout/react-draggable/issues/806)).

The workaround is to statically replace that expression at build time so bundlers never emit a bare `process` reference. The fix was already applied to `vite.config.mts` for the dev/Vite pipeline, but the production build uses a separate esbuild script (`builder/prod/prod.js`) that was not patched — causing the `Uncaught ReferenceError: process is not defined` crash in production.

This PR applies the identical `define` option to the esbuild production build, aligning both pipelines until upstream resolves the issue.