### PR TITLE
fix(migration): merge attack pattern case-insensitive duplicates with a low-level merge (#16793)

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
@@ -11,6 +11,7 @@ import {
   elBulk,
   elDeleteElements,
   elFindByIds,
+  elLoadById,
   elUpdateEntityConnections,
   elUpdateRelationConnections,
   ES_MAX_CONCURRENCY,
@@ -61,9 +62,14 @@ const lowLevelMergeGroup = async (
   sources: DynEntity[],
   newId: string,
 ) => {
-  const targetId = target.internal_id;
-  const targetName = target.name;
-  const targetIndex = target._index;
+  // `target` was loaded by fullEntitiesList, which paginates with the default withoutRels=true and therefore
+  // strips the denormalized rel_<type>.internal_id fields from _source. Reload it with the rels present so the
+  // dedup map below reflects the edges the target already holds; otherwise existing edges go undetected and the
+  // merge creates duplicate relations (and breaks the single-ref dedup, e.g. created-by).
+  const fullTarget = (await elLoadById<DynEntity>(context, SYSTEM_USER, target.internal_id, { type: entityType })) ?? target;
+  const targetId = fullTarget.internal_id;
+  const targetName = fullTarget.name;
+  const targetIndex = fullTarget._index;
   const sourceIds = sources.map((s) => s.internal_id);
   const sourceIdSet = new Set(sourceIds);
   const internalIds = new Set([targetId, ...sourceIds]);
@@ -72,7 +78,7 @@ const lowLevelMergeGroup = async (
   // In-memory dedup state: neighbors already connected to the target per relationship type. It is seeded
   // from the target denormalization and grown as source relations get redirected, so that two sources
   // pointing to the same neighbor do not create a duplicate edge.
-  const targetConnected = buildTargetConnected(target);
+  const targetConnected = buildTargetConnected(fullTarget);
   // Neighbors to add to the target denormalization, applied once at the end (grouped to avoid self conflicts).
   const targetAddByRelType: Record<string, Set<string>> = {};
 
@@ -174,19 +180,19 @@ const lowLevelMergeGroup = async (
   // Merge identity-bearing attributes onto the target and move its standard_id to the new value. The
   // previous standard_id and all source ids are archived in x_opencti_stix_ids so older references resolve.
   const stixIds = R.uniq([
-    ...(target[IDS_STIX] ?? []),
-    ...(target.standard_id !== newId ? [target.standard_id] : []),
+    ...(fullTarget[IDS_STIX] ?? []),
+    ...(fullTarget.standard_id !== newId ? [fullTarget.standard_id] : []),
     ...sources.flatMap((s) => [s.standard_id, ...(s[IDS_STIX] ?? [])]),
   ]).filter((id) => isNotEmptyField(id) && id !== newId);
   const aliasValues = R.uniq([
-    ...(target[aliasField] ?? []),
+    ...(fullTarget[aliasField] ?? []),
     ...sources.flatMap((s) => [...(s[aliasField] ?? []), s.name]),
   ]).filter((value) => isNotEmptyField(value));
   await elBulk(context, {
     refresh: true,
     timeout: BULK_TIMEOUT,
     body: [
-      { update: { _index: targetIndex, _id: target._id, retry_on_conflict: ES_RETRY_ON_CONFLICT } },
+      { update: { _index: targetIndex, _id: fullTarget._id, retry_on_conflict: ES_RETRY_ON_CONFLICT } },
       { doc: { standard_id: newId, [IDS_STIX]: stixIds, [aliasField]: aliasValues } },
     ],
   });

--- a/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
@@ -53,6 +53,20 @@ const describeError = (err: any) => ({
   errorStack: err?.stack,
 });
 
+// Add every non-empty id reachable from a denormalized rel_<type>.internal_id value into `into`.
+// Values are normally a flat string array, but the field is read defensively (an element could itself
+// be an array): we recurse into nested arrays and add scalars straight into the Set, so no intermediate
+// flattened copy is allocated even for heavily-connected targets.
+const collectConnectedIds = (value: any, into: Set<string>) => {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      collectConnectedIds(value[i], into);
+    }
+  } else if (isNotEmptyField(value)) {
+    into.add(value);
+  }
+};
+
 // Build the "already connected" map from the target's own denormalized rel_<type>.internal_id fields.
 // It is the cheap source of truth to deduplicate source relations against the target without ever
 // loading the (potentially huge) target neighborhood.
@@ -63,8 +77,9 @@ const buildTargetConnected = (target: DynEntity): Record<string, Set<string>> =>
     const key = keys[i];
     if (key.startsWith(REL_PREFIX) && key.endsWith(REL_SUFFIX)) {
       const relType = key.substring(REL_PREFIX.length, key.length - REL_SUFFIX.length);
-      const ids = (target[key] ?? []).flat(Infinity).filter((id: string) => isNotEmptyField(id));
-      connected[relType] = new Set(ids);
+      const ids = new Set<string>();
+      collectConnectedIds(target[key], ids);
+      connected[relType] = ids;
     }
   }
   return connected;
@@ -201,8 +216,11 @@ const lowLevelMergeGroup = async (
     return true;
   };
 
-  await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { fromId: sourceIds, callback: processRelations });
-  await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { toId: sourceIds, callback: processRelations });
+  // baseData keeps the streamed payload minimal: the callback only needs the base fields (internal_id,
+  // entity_type, _index) plus `connections`, which is part of the base projection and from which the
+  // engine reconstructs fromId / toId / fromType / toType on read.
+  await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { fromId: sourceIds, baseData: true, callback: processRelations });
+  await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { toId: sourceIds, baseData: true, callback: processRelations });
 
   // Merge identity-bearing attributes onto the target and move its standard_id to the new value. The
   // previous standard_id and all source ids are archived in x_opencti_stix_ids so older references resolve.

