### PR TITLE
fix(dashboard): respect interval in line widgets

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import testRender from '../../../../utils/tests/test-render';
+
+type BuildQueryVariables = (
+  dataSelection: unknown[],
+  config: unknown,
+  parameters?: { interval?: string },
+) => Record<string, unknown>;
+
+let capturedBuildQueryVariables: BuildQueryVariables | null = null;
+let capturedParameters: { interval?: string } | undefined;
+
+beforeEach(() => {
+  capturedBuildQueryVariables = null;
+  capturedParameters = undefined;
+});
+
+vi.mock('../../../../components/dashboard/useDashboardViz', () => ({
+  default: ({ dataSelection, buildQueryVariables, parameters }: {
+    dataSelection: unknown[];
+    buildQueryVariables: BuildQueryVariables;
+    parameters?: { interval?: string };
+  }) => {
+    capturedBuildQueryVariables = buildQueryVariables;
+    capturedParameters = parameters;
+    return {
+      resolvedDataSelection: dataSelection,
+      isMissingHostEntity: false,
+      isPreviewMode: false,
+      queryRef: null,
+    };
+  },
+}));
+
+vi.mock('../../../../components/dashboard/WidgetContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="widget-container">{children}</div>,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoData', () => ({
+  default: () => <div data-testid="widget-no-data" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetMultiLines', () => ({
+  default: () => <div data-testid="widget-multi-lines" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoHostEntity', () => ({
+  default: () => <div data-testid="widget-no-host" />,
+}));
+
+vi.mock('../../../../components/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+  LoaderVariant: { inElement: 'inElement' },
+}));
+
+vi.mock('../../../../components/dashboard/dashboard-viz-utils', () => ({
+  computeStartEndDates: () => ({ startDate: null, endDate: null }),
+}));
+
+import StixCoreObjectsMultiLineChart from './StixCoreObjectsMultiLineChart';
+
+describe('StixCoreObjectsMultiLineChart', () => {
+  const baseProps = {
+    config: { relativeDate: null, startDate: null, endDate: null },
+    dataSelection: [{
+      filters: { mode: 'and' as const, filters: [], filterGroups: [] },
+      date_attribute: 'created_at',
+    }],
+  };
+
+  it('forwards parameters.interval into the time-series query variables', () => {
+    testRender(<StixCoreObjectsMultiLineChart {...baseProps} parameters={{ interval: 'month' }} />);
+    expect(typeof capturedBuildQueryVariables).toBe('function');
+    const variables = capturedBuildQueryVariables!(baseProps.dataSelection, baseProps.config, capturedParameters);
+    expect(variables.interval).toBe('month');
+  });
+
+  it('defaults interval to day when parameters.interval is not provided', () => {
+    testRender(<StixCoreObjectsMultiLineChart {...baseProps} parameters={{}} />);
+    expect(typeof capturedBuildQueryVariables).toBe('function');
+    const variables = capturedBuildQueryVariables!(baseProps.dataSelection, baseProps.config, capturedParameters);
+    expect(variables.interval).toBe('day');
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -9,7 +9,7 @@ import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines'
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
+import type { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiLineChartTimeSeriesQuery } from './__generated__/StixCoreObjectsMultiLineChartTimeSeriesQuery.graphql';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
@@ -96,6 +96,7 @@ const DATA_SELECTION_TYPES = ['Stix-Core-Object'];
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixCoreObjectsMultiLineChartTimeSeriesQuery['variables'] => {
   const computed = computeStartEndDates(config);
   const startDate = computed.startDate ?? monthsAgo(12);
@@ -118,7 +119,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -142,6 +143,7 @@ const StixCoreObjectsMultiLineChart = ({
     query: stixCoreObjectsMultiLineChartTimeSeriesQuery,
     config,
     buildQueryVariables,
+    parameters,
   });
 
   const renderContent = () => {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import testRender from '../../../../utils/tests/test-render';
+
+type BuildQueryVariables = (
+  dataSelection: unknown[],
+  config: unknown,
+  parameters?: { interval?: string },
+) => Record<string, unknown>;
+
+let capturedBuildQueryVariables: BuildQueryVariables | null = null;
+let capturedParameters: { interval?: string } | undefined;
+
+beforeEach(() => {
+  capturedBuildQueryVariables = null;
+  capturedParameters = undefined;
+});
+
+vi.mock('apexcharts', () => ({ default: class ApexChartsMock {} }));
+
+vi.mock('../../../../components/dashboard/useDashboardViz', () => ({
+  default: ({ dataSelection, buildQueryVariables, parameters }: {
+    dataSelection: unknown[];
+    buildQueryVariables: BuildQueryVariables;
+    parameters?: { interval?: string };
+  }) => {
+    capturedBuildQueryVariables = buildQueryVariables;
+    capturedParameters = parameters;
+    return {
+      resolvedDataSelection: dataSelection,
+      isMissingHostEntity: false,
+      isPreviewMode: false,
+      queryRef: null,
+    };
+  },
+}));
+
+vi.mock('../../../../components/dashboard/WidgetContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="widget-container">{children}</div>,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoData', () => ({
+  default: () => <div data-testid="widget-no-data" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetMultiLines', () => ({
+  default: () => <div data-testid="widget-multi-lines" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoHostEntity', () => ({
+  default: () => <div data-testid="widget-no-host" />,
+}));
+
+vi.mock('../../../../components/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+  LoaderVariant: { inElement: 'inElement' },
+}));
+
+import StixRelationshipsMultiLineChart from './StixRelationshipsMultiLineChart';
+
+describe('StixRelationshipsMultiLineChart', () => {
+  const baseProps = {
+    config: { relativeDate: null, startDate: null, endDate: null },
+    dataSelection: [{
+      filters: { mode: 'and' as const, filters: [], filterGroups: [] },
+      date_attribute: 'created_at',
+    }],
+  };
+
+  it('forwards parameters.interval into the time-series query variables', () => {
+    testRender(<StixRelationshipsMultiLineChart {...baseProps} parameters={{ interval: 'week' }} />);
+    expect(typeof capturedBuildQueryVariables).toBe('function');
+    const variables = capturedBuildQueryVariables!(baseProps.dataSelection, baseProps.config, capturedParameters);
+    expect(variables.interval).toBe('week');
+  });
+
+  it('defaults interval to day when parameters.interval is not provided', () => {
+    testRender(<StixRelationshipsMultiLineChart {...baseProps} parameters={{}} />);
+    expect(typeof capturedBuildQueryVariables).toBe('function');
+    const variables = capturedBuildQueryVariables!(baseProps.dataSelection, baseProps.config, capturedParameters);
+    expect(variables.interval).toBe('day');
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
@@ -88,6 +88,7 @@ const StixRelationshipsMultiLineChartComponent = ({
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixRelationshipsMultiLineChartTimeSeriesQuery['variables'] => {
   const fallbackStart = monthsAgo(12);
   const fallbackEnd = now();
@@ -113,7 +114,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -149,6 +150,7 @@ const StixRelationshipsMultiLineChart = ({
     query: stixRelationshipsMultiLineChartTimeSeriesQuery,
     config,
     buildQueryVariables,
+    parameters,
   });
 
   const renderContent = () => {


### PR DESCRIPTION
## Proposed changes
- Fix dashboard Line visualization time-series queries to respect the widget `interval` parameter (day/week/month/year) instead of always requesting `day`.
- Pass widget `parameters` into useDashboardViz so query variable builders can use the selected interval when building GraphQL variables.

## Related issues
- closes #16857

## How to test this PR
1. Start OpenCTI normally and log in.
2. Go to **Dashboards** and open (or create) a dashboard.
3. Create a **new widget** (or edit an existing one) with:
   - **Visualization**: Line
   - **Date attribute**: `created_at` (Technical date) or `created` (Functional date)
   - **Interval**: set to **Month** (then also test **Week**)
   - Add any filter that returns enough entities to show multiple points (for example: Entity type = Incidents, Status = Analyzed)
4. Save the widget and observe the chart:
   - X-axis labels and points should align with the selected interval (month/week), not daily.
   - Aggregation should be grouped per selected interval (values summed per bucket).

## Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

## Further comments
The root cause was that the frontend line chart widgets were hardcoding `interval: 'day'` in their GraphQL query variables, so the backend always returned daily buckets regardless of the widget configuration. This change ensures the configured `parameters.interval` is used when building query variables.