### PR TITLE
fix(workflow): handle workflow to display check marks green for drafts (#16762)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
@@ -53,7 +53,7 @@ const subTypesLinesFragment = graphql`
       platform_hidden_type
       target_type
       availableSettings
-      workflow_id
+      workflow_published_version_id
     }
     statuses {
       id
@@ -110,7 +110,7 @@ const SubTypeLine: FunctionComponent<SubTypeLineProps> = ({
       return <DoNotDisturbOnOutlined fontSize="small" color="disabled" />;
     }
     if (nodeSubType.label === 'DraftWorkspace' && isFeatureEnable('DRAFT_WORKFLOW')) {
-      return nodeSubType.settings?.workflow_id
+      return nodeSubType.settings?.workflow_published_version_id
         ? <CheckCircleOutlined fontSize="small" color="success" />
         : <DoNotDisturbOnOutlined fontSize="small" color="primary" />;
     }

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
@@ -52,6 +52,7 @@ const subTypesLinesFragment = graphql`
       platform_hidden_type
       target_type
       availableSettings
+      workflow_id
     }
     statuses {
       id
@@ -105,6 +106,11 @@ const SubTypeLine: FunctionComponent<SubTypeLineProps> = ({
   const renderWorkflowStatus = () => {
     if (!nodeSubType.settings?.availableSettings?.includes('workflow_configuration')) {
       return <DoNotDisturbOnOutlined fontSize="small" color="disabled" />;
+    }
+    if (nodeSubType.label === 'DraftWorkspace') {
+      return nodeSubType.settings?.workflow_id
+        ? <CheckCircleOutlined fontSize="small" color="success" />
+        : <DoNotDisturbOnOutlined fontSize="small" color="primary" />;
     }
     if (nodeSubType.workflowEnabled) {
       return <CheckCircleOutlined fontSize="small" color="success" />;

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/SubTypesLine.tsx
@@ -14,6 +14,7 @@ import { DataColumns } from '../../../../components/list_lines';
 import { useFormatter } from '../../../../components/i18n';
 import type { Theme } from '../../../../components/Theme';
 import { SubTypesLine_node$key } from './__generated__/SubTypesLine_node.graphql';
+import useHelper from '../../../../utils/hooks/useHelper';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -92,6 +93,7 @@ const SubTypeLine: FunctionComponent<SubTypeLineProps> = ({
 }) => {
   const classes = useStyles();
   const { t_i18n } = useFormatter();
+  const { isFeatureEnable } = useHelper();
   const nodeSubType = useFragment(subTypesLinesFragment, node);
 
   const renderOptionIcon = (option: string) => {
@@ -107,7 +109,7 @@ const SubTypeLine: FunctionComponent<SubTypeLineProps> = ({
     if (!nodeSubType.settings?.availableSettings?.includes('workflow_configuration')) {
       return <DoNotDisturbOnOutlined fontSize="small" color="disabled" />;
     }
-    if (nodeSubType.label === 'DraftWorkspace') {
+    if (nodeSubType.label === 'DraftWorkspace' && isFeatureEnable('DRAFT_WORKFLOW')) {
       return nodeSubType.settings?.workflow_id
         ? <CheckCircleOutlined fontSize="small" color="success" />
         : <DoNotDisturbOnOutlined fontSize="small" color="primary" />;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10825,6 +10825,7 @@ type WorkflowEntityRef {
 type EntitySetting implements InternalObject & BasicObject {
   workflow_configuration: Boolean
   workflow_id: String
+  workflow_published_version_id: String
   id: ID!
   entity_type: String!
   standard_id: String!

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -8744,6 +8744,7 @@ export type EntitySetting = BasicObject & InternalObject & {
   updated_at: Scalars['DateTime']['output'];
   workflow_configuration?: Maybe<Scalars['Boolean']['output']>;
   workflow_id?: Maybe<Scalars['String']['output']>;
+  workflow_published_version_id?: Maybe<Scalars['String']['output']>;
 };
 
 
@@ -44346,6 +44347,7 @@ export type EntitySettingResolvers<ContextType = any, ParentType extends Resolve
   updated_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   workflow_configuration?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   workflow_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  workflow_published_version_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/opencti-platform/opencti-graphql/src/modules/workflow/api/workflow-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/api/workflow-resolvers.ts
@@ -7,6 +7,7 @@ import {
   getAllowedTransitions,
   getWorkflowDefinition,
   getWorkflowInstance,
+  getWorkflowPublishedVersionId,
   publishWorkflowDefinition,
   setWorkflowDefinition,
   triggerWorkflowEvent,
@@ -109,6 +110,11 @@ const workflowResolvers = {
     entity: (result: any) => result.entity,
     executionStatus: (result: any) => result.executionStatus ?? null,
     pendingTransition: (result: any) => result.instance?.pendingTransition ?? null,
+  },
+  EntitySetting: {
+    workflow_published_version_id: (entitySetting: any, _: any, context: AuthContext) => {
+      return getWorkflowPublishedVersionId(context, entitySetting);
+    },
   },
   DraftWorkspace: {
     workflowInstance: (draft: any, _: any, context: AuthContext) => {

--- a/opencti-platform/opencti-graphql/src/modules/workflow/api/workflow.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/api/workflow.graphql
@@ -49,6 +49,7 @@ type WorkflowEntityRef {
 extend type EntitySetting {
     workflow_configuration: Boolean
     workflow_id: String
+    workflow_published_version_id: String
 }
 
 type WorkflowDefinitionMutationResult {

--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
@@ -273,6 +273,24 @@ export const getWorkflowDefinition = async (
 };
 
 /**
+ * Returns the ID of the published version for the given entity setting's workflow, or null if not published.
+ */
+export const getWorkflowPublishedVersionId = async (
+  context: AuthContext,
+  entitySetting: BasicStoreEntityEntitySetting,
+): Promise<string | null> => {
+  if (!entitySetting.workflow_id) return null;
+  const executionContext = bypassDraftContext(context);
+  const workflowDefinitionEntity = await storeLoadById(
+    executionContext,
+    executionContext.user!,
+    entitySetting.workflow_id,
+    ENTITY_TYPE_WORKFLOW_DEFINITION,
+  ) as WorkflowDefinitionEntity | undefined;
+  return workflowDefinitionEntity?.published_version?.id ?? null;
+};
+
+/**
  * Create or update workflow definition for an entity type.
  */
 export const setWorkflowDefinition = async (

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-domain-test.ts
@@ -12,6 +12,7 @@ import {
   deleteWorkflowDefinition,
   triggerWorkflowEvent,
   clearWorkflowPendingState,
+  getWorkflowPublishedVersionId,
 } from '../../../src/modules/workflow/domain/workflow-domain';
 import { fullEntitiesList, storeLoadById } from '../../../src/database/middleware-loader';
 import { findByType } from '../../../src/modules/entitySetting/entitySetting-domain';
@@ -1352,5 +1353,67 @@ describe('clearWorkflowPendingState', () => {
     expect(patches.find((p: any) => p.key === 'pendingTransition')?.value[0]).toBeNull();
     const history = JSON.parse(patches.find((p: any) => p.key === 'history')?.value[0] ?? '[]');
     expect(history[history.length - 1].event).toBe('admin_clear_pending_state');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWorkflowPublishedVersionId
+// ---------------------------------------------------------------------------
+
+describe('getWorkflowPublishedVersionId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('returns null when entitySetting has no workflow_id', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace' } as any;
+
+    const result = await getWorkflowPublishedVersionId(mockContext, entitySetting);
+
+    expect(result).toBeNull();
+    expect(storeLoadById).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the WorkflowDefinitionEntity is not found', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace', workflow_id: 'wf-id' } as any;
+    (storeLoadById as any).mockResolvedValue(undefined);
+
+    const result = await getWorkflowPublishedVersionId(mockContext, entitySetting);
+
+    expect(result).toBeNull();
+    expect(storeLoadById).toHaveBeenCalledWith(mockContext, mockContext.user, 'wf-id', expect.any(String));
+  });
+
+  it('returns null when the WorkflowDefinitionEntity has no published_version', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace', workflow_id: 'wf-id' } as any;
+    (storeLoadById as any).mockResolvedValue({ id: 'wf-id', draft_version: { id: 'draft-v1' } });
+
+    const result = await getWorkflowPublishedVersionId(mockContext, entitySetting);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the published_version id when the workflow has been published', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace', workflow_id: 'wf-id' } as any;
+    (storeLoadById as any).mockResolvedValue({
+      id: 'wf-id',
+      published_version: { id: 'pub-v1', timestamp: '2024-01-01T00:00:00Z' },
+      draft_version: { id: 'draft-v2', timestamp: '2024-02-01T00:00:00Z' },
+    });
+
+    const result = await getWorkflowPublishedVersionId(mockContext, entitySetting);
+
+    expect(result).toBe('pub-v1');
+  });
+
+  it('returns the published_version id even when no draft exists (published and clean)', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace', workflow_id: 'wf-id' } as any;
+    (storeLoadById as any).mockResolvedValue({
+      id: 'wf-id',
+      published_version: { id: 'pub-v1', timestamp: '2024-01-01T00:00:00Z' },
+    });
+
+    const result = await getWorkflowPublishedVersionId(mockContext, entitySetting);
+
+    expect(result).toBe('pub-v1');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-resolvers-test.ts
@@ -7,6 +7,7 @@ import {
   triggerWorkflowEvent,
   clearWorkflowPendingState,
   getWorkflowInstance,
+  getWorkflowPublishedVersionId,
 } from '../../../src/modules/workflow/domain/workflow-domain';
 import { reportWorkflowAsyncActionResult } from '../../../src/modules/workflow/domain/workflow-async-completion';
 
@@ -20,6 +21,7 @@ vi.mock('../../../src/modules/workflow/domain/workflow-domain', () => ({
   deleteWorkflowDefinition: vi.fn(),
   triggerWorkflowEvent: vi.fn(),
   clearWorkflowPendingState: vi.fn(),
+  getWorkflowPublishedVersionId: vi.fn(),
 }));
 
 vi.mock('../../../src/modules/workflow/domain/workflow-async-completion', () => ({
@@ -844,5 +846,52 @@ describe('DraftWorkspace.workflowInstance resolver', () => {
     );
 
     expect(getWorkflowInstance).toHaveBeenCalledWith(mockContext, mockContext.user, 'draft-internal-id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EntitySetting.workflow_published_version_id
+// ---------------------------------------------------------------------------
+
+describe('EntitySetting.workflow_published_version_id resolver', () => {
+  it('calls getWorkflowPublishedVersionId with context and entitySetting, and returns the result', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace', workflow_id: 'wf-id' };
+    (getWorkflowPublishedVersionId as any).mockResolvedValue('pub-v1');
+
+    const result = await workflowResolvers.EntitySetting.workflow_published_version_id(
+      entitySetting,
+      {},
+      mockContext,
+    );
+
+    expect(getWorkflowPublishedVersionId).toHaveBeenCalledWith(mockContext, entitySetting);
+    expect(result).toBe('pub-v1');
+  });
+
+  it('returns null when the workflow has never been published', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace', workflow_id: 'wf-id' };
+    (getWorkflowPublishedVersionId as any).mockResolvedValue(null);
+
+    const result = await workflowResolvers.EntitySetting.workflow_published_version_id(
+      entitySetting,
+      {},
+      mockContext,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when entitySetting has no workflow_id', async () => {
+    const entitySetting = { id: 'es-1', target_type: 'DraftWorkspace' };
+    (getWorkflowPublishedVersionId as any).mockResolvedValue(null);
+
+    const result = await workflowResolvers.EntitySetting.workflow_published_version_id(
+      entitySetting,
+      {},
+      mockContext,
+    );
+
+    expect(getWorkflowPublishedVersionId).toHaveBeenCalledWith(mockContext, entitySetting);
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
### Proposed changes

* handle workflow to display check marks green for drafts 

### Related issues

* closes #16762 

### How to test this PR

- Go to Settings / customizations
- Find Drafts line
- See blue check mark in the workflow column
- Click on the line
- Define a workflow and publish
- return to Settings / Customizations
- See the green check mark

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality