### PR TITLE
feat(filters): shared saved filters telemetry (#11624)

### DIFF
--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -78,6 +78,8 @@ Here is an exhaustive list of the collected metrics:
 - The number of request access creations (RFI of request access type)
 - The number of custom views created
 - The number of custom views enabled
+- The number of shared saved filters (i.e. saved filters shared with others members than just the creator)
+- The number of access restriction updates on saved filters
 
 ### Email and notifications
 

--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -80,6 +80,8 @@ Here is an exhaustive list of the collected metrics:
 - The number of request access creations (RFI of request access type)
 - The number of custom views created
 - The number of custom views enabled
+- The number of shared saved filters (i.e. saved filters shared with others members than just the creator)
+- The number of access restriction updates on saved filters
 
 ### AI features
 

--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -80,8 +80,8 @@ Here is an exhaustive list of the collected metrics:
 - The number of request access creations (RFI of request access type)
 - The number of custom views created
 - The number of custom views enabled
-- The number of shared saved filters (i.e. saved filters shared with others members than just the creator)
-- The number of access restriction updates on saved filters
+- The number of shared saved filters (i.e. saved filters shared with members other than the creator)
+- The number of access restriction updates on shared saved filters
 
 ### AI features
 

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -65,6 +65,7 @@ export interface ListFilter<T extends BasicStoreCommon> {
   after?: string | undefined | null;
   orderBy?: any;
   baseData?: boolean;
+  baseFields?: string[];
   orderMode?: InputMaybe<OrderingMode> | OrderingMode;
   filters?: FilterGroupWithNested | null;
   noFiltersChecking?: boolean;

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -462,7 +462,12 @@ export const pageEntitiesConnection = async <T extends BasicStoreEntity>(
   return connection as BasicConnection<T>;
 };
 
-export const topEntitiesList = async <T extends BasicStoreEntity>(context: AuthContext, user: AuthUser, entityTypes: string[], args: EntityOptions<T> = {}) => {
+export const topEntitiesList = async <T extends BasicStoreEntity>(
+  context: AuthContext,
+  user: AuthUser,
+  entityTypes: string[],
+  args: EntityOptions<T> = {},
+) => {
   const data = await pageEntitiesConnection(context, user, entityTypes, args);
   return asyncMap(data.edges, (edge) => edge.node);
 };

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -33,6 +33,7 @@ import type { BasicStoreSettings } from '../types/settings';
 import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
+import { ENTITY_TYPE_SAVED_FILTER, type BasicStoreEntitySavedFilter } from '../modules/savedFilter/savedFilter-types';
 import { elAggregationCount, elCount } from '../database/engine';
 import {
   READ_INDEX_FILES,
@@ -66,6 +67,7 @@ import { findRolesWithCapabilityInDraft } from '../domain/user';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
 import { EnvStrategyType, isStrategyActivated } from '../modules/authenticationProvider/providers-configuration';
 import { listRules } from '../modules/retentionRules/retentionRules-domain';
+import { fullEntitiesList } from '../database/middleware-loader';
 
 const TELEMETRY_MANAGER_KEY = conf.get('telemetry_manager:lock_key');
 
@@ -104,7 +106,8 @@ const booleanTrueFilter = (key: string) => ({
 const TELEMETRY_CONSOLE_DEBUG = conf.get('telemetry_manager:console_debug') ?? false;
 const SCHEDULE_TIME = conf.get('telemetry_manager:interval') || 60000; // 1 minute default
 const FILIGRAN_OTLP_TELEMETRY = DEV_MODE
-  ? 'https://telemetry.staging.filigran.io/v1/metrics' : 'https://telemetry.filigran.io/v1/metrics';
+  ? 'https://telemetry.staging.filigran.io/v1/metrics'
+  : 'https://telemetry.filigran.io/v1/metrics';
 
 const ONE_MINUTE = 60 * 1000;
 const ONE_HOUR = 60 * ONE_MINUTE;
@@ -540,6 +543,15 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
       types: [ENTITY_TYPE_SECURITY_COVERAGE],
     });
     manager.setSecurityCoveragesCount(securityCoveragesCount);
+    // endregion
+
+    // region Shared saved filters
+    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_SAVED_FILTER], { includeAuthorities: true });
+    // saved filters with other members than the creator in restricted_members are considered shared
+    const sharedSavedFilters = savedFilters.filter((f) => (f.restricted_members ?? [])
+      .filter((m) => m.id != f.creator_id)
+      .length > 0);
+    manager.setSharedSavedFiltersCount(sharedSavedFilters.length);
     // endregion
 
     // region Knowledge graph scale

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -557,7 +557,7 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     const sharedSavedFiltersScript = 'def members = params._source.restricted_members; '
       + 'if (members == null || members.isEmpty()) { return false; } '
       + 'def creator = params._source.creator_id; '
-      + 'for (def m : members) { if (m.id != creator) { return true; } } '
+      + 'for (def m : members) { if (!creator.contains(m.id)) { return true; } } '
       + 'return false;';
     const sharedSavedFiltersCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, {
       types: [ENTITY_TYPE_SAVED_FILTER],

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -17,6 +17,7 @@ import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { ENTITY_TYPE_SAVED_FILTER, type BasicStoreEntitySavedFilter } from '../modules/savedFilter/savedFilter-types';
+import { isSavedFilterShared } from '../modules/savedFilter/savedFilter-domain';
 import { elCount } from '../database/engine';
 import { READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { FilterMode } from '../generated/graphql';
@@ -73,6 +74,7 @@ export const TELEMETRY_USER_LOGIN = 'userLoginCount';
 export const TELEMETRY_GAUGE_DECAY_RULE_CREATION = 'decayRuleCreationCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED = 'customViewCreatedCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED = 'customViewEnabledCount';
+export const TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES = 'sharedSavedFiltersPermissionChangesCount';
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -161,6 +163,11 @@ export const addCustomViewCreatedCount = () => {
 export const addCustomViewEnabledCount = () => {
   redisSetTelemetryAdd(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED, 1)
     .catch((reason) => logApp.warn('Error adding custom view enabled count to telemetry', { reason }));
+};
+
+export const addSharedSavedFiltersPermissionChangesCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES, 1)
+    .catch((reason) => logApp.warn('Error adding shared saved filters permission changes count to telemetry', { reason }));
 };
 
 // End Region user event counters
@@ -323,11 +330,13 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region Shared saved filters
-    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_SAVED_FILTER], { includeAuthorities: true });
-    // saved filters with other members than the creator in restricted_members are considered shared
-    const sharedSavedFilters = savedFilters.filter((f) => (f.restricted_members ?? [])
-      .filter((m) => m.id != f.creator_id)
-      .length > 0);
+    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(
+      context,
+      TELEMETRY_MANAGER_USER,
+      [ENTITY_TYPE_SAVED_FILTER],
+      { includeAuthorities: true, baseData: true, baseFields: ['creator_id', 'restricted_members'] },
+    );
+    const sharedSavedFilters = savedFilters.filter((f) => isSavedFilterShared(f));
     manager.setSharedSavedFiltersCount(sharedSavedFilters.length);
     // endregion
 
@@ -380,6 +389,8 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setCustomViewCreatedCount(customViewCreatedCountInRedis);
     const customViewEnabledCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
     manager.setCustomViewEnabledCount(customViewEnabledCountInRedis);
+    const sharedSavedFiltersPermissionChangesCountInRedis = await redisGetTelemetry(TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES);
+    manager.setSharedSavedFiltersPermissionChangesCount(sharedSavedFiltersPermissionChangesCountInRedis);
     // end region Telemetry user events
 
     logApp.debug(`[TELEMETRY] Fetching telemetry data successfully in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -16,6 +16,7 @@ import type { BasicStoreSettings } from '../types/settings';
 import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
+import { ENTITY_TYPE_SAVED_FILTER, type BasicStoreEntitySavedFilter } from '../modules/savedFilter/savedFilter-types';
 import { elCount } from '../database/engine';
 import { READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { FilterMode } from '../generated/graphql';
@@ -27,12 +28,14 @@ import { findRolesWithCapabilityInDraft } from '../domain/user';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
 import { EnvStrategyType, isStrategyActivated } from '../modules/authenticationProvider/providers-configuration';
 import { listRules } from '../modules/retentionRules/retentionRules-domain';
+import { fullEntitiesList } from '../database/middleware-loader';
 
 const TELEMETRY_MANAGER_KEY = conf.get('telemetry_manager:lock_key');
 const TELEMETRY_CONSOLE_DEBUG = conf.get('telemetry_manager:console_debug') ?? false;
 const SCHEDULE_TIME = conf.get('telemetry_manager:interval') || 60000; // 1 minute default
 const FILIGRAN_OTLP_TELEMETRY = DEV_MODE
-  ? 'https://telemetry.staging.filigran.io/v1/metrics' : 'https://telemetry.filigran.io/v1/metrics';
+  ? 'https://telemetry.staging.filigran.io/v1/metrics'
+  : 'https://telemetry.filigran.io/v1/metrics';
 
 const ONE_MINUTE = 60 * 1000;
 const TWO_MINUTE = 2 * ONE_MINUTE;
@@ -317,6 +320,15 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
       types: [ENTITY_TYPE_SECURITY_COVERAGE],
     });
     manager.setSecurityCoveragesCount(securityCoveragesCount);
+    // endregion
+
+    // region Shared saved filters
+    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_SAVED_FILTER], { includeAuthorities: true });
+    // saved filters with other members than the creator in restricted_members are considered shared
+    const sharedSavedFilters = savedFilters.filter((f) => (f.restricted_members ?? [])
+      .filter((m) => m.id != f.creator_id)
+      .length > 0);
+    manager.setSharedSavedFiltersCount(sharedSavedFilters.length);
     // endregion
 
     // region Telemetry user events

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -34,6 +34,7 @@ import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { ENTITY_TYPE_SAVED_FILTER, type BasicStoreEntitySavedFilter } from '../modules/savedFilter/savedFilter-types';
+import { isSavedFilterShared } from '../modules/savedFilter/savedFilter-domain';
 import { elAggregationCount, elCount } from '../database/engine';
 import {
   READ_INDEX_FILES,
@@ -149,6 +150,7 @@ export const TELEMETRY_USER_LOGIN = 'userLoginCount';
 export const TELEMETRY_GAUGE_DECAY_RULE_CREATION = 'decayRuleCreationCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED = 'customViewCreatedCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED = 'customViewEnabledCount';
+export const TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES = 'sharedSavedFiltersPermissionChangesCount';
 export const TELEMETRY_GAUGE_WORKFLOW_PUBLISH = 'workflowPublishCount';
 // AI usage counters. Backend-agnostic by design: a chatbot message or an Ask AI
 // call is the SAME feature whether it is served by the legacy path or by
@@ -285,6 +287,11 @@ export const addCustomViewCreatedCount = () => {
 export const addCustomViewEnabledCount = () => {
   redisSetTelemetryAdd(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED, 1)
     .catch((reason) => logApp.warn('Error adding custom view enabled count to telemetry', { reason }));
+};
+
+export const addSharedSavedFiltersPermissionChangesCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES, 1)
+    .catch((reason) => logApp.warn('Error adding shared saved filters permission changes count to telemetry', { reason }));
 };
 
 export const addWorkflowPublishCount = () => {
@@ -546,11 +553,13 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region Shared saved filters
-    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_SAVED_FILTER], { includeAuthorities: true });
-    // saved filters with other members than the creator in restricted_members are considered shared
-    const sharedSavedFilters = savedFilters.filter((f) => (f.restricted_members ?? [])
-      .filter((m) => m.id != f.creator_id)
-      .length > 0);
+    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(
+      context,
+      TELEMETRY_MANAGER_USER,
+      [ENTITY_TYPE_SAVED_FILTER],
+      { includeAuthorities: true, baseData: true, baseFields: ['creator_id', 'restricted_members'] },
+    );
+    const sharedSavedFilters = savedFilters.filter((f) => isSavedFilterShared(f));
     manager.setSharedSavedFiltersCount(sharedSavedFilters.length);
     // endregion
 
@@ -733,6 +742,8 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setCustomViewCreatedCount(customViewCreatedCountInRedis);
     const customViewEnabledCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
     manager.setCustomViewEnabledCount(customViewEnabledCountInRedis);
+    const sharedSavedFiltersPermissionChangesCountInRedis = await redisGetTelemetry(TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES);
+    manager.setSharedSavedFiltersPermissionChangesCount(sharedSavedFiltersPermissionChangesCountInRedis);
     const workflowPublishCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_WORKFLOW_PUBLISH);
     manager.setWorkflowPublishCount(workflowPublishCountInRedis);
     const chatbotMessageCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CHATBOT_MESSAGE);

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -148,7 +148,7 @@ export const TELEMETRY_USER_LOGIN = 'userLoginCount';
 export const TELEMETRY_GAUGE_DECAY_RULE_CREATION = 'decayRuleCreationCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED = 'customViewCreatedCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED = 'customViewEnabledCount';
-export const TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES = 'sharedSavedFiltersPermissionChangesCount';
+export const TELEMETRY_GAUGE_SAVED_FILTER_PERMISSION_CHANGES = 'sharedSavedFiltersPermissionChangesCount';
 export const TELEMETRY_GAUGE_WORKFLOW_PUBLISH = 'workflowPublishCount';
 // AI usage counters. Backend-agnostic by design: a chatbot message or an Ask AI
 // call is the SAME feature whether it is served by the legacy path or by
@@ -288,7 +288,7 @@ export const addCustomViewEnabledCount = () => {
 };
 
 export const addSharedSavedFiltersPermissionChangesCount = () => {
-  redisSetTelemetryAdd(TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES, 1)
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_SAVED_FILTER_PERMISSION_CHANGES, 1)
     .catch((reason) => logApp.warn('Error adding shared saved filters permission changes count to telemetry', { reason }));
 };
 
@@ -554,13 +554,22 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // A saved filter is considered shared when it has restricted_members entries
     // whose id differs from the creator_id. We use an internal_script filter to
     // count them directly in ES to avoid fetching the full entity list.
-    const sharedSavedFiltersScript = 'def members = params._source.restricted_members; '
-      + 'if (members == null || members.isEmpty()) { return false; } '
-      + 'def creator = params._source.creator_id; '
-      + 'for (def m : members) { if (!creator.contains(m.id)) { return true; } } '
-      + 'return false;';
+    const sharedSavedFiltersScript = `
+      def members = doc.containsKey('restricted_members.id.keyword')
+        ? doc['restricted_members.id.keyword']
+        : (doc.containsKey('restricted_members.id') ? doc['restricted_members.id'] : null);
+      if (members == null || members.size() == 0) return false;
+      def creator = (doc.containsKey('creator_id.keyword') && doc['creator_id.keyword'].size() > 0)
+        ? doc['creator_id.keyword'][0]
+        : null;
+      for (def m : members) {
+        if (m != null && m != creator && m != 'CREATOR') return true;
+      }
+      return false;
+    `;
     const sharedSavedFiltersCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, {
       types: [ENTITY_TYPE_SAVED_FILTER],
+      includeAuthorities: true,
       filters: {
         mode: FilterMode.And,
         filters: [{
@@ -753,7 +762,7 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setCustomViewCreatedCount(customViewCreatedCountInRedis);
     const customViewEnabledCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED);
     manager.setCustomViewEnabledCount(customViewEnabledCountInRedis);
-    const sharedSavedFiltersPermissionChangesCountInRedis = await redisGetTelemetry(TELEMETRY_SAVED_FILTER_PERMISSION_CHANGES);
+    const sharedSavedFiltersPermissionChangesCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_SAVED_FILTER_PERMISSION_CHANGES);
     manager.setSharedSavedFiltersPermissionChangesCount(sharedSavedFiltersPermissionChangesCountInRedis);
     const workflowPublishCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_WORKFLOW_PUBLISH);
     manager.setWorkflowPublishCount(workflowPublishCountInRedis);

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -33,7 +33,7 @@ import type { BasicStoreSettings } from '../types/settings';
 import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
-import { ENTITY_TYPE_SAVED_FILTER } from '../modules/savedFilter/savedFilter-types';
+import { type BasicStoreEntitySavedFilter, ENTITY_TYPE_SAVED_FILTER } from '../modules/savedFilter/savedFilter-types';
 import { elAggregationCount, elCount } from '../database/engine';
 import {
   READ_INDEX_FILES,
@@ -67,6 +67,8 @@ import { findRolesWithCapabilityInDraft } from '../domain/user';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
 import { EnvStrategyType, isStrategyActivated } from '../modules/authenticationProvider/providers-configuration';
 import { listRules } from '../modules/retentionRules/retentionRules-domain';
+import { fullEntitiesList } from '../database/middleware-loader';
+import { isSavedFilterShared } from '../modules/savedFilter/savedFilter-domain';
 
 const TELEMETRY_MANAGER_KEY = conf.get('telemetry_manager:lock_key');
 
@@ -551,36 +553,14 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region Shared saved filters
-    // A saved filter is considered shared when it has restricted_members entries
-    // whose id differs from the creator_id. We use an internal_script filter to
-    // count them directly in ES to avoid fetching the full entity list.
-    const sharedSavedFiltersScript = `
-      def members = doc.containsKey('restricted_members.id.keyword')
-        ? doc['restricted_members.id.keyword']
-        : (doc.containsKey('restricted_members.id') ? doc['restricted_members.id'] : null);
-      if (members == null || members.size() == 0) return false;
-      def creator = (doc.containsKey('creator_id.keyword') && doc['creator_id.keyword'].size() > 0)
-        ? doc['creator_id.keyword'][0]
-        : null;
-      for (def m : members) {
-        if (m != null && m != creator && m != 'CREATOR') return true;
-      }
-      return false;
-    `;
-    const sharedSavedFiltersCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, {
-      types: [ENTITY_TYPE_SAVED_FILTER],
-      includeAuthorities: true,
-      filters: {
-        mode: FilterMode.And,
-        filters: [{
-          key: ['restricted_members'],
-          values: [sharedSavedFiltersScript],
-          operator: 'internal_script',
-        }],
-        filterGroups: [],
-      },
-    });
-    manager.setSharedSavedFiltersCount(sharedSavedFiltersCount);
+    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(
+      context,
+      TELEMETRY_MANAGER_USER,
+      [ENTITY_TYPE_SAVED_FILTER],
+      { includeAuthorities: true, baseData: true, baseFields: ['creator_id', 'restricted_members'] },
+    );
+    const sharedSavedFilters = savedFilters.filter((f) => isSavedFilterShared(f));
+    manager.setSharedSavedFiltersCount(sharedSavedFilters.length);
     // endregion
 
     // region Knowledge graph scale

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -33,8 +33,7 @@ import type { BasicStoreSettings } from '../types/settings';
 import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
-import { ENTITY_TYPE_SAVED_FILTER, type BasicStoreEntitySavedFilter } from '../modules/savedFilter/savedFilter-types';
-import { isSavedFilterShared } from '../modules/savedFilter/savedFilter-domain';
+import { ENTITY_TYPE_SAVED_FILTER } from '../modules/savedFilter/savedFilter-types';
 import { elAggregationCount, elCount } from '../database/engine';
 import {
   READ_INDEX_FILES,
@@ -68,7 +67,6 @@ import { findRolesWithCapabilityInDraft } from '../domain/user';
 import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
 import { EnvStrategyType, isStrategyActivated } from '../modules/authenticationProvider/providers-configuration';
 import { listRules } from '../modules/retentionRules/retentionRules-domain';
-import { fullEntitiesList } from '../database/middleware-loader';
 
 const TELEMETRY_MANAGER_KEY = conf.get('telemetry_manager:lock_key');
 
@@ -553,14 +551,27 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region Shared saved filters
-    const savedFilters = await fullEntitiesList<BasicStoreEntitySavedFilter>(
-      context,
-      TELEMETRY_MANAGER_USER,
-      [ENTITY_TYPE_SAVED_FILTER],
-      { includeAuthorities: true, baseData: true, baseFields: ['creator_id', 'restricted_members'] },
-    );
-    const sharedSavedFilters = savedFilters.filter((f) => isSavedFilterShared(f));
-    manager.setSharedSavedFiltersCount(sharedSavedFilters.length);
+    // A saved filter is considered shared when it has restricted_members entries
+    // whose id differs from the creator_id. We use an internal_script filter to
+    // count them directly in ES to avoid fetching the full entity list.
+    const sharedSavedFiltersScript = 'def members = params._source.restricted_members; '
+      + 'if (members == null || members.isEmpty()) { return false; } '
+      + 'def creator = params._source.creator_id; '
+      + 'for (def m : members) { if (m.id != creator) { return true; } } '
+      + 'return false;';
+    const sharedSavedFiltersCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, {
+      types: [ENTITY_TYPE_SAVED_FILTER],
+      filters: {
+        mode: FilterMode.And,
+        filters: [{
+          key: ['restricted_members'],
+          values: [sharedSavedFiltersScript],
+          operator: 'internal_script',
+        }],
+        filterGroups: [],
+      },
+    });
+    manager.setSharedSavedFiltersCount(sharedSavedFiltersCount);
     // endregion
 
     // region Knowledge graph scale

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -6,14 +6,15 @@ import type { AuthContext, AuthUser } from '../../types/user';
 import { pageEntitiesConnection, storeLoadById } from '../../database/middleware-loader';
 import type { InputMaybe, MemberAccessInput, MutationSavedFilterFieldPatchArgs, QuerySavedFiltersArgs, SavedFilterAddInput } from '../../generated/graphql';
 import { createInternalObject, deleteInternalObject } from '../../domain/internalObject';
-import { getUserAccessRight, isUserHasCapability, KNOWLEDGE_KNSHAREFILTERS, MEMBER_ACCESS_RIGHT_ADMIN } from '../../utils/access';
+import { getUserAccessRight, isUserHasCapability, KNOWLEDGE_KNSHAREFILTERS, MEMBER_ACCESS_CREATOR, MEMBER_ACCESS_RIGHT_ADMIN } from '../../utils/access';
 import { addSharedSavedFiltersPermissionChangesCount } from '../../manager/telemetryManager';
 import { editAuthorizedMembers } from '../../utils/authorizedMembers';
 
 // saved filters with other members than the creator in restricted_members are considered shared
 export const isSavedFilterShared = (savedFilter: BasicStoreEntitySavedFilter) => {
+  const creatorId = Array.isArray(savedFilter.creator_id) ? savedFilter.creator_id[0] : savedFilter.creator_id;
   return (savedFilter.restricted_members ?? [])
-    .some((m) => m.id != savedFilter.creator_id);
+    .some((m) => m.id && m.id !== creatorId && m.id !== MEMBER_ACCESS_CREATOR);
 };
 
 const findById = (context: AuthContext, user: AuthUser, id: string) => {
@@ -103,8 +104,9 @@ export const savedFilterEditAuthorizedMembers = async (
     requiredCapabilities: [KNOWLEDGE_KNSHAREFILTERS],
     entityType: ENTITY_TYPE_SAVED_FILTER,
   };
+  const before = await findById(context, user, savedFilterId);
   const result = await editAuthorizedMembers(context, user, args);
-  addSharedSavedFiltersPermissionChangesCount();
+  if ((before && isSavedFilterShared(before)) || isSavedFilterShared(result)) addSharedSavedFiltersPermissionChangesCount();
   return result;
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -7,7 +7,14 @@ import { pageEntitiesConnection, storeLoadById } from '../../database/middleware
 import type { InputMaybe, MemberAccessInput, MutationSavedFilterFieldPatchArgs, QuerySavedFiltersArgs, SavedFilterAddInput } from '../../generated/graphql';
 import { createInternalObject, deleteInternalObject } from '../../domain/internalObject';
 import { getUserAccessRight, isUserHasCapability, KNOWLEDGE_KNSHAREFILTERS, MEMBER_ACCESS_RIGHT_ADMIN } from '../../utils/access';
+import { addSharedSavedFiltersPermissionChangesCount } from '../../manager/telemetryManager';
 import { editAuthorizedMembers } from '../../utils/authorizedMembers';
+
+// saved filters with other members than the creator in restricted_members are considered shared
+export const isSavedFilterShared = (savedFilter: BasicStoreEntitySavedFilter) => {
+  return (savedFilter.restricted_members ?? [])
+    .some((m) => m.id != savedFilter.creator_id);
+};
 
 const findById = (context: AuthContext, user: AuthUser, id: string) => {
   return storeLoadById<BasicStoreEntitySavedFilter>(context, user, id, ENTITY_TYPE_SAVED_FILTER);
@@ -96,7 +103,9 @@ export const savedFilterEditAuthorizedMembers = async (
     requiredCapabilities: [KNOWLEDGE_KNSHAREFILTERS],
     entityType: ENTITY_TYPE_SAVED_FILTER,
   };
-  return editAuthorizedMembers(context, user, args);
+  const result = await editAuthorizedMembers(context, user, args);
+  if (isSavedFilterShared(result)) addSharedSavedFiltersPermissionChangesCount();
+  return result;
 };
 
 export const getCurrentUserAccessRight = (

--- a/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/savedFilter/savedFilter-domain.ts
@@ -104,7 +104,7 @@ export const savedFilterEditAuthorizedMembers = async (
     entityType: ENTITY_TYPE_SAVED_FILTER,
   };
   const result = await editAuthorizedMembers(context, user, args);
-  if (isSavedFilterShared(result)) addSharedSavedFiltersPermissionChangesCount();
+  addSharedSavedFiltersPermissionChangesCount();
   return result;
 };
 

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -730,7 +730,6 @@ export class TelemetryMeterManager {
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
     this.registerGauge('shared_saved_filters_count', 'Number of saved filters shared with at least one other member (non-creator)', 'sharedSavedFiltersCount');
     this.registerGauge('shared_saved_filters_permission_changes', 'Number of access restriction updates on shared saved filters', 'sharedSavedFiltersPermissionChangesCount');
-    this.registerGauge('shared_saved_filters_count', 'Number of saved filters with access restriction', 'sharedSavedFiltersCount');
     this.registerGauge('workflow_publish_count', 'Number of workflow definitions published', 'workflowPublishCount');
     // region AI usage (backend-agnostic counters, see telemetryManager)
     this.registerGauge('chatbot_message_count', 'Number of chatbot messages sent (legacy and XTM One combined)', 'chatbotMessageCount');

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -133,7 +133,7 @@ export class TelemetryMeterManager {
   // Number of saved filters shared with at least one other member (non-creator)
   sharedSavedFiltersCount = 0;
 
-  // Number of times saved filter permissions were changed
+  // Number of access restriction updates on shared saved filters
   sharedSavedFiltersPermissionChangesCount = 0;
 
   // endregion providers usage
@@ -407,6 +407,6 @@ export class TelemetryMeterManager {
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
     this.registerGauge('shared_saved_filters_count', 'Number of saved filters shared with at least one other member (non-creator)', 'sharedSavedFiltersCount');
-    this.registerGauge('shared_saved_filters_permission_changes', 'Number of times saved filter permissions were changed', 'sharedSavedFiltersPermissionChangesCount');
+    this.registerGauge('shared_saved_filters_permission_changes', 'Number of access restriction updates on shared saved filters', 'sharedSavedFiltersPermissionChangesCount');
   }
 }

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -130,6 +130,9 @@ export class TelemetryMeterManager {
 
   customViewEnabledCount = 0;
 
+  // Number of shared saved filters = saved filters with access restriction
+  sharedSavedFiltersCount = 0;
+
   // endregion providers usage
 
   constructor(meterProvider: MeterProvider) {
@@ -328,6 +331,10 @@ export class TelemetryMeterManager {
     this.customViewEnabledCount = n;
   }
 
+  setSharedSavedFiltersCount(n: number) {
+    this.sharedSavedFiltersCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: {
     unit?: string;
     valueType?: ValueType;
@@ -392,5 +399,6 @@ export class TelemetryMeterManager {
     this.registerGauge('is_sso_github_strategy_enabled', 'GithubStrategy is configured and enabled', 'ssoGithubStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
+    this.registerGauge('shared_saved_filters_count', 'Number of saved filters with access restriction', 'sharedSavedFiltersCount');
   }
 }

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -233,6 +233,8 @@ export class TelemetryMeterManager {
 
   sharedSavedFiltersCount = 0;
 
+  sharedSavedFiltersPermissionChangesCount = 0;
+
   workflowPublishCount = 0;
 
   // endregion providers usage
@@ -523,6 +525,10 @@ export class TelemetryMeterManager {
     this.sharedSavedFiltersCount = n;
   }
 
+  setSharedSavedFiltersPermissionChangesCount(n: number) {
+    this.sharedSavedFiltersPermissionChangesCount = n;
+  }
+
   setWorkflowPublishCount(n: number) {
     this.workflowPublishCount = n;
   }
@@ -722,6 +728,8 @@ export class TelemetryMeterManager {
     this.registerGauge('is_sso_github_strategy_enabled', 'GithubStrategy is configured and enabled', 'ssoGithubStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
+    this.registerGauge('shared_saved_filters_count', 'Number of saved filters shared with at least one other member (non-creator)', 'sharedSavedFiltersCount');
+    this.registerGauge('shared_saved_filters_permission_changes', 'Number of times saved filter permissions were changed', 'sharedSavedFiltersPermissionChangesCount');
     this.registerGauge('shared_saved_filters_count', 'Number of saved filters with access restriction', 'sharedSavedFiltersCount');
     this.registerGauge('workflow_publish_count', 'Number of workflow definitions published', 'workflowPublishCount');
     // region AI usage (backend-agnostic counters, see telemetryManager)

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -133,6 +133,9 @@ export class TelemetryMeterManager {
   // Number of shared saved filters = saved filters with access restriction
   sharedSavedFiltersCount = 0;
 
+  // Number of times saved filter permissions were changed
+  sharedSavedFiltersPermissionChangesCount = 0;
+
   // endregion providers usage
 
   constructor(meterProvider: MeterProvider) {
@@ -335,6 +338,10 @@ export class TelemetryMeterManager {
     this.sharedSavedFiltersCount = n;
   }
 
+  setSharedSavedFiltersPermissionChangesCount(n: number) {
+    this.sharedSavedFiltersPermissionChangesCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: {
     unit?: string;
     valueType?: ValueType;
@@ -399,6 +406,7 @@ export class TelemetryMeterManager {
     this.registerGauge('is_sso_github_strategy_enabled', 'GithubStrategy is configured and enabled', 'ssoGithubStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
-    this.registerGauge('shared_saved_filters_count', 'Number of saved filters with access restriction', 'sharedSavedFiltersCount');
+    this.registerGauge('shared_saved_filters_count', 'Number of saved filters shared with at least one other member (non-creator)', 'sharedSavedFiltersCount');
+    this.registerGauge('shared_saved_filters_permission_changes', 'Number of times saved filter permissions were changed', 'sharedSavedFiltersPermissionChangesCount');
   }
 }

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -231,6 +231,8 @@ export class TelemetryMeterManager {
 
   customViewEnabledCount = 0;
 
+  sharedSavedFiltersCount = 0;
+
   workflowPublishCount = 0;
 
   // endregion providers usage
@@ -517,6 +519,10 @@ export class TelemetryMeterManager {
     this.customViewEnabledCount = n;
   }
 
+  setSharedSavedFiltersCount(n: number) {
+    this.sharedSavedFiltersCount = n;
+  }
+
   setWorkflowPublishCount(n: number) {
     this.workflowPublishCount = n;
   }
@@ -716,6 +722,7 @@ export class TelemetryMeterManager {
     this.registerGauge('is_sso_github_strategy_enabled', 'GithubStrategy is configured and enabled', 'ssoGithubStrategyEnabled', { unit: 'boolean' });
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
+    this.registerGauge('shared_saved_filters_count', 'Number of saved filters with access restriction', 'sharedSavedFiltersCount');
     this.registerGauge('workflow_publish_count', 'Number of workflow definitions published', 'workflowPublishCount');
     // region AI usage (backend-agnostic counters, see telemetryManager)
     this.registerGauge('chatbot_message_count', 'Number of chatbot messages sent (legacy and XTM One combined)', 'chatbotMessageCount');

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -729,7 +729,7 @@ export class TelemetryMeterManager {
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
     this.registerGauge('shared_saved_filters_count', 'Number of saved filters shared with at least one other member (non-creator)', 'sharedSavedFiltersCount');
-    this.registerGauge('shared_saved_filters_permission_changes', 'Number of times saved filter permissions were changed', 'sharedSavedFiltersPermissionChangesCount');
+    this.registerGauge('shared_saved_filters_permission_changes', 'Number of access restriction updates on shared saved filters', 'sharedSavedFiltersPermissionChangesCount');
     this.registerGauge('shared_saved_filters_count', 'Number of saved filters with access restriction', 'sharedSavedFiltersCount');
     this.registerGauge('workflow_publish_count', 'Number of workflow definitions published', 'workflowPublishCount');
     // region AI usage (backend-agnostic counters, see telemetryManager)

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -130,7 +130,7 @@ export class TelemetryMeterManager {
 
   customViewEnabledCount = 0;
 
-  // Number of shared saved filters = saved filters with access restriction
+  // Number of saved filters shared with at least one other member (non-creator)
   sharedSavedFiltersCount = 0;
 
   // Number of times saved filter permissions were changed

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
@@ -720,7 +720,7 @@ export const completeSpecialFilterKeys = async (
   }
   for (let index = 0; index < filters.length; index += 1) {
     const filter = filters[index];
-    const { key, operator } = filter;
+    const { key } = filter;
     const arrayKeys = Array.isArray(key) ? key : [key];
     if (arrayKeys.some((filterKey) => isComplexConversionFilterKey(filterKey))) {
       if (arrayKeys.length > 1) {
@@ -851,7 +851,6 @@ export const completeSpecialFilterKeys = async (
       }
     } else if (arrayKeys.some((filterKey) => isObjectAttribute(filterKey))
       && !arrayKeys.some((filterKey) => filterKey === 'connections')
-      && !['script', 'internal_script'].includes(operator ?? 'eq')
     ) {
       if (arrayKeys.length > 1) {
         throw UnsupportedError('A filter with these multiple keys is not supported', { keys: arrayKeys });

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-completeSpecialFilterKeys.ts
@@ -720,7 +720,7 @@ export const completeSpecialFilterKeys = async (
   }
   for (let index = 0; index < filters.length; index += 1) {
     const filter = filters[index];
-    const { key } = filter;
+    const { key, operator } = filter;
     const arrayKeys = Array.isArray(key) ? key : [key];
     if (arrayKeys.some((filterKey) => isComplexConversionFilterKey(filterKey))) {
       if (arrayKeys.length > 1) {
@@ -849,7 +849,10 @@ export const completeSpecialFilterKeys = async (
         const { newFilter } = await adaptFilterForMetricsFilterKeys(filter);
         finalFilters.push(newFilter);
       }
-    } else if (arrayKeys.some((filterKey) => isObjectAttribute(filterKey)) && !arrayKeys.some((filterKey) => filterKey === 'connections')) {
+    } else if (arrayKeys.some((filterKey) => isObjectAttribute(filterKey))
+      && !arrayKeys.some((filterKey) => filterKey === 'connections')
+      && !['script', 'internal_script'].includes(operator ?? 'eq')
+    ) {
       if (arrayKeys.length > 1) {
         throw UnsupportedError('A filter with these multiple keys is not supported', { keys: arrayKeys });
       }

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
@@ -91,6 +91,31 @@ it('should buildLocalMustFilter build query from ids filter with terms', () => {
   expect(query).toEqual(expectedQuery);
 });
 
+it('should buildLocalMustFilter build query from filter with internal_script operator', () => {
+  const scriptSource = 'def members = params._source.restricted_members; '
+    + "for (def m : members) { if (m['access_right'] == 'admin') { return true; } } "
+    + 'return false;';
+  const filter = {
+    key: ['restricted_members'],
+    values: [scriptSource],
+    operator: 'internal_script',
+  };
+  const query = buildLocalMustFilter(filter);
+  const expectedQuery = {
+    bool: {
+      should: [
+        {
+          script: {
+            script: scriptSource,
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+  expect(query).toEqual(expectedQuery);
+});
+
 it('should generate search clauses for both activity and history fields in historyFiltering mode', () => {
   const shouldSearch = elGenerateFullTextSearchShould('login', { historyFiltering: true });
   const topLevelActivityAndHistoryQueryString = shouldSearch.find(

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
@@ -91,31 +91,6 @@ it('should buildLocalMustFilter build query from ids filter with terms', () => {
   expect(query).toEqual(expectedQuery);
 });
 
-it('should buildLocalMustFilter build query from filter with internal_script operator', () => {
-  const scriptSource = 'def members = params._source.restricted_members; '
-    + "for (def m : members) { if (m['access_right'] == 'admin') { return true; } } "
-    + 'return false;';
-  const filter = {
-    key: ['restricted_members'],
-    values: [scriptSource],
-    operator: 'internal_script',
-  };
-  const query = buildLocalMustFilter(filter);
-  const expectedQuery = {
-    bool: {
-      should: [
-        {
-          script: {
-            script: scriptSource,
-          },
-        },
-      ],
-      minimum_should_match: 1,
-    },
-  };
-  expect(query).toEqual(expectedQuery);
-});
-
 it('should generate search clauses for both activity and history fields in historyFiltering mode', () => {
   const shouldSearch = elGenerateFullTextSearchShould('login', { historyFiltering: true });
   const topLevelActivityAndHistoryQueryString = shouldSearch.find(

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/savedFilter/savedFilter-domain-unit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/savedFilter/savedFilter-domain-unit-test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { isSavedFilterShared } from '../../../../src/modules/savedFilter/savedFilter-domain';
+import type { BasicStoreEntitySavedFilter } from '../../../../src/modules/savedFilter/savedFilter-types';
+
+const buildSavedFilter = (creatorId: string, restrictedMembers: { id: string; access_right: string }[] | undefined): BasicStoreEntitySavedFilter => {
+  return {
+    creator_id: creatorId,
+    restricted_members: restrictedMembers,
+  } as unknown as BasicStoreEntitySavedFilter;
+};
+
+describe('isSavedFilterShared', () => {
+  it('should return false when restricted_members is undefined', () => {
+    const filter = buildSavedFilter('user-1', undefined);
+    expect(isSavedFilterShared(filter)).toBe(false);
+  });
+
+  it('should return false when restricted_members is empty', () => {
+    const filter = buildSavedFilter('user-1', []);
+    expect(isSavedFilterShared(filter)).toBe(false);
+  });
+
+  it('should return false when restricted_members contains only the creator', () => {
+    const filter = buildSavedFilter('user-1', [
+      { id: 'user-1', access_right: 'admin' },
+    ]);
+    expect(isSavedFilterShared(filter)).toBe(false);
+  });
+
+  it('should return true when restricted_members contains another member', () => {
+    const filter = buildSavedFilter('user-1', [
+      { id: 'user-1', access_right: 'admin' },
+      { id: 'user-2', access_right: 'view' },
+    ]);
+    expect(isSavedFilterShared(filter)).toBe(true);
+  });
+
+  it('should return true when restricted_members contains only other members (no creator)', () => {
+    const filter = buildSavedFilter('user-1', [
+      { id: 'user-2', access_right: 'admin' },
+    ]);
+    expect(isSavedFilterShared(filter)).toBe(true);
+  });
+
+  it('should return true when shared with MEMBER_ACCESS_ALL', () => {
+    const filter = buildSavedFilter('user-1', [
+      { id: 'user-1', access_right: 'admin' },
+      { id: 'ALL', access_right: 'view' },
+    ]);
+    expect(isSavedFilterShared(filter)).toBe(true);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/savedFilter/savedFilter-domain-unit-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/savedFilter/savedFilter-domain-unit-test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { isSavedFilterShared } from '../../../../src/modules/savedFilter/savedFilter-domain';
 import type { BasicStoreEntitySavedFilter } from '../../../../src/modules/savedFilter/savedFilter-types';
+import { MEMBER_ACCESS_ALL, MEMBER_ACCESS_CREATOR } from '../../../../src/utils/access';
 
 const buildSavedFilter = (creatorId: string, restrictedMembers: { id: string; access_right: string }[] | undefined): BasicStoreEntitySavedFilter => {
   return {
-    creator_id: creatorId,
+    creator_id: [creatorId],
     restricted_members: restrictedMembers,
   } as unknown as BasicStoreEntitySavedFilter;
 };
@@ -42,10 +43,17 @@ describe('isSavedFilterShared', () => {
     expect(isSavedFilterShared(filter)).toBe(true);
   });
 
+  it('should return false when shared with MEMBER_ACCESS_CREATOR only', () => {
+    const filter = buildSavedFilter('user-1', [
+      { id: MEMBER_ACCESS_CREATOR, access_right: 'admin' },
+    ]);
+    expect(isSavedFilterShared(filter)).toBe(false);
+  });
+
   it('should return true when shared with MEMBER_ACCESS_ALL', () => {
     const filter = buildSavedFilter('user-1', [
       { id: 'user-1', access_right: 'admin' },
-      { id: 'ALL', access_right: 'view' },
+      { id: MEMBER_ACCESS_ALL, access_right: 'view' },
     ]);
     expect(isSavedFilterShared(filter)).toBe(true);
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -200,73 +200,73 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
+  });
 
-    test('AI and export feature entry points increment the usage counters', async () => {
-      // GIVEN a clean telemetry state in redis
-      await redisClearTelemetry();
+  test('AI and export feature entry points increment the usage counters', async () => {
+    // GIVEN a clean telemetry state in redis
+    await redisClearTelemetry();
 
-      // WHEN the text-based Ask AI features are called with a too-short content,
-      // they short-circuit before any LLM call but still count the attempt
-      expect(await fixSpelling(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-      expect(await makeShorter(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-      expect(await makeLonger(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-      expect(await changeTone(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-      expect(await summarize(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-      expect(await explain(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    // WHEN the text-based Ask AI features are called with a too-short content,
+    // they short-circuit before any LLM call but still count the attempt
+    expect(await fixSpelling(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await makeShorter(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await makeLonger(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await changeTone(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await summarize(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await explain(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
 
-      // AND WHEN the other feature entry points are called without any AI/XTM One
-      // configuration, they fail downstream but the counters keep the attempts
-      // semantics (incremented at the entry point, before the upstream call)
-      const attempt = async (fn: () => Promise<unknown>) => {
-        try {
-          await fn();
-        } catch {
-          // Expected without an AI configuration in the test platform.
-        }
-      };
-      await attempt(() => generateContainerReport(testContext, ADMIN_USER, { containerId: 'unknown-container-id' } as never));
-      await attempt(() => summarizeFiles(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
-      await attempt(() => convertFilesToStix(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
-      await attempt(() => generateNLQresponse(testContext, ADMIN_USER, { search: 'malware targeting the energy sector' } as never));
-      await attempt(() => aiActivity(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
-      await attempt(() => aiForecast(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
-      await attempt(() => aiHistory(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
-      await attempt(() => aiSummary(testContext, ADMIN_USER, { first: 1 }));
-
-      // AND WHEN export generations are requested (no export connector registered:
-      // the calls resolve or fail downstream, the attempts are counted either way)
-      await attempt(() => askListExport(testContext, ADMIN_USER, { entity_type: 'Report' }, 'application/json', [], {}, 'simple', [], []));
-      await attempt(() => askEntityExport(testContext, ADMIN_USER, 'application/json', {
-        id: 'unknown-entity-id',
-        entity_type: 'Report',
-        name: 'unknown',
-      }, 'simple', [], []));
-
-      // THEN every Ask AI feature has been counted exactly once under its
-      // dimensional key, and the scalar NLQ / export counters as well.
-      // The counters are fire-and-forget, so poll until the writes land.
-      const allCountersUpdated = async () => {
-        for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
-          const featureValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${ASK_AI_FEATURES[featureIndex]}`);
-          if (featureValue !== 1) return false;
-        }
-        const nlqValue = await redisGetTelemetry(TELEMETRY_GAUGE_NLQ);
-        const exportValue = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
-        return nlqValue === 1 && exportValue === 2;
-      };
-      let countersUpdated = await allCountersUpdated();
-      let pollCurrent = 0;
-      while (!countersUpdated && pollCurrent < 3) {
-        await waitInSec(1);
-        countersUpdated = await allCountersUpdated();
-        pollCurrent += 1;
+    // AND WHEN the other feature entry points are called without any AI/XTM One
+    // configuration, they fail downstream but the counters keep the attempts
+    // semantics (incremented at the entry point, before the upstream call)
+    const attempt = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn();
+      } catch {
+        // Expected without an AI configuration in the test platform.
       }
