### PR TITLE
fix(migrations): avoid patchAttribute in software standard_id rewrite

### DIFF
--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -93,7 +93,7 @@ export const up = async (next) => {
         await elBulk(context, { refresh: false, timeout: BULK_TIMEOUT, body: bulk });
       }
       mergedEntities += sources.length;
-      logApp.info(`${message} > merged ${sources.length} Software into ${target.internal_id} (${index + 1}/${collisionGroups.length})`);
+      logMigration.info(`${message} > merged ${sources.length} Software into ${target.internal_id} (${index + 1}/${collisionGroups.length})`);
     } catch (err) {
       // Do not abort the whole migration if one group fails: log and keep going,
       // the remaining Software observables can still have their standard_id rewritten.

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -21,7 +21,7 @@ export const up = async (next) => {
     // mergeEntities can mutate the stored x_opencti_stix_ids for the target entity (by adding
     // the merged entities' identifiers). Using an in-memory doc update here would clobber those.
     return [
-      { update: { _index: entity._index, _id: entity._id } },
+      { update: { _index: entity._index, _id: entity._id, retry_on_conflict: 5 } },
       {
         script: {
           lang: 'painless',

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -17,11 +17,29 @@ export const up = async (next) => {
   logMigration.info(`${message} > started`);
 
   const buildStandardIdUpdateOps = (entity, newId) => {
-    const existingStixIds = entity.x_opencti_stix_ids ?? [];
-    const updatedStixIds = R.uniq([...existingStixIds, entity.standard_id]);
+    // Use a scripted update to avoid overwriting x_opencti_stix_ids computed by mergeEntities.
+    // mergeEntities can mutate the stored x_opencti_stix_ids for the target entity (by adding
+    // the merged entities' identifiers). Using an in-memory doc update here would clobber those.
     return [
       { update: { _index: entity._index, _id: entity._id } },
-      { doc: { standard_id: newId, x_opencti_stix_ids: updatedStixIds } },
+      {
+        script: {
+          lang: 'painless',
+          source: `
+            if (ctx._source.x_opencti_stix_ids == null) {
+              ctx._source.x_opencti_stix_ids = new ArrayList();
+            }
+            if (params.previous_standard_id != null && !ctx._source.x_opencti_stix_ids.contains(params.previous_standard_id)) {
+              ctx._source.x_opencti_stix_ids.add(params.previous_standard_id);
+            }
+            ctx._source.standard_id = params.new_standard_id;
+          `,
+          params: {
+            previous_standard_id: entity.standard_id,
+            new_standard_id: newId,
+          },
+        },
+      },
     ];
   };
 

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -27,7 +27,7 @@ export const up = async (next) => {
           lang: 'painless',
           source: `
             if (ctx._source.x_opencti_stix_ids == null) {
-              ctx._source.x_opencti_stix_ids = new ArrayList();
+              ctx._source.x_opencti_stix_ids = [];
             }
             if (params.previous_standard_id != null && !ctx._source.x_opencti_stix_ids.contains(params.previous_standard_id)) {
               ctx._source.x_opencti_stix_ids.add(params.previous_standard_id);

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -68,8 +68,9 @@ export const up = async (next) => {
   // We pick the oldest entity (by created_at, falling back to internal_id) as the merge target
   // to preserve provenance; all the other entities are merged into it so that their relations,
   // markings, labels, stix ids... are kept. The merge target's standard_id is moved to the new
-  // value with patchAttribute so the middleware automatically archives the previous standard_id
-  // inside x_opencti_stix_ids.
+  // value with an Elasticsearch scripted update, so the previous standard_id is preserved in
+  // x_opencti_stix_ids and we don't overwrite any x_opencti_stix_ids updates performed by
+  // mergeEntities.
   const collisionGroups = groups.filter((g) => g.length > 1);
   logMigration.info(`${message} > ${collisionGroups.length} collision group(s) to merge`);
   let mergedEntities = 0;
@@ -89,7 +90,7 @@ export const up = async (next) => {
       await mergeEntities(context, SYSTEM_USER, target.internal_id, sources.map((s) => s.internal_id));
       if (target.standard_id !== newId) {
         const bulk = buildStandardIdUpdateOps(target, newId);
-        await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+        await elBulk(context, { refresh: false, timeout: BULK_TIMEOUT, body: bulk });
       }
       mergedEntities += sources.length;
       logApp.info(`${message} > merged ${sources.length} Software into ${target.internal_id} (${index + 1}/${collisionGroups.length})`);

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -88,11 +88,11 @@ export const up = async (next) => {
     const sources = sorted.slice(1).map((e) => e.sw);
     try {
       await mergeEntities(context, SYSTEM_USER, target.internal_id, sources.map((s) => s.internal_id));
+      mergedEntities += sources.length;
       if (target.standard_id !== newId) {
         const bulk = buildStandardIdUpdateOps(target, newId);
         await elBulk(context, { refresh: false, timeout: BULK_TIMEOUT, body: bulk });
       }
-      mergedEntities += sources.length;
       logMigration.info(`${message} > merged ${sources.length} Software into ${target.internal_id} (${index + 1}/${collisionGroups.length})`);
     } catch (err) {
       // Do not abort the whole migration if one group fails: log and keep going,

--- a/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1776859399668-software_case_insensitive_standard_id.js
@@ -5,7 +5,7 @@ import { generateStandardId } from '../schema/identifier';
 import { ENTITY_SOFTWARE } from '../schema/stixCyberObservable';
 import { READ_INDEX_STIX_CYBER_OBSERVABLES } from '../database/utils';
 import { fullEntitiesList } from '../database/middleware-loader';
-import { mergeEntities, patchAttribute } from '../database/middleware';
+import { mergeEntities } from '../database/middleware';
 import { BULK_TIMEOUT, elBulk, ES_MAX_CONCURRENCY, MAX_BULK_OPERATIONS } from '../database/engine';
 import { logApp, logMigration } from '../config/conf';
 
@@ -15,6 +15,15 @@ export const up = async (next) => {
   const context = executionContext('migration');
   const start = new Date().getTime();
   logMigration.info(`${message} > started`);
+
+  const buildStandardIdUpdateOps = (entity, newId) => {
+    const existingStixIds = entity.x_opencti_stix_ids ?? [];
+    const updatedStixIds = R.uniq([...existingStixIds, entity.standard_id]);
+    return [
+      { update: { _index: entity._index, _id: entity._id } },
+      { doc: { standard_id: newId, x_opencti_stix_ids: updatedStixIds } },
+    ];
+  };
 
   // 1. Load every existing Software observable (minimal but sufficient field set to
   // recompute a standard_id and to build the bulk update / merge operations).
@@ -59,10 +68,11 @@ export const up = async (next) => {
     const target = sorted[0].sw;
     const sources = sorted.slice(1).map((e) => e.sw);
     try {
-      if (target.standard_id !== newId) {
-        await patchAttribute(context, SYSTEM_USER, target.internal_id, target.entity_type, { standard_id: newId });
-      }
       await mergeEntities(context, SYSTEM_USER, target.internal_id, sources.map((s) => s.internal_id));
+      if (target.standard_id !== newId) {
+        const bulk = buildStandardIdUpdateOps(target, newId);
+        await elBulk(context, { refresh: true, timeout: BULK_TIMEOUT, body: bulk });
+      }
       mergedEntities += sources.length;
       logApp.info(`${message} > merged ${sources.length} Software into ${target.internal_id} (${index + 1}/${collisionGroups.length})`);
     } catch (err) {
@@ -80,12 +90,7 @@ export const up = async (next) => {
   for (let index = 0; index < singletonGroups.length; index += 1) {
     const { sw, newId } = singletonGroups[index][0];
     if (sw.standard_id === newId) continue;
-    const existingStixIds = sw.x_opencti_stix_ids ?? [];
-    const updatedStixIds = R.uniq([...existingStixIds, sw.standard_id]);
-    bulkOperations.push(
-      { update: { _index: sw._index, _id: sw._id } },
-      { doc: { standard_id: newId, x_opencti_stix_ids: updatedStixIds } },
-    );
+    bulkOperations.push(...buildStandardIdUpdateOps(sw, newId));
   }
 
   if (bulkOperations.length > 0) {


### PR DESCRIPTION
## Proposed changes
- Prevent crash loops in the Software `standard_id` case-insensitive rewrite migration by removing the `patchAttribute()` call that can raise `VALIDATION_ERROR: You cannot update incompatible attribute`.
- After merging duplicates, update the merge target’s `standard_id` using a direct Elasticsearch bulk update (`elBulk`) and archive the previous `standard_id` into `x_opencti_stix_ids` (same strategy already used for singleton rewrites).

## Related issues
- closes #16856
- related to #16485

## How to test this PR
1. Use an environment affected by the upgrade path (example from the issue):
   - Upgrade **OpenCTI 6.9.7 -> 7.260624.0**
2. Run the migration process (standard upgrade procedure).
3. Observe migration logs during the “Software standard_id case-insensitive rewrite” step:
   - Expected: migration completes without `VALIDATION_ERROR: You cannot update incompatible attribute`
   - Expected: duplicate Software entities that collide under the new case-insensitive standard id rules are merged successfully
   - Expected: rewritten entities have:
     - `standard_id` set to the new computed value
     - the previous `standard_id` preserved in `x_opencti_stix_ids`

## Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (reasoning + matches existing singleton bulk rewrite approach)
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

## Further comments
The migration already uses direct Elasticsearch bulk updates to rewrite `standard_id` for non-colliding Software entities. This change applies the same update approach to the merge target in collision groups, avoiding `patchAttribute()` which can trigger incompatible-attribute validation for Software during migration.