### PR TITLE
fix(draft-diff-panel): draft review panel not accessible without manage customization (#16706)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/DraftReviewDiffPanelContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/DraftReviewDiffPanelContent.tsx
@@ -24,7 +24,7 @@ const draftReviewDiffPanelContentQuery = graphql`
   query DraftReviewDiffPanelContentQuery($entityType: String!) {
     subType(id: $entityType) {
       settings {
-        attributesDefinitions {
+        attributeLabels {
           name
           label
         }
@@ -52,7 +52,7 @@ const DraftReviewDiffPanelContentComponent: FunctionComponent<DraftReviewDiffPan
     queryRef,
   );
 
-  const labelMap = buildFieldLabelMap(subTypeData.subType?.settings?.attributesDefinitions);
+  const labelMap = buildFieldLabelMap(subTypeData.subType?.settings?.attributeLabels);
 
   const renderHeader = () => {
     const link = resolveLink(entity.entity_type);

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/DraftReviewDiffPanelContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftReviewDiffPanel/DraftReviewDiffPanelContent.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent, Suspense } from 'react';
-import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
@@ -11,48 +10,28 @@ import { resolveLink } from '../../../../utils/Entity';
 import { containerTypes } from '../../../../utils/hooks/useAttributes';
 import { ErrorBoundary } from '../../Error';
 import { DraftEntitySelection } from '../DraftReviewEntityList';
-import { DraftReviewDiffPanelContentQuery } from './__generated__/DraftReviewDiffPanelContentQuery.graphql';
-import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
 import { buildFieldLabelMap, parseUpdatesPatch, RenderChangeValuesFn } from './draftReviewDiffPanelUtils';
 import ContainerObjectsTab from './ContainerObjectsTab';
 import EntityRelationsTab from './EntityRelationsTab';
 import EntityContainerRefsTab from './EntityContainerRefsTab';
 import DraftReviewResolvedChanges from './DraftReviewResolvedChanges';
 import DraftReviewEntityFields from './DraftReviewEntityFields';
-
-const draftReviewDiffPanelContentQuery = graphql`
-  query DraftReviewDiffPanelContentQuery($entityType: String!) {
-    subType(id: $entityType) {
-      settings {
-        attributeLabels {
-          name
-          label
-        }
-      }
-    }
-  }
-`;
+import useEntitySettings from '../../../../utils/hooks/useEntitySettings';
 
 interface DraftReviewDiffPanelContentComponentProps {
-  queryRef: PreloadedQuery<DraftReviewDiffPanelContentQuery>;
   draftId: string;
   entity: DraftEntitySelection;
 }
 
 const DraftReviewDiffPanelContentComponent: FunctionComponent<DraftReviewDiffPanelContentComponentProps> = ({
-  queryRef,
   draftId,
   entity,
 }) => {
   const { t_i18n } = useFormatter();
   const entityId = entity.id;
 
-  const subTypeData = usePreloadedQuery<DraftReviewDiffPanelContentQuery>(
-    draftReviewDiffPanelContentQuery,
-    queryRef,
-  );
-
-  const labelMap = buildFieldLabelMap(subTypeData.subType?.settings?.attributeLabels);
+  const entitySettings = useEntitySettings(entity.entity_type);
+  const labelMap = buildFieldLabelMap(entitySettings[0]?.attributeLabels);
 
   const renderHeader = () => {
     const link = resolveLink(entity.entity_type);
@@ -209,15 +188,9 @@ interface DraftReviewDiffPanelContentProps {
 }
 
 const DraftReviewDiffPanelContent: FunctionComponent<DraftReviewDiffPanelContentProps> = ({ draftId, entity }) => {
-  const queryRef = useQueryLoading<DraftReviewDiffPanelContentQuery>(
-    draftReviewDiffPanelContentQuery,
-    { entityType: entity.entity_type },
-  );
   return (
     <Suspense fallback={<Loader />}>
-      {queryRef && (
-        <DraftReviewDiffPanelContentComponent queryRef={queryRef} draftId={draftId} entity={entity} />
-      )}
+      <DraftReviewDiffPanelContentComponent draftId={draftId} entity={entity} />
     </Suspense>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingsFragment.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingsFragment.ts
@@ -26,6 +26,10 @@ export const entitySettingsFragment = graphql`
       width
       label
     }
