### PR TITLE
fix(filters): Saved filters icon in Activity (#16713)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemIcon.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemIcon.tsx
@@ -94,6 +94,7 @@ import {
   DatabaseExportOutline,
   FileDelimitedOutline,
   FileOutline,
+  FilterOutline,
   FilterVariant,
   Fire,
   FlaskOutline,
@@ -614,6 +615,8 @@ const iconSelector = (
       return <LockMinusOutline style={style} fontSize={fontSize} role="img" />;
     case 'customview':
       return <Insights style={style} fontSize={fontSize} role="img" />;
+    case 'savedfilter':
+      return <FilterOutline style={style} fontSize={fontSize} role="img" />;
     case 'default':
       return <CircleOutlined style={style} fontSize={fontSize} role="img" />;
     default:

--- a/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/activity/audit/Audit.tsx
@@ -219,10 +219,11 @@ const Audit = () => {
   ) : <></>;
   return (
     <div className={classes.container} data-testid="audit-page">
-      <Breadcrumbs elements={[{ label: t_i18n('Settings') }, { label: t_i18n('Activity') }, {
-        label: t_i18n('Events'),
-        current: true,
-      }]}
+      <Breadcrumbs elements={[
+        { label: t_i18n('Settings') },
+        { label: t_i18n('Activity') },
+        { label: t_i18n('Events'), current: true },
+      ]}
       />
       {settings.platform_demo && (
         <Alert severity="info" variant="outlined" style={{ marginBottom: 30 }}>


### PR DESCRIPTION
### Proposed changes
Add an icon for Saved filters activity events

<img width="812" height="251" alt="image" src="https://github.com/user-attachments/assets/c163b526-cc41-4e7f-8cc8-693f72a29ab0" />


### Related issues
fixes #16713