### PR TITLE
fix(workflow): Resolve entities during an async update of authorized members (#16843)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
@@ -85,8 +85,13 @@ export const reportWorkflowAsyncActionResult = async (
   }
 
   // All async tasks succeeded — run syncActions (phase 2)
-  // Load the full target entity so dynamic resolvers (AUTHOR, CREATORS, etc.) have the data they need
-  const fullEntity = await storeLoadById<any>(executionContext, executionUser, instanceEntity.entity_id, 'Basic-Object');
+  // Load the full target entity so dynamic resolvers (AUTHOR, CREATORS, etc.) have the data they need.
+  // Fall back to a minimal stub if the load fails (e.g. entity deleted during the async window or transient DB error).
+  const fullEntity = await storeLoadById<any>(executionContext, executionUser, instanceEntity.entity_id, 'Basic-Object')
+    .catch((err) => {
+      logApp.warn('[workflow-async-completion] Failed to load full entity, falling back to stub', { entityId: instanceEntity.entity_id, error: err });
+      return null;
+    });
   const workflowContext = {
     user: executionUser,
     entity: fullEntity ?? { id: instanceEntity.entity_id },

--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-async-completion.ts
@@ -85,9 +85,11 @@ export const reportWorkflowAsyncActionResult = async (
   }
 
   // All async tasks succeeded — run syncActions (phase 2)
+  // Load the full target entity so dynamic resolvers (AUTHOR, CREATORS, etc.) have the data they need
+  const fullEntity = await storeLoadById<any>(executionContext, executionUser, instanceEntity.entity_id, 'Basic-Object');
   const workflowContext = {
     user: executionUser,
-    entity: { id: instanceEntity.entity_id },
+    entity: fullEntity ?? { id: instanceEntity.entity_id },
     context: executionContext,
     runtimeParams: pendingTransition.runtimeParams ?? {},
   };

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-async-completion-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-async-completion-test.ts
@@ -398,4 +398,105 @@ describe('reportWorkflowAsyncActionResult', () => {
     const [, , , , patches] = (updateAttribute as any).mock.calls[0];
     expect(patches.find((p: any) => p.key === 'currentState')?.value[0]).toBe('reviewing');
   });
+
+  // ---------------------------------------------------------------------------
+  // Full entity loading (fix for "Draft author org" not resolved in onEnterActions)
+  // ---------------------------------------------------------------------------
+
+  describe('full entity loading for workflowContext', () => {
+    it('passes the full entity (with all relations) to onEnterActions', async () => {
+      const fullEntity = {
+        id: 'entity-id',
+        internal_id: 'entity-id',
+        entity_type: 'DraftWorkspace',
+        'createdBy': 'org-author-id',
+        creator_id: 'creator-id',
+      };
+      const pt = makePendingTransition({
+        asyncActions: [
+          { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+        ],
+        syncActions: [],
+        onEnterActions: [{ type: 'captureEntityAction', params: {} }],
+      });
+      const instance = makeInstance({ pendingTransition: JSON.stringify(pt) });
+
+      // First call: load workflow instance; second call: load full target entity
+      (storeLoadById as any)
+        .mockResolvedValueOnce(instance)
+        .mockResolvedValueOnce(fullEntity);
+
+      let capturedEntity: any;
+      (ActionRegistry as any).captureEntityAction = vi.fn().mockImplementation((ctx: any) => {
+        capturedEntity = ctx.entity;
+      });
+      (updateAttribute as any).mockResolvedValue({});
+
+      await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+      // The action must receive the full entity, not just { id }
+      expect(capturedEntity).toEqual(fullEntity);
+      expect(capturedEntity['createdBy']).toBe('org-author-id');
+      expect(capturedEntity.creator_id).toBe('creator-id');
+    });
+
+    it('passes the full entity (with all relations) to syncActions', async () => {
+      const fullEntity = {
+        id: 'entity-id',
+        internal_id: 'entity-id',
+        entity_type: 'DraftWorkspace',
+        'createdBy': 'org-author-id',
+      };
+      const pt = makePendingTransition({
+        asyncActions: [
+          { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+        ],
+        syncActions: [{ type: 'captureSyncEntity', params: {} }],
+        onEnterActions: [],
+      });
+      const instance = makeInstance({ pendingTransition: JSON.stringify(pt) });
+
+      (storeLoadById as any)
+        .mockResolvedValueOnce(instance)
+        .mockResolvedValueOnce(fullEntity);
+
+      let capturedEntity: any;
+      (ActionRegistry as any).captureSyncEntity = vi.fn().mockImplementation((ctx: any) => {
+        capturedEntity = ctx.entity;
+      });
+      (updateAttribute as any).mockResolvedValue({});
+
+      await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+      expect(capturedEntity).toEqual(fullEntity);
+      expect(capturedEntity['createdBy']).toBe('org-author-id');
+    });
+
+    it('falls back to { id } when the full target entity cannot be found (e.g. deleted during async window)', async () => {
+      const pt = makePendingTransition({
+        asyncActions: [
+          { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+        ],
+        syncActions: [],
+        onEnterActions: [{ type: 'captureFallbackEntity', params: {} }],
+      });
+      const instance = makeInstance({ pendingTransition: JSON.stringify(pt) });
+
+      // First call: load workflow instance; second call: entity not found
+      (storeLoadById as any)
+        .mockResolvedValueOnce(instance)
+        .mockResolvedValueOnce(null);
+
+      let capturedEntity: any;
+      (ActionRegistry as any).captureFallbackEntity = vi.fn().mockImplementation((ctx: any) => {
+        capturedEntity = ctx.entity;
+      });
+      (updateAttribute as any).mockResolvedValue({});
+
+      await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+      // Should fall back to minimal stub so the rest of the pipeline can still proceed
+      expect(capturedEntity).toEqual({ id: 'entity-id' });
+    });
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-async-completion-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-async-completion-test.ts
@@ -498,5 +498,97 @@ describe('reportWorkflowAsyncActionResult', () => {
       // Should fall back to minimal stub so the rest of the pipeline can still proceed
       expect(capturedEntity).toEqual({ id: 'entity-id' });
     });
+
+    it('falls back to { id } and logs a warning when storeLoadById throws (e.g. transient DB error)', async () => {
+      const pt = makePendingTransition({
+        asyncActions: [
+          { id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' },
+        ],
+        syncActions: [],
+        onEnterActions: [{ type: 'captureErrorFallbackEntity', params: {} }],
+      });
+      const instance = makeInstance({ pendingTransition: JSON.stringify(pt) });
+
+      (storeLoadById as any)
+        .mockResolvedValueOnce(instance)
+        .mockRejectedValueOnce(new Error('DB connection lost'));
+
+      let capturedEntity: any;
+      (ActionRegistry as any).captureErrorFallbackEntity = vi.fn().mockImplementation((ctx: any) => {
+        capturedEntity = ctx.entity;
+      });
+      (updateAttribute as any).mockResolvedValue({});
+
+      const { logApp } = await import('../../../src/config/conf');
+
+      await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+      // Should still proceed with the minimal stub
+      expect(capturedEntity).toEqual({ id: 'entity-id' });
+      // And the error should be logged
+      expect((logApp.warn as any)).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load full entity'),
+        expect.objectContaining({ entityId: 'entity-id' }),
+      );
+    });
+
+    // Regression test for #16843: the second storeLoadById call must happen and its result
+    // must reach the action so that dynamic members (AUTHOR/CREATORS/ASSIGNEES/PARTICIPANTS)
+    // can be resolved correctly.
+    it('calls storeLoadById a second time with the entity_id to load the full entity', async () => {
+      const pt = makePendingTransition({
+        asyncActions: [{ id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' }],
+        syncActions: [],
+        onEnterActions: [],
+      });
+      const instance = makeInstance({ pendingTransition: JSON.stringify(pt) });
+      const fullEntity = { id: 'entity-id', entity_type: 'DraftWorkspace' };
+
+      (storeLoadById as any)
+        .mockResolvedValueOnce(instance)
+        .mockResolvedValueOnce(fullEntity);
+      (updateAttribute as any).mockResolvedValue({});
+
+      await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+      // Must have been called exactly twice: once for instance, once for the full target entity
+      expect(storeLoadById).toHaveBeenCalledTimes(2);
+      const secondCall = (storeLoadById as any).mock.calls[1];
+      expect(secondCall[2]).toBe('entity-id'); // id argument
+      expect(secondCall[3]).toBe('Basic-Object'); // type argument
+    });
+
+    // Regression test for #16843: updateAuthorizedMembers running as an onEnterAction must
+    // receive an entity that carries RELATION_CREATED_BY so the AUTHOR dynamic member resolves.
+    it('passes RELATION_CREATED_BY on the entity to updateAuthorizedMembers in onEnterActions (AUTHOR resolution)', async () => {
+      const RELATION_CREATED_BY = 'createdBy';
+      const fullEntity = {
+        id: 'entity-id',
+        entity_type: 'DraftWorkspace',
+        [RELATION_CREATED_BY]: 'org-author-id',
+      };
+      const pt = makePendingTransition({
+        asyncActions: [{ id: 'slot-1', workId: 'work-1', type: 'asyncBulkAction', status: 'pending' }],
+        syncActions: [],
+        onEnterActions: [{ type: 'updateAuthorizedMembers', params: { members: [{ id: 'AUTHOR', access_right: 'edit' }] } }],
+      });
+      const instance = makeInstance({ pendingTransition: JSON.stringify(pt) });
+
+      (storeLoadById as any)
+        .mockResolvedValueOnce(instance)
+        .mockResolvedValueOnce(fullEntity);
+
+      let entitySeenByAction: any;
+      (ActionRegistry as any).updateAuthorizedMembers = vi.fn().mockImplementation((ctx: any) => {
+        entitySeenByAction = ctx.entity;
+      });
+      (updateAttribute as any).mockResolvedValue({});
+
+      await reportWorkflowAsyncActionResult(mockContext, mockUser, 'instance-id', 'slot-1', 'success');
+
+      // The action must see the full entity with RELATION_CREATED_BY so AUTHOR can resolve
+      expect(entitySeenByAction).toEqual(fullEntity);
+      expect(entitySeenByAction[RELATION_CREATED_BY]).toBe('org-author-id');
+    });
   });
 });


### PR DESCRIPTION
### Proposed changes

* Resolve entities during an async update of authorized members 

### Related issues

* closes #16843
* closes #16845 

### How to test this PR

- Have 4 users
- Create a draft workflow in settings / customizations / drafts / workflow
- Create a transition between 2 status
- In the transition, activate "Share with organizations" and select an organisation
- In the next status after this transition, activate "Update authorized members on enter"
- Add Draft author org, Creators, Assignee, Participant
- Log in with user1 to create a draft
- Add an organisation as Author
- Add user2 as assignee
- Add user3 as assignee
- Log in with user 4
- Go to the draft
- Click on the transition
- It will launch the share organisation
- After few seconds you have the next status
- You can check authorized members (can make few seconds to be updated in the front)
- You must to see the organisation ("draft author org"), user1 ("Creators"), user2 ("assignee"), user3 ("participant")

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality