### PR TITLE
fix(notification): prevent out-of-memory when computing digest notifications (#16691)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis-stream.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis-stream.ts
@@ -8,6 +8,7 @@ import {
   LIVE_STREAM_NAME,
   NOTIFICATION_STREAM_NAME,
   type RawStreamClient,
+  type SizedNotifEvent,
   type StreamProcessor,
   type StreamProcessorOption,
 } from './stream/stream-utils';
@@ -227,14 +228,63 @@ const rawFetchStreamEventsRangeFromEventId = async (
 
 // region opencti notification stream
 const notificationTrimming = conf.get('redis:notification_trimming') || 50000;
+// Number of notification stream entries fetched per XRANGE batch when reading a range (digest computation).
+// Reading the whole range in a single pass can exhaust the memory heap when the stream holds a very large number
+// of events, so we paginate and let the caller filter/transform each batch incrementally
+// (see handleDigestNotifications) instead of materializing the whole range at once.
+const notificationRangeBatchSize = conf.get('redis:notification_range_batch_size') || 1000;
 const rawStoreNotificationEvent = async <T extends StreamNotifEvent> (event: T) => {
   const eventStreamData = mapJSToStream(event);
   await getClientBase().call('XADD', REDIS_NOTIFICATION_STREAM_NAME, 'MAXLEN', '~', notificationTrimming, '*', ...eventStreamData);
 };
-const rawFetchRangeNotifications = async <T extends StreamNotifEvent> (start: Date, end: Date): Promise<Array<T>> => {
-  const streamResult = await getClientBase().call('XRANGE', REDIS_NOTIFICATION_STREAM_NAME, start.getTime(), end.getTime()) as any[];
-  const streamElements: Array<SseEvent<T>> = streamResult.map((r) => mapStreamToJS(r));
-  return streamElements.filter((s) => s.event === 'live').map((e) => e.data);
+// Byte size of a raw XRANGE entry [id, [field, value, ...]]: sum of the already-serialized stored
+// strings. Cheaper and more faithful than re-stringifying the parsed object to budget memory.
+const rawEntryByteSize = (rawFields: any[]): number => {
+  let size = 0;
+  for (let i = 0; i < rawFields.length; i += 1) {
+    size += Buffer.byteLength(rawFields[i]);
+  }
+  return size;
+};
+const rawFetchRangeNotifications = async <T extends StreamNotifEvent> (
+  start: Date,
+  end: Date,
+  // Called for each batch of 'live' notification events (with their stored byte size) in the range.
+  // Return false to stop the iteration early.
+  callback: (events: Array<SizedNotifEvent<T>>) => Promise<boolean | void> | boolean | void,
+): Promise<void> => {
+  const client = getClientBase();
+  const endId = `${end.getTime()}`;
+  let fromId = `${start.getTime()}`;
+  let isFirstBatch = true;
+  for (;;) {
+    // The '(' prefix excludes the cursor entry already processed at the end of the previous batch.
+    // cursor is in the form "timestamp - eventCursor"
+    const startId = isFirstBatch ? fromId : `(${fromId}`;
+    const streamResult = await client.call('XRANGE', REDIS_NOTIFICATION_STREAM_NAME, startId, endId, 'COUNT', notificationRangeBatchSize) as any[];
+    if (!streamResult || streamResult.length === 0) {
+      break;
+    }
+    const events: Array<SizedNotifEvent<T>> = [];
+    for (let i = 0; i < streamResult.length; i += 1) {
+      const parsed = mapStreamToJS(streamResult[i]);
+      if (parsed.event === 'live') {
+        events.push({ event: parsed.data as T, byteSize: rawEntryByteSize(streamResult[i][1]) });
+      }
+    }
+    if (events.length > 0) {
+      const shouldContinue = await callback(events);
+      if (shouldContinue === false) {
+        break;
+      }
+    }
+    // A short batch means the range is exhausted, no need for an extra empty XRANGE call.
+    if (streamResult.length < notificationRangeBatchSize) {
+      break;
+    }
+    fromId = R.last(streamResult)[0];
+    isFirstBatch = false;
+  }
 };
 // endregion
 

--- a/opencti-platform/opencti-graphql/src/database/stream/stream-handler.ts
+++ b/opencti-platform/opencti-graphql/src/database/stream/stream-handler.ts
@@ -13,6 +13,7 @@ import {
   isStreamPublishable,
   LIVE_STREAM_NAME,
   type RawStreamClient,
+  type SizedNotifEvent,
   STREAM_FULL_DEBUG_ACTIVATED,
   type StreamProcessor,
   type StreamProcessorOption,
@@ -156,8 +157,12 @@ export const fetchStreamEventsRangeFromEventId = async <T extends BaseEvent> (
 export const storeNotificationEvent = async <T extends StreamNotifEvent>(_context: AuthContext, event: T) => {
   await streamClient.rawStoreNotificationEvent(event);
 };
-export const fetchRangeNotifications = async <T extends StreamNotifEvent>(start: Date, end: Date): Promise<Array<T>> => {
-  return streamClient.rawFetchRangeNotifications<T>(start, end);
+export const fetchRangeNotifications = async <T extends StreamNotifEvent>(
+  start: Date,
+  end: Date,
+  callback: (events: Array<SizedNotifEvent<T>>) => Promise<boolean | void> | boolean | void,
+): Promise<void> => {
+  return streamClient.rawFetchRangeNotifications<T>(start, end, callback);
 };
 // endregion
 // region opencti audit stream

--- a/opencti-platform/opencti-graphql/src/database/stream/stream-utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/stream/stream-utils.ts
@@ -59,6 +59,13 @@ export type StreamInfo = {
   streamSize: number;
 };
 
+// A notification event read from a range, paired with the byte size it occupied in the Redis stream
+// (computed from the raw stored fields), so callers can budget memory without re-serializing the event.
+export interface SizedNotifEvent<T extends StreamNotifEvent> {
+  event: T;
+  byteSize: number;
+}
+
 export interface RawStreamClient {
   initializeStreams: () => Promise<void>;
   rawPushToStream: <T extends BaseEvent> (event: T) => Promise<void>;
@@ -74,7 +81,11 @@ export interface RawStreamClient {
     opts?: FetchEventRangeOption,
   ) => Promise<{ lastEventId: string }>;
   rawStoreNotificationEvent: <T extends StreamNotifEvent> (event: T) => Promise<void>;
-  rawFetchRangeNotifications: <T extends StreamNotifEvent> (start: Date, end: Date) => Promise<Array<T>>;
+  rawFetchRangeNotifications: <T extends StreamNotifEvent> (
+    start: Date,
+    end: Date,
+    callback: (events: Array<SizedNotifEvent<T>>) => Promise<boolean | void> | boolean | void,
+  ) => Promise<void>;
   rawStoreActivityEvent: (event: ActivityStreamEvent) => Promise<void>;
 }
 

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -43,6 +43,13 @@ const NOTIFICATION_LIVE_KEY = conf.get('notification_manager:lock_live_key');
 const NOTIFICATION_DIGEST_KEY = conf.get('notification_manager:lock_digest_key');
 const NOTIFICATION_MANAGER_NAME = 'notification_manager';
 export const EVENT_NOTIFICATION_VERSION = '1';
+// Hard cap on the cumulative byte size of the notification events aggregated into a single digest. The
+// notification stream can hold a very large number of events (e.g. a broad live trigger during a massive
+// ingest) and individual events vary a lot in size, so the digest is bounded by the total bytes retained
+// rather than by a raw event count. Beyond this size the digest content is truncated and a warning is
+// logged. Configurable (in bytes) through notification_manager:max_digest_content_size.
+export const DEFAULT_MAX_DIGEST_CONTENT_SIZE = 500 * 1024 * 1024; // 500 MB
+const MAX_DIGEST_CONTENT_SIZE = conf.get('notification_manager:max_digest_content_size') || DEFAULT_MAX_DIGEST_CONTENT_SIZE;
 const CRON_SCHEDULE_TIME = 60000; // 1 minute
 const STREAM_SCHEDULE_TIME = 10000;
 export const TRIGGER_EVENT_TYPES_VALUES = Object.values(TriggerEventType);
@@ -613,7 +620,37 @@ const notificationLiveStreamHandler = async (streamEvents: Array<SseEvent<DataEv
   }
 };
 
-const handleDigestNotifications = async (context: AuthContext) => {
+// Read the notification events of the [fromDate, toDate] range that belong to the given digest triggers.
+// The range is consumed in batches and "only" the matching events are kept in memory (instead of loading the
+// whole range). The retained content is bounded by its cumulative byte size (events may vary a lot in size) to
+// protect against out-of-memory on huge ranges.
+export const collectDigestContent = async (
+  fromDate: Date,
+  toDate: Date,
+  triggerIds: Array<string>,
+  maxContentByteSize: number = MAX_DIGEST_CONTENT_SIZE,
+): Promise<{ content: Array<KnowledgeNotificationEvent>; truncated: boolean; byteSize: number }> => {
+  const content: Array<KnowledgeNotificationEvent> = [];
+  let byteSize = 0;
+  let truncated = false;
+  await fetchRangeNotifications<KnowledgeNotificationEvent>(fromDate, toDate, (events) => {
+    for (let i = 0; i < events.length; i += 1) {
+      const { event: notification, byteSize: notificationSize } = events[i];
+      if (triggerIds.includes(notification.notification_id)) {
+        content.push(notification);
+        byteSize += notificationSize;
+        if (byteSize >= maxContentByteSize) {
+          truncated = true;
+          return false; // memory threshold reached, stop reading the range
+        }
+      }
+    }
+    return true;
+  });
+  return { content, truncated, byteSize };
+};
+
+export const handleDigestNotifications = async (context: AuthContext) => {
   const baseDate = utcDate().startOf('minutes');
   // Get digest that need to be executed
   const digestNotifications = await getDigestNotifications(context, baseDate);
@@ -622,8 +659,11 @@ const handleDigestNotifications = async (context: AuthContext) => {
     const { trigger, users } = digestNotifications[index];
     const { period, trigger_ids: triggerIds, notifiers, internal_id: notification_id, trigger_type: type } = trigger;
     const fromDate = baseDate.clone().subtract(1, period).toDate();
-    const rangeNotifications = await fetchRangeNotifications<KnowledgeNotificationEvent>(fromDate, baseDate.toDate());
-    const digestContent = rangeNotifications.filter((n) => triggerIds.includes(n.notification_id));
+    // Read the range in batches and only keep the events related to this digest (bounded by MAX_DIGEST_CONTENT_SIZE)
+    const { content: digestContent, truncated, byteSize } = await collectDigestContent(fromDate, baseDate.toDate(), triggerIds);
+    if (truncated) {
+      logApp.warn('[OPENCTI-MODULE] Digest content truncated, memory budget reached', { notification_id, period, kept: digestContent.length, byteSize, maxByteSize: MAX_DIGEST_CONTENT_SIZE });
+    }
     if (digestContent.length > 0) {
       // Range of results must filtered to keep only data related to the digest
       // And related to the users participating to the digest

--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 import * as jsonpatch from 'fast-json-patch';
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
 import type { Moment } from 'moment';
-import { type StreamProcessor } from '../database/stream/stream-utils';
+import { type SizedNotifEvent, type StreamProcessor } from '../database/stream/stream-utils';
 import { fetchRangeNotifications, storeNotificationEvent, createStreamProcessor } from '../database/stream/stream-handler';
 import { redisGetManagerEventState, redisSetManagerEventState } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
@@ -620,6 +620,29 @@ const notificationLiveStreamHandler = async (streamEvents: Array<SseEvent<DataEv
   }
 };
 
+interface DigestContentAccumulator { content: Array<KnowledgeNotificationEvent>; byteSize: number; truncated: boolean }
+// Accumulate the digest-matching events of a notification batch into `acc`, bounded by the byte budget.
+// Returns false to stop the range iteration once the cumulative byte budget is reached.
+const collectDigestBatch = (
+  acc: DigestContentAccumulator,
+  events: Array<SizedNotifEvent<KnowledgeNotificationEvent>>,
+  triggerIds: Set<string>,
+  maxContentByteSize: number,
+): boolean => {
+  for (let i = 0; i < events.length; i += 1) {
+    const { event: notification, byteSize: notificationSize } = events[i];
+    if (triggerIds.has(notification.notification_id)) {
+      acc.content.push(notification);
+      acc.byteSize += notificationSize;
+      if (acc.byteSize >= maxContentByteSize) {
+        acc.truncated = true;
+        return false; // memory threshold reached, stop reading the range
+      }
+    }
+  }
+  return true;
+};
+
 // Read the notification events of the [fromDate, toDate] range that belong to the given digest triggers.
 // The range is consumed in batches and "only" the matching events are kept in memory (instead of loading the
 // whole range). The retained content is bounded by its cumulative byte size (events may vary a lot in size) to
@@ -629,25 +652,15 @@ export const collectDigestContent = async (
   toDate: Date,
   triggerIds: Array<string>,
   maxContentByteSize: number = MAX_DIGEST_CONTENT_SIZE,
-): Promise<{ content: Array<KnowledgeNotificationEvent>; truncated: boolean; byteSize: number }> => {
-  const content: Array<KnowledgeNotificationEvent> = [];
-  let byteSize = 0;
-  let truncated = false;
-  await fetchRangeNotifications<KnowledgeNotificationEvent>(fromDate, toDate, (events) => {
-    for (let i = 0; i < events.length; i += 1) {
-      const { event: notification, byteSize: notificationSize } = events[i];
-      if (triggerIds.includes(notification.notification_id)) {
-        content.push(notification);
-        byteSize += notificationSize;
-        if (byteSize >= maxContentByteSize) {
-          truncated = true;
-          return false; // memory threshold reached, stop reading the range
-        }
-      }
-    }
-    return true;
-  });
-  return { content, truncated, byteSize };
+): Promise<DigestContentAccumulator> => {
+  const acc: DigestContentAccumulator = { content: [], byteSize: 0, truncated: false };
+  const triggerIdsSet = new Set(triggerIds);
+  await fetchRangeNotifications<KnowledgeNotificationEvent>(
+    fromDate,
+    toDate,
+    (events) => collectDigestBatch(acc, events, triggerIdsSet, maxContentByteSize),
+  );
+  return acc;
 };
 
 export const handleDigestNotifications = async (context: AuthContext) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/redis-stream-notifications-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/redis-stream-notifications-test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { StreamNotifEvent } from '../../../src/types/event';
+
+// Mock the Redis layer before importing the module under test, so no real connection is opened.
+const mockClient = { call: vi.fn() };
+vi.mock('../../../src/database/redis', () => ({
+  getClientBase: vi.fn(() => mockClient),
+  getClientXRANGE: vi.fn(() => mockClient),
+  createRedisClient: vi.fn(),
+}));
+
+import { fetchRangeNotifications } from '../../../src/database/stream/stream-handler';
+
+// Build a raw XRANGE entry [id, [field, jsonValue, ...]] the way mapJSToStream stores it.
+const buildEntry = (id: string, obj: Record<string, unknown>): [string, string[]] => {
+  const fields: string[] = [];
+  Object.entries(obj).forEach(([k, v]) => {
+    fields.push(k, JSON.stringify(v));
+  });
+  return [id, fields];
+};
+const liveEntry = (seq: number, notificationId: string) => buildEntry(`${1000 + seq}-0`, {
+  version: '1',
+  type: 'live',
+  notification_id: notificationId,
+  data: { id: `obj-${seq}` },
+});
+
+describe('rawFetchRangeNotifications (notification range pagination)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('paginates with an exclusive cursor, stops on a short batch and keeps only live events', async () => {
+    let callCount = 0;
+    mockClient.call.mockImplementation((...args: unknown[]) => {
+      const count = args[5] as number; // ['XRANGE', stream, startId, endId, 'COUNT', count]
+      callCount += 1;
+      if (callCount === 1) {
+        // A full batch (== COUNT) forces another iteration.
+        return Array.from({ length: count }, (_, i) => liveEntry(i, 'trigger-A'));
+      }
+      if (callCount === 2) {
+        // A short batch ends the loop; the non-live entry must be filtered out.
+        return [
+          liveEntry(count, 'trigger-A'),
+          buildEntry(`${1000 + count + 1}-0`, { version: '1', type: 'digest', notification_id: 'trigger-A' }),
+        ];
+      }
+      return [];
+    });
+
+    const received: Array<{ event: StreamNotifEvent; byteSize: number }> = [];
+    await fetchRangeNotifications<StreamNotifEvent>(new Date(1), new Date(2), (events) => {
+      received.push(...events);
+    });
+
+    // Only two XRANGE calls: the short second batch ends iteration without an extra empty call.
+    expect(mockClient.call).toHaveBeenCalledTimes(2);
+    const firstCallArgs = mockClient.call.mock.calls[0];
+    const secondCallArgs = mockClient.call.mock.calls[1];
+    const batchSize = firstCallArgs[5] as number;
+
+    // First call is inclusive of the start id and carries the COUNT batch size.
+    expect(firstCallArgs[0]).toBe('XRANGE');
+    expect(firstCallArgs[2]).toBe('1'); // new Date(1).getTime()
+    expect(firstCallArgs[3]).toBe('2'); // new Date(2).getTime()
+    expect(firstCallArgs[4]).toBe('COUNT');
+
+    // Second call excludes the last id processed in the first batch (the '(' prefix).
+    expect(secondCallArgs[2]).toBe(`(${1000 + (batchSize - 1)}-0`);
+
+    // All live events are delivered; the 'digest' entry of the second batch is filtered out.
+    expect(received).toHaveLength(batchSize + 1);
+    expect(received.every((e) => e.event.type === 'live')).toBe(true);
+    // Byte size comes from the raw stored fields (no re-serialization of the parsed object).
+    const firstEntryFields = liveEntry(0, 'trigger-A')[1];
+    const expectedFirstByteSize = firstEntryFields.reduce((acc, s) => acc + Buffer.byteLength(s), 0);
+    expect(received[0].byteSize).toBe(expectedFirstByteSize);
+  });
+
+  it('does not duplicate or skip events sharing a timestamp across batch boundaries', async () => {
+    // All entries share the millisecond '5' and differ only by sequence (5-0, 5-1, ...): the cursor
+    // must advance on the full "ms-seq" id, not on the millisecond, otherwise it would re-read or skip.
+    const sameTsEntry = (seq: number) => buildEntry(`5-${seq}`, {
+      version: '1',
+      type: 'live',
+      notification_id: 'trigger-A',
+      data: { id: `evt-${seq}` },
+    });
+    let batchSize = 0;
+    let callCount = 0;
+    mockClient.call.mockImplementation((...args: unknown[]) => {
+      const count = args[5] as number;
+      callCount += 1;
+      if (callCount === 1) {
+        batchSize = count;
+        return Array.from({ length: count }, (_, i) => sameTsEntry(i)); // 5-0 .. 5-(N-1)
+      }
+      if (callCount === 2) {
+        return [sameTsEntry(count), sameTsEntry(count + 1)]; // 5-N, 5-(N+1): short batch -> ends loop
+      }
+      return [];
+    });
+
+    const received: Array<{ event: StreamNotifEvent; byteSize: number }> = [];
+    await fetchRangeNotifications<StreamNotifEvent>(new Date(0), new Date(10), (events) => {
+      received.push(...events);
+    });
+
+    // The second XRANGE excludes the exact full id (ms-seq) of the last entry of the first batch.
+    expect(mockClient.call.mock.calls[1][2]).toBe(`(5-${batchSize - 1}`);
+    // Every event is delivered exactly once: no duplicate, no skip.
+    const ids = received.map((e) => (e.event as unknown as { data: { id: string } }).data.id);
+    expect(ids).toHaveLength(batchSize + 2);
+    expect(new Set(ids).size).toBe(batchSize + 2);
+  });
+
+  it('stops early when the callback returns false', async () => {
+    // Always return a full batch: without the early-stop the loop would never end.
+    mockClient.call.mockImplementation((...args: unknown[]) => {
+      const count = args[5] as number;
+      return Array.from({ length: count }, (_, i) => liveEntry(i, 'trigger-A'));
+    });
+
+    let batches = 0;
+    await fetchRangeNotifications(new Date(1), new Date(2), () => {
+      batches += 1;
+      return false;
+    });
+
+    expect(batches).toBe(1);
+    expect(mockClient.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke the callback when the range is empty', async () => {
+    mockClient.call.mockResolvedValue([]);
+    const callback = vi.fn();
+    await fetchRangeNotifications(new Date(1), new Date(2), callback);
+    expect(callback).not.toHaveBeenCalled();
+    expect(mockClient.call).toHaveBeenCalledTimes(1);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
@@ -43,6 +43,7 @@ const driveBatches = (batches: KnowledgeNotificationEvent[][]) => {
 describe('collectDigestContent', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    objSeq = 0; // keep tests isolated: the generated obj ids restart from 1 for each test
   });
 
   it('keeps only the events whose notification_id belongs to the digest triggers', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { KnowledgeNotificationEvent } from '../../../src/manager/notificationManager';
+import type { AuthContext, AuthUser } from '../../../src/types/user';
+import type { BasicStoreEntityTrigger } from '../../../src/modules/notification/notification-types';
 
 // Mock the stream layer so collectDigestContent is driven with canned batches (no Redis needed).
 const fetchRangeNotificationsMock = vi.fn();
@@ -9,7 +11,22 @@ vi.mock('../../../src/database/stream/stream-handler', () => ({
   createStreamProcessor: vi.fn(),
 }));
 
-import { collectDigestContent, DEFAULT_MAX_DIGEST_CONTENT_SIZE } from '../../../src/manager/notificationManager';
+// Mock the cache so getDigestNotifications is fed with canned triggers/users (no ElasticSearch needed).
+vi.mock('../../../src/database/cache', () => ({
+  getEntitiesListFromCache: vi.fn().mockResolvedValue([]),
+  getEntityFromCache: vi.fn(),
+}));
+
+// Mock the representative resolution so the digest message generation does not hit the database.
+vi.mock('../../../src/database/stix-representative', () => ({
+  extractStixRepresentative: vi.fn().mockResolvedValue('repr'),
+  extractStixRepresentativeForUser: vi.fn().mockResolvedValue('repr'),
+}));
+
+import { collectDigestContent, DEFAULT_MAX_DIGEST_CONTENT_SIZE, handleDigestNotifications } from '../../../src/manager/notificationManager';
+import { getEntitiesListFromCache, getEntityFromCache } from '../../../src/database/cache';
+import { storeNotificationEvent } from '../../../src/database/stream/stream-handler';
+import { ENTITY_TYPE_TRIGGER } from '../../../src/modules/notification/notification-types';
 
 let objSeq = 0;
 const liveEvent = (notificationId: string, userId = 'user-1'): KnowledgeNotificationEvent => {
@@ -19,7 +36,7 @@ const liveEvent = (notificationId: string, userId = 'user-1'): KnowledgeNotifica
     type: 'live',
     notification_id: notificationId,
     targets: [{ user: { user_id: userId, user_email: '', notifiers: [], user_service_account: false }, type: 'live', message: 'm' }],
-    data: { id: `obj-${objSeq}` } as KnowledgeNotificationEvent['data'],
+    data: { id: `obj-${objSeq}`, type: 'Report' } as KnowledgeNotificationEvent['data'],
     origin: {},
   };
 };
@@ -103,5 +120,73 @@ describe('collectDigestContent', () => {
 
   it('exposes a strictly positive default cap', () => {
     expect(DEFAULT_MAX_DIGEST_CONTENT_SIZE).toBeGreaterThan(0);
+  });
+});
+
+describe('handleDigestNotifications', () => {
+  // Freeze time so the digest trigger_time matches the computed run minute deterministically.
+  const FROZEN = new Date('2026-01-15T10:30:00.000Z');
+  const DIGEST_USER_ID = 'digest-user-1';
+
+  // A daily digest watching trigger-A, restricted to the digest user.
+  const digestTrigger = {
+    internal_id: 'digest-1',
+    id: 'digest-1',
+    trigger_type: 'digest',
+    period: 'day',
+    trigger_time: '10:30:00.000Z', // aligned with FROZEN (HH:mm:ss.SSS)
+    trigger_ids: ['trigger-A'],
+    notifiers: ['notifier-1'],
+    restricted_members: [{ id: DIGEST_USER_ID }],
+  } as unknown as BasicStoreEntityTrigger;
+
+  const digestUser = {
+    id: DIGEST_USER_ID,
+    internal_id: DIGEST_USER_ID,
+    user_email: 'digest-user@local',
+    user_service_account: false,
+    groups: [],
+    organizations: [],
+    personal_notifiers: [],
+  } as unknown as AuthUser;
+
+  // Feed getDigestNotifications: triggers list resolves the digest, users list resolves its member.
+  const primeCache = () => {
+    const resolveFromCache = (_ctx: AuthContext, _user: AuthUser, type: string) => {
+      return Promise.resolve(type === ENTITY_TYPE_TRIGGER ? [digestTrigger] : [digestUser]);
+    };
+    vi.mocked(getEntitiesListFromCache).mockImplementation(resolveFromCache as unknown as typeof getEntitiesListFromCache);
+    vi.mocked(getEntityFromCache).mockResolvedValue({ platform_notifier_auto_trigger_assignee: true } as unknown as Awaited<ReturnType<typeof getEntityFromCache>>);
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN);
+    primeCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    objSeq = 0;
+  });
+
+  it('stores a digest event built from the events collected for the digest triggers', async () => {
+    driveBatches([[
+      liveEvent('trigger-A', DIGEST_USER_ID),
+      liveEvent('trigger-B', DIGEST_USER_ID), // not part of the digest triggers, must be ignored
+      liveEvent('trigger-A', DIGEST_USER_ID),
+    ]]);
+    await handleDigestNotifications({} as AuthContext);
+    expect(vi.mocked(storeNotificationEvent)).toHaveBeenCalledTimes(1);
+    const digestEvent = vi.mocked(storeNotificationEvent).mock.calls[0][1] as unknown as { notification_id: string; data: unknown[] };
+    expect(digestEvent.notification_id).toBe('digest-1');
+    expect(digestEvent.data).toHaveLength(2); // only the two trigger-A events
+  });
+
+  it('does not emit a digest event when no collected event matches the digest', async () => {
+    driveBatches([[liveEvent('trigger-other', DIGEST_USER_ID)]]);
+    await handleDigestNotifications({} as AuthContext);
+    expect(vi.mocked(storeNotificationEvent)).not.toHaveBeenCalled();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { KnowledgeNotificationEvent } from '../../../src/manager/notificationManager';
+
+// Mock the stream layer so collectDigestContent is driven with canned batches (no Redis needed).
+const fetchRangeNotificationsMock = vi.fn();
+vi.mock('../../../src/database/stream/stream-handler', () => ({
+  fetchRangeNotifications: (...args: unknown[]) => fetchRangeNotificationsMock(...args),
+  storeNotificationEvent: vi.fn(),
+  createStreamProcessor: vi.fn(),
+}));
+
+import { collectDigestContent, DEFAULT_MAX_DIGEST_CONTENT_SIZE } from '../../../src/manager/notificationManager';
+
+let objSeq = 0;
+const liveEvent = (notificationId: string, userId = 'user-1'): KnowledgeNotificationEvent => {
+  objSeq += 1;
+  return {
+    version: '1',
+    type: 'live',
+    notification_id: notificationId,
+    targets: [{ user: { user_id: userId, user_email: '', notifiers: [], user_service_account: false }, type: 'live', message: 'm' }],
+    data: { id: `obj-${objSeq}` } as KnowledgeNotificationEvent['data'],
+    origin: {},
+  };
+};
+
+// Byte size of an event, mirroring how collectDigestContent measures the retained content.
+const eventBytes = (event: KnowledgeNotificationEvent) => Buffer.byteLength(JSON.stringify(event));
+
+// Wrap events the way rawFetchRangeNotifications delivers them: paired with their stored byte size.
+const sizedBatch = (events: KnowledgeNotificationEvent[]) => events.map((event) => ({ event, byteSize: eventBytes(event) }));
+
+// Make the mocked fetchRangeNotifications deliver the given batches, honouring an early-stop (false).
+const driveBatches = (batches: KnowledgeNotificationEvent[][]) => {
+  fetchRangeNotificationsMock.mockImplementation(async (_start, _end, callback) => {
+    for (let i = 0; i < batches.length; i += 1) {
+      const shouldContinue = await callback(sizedBatch(batches[i]));
+      if (shouldContinue === false) break;
+    }
+  });
+};
+
+describe('collectDigestContent', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps only the events whose notification_id belongs to the digest triggers', async () => {
+    driveBatches([[
+      liveEvent('trigger-A'),
+      liveEvent('trigger-B'),
+      liveEvent('trigger-A'),
+      liveEvent('trigger-C'),
+    ]]);
+    const { content, truncated } = await collectDigestContent(new Date(1), new Date(2), ['trigger-A', 'trigger-B']);
+    expect(truncated).toBe(false);
+    expect(content).toHaveLength(3);
+    expect(content.map((c) => c.notification_id).sort()).toEqual(['trigger-A', 'trigger-A', 'trigger-B']);
+  });
+
+  it('accumulates matching events across multiple batches', async () => {
+    driveBatches([
+      [liveEvent('trigger-A'), liveEvent('trigger-X')],
+      [liveEvent('trigger-A')],
+    ]);
+    const { content, truncated } = await collectDigestContent(new Date(1), new Date(2), ['trigger-A']);
+    expect(truncated).toBe(false);
+    expect(content).toHaveLength(2);
+  });
+
+  it('caps the content at the byte budget and reports truncation', async () => {
+    const events = Array.from({ length: 10 }, () => liveEvent('trigger-A'));
+    driveBatches([events]);
+    // Budget sized for exactly 3 events: truncation triggers when the cumulative byte size reaches it.
+    const budget = eventBytes(events[0]) + eventBytes(events[1]) + eventBytes(events[2]);
+    const { content, truncated, byteSize } = await collectDigestContent(new Date(1), new Date(2), ['trigger-A'], budget);
+    expect(truncated).toBe(true);
+    expect(content).toHaveLength(3);
+    expect(byteSize).toBeGreaterThanOrEqual(budget);
+  });
+
+  it('stops requesting further batches once the byte budget is reached', async () => {
+    const firstBatch = [liveEvent('trigger-A'), liveEvent('trigger-A'), liveEvent('trigger-A')];
+    const secondBatch = [liveEvent('trigger-A')];
+    let batchesConsumed = 0;
+    fetchRangeNotificationsMock.mockImplementation(async (_start, _end, callback) => {
+      const batches = [firstBatch, secondBatch];
+      for (let b = 0; b < batches.length; b += 1) {
+        batchesConsumed += 1;
+
+        const shouldContinue = await callback(sizedBatch(batches[b]));
+        if (shouldContinue === false) break;
+      }
+    });
+    // Budget sized for 2 events: truncation hits inside the first batch.
+    const budget = eventBytes(firstBatch[0]) + eventBytes(firstBatch[1]);
+    const { content, truncated } = await collectDigestContent(new Date(1), new Date(2), ['trigger-A'], budget);
+    expect(truncated).toBe(true);
+    expect(content).toHaveLength(2);
+    expect(batchesConsumed).toBe(1); // the second batch is never requested
+  });
+
+  it('exposes a strictly positive default cap', () => {
+    expect(DEFAULT_MAX_DIGEST_CONTENT_SIZE).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Read the notification stream range in paginated batches instead of loading the whole range at once. `rawFetchRangeNotifications` now paginates the `XRANGE` (exclusive `ms-seq` cursor + `COUNT`) and hands each batch to the caller, which filters and transforms it on the fly. Before, the whole range of the digest period was loaded and mapped before being filtered, which caused out-of-memory on large ranges.
* Keep in memory only the events that belong to the digest's triggers (filtering during the read), not the whole range.
* Bound the content kept per digest by its cumulative byte size (events vary a lot in size since each carries a full STIX object). The size is taken from the raw Redis fields already read, with no re-serialization. Past the budget the content is truncated, the read stops, and a warning is logged. New setting `notification_manager:max_digest_content_size` (bytes, default 500 MB).

### Related issues

* closes #16691
* closes OpenCTI-Platform/filigran-private#132

### How to test this PR

* Schedule a Digest notification on a trigger, generate matching events during the period, and check the digest is delivered with the expected content.
* Unit tests:
  ```
  cd opencti-platform/opencti-graphql
  yarn vitest run --config vitest.config.ci-unit.ts \
    tests/01-unit/database/redis-stream-notifications-test.ts \
    tests/01-unit/manager/digest-notification-test.ts
  ```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The range read advances on the full `ms-seq` stream id with an exclusive cursor, so events sharing the same timestamp across batch boundaries are read exactly once (no duplicate, no skip). Termination and the cursor use the raw `XRANGE` result (before the live filter), so a batch containing only non-live entries does not stop the iteration. Both are covered by unit tests.
