### PR TITLE
feat(observables): auto-populate AS number from Autonomous-System name (#8383)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableCreation.jsx
@@ -930,6 +930,29 @@ const StixCyberObservableCreation = ({
                               />
                             );
                           }
+                          if (
+                            attribute.value === 'name'
+                            && status.type === 'Autonomous-System'
+                          ) {
+                            const setDefaultAutonomousSystemId = (_, value) => {
+                              const match = value.match(/^as(\d+)$/i);
+                              if (match && !values.number) {
+                                setFieldValue('number', parseInt(match[1], 10));
+                              }
+                            };
+                            return (
+                              <Field
+                                component={TextField}
+                                variant="standard"
+                                key={attribute.value}
+                                name={attribute.value}
+                                label={t_i18n(attribute.value)}
+                                fullWidth={true}
+                                style={{ marginTop: 20 }}
+                                onSubmit={setDefaultAutonomousSystemId}
+                              />
+                            );
+                          }
                           return (
                             <Field
                               component={TextField}


### PR DESCRIPTION
When creating an Autonomous-System observable, automatically parse and set the `number` field if the name matches the pattern `AS<number>` (e.g., typing "AS1234" fills in 1234 as the AS number).

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Auto populate AS number field if name field is provided and starts with `AS`
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #8383 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
