### PR TITLE
docs(deployment): document admin init crash on legacy internal_id mismatch (#16410)

### DIFF
--- a/docs/docs/deployment/upgrade.md
+++ b/docs/docs/deployment/upgrade.md
@@ -33,3 +33,33 @@ When upgrading the platform, you have to replace all files and restart the platf
 ```bash
 $ yarn serv
 ```
+
+## Known issues
+
+### `User already exists` crash loop after upgrading a legacy platform
+
+!!! warning "Symptom"
+
+    After upgrading an older platform to 7.x, the platform crash-loops on boot during admin initialization and never becomes available. The logs show:
+
+    ```
+    FunctionalError: User already exists
+    ```
+
+**Cause**
+
+On boot, the platform resolves the admin account by its hardcoded identifier `OPENCTI_ADMIN_UUID` (`88ec0c6a-13ce-5e39-b486-354fe4a7084f`). On deployments where the admin account was created before this identifier became deterministic, the stored admin document has a **random** `internal_id` that does not match `OPENCTI_ADMIN_UUID`. As a result the admin lookup returns nothing, initialization falls into the *create* path, and creating the account collides with the existing admin on `user_email` — which raises `User already exists` and aborts startup.
+
+This can affect any deployment carrying a sufficiently old admin account forward across the 7.x upgrade.
+
+**How to confirm**
+
+Look up the admin account by the email configured in `APP__ADMIN__EMAIL` and compare its stored `internal_id` with `OPENCTI_ADMIN_UUID` (`88ec0c6a-13ce-5e39-b486-354fe4a7084f`). If they differ, you are hitting this issue.
+
+**Remediation**
+
+The reliable fix is to reconcile the existing admin account so its identity matches `OPENCTI_ADMIN_UUID`, which lets the initialization take the *patch* path on the next boot. Avoid working around the crash by setting a different `APP__ADMIN__EMAIL`: that creates a second admin and leaves the legacy admin orphaned while it still owns historical objects. Because reconciling the identity is a data operation, take a backup first and reach out on the [Slack community](https://community.filigran.io) if you need guidance for your deployment.
+
+!!! note "`APP__ADMIN__EXTERNALLY_MANAGED`"
+
+    Setting `APP__ADMIN__EXTERNALLY_MANAGED=true` (`app:admin:externally_managed`) forces the admin `account_status` to `Locked` on every boot. This is the recommended posture for SSO-primary deployments that do not want a usable local admin login.


### PR DESCRIPTION
## Proposed changes

Adds a **Known issues** section to the upgrade guide documenting the `User already exists` crash loop that can occur when upgrading an older platform to 7.x, as requested in #16410.

When a legacy admin account's stored `internal_id` does not match the hardcoded `OPENCTI_ADMIN_UUID` (`88ec0c6a-13ce-5e39-b486-354fe4a7084f`), `initAdmin()` takes the *create* path, collides on `user_email`, and aborts boot with `FunctionalError: User already exists`.

The entry covers:
- **Symptom** — the error and crash loop on boot.
- **Cause** — legacy `internal_id` ≠ `OPENCTI_ADMIN_UUID`.
- **How to confirm** — compare the admin account's `internal_id` against the constant.
- **Remediation** — reconcile the existing admin's identity (with a backup / community guidance) rather than changing `APP__ADMIN__EMAIL`, which orphans the legacy admin.
- **`APP__ADMIN__EXTERNALLY_MANAGED`** — documents that it forces the admin `account_status` to `Locked` on each boot.

All claims verified against `opencti-platform/opencti-graphql/src/domain/user.js` (`initAdmin()` at L2044, `User already exists` throw at L733) and `schema/general.js` (`OPENCTI_ADMIN_UUID`).

> The reporter also flagged a latent product angle (a clearer error message or a migration that repoints the legacy `internal_id`). This PR is documentation only; happy to split that into a separate engineering issue if maintainers want.

## Related issues

Closes #16410

## How to test

Review the rendered *Deployment → Upgrade* page: the new **Known issues** section appears with correctly formatted admonitions.