### PR TITLE
fix(backend): guard JSON.parse of workflow instance history (#16782)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
@@ -571,13 +571,22 @@ export const getWorkflowInstance = async (
     }
   }
 
+  // Parse the stored history defensively: a malformed history field must not
+  // crash the whole resolver (same guarding as the other history parses in this file).
+  let history: any[];
+  try {
+    history = JSON.parse(instanceEntity?.history || '[]');
+  } catch {
+    history = [];
+  }
+
   return {
     id,
     internal_id: id,
     __typename: 'WorkflowInstance',
     currentState: currentState || '',
     allowedTransitions,
-    history: JSON.parse(instanceEntity?.history || '[]'),
+    history,
     pendingStatus: instanceEntity?.pendingStatus ?? null,
     pendingError: instanceEntity?.pendingError ?? null,
     pendingTransition: pendingTransitionData,


### PR DESCRIPTION
## Proposed changes

`getWorkflowInstance` (`src/modules/workflow/domain/workflow-domain.ts`) parsed the stored `history` text field with an **unguarded** `JSON.parse` on the return path. A malformed `history` value therefore threw and made the workflow state of the affected entity unreadable.

This guards the parse (returning `[]` on failure), consistent with the two other `history` parses in the same file (lines ~796 and ~890) and the adjacent `pendingTransition` guard in the same function.

## Related issues

Closes #16782

## How to test

```bash
cd opencti-platform/opencti-graphql
yarn eslint --config eslint.config.mjs src/modules/workflow/domain/workflow-domain.ts   # clean
```

With a workflow instance whose `history` field is malformed JSON, `getWorkflowInstance` previously threw a `SyntaxError`; it now returns an empty history and the rest of the workflow state still loads.