### PR TITLE
fix(frontend): saved filter creator access right should not be updatable (#16797)

### DIFF
--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
@@ -76,7 +76,14 @@ const SavedFilterEditDialog = ({
   const { me } = useAuth();
   const hasShareFilterCapability = useGranted([KNOWLEDGE_KNSHAREFILTERS]);
 
-  const owner = { id: me.id, name: me.name, entity_type: 'User' };
+  const ownerMember = savedFilter.authorizedMembers?.find((a) => a.member_id === savedFilter.creator_id);
+  const owner = ownerMember
+    ? {
+        id: ownerMember.member_id,
+        name: ownerMember.name,
+        entity_type: ownerMember.entity_type,
+      }
+    : { id: me.id, name: me.name, entity_type: 'User' };
 
   const [commitFieldPatch] = useApiMutation(
     savedFilterFieldPatchMutation,

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterSharingSection.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterSharingSection.tsx
@@ -34,6 +34,7 @@ const SavedFilterSharingSection = ({
             addMeUserWithAdminRights={!isEditMode}
             hideInfo
             customAccessRights={['view', 'admin']}
+            disableOwnerAccessRightsEdition
           />
         </AccordionDetails>
       </Accordion>

--- a/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/AuthorizedMembersField.tsx
@@ -62,6 +62,7 @@ interface AuthorizedMembersFieldProps
   style?: CSSProperties;
   isDraftEntity?: boolean;
   disabled?: boolean;
+  disableOwnerAccessRightsEdition?: boolean;
 }
 
 const DYNAMIC_GROUPS_RESTRICTION_SUPPORTED = ['AUTHOR', 'CREATORS'];
@@ -112,6 +113,7 @@ const AuthorizedMembersField = ({
   style,
   isDraftEntity,
   disabled = false,
+  disableOwnerAccessRightsEdition = false,
 }: AuthorizedMembersFieldProps) => {
   const { t_i18n } = useFormatter();
   const { setFieldValue } = form;
@@ -571,7 +573,7 @@ const AuthorizedMembersField = ({
                             accessRights={accessRights}
                             ownerId={owner?.id}
                             onRemove={() => arrayHelpers.remove(index)}
-                            disabled={disabled}
+                            disabled={disableOwnerAccessRightsEdition && authorizedMember.value === owner?.id ? true : disabled}
                           />
                         )
                       : null))}


### PR DESCRIPTION
### Proposed changes
Saved filter edition pop-up
- the creator should be displayed (for now: the current user is displayed)
- the saved filter creator access rights should not be updatable

### Related issues
fixes #16797