### PR TITLE
docs(deployment): warn against flushing Redis and add recovery steps (#14881)

### DIFF
--- a/docs/docs/deployment/advanced/troubleshooting.md
+++ b/docs/docs/deployment/advanced/troubleshooting.md
@@ -82,3 +82,50 @@ The workers can have more or less verbose outputs:
 !!! warning "TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage watermark..."
     
     Disk full, no space left on the device for ElasticSearch.
+
+## Redis state management
+
+OpenCTI stores critical runtime state in Redis, not only a disposable cache. Among other things, Redis holds:
+
+* **Work tracking** — every connector ingestion job is tracked through work identifiers stored in Redis.
+* **Distributed locks** — used to prevent duplicate entity creation during concurrent ingestion.
+* **Stream coordination** — live stream and TAXII data-sharing positions.
+* **Caching and session data** — API caching and user sessions.
+
+!!! warning "Never run `FLUSHDB` or `FLUSHALL` on a live OpenCTI Redis"
+
+    Flushing Redis destroys all of the state above. RabbitMQ queues, however, live in a separate system and **survive the flush**, which leaves bundles in the queue that reference work identifiers that no longer exist. Workers then dequeue those bundles, try to update their (now missing) work, and the platform raises `WORK_NOT_ALIVE` errors (`Work is no longer alive, no request can be done within the context of this work`). The result is ingest nodes burning CPU on retries while ElasticSearch stays idle and the queue backlog never drains.
+
+### Symptoms of a flushed Redis
+
+* `WORK_NOT_ALIVE` errors in the platform and worker logs.
+* A growing RabbitMQ backlog that does not drain despite healthy infrastructure.
+* ElasticSearch idle (no write rejections, no active merges) while the queue is large.
+* Uneven ingest-node CPU — some workers hot in retry loops, others idle.
+* Works stuck "In progress" with no completed operations.
+
+### Recovery after a flush
+
+If `FLUSHDB`/`FLUSHALL` has already been run, the orphaned queues must be cleared so connectors can recreate fresh work:
+
+1. Purge the stale connector queues in RabbitMQ (the bundles referencing dead work identifiers).
+2. Reset the affected connector state in OpenCTI.
+3. Restart the ingest/worker pods.
+4. Restart the platform pods.
+5. Restart the connectors so they create new work identifiers.
+6. Monitor the logs until the `WORK_NOT_ALIVE` errors stop.
+
+### Safe alternatives when Redis memory is high
+
+High Redis memory is usually a symptom (often a connector queue backlog), so address the cause instead of flushing:
+
+* Identify what is consuming memory with `redis-cli --bigkeys`.
+* Purge the specific **RabbitMQ** connector queues that are backed up — not Redis.
+* Trim the event stream if stream growth is the issue.
+* Delete a specific stuck lock key surgically rather than flushing the whole database.
+
+### Recommended Redis configuration
+
+* Set `maxmemory` explicitly rather than relying on the container being OOM-killed.
+* Use `maxmemory-policy noeviction` so Redis never silently evicts the critical state listed above (a write will fail loudly instead of corrupting platform state).
+* Monitor memory usage, blocked clients and the slowlog.


### PR DESCRIPTION
## Proposed changes

Adds a **Redis state management** section to the deployment troubleshooting guide, as requested in #14881.

OpenCTI uses Redis for critical runtime state (work tracking, distributed locks, stream/TAXII positions, caching and sessions) — not just a disposable cache. Running `FLUSHDB`/`FLUSHALL` on a live instance destroys that state while RabbitMQ queues survive, leaving bundles that reference dead work IDs. Workers then raise `WORK_NOT_ALIVE` errors and the ingestion pipeline stalls (CPU burns on retries, ElasticSearch idle, backlog never drains).

The new section documents:
- **What Redis stores** and why it is critical.
- A clear **warning** never to flush a live OpenCTI Redis, with the failure chain.
- **Symptoms** of an accidental flush.
- A step-by-step **recovery procedure**.
- **Safe alternatives** when Redis memory is high (purge RabbitMQ queues, `--bigkeys`, stream trimming, surgical key deletion).
- **Recommended Redis configuration** (`maxmemory` + `maxmemory-policy noeviction`).

I verified the `WORK_NOT_ALIVE` error against the source (`opencti-graphql/src/config/errors.js`): `Work is no longer alive, no request can be done within the context of this work`. The section uses the existing `!!! warning` admonition style and lives next to the other operational errors on the page.

## Related issues

Closes #14881

## How to test

Render the docs locally (or review the diff): the new **Redis state management** section appears on the *Deployment → Advanced → Troubleshooting* page with a correctly formatted warning admonition.