### PR TITLE
feat(draft): Add author in draft widget attribute (#16825)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDistributionList.tsx
@@ -46,6 +46,11 @@ const draftsDistributionListQuery = graphql`
           id
           entity_type
         }
+        ... on StixObject {
+          representative {
+            main
+          }
+        }
         ... on Creator {
           name
         }

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDonut.tsx
@@ -45,6 +45,11 @@ const draftsDonutDistributionQuery = graphql`
           id
           entity_type
         }
+        ... on StixObject {
+          representative {
+            main
+          }
+        }
         ... on Creator {
           name
         }

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsHorizontalBars.tsx
@@ -46,6 +46,11 @@ const draftsHorizontalBarsDistributionQuery = graphql`
           id
           entity_type
         }
+        ... on StixObject {
+          representative {
+            main
+          }
+        }
         ... on Creator {
           id
           name

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -739,6 +739,7 @@ const WidgetCreationParameters = () => {
                                 { value: 'object-assignee.internal_id', label: 'Assignee' },
                                 { value: 'object-participant.internal_id', label: 'Participant' },
                                 { value: 'creator_id', label: 'Creator' },
+                                { value: 'created-by.internal_id', label: 'Author' },
                                 ...(isDraftWorkflowEnabled ? [{ value: 'workflowInstance', label: 'Workflow status' }] : []),
                               ].map(({ value, label }) => (
                                 <MenuItem key={value} value={value}>


### PR DESCRIPTION
### Proposed changes

* Add author in draft widget attribute

### Related issues

* closes #16825 

### How to test this PR

- Have some draft with different Author
- Create a dashboard
- Add a donut widget
- Select filter `Entity type = Draft`
- Select attribute `Author`
- See your donut organized by author and with names of author displayed on the bottom.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality