### PR TITLE
perf(client): group bundle objects by dependency to avoid worker lock…

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3582,8 +3582,8 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         # cross-worker lock contention / MISSING_REFERENCE retries for related objects.
         # Only the amqp queue path consumes the split result; the api path sends the
         # original bundle, so don't spend the grouping there.
-        group_by_deps = kwargs.get("group_by_deps", False) and self.queue_protocol == (
-            "amqp"
+        group_by_deps = (
+            kwargs.get("group_by_deps", False) and self.queue_protocol == "amqp"
         )
         max_group_size = kwargs.get("max_group_size", 50)
 

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3540,7 +3540,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :param group_by_deps: emit dependency-complete sub-bundles (an element with the
             objects it depends on) sent no_split, so related objects are processed
             atomically by a single worker instead of racing across workers on the same
-            entity (default: False)
+            entity. Only affects the message-queue (amqp) path; it is ignored when
+            no_split is True (the whole bundle is sent as-is) or queue_protocol is "api"
+            (default: False)
         :type group_by_deps: bool, optional
         :param max_group_size: maximum objects per group when group_by_deps is set
             (default: 50)

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3537,9 +3537,13 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :type send_to_s3: bool, optional
         :param no_split: Whether to send without splitting (default: False)
         :type no_split: bool, optional
-        :param group_by_deps: emit dependency-complete sub-bundles (an element with the direct refs it depends on) sent no_split, so related objects are processed atomically by a single worker instead of racing across workers on the same entity (default: False)
+        :param group_by_deps: emit dependency-complete sub-bundles (an element with the
+            objects it depends on) sent no_split, so related objects are processed
+            atomically by a single worker instead of racing across workers on the same
+            entity (default: False)
         :type group_by_deps: bool, optional
-        :param max_group_size: maximum objects per group when group_by_deps is set (default: 50)
+        :param max_group_size: maximum objects per group when group_by_deps is set
+            (default: 50)
         :type max_group_size: int, optional
 
         :return: List of processed bundle chunks
@@ -3571,9 +3575,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         )
         bundle_send_to_s3 = kwargs.get("send_to_s3", self.bundle_send_to_s3)
         no_split = kwargs.get("no_split", False)
-        # Emit dependency-complete sub-bundles (an element + the direct refs it depends
-        # on) sent no_split, so related objects are processed atomically by one worker -
-        # no cross-worker lock contention / MISSING_REFERENCE retries for related objects.
+        # Emit dependency-complete sub-bundles (an element + the objects it depends on)
+        # sent no_split, so related objects are processed atomically by one worker - no
+        # cross-worker lock contention / MISSING_REFERENCE retries for related objects.
         group_by_deps = kwargs.get("group_by_deps", False)
         max_group_size = kwargs.get("max_group_size", 50)
 

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3537,6 +3537,10 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :type send_to_s3: bool, optional
         :param no_split: Whether to send without splitting (default: False)
         :type no_split: bool, optional
+        :param group_by_deps: emit dependency-complete sub-bundles (an element with the direct refs it depends on) sent no_split, so related objects are processed atomically by a single worker instead of racing across workers on the same entity (default: False)
+        :type group_by_deps: bool, optional
+        :param max_group_size: maximum objects per group when group_by_deps is set (default: 50)
+        :type max_group_size: int, optional
 
         :return: List of processed bundle chunks
         :rtype: list
@@ -3567,6 +3571,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         )
         bundle_send_to_s3 = kwargs.get("send_to_s3", self.bundle_send_to_s3)
         no_split = kwargs.get("no_split", False)
+        # Emit dependency-complete sub-bundles (an element + the direct refs it depends
+        # on) sent no_split, so related objects are processed atomically by one worker -
+        # no cross-worker lock contention / MISSING_REFERENCE retries for related objects.
+        group_by_deps = kwargs.get("group_by_deps", False)
+        max_group_size = kwargs.get("max_group_size", 50)
 
         # In case of enrichment ingestion, ensure the sharing if needed
         if self.enrichment_shared_organizations is not None:
@@ -3709,6 +3718,8 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                     use_json=True,
                     event_version=event_version,
                     cleanup_inconsistent_bundle=cleanup_inconsistent_bundle,
+                    group_by_deps=group_by_deps,
+                    max_group_size=max_group_size,
                 )
             )
 
@@ -3759,7 +3770,8 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                         sequence=sequence,
                         update=update,
                         draft_id=draft_id,
-                        no_split=no_split,
+                        # grouped bundles must be processed whole, not re-split per object
+                        no_split=no_split or group_by_deps,
                     )
                 channel.close()
                 pika_connection.close()

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -3580,7 +3580,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         # Emit dependency-complete sub-bundles (an element + the objects it depends on)
         # sent no_split, so related objects are processed atomically by one worker - no
         # cross-worker lock contention / MISSING_REFERENCE retries for related objects.
-        group_by_deps = kwargs.get("group_by_deps", False)
+        # Only the amqp queue path consumes the split result; the api path sends the
+        # original bundle, so don't spend the grouping there.
+        group_by_deps = kwargs.get("group_by_deps", False) and self.queue_protocol == (
+            "amqp"
+        )
         max_group_size = kwargs.get("max_group_size", 50)
 
         # In case of enrichment ingestion, ensure the sharing if needed

--- a/client-python/pycti/utils/opencti_stix2_splitter.py
+++ b/client-python/pycti/utils/opencti_stix2_splitter.py
@@ -240,14 +240,76 @@ class OpenCTIStix2Splitter:
 
         return nb_deps
 
