### PR TITLE
fix(jsonmapper): add maxRecords parameter to jsonMappingExecution (#16921)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -162,7 +162,8 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
       });
       const paginationVariables = buildQueryObject(ingestion.query_attributes, { ...paginationData, ...responseHeaders }, false);
       nextExecutionState = { ...nextExecutionState, ...paginationVariables };
-      const paginationObjects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, paginationData, jsonMapperParsed);
+      const maxObjects = maxResults === 0 ? 0 : maxResults - objects.length;
+      const paginationObjects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, paginationData, jsonMapperParsed, maxObjects);
       if (paginationObjects.length > 0) {
         objects = objects.concat(paginationObjects);
       }

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -147,7 +147,7 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
   };
   const platformUsers = await getEntitiesMapFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
   const ingestionUser = ingestion.user_id ? platformUsers.get(ingestion.user_id) : null;
-  let objects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, requestData, jsonMapperParsed);
+  let objects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, requestData, jsonMapperParsed, maxResults);
   let nextExecutionState = buildQueryObject(ingestion.query_attributes, { ...requestData, ...responseHeaders }, false);
   // region Try to paginate with next page style
   if (ingestion.pagination_with_sub_page && isNotEmptyField(ingestion.pagination_with_sub_page_attribute_path)) {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -163,7 +163,7 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
   };
   const platformUsers = await getEntitiesMapFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
   const ingestionUser = ingestion.user_id ? platformUsers.get(ingestion.user_id) : null;
-  let objects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, requestData, jsonMapperParsed);
+  let objects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, requestData, jsonMapperParsed, maxResults);
   let nextExecutionState = buildQueryObject(ingestion.query_attributes, { ...requestData, ...responseHeaders }, false);
   // region Try to paginate with next page style
   if (ingestion.pagination_with_sub_page && isNotEmptyField(ingestion.pagination_with_sub_page_attribute_path)) {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -178,7 +178,8 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
       });
       const paginationVariables = buildQueryObject(ingestion.query_attributes, { ...paginationData, ...responseHeaders }, false);
       nextExecutionState = { ...nextExecutionState, ...paginationVariables };
-      const paginationObjects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, paginationData, jsonMapperParsed);
+      const maxObjects = maxResults === 0 ? 0 : maxResults - objects.length;
+      const paginationObjects = await jsonMappingExecution(context, ingestionUser || SYSTEM_USER, paginationData, jsonMapperParsed, maxObjects);
       if (paginationObjects.length > 0) {
         objects = objects.concat(paginationObjects);
       }

--- a/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-domain.ts
@@ -37,7 +37,7 @@ export const jsonMapperTest = async (context: AuthContext, user: AuthUser, confi
   const jsonMapperParsed = parseJsonMapper(parsedConfiguration);
   const { createReadStream } = await fileUpload;
   const data: string = await streamConverter(createReadStream());
-  const allObjects = await jsonMappingExecution(context, user, data, jsonMapperParsed);
+  const allObjects = await jsonMappingExecution(context, user, data, jsonMapperParsed, 50);
   return {
     objects: JSON.stringify(allObjects.slice(0, 50), null, 2), // Max 50 records to display
     nbRelationships: allObjects.filter((object) => object.type === 'relationship').length,

--- a/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
@@ -346,7 +346,7 @@ const computeOrderedRepresentations = (representations: JsonMapperRepresentation
   return [baseEntities, basedOnEntities, relationships];
 };
 
-const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: string | object, mapper: JsonMapperParsed, variables: Record<string, unknown> = {}) => {
+const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: string | object, mapper: JsonMapperParsed, maxRecords = 0, variables: Record<string, unknown> = {}) => {
   const refEntities = await handleRefEntities(context, SYSTEM_USER, mapper);
   const chosenMarkings = mapper.user_chosen_markings ?? [];
   const results = new Map<string, Map<string, Record<string, InputType>>>();
@@ -356,6 +356,7 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
 
   const processInput = (representation: JsonMapperRepresentation, input: any) => {
     let stixObject: StixObject | undefined;
+    let continueProcessing = true;
     try {
       stixObject = convertStoreToStix_2_1(input as unknown as StoreCommon);
     } catch (e) {
@@ -365,6 +366,9 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
     if (stixObject && !seenIds.has(stixObject.id)) {
       seenIds.add(stixObject.id);
       finalObjects.push(stixObject);
+      if (maxRecords !== 0 && finalObjects.length >= maxRecords) {
+        continueProcessing = false;
+      }
     }
 
     if (representation.type === JsonMapperRepresentationType.Relationship) {
@@ -385,6 +389,7 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
     } else {
       results.set(representation.id, new Map([[input.__identifier, input]]));
     }
+    return continueProcessing;
   };
 
   const baseJson = typeof data === 'string' ? JSON.parse(data) : data;
@@ -464,7 +469,10 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
                 inputNew.to = to;
                 inputNew.toType = toType;
                 inputNew.standard_id = generateStandardId(inputNew.entity_type, inputNew);
-                processInput(representation, inputNew);
+                const continueProcessing = processInput(representation, inputNew);
+                if (!continueProcessing) {
+                  return finalObjects;
+                }
               }
             }
           } else {
@@ -475,7 +483,10 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
             } else {
               input.__identifier = uuidv4();
             }
