### PR TITLE
fix(backend): recover from malformed JSON when loading the cache (#16692)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/cacheManager.ts
@@ -79,58 +79,73 @@ const workflowStatuses = (context: AuthContext) => {
 export const extractResolvedFiltersFromInstance = (instance: BasicStoreCommon) => {
   const initialFilterGroup = JSON.stringify(emptyFilterGroup);
   const filteringIds: string[] = []; // will contain the ids that are in the instance filters values
-  if (instance.entity_type === ENTITY_TYPE_STREAM_COLLECTION) {
-    const streamFilterIds = extractFilterGroupValuesToResolveForCache(
-      JSON.parse((instance as BasicStreamEntity).filters ?? initialFilterGroup),
-    );
-    pushAll(filteringIds, streamFilterIds);
-  } else if (instance.entity_type === ENTITY_TYPE_TRIGGER) {
-    const triggerFilterIds = extractFilterGroupValuesToResolveForCache(
-      JSON.parse((instance as BasicTriggerEntity).filters ?? initialFilterGroup),
-    );
-    pushAll(filteringIds, triggerFilterIds);
-  } else if (instance.entity_type === ENTITY_TYPE_CONNECTOR) {
-    const connFilters = (instance as BasicStoreEntityConnector).connector_trigger_filters?.length > 0
-      ? (instance as BasicStoreEntityConnector).connector_trigger_filters
-      : initialFilterGroup;
-    const connFilterIds = extractFilterGroupValuesToResolveForCache(JSON.parse(connFilters));
-    pushAll(filteringIds, connFilterIds);
-  } else if (instance.entity_type === ENTITY_TYPE_PLAYBOOK) {
-    const definition = JSON.parse((instance as BasicStoreEntityPlaybook).playbook_definition) as ComponentDefinition;
-    const configurations = definition.nodes.map((n) => JSON.parse(n.configuration));
-    // IDs from filters in playbook components.
-    const playbookFilterIds = configurations
-      .flatMap((config) => [config.filters, config.applyWithFilters])
-      .filter((f) => isNotEmptyField(f))
-      .flatMap((f) => extractFilterGroupValuesToResolveForCache(JSON.parse(f)));
-    // IDs from list of PIRs to listen.
-    const playbookInPirFilterIds = configurations
-      .map((config) => config.inPirFilters)
-      .map((f) => (f ?? []).map((i: { value: string }) => i.value))
-      .flat();
-    pushAll(filteringIds, playbookFilterIds);
-    pushAll(filteringIds, playbookInPirFilterIds);
-  } else if (instance.entity_type === ENTITY_TYPE_PIR) {
-    const pirFilterIds = extractFilterGroupValuesToResolveForCache(JSON.parse((instance as BasicStoreEntityPir).pir_filters));
-    const pirCriteriaIds = (instance as BasicStoreEntityPir).pir_criteria
-      .map((c) => extractFilterGroupValuesToResolveForCache(JSON.parse(c.filters)))
-      .flat();
-    pushAll(filteringIds, pirFilterIds);
-    pushAll(filteringIds, pirCriteriaIds);
-  } else if (instance.entity_type === ENTITY_TYPE_DECAY_RULE) {
-    const decayRuleFilters = (instance as BasicStoreEntityDecayRule).decay_filters;
-    if (decayRuleFilters) {
-      const decayRuleIds = extractFilterGroupValuesToResolveForCache(JSON.parse(decayRuleFilters));
-      pushAll(filteringIds, decayRuleIds);
+  try {
+    if (instance.entity_type === ENTITY_TYPE_STREAM_COLLECTION) {
+      const streamFilterIds = extractFilterGroupValuesToResolveForCache(
+        JSON.parse((instance as BasicStreamEntity).filters ?? initialFilterGroup),
+      );
+      pushAll(filteringIds, streamFilterIds);
+    } else if (instance.entity_type === ENTITY_TYPE_TRIGGER) {
+      const triggerFilterIds = extractFilterGroupValuesToResolveForCache(
+        JSON.parse((instance as BasicTriggerEntity).filters ?? initialFilterGroup),
+      );
+      pushAll(filteringIds, triggerFilterIds);
+    } else if (instance.entity_type === ENTITY_TYPE_CONNECTOR) {
+      const connFilters = (instance as BasicStoreEntityConnector).connector_trigger_filters?.length > 0
+        ? (instance as BasicStoreEntityConnector).connector_trigger_filters
+        : initialFilterGroup;
+      const connFilterIds = extractFilterGroupValuesToResolveForCache(JSON.parse(connFilters));
+      pushAll(filteringIds, connFilterIds);
+    } else if (instance.entity_type === ENTITY_TYPE_PLAYBOOK) {
+      const definition = JSON.parse((instance as BasicStoreEntityPlaybook).playbook_definition) as ComponentDefinition;
+      const configurations = definition.nodes.map((n) => JSON.parse(n.configuration));
+      // IDs from filters in playbook components.
+      const playbookFilterIds = configurations
+        .flatMap((config) => [config.filters, config.applyWithFilters])
+        .filter((f) => isNotEmptyField(f))
+        .flatMap((f) => extractFilterGroupValuesToResolveForCache(JSON.parse(f)));
+      // IDs from list of PIRs to listen.
+      const playbookInPirFilterIds = configurations
+        .map((config) => config.inPirFilters)
+        .map((f) => (f ?? []).map((i: { value: string }) => i.value))
+        .flat();
+      pushAll(filteringIds, playbookFilterIds);
+      pushAll(filteringIds, playbookInPirFilterIds);
+    } else if (instance.entity_type === ENTITY_TYPE_PIR) {
+      const pirFilterIds = extractFilterGroupValuesToResolveForCache(JSON.parse((instance as BasicStoreEntityPir).pir_filters));
+      const pirCriteriaIds = (instance as BasicStoreEntityPir).pir_criteria
+        .map((c) => extractFilterGroupValuesToResolveForCache(JSON.parse(c.filters)))
+        .flat();
+      pushAll(filteringIds, pirFilterIds);
+      pushAll(filteringIds, pirCriteriaIds);
+    } else if (instance.entity_type === ENTITY_TYPE_DECAY_RULE) {
+      const decayRuleFilters = (instance as BasicStoreEntityDecayRule).decay_filters;
+      if (decayRuleFilters) {
+        const decayRuleIds = extractFilterGroupValuesToResolveForCache(JSON.parse(decayRuleFilters));
+        pushAll(filteringIds, decayRuleIds);
+      }
+    } else if (instance.entity_type === ENTITY_TYPE_DECAY_EXCLUSION_RULE) {
+      const decayExclusionRuleIds = extractFilterGroupValuesToResolveForCache(JSON.parse((instance as BasicStoreEntityDecayExclusionRule).decay_exclusion_filters));
+      pushAll(filteringIds, decayExclusionRuleIds);
+    } else {
+      throw FunctionalError(
+        'Resolved filters are only saved in cache for streams, triggers, connectors and playbooks, not for this entity type',
+        { entity_type: instance.entity_type },
+      );
     }
-  } else if (instance.entity_type === ENTITY_TYPE_DECAY_EXCLUSION_RULE) {
-    const decayExclusionRuleIds = extractFilterGroupValuesToResolveForCache(JSON.parse((instance as BasicStoreEntityDecayExclusionRule).decay_exclusion_filters));
-    pushAll(filteringIds, decayExclusionRuleIds);
-  } else {
-    throw FunctionalError(
-      'Resolved filters are only saved in cache for streams, triggers, connectors and playbooks, not for this entity type',
-      { entity_type: instance.entity_type },
-    );
+  } catch (e) {
+    // A single instance holding a malformed JSON (e.g. an altered playbook node configuration)
+    // must not break the loading of the whole cache. Log the faulty instance and skip its
+    // filters instead. Other errors (e.g. unsupported entity type) are still propagated.
+    if (e instanceof SyntaxError) {
+      logApp.error('[OPENCTI-MODULE] Cache manager failed to parse the filters of an instance, skipping it', {
+        cause: e,
+        id: instance.internal_id,
+        entity_type: instance.entity_type,
+      });
+      return [];
+    }
+    throw e;
   }
   return filteringIds;
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/cacheManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/cacheManager-test.ts
@@ -38,5 +38,44 @@ describe('Cache Manager', () => {
         expect(result).toEqual(expectedResult);
       });
     });
+
+    describe('Recovery on malformed JSON', () => {
+      it('should return an empty array instead of throwing when a playbook definition is not valid JSON', () => {
+        const instanceWithMalformedDefinition = {
+          internal_id: 'playbook-malformed-1',
+          playbook_definition: '{"nodes": [', // truncated, invalid JSON
+          entity_type: 'Playbook',
+        } as unknown as BasicStoreCommon;
+        expect(() => extractResolvedFiltersFromInstance(instanceWithMalformedDefinition)).not.toThrow();
+        expect(extractResolvedFiltersFromInstance(instanceWithMalformedDefinition)).toEqual([]);
+      });
+
+      it('should return an empty array instead of throwing when a playbook node configuration is not valid JSON', () => {
+        const instanceWithMalformedNodeConfiguration = {
+          internal_id: 'playbook-malformed-2',
+          playbook_definition: '{"nodes":[{"id":"id1","component_id":"PLAYBOOK_INTERNAL_DATA_STREAM","configuration":"{not valid json}"}],"links":[]}',
+          entity_type: 'Playbook',
+        } as unknown as BasicStoreCommon;
+        expect(() => extractResolvedFiltersFromInstance(instanceWithMalformedNodeConfiguration)).not.toThrow();
+        expect(extractResolvedFiltersFromInstance(instanceWithMalformedNodeConfiguration)).toEqual([]);
+      });
+
+      it('should return an empty array instead of throwing when a stream filter is not valid JSON', () => {
+        const instanceWithMalformedFilters = {
+          internal_id: 'stream-malformed-1',
+          filters: '{"mode":"and",', // truncated, invalid JSON
+          entity_type: 'StreamCollection',
+        } as unknown as BasicStoreCommon;
+        expect(() => extractResolvedFiltersFromInstance(instanceWithMalformedFilters)).not.toThrow();
+        expect(extractResolvedFiltersFromInstance(instanceWithMalformedFilters)).toEqual([]);
+      });
+    });
+
+    describe('Unsupported entity type', () => {
+      it('should still throw for an entity type that does not support resolved filters', () => {
+        const unsupportedInstance = { internal_id: 'x', entity_type: 'Malware' } as unknown as BasicStoreCommon;
+        expect(() => extractResolvedFiltersFromInstance(unsupportedInstance)).toThrow();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Proposed changes

Some objects store JSON as text that is parsed on demand. `extractResolvedFiltersFromInstance` (used by `getEntitiesFromCache` to build the resolved-filters cache) called `JSON.parse` on those fields **without guarding**. A single object holding malformed JSON — for example a playbook whose node configuration was altered and re-imported — made the *entire* cache load throw, which then broke many platform operations (the issue reports failures such as creating an entity).

### Fix
- Wrap the extraction logic so a JSON `SyntaxError` is caught, logged with the faulty instance's `id` and `entity_type`, and that instance is **skipped** (returns no filtering ids) instead of aborting the whole cache load.
- Other errors (e.g. an unsupported entity type, which throws `FunctionalError`) are still propagated unchanged — only data/parse errors are recovered.

This matches the remediation suggested in the issue: *guard the parses, log the faulty object, and recover by not loading that object's filters.*

### Tests
Extended `tests/01-unit/manager/cacheManager-test.ts` with cases for a malformed playbook definition, a malformed playbook node configuration, and malformed stream filters (all return `[]` and do not throw), plus a check that unsupported entity types still throw.

## Related issues

Closes #16692

## How to test

```bash
cd opencti-platform/opencti-graphql
yarn vitest run --config vitest.config.ci-unit.ts tests/01-unit/manager/cacheManager-test.ts
```

All 7 tests pass locally (3 existing + 4 new). Before the fix, the malformed-JSON cases threw a `SyntaxError`; after it, the instance is skipped and the cache still loads.