+    def _group_by_dependencies(self, max_group_size):
+        """Group each element with the direct refs it depends on into one sub-bundle.
+
+        A relationship is grouped with its source/target, an object with its
+        created_by/markings. Sent no_split, a group is processed by a single worker in
+        one request, in dependency order, so objects that reference each other never
+        race across workers on the same entity ("too many concurrent call on the same
+        entities") and their shared refs resolve once instead of per object. Independent
+        elements still land in separate groups, preserving cross-worker parallelism.
+
+        ``self.cache_refs`` already holds each element's direct dependency ids (built by
+        ``enlist_element``); this only partitions the already-sorted elements, every
+        element ending up in exactly one group so the expectation count is unchanged.
+
+        :param max_group_size: maximum objects per group (oversized dependency chains
+            fall back to smaller groups)
+        :type max_group_size: int
+        :return: list of ``{"nb_deps": int, "elements": list}`` groups
+        :rtype: list
+        """
+        by_id = {element["id"]: element for element in self.elements}
+        emitted = set()
+        groups = []
+        # Roots with the most dependencies first (relationships before their endpoints),
+        # pulling their direct refs into the same group up to a safety cap.
+        for root in sorted(self.elements, key=lambda e: e["nb_deps"], reverse=True):
+            if root["id"] in emitted:
+                continue
+            group_ids = []
+            stack = [root["id"]]
+            while stack and len(group_ids) < max_group_size:
+                current = stack.pop()
+                if current in emitted or current not in by_id:
+                    continue
+                emitted.add(current)
+                group_ids.append(current)
+                for dependency in self.cache_refs.get(current, []):
+                    if dependency not in emitted and dependency in by_id:
+                        stack.append(dependency)
+            # dependencies first so referenced entities precede their relationships
+            elements = sorted(
+                (by_id[element_id] for element_id in group_ids),
+                key=lambda e: e["nb_deps"],
+            )
+            groups.append(
+                {
+                    "nb_deps": max(element["nb_deps"] for element in elements),
+                    "elements": elements,
+                }
+            )
+        # emit lighter (entity-only) groups before relationship-bearing ones
+        groups.sort(key=lambda group: group["nb_deps"])
+        return groups
+
     def split_bundle_with_expectations(
         self,
         bundle,
         use_json=True,
         event_version=None,
         cleanup_inconsistent_bundle=False,
+        group_by_deps=False,
+        max_group_size=50,
     ) -> Tuple[int, list, list]:
         """Split a valid STIX2 bundle into a list of bundles.
+
+        When ``group_by_deps`` is True, each emitted bundle contains an element together
+        with the direct refs it depends on (instead of exactly one object), so it can be
+        sent ``no_split`` and processed atomically by one worker -- avoiding the
+        cross-worker lock contention and MISSING_REFERENCE retries that one-object-per-
+        bundle splitting causes for dependency-heavy data.
 
         :param bundle: the STIX2 bundle to split
         :type bundle: str or dict
@@ -257,6 +319,11 @@ class OpenCTIStix2Splitter:
         :type event_version: str or None
         :param cleanup_inconsistent_bundle: whether to cleanup inconsistent references
         :type cleanup_inconsistent_bundle: bool
+        :param group_by_deps: group each element with the direct refs it depends on into
+            one bundle (sent no_split) instead of one object per bundle
+        :type group_by_deps: bool
+        :param max_group_size: maximum objects per group when group_by_deps is set
+        :type max_group_size: int
         :return: tuple of (number of expectations, incompatible items, list of bundles)
         :rtype: Tuple[int, list, list]
         """
@@ -298,9 +365,12 @@ class OpenCTIStix2Splitter:
 
         self.elements.sort(key=by_dep_size)
 
-        elements_with_deps = list(
-            map(lambda e: {"nb_deps": e["nb_deps"], "elements": [e]}, self.elements)
-        )
+        if group_by_deps:
+            elements_with_deps = self._group_by_dependencies(max_group_size)
+        else:
+            elements_with_deps = list(
+                map(lambda e: {"nb_deps": e["nb_deps"], "elements": [e]}, self.elements)
+            )
 
         number_expectations = 0
         for entity in elements_with_deps:

--- a/client-python/pycti/utils/opencti_stix2_splitter.py
+++ b/client-python/pycti/utils/opencti_stix2_splitter.py
@@ -425,6 +425,19 @@ class OpenCTIStix2Splitter:
 
         self.elements.sort(key=by_dep_size)
 
+        # enlist_element can append the same object twice when it is first reached via an
+        # internal id (e.g. a created_by_ref expressed as an OpenCTI UUID) and then again
+        # via its STIX id in the top-level loop. De-duplicate by canonical id so both the
+        # grouped and non-grouped paths emit each object exactly once with the same
+        # expectation count.
+        seen_ids = set()
+        unique_elements = []
+        for element in self.elements:
+            if element["id"] not in seen_ids:
+                seen_ids.add(element["id"])
+                unique_elements.append(element)
+        self.elements = unique_elements
+
         if group_by_deps:
             elements_with_deps = self._group_by_dependencies(max_group_size)
         else:

--- a/client-python/pycti/utils/opencti_stix2_splitter.py
+++ b/client-python/pycti/utils/opencti_stix2_splitter.py
@@ -241,6 +241,36 @@ class OpenCTIStix2Splitter:
 
         return nb_deps
 
