### PR TITLE
fix(ci): add telemetry profile to dev grafana service (#16777)

### DIFF
--- a/opencti-platform/opencti-dev/docker-compose.yml
+++ b/opencti-platform/opencti-dev/docker-compose.yml
@@ -173,6 +173,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     depends_on:
       - opencti-dev-telemetry-prometheus
+    profiles:
+      - "telemetry"
 
   # SAML / OpenId provider with keycloak - disabled by default
   # docker compose --profile keycloak up -d


### PR DESCRIPTION
## Proposed changes

The dev stack in `opencti-platform/opencti-dev` could not be started with the documented command:

```
$ docker compose up -d
service "opencti-dev-telemetry-grafana" depends on undefined service "opencti-dev-telemetry-prometheus": invalid compose project
```

`grafana` had no `profiles` while `depends_on` the `telemetry`-profiled `prometheus`, making the default project invalid. This change adds `profiles: [telemetry]` to `grafana`, consistent with the other telemetry services (`prometheus`, `otlp`, `jaeger`, `pyroscope`).

## Related issues

Closes #16777

## How to test

From `opencti-platform/opencti-dev`:

```bash
# Before: both fail with 'invalid compose project'
# After:
docker compose config >/dev/null && echo OK          # default project is valid
docker compose config --services                      # core services, no grafana
docker compose --profile telemetry config --services  # includes opencti-dev-telemetry-grafana
```

Verified locally: the default project is valid, grafana is excluded by default and included with `--profile telemetry`, and `docker compose up -d` brings up the core dependencies.