### PR TITLE
docs(composer): generate PKCS#8 RSA keys for XTM Composer (#16357)

### DIFF
--- a/docs/docs/deployment/integration-manager/installation.md
+++ b/docs/docs/deployment/integration-manager/installation.md
@@ -40,8 +40,8 @@ kubectl create namespace xtm-composer
 
 2. Create secret for RSA key:
 ```bash
-# Generate key
-openssl genrsa -out private_key_4096.pem 4096
+# Generate key (PKCS#8 format, as required by XTM Composer)
+openssl genpkey -algorithm RSA -out private_key_4096.pem -pkeyopt rsa_keygen_bits:4096
 
 # Create secret
 kubectl create secret generic xtm-composer-keys \
@@ -148,8 +148,8 @@ docker pull filigran/xtm-composer:latest
 # Create configuration directory
 mkdir -p /opt/xtm-composer/config
 
-# Generate RSA private key
-openssl genrsa -out /opt/xtm-composer/private_key_4096.pem 4096
+# Generate RSA private key (PKCS#8 format, as required by XTM Composer)
+openssl genpkey -algorithm RSA -out /opt/xtm-composer/private_key_4096.pem -pkeyopt rsa_keygen_bits:4096
 
 # Run container
 docker run -d \
@@ -206,7 +206,7 @@ networks:
    - After deployment, access the container console via Portainer
    - Generate the RSA key:
      ```bash
-     openssl genrsa -out /keys/private_key.pem 4096
+     openssl genpkey -algorithm RSA -out /keys/private_key.pem -pkeyopt rsa_keygen_bits:4096
      ```
    - Copy your configuration files to `/config`
 
@@ -261,9 +261,9 @@ volumes:
 
 Deploy with:
 ```bash
-# Generate RSA key first
+# Generate RSA key first (PKCS#8 format, as required by XTM Composer)
 mkdir -p keys
-openssl genrsa -out keys/private_key.pem 4096
+openssl genpkey -algorithm RSA -out keys/private_key.pem -pkeyopt rsa_keygen_bits:4096
 
 # Deploy the stack
 docker-compose up -d
@@ -295,8 +295,8 @@ cd xtm-composer
 # Build release binary
 cargo build --release
 
-# Generate RSA key
-openssl genrsa -out ./private_key_4096.pem 4096
+# Generate RSA key (PKCS#8 format, as required by XTM Composer)
+openssl genpkey -algorithm RSA -out ./private_key_4096.pem -pkeyopt rsa_keygen_bits:4096
 
 # Run the binary
 ./target/release/xtm-composer

--- a/docs/docs/deployment/integration-manager/quick-start.md
+++ b/docs/docs/deployment/integration-manager/quick-start.md
@@ -12,10 +12,10 @@ Before starting, ensure you have:
 
 ## Step 1: Generate RSA private key
 
-Generate a 4096-bit RSA private key for authentication:
+Generate a 4096-bit RSA private key for authentication. XTM Composer requires the key in PKCS#8 PEM format (`BEGIN PRIVATE KEY`), which `openssl genpkey` produces directly:
 
 ```bash
-openssl genrsa -out private_key_4096.pem 4096
+openssl genpkey -algorithm RSA -out private_key_4096.pem -pkeyopt rsa_keygen_bits:4096
 ```
 
 ## Step 2: Basic configuration

--- a/docs/docs/deployment/integration-manager/troubleshooting.md
+++ b/docs/docs/deployment/integration-manager/troubleshooting.md
@@ -114,9 +114,34 @@ RSA key ok
 ```
 
 If the key is invalid:
-- Regenerate the key: `openssl genrsa -out private_key_4096.pem 4096`
+- Regenerate the key: `openssl genpkey -algorithm RSA -out private_key_4096.pem -pkeyopt rsa_keygen_bits:4096`
 - Ensure it's in PKCS#8 PEM format
 - Verify the key size is 4096 bits
+
+### Wrong key format (PKCS#1 instead of PKCS#8)
+
+XTM Composer requires the private key in **PKCS#8** PEM format. If the composer fails to start with an error such as:
+
+```
+Invalid private key format. Expected PKCS#8 PEM format with 'BEGIN PRIVATE KEY' and 'END PRIVATE KEY' markers
+```
+
+the key is most likely in PKCS#1 format (`BEGIN RSA PRIVATE KEY`), which is what the legacy `openssl genrsa` command produces. Check the header of your key:
+
+```bash
+head -n 1 private_key_4096.pem
+```
+
+- PKCS#8 (correct): `-----BEGIN PRIVATE KEY-----`
+- PKCS#1 (needs conversion): `-----BEGIN RSA PRIVATE KEY-----`
+
+Convert an existing PKCS#1 key to PKCS#8 without regenerating it:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+    -in private_key_4096.pem \
+    -out private_key_4096_pkcs8.pem
+```
 
 ### 2. Check file permissions
 

