### PR TITLE
fix(client-python): remove the 1s per-message delay in ListenQueue (#16906)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -566,12 +566,11 @@ class ListenQueue(threading.Thread):
         # (AMQP heartbeats) while the processing thread is running
         while self.thread.is_alive():  # Loop while the thread is processing
             self.pika_connection.sleep(0.05)
-            if (
-                self.helper.work_id is not None
-                and time.monotonic() - last_ping > five_minutes
-            ):  # Ping every 5 minutes
+            now = time.monotonic()
+            # Ping every 5 minutes
+            if self.helper.work_id is not None and now - last_ping > five_minutes:
                 self.helper.api.work.ping(self.helper.work_id)
-                last_ping = time.monotonic()
+                last_ping = now
         self.helper.connector_logger.info(
             "Message processed, thread terminated",
             {"tag": method.delivery_tag},

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -560,18 +560,18 @@ class ListenQueue(threading.Thread):
         self.thread = threading.Thread(target=self._data_handler, args=[json_data])
         self.thread.start()
         five_minutes = 60 * 5
-        time_wait = 0
+        last_ping = time.monotonic()
         # Wait for end of execution of the _data_handler
+        # pika_connection.sleep is required to keep servicing the connection I/O
+        # (AMQP heartbeats) while the processing thread is running
         while self.thread.is_alive():  # Loop while the thread is processing
             self.pika_connection.sleep(0.05)
             if (
-                self.helper.work_id is not None and time_wait > five_minutes
+                self.helper.work_id is not None
+                and time.monotonic() - last_ping > five_minutes
             ):  # Ping every 5 minutes
                 self.helper.api.work.ping(self.helper.work_id)
-                time_wait = 0
-            else:
-                time_wait += 1
-            time.sleep(1)
+                last_ping = time.monotonic()
         self.helper.connector_logger.info(
             "Message processed, thread terminated",
             {"tag": method.delivery_tag},


### PR DESCRIPTION
### Proposed changes

* Remove the `time.sleep(1)` from the `ListenQueue._process_message` wait loop. This loop polls
  the processing thread once per iteration, so the 1s sleep capped every listen-based connector
  at ~1 message per second, whatever the actual processing time (see the near-perfect 1 msg/s
  rate reported in #16906).
* Base the 5-minute work ping on elapsed time (`time.monotonic()`) instead of counting loop
  iterations. The previous `time_wait > 300` check only meant "5 minutes" because each iteration
  happened to last ~1s.
* Keep `pika_connection.sleep(0.05)` untouched: it services the connection I/O so AMQP heartbeats
  keep flowing during long processing (added for that purpose after the 2023 revert of the async
  consumer).

Note: an "ephemeral" thread is still created for each message processing. This could be enhanced
later together with the concurrent processing work (see further comments).

### Related issues

* closes #16906 

### How to test this PR

1. Run hygiene connector against a queue with a backlog of enrichment tasks.
2. Before: the connector processes ~1 message per second, even when each message takes a few ms.
3. After: throughput matches the actual processing time of the callback (hygiene goes well above
   1 msg/s); RabbitMQ still shows 1 unacked message at a time (expected, processing is still
   sequential).
4. Long-running task check: with a task > 10s, the AMQP connection stays up (heartbeats still
   serviced by `pika_connection.sleep`); with a task > 5 min, the work ping still fires.

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Message processing stays strictly sequential: the pika callback still waits for the processing
thread before returning, so there is never more than one in-flight message per connector, and
connector-side thread pools (e.g. hygiene `HYGIENE_MAX_WORKERS`) remain ineffective. 


No unit test added: the change is timing behavior inside the pika consuming loop, which has no
existing unit coverage. To be validated manually with a connector against a live platform.