-            processInput(representation, input);
+            const continueProcessing = processInput(representation, input);
+            if (!continueProcessing) {
+              return finalObjects;
+            }
           }
         }
       }

--- a/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
@@ -346,7 +346,14 @@ const computeOrderedRepresentations = (representations: JsonMapperRepresentation
   return [baseEntities, basedOnEntities, relationships];
 };
 
-const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: string | object, mapper: JsonMapperParsed, maxRecords = 0, variables: Record<string, unknown> = {}) => {
+const jsonMappingExecution = async (
+  context: AuthContext,
+  user: AuthUser,
+  data: string | object,
+  mapper: JsonMapperParsed,
+  maxRecords = 0,
+  variables: Record<string, unknown> = {},
+) => {
   const refEntities = await handleRefEntities(context, SYSTEM_USER, mapper);
   const chosenMarkings = mapper.user_chosen_markings ?? [];
   const results = new Map<string, Map<string, Record<string, InputType>>>();

--- a/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
@@ -347,7 +347,7 @@ const computeOrderedRepresentations = (representations: JsonMapperRepresentation
   return [baseEntities, basedOnEntities, relationships];
 };
 
-const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: string | object, mapper: JsonMapperParsed, variables: Record<string, unknown> = {}) => {
+const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: string | object, mapper: JsonMapperParsed, maxRecords = 0, variables: Record<string, unknown> = {}) => {
   const refEntities = await handleRefEntities(context, SYSTEM_USER, mapper);
   const chosenMarkings = mapper.user_chosen_markings ?? [];
   const results = new Map<string, Map<string, Record<string, InputType>>>();
@@ -357,6 +357,7 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
 
   const processInput = (representation: JsonMapperRepresentation, input: any) => {
     let stixObject: StixObject | undefined;
+    let continueProcessing = true;
     try {
       stixObject = convertStoreToStix_2_1(input as unknown as StoreCommon);
     } catch (e) {
@@ -366,6 +367,9 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
     if (stixObject && !seenIds.has(stixObject.id)) {
       seenIds.add(stixObject.id);
       finalObjects.push(stixObject);
+      if (maxRecords !== 0 && finalObjects.length >= maxRecords) {
+        continueProcessing = false;
+      }
     }
 
     if (representation.type === JsonMapperRepresentationType.Relationship) {
@@ -386,6 +390,7 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
     } else {
       results.set(representation.id, new Map([[input.__identifier, input]]));
     }
+    return continueProcessing;
   };
 
   const baseJson = typeof data === 'string' ? JSON.parse(data) : data;
@@ -465,7 +470,10 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
                 inputNew.to = to;
                 inputNew.toType = toType;
                 inputNew.standard_id = generateStandardId(inputNew.entity_type, inputNew);
-                processInput(representation, inputNew);
+                const continueProcessing = processInput(representation, inputNew);
+                if (!continueProcessing) {
+                  return finalObjects;
+                }
               }
             }
           } else {
@@ -476,7 +484,10 @@ const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: 
             } else {
               input.__identifier = uuidv4();
             }
