### PR TITLE
fix(workflow): fix draft author org + Creators (#16699)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/TransitionForm.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/TransitionForm.test.tsx
@@ -8,7 +8,6 @@ import { WorkflowActionType, CommentMode } from './utils';
 import type { WorkflowEditionFormValues } from './WorkflowEditionDrawer';
 import type { FilterGroup } from '../../../../../utils/filters/filtersHelpers-types';
 import useEnterpriseEdition from '../../../../../utils/hooks/useEnterpriseEdition';
-import { CREATOR_AUTHORIZED_CONFIG } from '../../../../../utils/authorizedMembers';
 
 // ---------------------------------------------------------------------------
 // Mock heavy sub-components with no relevance to the tested logic
@@ -222,7 +221,7 @@ describe('TransitionForm – action toggles', () => {
     });
   });
 
-  it('pre-populates CREATOR with admin access when toggling "Update authorized members" ON', async () => {
+  it('pre-populates CREATORS with admin access when toggling "Update authorized members" ON', async () => {
     const onSubmit = vi.fn();
     const { user } = renderForm({ event: 'approve', comment: CommentMode.disabled, syncActions: [] }, onSubmit);
 
@@ -235,7 +234,7 @@ describe('TransitionForm – action toggles', () => {
       const uamAction = actions.find((a) => a.type === WorkflowActionType.updateAuthorizedMembers);
       expect(uamAction?.params?.authorized_members).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ value: CREATOR_AUTHORIZED_CONFIG.id, accessRight: 'admin' }),
+          expect.objectContaining({ value: 'CREATORS', accessRight: 'admin' }),
         ]),
       );
     });

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/TransitionForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/TransitionForm.tsx
@@ -11,7 +11,6 @@ import WorkflowConditionFilters from './WorkflowConditionFilters';
 import { WorkflowEditionFormValues } from './WorkflowEditionDrawer';
 import WorkflowFieldList from './WorkflowFieldList';
 import { CommentMode, CommentModeType, FEATURE_NAME, WorkflowActionType, WorkflowDataType } from './utils';
