### PR TITLE
fix(ui): fix the list members layout in update group drawer (#16766)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -132,7 +132,7 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
       disabled={disabled}
       controlledDial={UpdateGroupControlledDial}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'hidden' }}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
           <Tabs value={currentTab} onChange={(event, value) => setTab(value)}>
             <Tab label={t_i18n('Overview')} />

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -164,15 +164,13 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
                 paginationOptionsForUpdater={paginationOptionsForUserEdition}
                 storageKey={LOCAL_STORAGE_KEY}
               >
-                <SearchInput
-                  variant="thin"
-                  onSubmit={helpers.handleSearch}
-                  keyword={searchTerm}
-                  sx={{
-                    marginTop: 2,
-                    marginBottom: 2,
-                  }}
-                />
+                <Box sx={{ marginTop: 2, marginBottom: 2 }}>
+                  <SearchInput
+                    variant="thin"
+                    onSubmit={helpers.handleSearch}
+                    keyword={searchTerm}
+                  />
+                </Box>
               </GroupEditionUsers>
             </React.Suspense>
           </Box>

--- a/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/groups/GroupEditionContainer.tsx
@@ -132,8 +132,8 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
       disabled={disabled}
       controlledDial={UpdateGroupControlledDial}
     >
-      <>
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
           <Tabs value={currentTab} onChange={(event, value) => setTab(value)}>
             <Tab label={t_i18n('Overview')} />
             <Tab label={t_i18n('Roles')} />
@@ -154,31 +154,33 @@ const GroupEditionContainer: FunctionComponent<GroupEditionContainerProps> = ({
         )}
         {currentTab === 2 && <GroupEditionMarkings group={group} />}
         {currentTab === 3 && userQueryRef && (
-          <React.Suspense
-            fallback={<Loader variant={LoaderVariant.inline} />}
-          >
-            <GroupEditionUsers
-              group={group}
-              queryRef={userQueryRef}
-              paginationOptionsForUpdater={paginationOptionsForUserEdition}
-              storageKey={LOCAL_STORAGE_KEY}
+          <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+            <React.Suspense
+              fallback={<Loader variant={LoaderVariant.inline} />}
             >
-              <SearchInput
-                variant="thin"
-                onSubmit={helpers.handleSearch}
-                keyword={searchTerm}
-                sx={{
-                  marginTop: 2,
-                  marginBottom: 2,
-                }}
-              />
-            </GroupEditionUsers>
-          </React.Suspense>
+              <GroupEditionUsers
+                group={group}
+                queryRef={userQueryRef}
+                paginationOptionsForUpdater={paginationOptionsForUserEdition}
+                storageKey={LOCAL_STORAGE_KEY}
+              >
+                <SearchInput
+                  variant="thin"
+                  onSubmit={helpers.handleSearch}
+                  keyword={searchTerm}
+                  sx={{
+                    marginTop: 2,
+                    marginBottom: 2,
+                  }}
+                />
+              </GroupEditionUsers>
+            </React.Suspense>
+          </Box>
         )}
         {hasSetAccess && currentTab === 4 && (
           <GroupEditionConfidence group={group} context={editContext} />
         )}
-      </>
+      </Box>
     </Drawer>
   );
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*in update group drawer "members", the last member is completely truncated

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* Resolves #16766

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
1- go to settings>Group> Update a group > tab members 
2- the list must be fill the full screen
3- at the end of the list, the last member is not truncated

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
before
<img width="951" height="948" alt="image" src="https://github.com/user-attachments/assets/d0f63d76-c53d-4a8e-8de3-83291ee4dc69" />

after the fix
<img width="944" height="942" alt="image" src="https://github.com/user-attachments/assets/d5695f1a-836b-41df-b831-8f3a595e79b0" />
