### PR TITLE
fix(capabilities): fix capa for menu data import (#16805)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.test.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { createMockUserContext, testRenderHook } from '../tests/test-render';
+import useImportAccess from './useImportAccess';
+import { KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNGETEXPORT, KNOWLEDGE_KNUPDATE } from './useGranted';
+
+const cap = (name: string) => ({ name });
+
+const buildUserContext = (capabilities: string[], capabilitiesInDraft: string[] = []) => createMockUserContext({
+  me: {
+    id: 'test-user-id',
+    capabilities: capabilities.map(cap),
+    capabilitiesInDraft: capabilitiesInDraft.map(cap),
+    draftContext: null,
+  },
+});
+
+describe('Hook: useImportAccess', () => {
+  describe('hasOnlyAccessToImportDraftTab', () => {
+    it('should be false when user has no capabilities', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
+    });
+
+    it('should be false when user has KNOWLEDGE_KNASKIMPORT in base (full import access)', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNASKIMPORT]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
+    });
+
+    it('should be true when user has KNOWLEDGE_KNUPDATE in base (but not KNOWLEDGE_KNASKIMPORT)', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNUPDATE]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(true);
+    });
+
+    it('should be true when user has KNOWLEDGE_KNUPDATE in draft only', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([], [KNOWLEDGE_KNUPDATE]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(true);
+    });
+
+    it('should be false when user has only KNOWLEDGE_KNGETEXPORT (read-only capability)', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNGETEXPORT]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
+    });
+
+    it('should be false when user has only KNOWLEDGE_KNGETEXPORT in draft', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([], [KNOWLEDGE_KNGETEXPORT]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
+    });
+  });
+
+  describe('isForcedImportToDraft', () => {
+    it('should be false when user has no capabilities', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(false);
+    });
+
+    it('should be false when user has KNOWLEDGE_KNASKIMPORT in base', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNASKIMPORT]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(false);
+    });
+
+    it('should be true when user has KNOWLEDGE_KNASKIMPORT in draft only', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([], [KNOWLEDGE_KNASKIMPORT]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(true);
+    });
+
+    it('should be true when user has KNOWLEDGE_KNUPDATE in draft only', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([], [KNOWLEDGE_KNUPDATE]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(true);
+    });
+
+    it('should be false when user has KNOWLEDGE_KNUPDATE in base (not forced to draft)', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNUPDATE]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(false);
+    });
+
+    it('should be true when user has KNOWLEDGE_KNASKIMPORT in base but KNOWLEDGE_KNUPDATE only in draft', () => {
+      // Even with full import access, having KNUPDATE only in draft means edits must go through draft
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNASKIMPORT], [KNOWLEDGE_KNUPDATE]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(true);
+    });
+
+    it('should be false when user has both KNOWLEDGE_KNASKIMPORT and KNOWLEDGE_KNUPDATE in base', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE]) },
+      );
+      expect(hook.result.current.isForcedImportToDraft).toBe(false);
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.test.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createMockUserContext, testRenderHook } from '../tests/test-render';
 import useImportAccess from './useImportAccess';
-import { KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNGETEXPORT, KNOWLEDGE_KNUPDATE } from './useGranted';
+import { KNOWLEDGE, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNGETEXPORT, KNOWLEDGE_KNUPDATE } from './useGranted';
 
 const cap = (name: string) => ({ name });
 
@@ -60,6 +60,23 @@ describe('Hook: useImportAccess', () => {
       const { hook } = testRenderHook(
         () => useImportAccess(),
         { userContext: buildUserContext([], [KNOWLEDGE_KNGETEXPORT]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
+    });
+
+    it('should be false when user has only the base KNOWLEDGE capability (read-only access)', () => {
+      // Regression: old code matched any capability containing 'KNOWLEDGE', granting incorrect access
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([KNOWLEDGE]) },
+      );
+      expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
+    });
+
+    it('should be false when user has only the base KNOWLEDGE capability in draft', () => {
+      const { hook } = testRenderHook(
+        () => useImportAccess(),
+        { userContext: buildUserContext([], [KNOWLEDGE]) },
       );
       expect(hook.result.current.hasOnlyAccessToImportDraftTab).toBe(false);
     });

--- a/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useImportAccess.ts
@@ -1,9 +1,6 @@
-import useGranted, { getCapabilitiesName, KNOWLEDGE, KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE } from './useGranted';
-import useAuth from './useAuth';
+import useGranted, { KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNUPDATE } from './useGranted';
 
 const useImportAccess = () => {
-  const { me } = useAuth();
-
   // Has global import (KNOWLEDGE_KNASKIMPORT in base capabilities)
   const hasImportBaseCapability = useGranted([KNOWLEDGE_KNASKIMPORT]);
 
@@ -22,14 +19,12 @@ const useImportAccess = () => {
   // or if they only have KNOWLEDGE_KNUPDATE in draft (not in main).
   const isForcedImportToDraft = (!hasImportBaseCapability && hasAnyImportCapability) || hasKnowledgeUpdateInDraftOnly;
 
-  // Only access to Import Draft Tab
-  const userCapabilities = getCapabilitiesName(me.capabilities);
-  const userCapabilitiesInDraft = getCapabilitiesName(me.capabilitiesInDraft);
+  // Only access to Import Draft Tab: requires at minimum KNOWLEDGE_KNUPDATE (in main or draft)
+  const hasKnowledgeUpdate = useGranted([KNOWLEDGE_KNUPDATE], false, {
+    capabilitiesInDraft: [KNOWLEDGE_KNUPDATE],
+  });
 
-  const hasAnyKnowledgeCapability = [...userCapabilities, ...userCapabilitiesInDraft]
-    .some((cap) => cap.includes(KNOWLEDGE));
-
-  const hasOnlyAccessToImportDraftTab = !hasImportBaseCapability && hasAnyKnowledgeCapability;
+  const hasOnlyAccessToImportDraftTab = !hasImportBaseCapability && hasKnowledgeUpdate;
 
   return {
     isForcedImportToDraft,


### PR DESCRIPTION
### Proposed changes

* Check de capa Knowledge Update to access to the menu Data

### Related issues

* closes #16805 

### How to test this PR

- Create a user with only "access knowledge" capability
- Dont see the Data menu
- Give him the capa knowledge "Create update knowledge"
- See the Data menu
- You can try with only "Create update knowledge" in draft
- See the Data menu

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality