### PR TITLE
fix(form-submit): add no_split option to form submission (#16665)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
@@ -515,6 +515,7 @@ export const formSubmit = async (
       work_id: work.id,
       draft_id: draftId,
       update: true,
+      no_split: true,
     });
 
     logApp.info('[FORM] Bundle sent to connector queue', { formId: form.id, workId: work.id, bundleId: bundle.id });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/form-submit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/form-submit-test.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { formSubmit } from '../../../src/modules/form/form-domain';
 import * as draftWorkspaceDomain from '../../../src/modules/draftWorkspace/draftWorkspace-domain';
 import * as workDomain from '../../../src/domain/work';
+import * as rabbitmq from '../../../src/database/rabbitmq';
 import { BYPASS, SYSTEM_USER } from '../../../src/utils/access';
 
 const { mockStoreLoadById } = vi.hoisted(() => ({
@@ -450,6 +451,24 @@ describe('formSubmit', () => {
     expect(draftInput.description).toBeUndefined();
     expect(draftInput.objectAssignee).toBeUndefined();
     expect(draftInput.objectParticipant).toBeUndefined();
+  });
+
+  it('should send bundle with no_split:true to prevent race condition with multiple workers', async () => {
+    const input = {
+      formId: 'form-1',
+      values: JSON.stringify({ name: 'Test Individual' }),
+    };
+
+    mockStoreLoadById.mockResolvedValue(mockForm);
+    vi.spyOn(workDomain, 'createWork').mockResolvedValue({ id: 'work-1' } as any);
+    vi.spyOn(workDomain, 'updateExpectationsNumber').mockResolvedValue(undefined as any);
+
+    await formSubmit(mockContext, mockUser, input, false); // isDraft=false → pushToWorkerForConnector path
+
+    const pushSpy = vi.mocked(rabbitmq.pushToWorkerForConnector);
+    expect(pushSpy).toHaveBeenCalledOnce();
+    const message = pushSpy.mock.calls[0][1];
+    expect(message).toMatchObject({ no_split: true });
   });
 
   it('should bypass mandatory attributes when creating draft from form intake', async () => {


### PR DESCRIPTION
### Proposed changes

* Add `no_split: true` to the `pushToWorkerForConnector` call in `formSubmit` (`form-domain.ts`)
* Add unit test covering the `isDraft=false` path to assert `no_split: true` is passed

### Related issues
* closes #16665

### How to test this PR

**Unit test (local):**

 npx vitest run tests/01-unit/domain/form-submit-test.ts

**Functional test (requires multi-worker environment):**

The race condition only manifests with multiple workers consuming the same RabbitMQ queue simultaneously, so it cannot be reliably reproduced in a standard single-worker local setup.

To validate on a staging/multi-worker environment:
1. Configure a Form Intake with a container as main entity (e.g., Grouping) and additional entities (IOCs, Course of Action) with `includeInContainer: true`
2. Deploy with **3+ workers** on a loaded queue
3. Submit the form — verify the container contains **all** expected entities in its `object_refs`

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Form intake bundles are small (a few objects) and must be ingested atomically: the container and all its referenced entities need to be processed by the same worker in a single pass.

Without `no_split: true`, the worker (`push_handler.py`) splits bundles with more than one object into individual sub-bundles that are re-queued to RabbitMQ. With multiple workers consuming the queue, the container sub-bundle can be processed before its dependencies have been ingested. After 3 failed retries (~9 seconds), `middleware.ts` silently accepts the container **without** the unresolved `object_refs`.

The `no_split` flag is already supported by the worker (see `push_handler.py` line 124: `if len(content["objects"]) == 1 or data.get("no_split", False)`) and is already used by the `taskManager` for the same reason. This fix aligns form intake with that existing pattern.