### PR TITLE
feat(playbook): restrict AI agent run as to current user and service accounts (#16840)

### DIFF
--- a/docs/docs/usage/playbook-components.md
+++ b/docs/docs/usage/playbook-components.md
@@ -342,7 +342,7 @@ For more details, see [Organization segregation](https://docs.opencti.io/latest/
 
 This component sends the bundle to the configured AI agent. By default, it uses the "CTI STIX transformer" agent, which is configured to only use the STIX 2.1 data schema and returns a STIX bundle that can then be further processed by the playbook.
 
-Use **Additional user instructions** to provide the agent with a prompt to follow, and choose the user the agent should run as so that it only has access to the data it needs.
+Use **Additional user instructions** to provide the agent with a prompt to follow, and choose the user the agent should run as so that it only has access to the data it needs. For security reasons, the **Run as** selection is limited to yourself (the user editing the playbook) and service accounts.
 
 !!! warning "This component requires access to the XTM One platform and will consume usage of your XTM One quota."
 
@@ -401,7 +401,7 @@ This component passes the STIX 2.1 bundle to the data stream for writing. It has
 
 ### Send to AI
 
-This component passes the STIX 2.1 bundle to the AI agent, by default this will be set to the CTI STIX Consumer. Configure this component with the additional user provided instructions that will act as the user prompt and set the user account that the agent will run as to ensure it has the correct access permissions. Once the data is processed the playbook will complete and the bundle will continue to be processed by the AI agent depending on instructions. For example the instructions may specify the creation of a new weekly grouping of data to be created in OpenCTI, the AI agent would then create the new grouping in the Draft space within OpenCTI where an analyst can review the AI agent's output.
+This component passes the STIX 2.1 bundle to the AI agent, by default this will be set to the CTI STIX Consumer. Configure this component with the additional user provided instructions that will act as the user prompt and set the user account that the agent will run as to ensure it has the correct access permissions. For security reasons, the **Run as** selection is limited to yourself (the user editing the playbook) and service accounts. Once the data is processed the playbook will complete and the bundle will continue to be processed by the AI agent depending on instructions. For example the instructions may specify the creation of a new weekly grouping of data to be created in OpenCTI, the AI agent would then create the new grouping in the Draft space within OpenCTI where an analyst can review the AI agent's output.
 
 ### Send to notifier
 

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3187,6 +3187,7 @@
   "Only lowercase letters, numbers and hyphens are allowed": "Only lowercase letters, numbers and hyphens are allowed",
   "Only successful tests allow the ingestion creation.": "Only successful tests allow the ingestion creation.",
   "Only successful tests allow the ingestion edition.": "Only successful tests allow the ingestion edition.",
+  "Only yourself and service accounts can be selected": "Only yourself and service accounts can be selected",
   "only_eq_to": "Only equal to",
   "Open chatbot": "Open chatbot",
   "Open correlation details": "Open correlation details",

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/PlaybookFlowForm.tsx
@@ -15,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 import Button from '@common/button/Button';
 import OpenVocabField from '@components/common/form/OpenVocabField';
-import ObjectMembersField from '@components/common/form/ObjectMembersField';
 import MenuItem from '@mui/material/MenuItem';
 import { Field, Form, Formik, FormikConfig } from 'formik';
 import * as Yup from 'yup';
@@ -39,6 +38,7 @@ import PlaybookFlowFieldInPirFilters from './playbookFlowFields/PlaybookFlowFiel
 import PlaybookFlowFieldNumber from './playbookFlowFields/PlaybookFlowFieldNumber';
 import PlaybookFlowFieldOrganizations from './playbookFlowFields/PlaybookFlowFieldOrganizations';
 import PlaybookFlowFieldPeriod from './playbookFlowFields/PlaybookFlowFieldPeriod';
+import PlaybookFlowFieldRunAs from './playbookFlowFields/PlaybookFlowFieldRunAs';
 import PlaybookFlowFieldString from './playbookFlowFields/PlaybookFlowFieldString';
 import PlaybookFlowFieldTargets from './playbookFlowFields/PlaybookFlowFieldTargets';
 import PlaybookFlowFieldTriggerTime from './playbookFlowFields/PlaybookFlowFieldTriggerTime';
@@ -243,11 +243,10 @@ const PlaybookFlowForm = ({
                   }
                   if (propName === 'run_as') {
                     return (
-                      <ObjectMembersField
+                      <PlaybookFlowFieldRunAs
                         key={propName}
                         name={propName}
-                        label={t_i18n(property.$ref ?? 'Run as')}
-                        entityTypes={['User']}
+                        label={property.$ref ?? 'Run as'}
                         style={fieldSpacingContainerStyle}
                       />
                     );

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldRunAs.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldRunAs.tsx
@@ -1,0 +1,145 @@
+import { graphql } from 'react-relay';
+import makeStyles from '@mui/styles/makeStyles';
+import React, { FunctionComponent, useState } from 'react';
+import { Field } from 'formik';
+import type { Theme } from '../../../../../../components/Theme';
+import { fetchQuery } from '../../../../../../relay/environment';
+import { useFormatter } from '../../../../../../components/i18n';
+import useAuth from '../../../../../../utils/hooks/useAuth';
+import AutocompleteField from '../../../../../../components/AutocompleteField';
+import ItemIcon from '../../../../../../components/ItemIcon';
+import { FieldOption } from '../../../../../../utils/field';
+import { PlaybookFlowFieldRunAsQuery$data } from './__generated__/PlaybookFlowFieldRunAsQuery.graphql';
+
+// Deprecated - https://mui.com/system/styles/basics/
+// Do not use it for new code.
+const useStyles = makeStyles<Theme>((theme) => ({
+  icon: {
+    paddingTop: 4,
+    display: 'inline-block',
+    color: theme.palette.primary.main,
+  },
+  text: {
+    display: 'inline-block',
+    flexGrow: 1,
+    marginLeft: 10,
+  },
+}));
+
+// The agent runs on behalf of the configured user, so the picker is
+// deliberately restricted to identities the author is allowed to act as:
+// the author themselves and any service account. Service accounts are
+// fetched from the server with a dedicated filter (the generic `members`
+// API is reused untouched); the current user is injected client-side from
+// the auth context. The backend re-validates this on save.
+const playbookFlowFieldRunAsQuery = graphql`
+  query PlaybookFlowFieldRunAsQuery($search: String, $first: Int, $filters: FilterGroup) {
+    members(search: $search, first: $first, entityTypes: [User], filters: $filters) {
+      edges {
+        node {
+          id
+          entity_type
+          name
+        }
+      }
+    }
+  }
+`;
+
+const serviceAccountsFilter = {
+  mode: 'and',
+  filters: [{ key: ['user_service_account'], values: ['true'], operator: 'eq', mode: 'or' }],
+  filterGroups: [],
+};
+
+interface OptionRunAs extends FieldOption {
+  type: string;
+}
+
+interface PlaybookFlowFieldRunAsProps {
+  name: string;
+  label?: string;
+  style?: Record<string, string | number>;
+}
+
+const PlaybookFlowFieldRunAs: FunctionComponent<PlaybookFlowFieldRunAsProps> = ({
+  name,
+  label,
+  style,
+}) => {
+  const classes = useStyles();
+  const { t_i18n } = useFormatter();
+  const { me } = useAuth();
+  const currentUserOption: OptionRunAs = {
+    label: me.name,
+    value: me.id,
+    type: me.entity_type,
+  };
+  const [options, setOptions] = useState<OptionRunAs[]>([currentUserOption]);
+
+  const searchRunAs = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const search = event && event.target.value ? event.target.value : '';
+    fetchQuery(playbookFlowFieldRunAsQuery, {
+      search,
+      first: 50,
+      filters: serviceAccountsFilter,
+    })
+      .toPromise()
+      .then((data) => {
+        const serviceAccounts = (
+          (data as PlaybookFlowFieldRunAsQuery$data)?.members?.edges ?? []
+        ).map((edge) => ({
+          label: edge?.node.name,
+          value: edge?.node.id,
+          type: edge?.node.entity_type,
+        })) as OptionRunAs[];
+        // Always offer the current user, only hiding it when it does not
+        // match the current search input.
+        const lowerSearch = search.toLowerCase();
+        const selfMatchesSearch = !lowerSearch
+          || currentUserOption.label.toLowerCase().includes(lowerSearch);
+        const merged = [
+          ...(selfMatchesSearch ? [currentUserOption] : []),
+          ...serviceAccounts,
+        ];
+        const uniqueOptions = merged.filter(
+          (item, index) => merged.findIndex((e) => e.value === item.value) === index,
+        );
+        setOptions(uniqueOptions);
+      });
+  };
+
+  return (
+    <div style={{ width: '100%' }}>
+      <Field
+        component={AutocompleteField}
+        name={name}
+        multiple={false}
+        textfieldprops={{
+          variant: 'standard',
+          label: t_i18n(label ?? 'Run as'),
+          helperText: t_i18n('Only yourself and service accounts can be selected'),
+          onFocus: searchRunAs,
+        }}
+        style={style}
+        noOptionsText={t_i18n('No available options')}
+        options={options}
+        groupBy={(option: OptionRunAs) => option.type}
+        onInputChange={searchRunAs}
+        renderOption={(
+          props: React.HTMLAttributes<HTMLLIElement>,
+          option: OptionRunAs,
+        ) => (
+          <li {...props}>
+            <div className={classes.icon}>
+              <ItemIcon type={option.type} />
+            </div>
+            <div className={classes.text}>{option.label}</div>
+          </li>
+        )}
+      />
+    </div>
+  );
+};
+
+export default PlaybookFlowFieldRunAs;

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldRunAs.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/playbookFlow/playbookFlowFields/PlaybookFlowFieldRunAs.tsx
@@ -1,8 +1,7 @@
 import { graphql } from 'react-relay';
-import makeStyles from '@mui/styles/makeStyles';
+import Box from '@mui/material/Box';
 import React, { FunctionComponent, useState } from 'react';
 import { Field } from 'formik';
-import type { Theme } from '../../../../../../components/Theme';
 import { fetchQuery } from '../../../../../../relay/environment';
 import { useFormatter } from '../../../../../../components/i18n';
 import useAuth from '../../../../../../utils/hooks/useAuth';
@@ -10,21 +9,6 @@ import AutocompleteField from '../../../../../../components/AutocompleteField';
 import ItemIcon from '../../../../../../components/ItemIcon';
 import { FieldOption } from '../../../../../../utils/field';
 import { PlaybookFlowFieldRunAsQuery$data } from './__generated__/PlaybookFlowFieldRunAsQuery.graphql';
-
-// Deprecated - https://mui.com/system/styles/basics/
-// Do not use it for new code.
-const useStyles = makeStyles<Theme>((theme) => ({
-  icon: {
-    paddingTop: 4,
-    display: 'inline-block',
-    color: theme.palette.primary.main,
-  },
-  text: {
-    display: 'inline-block',
-    flexGrow: 1,
-    marginLeft: 10,
-  },
-}));
 
 // The agent runs on behalf of the configured user, so the picker is
 // deliberately restricted to identities the author is allowed to act as:
@@ -67,7 +51,6 @@ const PlaybookFlowFieldRunAs: FunctionComponent<PlaybookFlowFieldRunAsProps> = (
   label,
   style,
 }) => {
-  const classes = useStyles();
   const { t_i18n } = useFormatter();
   const { me } = useAuth();
   const currentUserOption: OptionRunAs = {
@@ -86,13 +69,16 @@ const PlaybookFlowFieldRunAs: FunctionComponent<PlaybookFlowFieldRunAsProps> = (
     })
       .toPromise()
       .then((data) => {
-        const serviceAccounts = (
+        // Drop any incomplete edge (relay can return a null node when an
+        // item is no longer accessible) so options always carry a defined
+        // value/type and `groupBy` never receives undefined.
+        const serviceAccounts: OptionRunAs[] = (
           (data as PlaybookFlowFieldRunAsQuery$data)?.members?.edges ?? []
-        ).map((edge) => ({
-          label: edge?.node.name,
-          value: edge?.node.id,
-          type: edge?.node.entity_type,
-        })) as OptionRunAs[];
+        ).flatMap((edge) => {
+          const node = edge?.node;
+          if (!node) return [];
+          return [{ label: node.name, value: node.id, type: node.entity_type }];
+        });
         // Always offer the current user, only hiding it when it does not
         // match the current search input.
         const lowerSearch = search.toLowerCase();
@@ -131,10 +117,12 @@ const PlaybookFlowFieldRunAs: FunctionComponent<PlaybookFlowFieldRunAsProps> = (
           option: OptionRunAs,
         ) => (
           <li {...props}>
-            <div className={classes.icon}>
+            <Box sx={{ paddingTop: '4px', display: 'inline-block', color: 'primary.main' }}>
               <ItemIcon type={option.type} />
-            </div>
-            <div className={classes.text}>{option.label}</div>
+            </Box>
+            <Box sx={{ display: 'inline-block', flexGrow: 1, marginLeft: '10px' }}>
+              {option.label}
+            </Box>
           </li>
         )}
       />

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -26,6 +26,7 @@ import { OPENCTI_ADMIN_UUID } from '../../../schema/general';
 import type { AuthContext, AuthUser } from '../../../types/user';
 import type { BasicStoreEntity } from '../../../types/store';
 import type { StixBundle } from '../../../types/stix-2-1-common';
+import type { ComponentDefinition } from '../playbook-types';
 
 // 5 minutes — agent runs may take a while when the LLM has to materialise
 // a large STIX bundle or call multiple tools. Keep well above the default
@@ -113,6 +114,11 @@ export const isAgentBoundToIntent = async (
   }
 };
 
+// A ``run_as`` configuration as stored on a playbook node: the member
+// picker saves a ``{ label, value }`` option object, while hand-written or
+// imported configs may carry a raw id string (or nothing at all).
+export type RunAsConfiguration = string | { label?: string; value?: string } | null;
+
 /**
  * Normalize the component ``run_as`` configuration into a plain user id.
  * The playbook form stores the member-picker selection as a
@@ -121,7 +127,7 @@ export const isAgentBoundToIntent = async (
  * user is configured.
  */
 export const resolveRunAsUserId = (
-  runAs?: string | { label?: string; value?: string } | null,
+  runAs?: RunAsConfiguration,
 ): string | undefined => {
   if (!runAs) return undefined;
   if (typeof runAs === 'string') return runAs.trim() || undefined;
@@ -129,31 +135,32 @@ export const resolveRunAsUserId = (
 };
 
 /**
- * Guardrail for the AI-agent ``run_as`` configuration. The agent runs on
- * behalf of the configured user (its email is embedded in the XTM One
+ * Core predicate behind the AI-agent ``run_as`` guardrail. The agent runs
+ * on behalf of the configured user (its email is embedded in the XTM One
  * JWT and any write-back to OpenCTI is attributed to that account), so a
  * playbook author must not be able to impersonate an arbitrary user.
  *
- * Only two kinds of ``run_as`` targets are accepted:
+ * Returns ``true`` only for identities the author is allowed to act as:
+ *  - an unset ``run_as`` (at runtime it falls back to the seeded platform
+ *    admin, see ``resolveAgentJwtUser``),
  *  - the author themselves (the currently authenticated user), and
  *  - a service account (``user_service_account = true``), which exists
  *    precisely to carry automated, non-human activity.
  *
- * An unset ``run_as`` is allowed: at runtime it falls back to the seeded
- * platform admin (see ``resolveAgentJwtUser``). The target user is loaded
- * with SYSTEM_USER so the decision depends only on the nature of the
- * account, not on the author's own visibility over it. Anything else is
- * refused with a ForbiddenAccess so the generic ``members`` query (used
- * by the picker and many other places) can stay untouched.
+ * The target user is loaded with SYSTEM_USER so the decision depends only
+ * on the nature of the account, not on the author's own visibility over
+ * it, and the check fails closed (returns ``false``) when the target
+ * cannot be loaded. The generic ``members`` query (used by the picker and
+ * many other places) is left untouched.
  */
-export const assertRunAsUserAllowed = async (
+export const isRunAsUserAllowed = async (
   context: AuthContext,
   user: AuthUser,
-  runAs?: string | { label?: string; value?: string } | null,
-): Promise<void> => {
+  runAs?: RunAsConfiguration,
+): Promise<boolean> => {
   const runAsUserId = resolveRunAsUserId(runAs);
   if (!runAsUserId || runAsUserId === user.id) {
-    return;
+    return true;
   }
   const target = await internalLoadById<BasicStoreEntity & { user_service_account?: boolean }>(
     context,
@@ -161,10 +168,109 @@ export const assertRunAsUserAllowed = async (
     runAsUserId,
     { type: ENTITY_TYPE_USER },
   );
-  if (target?.user_service_account === true) {
+  return target?.user_service_account === true;
+};
+
+/**
+ * Throwing variant of {@link isRunAsUserAllowed}, used by the playbook
+ * node save paths (add / replace / insert) where the value comes from the
+ * constrained picker: anything else is a crafted call and is refused with
+ * a ForbiddenAccess.
+ */
+export const assertRunAsUserAllowed = async (
+  context: AuthContext,
+  user: AuthUser,
+  runAs?: RunAsConfiguration,
+): Promise<void> => {
+  if (await isRunAsUserAllowed(context, user, runAs)) {
     return;
   }
-  throw ForbiddenAccess('The "run as" user must be yourself or a service account', { runAsUserId });
+  throw ForbiddenAccess('The "run as" user must be yourself or a service account', { runAsUserId: resolveRunAsUserId(runAs) });
+};
+
+/**
+ * Collect the ``run_as`` value carried by every node of a serialized
+ * playbook definition. Nodes without a configuration, with an unparseable
+ * configuration, or without a ``run_as`` are skipped. Used to apply the
+ * guardrail to the paths that persist a whole definition at once (import,
+ * duplicate, raw field patch) rather than a single node.
+ */
+const extractDefinitionRunAsValues = (playbookDefinition?: string | null): RunAsConfiguration[] => {
+  if (!playbookDefinition) return [];
+  let definition: ComponentDefinition;
+  try {
+    definition = JSON.parse(playbookDefinition) as ComponentDefinition;
+  } catch {
+    return [];
+  }
+  return (definition.nodes ?? [])
+    .map((node) => {
+      if (!node?.configuration) return null;
+      try {
+        const config = JSON.parse(node.configuration) as { run_as?: RunAsConfiguration };
+        return config.run_as ?? null;
+      } catch {
+        return null;
+      }
+    })
+    .filter((runAs) => runAs !== null);
+};
+
+/**
+ * Reject (throw) when any node of a whole serialized playbook definition
+ * carries a disallowed ``run_as``. Used by the raw ``playbookFieldPatch``
+ * path which the editor never uses to set the definition but which is
+ * exposed on the GraphQL API and could be abused by a crafted call.
+ */
+export const assertDefinitionRunAsAllowed = async (
+  context: AuthContext,
+  user: AuthUser,
+  playbookDefinition?: string | null,
+): Promise<void> => {
+  await Promise.all(
+    extractDefinitionRunAsValues(playbookDefinition)
+      .map((runAs) => assertRunAsUserAllowed(context, user, runAs)),
+  );
+};
+
+/**
+ * Sanitize a whole serialized playbook definition so that none of its
+ * nodes runs as a disallowed user: disallowed ``run_as`` values are reset
+ * to the acting user (always an allowed target). Used by the paths that
+ * persist a definition coming from outside the constrained editor - import
+ * (foreign user ids) and duplicate (another author's run_as) - where a
+ * hard failure would needlessly break a legitimate operation while reset
+ * still guarantees no impersonation. Returns the original string when
+ * nothing had to change (or when it cannot be parsed).
+ */
+export const sanitizeDefinitionRunAs = async (
+  context: AuthContext,
+  user: AuthUser,
+  playbookDefinition?: string | null,
+): Promise<string | null | undefined> => {
+  if (!playbookDefinition) return playbookDefinition;
+  let definition: ComponentDefinition;
+  try {
+    definition = JSON.parse(playbookDefinition) as ComponentDefinition;
+  } catch {
+    return playbookDefinition;
+  }
+  const selfOption = { label: user.name, value: user.id };
+  const mutations = await Promise.all((definition.nodes ?? []).map(async (node) => {
+    if (!node?.configuration) return false;
+    let config: { run_as?: RunAsConfiguration };
+    try {
+      config = JSON.parse(node.configuration) as { run_as?: RunAsConfiguration };
+    } catch {
+      return false;
+    }
+    if (config.run_as === undefined || config.run_as === null) return false;
+    if (await isRunAsUserAllowed(context, user, config.run_as)) return false;
+    config.run_as = selfOption;
+    node.configuration = JSON.stringify(config);
+    return true;
+  }));
+  return mutations.some((changed) => changed) ? JSON.stringify(definition) : playbookDefinition;
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -18,11 +18,12 @@ import xtmOneClient from '../../xtm/one/xtm-one-client';
 import { issueXtmJwt } from '../../../domain/xtm-auth';
 import { getHttpClient, getResponseError } from '../../../utils/http-client';
 import { logApp, PLATFORM_VERSION } from '../../../config/conf';
+import { ForbiddenAccess } from '../../../config/errors';
 import { AUTOMATION_MANAGER_USER, executionContext, SYSTEM_USER } from '../../../utils/access';
 import { internalLoadById } from '../../../database/middleware-loader';
 import { ENTITY_TYPE_USER } from '../../../schema/internalObject';
 import { OPENCTI_ADMIN_UUID } from '../../../schema/general';
-import type { AuthContext } from '../../../types/user';
+import type { AuthContext, AuthUser } from '../../../types/user';
 import type { BasicStoreEntity } from '../../../types/store';
 import type { StixBundle } from '../../../types/stix-2-1-common';
 
@@ -125,6 +126,45 @@ export const resolveRunAsUserId = (
   if (!runAs) return undefined;
   if (typeof runAs === 'string') return runAs.trim() || undefined;
   return runAs.value?.trim() || undefined;
+};
+
+/**
+ * Guardrail for the AI-agent ``run_as`` configuration. The agent runs on
+ * behalf of the configured user (its email is embedded in the XTM One
+ * JWT and any write-back to OpenCTI is attributed to that account), so a
+ * playbook author must not be able to impersonate an arbitrary user.
+ *
+ * Only two kinds of ``run_as`` targets are accepted:
+ *  - the author themselves (the currently authenticated user), and
+ *  - a service account (``user_service_account = true``), which exists
+ *    precisely to carry automated, non-human activity.
+ *
+ * An unset ``run_as`` is allowed: at runtime it falls back to the seeded
+ * platform admin (see ``resolveAgentJwtUser``). The target user is loaded
+ * with SYSTEM_USER so the decision depends only on the nature of the
+ * account, not on the author's own visibility over it. Anything else is
+ * refused with a ForbiddenAccess so the generic ``members`` query (used
+ * by the picker and many other places) can stay untouched.
+ */
+export const assertRunAsUserAllowed = async (
+  context: AuthContext,
+  user: AuthUser,
+  runAs?: string | { label?: string; value?: string } | null,
+): Promise<void> => {
+  const runAsUserId = resolveRunAsUserId(runAs);
+  if (!runAsUserId || runAsUserId === user.id) {
+    return;
+  }
+  const target = await internalLoadById<BasicStoreEntity & { user_service_account?: boolean }>(
+    context,
+    SYSTEM_USER,
+    runAsUserId,
+    { type: ENTITY_TYPE_USER },
+  );
+  if (target?.user_service_account === true) {
+    return;
+  }
+  throw ForbiddenAccess('The "run as" user must be yourself or a service account', { runAsUserId });
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -42,6 +42,7 @@ import { isCompatibleVersionWithMinimal } from '../../utils/version';
 import { buildPagination } from '../../database/utils';
 import { checkPlaybookFiltersAndBuildConfigWithCorrectFilters, deleteLinksAndAllChildren, updateImportedPlaybookDefinitionScope } from './playbook-utils';
 import { type SharingConfiguration } from './components/sharing-component';
+import { assertRunAsUserAllowed } from './components/ai-agent-shared';
 
 const MINIMAL_COMPATIBLE_VERSION = '6.7.14';
 
@@ -179,9 +180,19 @@ export const getPlaybookDefinition = async (context: AuthContext, playbook: Basi
   return playbook.playbook_definition;
 };
 
+// Enforce the AI-agent `run_as` guardrail on a freshly built node
+// configuration: the agent runs on behalf of the configured user, so only
+// the author themselves or a service account may be selected. Components
+// without a `run_as` value are a no-op (see assertRunAsUserAllowed).
+const validateNodeRunAs = async (context: AuthContext, user: AuthUser, configuration: string) => {
+  const { run_as: runAs } = JSON.parse(configuration) as { run_as?: string | { label?: string; value?: string } | null };
+  await assertRunAsUserAllowed(context, user, runAs);
+};
+
 export const playbookAddNode = async (context: AuthContext, user: AuthUser, id: string, input: PlaybookAddNodeInput) => {
   await checkEnterpriseEdition(context);
   const configuration = await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(context, user, input, user.id);
+  await validateNodeRunAs(context, user, configuration);
   const playbook = await findById(context, user, id);
   const definition = JSON.parse(playbook.playbook_definition ?? '{}') as ComponentDefinition;
   const relatedComponent = PLAYBOOK_COMPONENTS[input.component_id];
@@ -237,6 +248,7 @@ export const playbookReplaceNode = async (
 ) => {
   await checkEnterpriseEdition(context);
   const configuration = await checkPlaybookFiltersAndBuildConfigWithCorrectFilters(context, user, input, user.id);
+  await validateNodeRunAs(context, user, configuration);
 
   const playbook = await findById(context, user, id);
   const definition = JSON.parse(playbook.playbook_definition) as ComponentDefinition;

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -180,13 +180,21 @@ export const getPlaybookDefinition = async (context: AuthContext, playbook: Basi
   return playbook.playbook_definition;
 };
 
-// Enforce the AI-agent `run_as` guardrail on a freshly built node
-// configuration: the agent runs on behalf of the configured user, so only
-// the author themselves or a service account may be selected. Components
-// without a `run_as` value are a no-op (see assertRunAsUserAllowed).
-const validateNodeRunAs = async (context: AuthContext, user: AuthUser, configuration: string) => {
-  const { run_as: runAs } = JSON.parse(configuration) as { run_as?: string | { label?: string; value?: string } | null };
-  await assertRunAsUserAllowed(context, user, runAs);
+// Enforce the AI-agent `run_as` guardrail on a node configuration: the
+// agent runs on behalf of the configured user, so only the author
+// themselves or a service account may be selected. Components without a
+// `run_as` value are a no-op (see assertRunAsUserAllowed). The
+// configuration can be a raw client-provided JSON string (insert path),
+// so a parse failure is treated as "no run_as" rather than throwing here.
+const validateNodeRunAs = async (context: AuthContext, user: AuthUser, configuration?: string | null) => {
+  if (!configuration) return;
+  let parsed: { run_as?: string | { label?: string; value?: string } | null };
+  try {
+    parsed = JSON.parse(configuration);
+  } catch {
+    return;
+  }
+  await assertRunAsUserAllowed(context, user, parsed.run_as);
 };
 
 export const playbookAddNode = async (context: AuthContext, user: AuthUser, id: string, input: PlaybookAddNodeInput) => {
@@ -304,6 +312,7 @@ export const playbookInsertNode = async (
   input: PlaybookAddNodeInput,
 ) => {
   await checkEnterpriseEdition(context);
+  await validateNodeRunAs(context, user, input.configuration);
   const playbook = await findById(context, user, id);
   const definition = JSON.parse(playbook.playbook_definition) as ComponentDefinition;
   const relatedComponent = PLAYBOOK_COMPONENTS[input.component_id];

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-domain.ts
@@ -42,7 +42,7 @@ import { isCompatibleVersionWithMinimal } from '../../utils/version';
 import { buildPagination } from '../../database/utils';
 import { checkPlaybookFiltersAndBuildConfigWithCorrectFilters, deleteLinksAndAllChildren, updateImportedPlaybookDefinitionScope } from './playbook-utils';
 import { type SharingConfiguration } from './components/sharing-component';
-import { assertRunAsUserAllowed } from './components/ai-agent-shared';
+import { assertDefinitionRunAsAllowed, assertRunAsUserAllowed, sanitizeDefinitionRunAs } from './components/ai-agent-shared';
 
 const MINIMAL_COMPATIBLE_VERSION = '6.7.14';
 
@@ -490,6 +490,14 @@ export const playbookDelete = async (context: AuthContext, user: AuthUser, playb
 
 export const playbookEdit = async (context: AuthContext, user: AuthUser, id: string, input: EditInput[]) => {
   await checkEnterpriseEdition(context);
+  // The editor sets the definition through the granular node mutations, never
+  // through playbookFieldPatch, but the field patch is exposed on the API and
+  // could be used to persist a whole definition directly. Re-validate the
+  // run_as guardrail on any such crafted call so it cannot be bypassed.
+  const definitionInput = input.find((editInput) => editInput.key === 'playbook_definition');
+  if (definitionInput) {
+    await assertDefinitionRunAsAllowed(context, user, definitionInput.value?.[0]);
+  }
   const { element: updatedElem } = await updateAttribute(context, user, id, ENTITY_TYPE_PLAYBOOK, input);
   return notify(BUS_TOPICS[ABSTRACT_INTERNAL_OBJECT].EDIT_TOPIC, updatedElem, user);
 };
@@ -523,7 +531,10 @@ export const playbookImport = async (context: AuthContext, user: AuthUser, file:
   }
   const config = parsedData.configuration;
   const updatedPlaybookDefinition = updateImportedPlaybookDefinitionScope(config.playbook_definition, parsedData.openCTI_version);
-  config.playbook_definition = updatedPlaybookDefinition;
+  // Imported definitions carry user ids from another platform; reset any
+  // disallowed AI-agent run_as to the importing user so the import cannot set
+  // up an impersonation, without hard-failing on now-unknown foreign ids.
+  config.playbook_definition = await sanitizeDefinitionRunAs(context, user, updatedPlaybookDefinition);
 
   const importData = {
     name: config.name,
@@ -552,13 +563,17 @@ export const playbookImport = async (context: AuthContext, user: AuthUser, file:
 
 export const playbookDuplicate = async (context: AuthContext, user: AuthUser, id: string) => {
   const playbook = await findById(context, user, id);
+  // The source may run an AI-agent node as another (real) user; reset any
+  // disallowed run_as to the user performing the duplication so the copy
+  // cannot be used to keep impersonating that user.
+  const playbook_definition = (await sanitizeDefinitionRunAs(context, user, playbook.playbook_definition)) ?? undefined;
   const newPlaybook = {
     name: `${playbook.name} - copy`,
     description: playbook.description,
     playbook_running: false,
     playbook_start: playbook.playbook_start,
     playbook_mode: playbook.playbook_mode as string,
-    playbook_definition: playbook.playbook_definition,
+    playbook_definition,
   };
   const importPlaybook = await createPlaybook(context, user, newPlaybook);
   const importPlaybookId = importPlaybook.id;

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -57,6 +57,7 @@ import { ENTITY_TYPE_USER } from '../../../../../src/schema/internalObject';
 import { OPENCTI_ADMIN_UUID } from '../../../../../src/schema/general';
 import {
   AGENT_CALL_TIMEOUT_MS,
+  assertRunAsUserAllowed,
   buildAgentMessageContent,
   buildAgentSlugOneOf,
   buildPlaybookAutomationContext,
@@ -214,6 +215,49 @@ describe('ai-agent-shared', () => {
 
     it('should return the trimmed value from a member-picker option object', () => {
       expect(resolveRunAsUserId({ label: 'Alice', value: '  user-2 ' })).toBe('user-2');
+    });
+  });
+
+  describe('assertRunAsUserAllowed', () => {
+    const context = { source: 'test' } as any;
+    const author = { id: 'author-1' } as any;
+
+    it('should allow (without a DB lookup) when no run-as user is configured', async () => {
+      await expect(assertRunAsUserAllowed(context, author, null)).resolves.toBeUndefined();
+      await expect(assertRunAsUserAllowed(context, author, undefined)).resolves.toBeUndefined();
+      await expect(assertRunAsUserAllowed(context, author, { label: '', value: '' })).resolves.toBeUndefined();
+      expect(internalLoadById).not.toHaveBeenCalled();
+    });
+
+    it('should allow the current (authenticated) author without a DB lookup', async () => {
+      await expect(assertRunAsUserAllowed(context, author, { label: 'Me', value: 'author-1' })).resolves.toBeUndefined();
+      expect(internalLoadById).not.toHaveBeenCalled();
+    });
+
+    it('should allow a service account target', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'svc-1', user_service_account: true } as any);
+
+      await expect(assertRunAsUserAllowed(context, author, { label: 'Service', value: 'svc-1' })).resolves.toBeUndefined();
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        'svc-1',
+        { type: ENTITY_TYPE_USER },
+      );
+    });
+
+    it('should refuse a regular (non-service-account) user', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-2', user_service_account: false } as any);
+
+      await expect(assertRunAsUserAllowed(context, author, { label: 'Bob', value: 'user-2' }))
+        .rejects.toThrow(/service account/);
+    });
+
+    it('should refuse (fail closed) when the run-as user cannot be loaded', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+
+      await expect(assertRunAsUserAllowed(context, author, 'ghost-user'))
+        .rejects.toThrow(/service account/);
     });
   });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -57,13 +57,16 @@ import { ENTITY_TYPE_USER } from '../../../../../src/schema/internalObject';
 import { OPENCTI_ADMIN_UUID } from '../../../../../src/schema/general';
 import {
   AGENT_CALL_TIMEOUT_MS,
+  assertDefinitionRunAsAllowed,
   assertRunAsUserAllowed,
   buildAgentMessageContent,
   buildAgentSlugOneOf,
   buildPlaybookAutomationContext,
   callXtmAgent,
   isAgentBoundToIntent,
+  isRunAsUserAllowed,
   resolveRunAsUserId,
+  sanitizeDefinitionRunAs,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
 
@@ -258,6 +261,118 @@ describe('ai-agent-shared', () => {
 
       await expect(assertRunAsUserAllowed(context, author, 'ghost-user'))
         .rejects.toThrow(/service account/);
+    });
+  });
+
+  describe('isRunAsUserAllowed', () => {
+    const context = { source: 'test' } as any;
+    const author = { id: 'author-1' } as any;
+
+    it('should allow (without a DB lookup) an unset run-as or the current author', async () => {
+      await expect(isRunAsUserAllowed(context, author, null)).resolves.toBe(true);
+      await expect(isRunAsUserAllowed(context, author, { label: 'Me', value: 'author-1' })).resolves.toBe(true);
+      expect(internalLoadById).not.toHaveBeenCalled();
+    });
+
+    it('should allow a service account and refuse a regular or unknown user', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === 'svc-1') return { id, user_service_account: true };
+        if (id === 'user-2') return { id, user_service_account: false };
+        return null;
+      }) as any);
+
+      await expect(isRunAsUserAllowed(context, author, 'svc-1')).resolves.toBe(true);
+      await expect(isRunAsUserAllowed(context, author, 'user-2')).resolves.toBe(false);
+      await expect(isRunAsUserAllowed(context, author, 'ghost')).resolves.toBe(false);
+    });
+  });
+
+  describe('assertDefinitionRunAsAllowed', () => {
+    const context = { source: 'test' } as any;
+    const author = { id: 'author-1' } as any;
+
+    const definitionWith = (runAsValues: Array<unknown>) => JSON.stringify({
+      nodes: runAsValues.map((runAs, index) => ({
+        id: `node-${index}`,
+        name: `node-${index}`,
+        position: { x: 0, y: 0 },
+        component_id: 'PLAYBOOK_AI_AGENT_SEND_COMPONENT',
+        configuration: JSON.stringify(runAs === undefined ? {} : { run_as: runAs }),
+      })),
+      links: [],
+    });
+
+    it('should resolve for an empty, missing or unparseable definition', async () => {
+      await expect(assertDefinitionRunAsAllowed(context, author, undefined)).resolves.toBeUndefined();
+      await expect(assertDefinitionRunAsAllowed(context, author, '{not json')).resolves.toBeUndefined();
+      await expect(assertDefinitionRunAsAllowed(context, author, definitionWith([]))).resolves.toBeUndefined();
+      expect(internalLoadById).not.toHaveBeenCalled();
+    });
+
+    it('should resolve when every node targets the author, a service account or nothing', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'svc-1', user_service_account: true } as any);
+
+      const definition = definitionWith([undefined, { label: 'Me', value: 'author-1' }, { label: 'Svc', value: 'svc-1' }]);
+      await expect(assertDefinitionRunAsAllowed(context, author, definition)).resolves.toBeUndefined();
+    });
+
+    it('should reject when any node targets a regular user', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-2', user_service_account: false } as any);
+
+      const definition = definitionWith([{ label: 'Me', value: 'author-1' }, { label: 'Bob', value: 'user-2' }]);
+      await expect(assertDefinitionRunAsAllowed(context, author, definition)).rejects.toThrow(/service account/);
+    });
+  });
+
+  describe('sanitizeDefinitionRunAs', () => {
+    const context = { source: 'test' } as any;
+    const author = { id: 'author-1', name: 'Author One' } as any;
+
+    const parseNodeRunAs = (definition: string) => (JSON.parse(definition).nodes as Array<{ configuration: string }>)
+      .map((node) => JSON.parse(node.configuration).run_as);
+
+    it('should return the input unchanged when it is empty or unparseable', async () => {
+      await expect(sanitizeDefinitionRunAs(context, author, null)).resolves.toBeNull();
+      await expect(sanitizeDefinitionRunAs(context, author, '{not json')).resolves.toBe('{not json');
+      expect(internalLoadById).not.toHaveBeenCalled();
+    });
+
+    it('should keep allowed targets and reset disallowed ones to the acting user', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === 'svc-1') return { id, user_service_account: true };
+        return { id, user_service_account: false };
+      }) as any);
+
+      const definition = JSON.stringify({
+        nodes: [
+          { id: 'a', name: 'a', position: { x: 0, y: 0 }, component_id: 'C', configuration: JSON.stringify({ run_as: { label: 'Me', value: 'author-1' } }) },
+          { id: 'b', name: 'b', position: { x: 0, y: 0 }, component_id: 'C', configuration: JSON.stringify({ run_as: { label: 'Svc', value: 'svc-1' } }) },
+          { id: 'c', name: 'c', position: { x: 0, y: 0 }, component_id: 'C', configuration: JSON.stringify({ run_as: { label: 'Bob', value: 'user-2' } }) },
+          { id: 'd', name: 'd', position: { x: 0, y: 0 }, component_id: 'C', configuration: JSON.stringify({ other: true }) },
+        ],
+        links: [],
+      });
+
+      const sanitized = await sanitizeDefinitionRunAs(context, author, definition);
+      expect(sanitized).not.toBe(definition);
+      const [a, b, c, d] = parseNodeRunAs(sanitized as string);
+      expect(a).toEqual({ label: 'Me', value: 'author-1' });
+      expect(b).toEqual({ label: 'Svc', value: 'svc-1' });
+      expect(c).toEqual({ label: 'Author One', value: 'author-1' });
+      expect(d).toBeUndefined();
+    });
+
+    it('should return the original string when nothing has to change', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'svc-1', user_service_account: true } as any);
+
+      const definition = JSON.stringify({
+        nodes: [
+          { id: 'a', name: 'a', position: { x: 0, y: 0 }, component_id: 'C', configuration: JSON.stringify({ run_as: { label: 'Svc', value: 'svc-1' } }) },
+        ],
+        links: [],
+      });
+
+      await expect(sanitizeDefinitionRunAs(context, author, definition)).resolves.toBe(definition);
     });
   });
 


### PR DESCRIPTION
### Proposed changes

* The "run as" picker on the AI agent playbook components (Transform with AI agent, Send to AI agent) no longer lists every platform user. It now only offers identities the author is allowed to act as: the current (authenticated) user and service accounts.
* Frontend: a dedicated `PlaybookFlowFieldRunAs` field lists the current user (from the auth context) plus service accounts (the existing `members` query, filtered on `user_service_account`). The generic `ObjectMembersField` is no longer used for `run_as`. The field uses MUI `Box`/`sx` (no deprecated `@mui/styles`) and drops incomplete member edges so options always carry a defined value/type.
* Backend: the `run_as` guardrail is enforced on every path that can persist a node configuration or a whole playbook definition, so it cannot be bypassed by a crafted GraphQL call:
  * `playbookAddNode` / `playbookReplaceNode` / `playbookInsertNode` refuse a `run_as` that is neither the author nor a service account (`assertRunAsUserAllowed`).
  * `playbookFieldPatch` (`playbookEdit`) refuses a crafted `playbook_definition` that carries a disallowed `run_as` (`assertDefinitionRunAsAllowed`).
  * `playbookImport` and `playbookDuplicate` sanitize each node's `run_as`, resetting any disallowed target to the acting user (`sanitizeDefinitionRunAs`). These paths carry ids from another platform or another author, so resetting avoids breaking a legitimate operation while still preventing impersonation.
