### PR TITLE
fix(filters): Fix error for background tasks with empty filters (#16667)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -212,6 +212,28 @@ describe('Filters utils', () => {
       const result = removeIdAndIncorrectKeysFromFilterGroupObject(filters, ['entity_type']);
       expect(result!.filters.length).toEqual(0);
     });
+
+    it('should strip empty or undefined imbricated filterGroups', () => {
+      const filters: FilterGroup = {
+        mode: 'and',
+        filters: [
+          { id: 'f1', key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+        ],
+        filterGroups: [
+          emptyFilterGroup, // empty group, should be removed
+          {
+            mode: 'or',
+            filters: [
+              { id: 'f2', key: 'objectLabel', values: ['label1'], operator: 'eq', mode: 'or' },
+            ],
+            filterGroups: [],
+          },
+        ],
+      };
+      const result = removeIdAndIncorrectKeysFromFilterGroupObject(filters, ['entity_type', 'objectLabel']);
+      expect(result!.filterGroups.length).toEqual(1);
+      expect(result!.filterGroups[0].filters[0].key).toEqual('objectLabel');
+    });
   });
 
   describe('getEntityTypeTwoFirstLevelsFilterValues', () => {
@@ -746,6 +768,24 @@ describe('Function normalizeFilterGroupForBackend', () => {
     const result = normalizeFilterGroupForBackend(input);
     expect(result?.filterGroups![0].filters[0].key).toEqual(['name']);
     expect(result?.filterGroups![0].filters[0]).not.toHaveProperty('id');
+  });
+
+  it('should ignore imbricated empty filter groups', () => {
+    const input: FilterGroup = {
+      mode: 'and',
+      filters: [
+        { id: 'f1', key: 'entity_type', values: ['Malware'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [emptyFilterGroup],
+    };
+    const result = normalizeFilterGroupForBackend(input);
+    expect(result).toEqual({
+      mode: 'and',
+      filters: [
+        { key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' },
+      ],
+      filterGroups: [],
+    });
   });
 });
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -524,7 +524,9 @@ export function normalizeFilterGroupForBackend(
         ...f,
         key: Array.isArray(f.key) ? f.key : [f.key],
       })),
-    filterGroups: filterGroup.filterGroups.map((fg) => normalizeFilterGroupForBackend(fg)),
+    filterGroups: filterGroup.filterGroups
+      .filter((fg) => fg && isFilterGroupNotEmpty(fg))
+      .map((fg) => normalizeFilterGroupForBackend(fg)),
   } as GqlFilterGroup;
 }
 
@@ -894,7 +896,9 @@ export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGro
     mode: filters.mode,
     filters: removeFrontendIdAndEmptyFiltersFromFiltersArray(filters.filters
       .filter((f) => isFilterKeyAvailable(f.key, availableFilterKeys))),
-    filterGroups: filters.filterGroups.map((group) => removeIdAndIncorrectKeysFromFilterGroupObject(group, availableFilterKeys)) as FilterGroup[],
+    filterGroups: filters.filterGroups
+      .filter((fg) => fg && isFilterGroupNotEmpty(fg))
+      .map((fg) => removeIdAndIncorrectKeysFromFilterGroupObject(fg, availableFilterKeys)) as FilterGroup[],
   };
 };
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -525,8 +525,8 @@ export function normalizeFilterGroupForBackend(
         key: Array.isArray(f.key) ? f.key : [f.key],
       })),
     filterGroups: filterGroup.filterGroups
-      .filter((fg) => fg && isFilterGroupNotEmpty(fg))
-      .map((fg) => normalizeFilterGroupForBackend(fg)),
+      .map((fg) => normalizeFilterGroupForBackend(fg))
+      .filter((fg) => fg && isFilterGroupNotEmpty(fg)),
   } as GqlFilterGroup;
 }
 
@@ -897,8 +897,8 @@ export const removeIdAndIncorrectKeysFromFilterGroupObject = (filters: FilterGro
     filters: removeFrontendIdAndEmptyFiltersFromFiltersArray(filters.filters
       .filter((f) => isFilterKeyAvailable(f.key, availableFilterKeys))),
     filterGroups: filters.filterGroups
-      .filter((fg) => fg && isFilterGroupNotEmpty(fg))
-      .map((fg) => removeIdAndIncorrectKeysFromFilterGroupObject(fg, availableFilterKeys)) as FilterGroup[],
+      .map((fg) => removeIdAndIncorrectKeysFromFilterGroupObject(fg, availableFilterKeys))
+      .filter((fg) => fg && isFilterGroupNotEmpty(fg)) as FilterGroup[],
   };
 };
 


### PR DESCRIPTION
### Proposed changes
Remove imbricated empty filter groups in recursivity of functions removeIdAndIncorrectKeysFromFilterGroupObject and normalizeFilterGroupForBackend

To avoid errors when doing a background tasks with empty filters (ie a background task with not completed filters)

<img width="1691" height="710" alt="image" src="https://github.com/user-attachments/assets/f0378238-fee5-403f-b02f-6fef7829e177" />


### Related issues
fixes #16667