+    def _ordered_dependencies(self, element):
+        """Dependency ids of ``element`` with relationship/sighting endpoints first.
+
+        A relationship may also carry secondary refs (``created_by_ref``, markings); put
+        the endpoints (``source_ref``/``target_ref``/``sighting_of_ref``/
+        ``where_sighted_refs``) ahead of them so a tight ``max_group_size`` keeps a
+        relationship with both endpoints before pulling its secondary refs.
+        """
+        refs = self.cache_refs.get(element["id"], [])
+        if len(refs) <= 1:
+            return refs
+        ref_set = set(refs)
+        ordered = []
+        seen = set()
+        endpoints = [
+            element.get("source_ref"),
+            element.get("target_ref"),
+            element.get("sighting_of_ref"),
+            *(element.get("where_sighted_refs") or []),
+        ]
+        for value in endpoints:
+            if value in ref_set and value not in seen:
+                ordered.append(value)
+                seen.add(value)
+        for value in refs:
+            if value not in seen:
+                ordered.append(value)
+                seen.add(value)
+        return ordered
+
     def _group_by_dependencies(self, max_group_size):
         """Group each element with the objects it depends on into one sub-bundle.
 
@@ -298,7 +328,7 @@ class OpenCTIStix2Splitter:
                     continue
                 emitted.add(current["id"])
                 group_ids.append(current["id"])
-                for dependency_id in self.cache_refs.get(current["id"], []):
+                for dependency_id in self._ordered_dependencies(current):
                     dependency = by_id.get(dependency_id)
                     if dependency is not None and dependency["id"] not in emitted:
                         queue.append(dependency)

--- a/client-python/pycti/utils/opencti_stix2_splitter.py
+++ b/client-python/pycti/utils/opencti_stix2_splitter.py
@@ -250,7 +250,9 @@ class OpenCTIStix2Splitter:
         relationship with both endpoints before pulling its secondary refs.
         """
         refs = self.cache_refs.get(element["id"], [])
-        if len(refs) <= 1:
+        # Only relationships/sightings have endpoints to prioritise; for an entity the ref
+        # order (created_by/markings) doesn't affect grouping, so skip the reordering.
+        if len(refs) <= 1 or element.get("type") not in ("relationship", "sighting"):
             return refs
         ref_set = set(refs)
         ordered = []
@@ -284,12 +286,14 @@ class OpenCTIStix2Splitter:
         Independent elements still land in separate groups, preserving cross-worker
         parallelism.
 
-        Groups are emitted in build order (heaviest root first), and that order is
-        dependency-safe across group boundaries: a shared dependency is pulled in by its
-        highest-``nb_deps`` referencer, so the group holding it is built, and therefore
-        emitted, before any later group that only references it. (Cross-group references
-        remain best-effort under concurrent workers and rely on the platform's existing
-        MISSING_REFERENCE retry; grouping removes the within-group races entirely.)
+        Groups are emitted in build order (heaviest root first). With a normal
+        ``max_group_size`` a shared dependency is pulled into its highest-``nb_deps``
+        referencer's group, which is emitted before any later group that only references
+        it. This cross-group ordering is best-effort, not a guarantee: a very small cap can
+        leave an element separated from a dependency (``max_group_size=1`` emits a
+        relationship before its endpoints), and concurrent workers may process groups out
+        of order -- both cases fall back to the platform's existing MISSING_REFERENCE
+        retry. Grouping removes the within-group races entirely.
 
         ``self.cache_refs`` holds each element's dependency ids (built by
         ``enlist_element``); a ref may be a STIX id or an OpenCTI internal id, so the
@@ -311,13 +315,12 @@ class OpenCTIStix2Splitter:
                 by_id[internal_id] = element
         emitted = set()
         groups = []
-        # Heaviest roots first (relationships before their endpoints), pulling the refs
-        # they depend on into the same group up to the cap. Breadth-first so the direct
-        # refs (a relationship's source/target) are taken before transitive ones. Build
-        # order is the emit order: a shared dependency is pulled by its highest-nb_deps
-        # referencer, so the group holding it precedes any later group that only
-        # references it across a boundary.
-        for root in sorted(self.elements, key=lambda e: e["nb_deps"], reverse=True):
+        # self.elements is already sorted ascending by nb_deps in the caller; iterate in
+        # reverse for heaviest roots first (relationships before their endpoints) without
+        # re-sorting. Each root pulls the refs it depends on into its group up to the cap,
+        # breadth-first so direct refs (a relationship's source/target) win over
+        # transitive ones.
+        for root in reversed(self.elements):
             if root["id"] in emitted:
                 continue
             group_ids = []
@@ -337,12 +340,8 @@ class OpenCTIStix2Splitter:
                 (by_id[element_id] for element_id in group_ids),
                 key=lambda e: e["nb_deps"],
             )
-            groups.append(
-                {
-                    "nb_deps": max(element["nb_deps"] for element in elements),
-                    "elements": elements,
-                }
-            )
+            # elements is sorted ascending, so the last carries the group's max nb_deps
+            groups.append({"nb_deps": elements[-1]["nb_deps"], "elements": elements})
         # Keep build order: re-sorting here could place a group before the group that
         # holds one of its (de-duplicated) cross-boundary dependencies, reintroducing the
         # MISSING_REFERENCE race this feature removes.

--- a/client-python/pycti/utils/opencti_stix2_splitter.py
+++ b/client-python/pycti/utils/opencti_stix2_splitter.py
@@ -241,30 +241,41 @@ class OpenCTIStix2Splitter:
         return nb_deps
 
     def _group_by_dependencies(self, max_group_size):
-        """Group each element with the direct refs it depends on into one sub-bundle.
+        """Group each element with the objects it depends on into one sub-bundle.
 
-        A relationship is grouped with its source/target, an object with its
-        created_by/markings. Sent no_split, a group is processed by a single worker in
-        one request, in dependency order, so objects that reference each other never
-        race across workers on the same entity ("too many concurrent call on the same
-        entities") and their shared refs resolve once instead of per object. Independent
-        elements still land in separate groups, preserving cross-worker parallelism.
+        A relationship is grouped with its source/target and, transitively, the refs
+        those depend on (e.g. their author/markings), up to ``max_group_size``. Sent
+        no_split, a group is processed by a single worker in one request, in dependency
+        order, so objects that reference each other do not race across workers on the same
+        entity ("too many concurrent call on the same entities") and their shared refs
+        resolve once instead of per object. Independent elements still land in separate
+        groups, preserving cross-worker parallelism.
 
-        ``self.cache_refs`` already holds each element's direct dependency ids (built by
+        Groups are emitted in build order (heaviest root first), and that order is
+        dependency-safe across group boundaries: a shared dependency is pulled in by its
+        highest-``nb_deps`` referencer, so the group holding it is built, and therefore
+        emitted, before any later group that only references it. (Cross-group references
+        remain best-effort under concurrent workers and rely on the platform's existing
+        MISSING_REFERENCE retry; grouping removes the within-group races entirely.)
+
+        ``self.cache_refs`` already holds each element's dependency ids (built by
         ``enlist_element``); this only partitions the already-sorted elements, every
         element ending up in exactly one group so the expectation count is unchanged.
 
-        :param max_group_size: maximum objects per group (oversized dependency chains
-            fall back to smaller groups)
+        :param max_group_size: maximum objects per group (oversized dependency chains fall
+            back to smaller groups); coerced to at least 1
         :type max_group_size: int
         :return: list of ``{"nb_deps": int, "elements": list}`` groups
         :rtype: list
         """
+        max_group_size = max(1, int(max_group_size))
         by_id = {element["id"]: element for element in self.elements}
         emitted = set()
         groups = []
-        # Roots with the most dependencies first (relationships before their endpoints),
-        # pulling their direct refs into the same group up to a safety cap.
+        # Heaviest roots first (relationships before their endpoints), pulling the refs
+        # they depend on into the same group up to the cap. Build order is the emit order:
+        # a shared dependency is pulled by its highest-nb_deps referencer, so the group
+        # holding it precedes any later group that only references it across a boundary.
         for root in sorted(self.elements, key=lambda e: e["nb_deps"], reverse=True):
             if root["id"] in emitted:
                 continue
@@ -290,8 +301,9 @@ class OpenCTIStix2Splitter:
                     "elements": elements,
                 }
             )
-        # emit lighter (entity-only) groups before relationship-bearing ones
-        groups.sort(key=lambda group: group["nb_deps"])
+        # Keep build order: re-sorting here could place a group before the group that
+        # holds one of its (de-duplicated) cross-boundary dependencies, reintroducing the
+        # MISSING_REFERENCE race this feature removes.
         return groups
 
     def split_bundle_with_expectations(
@@ -306,10 +318,10 @@ class OpenCTIStix2Splitter:
         """Split a valid STIX2 bundle into a list of bundles.
 
         When ``group_by_deps`` is True, each emitted bundle contains an element together
-        with the direct refs it depends on (instead of exactly one object), so it can be
-        sent ``no_split`` and processed atomically by one worker -- avoiding the
-        cross-worker lock contention and MISSING_REFERENCE retries that one-object-per-
-        bundle splitting causes for dependency-heavy data.
+        with the objects it depends on (instead of exactly one object), so it can be sent
+        ``no_split`` and processed atomically by one worker -- avoiding the cross-worker
+        lock contention and MISSING_REFERENCE retries that one-object-per-bundle splitting
+        causes for dependency-heavy data.
 
         :param bundle: the STIX2 bundle to split
         :type bundle: str or dict
@@ -319,14 +331,21 @@ class OpenCTIStix2Splitter:
         :type event_version: str or None
         :param cleanup_inconsistent_bundle: whether to cleanup inconsistent references
         :type cleanup_inconsistent_bundle: bool
-        :param group_by_deps: group each element with the direct refs it depends on into
-            one bundle (sent no_split) instead of one object per bundle
+        :param group_by_deps: group each element with the objects it depends on into one
+            bundle (sent no_split) instead of one object per bundle
         :type group_by_deps: bool
         :param max_group_size: maximum objects per group when group_by_deps is set
         :type max_group_size: int
         :return: tuple of (number of expectations, incompatible items, list of bundles)
         :rtype: Tuple[int, list, list]
         """
+        # Reset per-call state so a reused splitter instance does not leak objects
+        # between bundles.
+        self.cache_index = {}
+        self.cache_refs = {}
+        self.elements = []
+        self.incompatible_items = []
+
         if use_json:
             try:
                 bundle_data = json.loads(bundle)

--- a/client-python/pycti/utils/opencti_stix2_splitter.py
+++ b/client-python/pycti/utils/opencti_stix2_splitter.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from collections import deque
 from typing import Tuple
 
 from typing_extensions import deprecated
@@ -243,13 +244,15 @@ class OpenCTIStix2Splitter:
     def _group_by_dependencies(self, max_group_size):
         """Group each element with the objects it depends on into one sub-bundle.
 
