### PR TITLE
test(frontend): add e2e coverage for the GraphiQL playground page (#10345)

### DIFF
--- a/opencti-platform/opencti-front/tests_e2e/model/playground.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/playground.pageModel.ts
@@ -1,0 +1,23 @@
+import { Page } from '@playwright/test';
+
+export default class PlaygroundPage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto('/public/graphql');
+  }
+
+  // The GraphiQL editor container, rendered once the playground is loaded.
+  getPage() {
+    return this.page.locator('.graphiql-container');
+  }
+
+  getPageTitle() {
+    return this.page.getByRole('button', { name: 'GraphQL playground' });
+  }
+
+  // Error boundary fallback shared by HighLevelError and SimpleError.
+  getErrorMessage() {
+    return this.page.getByText('An unknown error occurred');
+  }
+}

--- a/opencti-platform/opencti-front/tests_e2e/playground/playground.spec.ts
+++ b/opencti-platform/opencti-front/tests_e2e/playground/playground.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '../fixtures/baseFixtures';
+import PlaygroundPage from '../model/playground.pageModel';
+
+// The GraphQL playground is served on a public route, so it must render
+// without an authenticated session.
+test.describe('GraphQL playground', { tag: ['@ce'] }, () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('should display the public playground without errors', async ({ page }) => {
+    const playgroundPage = new PlaygroundPage(page);
+
+    await playgroundPage.goto();
+
+    // The playground title and the GraphiQL editor should be visible.
+    await expect(playgroundPage.getPageTitle()).toBeVisible();
+    await expect(playgroundPage.getPage()).toBeVisible();
+
+    // The error boundary fallback must not be displayed.
+    await expect(playgroundPage.getErrorMessage()).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Proposed changes

Adds Playwright end-to-end coverage for the public **GraphQL playground** page, as requested in #10345.

The test:
- opens `/public/graphql` **while unauthenticated** (per the maintainer note on the issue, the playground is a public route and must render without a session),
- asserts the playground title and the GraphiQL editor are visible,
- asserts the error-boundary fallback (`An unknown error occurred…`) is **not** displayed.

### Files added
- `tests_e2e/playground/playground.spec.ts` — the spec (unauthenticated via `test.use({ storageState: { cookies: [], origins: [] } })`)
- `tests_e2e/model/playground.pageModel.ts` — page model following the existing `model/` convention

## Related issues

Closes #10345

## How to test

From `opencti-platform/opencti-front` with the platform running:

```bash
yarn test:e2e --grep "GraphQL playground"
```

The playground is enabled by default (`app:graphql:playground:enabled`), so no extra configuration is required.