* The generic `members` query/resolver is left untouched.

### Related issues

* closes #16840

### How to test this PR

1. Enterprise Edition with XTM One configured (so the AI agent playbook components are available in the picker).
2. Create or edit a playbook and add a "Transform with AI agent" or "Send to AI agent" node.
3. Open the "Run as" field: only your own user and the platform service accounts should be listed (no other human users), with a helper text stating the restriction.
4. Backend guardrail: a direct `playbookAddNode` / `playbookReplaceNode` / `playbookInsertNode` / `playbookFieldPatch` call carrying a `run_as` that points to a regular (non-service-account) user other than yourself is rejected with a Forbidden access error.
5. Import or duplicate a playbook whose AI agent node runs as another (real) user: the node's `run_as` is reset to you, so the import/duplicate cannot keep impersonating that user.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The restriction is enforced on both sides on purpose: the picker filters the list for UX, and the backend constrains every `run_as` save path so the guardrail cannot be bypassed by a crafted GraphQL call. The shared logic lives in `ai-agent-shared` (`isRunAsUserAllowed`, `assertRunAsUserAllowed`, `assertDefinitionRunAsAllowed`, `sanitizeDefinitionRunAs`) and is unit-tested in `ai-agent-shared-test.ts`. Save paths fed by the constrained picker reject a disallowed value, while bulk paths that legitimately carry foreign / other-author ids (import, duplicate) reset it to the acting user instead of hard-failing. The generic `members` API is deliberately not modified.