-        A relationship is grouped with its source/target and, transitively, the refs
-        those depend on (e.g. their author/markings), up to ``max_group_size``. Sent
-        no_split, a group is processed by a single worker in one request, in dependency
-        order, so objects that reference each other do not race across workers on the same
-        entity ("too many concurrent call on the same entities") and their shared refs
-        resolve once instead of per object. Independent elements still land in separate
-        groups, preserving cross-worker parallelism.
+        A relationship is grouped with its source/target first and then, breadth-first,
+        the refs those depend on (e.g. their author/markings), up to ``max_group_size`` --
+        direct refs are taken before transitive ones, so a small cap still keeps a
+        relationship with both endpoints. Sent no_split, a group is processed by a single
+        worker in one request, in dependency order, so objects that reference each other
+        do not race across workers on the same entity ("too many concurrent call on the
+        same entities") and their shared refs resolve once instead of per object.
+        Independent elements still land in separate groups, preserving cross-worker
+        parallelism.
 
         Groups are emitted in build order (heaviest root first), and that order is
         dependency-safe across group boundaries: a shared dependency is pulled in by its
@@ -258,8 +261,9 @@ class OpenCTIStix2Splitter:
         remain best-effort under concurrent workers and rely on the platform's existing
         MISSING_REFERENCE retry; grouping removes the within-group races entirely.)
 
-        ``self.cache_refs`` already holds each element's dependency ids (built by
-        ``enlist_element``); this only partitions the already-sorted elements, every
+        ``self.cache_refs`` holds each element's dependency ids (built by
+        ``enlist_element``); a ref may be a STIX id or an OpenCTI internal id, so the
+        lookup is indexed by both. This only partitions the already-sorted elements, every
         element ending up in exactly one group so the expectation count is unchanged.
 
         :param max_group_size: maximum objects per group (oversized dependency chains fall
@@ -269,27 +273,35 @@ class OpenCTIStix2Splitter:
         :rtype: list
         """
         max_group_size = max(1, int(max_group_size))
-        by_id = {element["id"]: element for element in self.elements}
+        # Index by STIX id and internal ids: a _ref may be expressed either way.
+        by_id = {}
+        for element in self.elements:
+            by_id[element["id"]] = element
+            for internal_id in self.get_internal_ids_in_extension(element):
+                by_id[internal_id] = element
         emitted = set()
         groups = []
         # Heaviest roots first (relationships before their endpoints), pulling the refs
-        # they depend on into the same group up to the cap. Build order is the emit order:
-        # a shared dependency is pulled by its highest-nb_deps referencer, so the group
-        # holding it precedes any later group that only references it across a boundary.
+        # they depend on into the same group up to the cap. Breadth-first so the direct
+        # refs (a relationship's source/target) are taken before transitive ones. Build
+        # order is the emit order: a shared dependency is pulled by its highest-nb_deps
+        # referencer, so the group holding it precedes any later group that only
+        # references it across a boundary.
         for root in sorted(self.elements, key=lambda e: e["nb_deps"], reverse=True):
             if root["id"] in emitted:
                 continue
             group_ids = []
-            stack = [root["id"]]
-            while stack and len(group_ids) < max_group_size:
-                current = stack.pop()
-                if current in emitted or current not in by_id:
+            queue = deque([root])
+            while queue and len(group_ids) < max_group_size:
+                current = queue.popleft()
+                if current["id"] in emitted:
                     continue
-                emitted.add(current)
-                group_ids.append(current)
-                for dependency in self.cache_refs.get(current, []):
-                    if dependency not in emitted and dependency in by_id:
-                        stack.append(dependency)
+                emitted.add(current["id"])
+                group_ids.append(current["id"])
+                for dependency_id in self.cache_refs.get(current["id"], []):
+                    dependency = by_id.get(dependency_id)
+                    if dependency is not None and dependency["id"] not in emitted:
+                        queue.append(dependency)
             # dependencies first so referenced entities precede their relationships
             elements = sorted(
                 (by_id[element_id] for element_id in group_ids),

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -319,3 +319,66 @@ def test_split_bundle_group_by_deps_orders_shared_dependency_first():
             assert (
                 holder_idx < i
             ), "bundle holding the shared dependency must come first"
+
+
+def test_split_bundle_group_by_deps_keeps_endpoints_under_small_cap():
+    # Breadth-first traversal must take the relationship's direct source/target before
+    # any transitive ref, so even a tight max_group_size keeps both endpoints with the
+    # relationship. The target carries an author; a depth-first walk could pull that
+    # author into the cap and drop the source endpoint.
+    author = "identity--22222222-2222-4222-8222-222222222222"
+    ind = "indicator--a740531e-63ff-4e49-a9e1-a0a3eed0e3e7"
+    mal = "malware--9c4638ec-f1de-4ddb-b58d-a0e0b1c2d3e4"
+    rel = "relationship--0c4638ec-f1de-4ddb-b58d-a0e0b1c2d3e5"
+    bundle = json.dumps(
+        {
+            "type": "bundle",
+            "id": "bundle--" + str(uuid.uuid4()),
+            "objects": [
+                {
+                    "type": "identity",
+                    "id": author,
+                    "spec_version": "2.1",
+                    "name": "A",
+                    "identity_class": "organization",
+                },
+                {
+                    "type": "malware",
+                    "id": mal,
+                    "spec_version": "2.1",
+                    "name": "X",
+                    "is_family": True,
+                    "created_by_ref": author,
+                },
+                {
+                    "type": "indicator",
+                    "id": ind,
+                    "spec_version": "2.1",
+                    "name": "h",
+                    "pattern_type": "stix",
+                    "pattern": "[file:name = 'x']",
+                },
+                {
+                    "type": "relationship",
+                    "id": rel,
+                    "spec_version": "2.1",
+                    "relationship_type": "indicates",
+                    "source_ref": ind,
+                    "target_ref": mal,
+                },
+            ],
+        }
+    )
+    stix_splitter = OpenCTIStix2Splitter()
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
+        bundle, group_by_deps=True, max_group_size=3
+    )
+    assert expectations == 4
+    rel_bundle = next(
+        json.loads(b)["objects"]
+        for b in bundles
+        if any(obj["id"] == rel for obj in json.loads(b)["objects"])
+    )
+    grouped = {obj["id"] for obj in rel_bundle}
+    assert {ind, mal, rel} <= grouped, "both endpoints kept with the relationship"
+    assert len(rel_bundle) <= 3

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -448,3 +448,20 @@ def test_split_bundle_group_by_deps_endpoints_beat_relationship_own_refs():
         rel,
     } <= grouped, "endpoints grouped ahead of the relationship's author"
     assert len(rel_bundle) <= 3
+
+
+def test_split_bundle_group_by_deps_internal_id_refs():
+    # Dependencies expressed via OpenCTI internal ids (this fixture has a created_by_ref
+    # that is an internal UUID, not a STIX id) must still be indexed, so grouping keeps
+    # the partition exact rather than dropping the dependency.
+    with open("./tests/data/bundle_with_internal_ids.json") as file:
+        content = file.read()
+    base_ids = {obj["id"] for obj in json.loads(content)["objects"]}
+    stix_splitter = OpenCTIStix2Splitter()
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
+        content, group_by_deps=True
+    )
+    assert expectations == 4
+    seen = [obj["id"] for b in bundles for obj in json.loads(b)["objects"]]
+    assert len(seen) == len(set(seen)), "no object duplicated across grouped bundles"
+    assert set(seen) == base_ids, "every input object emitted exactly once"

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -382,3 +382,69 @@ def test_split_bundle_group_by_deps_keeps_endpoints_under_small_cap():
     grouped = {obj["id"] for obj in rel_bundle}
     assert {ind, mal, rel} <= grouped, "both endpoints kept with the relationship"
     assert len(rel_bundle) <= 3
+
+
+def test_split_bundle_group_by_deps_endpoints_beat_relationship_own_refs():
+    # The relationship itself carries created_by_ref (listed before its endpoints). Under
+    # a tight cap, both endpoints must still group with the relationship ahead of its own
+    # created_by, otherwise an endpoint would be referenced across a group boundary.
+    author = "identity--22222222-2222-4222-8222-222222222222"
+    ind = "indicator--a740531e-63ff-4e49-a9e1-a0a3eed0e3e7"
+    mal = "malware--9c4638ec-f1de-4ddb-b58d-a0e0b1c2d3e4"
+    rel = "relationship--0c4638ec-f1de-4ddb-b58d-a0e0b1c2d3e5"
+    bundle = json.dumps(
+        {
+            "type": "bundle",
+            "id": "bundle--" + str(uuid.uuid4()),
+            "objects": [
+                {
+                    "type": "identity",
+                    "id": author,
+                    "spec_version": "2.1",
+                    "name": "A",
+                    "identity_class": "organization",
+                },
+                {
+                    "type": "indicator",
+                    "id": ind,
+                    "spec_version": "2.1",
+                    "name": "h",
+                    "pattern_type": "stix",
+                    "pattern": "[file:name = 'x']",
+                },
+                {
+                    "type": "malware",
+                    "id": mal,
+                    "spec_version": "2.1",
+                    "name": "X",
+                    "is_family": True,
+                },
+                {
+                    "type": "relationship",
+                    "id": rel,
+                    "spec_version": "2.1",
+                    "created_by_ref": author,  # before the endpoints, on purpose
+                    "relationship_type": "indicates",
+                    "source_ref": ind,
+                    "target_ref": mal,
+                },
+            ],
+        }
+    )
+    stix_splitter = OpenCTIStix2Splitter()
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
+        bundle, group_by_deps=True, max_group_size=3
+    )
+    assert expectations == 4
+    rel_bundle = next(
+        json.loads(b)["objects"]
+        for b in bundles
+        if any(obj["id"] == rel for obj in json.loads(b)["objects"])
+    )
+    grouped = {obj["id"] for obj in rel_bundle}
+    assert {
+        ind,
+        mal,
+        rel,
+    } <= grouped, "endpoints grouped ahead of the relationship's author"
+    assert len(rel_bundle) <= 3

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -239,3 +239,83 @@ def test_split_bundle_group_by_deps_colocates_relationship():
     assert {ind, mal, rel} <= set(order), "relationship grouped with both endpoints"
     assert order.index(ind) < order.index(rel), "source precedes the relationship"
     assert order.index(mal) < order.index(rel), "target precedes the relationship"
+
+
+def test_split_bundle_group_by_deps_orders_shared_dependency_first():
+    # A shared dependency can live in only one group. The bundle that holds it must be
+    # emitted before any bundle that only references it across a group boundary, even
+    # when the holding group is heavier (rel_a carries an extra author dep). Guards
+    # against re-ordering the groups, which would reintroduce a MISSING_REFERENCE race.
+    shared = "malware--11111111-1111-4111-8111-111111111111"
+    author = "identity--22222222-2222-4222-8222-222222222222"
+    ind_a = "indicator--aaaaaaaa-1111-4111-8111-111111111111"
+    ind_b = "indicator--bbbbbbbb-1111-4111-8111-111111111111"
+    rel_a = "relationship--aaaaaaaa-2222-4222-8222-222222222222"
+    rel_b = "relationship--bbbbbbbb-2222-4222-8222-222222222222"
+
+    def indicator(identifier, name, created_by=None):
+        obj = {
+            "type": "indicator",
+            "id": identifier,
+            "spec_version": "2.1",
+            "name": name,
+            "pattern_type": "stix",
+            "pattern": "[file:name = '%s']" % name,
+        }
+        if created_by is not None:
+            obj["created_by_ref"] = created_by
+        return obj
+
+    def relationship(identifier, source):
+        return {
+            "type": "relationship",
+            "id": identifier,
+            "spec_version": "2.1",
+            "relationship_type": "indicates",
+            "source_ref": source,
+            "target_ref": shared,
+        }
+
+    bundle = json.dumps(
+        {
+            "type": "bundle",
+            "id": "bundle--" + str(uuid.uuid4()),
+            "objects": [
+                {
+                    "type": "malware",
+                    "id": shared,
+                    "spec_version": "2.1",
+                    "name": "Fam",
+                    "is_family": True,
+                },
+                {
+                    "type": "identity",
+                    "id": author,
+                    "spec_version": "2.1",
+                    "name": "A",
+                    "identity_class": "organization",
+                },
+                indicator(ind_a, "a", created_by=author),
+                indicator(ind_b, "b"),
+                relationship(rel_a, ind_a),
+                relationship(rel_b, ind_b),
+            ],
+        }
+    )
+    stix_splitter = OpenCTIStix2Splitter()
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
+        bundle, group_by_deps=True
+    )
+    assert expectations == 6
+
+    def ids(serialized):
+        return [obj["id"] for obj in json.loads(serialized)["objects"]]
+
+    holder_idx = next(i for i, b in enumerate(bundles) if shared in ids(b))
+    for i, b in enumerate(bundles):
+        objects = json.loads(b)["objects"]
+        references_shared = any(obj.get("target_ref") == shared for obj in objects)
+        if references_shared and shared not in ids(b):
+            assert (
+                holder_idx < i
+            ), "bundle holding the shared dependency must come first"

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -167,3 +167,75 @@ def test_create_bundle():
     ]:
         assert key in bundle
     assert len(bundle.keys()) == 6
+
+
+def test_split_bundle_group_by_deps_partition():
+    # group_by_deps must still emit every object exactly once (disjoint partition),
+    # so the work expectation count is unchanged versus one-object-per-bundle splitting.
+    with open("./tests/data/DATA-TEST-STIX2_v2.json") as file:
+        content = file.read()
+    base_ids = {obj["id"] for obj in json.loads(content)["objects"]}
+    stix_splitter = OpenCTIStix2Splitter()
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
+        content, group_by_deps=True
+    )
+    assert expectations == 59
+    seen = [obj["id"] for b in bundles for obj in json.loads(b)["objects"]]
+    assert len(seen) == len(set(seen)), "no object duplicated across grouped bundles"
+    assert set(seen) == base_ids, "every input object emitted exactly once"
+    assert any(
+        len(json.loads(b)["objects"]) > 1 for b in bundles
+    ), "grouping must produce at least one multi-object bundle"
+
+
+def test_split_bundle_group_by_deps_colocates_relationship():
+    # A relationship and both of its endpoints must land in the same bundle, endpoints
+    # first, so a single worker creates them in order with no cross-worker race.
+    ind = "indicator--a740531e-63ff-4e49-a9e1-a0a3eed0e3e7"
+    mal = "malware--9c4638ec-f1de-4ddb-b58d-a0e0b1c2d3e4"
+    rel = "relationship--0c4638ec-f1de-4ddb-b58d-a0e0b1c2d3e5"
+    bundle = json.dumps(
+        {
+            "type": "bundle",
+            "id": "bundle--" + str(uuid.uuid4()),
+            "objects": [
+                {
+                    "type": "malware",
+                    "id": mal,
+                    "spec_version": "2.1",
+                    "name": "X",
+                    "is_family": True,
+                },
+                {
+                    "type": "indicator",
+                    "id": ind,
+                    "spec_version": "2.1",
+                    "name": "h",
+                    "pattern_type": "stix",
+                    "pattern": "[file:name = 'x']",
+                },
+                {
+                    "type": "relationship",
+                    "id": rel,
+                    "spec_version": "2.1",
+                    "relationship_type": "indicates",
+                    "source_ref": ind,
+                    "target_ref": mal,
+                },
+            ],
+        }
+    )
+    stix_splitter = OpenCTIStix2Splitter()
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
+        bundle, group_by_deps=True
+    )
+    assert expectations == 3
+    rel_bundle = next(
+        json.loads(b)["objects"]
+        for b in bundles
+        if any(obj["id"] == rel for obj in json.loads(b)["objects"])
+    )
+    order = [obj["id"] for obj in rel_bundle]
+    assert {ind, mal, rel} <= set(order), "relationship grouped with both endpoints"
+    assert order.index(ind) < order.index(rel), "source precedes the relationship"
+    assert order.index(mal) < order.index(rel), "target precedes the relationship"

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -465,3 +465,44 @@ def test_split_bundle_group_by_deps_internal_id_refs():
     seen = [obj["id"] for b in bundles for obj in json.loads(b)["objects"]]
     assert len(seen) == len(set(seen)), "no object duplicated across grouped bundles"
     assert set(seen) == base_ids, "every input object emitted exactly once"
+
+
+def test_split_bundle_dedups_object_reached_by_internal_id():
+    # X is referenced by its internal id (A.created_by_ref) and A appears first, so
+    # enlist_element reaches X via the internal id before its STIX id and can list it
+    # twice. The grouped and non-grouped paths must report the SAME expectation count
+    # (each object once) -- not double-count X on one path and dedup it on the other.
+    x_internal = "11111111-1111-4111-8111-111111111111"
+    x_stix = "identity--22222222-2222-4222-8222-222222222222"
+    a_stix = "malware--33333333-3333-4333-8333-333333333333"
+    bundle = json.dumps(
+        {
+            "type": "bundle",
+            "id": "bundle--" + str(uuid.uuid4()),
+            "objects": [
+                {
+                    "type": "malware",
+                    "id": a_stix,
+                    "spec_version": "2.1",
+                    "name": "A",
+                    "is_family": True,
+                    "created_by_ref": x_internal,
+                },
+                {
+                    "type": "identity",
+                    "id": x_stix,
+                    "spec_version": "2.1",
+                    "name": "X",
+                    "identity_class": "organization",
+                    "x_opencti_id": x_internal,
+                },
+            ],
+        }
+    )
+    n_split, _, _ = OpenCTIStix2Splitter().split_bundle_with_expectations(bundle)
+    n_grouped, _, grouped = OpenCTIStix2Splitter().split_bundle_with_expectations(
+        bundle, group_by_deps=True
+    )
+    assert n_split == n_grouped == 2, "both paths count each object exactly once"
+    seen = [obj["id"] for b in grouped for obj in json.loads(b)["objects"]]
+    assert sorted(seen) == sorted([a_stix, x_stix])


### PR DESCRIPTION
Target: OpenCTI-Platform/opencti (monorepo), paths under client-python/
Branch: khalidelborai:feat/splitter-dependency-grouping -> base master
Title:  perf(client): group bundle objects by dependency to avoid worker lock contention

### Proposed changes

* Add an opt-in `group_by_deps` flag to `split_bundle_with_expectations`. Right now the
  splitter emits one object per bundle. With the flag on, it keeps each object together
  with the refs it directly depends on (a relationship with its source/target, an object
  with its markings and author). It reuses the dependency info `enlist_element` already
  collects, and every object still ends up in exactly one bundle, so the expectation count
  doesn't change.
* `send_stix2_bundle` takes `group_by_deps` / `max_group_size` and routes grouped bundles
  through the existing `no_split` path, so a worker handles each group whole.

### Why

Splitting every bundle down to one object per message means a relationship and its two
endpoints go out as three separate messages and get picked up by three different workers at
once. The relationship tries to lock an endpoint while another worker is still writing it,
and you get:

```
LOCK_ERROR: too many concurrent call on the same entities
```

plus MISSING_REFERENCE retries when the relationship lands before its target. On a backfill
of indicators linked to malware families this dropped us from hundreds of objects/sec to
single digits.

Grouping the related objects fixes it: one worker creates them in order, nothing races, and
shared refs like the author or TLP marking get resolved once instead of once per object.
Unrelated objects still go in separate bundles, so parallelism across workers is kept.

Default behaviour doesn't change, you only get grouping if you ask for it. `max_group_size`
(default 50) keeps a heavily connected entity from dragging a huge chain into one bundle.
The `no_split` queue path this builds on already exists in the worker, so this is just the
splitter side of it.

### Impact on ingestion speed

Measured on our setup (OpenCTI 7.26x, 6 workers, Elasticsearch idle the whole time, so
nothing was actually saturated):

* Same data, one connector thread, sent as a single grouped bundle vs split into one object
  per message: about 34 objects/min on the split path, about 1700 objects/min grouped. The
  split path burns its time re-resolving the shared author/marking refs once per object and
  retrying on lock timeouts.
* `LOCK_ERROR: too many concurrent call on the same entities` in the worker logs went from
  ~130/min to 0.
* When bundles weren't fighting each other the platform held 100+ objects/sec; on the split
  path the same workers sat in single digits, not because CPU or ES were maxed (both had
  headroom) but because they were stuck waiting on each other's locks.

For any connector that emits linked objects (an observable/indicator plus what it points
to, relationships, MISP galaxies, enrichment output) this is the difference between the
workers running flat out and the workers blocking on the same entities. Connectors that
only push standalone objects see little change either way, which is why it stays opt-in.

### Related issues

* closes <!-- link the same-bundle MISSING_REFERENCE / slow ingestion issue here -->

### How to test this PR

From `client-python/`:

```
pytest tests/01-unit/utils/test_opencti_stix2_splitter.py
```

The added unit tests in `test_opencti_stix2_splitter.py` cover the grouping path:
- partition stays exact (no duplicates, expectation count unchanged)
- a relationship is grouped with both of its endpoints, endpoints first
- the bundle holding a shared dependency is emitted before bundles that only reference it
- both endpoints stay with the relationship under a tight `max_group_size`
- endpoints win the cap over the relationship's own `created_by`
- dependencies referenced by OpenCTI internal ids are co-located / partitioned
- the grouped and non-grouped paths report the same expectation count (no double-count)

End to end: point a connector that emits linked objects at a platform and call
`send_stix2_bundle(bundle, group_by_deps=True)`. Its `push_*` queue carries grouped bundles
(no_split) and the worker logs stop reporting "too many concurrent call on the same
entities".

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

`group_by_deps` is off by default, so existing connectors are unaffected. It reuses the
`no_split` message flag the worker already honours; it only changes how the splitter
partitions a bundle. `max_group_size` bounds the worst case so a supernode dependency can't
pull a giant chain into one bundle.

