### PR TITLE
fix(playbook): component configuration remains when the component is replaced (#16016)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -44,7 +44,7 @@ import PlaybookFlowFieldTargets from './playbookFlowFields/PlaybookFlowFieldTarg
 import PlaybookFlowFieldTriggerTime from './playbookFlowFields/PlaybookFlowFieldTriggerTime';
 import PlaybookFlowFieldActions from './playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions';
 import { PlaybookUpdateActionsForm } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
-import { computeInitialComponentConfigValues } from './playbookComponents-utils';
+import { computeInitialComponentConfigValues, PlaybookFlowFormValues } from './playbookComponents-utils';
 
 export type PlaybookFlowFormData
   // Component: update knowledge
@@ -100,7 +100,7 @@ const PlaybookFlowForm = ({
     : null;
 
   // Submit function that formats correctly the data for the backend.
-  const onSubmit: FormikConfig<PlaybookFlowFormData>['onSubmit'] = (values, { resetForm }) => {
+  const onSubmit: FormikConfig<PlaybookFlowFormValues>['onSubmit'] = (values, { resetForm }) => {
     const { name, description, actionsFormValues, ...config } = values;
     let finalConfig: PlaybookConfig = config;
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -27,7 +27,7 @@ import { parse } from '../../../../../utils/Time';
 import { fieldSpacingContainerStyle } from '../../../../../utils/field';
 import { deserializeFilterGroupForFrontend, emptyFilterGroup, serializeFilterGroupForBackend } from '../../../../../utils/filters/filtersUtils';
 import useFiltersState from '../../../../../utils/filters/useFiltersState';
-import type { PlaybookComponentConfigSchema, PlaybookComponents, PlaybookConfig, PlaybookNode } from '../types/playbook-types';
+import type { PlaybookBundleElementsToApply, PlaybookComponentConfigSchema, PlaybookComponents, PlaybookConfig, PlaybookNode } from '../types/playbook-types';
 import PlaybookFlowFieldAccessRestrictions from './playbookFlowFields/PlaybookFlowFieldAccessRestrictions';
 import PlaybookFlowFieldArray, { PlaybookFlowFieldArrayProps } from './playbookFlowFields/PlaybookFlowFieldArray';
 import PlaybookFlowFieldAuthorizedMembers from './playbookFlowFields/PlaybookFlowFieldAuthorizedMembers';
@@ -59,6 +59,7 @@ export type PlaybookFlowFormData
       day?: string;
       // Component: Container wrapper
       all?: boolean;
+      applyToElements?: PlaybookBundleElementsToApply;
     };
 
 interface PlaybookFlowFormProps {

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -44,22 +44,26 @@ import PlaybookFlowFieldTargets from './playbookFlowFields/PlaybookFlowFieldTarg
 import PlaybookFlowFieldTriggerTime from './playbookFlowFields/PlaybookFlowFieldTriggerTime';
 import PlaybookFlowFieldActions from './playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions';
 import { PlaybookUpdateActionsForm } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
-import { computeInitialComponentConfigValues, PlaybookFlowFormValues } from './playbookComponents-utils';
+import { computeInitialComponentConfigValues } from './playbookComponents-utils';
 
 export type PlaybookFlowFormData
   // Component: update knowledge
   = PlaybookUpdateActionsForm
     & {
-    // Common for every component
+    // Common for several components
       name: string;
       description?: string;
+      applyToElements?: PlaybookBundleElementsToApply;
+      filters?: string;
       // Component: CRON
       time?: string;
       period?: string;
       day?: string;
+      triggerTime?: string;
       // Component: Container wrapper
-      all?: boolean;
-      applyToElements?: PlaybookBundleElementsToApply;
+      newContainer?: boolean;
+      // Component : create indicator and create observable
+      wrap_in_container?: boolean;
     };
 
 interface PlaybookFlowFormProps {
@@ -101,7 +105,7 @@ const PlaybookFlowForm = ({
     : null;
 
   // Submit function that formats correctly the data for the backend.
-  const onSubmit: FormikConfig<PlaybookFlowFormValues>['onSubmit'] = (values, { resetForm }) => {
+  const onSubmit: FormikConfig<PlaybookFlowFormData>['onSubmit'] = (values, { resetForm }) => {
     const { name, description, actionsFormValues, ...config } = values;
     let finalConfig: PlaybookConfig = config;
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -43,7 +43,8 @@ import PlaybookFlowFieldString from './playbookFlowFields/PlaybookFlowFieldStrin
 import PlaybookFlowFieldTargets from './playbookFlowFields/PlaybookFlowFieldTargets';
 import PlaybookFlowFieldTriggerTime from './playbookFlowFields/PlaybookFlowFieldTriggerTime';
 import PlaybookFlowFieldActions from './playbookFlowFields/playbookFlowFieldsActions/PlaybookFlowFieldActions';
-import { PlaybookUpdateAction, PlaybookUpdateActionsForm } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
+import { PlaybookUpdateActionsForm } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
+import { computeInitialComponentConfigValues } from './playbookComponents-utils';
 
 export type PlaybookFlowFormData
   // Component: update knowledge
@@ -148,55 +149,7 @@ const PlaybookFlowForm = ({
     name: Yup.string().trim().required(t_i18n('This field is required')),
   });
 
-  // region initial values
-
-  const initialValues: PlaybookFlowFormData = {
-    name: '',
-    description: '',
-  };
-
-  if (!currentConfig) {
-    // Get default values from schema.
-    initialValues.name = selectedComponent?.name ?? '';
-    initialValues.description = '';
-    Object.entries(configurationSchema?.properties ?? {})
-      .forEach(([propName, property]) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-        initialValues[propName] = property.default;
-        if (propName === 'actions') initialValues.actionsFormValues = [];
-      });
-  } else {
-    // Get values from saved config.
-    initialValues.name = nodeData?.component?.id === selectedComponent?.id
-      ? nodeData?.name ?? ''
-      : selectedComponent?.name ?? '';
-    initialValues.description = nodeData?.component?.id === selectedComponent?.id
-      ? nodeData?.description ?? ''
-      : '';
-    const actionsFormValues: PlaybookUpdateAction['value'][] = [];
-    Object.entries(currentConfig)
-      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-      .forEach(([key, value]) => {
-        if (/actions-\d-value/.test(key)) actionsFormValues.push(value);
-        else {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-          initialValues[key] = value;
-        }
-        initialValues.actionsFormValues = actionsFormValues;
-      });
-    // Ensure applyToElements defaults to 'only-main' for existing configs missing it
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if (!initialValues.applyToElements && configurationSchema?.properties?.applyToElements) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      initialValues.applyToElements = 'only-main';
-    }
-  }
-
-  // endregion
+  const initialValues = computeInitialComponentConfigValues({ action, currentConfig, configurationSchema, nodeData, selectedComponent });
 
   return (
     <div style={{ padding: '0px 0px 20px 0px' }}>

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { computeInitialComponentConfigValues, groupAndSortPlaybookComponents, NodeData } from './playbookComponents-utils';
-import type { PlaybookComponent, PlaybookComponentConfigSchema } from '../types/playbook-types';
+import type { PlaybookComponent, PlaybookComponentConfigSchema, PlaybookConfig } from '../types/playbook-types';
 
 describe('playbookComponents-utils', () => {
   describe('groupAndSortPlaybookComponents', () => {
@@ -93,7 +93,7 @@ describe('playbookComponents-utils', () => {
       required: [],
       properties: {
         filters: { type: 'string', $ref: 'Filters', default: '' },
-        excludeMainElement: { type: 'boolean', $ref: 'Exclude main', default: false },
+        triggerTime: { type: 'string', $ref: 'Trigger time', default: '08:00:00.000Z' },
       },
     } as unknown as PlaybookComponentConfigSchema;
 
@@ -120,7 +120,7 @@ describe('playbookComponents-utils', () => {
     });
 
     it('uses schema defaults when action is replace', () => {
-      const oldConfig = { filters: '{"mode":"and","filters":[]}', excludeMainElement: true };
+      const oldConfig = { filters: '{"mode":"and","filters":[]}', triggerTime: '10:30:00.000Z' };
 
       const result = computeInitialComponentConfigValues({
         action: 'replace',
@@ -136,7 +136,7 @@ describe('playbookComponents-utils', () => {
       expect((result).wrap_in_container).toBe(true);
       // Should not contain props of component A
       expect((result).filters).toBeUndefined();
-      expect((result).excludeMainElement).toBeUndefined();
+      expect((result).triggerTime).toBeUndefined();
     });
 
     it('keeps existing config when action is config (editing same component)', () => {
@@ -158,12 +158,11 @@ describe('playbookComponents-utils', () => {
     it('does not leak old config properties into new component on replace', () => {
       const oldConfig = {
         filters: '{"mode":"and","filters":[]}',
-        excludeMainElement: true,
         newContainer: false,
         actions: [],
-        applyToElements: 'all',
+        applyToElements: 'all-elements',
         wrap_in_container: false,
-      };
+      } as unknown as PlaybookConfig;
 
       const result = computeInitialComponentConfigValues({
         action: 'replace',
@@ -173,9 +172,9 @@ describe('playbookComponents-utils', () => {
         configurationSchema: schemaB,
       });
 
-      // Only props from new schame should be there
+      // Only props from new schema should be there
       expect((result).wrap_in_container).toBe(true); // default from schema B
-      expect((result).excludeMainElement).toBeUndefined();
+      expect((result).triggerTime).toBeUndefined();
       expect((result).newContainer).toBeUndefined();
       expect((result).actions).toBeUndefined();
       expect((result).applyToElements).toBeUndefined();

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.test.ts
@@ -1,85 +1,185 @@
 import { describe, expect, it } from 'vitest';
-import { groupAndSortPlaybookComponents } from './playbookComponents-utils';
-import type { PlaybookComponent } from '../types/playbook-types';
+import { computeInitialComponentConfigValues, groupAndSortPlaybookComponents, NodeData } from './playbookComponents-utils';
+import type { PlaybookComponent, PlaybookComponentConfigSchema } from '../types/playbook-types';
 
-const playbook = (overrides: Partial<PlaybookComponent> & { id: string; name: string }): PlaybookComponent => ({
-  description: '',
-  icon: '',
-  category: 'start_playbook',
-  is_entry_point: false,
-  is_internal: false,
-  configuration_schema: '',
-  ports: [],
-  ...overrides,
-});
+describe('playbookComponents-utils', () => {
+  describe('groupAndSortPlaybookComponents', () => {
+    const playbook = (overrides: Partial<PlaybookComponent> & { id: string; name: string }): PlaybookComponent => ({
+      description: '',
+      icon: '',
+      category: 'start_playbook',
+      is_entry_point: false,
+      is_internal: false,
+      configuration_schema: '',
+      ports: [],
+      ...overrides,
+    });
+    it('returns empty array for empty input', () => {
+      expect(groupAndSortPlaybookComponents([], false)).toEqual([]);
+    });
 
-describe('groupAndSortPlaybookComponents', () => {
-  it('returns empty array for empty input', () => {
-    expect(groupAndSortPlaybookComponents([], false)).toEqual([]);
+    it('filters by is_entry_point — returns only entry-point playbooks when isEntryPoint=true', () => {
+      const playbooks = [
+        playbook({ id: 'PLAYBOOK_INTERNAL_MANUAL_TRIGGER', name: 'Manual Trigger', category: 'start_playbook', is_entry_point: true }),
+        playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
+      ];
+      const result = groupAndSortPlaybookComponents(playbooks, true);
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe('start_playbook');
+      expect(result[0].items).toHaveLength(1);
+      expect(result[0].items[0].id).toBe('PLAYBOOK_INTERNAL_MANUAL_TRIGGER');
+    });
+
+    it('filters by is_entry_point — returns only non-entry-point playbooks when isEntryPoint=false', () => {
+      const playbooks = [
+        playbook({ id: 'PLAYBOOK_INTERNAL_MANUAL_TRIGGER', name: 'Manual Trigger', category: 'start_playbook', is_entry_point: true }),
+        playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
+      ];
+      const result = groupAndSortPlaybookComponents(playbooks, false);
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe('transform_and_enrich');
+      expect(result[0].items[0].id).toBe('PLAYBOOK_LOGGER_COMPONENT');
+    });
+
+    it('sorts components alphabetically within a group', () => {
+      const playbooks = [
+        playbook({ id: 'PLAYBOOK_REDUCING_COMPONENT', name: 'Reduce knowledge', category: 'transform_and_enrich', is_entry_point: false }),
+        playbook({ id: 'PLAYBOOK_RULE_COMPONENT', name: 'Apply predefined rule', category: 'transform_and_enrich', is_entry_point: false }),
+        playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data in standard output', category: 'transform_and_enrich', is_entry_point: false }),
+      ];
+      const result = groupAndSortPlaybookComponents(playbooks, false);
+      expect(result[0].items[0].name).toContain('Apply predefined rule');
+      expect(result[0].items[1].name).toContain('Log data in standard output');
+      expect(result[0].items[2].name).toContain('Reduce knowledge');
+    });
+
+    it('respects PLAYBOOK_CATEGORY_ORDER group sequence regardless of input order', () => {
+      const playbooks = [
+        playbook({ id: 'PLAYBOOK_NOTIFIER_COMPONENT', name: 'Send to notifier', category: 'end_playbook', is_entry_point: false }),
+        playbook({ id: 'PLAYBOOK_SHARING_COMPONENT', name: 'Share with organizations', category: 'share_and_access', is_entry_point: false }),
+        playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
+      ];
+      const result = groupAndSortPlaybookComponents(playbooks, false);
+      const categories = result.map((g) => g.category);
+      expect(categories).toEqual(['transform_and_enrich', 'share_and_access', 'end_playbook']);
+    });
+
+    it('omits groups that have no matching components', () => {
+      const playbooks = [
+        playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
+      ];
+      const result = groupAndSortPlaybookComponents(playbooks, false);
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe('transform_and_enrich');
+    });
+
+    it('handles a single component correctly', () => {
+      const playbooks = [
+        playbook({ id: 'PLAYBOOK_INGESTION_COMPONENT', name: 'Send for ingestion', category: 'end_playbook', is_entry_point: false }),
+      ];
+      const result = groupAndSortPlaybookComponents(playbooks, false);
+      expect(result).toHaveLength(1);
+      expect(result[0].category).toBe('end_playbook');
+      expect(result[0].items).toHaveLength(1);
+    });
   });
 
-  it('filters by is_entry_point — returns only entry-point playbooks when isEntryPoint=true', () => {
-    const playbooks = [
-      playbook({ id: 'PLAYBOOK_INTERNAL_MANUAL_TRIGGER', name: 'Manual Trigger', category: 'start_playbook', is_entry_point: true }),
-      playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
-    ];
-    const result = groupAndSortPlaybookComponents(playbooks, true);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('start_playbook');
-    expect(result[0].items).toHaveLength(1);
-    expect(result[0].items[0].id).toBe('PLAYBOOK_INTERNAL_MANUAL_TRIGGER');
-  });
+  describe('computeInitialComponentConfigValues', () => {
+    const COMPONENT_A = { id: 'PLAYBOOK_COMPONENT_A', name: 'Component A' } as unknown as PlaybookComponent;
+    const COMPONENT_B = { id: 'PLAYBOOK_COMPONENT_B', name: 'Component B' } as unknown as PlaybookComponent;
 
-  it('filters by is_entry_point — returns only non-entry-point playbooks when isEntryPoint=false', () => {
-    const playbooks = [
-      playbook({ id: 'PLAYBOOK_INTERNAL_MANUAL_TRIGGER', name: 'Manual Trigger', category: 'start_playbook', is_entry_point: true }),
-      playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
-    ];
-    const result = groupAndSortPlaybookComponents(playbooks, false);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('transform_and_enrich');
-    expect(result[0].items[0].id).toBe('PLAYBOOK_LOGGER_COMPONENT');
-  });
+    const schemaA = {
+      type: 'object',
+      required: [],
+      properties: {
+        filters: { type: 'string', $ref: 'Filters', default: '' },
+        excludeMainElement: { type: 'boolean', $ref: 'Exclude main', default: false },
+      },
+    } as unknown as PlaybookComponentConfigSchema;
 
-  it('sorts components alphabetically within a group', () => {
-    const playbooks = [
-      playbook({ id: 'PLAYBOOK_REDUCING_COMPONENT', name: 'Reduce knowledge', category: 'transform_and_enrich', is_entry_point: false }),
-      playbook({ id: 'PLAYBOOK_RULE_COMPONENT', name: 'Apply predefined rule', category: 'transform_and_enrich', is_entry_point: false }),
-      playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data in standard output', category: 'transform_and_enrich', is_entry_point: false }),
-    ];
-    const result = groupAndSortPlaybookComponents(playbooks, false);
-    expect(result[0].items[0].name).toContain('Apply predefined rule');
-    expect(result[0].items[1].name).toContain('Log data in standard output');
-    expect(result[0].items[2].name).toContain('Reduce knowledge');
-  });
+    const schemaB = {
+      type: 'object',
+      required: [],
+      properties: {
+        wrap_in_container: { type: 'boolean', $ref: 'Wrap', default: true },
+      },
+    } as unknown as PlaybookComponentConfigSchema;
 
-  it('respects PLAYBOOK_CATEGORY_ORDER group sequence regardless of input order', () => {
-    const playbooks = [
-      playbook({ id: 'PLAYBOOK_NOTIFIER_COMPONENT', name: 'Send to notifier', category: 'end_playbook', is_entry_point: false }),
-      playbook({ id: 'PLAYBOOK_SHARING_COMPONENT', name: 'Share with organizations', category: 'share_and_access', is_entry_point: false }),
-      playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
-    ];
-    const result = groupAndSortPlaybookComponents(playbooks, false);
-    const categories = result.map((g) => g.category);
-    expect(categories).toEqual(['transform_and_enrich', 'share_and_access', 'end_playbook']);
-  });
+    it('uses schema defaults when there is no existing config', () => {
+      const result = computeInitialComponentConfigValues({
+        action: 'add',
+        currentConfig: null,
+        configurationSchema: schemaB,
+        nodeData: undefined,
+        selectedComponent: COMPONENT_B,
+      });
 
-  it('omits groups that have no matching components', () => {
-    const playbooks = [
-      playbook({ id: 'PLAYBOOK_LOGGER_COMPONENT', name: 'Log data', category: 'transform_and_enrich', is_entry_point: false }),
-    ];
-    const result = groupAndSortPlaybookComponents(playbooks, false);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('transform_and_enrich');
-  });
+      expect(result.name).toBe('Component B');
+      expect(result.description).toBe('');
+      expect((result).wrap_in_container).toBe(true);
+    });
 
-  it('handles a single component correctly', () => {
-    const playbooks = [
-      playbook({ id: 'PLAYBOOK_INGESTION_COMPONENT', name: 'Send for ingestion', category: 'end_playbook', is_entry_point: false }),
-    ];
-    const result = groupAndSortPlaybookComponents(playbooks, false);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe('end_playbook');
-    expect(result[0].items).toHaveLength(1);
+    it('uses schema defaults when action is replace', () => {
+      const oldConfig = { filters: '{"mode":"and","filters":[]}', excludeMainElement: true };
+
+      const result = computeInitialComponentConfigValues({
+        action: 'replace',
+        currentConfig: oldConfig,
+        configurationSchema: schemaB,
+        nodeData: { name: 'My node', component: COMPONENT_A } as unknown as NodeData,
+        selectedComponent: COMPONENT_B,
+      });
+
+      // Should use default props of component B
+      expect(result.name).toBe('Component B');
+      expect(result.description).toBe('');
+      expect((result).wrap_in_container).toBe(true);
+      // Should not contain props of component A
+      expect((result).filters).toBeUndefined();
+      expect((result).excludeMainElement).toBeUndefined();
+    });
+
+    it('keeps existing config when action is config (editing same component)', () => {
+      const existingConfig = { filters: '{"mode":"and","filters":[{"key":"type"}]}' };
+
+      const result = computeInitialComponentConfigValues({
+        action: 'config',
+        currentConfig: existingConfig,
+        nodeData: { name: 'My node', description: 'desc', component: COMPONENT_A } as unknown as NodeData,
+        configurationSchema: schemaA,
+        selectedComponent: COMPONENT_A,
+      });
+
+      expect(result.name).toBe('My node');
+      expect(result.description).toBe('desc');
+      expect((result).filters).toBe('{"mode":"and","filters":[{"key":"type"}]}');
+    });
+
+    it('does not leak old config properties into new component on replace', () => {
+      const oldConfig = {
+        filters: '{"mode":"and","filters":[]}',
+        excludeMainElement: true,
+        newContainer: false,
+        actions: [],
+        applyToElements: 'all',
+        wrap_in_container: false,
+      };
+
+      const result = computeInitialComponentConfigValues({
+        action: 'replace',
+        currentConfig: oldConfig,
+        nodeData: { name: 'Old node', component: COMPONENT_A } as unknown as NodeData,
+        selectedComponent: COMPONENT_B,
+        configurationSchema: schemaB,
+      });
+
+      // Only props from new schame should be there
+      expect((result).wrap_in_container).toBe(true); // default from schema B
+      expect((result).excludeMainElement).toBeUndefined();
+      expect((result).newContainer).toBeUndefined();
+      expect((result).actions).toBeUndefined();
+      expect((result).applyToElements).toBeUndefined();
+      expect((result).filters).toBeUndefined();
+    });
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { computeInitialComponentConfigValues, groupAndSortPlaybookComponents, NodeData } from './playbookComponents-utils';
-import type { PlaybookComponent, PlaybookComponentConfigSchema, PlaybookConfig } from '../types/playbook-types';
+import { PlaybookBundleElementsToApply, type PlaybookComponent, type PlaybookComponentConfigSchema, type PlaybookConfig } from '../types/playbook-types';
 
 describe('playbookComponents-utils', () => {
   describe('groupAndSortPlaybookComponents', () => {
@@ -160,7 +160,7 @@ describe('playbookComponents-utils', () => {
         filters: '{"mode":"and","filters":[]}',
         newContainer: false,
         actions: [],
-        applyToElements: 'all-elements',
+        applyToElements: PlaybookBundleElementsToApply.ALL,
         wrap_in_container: false,
       } as unknown as PlaybookConfig;
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -55,7 +55,7 @@ export interface NodeData {
   configuration?: PlaybookConfig;
   component?: PlaybookComponent;
 }
-interface computeInitialComponentConfigValuesParams {
+interface ComputeInitialComponentConfigValuesParams {
   action: string | null;
   currentConfig: PlaybookConfig | null;
   configurationSchema: PlaybookComponentConfigSchema | null;
@@ -63,7 +63,7 @@ interface computeInitialComponentConfigValuesParams {
   selectedComponent?: PlaybookComponent | null;
 }
 
-export type PlaybookFlowFormValues = PlaybookFlowFormData & Record<string, unknown>;
+export type PlaybookFlowFormValues = PlaybookFlowFormData;
 
 export const computeInitialComponentConfigValues = ({
   action,
@@ -71,7 +71,7 @@ export const computeInitialComponentConfigValues = ({
   nodeData,
   configurationSchema,
   selectedComponent,
-}: computeInitialComponentConfigValuesParams): PlaybookFlowFormValues => {
+}: ComputeInitialComponentConfigValuesParams): PlaybookFlowFormValues => {
   const initialValues: PlaybookFlowFormValues = {
     name: '',
     description: '',

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -67,14 +67,16 @@ interface computeInitialComponentConfigValuesParams {
   selectedComponent?: PlaybookComponent | null;
 }
 
+export type PlaybookFlowFormValues = PlaybookFlowFormData & Record<string, unknown>;
+
 export const computeInitialComponentConfigValues = ({
   action,
   currentConfig,
   nodeData,
   configurationSchema,
   selectedComponent,
-}: computeInitialComponentConfigValuesParams): PlaybookFlowFormData & Record<string, unknown> => {
-  const initialValues: PlaybookFlowFormData & Record<string, unknown> = {
+}: computeInitialComponentConfigValuesParams): PlaybookFlowFormValues => {
+  const initialValues: PlaybookFlowFormValues = {
     name: '',
     description: '',
   };
@@ -87,8 +89,6 @@ export const computeInitialComponentConfigValues = ({
     initialValues.description = '';
     Object.entries(configurationSchema?.properties ?? {})
       .forEach(([propName, property]) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         initialValues[propName] = property.default;
         if (propName === 'actions') initialValues.actionsFormValues = [];
       });
@@ -111,8 +111,6 @@ export const computeInitialComponentConfigValues = ({
         initialValues.actionsFormValues = actionsFormValues;
       });
     // Ensure applyToElements defaults to 'only-main' for existing configs missing it
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     if (!initialValues.applyToElements && configurationSchema?.properties?.applyToElements) {
       initialValues.applyToElements = 'only-main';
     }

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -14,7 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import type { PlaybookCategory } from './__generated__/PlaybookFlow_playbookComponents.graphql';
-import type { PlaybookComponent, PlaybookComponents } from '../types/playbook-types';
+import type { PlaybookComponent, PlaybookComponentConfigSchema, PlaybookComponents, PlaybookConfig } from '../types/playbook-types';
+import { PlaybookFlowFormData } from './PlaybookFlowForm';
+import { PlaybookUpdateAction } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
 
 export const PLAYBOOK_CATEGORY_ORDER = [
   'start_playbook',
@@ -46,3 +48,75 @@ export function groupAndSortPlaybookComponents(
     }))
     .filter((g) => g.items.length > 0);
 }
+
+export interface NodeData {
+  name?: string | undefined;
+  description?: string | undefined;
+  configuration?: PlaybookConfig | undefined;
+  component?: PlaybookComponent;
+  openConfig: (nodeId: string) => void;
+  openReplace: (nodeId: string) => void;
+  openAddSibling: (nodeId: string) => void;
+  openDelete: (nodeId: string) => void;
+}
+interface computeInitialComponentConfigValuesParams {
+  action: string | null;
+  currentConfig: PlaybookConfig | null;
+  configurationSchema: PlaybookComponentConfigSchema | null;
+  nodeData?: NodeData;
+  selectedComponent?: PlaybookComponent | null;
+}
+
+export const computeInitialComponentConfigValues = ({
+  action,
+  currentConfig,
+  nodeData,
+  configurationSchema,
+  selectedComponent,
+}: computeInitialComponentConfigValuesParams): PlaybookFlowFormData & Record<string, unknown> => {
+  const initialValues: PlaybookFlowFormData & Record<string, unknown> = {
+    name: '',
+    description: '',
+  };
+
+  const componentIsReplaced = action === 'replace';
+
+  if (!currentConfig || componentIsReplaced) {
+    // Get default values from schema.
+    initialValues.name = selectedComponent?.name ?? '';
+    initialValues.description = '';
+    Object.entries(configurationSchema?.properties ?? {})
+      .forEach(([propName, property]) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        initialValues[propName] = property.default;
+        if (propName === 'actions') initialValues.actionsFormValues = [];
+      });
+  } else {
+    // Get values from saved config.
+    initialValues.name = nodeData?.component?.id === selectedComponent?.id
+      ? nodeData?.name ?? ''
+      : selectedComponent?.name ?? '';
+    initialValues.description = nodeData?.component?.id === selectedComponent?.id
+      ? nodeData?.description ?? ''
+      : '';
+    const actionsFormValues: PlaybookUpdateAction['value'][] = [];
+    Object.entries(currentConfig)
+      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
+      .forEach(([key, value]) => {
+        if (/actions-\d-value/.test(key)) actionsFormValues.push(value);
+        else {
+          initialValues[key] = value;
+        }
+        initialValues.actionsFormValues = actionsFormValues;
+      });
+    // Ensure applyToElements defaults to 'only-main' for existing configs missing it
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    if (!initialValues.applyToElements && configurationSchema?.properties?.applyToElements) {
+      initialValues.applyToElements = 'only-main';
+    }
+  }
+
+  return initialValues;
+};

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -63,16 +63,14 @@ interface ComputeInitialComponentConfigValuesParams {
   selectedComponent?: PlaybookComponent | null;
 }
 
-export type PlaybookFlowFormValues = PlaybookFlowFormData;
-
 export const computeInitialComponentConfigValues = ({
   action,
   currentConfig,
   nodeData,
   configurationSchema,
   selectedComponent,
-}: ComputeInitialComponentConfigValuesParams): PlaybookFlowFormValues => {
-  const initialValues: PlaybookFlowFormValues = {
+}: ComputeInitialComponentConfigValuesParams): PlaybookFlowFormData => {
+  const initialValues: PlaybookFlowFormData = {
     name: '',
     description: '',
   };

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -50,9 +50,9 @@ export function groupAndSortPlaybookComponents(
 }
 
 export interface NodeData {
-  name?: string | undefined;
-  description?: string | undefined;
-  configuration?: PlaybookConfig | undefined;
+  name?: string;
+  description?: string;
+  configuration?: PlaybookConfig;
   component?: PlaybookComponent;
 }
 interface computeInitialComponentConfigValuesParams {

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -15,8 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import type { PlaybookCategory } from './__generated__/PlaybookFlow_playbookComponents.graphql';
 import type { PlaybookComponent, PlaybookComponentConfigSchema, PlaybookComponents, PlaybookConfig } from '../types/playbook-types';
-import { PlaybookFlowFormData } from './PlaybookFlowForm';
-import { PlaybookUpdateAction } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
+import type { PlaybookFlowFormData } from './PlaybookFlowForm';
+import type { PlaybookUpdateAction } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
 
 export const PLAYBOOK_CATEGORY_ORDER = [
   'start_playbook',
@@ -54,10 +54,6 @@ export interface NodeData {
   description?: string | undefined;
   configuration?: PlaybookConfig | undefined;
   component?: PlaybookComponent;
-  openConfig: (nodeId: string) => void;
-  openReplace: (nodeId: string) => void;
-  openAddSibling: (nodeId: string) => void;
-  openDelete: (nodeId: string) => void;
 }
 interface computeInitialComponentConfigValuesParams {
   action: string | null;

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookComponents-utils.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 
 import type { PlaybookCategory } from './__generated__/PlaybookFlow_playbookComponents.graphql';
-import type { PlaybookComponent, PlaybookComponentConfigSchema, PlaybookComponents, PlaybookConfig } from '../types/playbook-types';
+import { PlaybookBundleElementsToApply, type PlaybookComponent, type PlaybookComponentConfigSchema, type PlaybookComponents, type PlaybookConfig } from '../types/playbook-types';
 import type { PlaybookFlowFormData } from './PlaybookFlowForm';
 import type { PlaybookUpdateAction } from './playbookFlowFields/playbookFlowFieldsActions/playbookAction-types';
 
@@ -108,7 +108,7 @@ export const computeInitialComponentConfigValues = ({
       });
     // Ensure applyToElements defaults to 'only-main' for existing configs missing it
     if (!initialValues.applyToElements && configurationSchema?.properties?.applyToElements) {
-      initialValues.applyToElements = 'only-main';
+      initialValues.applyToElements = PlaybookBundleElementsToApply.ONLY_MAIN;
     }
   }
 

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
@@ -4,13 +4,14 @@ import { PlaybookUpdateAction } from '../playbookFlow/playbookFlowFields/playboo
 
 export type PlaybookComponents = NonNullable<PlaybookFlow_playbookComponents$data['playbookComponents']>;
 export type PlaybookComponent = NonNullable<PlaybookComponents[number]>;
+type PlaybookBundleElementsToApply = 'all-elements' | 'only-main' | 'all-except-main';
 
 export interface PlaybookConfig {
   filters?: string;
   applyWithFilters?: string;
   actions?: PlaybookUpdateAction[];
   triggerTime?: string;
-  applyToElements?: string;
+  applyToElements?: PlaybookBundleElementsToApply;
 }
 
 export interface PlaybookDefinitionNode {

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
@@ -4,7 +4,12 @@ import { PlaybookUpdateAction } from '../playbookFlow/playbookFlowFields/playboo
 
 export type PlaybookComponents = NonNullable<PlaybookFlow_playbookComponents$data['playbookComponents']>;
 export type PlaybookComponent = NonNullable<PlaybookComponents[number]>;
-type PlaybookBundleElementsToApply = 'all-elements' | 'only-main' | 'all-except-main';
+
+export enum PlaybookBundleElementsToApply {
+  ALL = 'all-elements',
+  ONLY_MAIN = 'only-main',
+  ALL_EXCEPT_MAIN = 'all-except-main',
+}
 
 export interface PlaybookConfig {
   filters?: string;

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/playbook-types.ts
@@ -10,6 +10,7 @@ export interface PlaybookConfig {
   applyWithFilters?: string;
   actions?: PlaybookUpdateAction[];
   triggerTime?: string;
+  applyToElements?: string;
 }
 
 export interface PlaybookDefinitionNode {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added a condition "componentIsReplaced" to initialize values and config when a component is replaced in playbook
* Moved the logic of initializing values in computeInitialComponentConfigValues in playbookComponents-utils.ts

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16016 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

To test :
- Create a playbook with a component (ex Manipulate knowledge with an action)
- Replace the component with a component with different configuration settings (ex extract observable)
- Export the playbook
- In the playbook definition, you should not see any elements of the first component settings (ex actions for manipulate knowledge component) in the component configuration :
<img width="1278" height="175" alt="Capture d’écran 2026-06-25 à 09 43 23" src="https://github.com/user-attachments/assets/b9e0d8ad-0085-40c6-9023-f8b9c434e050" />


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