+    };
+    await attempt(() => generateContainerReport(testContext, ADMIN_USER, { containerId: 'unknown-container-id' } as never));
+    await attempt(() => summarizeFiles(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
+    await attempt(() => convertFilesToStix(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
+    await attempt(() => generateNLQresponse(testContext, ADMIN_USER, { search: 'malware targeting the energy sector' } as never));
+    await attempt(() => aiActivity(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+    await attempt(() => aiForecast(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+    await attempt(() => aiHistory(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+    await attempt(() => aiSummary(testContext, ADMIN_USER, { first: 1 }));
+
+    // AND WHEN export generations are requested (no export connector registered:
+    // the calls resolve or fail downstream, the attempts are counted either way)
+    await attempt(() => askListExport(testContext, ADMIN_USER, { entity_type: 'Report' }, 'application/json', [], {}, 'simple', [], []));
+    await attempt(() => askEntityExport(testContext, ADMIN_USER, 'application/json', {
+      id: 'unknown-entity-id',
+      entity_type: 'Report',
+      name: 'unknown',
+    }, 'simple', [], []));
+
+    // THEN every Ask AI feature has been counted exactly once under its
+    // dimensional key, and the scalar NLQ / export counters as well.
+    // The counters are fire-and-forget, so poll until the writes land.
+    const allCountersUpdated = async () => {
       for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
-        const feature = ASK_AI_FEATURES[featureIndex];
-        expect(await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`), `feature ${feature} should be counted once`).toBe(1);
+        const featureValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${ASK_AI_FEATURES[featureIndex]}`);
+        if (featureValue !== 1) return false;
       }
-      expect(await redisGetTelemetry(TELEMETRY_GAUGE_NLQ)).toBe(1);
-      expect(await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED)).toBe(2);
-    });
+      const nlqValue = await redisGetTelemetry(TELEMETRY_GAUGE_NLQ);
+      const exportValue = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
+      return nlqValue === 1 && exportValue === 2;
+    };
+    let countersUpdated = await allCountersUpdated();
+    let pollCurrent = 0;
+    while (!countersUpdated && pollCurrent < 3) {
+      await waitInSec(1);
+      countersUpdated = await allCountersUpdated();
+      pollCurrent += 1;
+    }
+    for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
+      const feature = ASK_AI_FEATURES[featureIndex];
+      expect(await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`), `feature ${feature} should be counted once`).toBe(1);
+    }
+    expect(await redisGetTelemetry(TELEMETRY_GAUGE_NLQ)).toBe(1);
+    expect(await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED)).toBe(2);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -11,6 +11,56 @@ import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
 import { addSavedFilter, deleteSavedFilter, savedFilterEditAuthorizedMembers } from '../../../src/modules/savedFilter/savedFilter-domain';
 
 describe('Telemetry manager test coverage', () => {
+  let sharedFilterId: string;
+  let unsharedFilterId: string;
+  let shareWithCreatorFilterId: string;
+
+  // create shared saved filters
+  beforeAll(async () => {
+    const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
+
+    // Create a saved filter and share it (restricted_members > 1)
+    const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+      name: 'telemetry-shared-filter',
+      filters: savedFilter,
+      scope: 'Incident',
+    });
+    sharedFilterId = sharedSavedFilter.id;
+    await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
+      { id: ADMIN_USER.id, access_right: 'admin' },
+      { id: USER_EDITOR.id, access_right: 'view' },
+    ]);
+
+    // Create a saved filter that is NOT shared
+    const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+      name: 'telemetry-unshared-filter',
+      filters: savedFilter,
+      scope: 'Incident',
+    });
+    unsharedFilterId = unshareSavedFilter.id;
+
+    // Create a saved filter that is artificially shared with the creator at creation
+    const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+      name: 'telemetry-unshared-filter',
+      filters: savedFilter,
+      scope: 'Incident',
+    });
+    shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
+    await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
+      { id: ADMIN_USER.id, access_right: 'admin' },
+    ]);
+
+    // Wait for cache refresh
+    await waitInSec(2);
+  });
+
+  // delete the shared saved filters
+  afterAll(async () => {
+    await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
+    await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
+    await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
+  });
+
   test('Verify that metrics get collected from both elastic and redis', async () => {
     // GIVEN a configured telemetry
     const filigranResource = resourceFromAttributes({
@@ -68,77 +118,8 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
-  });
 
-  describe('shared_saved_filters_count telemetry', () => {
-    let sharedFilterId: string;
-    let unsharedFilterId: string;
-    let shareWithCreatorFilterId: string;
-
-    const buildMeterManager = () => {
-      const filigranResource = resourceFromAttributes({
-        [ATTR_SERVICE_NAME]: TELEMETRY_SERVICE_NAME,
-        [ATTR_SERVICE_VERSION]: PLATFORM_VERSION,
-        [ATTR_SERVICE_INSTANCE_ID]: 'api-test-telemetry-shared-filters',
-        'service.instance.creation': new Date().toUTCString(),
-      });
-      const resource = defaultResource().merge(filigranResource);
-      const meterProvider = new MeterProvider(({ resource, readers: [] }));
-      const meterManager = new TelemetryMeterManager(meterProvider);
-      meterManager.registerFiligranTelemetry();
-      return meterManager;
-    };
-
-    beforeAll(async () => {
-      const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
-
-      // Create a saved filter and share it (restricted_members > 1)
-      const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-        name: 'telemetry-shared-filter',
-        filters: savedFilter,
-        scope: 'Incident',
-      });
-      sharedFilterId = sharedSavedFilter.id;
-      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
-        { id: ADMIN_USER.id, access_right: 'admin' },
-        { id: USER_EDITOR.id, access_right: 'view' },
-      ]);
-
-      // Create a saved filter that is NOT shared
-      const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-        name: 'telemetry-unshared-filter',
-        filters: savedFilter,
-        scope: 'Incident',
-      });
-      unsharedFilterId = unshareSavedFilter.id;
-
-      // Create a saved filter that is artificially shared with the creator at creation
-      const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-        name: 'telemetry-unshared-filter',
-        filters: savedFilter,
-        scope: 'Incident',
-      });
-      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
-      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
-        { id: ADMIN_USER.id, access_right: 'admin' },
-      ]);
-
-      // Wait for cache refresh
-      await waitInSec(2);
-    });
-
-    afterAll(async () => {
-      await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
-      await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
-      await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
-    });
-
-    test('sharedSavedFiltersCount counts only filters with restricted_members > 1', async () => {
-      const meterManager = buildMeterManager();
-      await fetchTelemetryData(meterManager);
-
-      // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
-      expect(meterManager.sharedSavedFiltersCount).toEqual(1);
-    });
+    // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
+    expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -118,10 +118,10 @@ describe('Telemetry manager test coverage', () => {
         filters: savedFilter,
         scope: 'Incident',
       });
+      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
       await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
         { id: ADMIN_USER.id, access_right: 'admin' },
       ]);
-      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
 
       // Wait for cache refresh
       await waitInSec(2);

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -49,7 +49,7 @@ describe('Telemetry manager test coverage', () => {
   beforeAll(async () => {
     const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
 
-    // Create a saved filter and share it (restricted_members > 1)
+    // Create a saved filter and share it with someone else than the creator
     const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
       name: 'telemetry-shared-filter',
       filters: savedFilter,

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { ATTR_SERVICE_INSTANCE_ID, ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
@@ -37,6 +37,8 @@ import { aiActivity, aiForecast, aiHistory } from '../../../src/domain/stixCoreO
 import { aiSummary } from '../../../src/domain/container';
 import { askEntityExport, askListExport } from '../../../src/domain/stix';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
+import { addSavedFilter, deleteSavedFilter, savedFilterEditAuthorizedMembers } from '../../../src/modules/savedFilter/savedFilter-domain';
 
 describe('Telemetry manager test coverage', () => {
   test('Verify that metrics get collected from both elastic and redis', async () => {
@@ -128,6 +130,78 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
+  });
+
+  describe('shared_saved_filters_count telemetry', () => {
+    let sharedFilterId: string;
+    let unsharedFilterId: string;
+    let shareWithCreatorFilterId: string;
+
+    const buildMeterManager = () => {
+      const filigranResource = resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: TELEMETRY_SERVICE_NAME,
+        [ATTR_SERVICE_VERSION]: PLATFORM_VERSION,
+        [ATTR_SERVICE_INSTANCE_ID]: 'api-test-telemetry-shared-filters',
+        'service.instance.creation': new Date().toUTCString(),
+      });
+      const resource = defaultResource().merge(filigranResource);
+      const meterProvider = new MeterProvider(({ resource, readers: [] }));
+      const meterManager = new TelemetryMeterManager(meterProvider);
+      meterManager.registerFiligranTelemetry();
+      return meterManager;
+    };
+
+    beforeAll(async () => {
+      const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
+
+      // Create a saved filter and share it (restricted_members > 1)
+      const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-shared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      sharedFilterId = sharedSavedFilter.id;
+      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
+        { id: ADMIN_USER.id, access_right: 'admin' },
+        { id: USER_EDITOR.id, access_right: 'view' },
+      ]);
+
+      // Create a saved filter that is NOT shared
+      const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-unshared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      unsharedFilterId = unshareSavedFilter.id;
+
+      // Create a saved filter that is artificially shared with the creator at creation
+      const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-unshared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
+        { id: ADMIN_USER.id, access_right: 'admin' },
+      ]);
+      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
+
+      // Wait for cache refresh
+      await waitInSec(2);
+    });
+
+    afterAll(async () => {
+      await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
+      await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
+      await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
+    });
+
+    test('sharedSavedFiltersCount counts only filters with restricted_members > 1', async () => {
+      const meterManager = buildMeterManager();
+      await fetchTelemetryData(meterManager);
+
+      // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
+      expect(meterManager.sharedSavedFiltersCount).toEqual(1);
+    });
   });
 
   test('AI and export feature entry points increment the usage counters', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -36,7 +36,6 @@ import {
 import { aiActivity, aiForecast, aiHistory } from '../../../src/domain/stixCoreObject';
 import { aiSummary } from '../../../src/domain/container';
 import { askEntityExport, askListExport } from '../../../src/domain/stix';
-import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
 import { addSavedFilter, deleteSavedFilter, savedFilterEditAuthorizedMembers } from '../../../src/modules/savedFilter/savedFilter-domain';
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -41,6 +41,56 @@ import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
 import { addSavedFilter, deleteSavedFilter, savedFilterEditAuthorizedMembers } from '../../../src/modules/savedFilter/savedFilter-domain';
 
 describe('Telemetry manager test coverage', () => {
+  let sharedFilterId: string;
+  let unsharedFilterId: string;
+  let shareWithCreatorFilterId: string;
+
+  // create shared saved filters
+  beforeAll(async () => {
+    const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
+
+    // Create a saved filter and share it (restricted_members > 1)
+    const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+      name: 'telemetry-shared-filter',
+      filters: savedFilter,
+      scope: 'Incident',
+    });
+    sharedFilterId = sharedSavedFilter.id;
+    await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
+      { id: ADMIN_USER.id, access_right: 'admin' },
+      { id: USER_EDITOR.id, access_right: 'view' },
+    ]);
+
+    // Create a saved filter that is NOT shared
+    const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+      name: 'telemetry-unshared-filter',
+      filters: savedFilter,
+      scope: 'Incident',
+    });
+    unsharedFilterId = unshareSavedFilter.id;
+
+    // Create a saved filter that is artificially shared with the creator at creation
+    const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+      name: 'telemetry-unshared-filter',
+      filters: savedFilter,
+      scope: 'Incident',
+    });
+    shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
+    await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
+      { id: ADMIN_USER.id, access_right: 'admin' },
+    ]);
+
+    // Wait for cache refresh
+    await waitInSec(2);
+  });
+
+  // delete the shared saved filters
+  afterAll(async () => {
+    await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
+    await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
+    await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
+  });
+
   test('Verify that metrics get collected from both elastic and redis', async () => {
     // GIVEN a configured telemetry
     const filigranResource = resourceFromAttributes({
@@ -130,78 +180,9 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
-  });
 
-  describe('shared_saved_filters_count telemetry', () => {
-    let sharedFilterId: string;
-    let unsharedFilterId: string;
-    let shareWithCreatorFilterId: string;
-
-    const buildMeterManager = () => {
-      const filigranResource = resourceFromAttributes({
-        [ATTR_SERVICE_NAME]: TELEMETRY_SERVICE_NAME,
-        [ATTR_SERVICE_VERSION]: PLATFORM_VERSION,
-        [ATTR_SERVICE_INSTANCE_ID]: 'api-test-telemetry-shared-filters',
-        'service.instance.creation': new Date().toUTCString(),
-      });
-      const resource = defaultResource().merge(filigranResource);
-      const meterProvider = new MeterProvider(({ resource, readers: [] }));
-      const meterManager = new TelemetryMeterManager(meterProvider);
-      meterManager.registerFiligranTelemetry();
-      return meterManager;
-    };
-
-    beforeAll(async () => {
-      const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
-
-      // Create a saved filter and share it (restricted_members > 1)
-      const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-        name: 'telemetry-shared-filter',
-        filters: savedFilter,
-        scope: 'Incident',
-      });
-      sharedFilterId = sharedSavedFilter.id;
-      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
-        { id: ADMIN_USER.id, access_right: 'admin' },
-        { id: USER_EDITOR.id, access_right: 'view' },
-      ]);
-
-      // Create a saved filter that is NOT shared
-      const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-        name: 'telemetry-unshared-filter',
-        filters: savedFilter,
-        scope: 'Incident',
-      });
-      unsharedFilterId = unshareSavedFilter.id;
-
-      // Create a saved filter that is artificially shared with the creator at creation
-      const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-        name: 'telemetry-unshared-filter',
-        filters: savedFilter,
-        scope: 'Incident',
-      });
-      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
-      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
-        { id: ADMIN_USER.id, access_right: 'admin' },
-      ]);
-
-      // Wait for cache refresh
-      await waitInSec(2);
-    });
-
-    afterAll(async () => {
-      await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
-      await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
-      await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
-    });
-
-    test('sharedSavedFiltersCount counts only filters with restricted_members > 1', async () => {
-      const meterManager = buildMeterManager();
-      await fetchTelemetryData(meterManager);
-
-      // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
-      expect(meterManager.sharedSavedFiltersCount).toEqual(1);
-    });
+    // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
+    expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
   });
 
   test('AI and export feature entry points increment the usage counters', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -40,62 +40,10 @@ import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
 import { addSavedFilter, deleteSavedFilter, savedFilterEditAuthorizedMembers } from '../../../src/modules/savedFilter/savedFilter-domain';
 
 describe('Telemetry manager test coverage', () => {
-  let sharedFilterId: string;
-  let unsharedFilterId: string;
-  let shareWithCreatorFilterId: string;
+  let filigranTelemetryMeterManager: TelemetryMeterManager;
 
-  // create shared saved filters
-  beforeAll(async () => {
-    const savedFilter = JSON.stringify({
-      mode: 'and',
-      filters: [{ key: 'objectLabel', value: [], operator: 'nil' }],
-      filterGroups: [],
-    });
-
-    // Create a saved filter and share it with someone else than the creator
-    const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-      name: 'telemetry-shared-filter',
-      filters: savedFilter,
-      scope: 'Incident',
-    });
-    sharedFilterId = sharedSavedFilter.id;
-    await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
-      { id: ADMIN_USER.id, access_right: 'admin' },
-      { id: USER_EDITOR.id, access_right: 'view' },
-    ]);
-
-    // Create a saved filter that is NOT shared
-    const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-      name: 'telemetry-unshared-filter',
-      filters: savedFilter,
-      scope: 'Incident',
-    });
-    unsharedFilterId = unshareSavedFilter.id;
-
-    // Create a saved filter that is artificially shared with the creator at creation
-    const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
-      name: 'telemetry-unshared-filter',
-      filters: savedFilter,
-      scope: 'Incident',
-    });
-    shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
-    await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
-      { id: ADMIN_USER.id, access_right: 'admin' },
-    ]);
-
-    // Wait for cache refresh
-    await waitInSec(2);
-  });
-
-  // delete the shared saved filters
-  afterAll(async () => {
-    await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
-    await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
-    await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
-  });
-
-  test('Verify that metrics get collected from both elastic and redis', async () => {
-    // GIVEN a configured telemetry
+  beforeAll(() => {
+    // given a configured telemetry
     const filigranResource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: TELEMETRY_SERVICE_NAME,
       [ATTR_SERVICE_VERSION]: PLATFORM_VERSION,
@@ -103,12 +51,81 @@ describe('Telemetry manager test coverage', () => {
       'service.instance.creation': new Date().toUTCString(),
     });
     const resource = defaultResource().merge(filigranResource);
-
     // no readers so no data is sent for this test
     const filigranMeterProvider = new MeterProvider(({ resource, readers: [] }));
-    const filigranTelemetryMeterManager = new TelemetryMeterManager(filigranMeterProvider);
+    filigranTelemetryMeterManager = new TelemetryMeterManager(filigranMeterProvider);
     filigranTelemetryMeterManager.registerFiligranTelemetry();
-    // AND Given starting from clean state in redis
+  });
+
+  describe('Verify saved filters telemetry metrics get collected', () => {
+    let sharedFilterId: string;
+    let unsharedFilterId: string;
+    let shareWithCreatorFilterId: string;
+
+    beforeAll(async () => {
+      // create shared saved filters
+
+      const savedFilter = JSON.stringify({
+        mode: 'and',
+        filters: [{ key: 'objectLabel', value: [], operator: 'nil' }],
+        filterGroups: [],
+      });
+
+      // Create a saved filter and share it with someone else than the creator
+      const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-shared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      sharedFilterId = sharedSavedFilter.id;
+      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
+        { id: ADMIN_USER.id, access_right: 'admin' },
+        { id: USER_EDITOR.id, access_right: 'view' },
+      ]);
+
+      // Create a saved filter that is NOT shared
+      const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-unshared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      unsharedFilterId = unshareSavedFilter.id;
+
+      // Create a saved filter that is artificially shared with the creator at creation
+      const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-unshared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
+      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
+        { id: ADMIN_USER.id, access_right: 'admin' },
+      ]);
+
+      // Wait for cache refresh and fire-and-forget Redis writes
+      await waitInSec(2);
+    });
+
+    afterAll(async () => {
+      // delete the shared saved filters
+      await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
+      await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
+      await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
+    });
+
+    test('shared saved filters count and permission changes are collected', async () => {
+      // WHEN telemetry data is fetched after filter creation
+      await fetchTelemetryData(filigranTelemetryMeterManager);
+
+      // THEN 1 shared saved filter should be counted (shared with non-creator members)
+      expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
+      // AND 1 permission change event was recorded (the share with USER_EDITOR)
+      expect(filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount).toEqual(1);
+    });
+  });
+
+  test('Verify that metrics get collected from both elastic and redis', async () => {
+    // GIVEN starting from clean state in redis
     await redisClearTelemetry();
     const disseminationGaugeValueReset = await redisGetTelemetry(TELEMETRY_GAUGE_DISSEMINATION);
     expect(disseminationGaugeValueReset).toBe(0);
@@ -183,10 +200,6 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
-
-    // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with other members than just the creator
-    expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
-    expect(filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount).toEqual(1);
 
     test('AI and export feature entry points increment the usage counters', async () => {
       // GIVEN a clean telemetry state in redis

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -19,7 +19,7 @@ describe('Telemetry manager test coverage', () => {
   beforeAll(async () => {
     const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
 
-    // Create a saved filter and share it (restricted_members > 1)
+    // Create a saved filter and share it with someone else than the creator
     const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
       name: 'telemetry-shared-filter',
       filters: savedFilter,

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { defaultResource, resourceFromAttributes } from '@opentelemetry/resources';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { ATTR_SERVICE_INSTANCE_ID, ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
@@ -7,6 +7,8 @@ import { PLATFORM_VERSION } from '../../../src/config/conf';
 import { addDisseminationCount, fetchTelemetryData, TELEMETRY_GAUGE_DISSEMINATION, TELEMETRY_GAUGE_DRAFT_CREATION } from '../../../src/manager/telemetryManager';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../../../src/database/redis';
 import { waitInSec } from '../../../src/database/utils';
+import { ADMIN_USER, testContext, USER_EDITOR } from '../../utils/testQuery';
+import { addSavedFilter, deleteSavedFilter, savedFilterEditAuthorizedMembers } from '../../../src/modules/savedFilter/savedFilter-domain';
 
 describe('Telemetry manager test coverage', () => {
   test('Verify that metrics get collected from both elastic and redis', async () => {
@@ -66,5 +68,77 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
+  });
+
+  describe('shared_saved_filters_count telemetry', () => {
+    let sharedFilterId: string;
+    let unsharedFilterId: string;
+    let shareWithCreatorFilterId: string;
+
+    const buildMeterManager = () => {
+      const filigranResource = resourceFromAttributes({
+        [ATTR_SERVICE_NAME]: TELEMETRY_SERVICE_NAME,
+        [ATTR_SERVICE_VERSION]: PLATFORM_VERSION,
+        [ATTR_SERVICE_INSTANCE_ID]: 'api-test-telemetry-shared-filters',
+        'service.instance.creation': new Date().toUTCString(),
+      });
+      const resource = defaultResource().merge(filigranResource);
+      const meterProvider = new MeterProvider(({ resource, readers: [] }));
+      const meterManager = new TelemetryMeterManager(meterProvider);
+      meterManager.registerFiligranTelemetry();
+      return meterManager;
+    };
+
+    beforeAll(async () => {
+      const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
+
+      // Create a saved filter and share it (restricted_members > 1)
+      const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-shared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      sharedFilterId = sharedSavedFilter.id;
+      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, sharedFilterId, [
+        { id: ADMIN_USER.id, access_right: 'admin' },
+        { id: USER_EDITOR.id, access_right: 'view' },
+      ]);
+
+      // Create a saved filter that is NOT shared
+      const unshareSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-unshared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      unsharedFilterId = unshareSavedFilter.id;
+
+      // Create a saved filter that is artificially shared with the creator at creation
+      const shareWithCreatorSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
+        name: 'telemetry-unshared-filter',
+        filters: savedFilter,
+        scope: 'Incident',
+      });
+      await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
+        { id: ADMIN_USER.id, access_right: 'admin' },
+      ]);
+      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
+
+      // Wait for cache refresh
+      await waitInSec(2);
+    });
+
+    afterAll(async () => {
+      await deleteSavedFilter(testContext, ADMIN_USER, sharedFilterId);
+      await deleteSavedFilter(testContext, ADMIN_USER, unsharedFilterId);
+      await deleteSavedFilter(testContext, ADMIN_USER, shareWithCreatorFilterId);
+    });
+
+    test('sharedSavedFiltersCount counts only filters with restricted_members > 1', async () => {
+      const meterManager = buildMeterManager();
+      await fetchTelemetryData(meterManager);
+
+      // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
+      expect(meterManager.sharedSavedFiltersCount).toEqual(1);
+    });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -46,7 +46,11 @@ describe('Telemetry manager test coverage', () => {
 
   // create shared saved filters
   beforeAll(async () => {
-    const savedFilter = JSON.stringify({ mode: 'and', filters: [{ key: 'objectLabel', value: [], operator: 'nil' }], filterGroups: [] });
+    const savedFilter = JSON.stringify({
+      mode: 'and',
+      filters: [{ key: 'objectLabel', value: [], operator: 'nil' }],
+      filterGroups: [],
+    });
 
     // Create a saved filter and share it with someone else than the creator
     const sharedSavedFilter = await addSavedFilter(testContext, ADMIN_USER, {
@@ -180,71 +184,76 @@ describe('Telemetry manager test coverage', () => {
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
 
-    // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with others than just the creator
+    // 1 shared saved filter should be counted: sharedSavedFilter, because it is shared with other members than just the creator
     expect(filigranTelemetryMeterManager.sharedSavedFiltersCount).toEqual(1);
-  });
+    expect(filigranTelemetryMeterManager.sharedSavedFiltersPermissionChangesCount).toEqual(1);
 
-  test('AI and export feature entry points increment the usage counters', async () => {
-    // GIVEN a clean telemetry state in redis
-    await redisClearTelemetry();
+    test('AI and export feature entry points increment the usage counters', async () => {
+      // GIVEN a clean telemetry state in redis
+      await redisClearTelemetry();
 
-    // WHEN the text-based Ask AI features are called with a too-short content,
-    // they short-circuit before any LLM call but still count the attempt
-    expect(await fixSpelling(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-    expect(await makeShorter(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-    expect(await makeLonger(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-    expect(await changeTone(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-    expect(await summarize(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
-    expect(await explain(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+      // WHEN the text-based Ask AI features are called with a too-short content,
+      // they short-circuit before any LLM call but still count the attempt
+      expect(await fixSpelling(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+      expect(await makeShorter(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+      expect(await makeLonger(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+      expect(await changeTone(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+      expect(await summarize(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+      expect(await explain(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
 
-    // AND WHEN the other feature entry points are called without any AI/XTM One
-    // configuration, they fail downstream but the counters keep the attempts
-    // semantics (incremented at the entry point, before the upstream call)
-    const attempt = async (fn: () => Promise<unknown>) => {
-      try {
-        await fn();
-      } catch {
-        // Expected without an AI configuration in the test platform.
+      // AND WHEN the other feature entry points are called without any AI/XTM One
+      // configuration, they fail downstream but the counters keep the attempts
+      // semantics (incremented at the entry point, before the upstream call)
+      const attempt = async (fn: () => Promise<unknown>) => {
+        try {
+          await fn();
+        } catch {
+          // Expected without an AI configuration in the test platform.
+        }
+      };
+      await attempt(() => generateContainerReport(testContext, ADMIN_USER, { containerId: 'unknown-container-id' } as never));
+      await attempt(() => summarizeFiles(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
+      await attempt(() => convertFilesToStix(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
+      await attempt(() => generateNLQresponse(testContext, ADMIN_USER, { search: 'malware targeting the energy sector' } as never));
+      await attempt(() => aiActivity(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+      await attempt(() => aiForecast(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+      await attempt(() => aiHistory(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+      await attempt(() => aiSummary(testContext, ADMIN_USER, { first: 1 }));
+
+      // AND WHEN export generations are requested (no export connector registered:
+      // the calls resolve or fail downstream, the attempts are counted either way)
+      await attempt(() => askListExport(testContext, ADMIN_USER, { entity_type: 'Report' }, 'application/json', [], {}, 'simple', [], []));
+      await attempt(() => askEntityExport(testContext, ADMIN_USER, 'application/json', {
+        id: 'unknown-entity-id',
+        entity_type: 'Report',
+        name: 'unknown',
+      }, 'simple', [], []));
+
+      // THEN every Ask AI feature has been counted exactly once under its
+      // dimensional key, and the scalar NLQ / export counters as well.
+      // The counters are fire-and-forget, so poll until the writes land.
+      const allCountersUpdated = async () => {
+        for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
+          const featureValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${ASK_AI_FEATURES[featureIndex]}`);
+          if (featureValue !== 1) return false;
+        }
+        const nlqValue = await redisGetTelemetry(TELEMETRY_GAUGE_NLQ);
+        const exportValue = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
+        return nlqValue === 1 && exportValue === 2;
+      };
+      let countersUpdated = await allCountersUpdated();
+      let pollCurrent = 0;
+      while (!countersUpdated && pollCurrent < 3) {
+        await waitInSec(1);
+        countersUpdated = await allCountersUpdated();
+        pollCurrent += 1;
       }
-    };
-    await attempt(() => generateContainerReport(testContext, ADMIN_USER, { containerId: 'unknown-container-id' } as never));
-    await attempt(() => summarizeFiles(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
-    await attempt(() => convertFilesToStix(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
-    await attempt(() => generateNLQresponse(testContext, ADMIN_USER, { search: 'malware targeting the energy sector' } as never));
-    await attempt(() => aiActivity(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
-    await attempt(() => aiForecast(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
-    await attempt(() => aiHistory(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
-    await attempt(() => aiSummary(testContext, ADMIN_USER, { first: 1 }));
-
-    // AND WHEN export generations are requested (no export connector registered:
-    // the calls resolve or fail downstream, the attempts are counted either way)
-    await attempt(() => askListExport(testContext, ADMIN_USER, { entity_type: 'Report' }, 'application/json', [], {}, 'simple', [], []));
-    await attempt(() => askEntityExport(testContext, ADMIN_USER, 'application/json', { id: 'unknown-entity-id', entity_type: 'Report', name: 'unknown' }, 'simple', [], []));
-
-    // THEN every Ask AI feature has been counted exactly once under its
-    // dimensional key, and the scalar NLQ / export counters as well.
-    // The counters are fire-and-forget, so poll until the writes land.
-    const allCountersUpdated = async () => {
       for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
-        const featureValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${ASK_AI_FEATURES[featureIndex]}`);
-        if (featureValue !== 1) return false;
+        const feature = ASK_AI_FEATURES[featureIndex];
+        expect(await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`), `feature ${feature} should be counted once`).toBe(1);
       }
-      const nlqValue = await redisGetTelemetry(TELEMETRY_GAUGE_NLQ);
-      const exportValue = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
-      return nlqValue === 1 && exportValue === 2;
-    };
-    let countersUpdated = await allCountersUpdated();
-    let pollCurrent = 0;
-    while (!countersUpdated && pollCurrent < 3) {
-      await waitInSec(1);
-      countersUpdated = await allCountersUpdated();
-      pollCurrent += 1;
-    }
-    for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
-      const feature = ASK_AI_FEATURES[featureIndex];
-      expect(await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`), `feature ${feature} should be counted once`).toBe(1);
-    }
-    expect(await redisGetTelemetry(TELEMETRY_GAUGE_NLQ)).toBe(1);
-    expect(await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED)).toBe(2);
+      expect(await redisGetTelemetry(TELEMETRY_GAUGE_NLQ)).toBe(1);
+      expect(await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED)).toBe(2);
+    });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -180,10 +180,10 @@ describe('Telemetry manager test coverage', () => {
         filters: savedFilter,
         scope: 'Incident',
       });
+      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
       await savedFilterEditAuthorizedMembers(testContext, ADMIN_USER, shareWithCreatorFilterId, [
         { id: ADMIN_USER.id, access_right: 'admin' },
       ]);
-      shareWithCreatorFilterId = shareWithCreatorSavedFilter.id;
 
       // Wait for cache refresh
       await waitInSec(2);


### PR DESCRIPTION
### Proposed changes
Add telemetry for shared saved filters:
- shared_saved_filters_count: Number of shared saved filters, ie number of saved filters shared with others members than just the creator
- shared_saved_filters_permission_changes: Number of access restriction updates on shared saved filters

### Related issues
closes #11624