### PR TITLE
fix(form-intakes): fix author with custom label (#16699)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
@@ -227,11 +227,24 @@ export const resolveMainEntityAuthorFromValues = (
   values: Record<string, any>,
 ): string | null => {
   const createdByField = schema.fields.find((f) => f.type === FormFieldType.CreatedBy);
-  const createdByKey = createdByField?.name ?? 'createdBy';
-  const possibleAuthor = values[createdByKey]
-    || values.mainEntityFields?.[createdByKey]
-    || (values.mainEntityGroups && values.mainEntityGroups.length > 0 ? values.mainEntityGroups[0][createdByKey] : undefined);
-  return normalizeOptionId(possibleAuthor) || null;
+  const createdByKeys = Array.from(new Set([
+    createdByField?.name,
+    createdByField?.attributeMapping?.attributeName,
+    'createdBy',
+  ].filter((k): k is string => typeof k === 'string' && k.length > 0)));
+  const resolveIn = (container: any): string | undefined => {
+    for (let i = 0; i < createdByKeys.length; i += 1) {
+      const id = normalizeOptionId(container?.[createdByKeys[i]]);
+      if (id) return id;
+    }
+    return undefined;
+  };
+  return (
+    resolveIn(values)
+    || resolveIn(values.mainEntityFields)
+    || resolveIn(Array.isArray(values.mainEntityGroups) ? values.mainEntityGroups[0] : undefined)
+    || null
+  );
 };
 
 export const resolveDraftFieldDefaults = (

--- a/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
@@ -4,7 +4,7 @@ import type { FileHandle } from 'fs/promises';
 import { createEntity, deleteElementById, patchAttribute, updateAttribute } from '../../database/middleware';
 import { fullEntitiesList, pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import type { BasicStoreEntityForm, FormSchemaDefinition, StoreEntityForm } from './form-types';
-import { ENTITY_TYPE_FORM, FormSchemaDefinitionSchema } from './form-types';
+import { ENTITY_TYPE_FORM, FormFieldType, FormSchemaDefinitionSchema } from './form-types';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { FunctionalError } from '../../config/errors';
 import { connectorIdFromIngestId, registerConnectorForIngestion, unregisterConnectorForIngestion } from '../../domain/connector';
@@ -220,6 +220,18 @@ const normalizeOptionId = (option: unknown): string | undefined => {
     return typeof optionValue === 'string' && optionValue.length > 0 ? optionValue : undefined;
   }
   return typeof option === 'string' && option.length > 0 ? option : undefined;
+};
+
+export const resolveMainEntityAuthorFromValues = (
+  schema: FormSchemaDefinition,
+  values: Record<string, any>,
+): string | null => {
+  const createdByField = schema.fields.find((f) => f.type === FormFieldType.CreatedBy);
+  const createdByKey = createdByField?.name ?? 'createdBy';
+  const possibleAuthor = values[createdByKey]
+    || values.mainEntityFields?.[createdByKey]
+    || (values.mainEntityGroups && values.mainEntityGroups.length > 0 ? values.mainEntityGroups[0][createdByKey] : undefined);
+  return normalizeOptionId(possibleAuthor) || null;
 };
 
 export const resolveDraftFieldDefaults = (
@@ -473,10 +485,7 @@ export const formSubmit = async (
         if (schema.draftDefaults.author.type === 'static') {
           createdBy = schema.draftDefaults.author.defaultValue || null;
         } else if (schema.draftDefaults.author.type === 'main_entity_author') {
-          const possibleAuthor = values.createdBy
-            || values.mainEntityFields?.createdBy
-            || (values.mainEntityGroups && values.mainEntityGroups.length > 0 ? values.mainEntityGroups[0].createdBy : undefined);
-          createdBy = normalizeOptionId(possibleAuthor) || null;
+          createdBy = resolveMainEntityAuthorFromValues(schema, values);
         } else if (schema.draftDefaults.author.type === 'none') {
           createdBy = null;
         }

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-domain-test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMainEntityAuthorFromValues } from '../../../../src/modules/form/form-domain';
+import { FormFieldType, type FormSchemaDefinition } from '../../../../src/modules/form/form-types';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const makeCreatedByField = (name: string) => ({
+  id: name,
+  name,
+  label: name,
+  type: FormFieldType.CreatedBy,
+  required: false,
+  attributeMapping: { entity: 'main_entity', attributeName: 'createdBy' },
+});
+
+const baseSchema = (overrides: Partial<FormSchemaDefinition> = {}): FormSchemaDefinition => ({
+  mainEntityType: 'Report',
+  version: '2.0',
+  fields: [],
+  ...overrides,
+});
+
+// ─── resolveMainEntityAuthorFromValues ──────────────────────────────────────
+
+describe('resolveMainEntityAuthorFromValues', () => {
+  describe('direct values (single-entity mode)', () => {
+    it('resolves author when field name is the default "createdBy"', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('createdBy')] });
+      const values = { createdBy: 'identity--org-1' };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-1');
+    });
+
+    it('resolves author when field has a custom name from a renamed label', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('author')] });
+      const values = { author: 'identity--org-1' };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-1');
+    });
+
+    it('returns null when the value is absent', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('author')] });
+      expect(resolveMainEntityAuthorFromValues(schema, {})).toBeNull();
+    });
+
+    it('resolves author from an option object with a value property', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('author')] });
+      const values = { author: { value: 'identity--org-1', label: 'Org 1' } };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-1');
+    });
+  });
+
+  describe('mainEntityFields mode (multiple=false, additional fields)', () => {
+    it('resolves author from mainEntityFields when field name is the default "createdBy"', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('createdBy')] });
+      const values = { mainEntityFields: { createdBy: 'identity--org-2' } };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-2');
+    });
+
+    it('resolves author from mainEntityFields when field has a custom name', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('author')] });
+      const values = { mainEntityFields: { author: 'identity--org-2' } };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-2');
+    });
+  });
+
+  describe('mainEntityGroups mode (multiple=true)', () => {
+    it('resolves author from the first group when field name is the default "createdBy"', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('createdBy')] });
+      const values = { mainEntityGroups: [{ createdBy: 'identity--org-3' }, { createdBy: 'identity--org-4' }] };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-3');
+    });
+
+    it('resolves author from the first group when field has a custom name', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('auteur')] });
+      const values = { mainEntityGroups: [{ auteur: 'identity--org-3' }] };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-3');
+    });
+
+    it('returns null when mainEntityGroups is empty', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('createdBy')] });
+      const values = { mainEntityGroups: [] };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBeNull();
+    });
+  });
+
+  describe('schema without a createdBy field', () => {
+    it('falls back to "createdBy" key and resolves correctly when present', () => {
+      const schema = baseSchema({ fields: [] }); // no createdBy field
+      const values = { createdBy: 'identity--org-5' };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-5');
+    });
+
+    it('returns null when no createdBy field in schema and value is absent', () => {
+      const schema = baseSchema({ fields: [] });
+      expect(resolveMainEntityAuthorFromValues(schema, {})).toBeNull();
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/forms/form-domain-test.ts
@@ -4,13 +4,13 @@ import { FormFieldType, type FormSchemaDefinition } from '../../../../src/module
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-const makeCreatedByField = (name: string) => ({
+const makeCreatedByField = (name: string, attributeName = 'createdBy') => ({
   id: name,
   name,
   label: name,
   type: FormFieldType.CreatedBy,
   required: false,
-  attributeMapping: { entity: 'main_entity', attributeName: 'createdBy' },
+  attributeMapping: { entity: 'main_entity', attributeName },
 });
 
 const baseSchema = (overrides: Partial<FormSchemaDefinition> = {}): FormSchemaDefinition => ({
@@ -92,6 +92,28 @@ describe('resolveMainEntityAuthorFromValues', () => {
     it('returns null when no createdBy field in schema and value is absent', () => {
       const schema = baseSchema({ fields: [] });
       expect(resolveMainEntityAuthorFromValues(schema, {})).toBeNull();
+    });
+  });
+
+  describe('attributeMapping.attributeName fallback', () => {
+    it('resolves author via attributeMapping.attributeName when value is stored under the canonical attribute key', () => {
+      // Simulates a programmatic API submission that uses the attribute name ('createdBy')
+      // even though field.name is customized ('author')
+      const schema = baseSchema({ fields: [makeCreatedByField('author', 'createdBy')] });
+      const values = { createdBy: 'identity--org-6' };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-6');
+    });
+
+    it('resolves via attributeMapping.attributeName in mainEntityFields when field.name key is absent', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('author', 'createdBy')] });
+      const values = { mainEntityFields: { createdBy: 'identity--org-7' } };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--org-7');
+    });
+
+    it('prefers field.name key over attributeMapping.attributeName when both are present', () => {
+      const schema = baseSchema({ fields: [makeCreatedByField('author', 'createdBy')] });
+      const values = { author: 'identity--primary', createdBy: 'identity--secondary' };
+      expect(resolveMainEntityAuthorFromValues(schema, values)).toBe('identity--primary');
     });
   });
 });


### PR DESCRIPTION
### Proposed changes

* Resolve "Author" of the main entity by the label in the schema
* Before it only resolved by the key "Created By", but that key can be updated by the user.

### Related issues

* closes #16699 

### How to test this PR

- Create a Form Intakes (Data / ingestion)
- Give a name
- Select `Create as draft by default`
- In `Advanced draft settings`, for `Draft author`, select `Main entity author`
- In the bottom, click `Add field`
- Select "Created by"
- Change the `Field label`
- Submit to create the form intakes
- In the list, click in this new form intakes
- Give a Report name
- See your custom label in the field
- Select an organization
- Keep empty the `Draft author` field (it will be populated automatically with the author of the entity)
- Submit
- Go to the overview of the draft
- You must to see the organization selected for the entity author as the draft author.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality