### PR TITLE
fix(client-python): upgrade starlette to >=1.3.0 to fix CVE-2026-54282 (#16731)

### DIFF
--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -15,7 +15,8 @@ prometheus-client~=0.25.0
 opentelemetry-api~=1.35.0
 opentelemetry-sdk~=1.35.0
 deprecation~=2.1.0
-fastapi>=0.115.2, <1
+fastapi>=0.136.0, <1
+starlette>=1.3.0, <2
 uvicorn[standard]>=0.41.0,<1
 # OpenCTI
 filigran-sseclient>=1.0.2

--- a/client-python/requirements.txt
+++ b/client-python/requirements.txt
@@ -15,7 +15,7 @@ prometheus-client~=0.25.0
 opentelemetry-api~=1.35.0
 opentelemetry-sdk~=1.35.0
 deprecation~=2.1.0
-fastapi>=0.136.0, <1
+fastapi>=0.133.0, <1
 starlette>=1.3.0, <2
 uvicorn[standard]>=0.41.0,<1
 # OpenCTI


### PR DESCRIPTION
## Summary

Starlette < 1.3.0 is vulnerable to [CVE-2026-54282](https://github.com/advisories/ghsa-jp82-jpqv-5vv3) — an unvalidated HTTP request path allows an attacker to poison `request.url.hostname` by sending a path that doesn't start with `/` (e.g. `@google.com`). This can mislead applications using `request.url` for host-based authorization, redirects/callbacks, SSRF targets, cache keys, or audit logs.

**Affected component:** `client-python` (via transitive dependency `fastapi` → `starlette`)

## Changes

- Pin `starlette>=1.3.0, <2` explicitly in `client-python/requirements.txt`
- Bump `fastapi` minimum to `0.133.0`, the first release that dropped the `starlette <1.0.0` upper bound (making it compatible with starlette 1.x)

## References

- Closes #16731
- https://github.com/advisories/ghsa-jp82-jpqv-5vv3
- https://security.snyk.io/vuln/SNYK-PYTHON-STARLETTE-17342519