--- a/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
@@ -94,6 +94,13 @@ const buildTargetConnected = (target: DynEntity): Record<string, Set<string>> =>
 // connections redirect is written LAST. The redirect is the "commit": only once it lands does the
 // relation stop matching the source stream. Every write is idempotent, so re-running the group after a
 // partial failure converges - already-redirected relations are skipped, the rest are reprocessed.
+//
+// This denorm-first ordering is deliberate so a retried group never loses an edge it already redirected.
+// The two writes (relation doc + denorm doc) are inherently non-atomic, so a crash in the narrow window
+// between them can leave a stale rel_* entry on the target/neighbor that no relation backs. We accept that
+// bounded, cache-only drift rather than the only complete alternative - recomputing the denormalization
+// from the target's live relations, which would require loading the (huge) canonical neighborhood this
+// migration exists to avoid. The relation `connections` (the authoritative graph) stay consistent regardless.
 const lowLevelMergeGroup = async (
   context: AuthContext,
   entityType: string,

--- a/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
@@ -1,0 +1,292 @@
+import * as R from 'ramda';
+import { Promise as BluePromise } from 'bluebird';
+import { executionContext, SYSTEM_USER } from '../utils/access';
+import { generateStandardId } from '../schema/identifier';
+import { ATTRIBUTE_ALIASES, ATTRIBUTE_ALIASES_OPENCTI, ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION } from '../schema/stixDomainObject';
+import { isNotEmptyField, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
+import { fullEntitiesList, fullRelationsList } from '../database/middleware-loader';
+import {
+  BULK_TIMEOUT,
+  elBatchIdsWithRelCount,
+  elBulk,
+  elDeleteElements,
+  elFindByIds,
+  elUpdateEntityConnections,
+  elUpdateRelationConnections,
+  ES_MAX_CONCURRENCY,
+  ES_RETRY_ON_CONFLICT,
+  isImpactedTypeAndSide,
+  MAX_BULK_OPERATIONS,
+  ROLE_FROM,
+  ROLE_TO,
+} from '../database/engine';
+import { ABSTRACT_STIX_RELATIONSHIP, IDS_STIX } from '../schema/general';
+import { isSingleRelationsRef } from '../schema/stixEmbeddedRelationship';
+import { logApp, logMigration } from '../config/conf';
+import type { AuthContext } from '../types/user';
+import type { BasicStoreBase, BasicStoreEntity, BasicStoreObject, BasicStoreRelation } from '../types/store';
+
+const message = '[MIGRATION] Attack Pattern / Course of Action case-insensitive duplicate low-level merge';
+
+const REL_PREFIX = 'rel_';
+const REL_SUFFIX = '.internal_id';
+
+type DynEntity = BasicStoreEntity & Record<string, any>;
+
+// Build the "already connected" map from the target's own denormalized rel_<type>.internal_id fields.
+// It is the cheap source of truth to deduplicate source relations against the target without ever
+// loading the (potentially huge) target neighborhood.
+const buildTargetConnected = (target: DynEntity): Record<string, Set<string>> => {
+  const connected: Record<string, Set<string>> = {};
+  const keys = Object.keys(target);
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    if (key.startsWith(REL_PREFIX) && key.endsWith(REL_SUFFIX)) {
+      const relType = key.substring(REL_PREFIX.length, key.length - REL_SUFFIX.length);
+      const ids = (target[key] ?? []).flat(Infinity).filter((id: string) => isNotEmptyField(id));
+      connected[relType] = new Set(ids);
+    }
+  }
+  return connected;
+};
+
+// Low-level equivalent of mergeEntities for the migration: it redirects every relation of the sources
+// onto the target and merges identity attributes, using only engine primitives and painless scripts.
+// It deliberately skips the high-level overhead of mergeEntities (locks, full ref resolution of the
+// canonical entity, stream merge events, bus notifications, redis deletions, trash).
+const lowLevelMergeGroup = async (
+  context: AuthContext,
+  entityType: string,
+  target: DynEntity,
+  sources: DynEntity[],
+  newId: string,
+) => {
+  const targetId = target.internal_id;
+  const targetName = target.name;
+  const targetIndex = target._index;
+  const sourceIds = sources.map((s) => s.internal_id);
+  const sourceIdSet = new Set(sourceIds);
+  const internalIds = new Set([targetId, ...sourceIds]);
+  const aliasField = entityType === ENTITY_TYPE_COURSE_OF_ACTION ? ATTRIBUTE_ALIASES_OPENCTI : ATTRIBUTE_ALIASES;
+
+  // In-memory dedup state: neighbors already connected to the target per relationship type. It is seeded
+  // from the target denormalization and grown as source relations get redirected, so that two sources
+  // pointing to the same neighbor do not create a duplicate edge.
+  const targetConnected = buildTargetConnected(target);
+  // Neighbors to add to the target denormalization, applied once at the end (grouped to avoid self conflicts).
+  const targetAddByRelType: Record<string, Set<string>> = {};
+
+  // Streamed, page-by-page processing of every relation attached to the sources (both directions),
+  // keeping memory flat and parallelizing the elastic writes.
+  const processRelations = async (relations: BasicStoreRelation[]) => {
+    const neighborIds = R.uniq(
+      relations
+        .map((rel) => (sourceIdSet.has(rel.fromId) ? rel.toId : rel.fromId))
+        .filter((id) => isNotEmptyField(id) && !internalIds.has(id)),
+    );
+    const indexByNeighborId: Record<string, string> = {};
+    if (neighborIds.length > 0) {
+      const neighbors = await elFindByIds(context, SYSTEM_USER, neighborIds, { baseData: true }) as BasicStoreBase[];
+      for (let i = 0; i < neighbors.length; i += 1) {
+        indexByNeighborId[neighbors[i].internal_id] = neighbors[i]._index;
+      }
+    }
+    const relConnectionUpdates: any[] = [];
+    const neighborUpdates: any[] = [];
+    for (let i = 0; i < relations.length; i += 1) {
+      const rel = relations[i];
+      const relType = rel.entity_type;
+      const fromIsSource = sourceIdSet.has(rel.fromId);
+      const sourceSideId = fromIsSource ? rel.fromId : rel.toId;
+      const neighborId = fromIsSource ? rel.toId : rel.fromId;
+      // Self / internal relation (neighbor is the target or another merged source): keep it on the source,
+      // it will be removed when the source is deleted (no self-loop on the target).
+      if (internalIds.has(neighborId)) {
+        continue;
+      }
+      // Single ref already held by the target (e.g. created-by): the target keeps its own, drop the source one.
+      if (isSingleRelationsRef(entityType, relType) && (targetConnected[relType]?.size ?? 0) > 0) {
+        continue;
+      }
+      // Duplicate edge: the target is already connected to this neighbor through the same type, drop it.
+      if (targetConnected[relType]?.has(neighborId)) {
+        continue;
+      }
+      // Redirect the source side of the relation onto the target. Only the connections array is rewritten:
+      // fromId / toId / fromName / toName are reconstructed from connections on read (engine-data-converter).
+      relConnectionUpdates.push({
+        _index: rel._index,
+        id: rel.internal_id,
+        toReplace: sourceSideId,
+        data: { internal_id: targetId, name: targetName },
+      });
+      // Replace the source id by the target id in the neighbor's denormalized rel_<type>.internal_id.
+      const neighborRole = fromIsSource ? ROLE_TO : ROLE_FROM;
+      if (isImpactedTypeAndSide(relType, rel.fromType, rel.toType, neighborRole) && indexByNeighborId[neighborId]) {
+        neighborUpdates.push({
+          _index: indexByNeighborId[neighborId],
+          id: neighborId,
+          toReplace: sourceSideId,
+          relationType: relType,
+          data: { internal_id: targetId },
+        });
+      }
+      // The neighbor must be added to the target denormalization (applied once at the end).
+      const targetRole = fromIsSource ? ROLE_FROM : ROLE_TO;
+      if (isImpactedTypeAndSide(relType, rel.fromType, rel.toType, targetRole)) {
+        if (!targetAddByRelType[relType]) targetAddByRelType[relType] = new Set();
+        targetAddByRelType[relType].add(neighborId);
+      }
+      // Mark the neighbor as connected so the next source relation to it (same type) is deduplicated.
+      if (!targetConnected[relType]) targetConnected[relType] = new Set();
+      targetConnected[relType].add(neighborId);
+    }
+    // Apply this page in parallel bulks.
+    await BluePromise.map(
+      R.splitEvery(MAX_BULK_OPERATIONS, relConnectionUpdates),
+      (batch) => elUpdateRelationConnections(context, batch),
+      { concurrency: ES_MAX_CONCURRENCY },
+    );
+    await BluePromise.map(
+      R.splitEvery(MAX_BULK_OPERATIONS, neighborUpdates),
+      (batch) => elUpdateEntityConnections(context, batch),
+      { concurrency: ES_MAX_CONCURRENCY },
+    );
+    return true;
+  };
+
+  await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { fromId: sourceIds, callback: processRelations });
+  await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { toId: sourceIds, callback: processRelations });
+
+  // Add all redirected neighbors to the target denormalization, one update per type to avoid conflicts on the target doc.
+  const targetAddEntries = Object.entries(targetAddByRelType);
+  for (let i = 0; i < targetAddEntries.length; i += 1) {
+    const [relType, neighbors] = targetAddEntries[i];
+    await elUpdateEntityConnections(context, [{
+      _index: targetIndex,
+      id: targetId,
+      toReplace: null,
+      relationType: relType,
+      data: { internal_id: Array.from(neighbors) },
+    }]);
+  }
+
+  // Merge identity-bearing attributes onto the target and move its standard_id to the new value. The
+  // previous standard_id and all source ids are archived in x_opencti_stix_ids so older references resolve.
+  const stixIds = R.uniq([
+    ...(target[IDS_STIX] ?? []),
+    ...(target.standard_id !== newId ? [target.standard_id] : []),
+    ...sources.flatMap((s) => [s.standard_id, ...(s[IDS_STIX] ?? [])]),
+  ]).filter((id) => isNotEmptyField(id) && id !== newId);
+  const aliasValues = R.uniq([
+    ...(target[aliasField] ?? []),
+    ...sources.flatMap((s) => [...(s[aliasField] ?? []), s.name]),
+  ]).filter((value) => isNotEmptyField(value));
+  await elBulk(context, {
+    refresh: true,
+    timeout: BULK_TIMEOUT,
+    body: [
+      { update: { _index: targetIndex, _id: target._id, retry_on_conflict: ES_RETRY_ON_CONFLICT } },
+      { doc: { standard_id: newId, [IDS_STIX]: stixIds, [aliasField]: aliasValues } },
+    ],
+  });
+
+  // Remove the source entities. elDeleteElements also deletes the leftover (duplicate / internal) relations
+  // still attached to the sources - found through a live connections query, not the stale denormalization -
+  // and cleans the corresponding rel_<type>.internal_id on their neighbors. forceDelete skips the trash.
+  await elDeleteElements(context, SYSTEM_USER, sources as unknown as BasicStoreObject[], { forceDelete: true });
+};
+
+const migrateEntityType = async (context: AuthContext, entityType: string) => {
+  const allEntities = await fullEntitiesList(
+    context,
+    SYSTEM_USER,
+    [entityType],
+    { indices: [READ_INDEX_STIX_DOMAIN_OBJECTS] },
+  ) as DynEntity[];
+  if (allEntities.length === 0) {
+    logMigration.info(`${message} > no ${entityType} found, skipping`);
+    return { merged: 0, collisions: 0 };
+  }
+  logMigration.info(`${message} > ${allEntities.length} ${entityType}(s) to evaluate`);
+
+  // Recompute the new (case-insensitive) standard_id and group by it. Groups with more than one element
+  // are duplicates that collide under the new rule and must be merged.
+  const entitiesWithNewId = allEntities.map((entity) => ({ entity, newId: generateStandardId(entityType, entity) }));
+  const groupedByNewId = R.groupBy((e) => e.newId, entitiesWithNewId);
+  const collisionGroups = Object.values(groupedByNewId).filter((g) => (g?.length ?? 0) > 1) as { entity: DynEntity; newId: string }[][];
+  logMigration.info(`${message} > ${collisionGroups.length} ${entityType} collision group(s) to merge`);
+  if (collisionGroups.length === 0) {
+    return { merged: 0, collisions: 0 };
+  }
+
+  // Batch-resolve the relation count of every colliding entity in a single request. The most-connected
+  // entity is picked as the merge target so the amount of relation rewriting is minimized.
+  const collidingEntities = collisionGroups.flat().map((e) => e.entity);
+  const relCountByInternalId = new Map<string, number>();
+  const batchInput = collidingEntities.map((e) => ({ id: e.internal_id, type: e.entity_type }));
+  const reloaded = await elBatchIdsWithRelCount(context, SYSTEM_USER, batchInput);
+  for (let i = 0; i < batchInput.length; i += 1) {
+    const reloadedEntity = reloaded[i] as any;
+    const count = reloadedEntity?.script_field_denormalization_count?.[0] ?? 0;
+    relCountByInternalId.set(batchInput[i].id, count);
+  }
+
+  // Groups are merged sequentially on purpose: without distributed locks, sequential processing keeps
+  // relations between two distinct duplicates consistent (each group fully completes, with refresh,
+  // before the next one). The heavy per-group elastic work is parallelized inside lowLevelMergeGroup.
+  let mergedEntities = 0;
+  for (let index = 0; index < collisionGroups.length; index += 1) {
+    const group = collisionGroups[index];
+    const { newId } = group[0];
+    const sorted = R.sortWith(
+      [
+        R.descend((e) => relCountByInternalId.get(e.entity.internal_id) ?? 0),
+        R.ascend((e) => e.entity.created_at || ''),
+        R.ascend((e) => e.entity.internal_id || ''),
+      ],
+      group,
+    );
+    const target = sorted[0].entity;
+    const sources = sorted.slice(1).map((e) => e.entity);
+    try {
+      await lowLevelMergeGroup(context, entityType, target, sources, newId);
+      mergedEntities += sources.length;
+      logMigration.info(
+        `${message} > merged ${sources.length} ${entityType} into ${target.internal_id}`
+        + ` (target rel_count=${relCountByInternalId.get(target.internal_id) ?? 0})`
+        + ` (${index + 1}/${collisionGroups.length})`,
+      );
+    } catch (err) {
+      // Do not abort the whole migration if one group fails: log and keep going.
+      logApp.error(`${message} > failed to merge group for ${newId}`, { cause: err, targetId: target.internal_id, sourceIds: sources.map((s) => s.internal_id) });
+    }
+  }
+
+  return { merged: mergedEntities, collisions: collisionGroups.length };
+};
+
+export const up = async (next: (error?: Error) => void) => {
+  const context = executionContext('migration');
+  const start = new Date().getTime();
+  logMigration.info(`${message} > started`);
+
+  const stats = { merged: 0, collisions: 0 };
+  for (const entityType of [ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION]) {
+    const typeStats = await migrateEntityType(context, entityType);
+    stats.merged += typeStats.merged;
+    stats.collisions += typeStats.collisions;
+  }
+
+  logMigration.info(
+    `${message} > done in ${new Date().getTime() - start} ms`
+    + ` (${stats.merged} duplicate(s) merged across ${stats.collisions} group(s))`,
+  );
+  next();
+};
+
+export const down = async (next: (error?: Error) => void) => {
+  // Not reversible: source standard_ids are preserved in x_opencti_stix_ids so nothing is lost, but the
+  // pre-merge state required to recompute previous ids is no longer available after the merges.
+  next();
+};