+    attributeLabels {
+      name
+      label
+    }
     requestAccessConfiguration {
       id
       approval_admin {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10836,6 +10836,7 @@ type EntitySetting implements InternalObject & BasicObject {
   enforce_reference: Boolean
   attributes_configuration: String
   attributesDefinitions: [TypeAttribute!]!
+  attributeLabels: [AttributeLabel!]!
   mandatoryAttributes: [String!]!
   scaleAttributes: [ScaleAttribute!]!
   defaultValuesAttributes: [DefaultValueAttribute!]!
@@ -13099,6 +13100,11 @@ type TypeAttribute {
   label: String
   defaultValues: [DefaultValue!]
   scale: String
+}
+
+type AttributeLabel {
+  name: String!
+  label: String
 }
 
 type ScaleAttribute {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -1380,6 +1380,12 @@ export type AttributeEditMutationsFieldPatchArgs = {
   input: Array<InputMaybe<EditInput>>;
 };
 
+export type AttributeLabel = {
+  __typename?: 'AttributeLabel';
+  label?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+};
+
 export type AttributePath = {
   __typename?: 'AttributePath';
   configuration?: Maybe<AttributeColumnConfiguration>;
@@ -8721,6 +8727,7 @@ export enum EmailTemplateOrdering {
 
 export type EntitySetting = BasicObject & InternalObject & {
   __typename?: 'EntitySetting';
+  attributeLabels: Array<AttributeLabel>;
   attributesDefinitions: Array<TypeAttribute>;
   attributes_configuration?: Maybe<Scalars['String']['output']>;
   availableSettings: Array<Scalars['String']['output']>;
@@ -39354,6 +39361,7 @@ export type ResolversTypes = ResolversObject<{
   AttributeConnection: ResolverTypeWrapper<AttributeConnection>;
   AttributeEdge: ResolverTypeWrapper<AttributeEdge>;
   AttributeEditMutations: ResolverTypeWrapper<AttributeEditMutations>;
+  AttributeLabel: ResolverTypeWrapper<AttributeLabel>;
   AttributePath: ResolverTypeWrapper<AttributePath>;
   AttributeRef: ResolverTypeWrapper<AttributeRef>;
   AttributeRefInput: AttributeRefInput;
@@ -40498,6 +40506,7 @@ export type ResolversParentTypes = ResolversObject<{
   AttributeConnection: AttributeConnection;
   AttributeEdge: AttributeEdge;
   AttributeEditMutations: AttributeEditMutations;
+  AttributeLabel: AttributeLabel;
   AttributePath: AttributePath;
   AttributeRef: AttributeRef;
   AttributeRefInput: AttributeRefInput;
@@ -41912,6 +41921,11 @@ export type AttributeEdgeResolvers<ContextType = any, ParentType extends Resolve
 export type AttributeEditMutationsResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttributeEditMutations'] = ResolversParentTypes['AttributeEditMutations']> = ResolversObject<{
   delete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   fieldPatch?: Resolver<Maybe<ResolversTypes['Attribute']>, ParentType, ContextType, RequireFields<AttributeEditMutationsFieldPatchArgs, 'input'>>;
+}>;
+
+export type AttributeLabelResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttributeLabel'] = ResolversParentTypes['AttributeLabel']> = ResolversObject<{
+  label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
 export type AttributePathResolvers<ContextType = any, ParentType extends ResolversParentTypes['AttributePath'] = ResolversParentTypes['AttributePath']> = ResolversObject<{
@@ -44323,6 +44337,7 @@ export type EmailTemplateEdgeResolvers<ContextType = any, ParentType extends Res
 }>;
 
 export type EntitySettingResolvers<ContextType = any, ParentType extends ResolversParentTypes['EntitySetting'] = ResolversParentTypes['EntitySetting']> = ResolversObject<{
+  attributeLabels?: Resolver<Array<ResolversTypes['AttributeLabel']>, ParentType, ContextType>;
   attributesDefinitions?: Resolver<Array<ResolversTypes['TypeAttribute']>, ParentType, ContextType>;
   attributes_configuration?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   availableSettings?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
@@ -53068,6 +53083,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   AttributeConnection?: AttributeConnectionResolvers<ContextType>;
   AttributeEdge?: AttributeEdgeResolvers<ContextType>;
   AttributeEditMutations?: AttributeEditMutationsResolvers<ContextType>;
+  AttributeLabel?: AttributeLabelResolvers<ContextType>;
   AttributePath?: AttributePathResolvers<ContextType>;
   AttributeRef?: AttributeRefResolvers<ContextType>;
   AttributesMap?: AttributesMapResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-domain.ts
@@ -16,6 +16,8 @@ import { INPUT_AUTHORIZED_MEMBERS } from '../../schema/general';
 import { containsValidAdmin } from '../../utils/authorizedMembers';
 import { FunctionalError } from '../../config/errors';
 import { getEntitySettingSchemaAttributes, getMandatoryAttributesForSetting } from './entitySetting-attributeUtils';
+import { schemaAttributesDefinition } from '../../schema/schema-attributes';
+import { schemaRelationsRefDefinition } from '../../schema/schema-relationsRef';
 import { schemaOverviewLayoutCustomization } from '../../schema/schema-overviewLayoutCustomization';
 import { canViewTemplates } from '../fintelTemplate/fintelTemplate-domain';
 import { type BasicStoreEntityFintelTemplate, ENTITY_TYPE_FINTEL_TEMPLATE } from '../fintelTemplate/fintelTemplate-types';
@@ -169,13 +171,18 @@ export const queryEntitySettingSchemaAttributes = async (
   return getEntitySettingSchemaAttributes(context, user, entitySetting);
 };
 
-export const queryEntitySettingAttributeLabels = async (
-  context: AuthContext,
-  user: AuthUser,
+export const queryEntitySettingAttributeLabels = (
   entitySetting: BasicStoreEntityEntitySetting,
-): Promise<{ name: string; label: string | null }[]> => {
-  const attributes = await getEntitySettingSchemaAttributes(context, user, entitySetting);
-  return attributes.map((a) => ({ name: a.name, label: a.label ?? null }));
+): { name: string; label: string | null }[] => {
+  if (!entitySetting) return [];
+  const { target_type } = entitySetting;
+  const attrsFromSchema = Array.from(schemaAttributesDefinition.getAttributes(target_type).values())
+    .filter((attr) => attr.editDefault || attr.mandatoryType === 'external' || attr.mandatoryType === 'customizable')
+    .map((attr) => ({ name: attr.name, label: attr.label ?? null }));
+  const attrsFromRefs = Array.from(schemaRelationsRefDefinition.getRelationsRef(target_type).values())
+    .filter((ref) => ref.mandatoryType === 'external' || ref.mandatoryType === 'customizable')
+    .map((ref) => ({ name: ref.name, label: ref.label ?? null }));
+  return [...attrsFromSchema, ...attrsFromRefs];
 };
 
 export const queryScaleAttributesForSetting = async (

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-domain.ts
@@ -169,6 +169,15 @@ export const queryEntitySettingSchemaAttributes = async (
   return getEntitySettingSchemaAttributes(context, user, entitySetting);
 };
 
+export const queryEntitySettingAttributeLabels = async (
+  context: AuthContext,
+  user: AuthUser,
+  entitySetting: BasicStoreEntityEntitySetting,
+): Promise<{ name: string; label: string | null }[]> => {
+  const attributes = await getEntitySettingSchemaAttributes(context, user, entitySetting);
+  return attributes.map((a) => ({ name: a.name, label: a.label ?? null }));
+};
+
 export const queryScaleAttributesForSetting = async (
   context: AuthContext,
   user: AuthUser,

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-resolvers.ts
@@ -26,7 +26,7 @@ const entitySettingResolvers: Resolvers = {
   },
   EntitySetting: {
     attributesDefinitions: (entitySetting, _, context) => queryEntitySettingSchemaAttributes(context, context.user, entitySetting),
-    attributeLabels: (entitySetting, _, context) => queryEntitySettingAttributeLabels(context, context.user, entitySetting),
+    attributeLabels: (entitySetting) => queryEntitySettingAttributeLabels(entitySetting),
     mandatoryAttributes: (entitySetting, _, context) => queryMandatoryAttributesForSetting(context, context.user, entitySetting),
     scaleAttributes: (entitySetting, _, context) => queryScaleAttributesForSetting(context, context.user, entitySetting),
     defaultValuesAttributes: (entitySetting, _, context) => queryDefaultValuesAttributesForSetting(context, context.user, entitySetting),

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting-resolvers.ts
@@ -7,6 +7,7 @@ import {
   getTemplatesForSetting,
   queryDefaultValuesAttributesForSetting,
   queryEntitySettingSchemaAttributes,
+  queryEntitySettingAttributeLabels,
   queryMandatoryAttributesForSetting,
   queryScaleAttributesForSetting,
 } from './entitySetting-domain';
@@ -25,6 +26,7 @@ const entitySettingResolvers: Resolvers = {
   },
   EntitySetting: {
     attributesDefinitions: (entitySetting, _, context) => queryEntitySettingSchemaAttributes(context, context.user, entitySetting),
+    attributeLabels: (entitySetting, _, context) => queryEntitySettingAttributeLabels(context, context.user, entitySetting),
     mandatoryAttributes: (entitySetting, _, context) => queryMandatoryAttributesForSetting(context, context.user, entitySetting),
     scaleAttributes: (entitySetting, _, context) => queryScaleAttributesForSetting(context, context.user, entitySetting),
     defaultValuesAttributes: (entitySetting, _, context) => queryDefaultValuesAttributesForSetting(context, context.user, entitySetting),

--- a/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/entitySetting/entitySetting.graphql
@@ -16,6 +16,11 @@ type TypeAttribute {
   scale: String
 }
 
+type AttributeLabel {
+  name: String!
+  label: String
+}
+
 
 type ScaleAttribute {
   name: String!
@@ -52,6 +57,7 @@ type EntitySetting implements InternalObject & BasicObject {
   # The underlying data is already exposed through mandatoryAttributes / scaleAttributes /
   # defaultValuesAttributes (all plain @auth), so this only requires authentication.
   attributesDefinitions: [TypeAttribute!]! @auth
+  attributeLabels: [AttributeLabel!]! @auth
   mandatoryAttributes: [String!]! @auth
   scaleAttributes: [ScaleAttribute!]! @auth
   defaultValuesAttributes: [DefaultValueAttribute!]! @auth

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/subType-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/subType-test.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from 'vitest';
 import gql from 'graphql-tag';
-import { ADMIN_USER, isSorted, testContext } from '../../utils/testQuery';
-import { queryAsAdmin } from '../../utils/testQueryHelper';
+import { ADMIN_USER, isSorted, testContext, USER_PARTICIPATE } from '../../utils/testQuery';
+import { queryAsAdmin, queryAsUser, queryAsUserIsExpectedForbidden } from '../../utils/testQueryHelper';
 import { ENTITY_TYPE_DATA_COMPONENT } from '../../../src/schema/stixDomainObject';
 import { STIX_CYBER_OBSERVABLES } from '../../../src/schema/stixCyberObservable';
 import { ENTITY_TYPE_CONTAINER_CASE_RFI } from '../../../src/modules/case/case-rfi/case-rfi-types';
@@ -34,6 +34,19 @@ const SUB_TYPE_ATTRIBUTES_QUERY = gql`
           name
         }
         mandatoryAttributes
+      }
+    }
+  }
+`;
+
+const SUB_TYPE_ATTRIBUTE_LABELS_QUERY = gql`
+  query subType($id: String!) {
+    subType(id: $id) {
+      settings {
+        attributeLabels {
+          name
+          label
+        }
       }
     }
   }
@@ -132,6 +145,16 @@ describe('SubType resolver standard behavior', () => {
     expect(mandatoryAttributes.includes('name')).toBeTruthy();
     expect(mandatoryAttributes.length).toEqual(1);
   });
+  it('should return attributeLabels for a user with KNOWLEDGE capability only', async () => {
+    const queryResult = await queryAsUser(USER_PARTICIPATE, { query: SUB_TYPE_ATTRIBUTE_LABELS_QUERY, variables: { id: ENTITY_TYPE_DATA_COMPONENT } });
+    const attributeLabels = queryResult?.data?.subType.settings.attributeLabels;
+    expect(attributeLabels).toBeDefined();
+    expect(attributeLabels.map((attr: { name: string }) => attr.name).includes('name')).toBeTruthy();
+    expect(attributeLabels.length).toEqual(5);
+  });
+  it('should forbid attributesDefinitions for a user with KNOWLEDGE capability only', async () => {
+    await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, { query: SUB_TYPE_ATTRIBUTES_QUERY, variables: { id: ENTITY_TYPE_DATA_COMPONENT } });
+  });
 });
 
 describe('SubType resolver for RFI and request access use case', () => {
@@ -173,7 +196,7 @@ describe('SubType resolver for RFI use case', () => {
           order: 2,
           template_id: inProgressStatusId,
           scope: StatusScope.Global,
-        }
+        },
       },
     });
 
@@ -185,7 +208,7 @@ describe('SubType resolver for RFI use case', () => {
           order: 0,
           template_id: newStatusId,
           scope: StatusScope.Global,
-        }
+        },
       },
     });
     const rfiEntitySettingsWithWorkflow = await queryAsAdminWithSuccess({


### PR DESCRIPTION
### Proposed changes

* Add a new `attributeLabels` field on `EntitySetting` (GraphQL) protected by `@auth` only, returning just the `name` and `label` of each attribute
* Fix `DraftReviewDiffPanel` right panel being empty for users with only `KNOWLEDGE` capability by replacing the `attributesDefinitions` query (requires `SETTINGS_SETCUSTOMIZATION`) with the new `attributeLabels` query

### Related issues
* closes #16706 

### How to test this PR
1. Create a user with only the `KNOWLEDGE` capability (no `SETTINGS_SETCUSTOMIZATION`)
2. Open a draft workspace and navigate to the diff review panel
3. Verify that the right panel correctly displays entity attribute labels for changes
4. Also verify that a user with `SETTINGS_SETCUSTOMIZATION` still sees the panel correctly

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

`EntitySetting.attributesDefinitions` exposes the full attribute configuration (mandatory, default values, scale, etc.) and is intentionally restricted to `SETTINGS_SETCUSTOMIZATION`. The diff panel only needs attribute labels for display purposes, so a dedicated `attributeLabels` field accessible to any authenticated user is the minimal, non-breaking fix.