### PR TITLE
fix(dashboard): remove mitre_id from front representative (#16603)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
+++ b/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
@@ -139,7 +139,7 @@ export const getMainRepresentative = (n: any, fallback = 'Unknown') => {
       && getRelationshipMainRepresentative(n.from, n.to))
     || n.main_entity_name
     || fallback;
-  return n.x_mitre_id ? `[${n.x_mitre_id}] ${mainValue}` : mainValue;
+  return mainValue;
 };
 
 // equivalent to querying representative.secondary

--- a/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
+++ b/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
@@ -139,7 +139,7 @@ export const getMainRepresentative = (n: any, fallback = 'Unknown') => {
       && getRelationshipMainRepresentative(n.from, n.to))
     || n.main_entity_name
     || fallback;
-return n.representative?.main ? mainValue : (n.x_mitre_id ? `[${n.x_mitre_id}] ${mainValue}` : mainValue);
+  return n.representative?.main ? mainValue : (n.x_mitre_id ? `[${n.x_mitre_id}] ${mainValue}` : mainValue);
 };
 
 // equivalent to querying representative.secondary

--- a/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
+++ b/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
@@ -139,7 +139,7 @@ export const getMainRepresentative = (n: any, fallback = 'Unknown') => {
       && getRelationshipMainRepresentative(n.from, n.to))
     || n.main_entity_name
     || fallback;
-  return n.representative?.main ? mainValue : (n.x_mitre_id ? `[${n.x_mitre_id}] ${mainValue}` : mainValue);
+  return n.x_mitre_id && !n.representative?.main ? `[${n.x_mitre_id}] ${mainValue}` : mainValue;
 };
 
 // equivalent to querying representative.secondary

--- a/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
+++ b/opencti-platform/opencti-front/src/utils/defaultRepresentatives.ts
@@ -139,7 +139,7 @@ export const getMainRepresentative = (n: any, fallback = 'Unknown') => {
       && getRelationshipMainRepresentative(n.from, n.to))
     || n.main_entity_name
     || fallback;
-  return mainValue;
+return n.representative?.main ? mainValue : (n.x_mitre_id ? `[${n.x_mitre_id}] ${mainValue}` : mainValue);
 };
 
 // equivalent to querying representative.secondary


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* x_mitre_id is already set in main representative in the backend in extractEntityRepresentativeName from entity-representative. There is no need to apply it a second time in the front
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16603

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
