### PR TITLE
fix(draft): bypass draft context for some draft element creation (#16801)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/stixObjectOrStixRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/domain/stixObjectOrStixRelationship.ts
@@ -3,6 +3,7 @@ import { READ_PLATFORM_INDICES, UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE } 
 import { type EntityOptions, storeLoadById } from '../database/middleware-loader';
 import { ABSTRACT_STIX_OBJECT, ABSTRACT_STIX_REF_RELATIONSHIP, ABSTRACT_STIX_RELATIONSHIP } from '../schema/general';
 import { FunctionalError, UnsupportedError } from '../config/errors';
+import { bypassDraftContext } from '../utils/draftContext';
 import { isStixRefRelationship, RELATION_CREATED_BY, RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
 import { pageEntitiesOrRelationsConnection, storeLoadByIdWithRefs, transformPatchToInput, updateAttributeFromLoadedWithRefs, validateCreatedBy } from '../database/middleware';
 import { notify } from '../database/redis';
@@ -35,7 +36,11 @@ const patchElementWithRefRelationships = async (
   operation: 'add' | 'remove',
   opts = {},
 ) => {
-  const initial = await storeLoadByIdWithRefs(context, user, stixObjectOrRelationshipId, { type });
+  let initial = await storeLoadByIdWithRefs(context, user, stixObjectOrRelationshipId, { type });
+  if (!initial) {
+    const bypassedContext = bypassDraftContext(context);
+    initial = await storeLoadByIdWithRefs(bypassedContext, user, stixObjectOrRelationshipId, { type });
+  }
   if (!initial) {
     throw FunctionalError('Element can not be loaded', { stixObjectOrRelationshipId });
   }

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -262,8 +262,9 @@ export const addDraftWorkspace = async (context: AuthContext, user: AuthUser, in
     });
   }
   const draftWorkspaceInput = { ...inputWithBypassedMandatoryAttributes, authorized_members: authorizedMembers, ...defaultOps };
+  const executionContext = bypassDraftContext(context);
   const createdDraftWorkspace = await createEntity(
-    context,
+    executionContext,
     user,
     draftWorkspaceInput,
     ENTITY_TYPE_DRAFT_WORKSPACE,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* bypass draft context for draft workspace creation
* fallback to bypassing draft context when searching elements to link to new draft element

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16801 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
