### PR TITLE
feat(draftworkflow): rename Status by Validation progress (#16540)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
@@ -96,7 +96,7 @@ const ConnectorWorkLine: FunctionComponent<
             </Grid>
             <Grid item xs={4}>
               <Label>
-                {t_i18n('Status')}
+                {t_i18n('Validation progress')}
               </Label>
               <TaskStatus status={workStatus} label={t_i18n(workStatus)} />
             </Grid>

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorWorkLine.tsx
@@ -40,10 +40,11 @@ interface ConnectorWorkLineProps {
   workProcessedNumber: number | null | undefined;
   workErrors: WorkMessages | null | undefined;
   readOnly?: boolean | undefined;
+  statusLabel?: string;
 }
 const ConnectorWorkLine: FunctionComponent<
   ConnectorWorkLineProps
-> = ({ workId, workName, workStatus, workReceivedTime, workEndTime, workExpectedNumber, workProcessedNumber, workErrors, readOnly }) => {
+> = ({ workId, workName, workStatus, workReceivedTime, workEndTime, workExpectedNumber, workProcessedNumber, workErrors, readOnly, statusLabel }) => {
   const { t_i18n, nsdt } = useFormatter();
 
   const [commit] = useApiMutation(connectorWorksWorkDeletionMutation);
@@ -96,7 +97,7 @@ const ConnectorWorkLine: FunctionComponent<
             </Grid>
             <Grid item xs={4}>
               <Label>
-                {t_i18n('Validation progress')}
+                {statusLabel ?? t_i18n('Status')}
               </Label>
               <TaskStatus status={workStatus} label={t_i18n(workStatus)} />
             </Grid>

--- a/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/drafts/DraftRoot.tsx
@@ -190,6 +190,7 @@ const RootDraftComponent = ({ draftId, queryRef, refetch }: RootDraftComponentPr
                 workExpectedNumber={validationWork.tracking?.import_processed_number}
                 workProcessedNumber={validationWork.tracking?.import_expected_number}
                 workErrors={validationWork.errors}
+                statusLabel={t_i18n('Validation progress')}
                 readOnly
               />
             </Paper>


### PR DESCRIPTION
### Proposed changes

- Dynamic label for task status
* In draft context : rename `Status` by `Validation progress` to avoid any confusion between the workflow statuses and the validation status

### Related issues

* closes #16540 

### How to test this PR

- Go to a draft already "Approved"
- See the task displayed on the top of the page
- Look at the label displayed

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments
<img width="1616" height="370" alt="image" src="https://github.com/user-attachments/assets/5a436570-8d59-4090-ad6e-8ac5d75cc375" />