-            processInput(representation, input);
+            const continueProcessing = processInput(representation, input);
+            if (!continueProcessing) {
+              return finalObjects;
+            }
           }
         }
       }

--- a/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
+++ b/opencti-platform/opencti-graphql/src/parser/json-mapper.ts
@@ -347,7 +347,14 @@ const computeOrderedRepresentations = (representations: JsonMapperRepresentation
   return [baseEntities, basedOnEntities, relationships];
 };
 
-const jsonMappingExecution = async (context: AuthContext, user: AuthUser, data: string | object, mapper: JsonMapperParsed, maxRecords = 0, variables: Record<string, unknown> = {}) => {
+const jsonMappingExecution = async (
+  context: AuthContext,
+  user: AuthUser,
+  data: string | object,
+  mapper: JsonMapperParsed,
+  maxRecords = 0,
+  variables: Record<string, unknown> = {},
+) => {
   const refEntities = await handleRefEntities(context, SYSTEM_USER, mapper);
   const chosenMarkings = mapper.user_chosen_markings ?? [];
   const results = new Map<string, Map<string, Record<string, InputType>>>();

--- a/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
@@ -69,7 +69,7 @@ describe('JSON mapper testing', () => {
     expect(organization.identity_class).toBe('organization');
   });
   it('should misp correctly parsed', async () => {
-    const objects = await jsonMappingExecution(testContext, ADMIN_USER, misp_data, misp_mapper, { externalUri: 'http://localhost' });
+    const objects = await jsonMappingExecution(testContext, ADMIN_USER, misp_data, misp_mapper, 0, { externalUri: 'http://localhost' });
     const { mapById, mapByType } = buildMaps(objects);
     expect(mapByType.get('marking-definition').length).toBe(1);
     expect(mapByType.get('location').length).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/parser/json-parser-test.js
@@ -71,7 +71,7 @@ describe('JSON mapper testing', () => {
     expect(organization.identity_class).toBe('organization');
   });
   it('should misp correctly parsed', async () => {
-    const objects = await jsonMappingExecution(testContext, ADMIN_USER, misp_data, misp_mapper, { externalUri: 'http://localhost' });
+    const objects = await jsonMappingExecution(testContext, ADMIN_USER, misp_data, misp_mapper, 0, { externalUri: 'http://localhost' });
     const { mapById, mapByType } = buildMaps(objects);
     expect(mapByType.get('marking-definition').length).toBe(1);
     expect(mapByType.get('location').length).toBe(1);

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
@@ -1,9 +1,10 @@
 import { Readable } from 'node:stream';
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { addIngestionJson, deleteIngestionJson, ingestionJsonEditField, testJsonIngestionMapping } from '../../../../src/modules/ingestion/ingestion-json-domain';
 import { ADMIN_USER, testContext } from '../../../utils/testQuery';
 import { type EditInput, IngestionAuthType, type IngestionJsonAddInput, JsonMapperRepresentationType } from '../../../../src/generated/graphql';
 import * as ingestionConfigMock from '../../../../src/manager/ingestionManager/ingestionManagerConfiguration';
+import * as httpClientModule from '../../../../src/utils/http-client';
 import type { BasicStoreEntityIngestionJson } from '../../../../src/modules/ingestion/ingestion-types';
 import { createJsonMapper, deleteJsonMapper, jsonMapperTest } from '../../../../src/modules/internal/jsonMapper/jsonMapper-domain';
 import type { FileUploadData } from '../../../../src/database/file-storage';
@@ -198,6 +199,106 @@ describe('Ingestion Json domain - complex path coverage', async () => {
     expect(result.nbRelationships).toBe(0);
     expect(parsedObjects[0].name).toBe('tool-1');
     expect(parsedObjects[49].name).toBe('tool-50');
+    expect(parsedObjects.some((o: any) => o.name === 'tool-51')).toBe(false);
+  });
+});
+
+describe('Ingestion Json domain - ingestionJsonTester mutation (testJsonIngestionMapping)', async () => {
+  let mapperId: string;
+
+  // A minimal tool-only representation used in the limit test below
+  const simpleToolRepresentations = [
+    {
+      id: 'tool-rep',
+      type: JsonMapperRepresentationType.Entity,
+      target: {
+        entity_type: ENTITY_TYPE_TOOL,
+        path: '$.objects[?(@.type == "tool")]',
+      },
+      attributes: [
+        {
+          mode: 'simple',
+          key: 'name',
+          attr_path: { path: '$.name' },
+        },
+      ],
+    },
+  ];
+
+  beforeAll(async () => {
+    const mapper = await createJsonMapper(testContext, ADMIN_USER, {
+      name: 'IngestionJsonTester Test Mapper',
+      representations: JSON.stringify(simpleToolRepresentations),
+    });
+    mapperId = mapper.id;
+  });
+
+  afterAll(async () => {
+    if (mapperId) {
+      await deleteJsonMapper(testContext, ADMIN_USER, mapperId);
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const buildMockHttpClient = (responseData: unknown) => ({
+    call: vi.fn().mockResolvedValue({ data: responseData, headers: {} }),
+  });
+
+  it('should testJsonIngestionMapping return parsed entities from the mocked HTTP response', async () => {
+    vi.spyOn(httpClientModule, 'getHttpClient').mockReturnValue(buildMockHttpClient(JSON.parse(stixBundleDataFormulaMatrix)) as any);
+
+    // stixBundleDataFormulaMatrix contains 3 tools (7-Zip, 3proxy, 16Shop) with no orgs matched by the simple mapper
+    const input: IngestionJsonAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'IngestionJsonTester happy-path feed',
+      uri: 'https://example.com/feed.json',
+      user_id: ADMIN_USER.id,
+      json_mapper_id: mapperId,
+      verb: 'GET',
+    };
+
+    const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
+
+    expect(result).toBeDefined();
+    // The simple mapper only picks up tools (3 tools in the bundle)
+    expect(result.nbEntities).toBe(3);
+    expect(result.nbRelationships).toBe(0);
+
+    const parsedObjects = JSON.parse(result.objects);
+    expect(parsedObjects.length).toBe(3);
+    const names = parsedObjects.map((o: any) => o.name);
+    expect(names).toContain('7-Zip');
+    expect(names).toContain('3proxy');
+    expect(names).toContain('16Shop');
+  });
+
+  it('should testJsonIngestionMapping cap results at 50 when the feed returns more than 50 objects', async () => {
+    const manyTools = Array.from({ length: 60 }, (_, i) => ({
+      type: 'tool',
+      name: `tool-${i + 1}`,
+    }));
+
+    vi.spyOn(httpClientModule, 'getHttpClient').mockReturnValue(buildMockHttpClient({ objects: manyTools }) as any);
+
+    const input: IngestionJsonAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'IngestionJsonTester limit-50 feed',
+      uri: 'https://example.com/feed-large.json',
+      user_id: ADMIN_USER.id,
+      json_mapper_id: mapperId,
+      verb: 'GET',
+    };
+
+    const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
+    const parsedObjects = JSON.parse(result.objects);
+
+    // Feed has 60 tools but the mutation limits execution to 50
+    expect(manyTools.length).toBeGreaterThan(50);
+    expect(parsedObjects.length).toBeLessThanOrEqual(50);
+    expect(result.nbEntities).toBeLessThanOrEqual(50);
     expect(parsedObjects.some((o: any) => o.name === 'tool-51')).toBe(false);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
@@ -258,6 +258,7 @@ describe('Ingestion Json domain - ingestionJsonTester mutation (testJsonIngestio
       user_id: ADMIN_USER.id,
       json_mapper_id: mapperId,
       verb: 'GET',
+      body: '',
     };
 
     const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
@@ -290,6 +291,7 @@ describe('Ingestion Json domain - ingestionJsonTester mutation (testJsonIngestio
       user_id: ADMIN_USER.id,
       json_mapper_id: mapperId,
       verb: 'GET',
+      body: '',
     };
 
     const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
@@ -203,6 +203,127 @@ describe('Ingestion Json domain - complex path coverage', async () => {
   });
 });
 
+describe('Ingestion Json domain - pagination with sub-page coverage', async () => {
+  let mapperId: string;
+
+  const simpleToolRepresentations = [
+    {
+      id: 'tool-rep-pagination',
+      type: JsonMapperRepresentationType.Entity,
+      target: {
+        entity_type: ENTITY_TYPE_TOOL,
+        path: '$.objects[?(@.type == "tool")]',
+      },
+      attributes: [
+        {
+          mode: 'simple',
+          key: 'name',
+          attr_path: { path: '$.name' },
+        },
+      ],
+    },
+  ];
+
+  beforeAll(async () => {
+    const mapper = await createJsonMapper(testContext, ADMIN_USER, {
+      name: 'Pagination Sub-Page Test Mapper',
+      representations: JSON.stringify(simpleToolRepresentations),
+    });
+    mapperId = mapper.id;
+  });
+
+  afterAll(async () => {
+    if (mapperId) {
+      await deleteJsonMapper(testContext, ADMIN_USER, mapperId);
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should follow the next-page URL and combine results from multiple pages', async () => {
+    const page1Data = {
+      objects: Array.from({ length: 5 }, (_, i) => ({ type: 'tool', name: `tool-page1-${i + 1}` })),
+      next_url: 'https://example.com/feed?page=2',
+    };
+    const page2Data = {
+      objects: Array.from({ length: 5 }, (_, i) => ({ type: 'tool', name: `tool-page2-${i + 1}` })),
+      // no next_url → pagination stops
+    };
+
+    const callMock = vi.fn()
+      .mockResolvedValueOnce({ data: page1Data, headers: {} })
+      .mockResolvedValueOnce({ data: page2Data, headers: {} });
+
+    vi.spyOn(httpClientModule, 'getHttpClient').mockReturnValue({ call: callMock } as any);
+
+    const input: IngestionJsonAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'Pagination sub-page feed',
+      uri: 'https://example.com/feed.json',
+      user_id: ADMIN_USER.id,
+      json_mapper_id: mapperId,
+      verb: 'GET',
+      body: '',
+      pagination_with_sub_page: true,
+      pagination_with_sub_page_attribute_path: '$.next_url',
+    };
+
+    const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
+    const parsedObjects = JSON.parse(result.objects);
+
+    // Both pages were fetched
+    expect(callMock).toHaveBeenCalledTimes(2);
+    // 5 tools from page 1 + 5 tools from page 2 = 10 total
+    expect(result.nbEntities).toBe(10);
+    expect(result.nbRelationships).toBe(0);
+    expect(parsedObjects.some((o: any) => o.name === 'tool-page1-1')).toBe(true);
+    expect(parsedObjects.some((o: any) => o.name === 'tool-page2-5')).toBe(true);
+  });
+
+  it('should stop pagination at 50-object cap even when sub-pages would exceed it', async () => {
+    // Page 1: 40 tools + next_url
+    const page1Data = {
+      objects: Array.from({ length: 40 }, (_, i) => ({ type: 'tool', name: `tool-p1-${i + 1}` })),
+      next_url: 'https://example.com/feed?page=2',
+    };
+    // Page 2: 20 tools (would bring total to 60, but cap is 50)
+    const page2Data = {
+      objects: Array.from({ length: 20 }, (_, i) => ({ type: 'tool', name: `tool-p2-${i + 1}` })),
+    };
+
+    const callMock = vi.fn()
+      .mockResolvedValueOnce({ data: page1Data, headers: {} })
+      .mockResolvedValueOnce({ data: page2Data, headers: {} });
+
+    vi.spyOn(httpClientModule, 'getHttpClient').mockReturnValue({ call: callMock } as any);
+
+    const input: IngestionJsonAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'Pagination cap-50 feed',
+      uri: 'https://example.com/feed-large.json',
+      user_id: ADMIN_USER.id,
+      json_mapper_id: mapperId,
+      verb: 'GET',
+      body: '',
+      pagination_with_sub_page: true,
+      pagination_with_sub_page_attribute_path: '$.next_url',
+    };
+
+    const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
+    const parsedObjects = JSON.parse(result.objects);
+
+    // Result must be capped at 50 even though page1 (40) + page2 (20) = 60
+    expect(parsedObjects.length).toBeLessThanOrEqual(50);
+    expect(result.nbEntities).toBeLessThanOrEqual(50);
+    // tool-p1-1 is from page 1, must be present
+    expect(parsedObjects.some((o: any) => o.name === 'tool-p1-1')).toBe(true);
+    // tool-p2-11 would be the 51st object, must NOT be present
+    expect(parsedObjects.some((o: any) => o.name === 'tool-p2-11')).toBe(false);
+  });
+});
+
 describe('Ingestion Json domain - ingestionJsonTester mutation (testJsonIngestionMapping)', async () => {
   let mapperId: string;
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
@@ -2,12 +2,13 @@ import { Readable } from 'node:stream';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { addIngestionJson, deleteIngestionJson, ingestionJsonEditField, testJsonIngestionMapping } from '../../../../src/modules/ingestion/ingestion-json-domain';
 import { ADMIN_USER, testContext } from '../../../utils/testQuery';
-import { type EditInput, IngestionAuthType, type IngestionJsonAddInput } from '../../../../src/generated/graphql';
+import { type EditInput, IngestionAuthType, type IngestionJsonAddInput, JsonMapperRepresentationType } from '../../../../src/generated/graphql';
 import * as ingestionConfigMock from '../../../../src/manager/ingestionManager/ingestionManagerConfiguration';
 import type { BasicStoreEntityIngestionJson } from '../../../../src/modules/ingestion/ingestion-types';
 import { createJsonMapper, deleteJsonMapper, jsonMapperTest } from '../../../../src/modules/internal/jsonMapper/jsonMapper-domain';
 import type { FileUploadData } from '../../../../src/database/file-storage';
 import { regexpTestData, representationsFormulaMatrix, representationsRegExpr, stixBundleDataFormulaMatrix } from './ingestionManager-testData/ingestion-json-data';
+import { ENTITY_TYPE_TOOL } from '../../../../src/schema/stixDomainObject';
 
 describe('Ingestion Json domain - Deny list coverage', async () => {
   let myJsonFeed: BasicStoreEntityIngestionJson;
@@ -155,5 +156,48 @@ describe('Ingestion Json domain - complex path coverage', async () => {
 
     // "No reference available." -> no match, returns original description
     expect(sliver.description).toBe('Open-source adversary emulation framework. No reference available.');
+  });
+
+  it('should stop jsonMapperTest parsing at 50 objects when input contains more records', async () => {
+    const representations = [{
+      id: 'tool-representation-limit-50',
+      type: JsonMapperRepresentationType.Entity,
+      target: {
+        entity_type: ENTITY_TYPE_TOOL,
+        path: '$.objects[?(@.type == "tool")]',
+      },
+      attributes: [{
+        mode: 'simple',
+        key: 'name',
+        attr_path: { path: '$.name' },
+      }],
+    }];
+
+    const toolObjects = Array.from({ length: 60 }, (_, index) => ({
+      type: 'tool',
+      name: `tool-${index + 1}`,
+    }));
+
+    const configuration = JSON.stringify({
+      name: 'Mapper test limit to 50',
+      representations,
+    });
+
+    const fileUpload: Promise<FileUploadData> = Promise.resolve({
+      createReadStream: () => Readable.from(Buffer.from(JSON.stringify({ objects: toolObjects }))),
+      filename: 'limit-50-test.json',
+      mimeType: 'application/json',
+    });
+
+    const result = await jsonMapperTest(testContext, ADMIN_USER, configuration, fileUpload);
+    const parsedObjects = JSON.parse(result.objects);
+
+    expect(toolObjects.length).toBeGreaterThan(50);
+    expect(parsedObjects).toHaveLength(50);
+    expect(result.nbEntities).toBe(50);
+    expect(result.nbRelationships).toBe(0);
+    expect(parsedObjects[0].name).toBe('tool-1');
+    expect(parsedObjects[49].name).toBe('tool-50');
+    expect(parsedObjects.some((o: any) => o.name === 'tool-51')).toBe(false);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
@@ -2,12 +2,13 @@ import { Readable } from 'node:stream';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { addIngestionJson, deleteIngestionJson, ingestionJsonEditField, testJsonIngestionMapping } from '../../../../src/modules/ingestion/ingestion-json-domain';
 import { ADMIN_USER, testContext } from '../../../utils/testQuery';
-import { type EditInput, IngestionAuthType, type IngestionJsonAddInput } from '../../../../src/generated/graphql';
+import { type EditInput, IngestionAuthType, type IngestionJsonAddInput, JsonMapperRepresentationType } from '../../../../src/generated/graphql';
 import * as uriDenyListConfigMock from '../../../../src/config/uriDenyList';
 import type { BasicStoreEntityIngestionJson } from '../../../../src/modules/ingestion/ingestion-types';
 import { createJsonMapper, deleteJsonMapper, jsonMapperTest } from '../../../../src/modules/internal/jsonMapper/jsonMapper-domain';
 import type { FileUploadData } from '../../../../src/database/file-storage';
 import { regexpTestData, representationsFormulaMatrix, representationsRegExpr, stixBundleDataFormulaMatrix } from './ingestionManager-testData/ingestion-json-data';
+import { ENTITY_TYPE_TOOL } from '../../../../src/schema/stixDomainObject';
 
 describe('Ingestion Json domain - Deny list coverage', async () => {
   let myJsonFeed: BasicStoreEntityIngestionJson;
@@ -155,5 +156,48 @@ describe('Ingestion Json domain - complex path coverage', async () => {
 
     // "No reference available." -> no match, returns original description
     expect(sliver.description).toBe('Open-source adversary emulation framework. No reference available.');
+  });
+
+  it('should stop jsonMapperTest parsing at 50 objects when input contains more records', async () => {
+    const representations = [{
+      id: 'tool-representation-limit-50',
+      type: JsonMapperRepresentationType.Entity,
+      target: {
+        entity_type: ENTITY_TYPE_TOOL,
+        path: '$.objects[?(@.type == "tool")]',
+      },
+      attributes: [{
+        mode: 'simple',
+        key: 'name',
+        attr_path: { path: '$.name' },
+      }],
+    }];
+
+    const toolObjects = Array.from({ length: 60 }, (_, index) => ({
+      type: 'tool',
+      name: `tool-${index + 1}`,
+    }));
+
+    const configuration = JSON.stringify({
+      name: 'Mapper test limit to 50',
+      representations,
+    });
+
+    const fileUpload: Promise<FileUploadData> = Promise.resolve({
+      createReadStream: () => Readable.from(Buffer.from(JSON.stringify({ objects: toolObjects }))),
+      filename: 'limit-50-test.json',
+      mimeType: 'application/json',
+    });
+
+    const result = await jsonMapperTest(testContext, ADMIN_USER, configuration, fileUpload);
+    const parsedObjects = JSON.parse(result.objects);
+
+    expect(toolObjects.length).toBeGreaterThan(50);
+    expect(parsedObjects).toHaveLength(50);
+    expect(result.nbEntities).toBe(50);
+    expect(result.nbRelationships).toBe(0);
+    expect(parsedObjects[0].name).toBe('tool-1');
+    expect(parsedObjects[49].name).toBe('tool-50');
+    expect(parsedObjects.some((o: any) => o.name === 'tool-51')).toBe(false);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-domain-test.ts
@@ -1,9 +1,10 @@
 import { Readable } from 'node:stream';
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { addIngestionJson, deleteIngestionJson, ingestionJsonEditField, testJsonIngestionMapping } from '../../../../src/modules/ingestion/ingestion-json-domain';
 import { ADMIN_USER, testContext } from '../../../utils/testQuery';
 import { type EditInput, IngestionAuthType, type IngestionJsonAddInput, JsonMapperRepresentationType } from '../../../../src/generated/graphql';
 import * as uriDenyListConfigMock from '../../../../src/config/uriDenyList';
+import * as httpClientModule from '../../../../src/utils/http-client';
 import type { BasicStoreEntityIngestionJson } from '../../../../src/modules/ingestion/ingestion-types';
 import { createJsonMapper, deleteJsonMapper, jsonMapperTest } from '../../../../src/modules/internal/jsonMapper/jsonMapper-domain';
 import type { FileUploadData } from '../../../../src/database/file-storage';
@@ -198,6 +199,106 @@ describe('Ingestion Json domain - complex path coverage', async () => {
     expect(result.nbRelationships).toBe(0);
     expect(parsedObjects[0].name).toBe('tool-1');
     expect(parsedObjects[49].name).toBe('tool-50');
+    expect(parsedObjects.some((o: any) => o.name === 'tool-51')).toBe(false);
+  });
+});
+
+describe('Ingestion Json domain - ingestionJsonTester mutation (testJsonIngestionMapping)', async () => {
+  let mapperId: string;
+
+  // A minimal tool-only representation used in the limit test below
+  const simpleToolRepresentations = [
+    {
+      id: 'tool-rep',
+      type: JsonMapperRepresentationType.Entity,
+      target: {
+        entity_type: ENTITY_TYPE_TOOL,
+        path: '$.objects[?(@.type == "tool")]',
+      },
+      attributes: [
+        {
+          mode: 'simple',
+          key: 'name',
+          attr_path: { path: '$.name' },
+        },
+      ],
+    },
+  ];
+
+  beforeAll(async () => {
+    const mapper = await createJsonMapper(testContext, ADMIN_USER, {
+      name: 'IngestionJsonTester Test Mapper',
+      representations: JSON.stringify(simpleToolRepresentations),
+    });
+    mapperId = mapper.id;
+  });
+
+  afterAll(async () => {
+    if (mapperId) {
+      await deleteJsonMapper(testContext, ADMIN_USER, mapperId);
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const buildMockHttpClient = (responseData: unknown) => ({
+    call: vi.fn().mockResolvedValue({ data: responseData, headers: {} }),
+  });
+
+  it('should testJsonIngestionMapping return parsed entities from the mocked HTTP response', async () => {
+    vi.spyOn(httpClientModule, 'getHttpClient').mockReturnValue(buildMockHttpClient(JSON.parse(stixBundleDataFormulaMatrix)) as any);
+
+    // stixBundleDataFormulaMatrix contains 3 tools (7-Zip, 3proxy, 16Shop) with no orgs matched by the simple mapper
+    const input: IngestionJsonAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'IngestionJsonTester happy-path feed',
+      uri: 'https://example.com/feed.json',
+      user_id: ADMIN_USER.id,
+      json_mapper_id: mapperId,
+      verb: 'GET',
+    };
+
+    const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
+
+    expect(result).toBeDefined();
+    // The simple mapper only picks up tools (3 tools in the bundle)
+    expect(result.nbEntities).toBe(3);
+    expect(result.nbRelationships).toBe(0);
+
+    const parsedObjects = JSON.parse(result.objects);
+    expect(parsedObjects.length).toBe(3);
+    const names = parsedObjects.map((o: any) => o.name);
+    expect(names).toContain('7-Zip');
+    expect(names).toContain('3proxy');
+    expect(names).toContain('16Shop');
+  });
+
+  it('should testJsonIngestionMapping cap results at 50 when the feed returns more than 50 objects', async () => {
+    const manyTools = Array.from({ length: 60 }, (_, i) => ({
+      type: 'tool',
+      name: `tool-${i + 1}`,
+    }));
+
+    vi.spyOn(httpClientModule, 'getHttpClient').mockReturnValue(buildMockHttpClient({ objects: manyTools }) as any);
+
+    const input: IngestionJsonAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: 'IngestionJsonTester limit-50 feed',
+      uri: 'https://example.com/feed-large.json',
+      user_id: ADMIN_USER.id,
+      json_mapper_id: mapperId,
+      verb: 'GET',
+    };
+
+    const result = await testJsonIngestionMapping(testContext, ADMIN_USER, input);
+    const parsedObjects = JSON.parse(result.objects);
+
+    // Feed has 60 tools but the mutation limits execution to 50
+    expect(manyTools.length).toBeGreaterThan(50);
+    expect(parsedObjects.length).toBeLessThanOrEqual(50);
+    expect(result.nbEntities).toBeLessThanOrEqual(50);
     expect(parsedObjects.some((o: any) => o.name === 'tool-51')).toBe(false);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add maxRecords parameter to jsonMappingExecution
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16921

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
