### PR TITLE
fix(backend): use relationshipType in groupDeleteRelation error message (#16780)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/group.js
+++ b/opencti-platform/opencti-graphql/src/domain/group.js
@@ -228,7 +228,7 @@ export const groupDeleteRelation = async (context, user, groupId, fromId, toId, 
     throw FunctionalError('Cannot delete the relation, Group cannot be found.', { groupId });
   }
   if (!isInternalRelationship(relationshipType)) {
-    throw FunctionalError(`Only ${ABSTRACT_INTERNAL_RELATIONSHIP} can be deleted through this method, got ${input.relationship_type}.`);
+    throw FunctionalError(`Only ${ABSTRACT_INTERNAL_RELATIONSHIP} can be deleted through this method, got ${relationshipType}.`);
   }
   let target;
   if (fromId) {


### PR DESCRIPTION
## Proposed changes

`groupDeleteRelation` in `src/domain/group.js` referenced the local `input` variable in its validation error message **before `input` is declared** (it is a `const` declared ~10 lines further down). Accessing it there hits the temporal dead zone, so calling the function with a non-internal `relationshipType` throws `ReferenceError: Cannot access 'input' before initialization` instead of the intended `FunctionalError` with a clear message.

The fix uses the `relationshipType` parameter (already in scope) directly in the message — a one-line change.

## Related issues

Closes #16780

## How to test

Call `groupDeleteRelation` with a non-internal relationship type; it now returns the intended validation error (`Only ... can be deleted through this method, got <type>.`) instead of a `ReferenceError`.