-import { CREATOR_AUTHORIZED_CONFIG } from '../../../../../utils/authorizedMembers';
 
 const TransitionForm = () => {
   const { t_i18n } = useFormatter();
@@ -44,7 +43,7 @@ const TransitionForm = () => {
     const currentActions = values.syncActions ?? [];
     if (checked) {
       const newAction = actionType === WorkflowActionType.updateAuthorizedMembers
-        ? { type: actionType, params: { authorized_members: [{ label: 'Creator', type: CREATOR_AUTHORIZED_CONFIG.type, value: CREATOR_AUTHORIZED_CONFIG.id, accessRight: 'admin' as const, groupsRestriction: [] }] } }
+        ? { type: actionType, params: { authorized_members: [{ label: 'Creators', type: 'Dynamic options', value: 'CREATORS', accessRight: 'admin' as const, groupsRestriction: [] }] } }
         : { type: actionType };
       setFieldValue('syncActions', [...currentActions, newAction]);
     } else {

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/WorkflowFieldItem.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/workflow/WorkflowFieldItem.tsx
@@ -20,7 +20,6 @@ const WorkflowFieldItem = ({ field, isCondition }: WorkflowFieldItemProps) => {
         name={`${name}.params.authorized_members`}
         component={AuthorizedMembersField}
         showAllMembersLine
-        showCreatorLine
         withDynamicKeys
         allowDynamicGroupsRestriction
         dynamicContextTypeLabel="Dynamic from draft"

--- a/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
@@ -332,6 +332,7 @@ const makeCompositeKey = (id: string, groupsRestrictionIds: string[] | undefined
 export const resolveAuthorizedMembersForDraft = (
   user: AuthUser,
   rawRules: unknown[],
+  createdBy: string | null = null,
 ): MemberAccessInput[] => {
   const authorizedMembersMap = new Map<string, MemberAccessInput>();
   rawRules.forEach((rule) => {
@@ -355,19 +356,16 @@ export const resolveAuthorizedMembersForDraft = (
     }
 
     if (value === 'AUTHOR') {
-      if (user.organizations) {
-        user.organizations.forEach((org) => {
-          // Each (org, groupsRestriction) combination is a separate entry so that
-          // e.g. "Org A + analyst → edit" and "Org A + manager → view" are kept distinct.
-          const key = makeCompositeKey(org.internal_id, groupsRestrictionIds);
-          if (!authorizedMembersMap.has(key)) {
-            authorizedMembersMap.set(key, {
-              id: org.internal_id,
-              access_right: accessRight,
-              groups_restriction_ids: groupsRestrictionIds,
-            });
-          }
-        });
+      if (createdBy) {
+        // AUTHOR resolves to the STIX author of the draft (the createdBy entity, typically an Organization).
+        const key = makeCompositeKey(createdBy, groupsRestrictionIds);
+        if (!authorizedMembersMap.has(key)) {
+          authorizedMembersMap.set(key, {
+            id: createdBy,
+            access_right: accessRight,
+            groups_restriction_ids: groupsRestrictionIds,
+          });
+        }
       }
       return;
     }
@@ -489,9 +487,9 @@ export const formSubmit = async (
       const canOverrideAuthorizedMembers = isFormIntakeDefaultsEnabled && (isBypass || schema.draftDefaults?.authorizedMembers?.isEditable);
       let authorized_members: MemberAccessInput[] = [];
       if (canOverrideAuthorizedMembers && Array.isArray(values.draftAuthorizedMembers)) {
-        authorized_members = resolveAuthorizedMembersForDraft(user, values.draftAuthorizedMembers);
+        authorized_members = resolveAuthorizedMembersForDraft(user, values.draftAuthorizedMembers, createdBy);
       } else if (isFormIntakeDefaultsEnabled && schema.draftDefaults?.authorizedMembers?.enabled && schema.draftDefaults.authorizedMembers.defaults) {
-        authorized_members = resolveAuthorizedMembersForDraft(user, schema.draftDefaults.authorizedMembers.defaults);
+        authorized_members = resolveAuthorizedMembersForDraft(user, schema.draftDefaults.authorizedMembers.defaults, createdBy);
       }
 
       const draftInput: DraftWorkspaceAddInput & { bypassMandatoryAttributes?: boolean } = {

--- a/opencti-platform/opencti-graphql/src/modules/workflow/registry/workflow-actions.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/registry/workflow-actions.ts
@@ -6,33 +6,26 @@ import { z } from 'zod';
 import { editAuthorizedMembers } from '../../../utils/authorizedMembers';
 import type { MemberAccessInput } from '../../../generated/graphql';
 import { KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS } from '../../../utils/access';
-import { storeLoadById } from '../../../database/middleware-loader';
-import { RELATION_OBJECT_ASSIGNEE, RELATION_OBJECT_PARTICIPANT } from '../../../schema/stixRefRelationship';
-import { RELATION_PARTICIPATE_TO } from '../../../schema/internalRelationship';
-import type { BasicOrganizationEntity } from '../../../types/store';
+import { RELATION_CREATED_BY, RELATION_OBJECT_ASSIGNEE, RELATION_OBJECT_PARTICIPANT } from '../../../schema/stixRefRelationship';
 
 /**
  * Resolves dynamic authorized member keys (AUTHOR, CREATORS, ASSIGNEES, PARTICIPANTS)
  */
-const resolveDynamicAuthorizedMembers = async (
-  context: any,
-  user: any,
+const resolveDynamicAuthorizedMembers = (
   entity: any,
   rawMembers: Array<{ id: string; access_right: string; groups_restriction_ids?: string[] }>,
-): Promise<MemberAccessInput[]> => {
+): MemberAccessInput[] => {
   const resolved: MemberAccessInput[] = [];
   for (const member of rawMembers) {
     const { id, access_right, groups_restriction_ids } = member;
     if (id === 'AUTHOR') {
-      // It resolves to the organization of the draft author
-      const creatorIds: string[] = Array.isArray(entity.creator_id)
-        ? entity.creator_id
-        : (entity.creator_id ? [entity.creator_id] : []);
-      for (const creatorId of creatorIds) {
-        const userEntity = await storeLoadById<BasicOrganizationEntity>(context, user, creatorId, 'Basic-Object').catch(() => null);
-        for (const orgId of userEntity?.[RELATION_PARTICIPATE_TO] ?? []) {
-          resolved.push({ id: orgId, access_right, groups_restriction_ids });
-        }
+      // AUTHOR resolves to the STIX author of the draft (the createdBy entity, typically an Organization).
+      const createdByRef = entity[RELATION_CREATED_BY];
+      const createdByIds: string[] = Array.isArray(createdByRef)
+        ? createdByRef
+        : (createdByRef ? [createdByRef] : []);
+      for (const authorId of createdByIds) {
+        if (authorId) resolved.push({ id: authorId, access_right, groups_restriction_ids });
       }
     } else if (id === 'CREATORS') {
       const creatorIds: string[] = Array.isArray(entity.creator_id)
@@ -96,7 +89,7 @@ export const ActionRegistry: Record<string, ActionFunction> = {
   updateAuthorizedMembers: async (executionContext, params) => {
     const { entity, context, user } = executionContext;
     const rawMembers: Array<{ id: string; access_right: string; groups_restriction_ids?: string[] }> = params?.authorized_members ?? [];
-    const resolvedMembers = await resolveDynamicAuthorizedMembers(context, user, entity, rawMembers);
+    const resolvedMembers = resolveDynamicAuthorizedMembers(entity, rawMembers);
 
     if (entity?.entity_type === 'DraftWorkspace') {
       await draftWorkspaceEditAuthorizedMembers(context, user, entity.id, resolvedMembers);

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/form-draft-defaults-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/form-draft-defaults-test.ts
@@ -229,21 +229,20 @@ describe('resolveAuthorizedMembersForDraft', () => {
     expect(result).toContainEqual({ id: 'org-a', access_right: 'view', groups_restriction_ids: ['group-analyst'] });
   });
 
-  it('should produce separate AUTHOR entries per org when multiple orgs have different restrictions', () => {
-    const user = makeUser([{ internal_id: 'org-a' }, { internal_id: 'org-b' }]);
+  it('should produce separate AUTHOR entries per group restriction for the createdBy org', () => {
+    const user = makeUser();
+    const createdBy = 'org-a';
     const rules = [
       { type: 'AUTHOR_ORG', intersectionGroup: 'group-analyst' },
       { type: 'AUTHOR_ORG', intersectionGroup: 'group-manager' },
     ];
 
-    const result = resolveAuthorizedMembersForDraft(user, rules);
+    const result = resolveAuthorizedMembersForDraft(user, rules, createdBy);
 
-    // Each org gets two entries (one per group restriction)
-    expect(result).toHaveLength(4);
+    // Each group restriction produces a separate entry for the createdBy org
+    expect(result).toHaveLength(2);
     expect(result).toContainEqual({ id: 'org-a', access_right: 'admin', groups_restriction_ids: ['group-analyst'] });
     expect(result).toContainEqual({ id: 'org-a', access_right: 'admin', groups_restriction_ids: ['group-manager'] });
-    expect(result).toContainEqual({ id: 'org-b', access_right: 'admin', groups_restriction_ids: ['group-analyst'] });
-    expect(result).toContainEqual({ id: 'org-b', access_right: 'admin', groups_restriction_ids: ['group-manager'] });
   });
 
   it('should always produce a single unrestricted CREATORS entry regardless of duplicates', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/form-submit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/form-submit-test.ts
@@ -137,10 +137,6 @@ describe('formSubmit', () => {
 
   it('should resolve authorized members with intersection logic', async () => {
     const orgId = 'org-1';
-    const userWithOrg = {
-      ...mockUser,
-      organizations: [{ internal_id: orgId }],
-    };
 
     const input = {
       formId: 'form-1',
@@ -154,6 +150,7 @@ describe('formSubmit', () => {
       ],
       mainEntityType: 'Individual',
       draftDefaults: {
+        author: { type: 'static', defaultValue: orgId, isEditable: false },
         authorizedMembers: {
           enabled: true,
           defaults: [
@@ -164,7 +161,7 @@ describe('formSubmit', () => {
     });
     mockStoreLoadById.mockResolvedValue(form);
 
-    await formSubmit(mockContext, userWithOrg, input, true);
+    await formSubmit(mockContext, mockUser, input, true);
 
     expect(draftWorkspaceDomain.addDraftWorkspace).toHaveBeenCalledWith(
       expect.anything(),
@@ -182,10 +179,6 @@ describe('formSubmit', () => {
 
   it('should resolve dynamic authorized members logic (AUTHOR)', async () => {
     const orgId = 'org-1';
-    const userWithOrg = {
-      ...mockUser,
-      organizations: [{ internal_id: orgId }],
-    };
 
     const input = {
       formId: 'form-1',
@@ -199,6 +192,7 @@ describe('formSubmit', () => {
       ],
       mainEntityType: 'Individual',
       draftDefaults: {
+        author: { type: 'static', defaultValue: orgId, isEditable: false },
         authorizedMembers: {
           enabled: true,
           defaults: [
@@ -209,7 +203,7 @@ describe('formSubmit', () => {
     });
     mockStoreLoadById.mockResolvedValue(form);
 
-    await formSubmit(mockContext, userWithOrg, input, true);
+    await formSubmit(mockContext, mockUser, input, true);
 
     expect(draftWorkspaceDomain.addDraftWorkspace).toHaveBeenCalledWith(
       expect.anything(),
@@ -269,10 +263,6 @@ describe('formSubmit', () => {
 
   it('should resolve groupsRestriction from id entries in schema defaults', async () => {
     const orgId = 'org-1';
-    const userWithOrg = {
-      ...mockUser,
-      organizations: [{ internal_id: orgId }],
-    };
 
     const input = {
       formId: 'form-1',
@@ -286,6 +276,7 @@ describe('formSubmit', () => {
       ],
       mainEntityType: 'Individual',
       draftDefaults: {
+        author: { type: 'static', defaultValue: orgId, isEditable: false },
         authorizedMembers: {
           enabled: true,
           defaults: [
@@ -296,7 +287,7 @@ describe('formSubmit', () => {
     });
     mockStoreLoadById.mockResolvedValue(form);
 
-    await formSubmit(mockContext, userWithOrg, input, true);
+    await formSubmit(mockContext, mockUser, input, true);
 
     expect(draftWorkspaceDomain.addDraftWorkspace).toHaveBeenCalledWith(
       expect.anything(),

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-actions-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-actions-test.ts
@@ -17,12 +17,9 @@ vi.mock('../../../src/config/conf', () => ({
 // Mock schema constants to prevent loading attribute-definition.ts which
 // transitively needs TEST_MODE, BUS_TOPICS, etc. from conf.
 vi.mock('../../../src/schema/stixRefRelationship', () => ({
+  RELATION_CREATED_BY: 'created-by',
   RELATION_OBJECT_ASSIGNEE: 'object-assignee',
   RELATION_OBJECT_PARTICIPANT: 'object-participant',
-}));
-
-vi.mock('../../../src/schema/internalRelationship', () => ({
-  RELATION_PARTICIPATE_TO: 'participate-to',
 }));
 
 vi.mock('../../../src/utils/authorizedMembers', () => ({
@@ -31,12 +28,6 @@ vi.mock('../../../src/utils/authorizedMembers', () => ({
 
 vi.mock('../../../src/utils/access', () => ({
   KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS: 'KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS',
-}));
-
-// storeLoadById is used to resolve the AUTHOR entity type.
-// Each test that needs AUTHOR resolution will configure the return value.
-vi.mock('../../../src/database/middleware-loader', () => ({
-  storeLoadById: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -196,7 +187,6 @@ describe('ActionRegistry.updateAuthorizedMembers (AUTHOR)', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.doMock('../../../src/utils/authorizedMembers', () => ({ editAuthorizedMembers: vi.fn() }));
-    vi.doMock('../../../src/database/middleware-loader', () => ({ storeLoadById: vi.fn() }));
     vi.doMock('../../../src/modules/draftWorkspace/draftWorkspace-domain', () => ({
       validateDraftWorkspace: vi.fn(),
       draftWorkspaceEditAuthorizedMembers: vi.fn(),
@@ -207,6 +197,11 @@ describe('ActionRegistry.updateAuthorizedMembers (AUTHOR)', () => {
     });
     vi.doMock('../../../src/schema/identifier', () => ({ generateInternalId: vi.fn() }));
     vi.doMock('../../../src/utils/access', () => ({ KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS: 'KNMANAGEAUTHMEMBERS' }));
+    vi.doMock('../../../src/schema/stixRefRelationship', () => ({
+      RELATION_CREATED_BY: 'created-by',
+      RELATION_OBJECT_ASSIGNEE: 'object-assignee',
+      RELATION_OBJECT_PARTICIPANT: 'object-participant',
+    }));
     const mod = await import('../../../src/modules/workflow/registry/workflow-actions');
     freshRegistry = mod.ActionRegistry as any;
   });
@@ -222,75 +217,23 @@ describe('ActionRegistry.updateAuthorizedMembers (AUTHOR)', () => {
     context: {},
   });
 
-  it('pushes only the participate-to org IDs for AUTHOR (not the creator itself)', async () => {
-    const { storeLoadById } = await import('../../../src/database/middleware-loader');
+  it('resolves AUTHOR to the createdBy entity ID (string)', async () => {
     const { editAuthorizedMembers } = await import('../../../src/utils/authorizedMembers');
-    vi.mocked(storeLoadById).mockResolvedValue({ 'participate-to': ['org-id'] } as any);
-
-    const ctx = makeUpdateCtx({ creator_id: 'creator-user-id' });
+    const ctx = makeUpdateCtx({ 'created-by': 'org-id' });
     await freshRegistry.updateAuthorizedMembers(ctx, {
       authorized_members: [{ id: 'AUTHOR', access_right: 'edit', groups_restriction_ids: ['group-1'] }],
     });
     expect(editAuthorizedMembers).toHaveBeenCalledWith(
       ctx.context, ctx.user,
       expect.objectContaining({
-        input: [
-          { id: 'org-id', access_right: 'edit', groups_restriction_ids: ['group-1'] },
-        ],
+        input: [{ id: 'org-id', access_right: 'edit', groups_restriction_ids: ['group-1'] }],
       }),
     );
   });
 
-  it('produces empty resolved list when creator has no participate-to orgs', async () => {
-    const { storeLoadById } = await import('../../../src/database/middleware-loader');
+  it('resolves AUTHOR to all IDs when createdBy is an array', async () => {
     const { editAuthorizedMembers } = await import('../../../src/utils/authorizedMembers');
-    vi.mocked(storeLoadById).mockResolvedValue({} as any);
-
-    const ctx = makeUpdateCtx({ creator_id: 'creator-user-id' });
-    await freshRegistry.updateAuthorizedMembers(ctx, {
-      authorized_members: [{ id: 'AUTHOR', access_right: 'edit', groups_restriction_ids: [] }],
-    });
-    expect(editAuthorizedMembers).toHaveBeenCalledWith(
-      ctx.context, ctx.user,
-      expect.objectContaining({ input: [] }),
-    );
-  });
-
-  it('produces empty resolved list when creator_id is absent', async () => {
-    const { editAuthorizedMembers } = await import('../../../src/utils/authorizedMembers');
-    const ctx = makeUpdateCtx(); // no creator_id
-    await freshRegistry.updateAuthorizedMembers(ctx, {
-      authorized_members: [{ id: 'AUTHOR', access_right: 'admin', groups_restriction_ids: [] }],
-    });
-    expect(editAuthorizedMembers).toHaveBeenCalledWith(
-      ctx.context, ctx.user,
-      expect.objectContaining({ input: [] }),
-    );
-  });
-
-  it('produces empty resolved list when storeLoadById rejects', async () => {
-    const { storeLoadById } = await import('../../../src/database/middleware-loader');
-    const { editAuthorizedMembers } = await import('../../../src/utils/authorizedMembers');
-    vi.mocked(storeLoadById).mockRejectedValue(new Error('DB unavailable'));
-
-    const ctx = makeUpdateCtx({ creator_id: 'some-id' });
-    await freshRegistry.updateAuthorizedMembers(ctx, {
-      authorized_members: [{ id: 'AUTHOR', access_right: 'edit', groups_restriction_ids: [] }],
-    });
-    expect(editAuthorizedMembers).toHaveBeenCalledWith(
-      ctx.context, ctx.user,
-      expect.objectContaining({ input: [] }),
-    );
-  });
-
-  it('handles an array of creator_ids and accumulates all orgs', async () => {
-    const { storeLoadById } = await import('../../../src/database/middleware-loader');
-    const { editAuthorizedMembers } = await import('../../../src/utils/authorizedMembers');
-    vi.mocked(storeLoadById)
-      .mockResolvedValueOnce({ 'participate-to': ['org-a'] } as any)
-      .mockResolvedValueOnce({ 'participate-to': ['org-b'] } as any);
-
-    const ctx = makeUpdateCtx({ creator_id: ['user-1', 'user-2'] });
+    const ctx = makeUpdateCtx({ 'created-by': ['org-a', 'org-b'] });
     await freshRegistry.updateAuthorizedMembers(ctx, {
       authorized_members: [{ id: 'AUTHOR', access_right: 'view', groups_restriction_ids: [] }],
     });
@@ -302,6 +245,18 @@ describe('ActionRegistry.updateAuthorizedMembers (AUTHOR)', () => {
           { id: 'org-b', access_right: 'view', groups_restriction_ids: [] },
         ],
       }),
+    );
+  });
+
+  it('produces empty resolved list when createdBy is absent', async () => {
+    const { editAuthorizedMembers } = await import('../../../src/utils/authorizedMembers');
+    const ctx = makeUpdateCtx(); // no 'created-by' field
+    await freshRegistry.updateAuthorizedMembers(ctx, {
+      authorized_members: [{ id: 'AUTHOR', access_right: 'admin', groups_restriction_ids: [] }],
+    });
+    expect(editAuthorizedMembers).toHaveBeenCalledWith(
+      ctx.context, ctx.user,
+      expect.objectContaining({ input: [] }),
     );
   });
 });
@@ -316,7 +271,7 @@ describe('ActionRegistry.updateAuthorizedMembers (CREATORS)', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.doMock('../../../src/utils/authorizedMembers', () => ({ editAuthorizedMembers: vi.fn() }));
-    vi.doMock('../../../src/database/middleware-loader', () => ({ storeLoadById: vi.fn() }));
+    vi.doMock('../../../src/schema/stixRefRelationship', () => ({ RELATION_CREATED_BY: 'created-by', RELATION_OBJECT_ASSIGNEE: 'object-assignee', RELATION_OBJECT_PARTICIPANT: 'object-participant' }));
     vi.doMock('../../../src/modules/draftWorkspace/draftWorkspace-domain', () => ({
       validateDraftWorkspace: vi.fn(),
       draftWorkspaceEditAuthorizedMembers: vi.fn(),
@@ -396,7 +351,7 @@ describe('ActionRegistry.updateAuthorizedMembers (ASSIGNEES)', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.doMock('../../../src/utils/authorizedMembers', () => ({ editAuthorizedMembers: vi.fn() }));
-    vi.doMock('../../../src/database/middleware-loader', () => ({ storeLoadById: vi.fn() }));
+    vi.doMock('../../../src/schema/stixRefRelationship', () => ({ RELATION_CREATED_BY: 'created-by', RELATION_OBJECT_ASSIGNEE: 'object-assignee', RELATION_OBJECT_PARTICIPANT: 'object-participant' }));
     vi.doMock('../../../src/modules/draftWorkspace/draftWorkspace-domain', () => ({
       validateDraftWorkspace: vi.fn(),
       draftWorkspaceEditAuthorizedMembers: vi.fn(),
@@ -477,7 +432,7 @@ describe('ActionRegistry.updateAuthorizedMembers (PARTICIPANTS)', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.doMock('../../../src/utils/authorizedMembers', () => ({ editAuthorizedMembers: vi.fn() }));
-    vi.doMock('../../../src/database/middleware-loader', () => ({ storeLoadById: vi.fn() }));
+    vi.doMock('../../../src/schema/stixRefRelationship', () => ({ RELATION_CREATED_BY: 'created-by', RELATION_OBJECT_ASSIGNEE: 'object-assignee', RELATION_OBJECT_PARTICIPANT: 'object-participant' }));
     vi.doMock('../../../src/modules/draftWorkspace/draftWorkspace-domain', () => ({
       validateDraftWorkspace: vi.fn(),
       draftWorkspaceEditAuthorizedMembers: vi.fn(),
@@ -569,7 +524,7 @@ describe('ActionRegistry.validateDraft', () => {
       return { ...actual, logApp: { info: vi.fn(), error: vi.fn(), warn: vi.fn() } };
     });
     vi.doMock('../../../src/utils/authorizedMembers', () => ({ editAuthorizedMembers: vi.fn() }));
-    vi.doMock('../../../src/database/middleware-loader', () => ({ storeLoadById: vi.fn() }));
+    vi.doMock('../../../src/schema/stixRefRelationship', () => ({ RELATION_CREATED_BY: 'created-by', RELATION_OBJECT_ASSIGNEE: 'object-assignee', RELATION_OBJECT_PARTICIPANT: 'object-participant' }));
     vi.doMock('../../../src/schema/identifier', () => ({ generateInternalId: vi.fn() }));
     vi.doMock('../../../src/utils/access', () => ({ KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS: 'KNMANAGEAUTHMEMBERS' }));
     const mod = await import('../../../src/modules/workflow/registry/workflow-actions');


### PR DESCRIPTION
### Proposed changes

* The AM `draft author (org)`target the `author` and not `creator` anymore
* Replace the `Creator` key by the right `Creators` key in AM in workflow transition form

### Related issues

* closes #16699 

### How to test this PR

Workflow transition :
- Create a draft workflow in Settings / Customization / Draft
- Add 2 status to have a transition
- Enable AM on this transition => See `Creators` and not `Creator` on the list
- NOT MANDATORY : Give "can manage" to "everyone" to simplify your tests
- Add `draft author (org)` in the list and select a group
- Create a draft
- Add an Organisation as Author
- Click on the transition
- After a delay, check AM => See the organisation with the selected group

Form intake
- Create a Form Intake in Data / ingestion / Form intake
- Select "Report" entity type
- Enable "create as draft by default"
- In "advanced draft settings" / draft Author
  - Select "Main entity author"
  - Enable "Activate access restriction"
  - Select "draft author (org)"
- in the bottom, Click on "Add field"
- "Map to attribute" : select "created by" (this is the author of the report -the main entity-)
- Create the form intake
- Click on it on the list to open the form
- Give a name and an author on created by
- Keep empty the "draft author" field
- Submit
- In the new draft created, check the AM
- You must to see your organisation gave in the "created by" field of the report

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality