### PR TITLE
fix(frontend): restore entity-only distribution in report and grouping details widgets (#16633)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingDetails.jsx
@@ -45,6 +45,12 @@ const GroupingDetailsComponent = (props) => {
             operator: 'eq',
             mode: 'or',
           },
+          {
+            key: 'toTypes',
+            values: ['Stix-Core-Object'],
+            operator: 'eq',
+            mode: 'or',
+          },
         ],
         filterGroups: [],
       },

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportDetails.jsx
@@ -65,6 +65,12 @@ const ReportDetails = ({ report }) => {
             operator: 'eq',
             mode: 'or',
           },
+          {
+            key: 'toTypes',
+            values: ['Stix-Core-Object'],
+            operator: 'eq',
+            mode: 'or',
+          },
         ],
         filterGroups: [],
       },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The distribution widget in Report and Grouping details was showing relationship types in addition to entity types.
The filtering has been updated to restore the expected behavior: entity-type distribution only for linked objects.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16633

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