--- a/docs/docs/deployment/integration-manager/troubleshooting.md
+++ b/docs/docs/deployment/integration-manager/troubleshooting.md
@@ -103,14 +103,14 @@ opencti:
 
 ### 1. Verify RSA key
 
-Check that your RSA key is valid:
+Check that your RSA key is valid (`openssl pkey` works with the PKCS#8 keys used by XTM Composer):
 ```bash
-openssl rsa -in private_key_4096.pem -check
+openssl pkey -in private_key_4096.pem -check -noout
 ```
 
 Expected output:
 ```
-RSA key ok
+Key is valid
 ```
 
 If the key is invalid:
@@ -118,7 +118,7 @@ If the key is invalid:
 - Ensure it's in PKCS#8 PEM format
 - Verify the key size is 4096 bits
 
-### Wrong key format (PKCS#1 instead of PKCS#8)
+#### Wrong key format (PKCS#1 instead of PKCS#8)
 
 XTM Composer requires the private key in **PKCS#8** PEM format. If the composer fails to start with an error such as:
 
@@ -126,7 +126,7 @@ XTM Composer requires the private key in **PKCS#8** PEM format. If the composer 
 Invalid private key format. Expected PKCS#8 PEM format with 'BEGIN PRIVATE KEY' and 'END PRIVATE KEY' markers
 ```
 
-the key is most likely in PKCS#1 format (`BEGIN RSA PRIVATE KEY`), which is what the legacy `openssl genrsa` command produces. Check the header of your key:
+The key is most likely in PKCS#1 format (`BEGIN RSA PRIVATE KEY`), which is what the legacy `openssl genrsa` command produces. Check the header of your key:
 
 ```bash
 head -n 1 private_key_4096.pem
@@ -142,6 +142,10 @@ openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
     -in private_key_4096.pem \
     -out private_key_4096_pkcs8.pem
 ```
+
+Then either rename the converted key back to the original filename or update
+`credentials_key_filepath` in your configuration to point at the new
+`private_key_4096_pkcs8.pem` file, and restart XTM Composer.
 
 ### 2. Check file permissions
 

--- a/docs/docs/development/integration-manager.md
+++ b/docs/docs/development/integration-manager.md
@@ -55,8 +55,8 @@ rustup component add rustfmt
 ### 4. Generate Development Keys
 
 ```bash
-# Generate RSA private key for development
-openssl genrsa -out private_key_4096.pem 4096
+# Generate RSA private key for development (PKCS#8 format, as required by XTM Composer)
+openssl genpkey -algorithm RSA -out private_key_4096.pem -pkeyopt rsa_keygen_bits:4096
 ```
 
 ### 5. Create Development Configuration


### PR DESCRIPTION
## Proposed changes

The XTM Composer binary (Rust) requires the RSA private key in **PKCS#8** PEM format (`-----BEGIN PRIVATE KEY-----`). However, the documentation instructs users to generate the key with `openssl genrsa`, which produces a **PKCS#1** key (`-----BEGIN RSA PRIVATE KEY-----`). With a PKCS#1 key the composer panics on startup:

```
Invalid private key format. Expected PKCS#8 PEM format with 'BEGIN PRIVATE KEY' and 'END PRIVATE KEY' markers
```

This PR replaces every `openssl genrsa` invocation in the docs with `openssl genpkey`, which emits PKCS#8 directly, and adds a troubleshooting section for users who already have a PKCS#1 key.

### Files changed
- `deployment/integration-manager/installation.md` — 5 key-generation commands updated (Kubernetes secret, Docker CLI, Portainer, standalone compose, binary build)
- `deployment/integration-manager/quick-start.md` — key-generation command updated + note on the required format
- `deployment/integration-manager/troubleshooting.md` — fixed the `regenerate` command and added a **"Wrong key format (PKCS#1 instead of PKCS#8)"** section with detection and conversion steps
- `development/integration-manager.md` — development key-generation command updated

> Note: the EE Kubernetes Helm chart page referenced in the issue lives in a separate repository and is not part of this docs tree, so it is not touched here. The Docker Compose path is already correct (it uses the `rsa-key-generator` sidecar).

## Related issues

Closes #16357

## How to test

Run the updated command and confirm the key header is PKCS#8:

```bash
openssl genpkey -algorithm RSA -out private_key_4096.pem -pkeyopt rsa_keygen_bits:4096
head -n 1 private_key_4096.pem   # -> -----BEGIN PRIVATE KEY-----
```

To convert an existing PKCS#1 key (as documented in the new troubleshooting section):

```bash
openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in private_key_4096.pem -out private_key_4096_pkcs8.pem
```