### PR TITLE
fix(widget): Public relationship heatmap widget when no filters (#16895)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/publicDashboard/publicDashboard-domain.ts
@@ -30,7 +30,7 @@ import { publishUserAction } from '../../listener/UserActionListener';
 import { findAllWorkspaces } from '../workspace/workspace-domain';
 import { ENTITY_TYPE_MARKING_DEFINITION } from '../../schema/stixMetaObject';
 import { getEntitiesMapFromCache } from '../../database/cache';
-import type { BasicStoreRelation, NumberResult, BasicConnection, StoreEntity, StoreMarkingDefinition } from '../../types/store';
+import type { BasicConnection, BasicStoreRelation, NumberResult, StoreEntity, StoreMarkingDefinition } from '../../types/store';
 import { checkUserIsAdminOnDashboard, getWidgetArguments, sanitizePublicDashboardUriKey } from './publicDashboard-utils';
 import {
   findStixCoreObjectPaginated,
@@ -326,14 +326,9 @@ export const publicStixRelationshipsMultiTimeSeries = async (
   const { user, dataSelection, parameters } = await ensurePublicContext(context, args.uriKey, args.widgetId);
 
   const timeSeriesParameters = dataSelection.map((selection) => {
-    const filters = {
-      filterGroups: [selection.filters],
-      filters: [],
-      mode: 'and',
-    };
     return {
       field: selection.date_attribute,
-      filters,
+      filters: selection.filters,
       dynamicFrom: selection.dynamicFrom,
       dynamicTo: selection.dynamicTo,
     };
@@ -593,9 +588,7 @@ export const publicStixCoreObjectsPaginated = async (
   const parameters = {
     startDate: args.startDate,
     endDate: args.endDate,
-    types: [
-      ABSTRACT_STIX_CORE_OBJECT,
-    ],
+    types: [ABSTRACT_STIX_CORE_OBJECT],
     filters,
     orderBy: selection.date_attribute,
     orderMode: 'desc',

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-data.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-data.ts
@@ -205,6 +205,43 @@ export const PRIVATE_DASHBOARD_MANIFEST = {
         static: false
       }
     },
+    'f05b4f8f-9386-4890-9f9c-a6bd5b0913eb': {
+      id: 'f05b4f8f-9386-4890-9f9c-a6bd5b0913eb',
+      type: 'line',
+      perspective: 'relationships',
+      dataSelection: [
+        {
+          label: '',
+          attribute: 'entity_type',
+          date_attribute: 'created_at',
+          perspective: 'relationships',
+          isTo: true,
+          filters: undefined,
+          dynamicFrom: {
+            mode: 'and',
+            filters: [{
+              key: ['description'],
+              values: ['widget tests'],
+              operator: 'search',
+              mode: 'or'
+            }],
+            filterGroups: []
+          }
+        }
+      ],
+      parameters: {
+        title: 'Evolution of attacks without filters'
+      },
+      layout: {
+        w: 3,
+        h: 4,
+        x: 2,
+        y: 4,
+        i: 'f05b4f8f-9386-4890-9f9c-a6bd5b0913eb',
+        moved: false,
+        static: false
+      }
+    },
     '9865bec0-d8b1-4592-b14e-0e81e1645f59': {
       id: '9865bec0-d8b1-4592-b14e-0e81e1645f59',
       type: 'donut',

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-test.js
@@ -831,7 +831,7 @@ describe('PublicDashboard resolver', () => {
           const { publicStixRelationshipsMultiTimeSeries } = data;
           const attacksData = publicStixRelationshipsMultiTimeSeries[0].data;
           expect(attacksData.length).toEqual(1);
-          expect(attacksData[0].value).toEqual(4);
+          expect(attacksData[0].value).toEqual(7);
         });
 
         it('should return the data for API: SCO Distribution', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-test.js
@@ -800,6 +800,40 @@ describe('PublicDashboard resolver', () => {
           expect(attacksData[0].value).toEqual(4); // same result as for '6dbb6564-3e4a-4a28-85b1-e2ac479e38e7' widget
         });
 
+        it('should return the data for API: SCR Time series when filters is undefined', async () => {
+          const API_SCR_LIST_QUERY = gql`
+            query PublicStixRelationshipsMultiTimeSeries(
+              $startDate: DateTime
+              $endDate: DateTime
+              $uriKey: String!
+              $widgetId : String!
+            ) {
+              publicStixRelationshipsMultiTimeSeries(
+                startDate: $startDate
+                endDate: $endDate
+                uriKey: $uriKey
+                widgetId : $widgetId
+              ) {
+                data {
+                  date
+                  value
+                }
+              }
+            }
+          `;
+          const { data } = await queryAsAdmin({
+            query: API_SCR_LIST_QUERY,
+            variables: {
+              uriKey: publicDashboardUriKey,
+              widgetId: 'f05b4f8f-9386-4890-9f9c-a6bd5b0913eb',
+            },
+          });
+          const { publicStixRelationshipsMultiTimeSeries } = data;
+          const attacksData = publicStixRelationshipsMultiTimeSeries[0].data;
+          expect(attacksData.length).toEqual(1);
+          expect(attacksData[0].value).toEqual(4);
+        });
+
         it('should return the data for API: SCO Distribution', async () => {
           const API_SCO_DONUT_QUERY = gql`
             query PublicStixCoreObjectsDistribution(

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/publicDashboard-test.js
@@ -800,7 +800,7 @@ describe('PublicDashboard resolver', () => {
           expect(attacksData[0].value).toEqual(4); // same result as for '6dbb6564-3e4a-4a28-85b1-e2ac479e38e7' widget
         });
 
-        it('should return the data for API: SCR Time series when filters is undefined', async () => {
+        it('should return the data for API: SCR Time series when filters are undefined', async () => {
           const API_SCR_LIST_QUERY = gql`
             query PublicStixRelationshipsMultiTimeSeries(
               $startDate: DateTime


### PR DESCRIPTION
### Proposed changes
- Fix the error displayed for public relationship heatmap widgets when there is no filters
(The issue came from the fact that filters contained an undefined filter group if no filters where defined)
- Add tests for the concerned resolver

### Related issues
closes #16895