--- a/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
@@ -1,7 +1,7 @@
 import * as R from 'ramda';
 import { Promise as BluePromise } from 'bluebird';
 import { executionContext, SYSTEM_USER } from '../utils/access';
-import { generateStandardId } from '../schema/identifier';
+import { generateAliasesId, generateStandardId } from '../schema/identifier';
 import { ATTRIBUTE_ALIASES, ATTRIBUTE_ALIASES_OPENCTI, ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION } from '../schema/stixDomainObject';
 import { isNotEmptyField, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { fullEntitiesList, fullRelationsList } from '../database/middleware-loader';
@@ -21,11 +21,11 @@ import {
   ROLE_FROM,
   ROLE_TO,
 } from '../database/engine';
-import { ABSTRACT_STIX_RELATIONSHIP, IDS_STIX } from '../schema/general';
+import { ABSTRACT_STIX_RELATIONSHIP, IDS_STIX, INTERNAL_IDS_ALIASES } from '../schema/general';
 import { isSingleRelationsRef } from '../schema/stixEmbeddedRelationship';
 import { logApp, logMigration } from '../config/conf';
 import type { AuthContext } from '../types/user';
-import type { BasicStoreBase, BasicStoreEntity, BasicStoreObject, BasicStoreRelation } from '../types/store';
+import type { BasicStoreBase, BasicStoreEntity, BasicStoreRelation } from '../types/store';
 
 const message = '[MIGRATION] Attack Pattern / Course of Action case-insensitive duplicate low-level merge';
 
@@ -215,19 +215,23 @@ const lowLevelMergeGroup = async (
     ...(fullTarget[aliasField] ?? []),
     ...sources.flatMap((s) => [...(s[aliasField] ?? []), s.name]),
   ]).filter((value) => isNotEmptyField(value));
+  // Recompute the derived alias internal ids (i_aliases_ids) from the merged aliases, exactly as mergeEntities
+  // does on every alias change. Without it the engine's alias-based id resolution would ignore the source
+  // names/aliases now carried by the target, so an upsert referencing one of them could recreate a duplicate.
+  const aliasesIds = generateAliasesId(aliasValues, fullTarget);
   await elBulk(context, {
     refresh: true,
     timeout: BULK_TIMEOUT,
     body: [
       { update: { _index: targetIndex, _id: fullTarget._id, retry_on_conflict: ES_RETRY_ON_CONFLICT } },
-      { doc: { standard_id: newId, [IDS_STIX]: stixIds, [aliasField]: aliasValues } },
+      { doc: { standard_id: newId, [IDS_STIX]: stixIds, [aliasField]: aliasValues, [INTERNAL_IDS_ALIASES]: aliasesIds } },
     ],
   });
 
   // Remove the source entities. elDeleteElements also deletes the leftover (duplicate / internal) relations
   // still attached to the sources - found through a live connections query, not the stale denormalization -
   // and cleans the corresponding rel_<type>.internal_id on their neighbors. forceDelete skips the trash.
-  await elDeleteElements(context, SYSTEM_USER, sources as unknown as BasicStoreObject[], { forceDelete: true });
+  await elDeleteElements(context, SYSTEM_USER, sources, { forceDelete: true });
   return { redirected };
 };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
+++ b/opencti-platform/opencti-graphql/src/migrations/1782287997404-attack_pattern_case_insensitive_low_level_merge.ts
@@ -31,8 +31,27 @@ const message = '[MIGRATION] Attack Pattern / Course of Action case-insensitive 
 
 const REL_PREFIX = 'rel_';
 const REL_SUFFIX = '.internal_id';
+// A failing group is retried once: most failures are transient (engine timeout, version conflict on a
+// heavily connected neighbor) and succeed on a second attempt.
+const MAX_MERGE_ATTEMPTS = 2;
+const RETRY_DELAY_MS = 3000;
 
 type DynEntity = BasicStoreEntity & Record<string, any>;
+
+const wait = (ms: number) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+// Extract a loggable, accurate view of an error. The platform logger only unwraps message/stack for
+// values that pass `instanceof Error` / `instanceof GraphQLError`; in the bundled build that check can
+// miss (duplicate graphql copies, engine client errors...), which is why a bare `{ cause: err }` ends up
+// serialized as `{}`. Reading the properties defensively guarantees we always log the real reason.
+const describeError = (err: any) => ({
+  errorName: err?.name,
+  errorMessage: err?.message ?? String(err),
+  errorCode: err?.extensions?.code,
+  errorStack: err?.stack,
+});
 
 // Build the "already connected" map from the target's own denormalized rel_<type>.internal_id fields.
 // It is the cheap source of truth to deduplicate source relations against the target without ever
@@ -55,6 +74,11 @@ const buildTargetConnected = (target: DynEntity): Record<string, Set<string>> =>
 // onto the target and merges identity attributes, using only engine primitives and painless scripts.
 // It deliberately skips the high-level overhead of mergeEntities (locks, full ref resolution of the
 // canonical entity, stream merge events, bus notifications, redis deletions, trash).
+//
+// Retry safety: per page, the denormalizations (neighbor rel_*, target rel_*) are written FIRST and the
+// connections redirect is written LAST. The redirect is the "commit": only once it lands does the
+// relation stop matching the source stream. Every write is idempotent, so re-running the group after a
+// partial failure converges - already-redirected relations are skipped, the rest are reprocessed.
 const lowLevelMergeGroup = async (
   context: AuthContext,
   entityType: string,
@@ -65,7 +89,8 @@ const lowLevelMergeGroup = async (
   // `target` was loaded by fullEntitiesList, which paginates with the default withoutRels=true and therefore
   // strips the denormalized rel_<type>.internal_id fields from _source. Reload it with the rels present so the
   // dedup map below reflects the edges the target already holds; otherwise existing edges go undetected and the
-  // merge creates duplicate relations (and breaks the single-ref dedup, e.g. created-by).
+  // merge creates duplicate relations (and breaks the single-ref dedup, e.g. created-by). Reloading also makes
+  // a retried group dedup against reality (edges already redirected by a previous attempt are accounted for).
   const fullTarget = (await elLoadById<DynEntity>(context, SYSTEM_USER, target.internal_id, { type: entityType })) ?? target;
   const targetId = fullTarget.internal_id;
   const targetName = fullTarget.name;
@@ -79,8 +104,7 @@ const lowLevelMergeGroup = async (
   // from the target denormalization and grown as source relations get redirected, so that two sources
   // pointing to the same neighbor do not create a duplicate edge.
   const targetConnected = buildTargetConnected(fullTarget);
-  // Neighbors to add to the target denormalization, applied once at the end (grouped to avoid self conflicts).
-  const targetAddByRelType: Record<string, Set<string>> = {};
+  let redirected = 0;
 
   // Streamed, page-by-page processing of every relation attached to the sources (both directions),
   // keeping memory flat and parallelizing the elastic writes.
@@ -99,6 +123,7 @@ const lowLevelMergeGroup = async (
     }
     const relConnectionUpdates: any[] = [];
     const neighborUpdates: any[] = [];
+    const pageTargetAddByRelType: Record<string, Set<string>> = {};
     for (let i = 0; i < relations.length; i += 1) {
       const rel = relations[i];
       const relType = rel.entity_type;
@@ -137,45 +162,47 @@ const lowLevelMergeGroup = async (
           data: { internal_id: targetId },
         });
       }
-      // The neighbor must be added to the target denormalization (applied once at the end).
+      // The neighbor must be added to the target denormalization (applied below, before the redirect).
       const targetRole = fromIsSource ? ROLE_FROM : ROLE_TO;
       if (isImpactedTypeAndSide(relType, rel.fromType, rel.toType, targetRole)) {
-        if (!targetAddByRelType[relType]) targetAddByRelType[relType] = new Set();
-        targetAddByRelType[relType].add(neighborId);
+        if (!pageTargetAddByRelType[relType]) pageTargetAddByRelType[relType] = new Set();
+        pageTargetAddByRelType[relType].add(neighborId);
       }
       // Mark the neighbor as connected so the next source relation to it (same type) is deduplicated.
       if (!targetConnected[relType]) targetConnected[relType] = new Set();
       targetConnected[relType].add(neighborId);
     }
-    // Apply this page in parallel bulks.
-    await BluePromise.map(
-      R.splitEvery(MAX_BULK_OPERATIONS, relConnectionUpdates),
-      (batch) => elUpdateRelationConnections(context, batch),
-      { concurrency: ES_MAX_CONCURRENCY },
-    );
+    // 1. Denormalize the neighbors (replace the source id by the target id), idempotent on retry.
     await BluePromise.map(
       R.splitEvery(MAX_BULK_OPERATIONS, neighborUpdates),
       (batch) => elUpdateEntityConnections(context, batch),
       { concurrency: ES_MAX_CONCURRENCY },
     );
+    // 2. Denormalize the target (add the neighbors of this page), one update per type to avoid conflicts
+    // on the target document. Done before the redirect so a retried group never loses these edges.
+    const pageTargetEntries = Object.entries(pageTargetAddByRelType);
+    for (let i = 0; i < pageTargetEntries.length; i += 1) {
+      const [relType, neighbors] = pageTargetEntries[i];
+      await elUpdateEntityConnections(context, [{
+        _index: targetIndex,
+        id: targetId,
+        toReplace: null,
+        relationType: relType,
+        data: { internal_id: Array.from(neighbors) },
+      }]);
+    }
+    // 3. Commit: redirect the relation connections (this is what makes the relation leave the source stream).
+    await BluePromise.map(
+      R.splitEvery(MAX_BULK_OPERATIONS, relConnectionUpdates),
+      (batch) => elUpdateRelationConnections(context, batch),
+      { concurrency: ES_MAX_CONCURRENCY },
+    );
+    redirected += relConnectionUpdates.length;
     return true;
   };
 
   await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { fromId: sourceIds, callback: processRelations });
   await fullRelationsList(context, SYSTEM_USER, ABSTRACT_STIX_RELATIONSHIP, { toId: sourceIds, callback: processRelations });
-
-  // Add all redirected neighbors to the target denormalization, one update per type to avoid conflicts on the target doc.
-  const targetAddEntries = Object.entries(targetAddByRelType);
-  for (let i = 0; i < targetAddEntries.length; i += 1) {
-    const [relType, neighbors] = targetAddEntries[i];
-    await elUpdateEntityConnections(context, [{
-      _index: targetIndex,
-      id: targetId,
-      toReplace: null,
-      relationType: relType,
-      data: { internal_id: Array.from(neighbors) },
-    }]);
-  }
 
   // Merge identity-bearing attributes onto the target and move its standard_id to the new value. The
   // previous standard_id and all source ids are archived in x_opencti_stix_ids so older references resolve.
@@ -201,6 +228,46 @@ const lowLevelMergeGroup = async (
   // still attached to the sources - found through a live connections query, not the stale denormalization -
   // and cleans the corresponding rel_<type>.internal_id on their neighbors. forceDelete skips the trash.
   await elDeleteElements(context, SYSTEM_USER, sources as unknown as BasicStoreObject[], { forceDelete: true });
+  return { redirected };
+};
+
+// Merge a single collision group, retrying once on failure (each attempt fully reloads the target and is
+// idempotent). Returns true when the group was merged, false when it failed after every attempt.
+const mergeGroupWithRetry = async (
+  context: AuthContext,
+  entityType: string,
+  target: DynEntity,
+  sources: DynEntity[],
+  newId: string,
+  progress: string,
+) => {
+  const targetId = target.internal_id;
+  const sourceIds = sources.map((s) => s.internal_id);
+  for (let attempt = 1; attempt <= MAX_MERGE_ATTEMPTS; attempt += 1) {
+    const attemptStart = new Date().getTime();
+    try {
+      const { redirected } = await lowLevelMergeGroup(context, entityType, target, sources, newId);
+      logMigration.info(
+        `${message} > merged ${sources.length} ${entityType} into ${targetId}`
+        + ` (${redirected} relation(s) redirected, attempt ${attempt}/${MAX_MERGE_ATTEMPTS}, ${new Date().getTime() - attemptStart} ms) ${progress}`,
+      );
+      return true;
+    } catch (err) {
+      if (attempt < MAX_MERGE_ATTEMPTS) {
+        logApp.warn(
+          `${message} > merge attempt ${attempt}/${MAX_MERGE_ATTEMPTS} failed for group ${newId}, retrying in ${RETRY_DELAY_MS} ms ${progress}`,
+          { ...describeError(err), targetId, sourceIds },
+        );
+        await wait(RETRY_DELAY_MS);
+      } else {
+        logApp.error(
+          `${message} > failed to merge group for ${newId} after ${MAX_MERGE_ATTEMPTS} attempts ${progress}`,
+          { ...describeError(err), targetId, sourceIds },
+        );
+      }
+    }
+  }
+  return false;
 };
 
 const migrateEntityType = async (context: AuthContext, entityType: string) => {
@@ -212,7 +279,7 @@ const migrateEntityType = async (context: AuthContext, entityType: string) => {
   ) as DynEntity[];
   if (allEntities.length === 0) {
     logMigration.info(`${message} > no ${entityType} found, skipping`);
-    return { merged: 0, collisions: 0 };
+    return { merged: 0, collisions: 0, failed: 0 };
   }
   logMigration.info(`${message} > ${allEntities.length} ${entityType}(s) to evaluate`);
 
@@ -223,7 +290,7 @@ const migrateEntityType = async (context: AuthContext, entityType: string) => {
   const collisionGroups = Object.values(groupedByNewId).filter((g) => (g?.length ?? 0) > 1) as { entity: DynEntity; newId: string }[][];
   logMigration.info(`${message} > ${collisionGroups.length} ${entityType} collision group(s) to merge`);
   if (collisionGroups.length === 0) {
-    return { merged: 0, collisions: 0 };
+    return { merged: 0, collisions: 0, failed: 0 };
   }
 
   // Batch-resolve the relation count of every colliding entity in a single request. The most-connected
@@ -242,6 +309,7 @@ const migrateEntityType = async (context: AuthContext, entityType: string) => {
   // relations between two distinct duplicates consistent (each group fully completes, with refresh,
   // before the next one). The heavy per-group elastic work is parallelized inside lowLevelMergeGroup.
   let mergedEntities = 0;
+  let failedGroups = 0;
   for (let index = 0; index < collisionGroups.length; index += 1) {
     const group = collisionGroups[index];
     const { newId } = group[0];
@@ -255,21 +323,20 @@ const migrateEntityType = async (context: AuthContext, entityType: string) => {
     );
     const target = sorted[0].entity;
     const sources = sorted.slice(1).map((e) => e.entity);
-    try {
-      await lowLevelMergeGroup(context, entityType, target, sources, newId);
+    const progress = `(${index + 1}/${collisionGroups.length})`;
+    logMigration.info(
+      `${message} > merging group ${progress}: ${sources.length} source(s) into ${target.internal_id}`
+      + ` (target rel_count=${relCountByInternalId.get(target.internal_id) ?? 0})`,
+    );
+    const success = await mergeGroupWithRetry(context, entityType, target, sources, newId, progress);
+    if (success) {
       mergedEntities += sources.length;
-      logMigration.info(
-        `${message} > merged ${sources.length} ${entityType} into ${target.internal_id}`
-        + ` (target rel_count=${relCountByInternalId.get(target.internal_id) ?? 0})`
-        + ` (${index + 1}/${collisionGroups.length})`,
-      );
-    } catch (err) {
-      // Do not abort the whole migration if one group fails: log and keep going.
-      logApp.error(`${message} > failed to merge group for ${newId}`, { cause: err, targetId: target.internal_id, sourceIds: sources.map((s) => s.internal_id) });
+    } else {
+      failedGroups += 1;
     }
   }
 
-  return { merged: mergedEntities, collisions: collisionGroups.length };
+  return { merged: mergedEntities, collisions: collisionGroups.length, failed: failedGroups };
 };
 
 export const up = async (next: (error?: Error) => void) => {
@@ -277,16 +344,17 @@ export const up = async (next: (error?: Error) => void) => {
   const start = new Date().getTime();
   logMigration.info(`${message} > started`);
 
-  const stats = { merged: 0, collisions: 0 };
+  const stats = { merged: 0, collisions: 0, failed: 0 };
   for (const entityType of [ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION]) {
     const typeStats = await migrateEntityType(context, entityType);
     stats.merged += typeStats.merged;
     stats.collisions += typeStats.collisions;
+    stats.failed += typeStats.failed;
   }
 
   logMigration.info(
     `${message} > done in ${new Date().getTime() - start} ms`
-    + ` (${stats.merged} duplicate(s) merged across ${stats.collisions} group(s))`,
+    + ` (${stats.merged} duplicate(s) merged across ${stats.collisions} group(s), ${stats.failed} group(s) failed)`,
   );
   next();
 };


### PR DESCRIPTION
### Proposed changes

* Add migration `1782287997404-attack_pattern_case_insensitive_low_level_merge.ts` that merges the Attack Pattern / Course of Action duplicates colliding on the new case-insensitive `x_mitre_id` standard_id, replacing the `mergeEntities()` call with a low-level merge.
* The merge is built only from existing engine primitives (no new functions, no stream events): `elUpdateRelationConnections` redirects each source relation onto the target by rewriting its `connections` (fromId/toId are reconstructed from connections on read), `elUpdateEntityConnections` keeps the denormalized `rel_*` consistent on neighbors and on the target, and `elDeleteElements(..., { forceDelete: true })` removes the sources together with the leftover duplicate/internal relations (found through a live `connections` query) and cleans the neighbors' `rel_*`.
* Dedup is respected via the target's own denormalized `rel_*` (membership check, plus single-ref and self/internal handling) so no duplicate edges remain. Source relations are streamed (paginated callback, memory-flat) and rewritten in parallel bulks (`ES_MAX_CONCURRENCY`). The `standard_id` is moved to the new value and the previous standard_id plus all source ids are archived in `x_opencti_stix_ids`.
* Identity attributes are merged onto the target: the source names are added as target aliases and the derived `i_aliases_ids` is regenerated from the merged aliases (exactly as `mergeEntities` does), so alias-based id resolution keeps resolving the merged names/aliases to the target.
* "The rest of the logic is good": the group-by-recomputed-standard_id and pick-the-most-connected-entity-as-target (`elBatchIdsWithRelCount`) logic is preserved.

### Why

`mergeEntities()` is a high-level orchestration for live, single-merge user actions. Per collision group it locks all participants, fully resolves the canonical entity with refs (twice), loads the entire neighborhood of the most-connected entity via `loadMergeEntitiesDependencies`, then builds and publishes a stream merge event, notifies the bus and writes redis deletions. All of this scales with the (huge) canonical entity and is pure overhead for an offline, idempotent migration - it is what hangs on ~30% of platforms (see #16775, skipped in #16779). None of locks/stream-events/notify/trash are needed for a migration.

This migration only ever touches the (smaller) source side; the canonical neighborhood is never loaded. Groups are processed sequentially so relations between two distinct duplicates stay consistent without locks (each group fully completes, with refresh, before the next), while the heavy per-group ES work is parallelized.

### Review hardening

This branch also folds in the fixes raised during the in-PR review:

* `94de243` - reload the merge target with `elLoadById` (which forces `withoutRels=false`) before building the dedup map, so the target's existing edges are detected and the single-ref dedup (e.g. `created-by`) works; otherwise `fullEntitiesList` strips `rel_*` from `_source` and the merge could create duplicate relations.
* `ea757d8` - retry each colliding group once on failure (most failures are transient: engine timeout, version conflict on a heavily connected neighbor), reorder the per-page writes so the denormalizations land before the connections redirect (the redirect is the idempotent commit that makes a relation leave the source stream), and log accurate error details plus per-group/per-type progress.
* `79f4e35` - regenerate `i_aliases_ids` from the merged aliases (without it the engine's alias-based id resolution would miss the merged source names and could recreate a duplicate), and drop a redundant `as unknown as BasicStoreObject[]` cast on `elDeleteElements` (`sources` is already `BasicStoreBase`-assignable).
* `6426f35` - apply the review performance points: `buildTargetConnected` fills the dedup `Set` by iteration instead of allocating a `flat(Infinity)` copy, and both `fullRelationsList` streams pass `baseData: true` (the callback only needs base fields plus `connections`, from which `fromId`/`toId`/`fromType`/`toType` are reconstructed on read), shrinking the streamed payload with no behavior change.
* `d9088f2` - document the deliberate denorm-first ordering and its bounded, cache-only partial-failure trade-off in code; a full reconcile would require loading the canonical neighborhood this migration avoids, and the relation `connections` (the authoritative graph) stay consistent regardless.

### Related issues

* closes #16793
* context: #16132 (case-insensitive change), #16485 (previous fix migration), #16775 / #16779 (hang + skip)

### How to test this PR

1. On a dataset with Attack Patterns / Courses of Action that differ only by `x_mitre_id` case (e.g. `T1059` vs `t1059`), with relations and container memberships on both variants (some shared with the canonical one, some unique).
2. Run the migration (platform startup, or `yarn migrate:up`).
3. Verify: each colliding group is collapsed onto the most-connected entity; its `standard_id` is the new case-insensitive value and the old ids are in `x_opencti_stix_ids`; the merged aliases and their `i_aliases_ids` are present on the target; the neighbors' and target's denormalized `rel_*` are consistent; there are no duplicate edges and no relations left pointing at the deleted sources; no merge events were emitted on the stream.
4. Re-run the migration: it is idempotent (already-merged groups are now size 1 and skipped).

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

- Dedup uses the target's denormalized `rel_*` for the membership check, which - unlike `mergeEntities` - ignores the `noDate` nuance on dated core relationships. For a de-duplication migration this is acceptable and arguably preferable (it guarantees a single edge per neighbor), but it is slightly more aggressive than `mergeEntities` in the rare case where both the canonical and the duplicate hold a dated relationship to the same neighbor.
- S3 file moving is intentionally not performed (Attack Patterns / Courses of Action virtually never carry attachments); the source documents are deleted as usual.
- Scope mirrors the skipped `1781773324212` migration (collision merges only); the non-colliding `standard_id` rewrites are already handled by `1779435787999`.
