### PR TITLE
fix(backend): distribute background tasks across least-used queues (#16631)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -509,15 +509,25 @@ export const getConnectorQueueSize = async (context, user, connectorId) => {
   }
   return targetQueues.length > 0 ? targetQueues.reduce((a, b) => (a.messages ?? 0) + (b.messages ?? 0)) : 0;
 };
+// Return the queues holding the fewest messages among the given candidates.
+// Exported for testing.
+export const filterLeastUsedQueues = (queues) => {
+  const minMessages = Math.min(...queues.map((queue) => queue.messages ?? 0));
+  return queues.filter((queue) => (queue.messages ?? 0) === minMessages);
+};
 export const getBestBackgroundConnectorId = async (context, user) => {
   let stats = metricsCache.get('cached_metrics');
   if (!stats) {
     stats = await metrics(context, user);
     metricsCache.set('cached_metrics', stats);
   }
-  // Find the least used push queue
+  // Find the least used push queues
   const targetQueues = stats.queues.filter((queue) => queue.name.startsWith(`${RABBIT_QUEUE_PREFIX}push_background-task`));
-  const bestQueue = targetQueues.sort((a, b) => (a.messages ?? 0) - (b.messages ?? 0))[0];
+  const leastUsedQueues = filterLeastUsedQueues(targetQueues);
+  // Pick one at random among the least used queues. The metrics are cached for a short window,
+  // so a burst of tasks created within that window would otherwise all be routed to the first
+  // queue (sort index 0) and pile up on a single queue while the others stay idle.
+  const bestQueue = leastUsedQueues[Math.floor(Math.random() * leastUsedQueues.length)];
   return bestQueue.name.substring(`${RABBIT_QUEUE_PREFIX}push_`.length);
 };
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/rabbitmq-test.ts
@@ -66,7 +66,7 @@ vi.mock('lru-cache', () => {
   return { LRUCache: FakeLRUCache };
 });
 
-import { getConnectorQueueSize, metrics } from '../../../src/database/rabbitmq';
+import { filterLeastUsedQueues, getBestBackgroundConnectorId, getConnectorQueueSize, metrics } from '../../../src/database/rabbitmq';
 
 describe('rabbitmq: metrics', () => {
   const context = {};
@@ -257,5 +257,88 @@ describe('rabbitmq: getConnectorQueueSize', () => {
 
     const result = await getConnectorQueueSize(context, user, 'connector-abc');
     expect(result).toBe(15);
+  });
+});
+
+describe('rabbitmq: filterLeastUsedQueues', () => {
+  it('should return the single queue with the fewest messages', () => {
+    const queues = [
+      { name: 'opencti_push_background-task-0', messages: 5 },
+      { name: 'opencti_push_background-task-1', messages: 2 },
+      { name: 'opencti_push_background-task-2', messages: 9 },
+    ];
+    expect(filterLeastUsedQueues(queues).map((q) => q.name)).toEqual(['opencti_push_background-task-1']);
+  });
+
+  it('should return all queues tied at the minimum message count', () => {
+    const queues = [
+      { name: 'opencti_push_background-task-0', messages: 0 },
+      { name: 'opencti_push_background-task-1', messages: 0 },
+      { name: 'opencti_push_background-task-2', messages: 3 },
+      { name: 'opencti_push_background-task-3', messages: 0 },
+    ];
+    expect(filterLeastUsedQueues(queues).map((q) => q.name)).toEqual([
+      'opencti_push_background-task-0',
+      'opencti_push_background-task-1',
+      'opencti_push_background-task-3',
+    ]);
+  });
+
+  it('should treat a missing messages count as 0', () => {
+    const queues = [
+      { name: 'opencti_push_background-task-0' },
+      { name: 'opencti_push_background-task-1', messages: 4 },
+    ];
+    expect(filterLeastUsedQueues(queues).map((q) => q.name)).toEqual(['opencti_push_background-task-0']);
+  });
+});
+
+describe('rabbitmq: getBestBackgroundConnectorId', () => {
+  const context = {};
+  const user = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockQueues = (queues: { name: string; messages?: number }[]) => {
+    mockHttpClient.get.mockImplementation((url: string) => {
+      if (url === '/api/overview') {
+        return Promise.resolve({ data: { rabbitmq_version: '3.12.0' } });
+      }
+      if (url.includes('/api/queues')) {
+        return Promise.resolve({ data: queues.map((q) => ({ consumers: 1, ...q })) });
+      }
+      return Promise.resolve({ data: {} });
+    });
+  };
+
+  it('should select the least used background-task queue', async () => {
+    mockQueues([
+      { name: 'opencti_push_background-task-0', messages: 5 },
+      { name: 'opencti_push_background-task-1', messages: 1 },
+      { name: 'opencti_push_background-task-2', messages: 8 },
+    ]);
+    const result = await getBestBackgroundConnectorId(context, user);
+    expect(result).toBe('background-task-1');
+  });
+
+  it('should only ever return one of the least used queues when several are tied', async () => {
+    mockQueues([
+      { name: 'opencti_push_background-task-0', messages: 0 },
+      { name: 'opencti_push_background-task-1', messages: 0 },
+      { name: 'opencti_push_background-task-2', messages: 7 },
+      { name: 'opencti_push_background-task-3', messages: 0 },
+    ]);
+    const tiedAtMinimum = new Set(['background-task-0', 'background-task-1', 'background-task-3']);
+    // Random selection: run many times, every result must be among the tied-minimum queues.
+    for (let i = 0; i < 50; i += 1) {
+      const result = await getBestBackgroundConnectorId(context, user);
+      expect(tiedAtMinimum.has(result)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## Proposed changes

`getBestBackgroundConnectorId` selected the background-task queue with the fewest messages but always took **sort index 0** among ties. Since the RabbitMQ metrics are cached for a short window (`metricsCache`, 15s), a burst of background tasks created within that window all observe identical message counts and are therefore all routed to `background-task-0` — piling up on one queue while the others stay idle (most visible with `APP__TASK_SCHEDULER__MAX_QUEUES_BREAKDOWN` set high, e.g. 10).

This implements the approach agreed in the issue: among the least-used queues, **pick one at random** so bursts spread across the available queues instead of always hitting index 0. The selection of the least-used set is extracted into a pure `filterLeastUsedQueues` helper and unit-tested.

## Related issues

Closes #16631

Implements the fix direction confirmed by @JeremyCloarec in the issue (random selection among the queues tied at the minimum).

## How to test

```bash
cd opencti-platform/opencti-graphql
yarn vitest run --config vitest.config.ci-unit.ts tests/01-unit/database/rabbitmq-test.ts
```

14 tests pass (existing + new): `filterLeastUsedQueues` returns the single minimum / all ties / treats missing count as 0; `getBestBackgroundConnectorId` selects the least-used queue and, when several are tied at the minimum, only ever returns one of the tied queues across many runs.