### PR TITLE
fix(pycti): update query to include missing data (#16902)

### DIFF
--- a/client-python/pycti/entities/opencti_stix_object_or_stix_relationship.py
+++ b/client-python/pycti/entities/opencti_stix_object_or_stix_relationship.py
@@ -397,6 +397,8 @@ class StixObjectOrStixRelationship:
                 standard_id
                 entity_type
                 parent_types
+                created_at
+                relationship_type
                 createdBy {
                     ... on Identity {
                         id
@@ -448,6 +450,226 @@ class StixObjectOrStixRelationship:
                             created
                             modified
                         }
+                    }
+                }
+                from {
+                    ... on BasicObject {
+                        id
+                        entity_type
+                        parent_types
+                    }
+                    ... on BasicRelationship {
+                        id
+                        entity_type
+                        parent_types
+                    }
+                    ... on StixObject {
+                        standard_id
+                        spec_version
+                        created_at
+                        updated_at
+                    }
+                    ... on AttackPattern {
+                        name
+                    }
+                    ... on Campaign {
+                        name
+                    }
+                    ... on CourseOfAction {
+                        name
+                    }
+                    ... on Individual {
+                        name
+                    }
+                    ... on Organization {
+                        name
+                    }
+                    ... on Sector {
+                        name
+                    }
+                    ... on System {
+                        name
+                    }
+                    ... on Indicator {
+                        name
+                    }
+                    ... on Infrastructure {
+                        name
+                    }
+                    ... on IntrusionSet {
+                        name
+                    }
+                    ... on Position {
+                        name
+                    }
+                    ... on City {
+                        name
+                    }
+                    ... on Country {
+                        name
+                    }
+                    ... on Region {
+                        name
+                    }
+                    ... on Malware {
+                        name
+                    }
+                    ... on ThreatActor {
+                        name
+                    }
+                    ... on Tool {
+                        name
+                    }
+                    ... on Vulnerability {
+                        name
+                    }
+                    ... on Incident {
+                        name
+                    }
+                    ... on Event {
+                        name
+                        description
+                    }
+                    ... on Channel {
+                        name
+                        description
+                    }
+                    ... on Narrative {
+                        name
+                        description
+                    }
+                    ... on Language {
+                        name
+                    }
+                    ... on DataComponent {
+                        name
+                        description
+                    }
+                    ... on DataSource {
+                        name
+                        description
+                    }
+                    ... on Case {
+                        name
+                    }
+                    ... on StixCyberObservable {
+                        observable_value
+                    }
+                    ... on StixCoreRelationship {
+                        standard_id
+                        spec_version
+                        created_at
+                        updated_at
+                    }
+                }
+                to {
+                    ... on BasicObject {
+                        id
+                        entity_type
+                        parent_types
+                    }
+                    ... on BasicRelationship {
+                        id
+                        entity_type
+                        parent_types
+                    }
+                    ... on StixObject {
+                        standard_id
+                        spec_version
+                        created_at
+                        updated_at
+                    }
+                    ... on AttackPattern {
+                        name
+                    }
+                    ... on Campaign {
+                        name
+                    }
+                    ... on CourseOfAction {
+                        name
+                    }
+                    ... on Individual {
+                        name
+                    }
+                    ... on Organization {
+                        name
+                    }
+                    ... on Sector {
+                        name
+                    }
+                    ... on System {
+                        name
+                    }
+                    ... on Indicator {
+                        name
+                    }
+                    ... on Infrastructure {
+                        name
+                    }
+                    ... on IntrusionSet {
+                        name
+                    }
+                    ... on Position {
+                        name
+                    }
+                    ... on City {
+                        name
+                    }
+                    ... on Country {
+                        name
+                    }
+                    ... on Region {
+                        name
+                    }
+                    ... on Malware {
+                        name
+                    }
+                    ... on ThreatActor {
+                        name
+                    }
+                    ... on Tool {
+                        name
+                    }
+                    ... on Vulnerability {
+                        name
+                    }
+                    ... on Incident {
+                        name
+                    }
+                    ... on Event {
+                        name
+                        description
+                    }
+                    ... on Channel {
+                        name
+                        description
+                    }
+                    ... on Narrative {
+                        name
+                        description
+                    }
+                    ... on Language {
+                        name
+                    }
+                    ... on DataComponent {
+                        name
+                        description
+                    }
+                    ... on DataSource {
+                        name
+                        description
+                    }
+                    ... on Case {
+                        name
+                    }
+                    ... on StixCyberObservable {
+                        observable_value
+                    }
+                    ... on StixCoreRelationship {
+                        standard_id
+                        spec_version
+                        created_at
+                        updated_at
                     }
                 }
                 revoked


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update query to include relationship_type, created_at, to, and from

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* fixes #16902 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

1. perform a csv export on a selection of relationships on the data/relationships page
2. confirm that relationship_type, created_at, to, and from are included

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
This must be merged in before #15593 because this bug becomes very apparent when the user can select their columns for export. 