### PR TITLE
feat(xtm-hub): auto register when platform_token is present in env variable (#16676)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -2,7 +2,7 @@ import { getEntitiesListFromCache, getEntityFromCache } from '../database/cache'
 import type { BasicStoreSettings } from '../types/settings';
 import type { AuthContext, AuthUser } from '../types/user';
 import { ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER } from '../schema/internalObject';
-import { xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
+import { getHubBackendUrl, xtmHubClient } from '../modules/xtm/hub/xtm-hub-client';
 import { type AutoRegisterInput, XtmHubRegistrationStatus } from '../generated/graphql';
 import { updateAttribute } from '../database/middleware';
 import { booleanConf, BUS_TOPICS, logApp, PLATFORM_VERSION } from '../config/conf';
@@ -105,6 +105,45 @@ export const autoRegisterOpenCTI = async (context: AuthContext, user: AuthUser, 
     ],
   );
   return { success: true };
+};
+
+export const autoRegisterOpenCTIOnStartup = async (
+  context: AuthContext,
+  user: AuthUser,
+  platformToken: string,
+): Promise<{ success: boolean }> => {
+  if (!platformToken) {
+    return { success: false };
+  }
+
+  const settings = await getEntityFromCache<BasicStoreSettings>(context, user, ENTITY_TYPE_SETTINGS);
+  if (settings.xtm_hub_registration_status === XtmHubRegistrationStatus.Registered) {
+    logApp.info('[XTMH][AUTO-REGISTER][BOOT] Skipping startup auto-registration: platform already registered');
+    return { success: false };
+  }
+
+  const hubUrl = getHubBackendUrl();
+  if (!hubUrl) {
+    logApp.warn('[XTMH][AUTO-REGISTER][BOOT] Skipping startup auto-registration: XTM Hub URL is not configured');
+    return { success: false };
+  }
+
+  const { isReachable } = await xtmHubClient.isBackendReachable();
+  if (!isReachable) {
+    logApp.warn('[XTMH][AUTO-REGISTER][BOOT] Skipping startup auto-registration: XTM Hub backend is unreachable');
+    return { success: false };
+  }
+
+  try {
+    const response = await autoRegisterOpenCTI(context, user, { platform_token: platformToken });
+    if (!response.success) {
+      logApp.warn('[XTMH][AUTO-REGISTER][BOOT] Startup auto-registration failed');
+    }
+    return response;
+  } catch (error) {
+    logApp.warn('[XTMH][AUTO-REGISTER][BOOT] Startup auto-registration failed with error', { error });
+    return { success: false };
+  }
 };
 
 const resetRegistration = async (context: AuthContext, user: AuthUser, settings: BasicStoreSettings) => {

--- a/opencti-platform/opencti-graphql/src/manager/hubRegistrationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/hubRegistrationManager.ts
@@ -1,7 +1,7 @@
 import { type ManagerDefinition, registerManager } from './managerModule';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { executionContext, HUB_REGISTRATION_MANAGER_USER } from '../utils/access';
-import { checkXTMHubConnectivity, loadAndSaveLatestNewsFeed } from '../domain/xtm-hub';
+import { autoRegisterOpenCTIOnStartup, checkXTMHubConnectivity, loadAndSaveLatestNewsFeed } from '../domain/xtm-hub';
 import { XtmHubRegistrationStatus } from '../generated/graphql';
 import { cleanOldNewsFeedItems } from '../modules/xtm/hub/news-feed/news-feed-domain';
 import moment from 'moment';
@@ -11,6 +11,8 @@ const HUB_REGISTRATION_MANAGER_KEY = conf.get('hub_registration_manager:lock_key
 const SCHEDULE_TIME = conf.get('hub_registration_manager:interval') || 60 * 60 * 1000; // 1 hour
 const NEWS_FEED_CLEANUP_INTERVAL_VALUE = conf.get('hub_registration_manager:news_feed_cleanup_interval_value') || 180;
 const NEWS_FEED_CLEANUP_INTERVAL_UNIT = conf.get('hub_registration_manager:news_feed_cleanup_interval_unit') || 'days';
+const BOOT_DELAY = 35_000; // Run shortly after XTM One startup registration (30s)
+const XTM_HUB_PLATFORM_TOKEN = process.env.XTM_HUB_PLATFORM_TOKEN?.trim();
 
 const VALID_CLEANUP_UNITS = ['seconds', 'minutes', 'hours', 'days', 'weeks', 'months', 'years'] as const;
 type ValidCleanupUnit = typeof VALID_CLEANUP_UNITS[number];
@@ -62,6 +64,15 @@ export const hubRegistrationManager = async () => {
   }
 };
 
+export const autoRegisterOnBoot = async (platformToken: string): Promise<void> => {
+  const context = executionContext('hub_registration_boot_auto_register');
+  try {
+    await autoRegisterOpenCTIOnStartup(context, HUB_REGISTRATION_MANAGER_USER, platformToken);
+  } catch (error) {
+    logApp.warn('[XTMH][AUTO-REGISTER][BOOT] Startup auto-registration manager failed', { error });
+  }
+};
+
 const HUB_REGISTRATION_MANAGER_DEFINITION: ManagerDefinition = {
   id: 'HUB_REGISTRATION_MANAGER',
   label: 'XTM Hub registration manager',
@@ -80,3 +91,9 @@ const HUB_REGISTRATION_MANAGER_DEFINITION: ManagerDefinition = {
   },
 };
 registerManager(HUB_REGISTRATION_MANAGER_DEFINITION);
+
+if (HUB_REGISTRATION_MANAGER_ENABLED && XTM_HUB_PLATFORM_TOKEN) {
+  setTimeout(() => {
+    void autoRegisterOnBoot(XTM_HUB_PLATFORM_TOKEN);
+  }, BOOT_DELAY);
+}

--- a/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
+++ b/opencti-platform/opencti-graphql/src/modules/xtm/hub/xtm-hub-client.ts
@@ -20,14 +20,21 @@ interface ConsumeProvisionedNewsFeedItemsResponse {
   available_news_feed_types: NewsFeedItemType[];
 }
 
-const HUB_BACKEND_URL = conf.get('xtm:xtmhub_api_override_url') ?? conf.get('xtm:xtmhub_url');
 const HUB_OPENCTI_IDENTIFIER = 'opencti';
+
+export const getHubBackendUrl = (): string | undefined => {
+  const overrideUrl = conf.get('xtm:xtmhub_api_override_url');
+  const hubUrl = conf.get('xtm:xtmhub_url');
+  const normalizedOverride = typeof overrideUrl === 'string' ? overrideUrl.trim() : '';
+  const normalizedHub = typeof hubUrl === 'string' ? hubUrl.trim() : '';
+  return normalizedOverride || normalizedHub || undefined;
+};
 
 export const xtmHubClient = {
   isBackendReachable: async (): Promise<{ isReachable: boolean }> => {
     try {
       const httpClient = getHttpClient({
-        baseURL: HUB_BACKEND_URL,
+        baseURL: getHubBackendUrl(),
         responseType: 'json',
       });
 
@@ -59,7 +66,7 @@ export const xtmHubClient = {
       },
     };
     const httpClient = getHttpClient({
-      baseURL: HUB_BACKEND_URL,
+      baseURL: getHubBackendUrl(),
       responseType: 'json',
     });
 
@@ -95,7 +102,7 @@ export const xtmHubClient = {
       },
     };
     const httpClient = getHttpClient({
-      baseURL: HUB_BACKEND_URL,
+      baseURL: getHubBackendUrl(),
       responseType: 'json',
       headers: {
         'Content-Type': 'application/json',
@@ -139,7 +146,7 @@ export const xtmHubClient = {
     `;
 
     const httpClient = getHttpClient({
-      baseURL: HUB_BACKEND_URL,
+      baseURL: getHubBackendUrl(),
       responseType: 'json',
       headers: {
         'Content-Type': 'application/json',
@@ -177,7 +184,7 @@ export const xtmHubClient = {
     };
 
     const httpClient = getHttpClient({
-      baseURL: HUB_BACKEND_URL,
+      baseURL: getHubBackendUrl(),
       responseType: 'json',
       headers: {
         'Content-Type': 'application/json',

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/hubRegistrationManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/hubRegistrationManager-test.ts
@@ -3,6 +3,7 @@ import { XtmHubRegistrationStatus } from '../../../src/generated/graphql';
 
 // Mock dependencies before importing the module under test
 vi.mock('../../../src/domain/xtm-hub', () => ({
+  autoRegisterOpenCTIOnStartup: vi.fn(),
   checkXTMHubConnectivity: vi.fn(),
   loadAndSaveLatestNewsFeed: vi.fn(),
 }));
@@ -15,6 +16,11 @@ vi.mock('../../../src/utils/access', () => ({
 vi.mock('../../../src/config/conf', () => ({
   default: { get: vi.fn().mockReturnValue(undefined) },
   booleanConf: vi.fn().mockReturnValue(true),
+  logApp: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 vi.mock('../../../src/manager/managerModule', () => ({
@@ -25,10 +31,11 @@ vi.mock('../../../src/modules/xtm/hub/news-feed/news-feed-domain', () => ({
   cleanOldNewsFeedItems: vi.fn(),
 }));
 
-import { hubRegistrationManager } from '../../../src/manager/hubRegistrationManager';
-import { checkXTMHubConnectivity, loadAndSaveLatestNewsFeed } from '../../../src/domain/xtm-hub';
+import { autoRegisterOpenCTIOnStartup, checkXTMHubConnectivity, loadAndSaveLatestNewsFeed } from '../../../src/domain/xtm-hub';
+import { autoRegisterOnBoot, hubRegistrationManager } from '../../../src/manager/hubRegistrationManager';
 import { cleanOldNewsFeedItems } from '../../../src/modules/xtm/hub/news-feed/news-feed-domain';
 
+const mockAutoRegisterOpenCTIOnStartup = vi.mocked(autoRegisterOpenCTIOnStartup);
 const mockCleanOldNewsFeedItems = vi.mocked(cleanOldNewsFeedItems);
 const mockCheckXTMHubConnectivity = vi.mocked(checkXTMHubConnectivity);
 const mockLoadAndSaveLatestNewsFeed = vi.mocked(loadAndSaveLatestNewsFeed);
@@ -94,5 +101,24 @@ describe('hubRegistrationManager', () => {
     await hubRegistrationManager();
 
     expect(mockCleanOldNewsFeedItems).toHaveBeenCalledOnce();
+  });
+
+  it('should call startup auto-registration helper when triggered on boot', async () => {
+    mockAutoRegisterOpenCTIOnStartup.mockResolvedValue({ success: true });
+
+    await autoRegisterOnBoot('platform-token');
+
+    expect(mockAutoRegisterOpenCTIOnStartup).toHaveBeenCalledOnce();
+    expect(mockAutoRegisterOpenCTIOnStartup).toHaveBeenCalledWith(
+      {},
+      { id: 'hub-manager-user' },
+      'platform-token',
+    );
+  });
+
+  it('should not throw if startup auto-registration helper fails', async () => {
+    mockAutoRegisterOpenCTIOnStartup.mockRejectedValue(new Error('boot registration failed'));
+
+    await expect(autoRegisterOnBoot('platform-token')).resolves.toBeUndefined();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/xtm/xtm-hub-client-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/xtm/xtm-hub-client-test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import conf from '../../../../src/config/conf';
+import { getHubBackendUrl } from '../../../../src/modules/xtm/hub/xtm-hub-client';
+
+describe('xtm-hub-client', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getHubBackendUrl', () => {
+    it('should prefer override URL when both URLs are configured', () => {
+      vi.spyOn(conf, 'get').mockImplementation((key?: string) => {
+        if (key === 'xtm:xtmhub_api_override_url') return '  https://override.local  ';
+        if (key === 'xtm:xtmhub_url') return 'https://hub.local';
+        return undefined;
+      });
+
+      expect(getHubBackendUrl()).toBe('https://override.local');
+    });
+
+    it('should fallback to hub URL when override URL is empty', () => {
+      vi.spyOn(conf, 'get').mockImplementation((key?: string) => {
+        if (key === 'xtm:xtmhub_api_override_url') return '   ';
+        if (key === 'xtm:xtmhub_url') return '  https://hub.local  ';
+        return undefined;
+      });
+
+      expect(getHubBackendUrl()).toBe('https://hub.local');
+    });
+
+    it('should return undefined when both URLs are missing or blank', () => {
+      vi.spyOn(conf, 'get').mockImplementation((key?: string) => {
+        if (key === 'xtm:xtmhub_api_override_url') return undefined;
+        if (key === 'xtm:xtmhub_url') return '';
+        return undefined;
+      });
+
+      expect(getHubBackendUrl()).toBeUndefined();
+    });
+
+    it('should ignore non-string values', () => {
+      vi.spyOn(conf, 'get').mockImplementation((key?: string) => {
+        if (key === 'xtm:xtmhub_api_override_url') return 42;
+        if (key === 'xtm:xtmhub_url') return false;
+        return undefined;
+      });
+
+      expect(getHubBackendUrl()).toBeUndefined();
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import * as cache from '../../../src/database/cache';
-import { autoRegisterOpenCTI, checkXTMHubConnectivity, loadAndSaveLatestNewsFeed } from '../../../src/domain/xtm-hub';
+import { autoRegisterOpenCTI, autoRegisterOpenCTIOnStartup, checkXTMHubConnectivity, loadAndSaveLatestNewsFeed } from '../../../src/domain/xtm-hub';
 import { testContext } from '../../utils/testQuery';
 import { HUB_REGISTRATION_MANAGER_USER } from '../../../src/utils/access';
 import { type AutoRegisterInput, XtmHubRegistrationStatus } from '../../../src/generated/graphql';
@@ -370,6 +370,91 @@ describe('XTM hub', () => {
 
       await autoRegisterOpenCTI(testContext, HUB_REGISTRATION_MANAGER_USER, input);
       expect(settingsEditFieldSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('autoRegisterOpenCTIOnStartup', () => {
+    let autoRegisterSpy: MockInstance;
+    let isBackendReachableSpy: MockInstance;
+    let getEntityFromCacheSpy: MockInstance;
+    let getEntitiesListFromCacheSpy: MockInstance;
+    let settingsEditFieldSpy: MockInstance;
+    let confGetSpy: MockInstance;
+
+    beforeEach(() => {
+      autoRegisterSpy = vi.spyOn(xtmHubClient, 'autoRegister').mockResolvedValue({ success: true });
+      isBackendReachableSpy = vi.spyOn(xtmHubClient, 'isBackendReachable').mockResolvedValue({ isReachable: true });
+      getEntityFromCacheSpy = vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({
+        id: 'settings_id',
+        platform_url: 'https://opencti.local',
+        platform_title: 'OpenCTI',
+        xtm_hub_registration_status: XtmHubRegistrationStatus.Unregistered,
+      } as BasicStoreSettings);
+      getEntitiesListFromCacheSpy = vi.spyOn(cache, 'getEntitiesListFromCache').mockResolvedValue([]);
+      settingsEditFieldSpy = vi.spyOn(settingsModule, 'settingsEditField').mockResolvedValue({});
+      confGetSpy = vi.spyOn(conf.default, 'get').mockImplementation((key: string | undefined) => {
+        if (key === 'xtm:xtmhub_url') return 'https://hub.filigran.io';
+        return undefined;
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should skip startup auto-registration when already registered', async () => {
+      getEntityFromCacheSpy.mockResolvedValue({
+        id: 'settings_id',
+        xtm_hub_registration_status: XtmHubRegistrationStatus.Registered,
+      });
+
+      const result = await autoRegisterOpenCTIOnStartup(testContext, HUB_REGISTRATION_MANAGER_USER, 'test-token');
+
+      expect(result.success).toBe(false);
+      expect(isBackendReachableSpy).not.toHaveBeenCalled();
+      expect(autoRegisterSpy).not.toHaveBeenCalled();
+    });
+
+    it('should skip startup auto-registration when XTM Hub URL is not configured', async () => {
+      confGetSpy.mockImplementation((key: string) => {
+        if (key === 'xtm:xtmhub_url') return '';
+        return undefined;
+      });
+
+      const result = await autoRegisterOpenCTIOnStartup(testContext, HUB_REGISTRATION_MANAGER_USER, 'test-token');
+
+      expect(result.success).toBe(false);
+      expect(isBackendReachableSpy).not.toHaveBeenCalled();
+      expect(autoRegisterSpy).not.toHaveBeenCalled();
+    });
+
+    it('should skip startup auto-registration when XTM Hub backend is unreachable', async () => {
+      isBackendReachableSpy.mockResolvedValue({ isReachable: false });
+
+      const result = await autoRegisterOpenCTIOnStartup(testContext, HUB_REGISTRATION_MANAGER_USER, 'test-token');
+
+      expect(result.success).toBe(false);
+      expect(autoRegisterSpy).not.toHaveBeenCalled();
+      expect(settingsEditFieldSpy).not.toHaveBeenCalled();
+    });
+
+    it('should auto-register on startup when all guards pass', async () => {
+      const result = await autoRegisterOpenCTIOnStartup(testContext, HUB_REGISTRATION_MANAGER_USER, 'test-token');
+
+      expect(result.success).toBe(true);
+      expect(isBackendReachableSpy).toHaveBeenCalledOnce();
+      expect(autoRegisterSpy).toHaveBeenCalledWith(
+        {
+          platformId: 'settings_id',
+          platformToken: 'test-token',
+          platformUrl: 'https://opencti.local',
+          platformTitle: 'OpenCTI',
+        },
+        expect.any(String),
+        0,
+      );
+      expect(getEntitiesListFromCacheSpy).toHaveBeenCalled();
+      expect(settingsEditFieldSpy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
This PR adds a “boot-time” XTM Hub auto-registration flow so an OpenCTI instance can automatically register itself shortly after startup when a platform token is provided via an environment variable, aligning with the XTM Hub demo onboarding needs.

### Proposed changes

* Introduces autoRegisterOpenCTIOnStartup in the XTM Hub domain to run guarded auto-registration at startup.
* Adds a boot-time trigger in hubRegistrationManager (delayed setTimeout) when XTM_HUB_PLATFORM_TOKEN is set.
* Extends unit/integration test coverage for the new startup auto-registration behavior and boot trigger.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16676 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
