### PR TITLE
feat(redis): add connector logs ttl and ingestion history in redis (#8920)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -769,13 +769,54 @@ export const redisGetManagerEventState = async (managerName: string) => {
 // endregion
 
 // region connector logs
+export interface FeedLog {
+  timestamp: string;
+  status: 'success' | 'error';
+  messages: string[];
+  count?: number;
+}
+
 export const redisSetConnectorLogs = async (connectorId: string, logs: string[]) => {
   const data = JSON.stringify(logs);
-  await getClientBase().set(`connector-${connectorId}-logs`, data);
+  await getClientBase().set(`connector-${connectorId}-logs`, data, 'EX', FIVE_MINUTES);
 };
 export const redisGetConnectorLogs = async (connectorId: string): Promise<string[]> => {
   const rawLogs = await getClientBase().get(`connector-${connectorId}-logs`);
   return rawLogs ? JSON.parse(rawLogs) : [];
+};
+
+const getIngestionLogKey = (feedId: string) => `ingestion-${feedId}-history`;
+
+const redisPushIngestionLog = async (feedId: string, log: FeedLog) => {
+  const key = getIngestionLogKey(feedId);
+  const data = JSON.stringify(log);
+  await redisTx(getClientBase(), async (tx) => {
+    await tx.lpush(key, data);
+    await tx.ltrim(key, 0, 19);
+  });
+};
+
+export const redisAddIngestionHistory = async (feedId: string, log: FeedLog) => {
+  const clientBase = getClientBase();
+  const key = getIngestionLogKey(feedId);
+  const latestLogData = await clientBase.lindex(key, 0);
+  if (latestLogData) {
+    const latestLog: FeedLog = JSON.parse(latestLogData);
+    const isSameStatus = latestLog.status === log.status;
+    const isSameMessage = latestLog.messages.toString() === log.messages.toString();
+    const count = latestLog.count ?? 0;
+    if (isSameStatus && isSameMessage && count < 100) {
+      const updatedLog: FeedLog = { ...latestLog, count: count + 1, timestamp: log.timestamp };
+      await clientBase.lset(key, 0, JSON.stringify(updatedLog));
+      return;
+    }
+  }
+  await redisPushIngestionLog(feedId, log);
+};
+
+export const redisGetConnectorHistory = async (feedId: string): Promise<FeedLog[]> => {
+  const rawLogs = await getClientBase().lrange(getIngestionLogKey(feedId), 0, -1);
+  return rawLogs.map((entry) => JSON.parse(entry) as FeedLog);
 };
 // endregion
 

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -787,34 +787,58 @@ export const redisGetConnectorLogs = async (connectorId: string): Promise<string
 
 const getIngestionLogKey = (feedId: string) => `ingestion-${feedId}-history`;
 
-const redisPushIngestionLog = async (feedId: string, log: FeedLog) => {
-  const key = getIngestionLogKey(feedId);
-  const data = JSON.stringify(log);
-  await redisTx(getClientBase(), async (tx) => {
-    await tx.lpush(key, data);
-    await tx.ltrim(key, 0, 19);
-  });
-};
+const INGESTION_DEDUP_MAX_COUNT = 100;
+const INGESTION_HISTORY_MAX_LENGTH = 20;
+const INGESTION_HISTORY_UPDATE_RETRIES = 5;
 
 export const redisAddIngestionHistory = async (feedId: string, log: FeedLog) => {
   const clientBase = getClientBase();
   const key = getIngestionLogKey(feedId);
-  const latestLogData = await clientBase.lindex(key, 0);
-  if (latestLogData) {
-    const latestLog: FeedLog = JSON.parse(latestLogData);
-    const isSameStatus = latestLog.status === log.status;
-    const isSameMessage = latestLog.messages.toString() === log.messages.toString();
-    const count = latestLog.count ?? 0;
-    if (isSameStatus && isSameMessage && count < 100) {
-      const updatedLog: FeedLog = { ...latestLog, count: count + 1, timestamp: log.timestamp };
-      await clientBase.lset(key, 0, JSON.stringify(updatedLog));
-      return;
+  const incomingMessages = JSON.stringify(log.messages);
+
+  for (let attempt = 0; attempt < INGESTION_HISTORY_UPDATE_RETRIES; attempt += 1) {
+    await clientBase.watch(key);
+    try {
+      const latestLogData = await clientBase.lindex(key, 0);
+      const tx = clientBase.multi();
+
+      if (latestLogData) {
+        const latestLog: FeedLog = JSON.parse(latestLogData);
+        const isSameStatus = latestLog.status === log.status;
+        const isSameMessage = JSON.stringify(latestLog.messages) === incomingMessages;
+        const count = latestLog.count ?? 1;
+
+        if (isSameStatus && isSameMessage && count < INGESTION_DEDUP_MAX_COUNT) {
+          const updatedLog: FeedLog = {
+            ...latestLog,
+            count: count + 1,
+            timestamp: log.timestamp,
+          };
+          tx.lset(key, 0, JSON.stringify(updatedLog));
+        } else {
+          tx.lpush(key, JSON.stringify(log));
+          tx.ltrim(key, 0, INGESTION_HISTORY_MAX_LENGTH - 1);
+        }
+      } else {
+        tx.lpush(key, JSON.stringify(log));
+        tx.ltrim(key, 0, INGESTION_HISTORY_MAX_LENGTH - 1);
+      }
+
+      const result = await tx.exec();
+      if (result !== null) {
+        return;
+      }
+    } finally {
+      await clientBase.unwatch();
     }
   }
-  await redisPushIngestionLog(feedId, log);
+
+  throw DatabaseError('Redis transaction conflict while updating ingestion history', {
+    feedId,
+  });
 };
 
-export const redisGetConnectorHistory = async (feedId: string): Promise<FeedLog[]> => {
+export const redisGetIngestionHistory = async (feedId: string): Promise<FeedLog[]> => {
   const rawLogs = await getClientBase().lrange(getIngestionLogKey(feedId), 0, -1);
   return rawLogs.map((entry) => JSON.parse(entry) as FeedLog);
 };

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -778,7 +778,7 @@ export interface FeedLog {
 
 export const redisSetConnectorLogs = async (connectorId: string, logs: string[]) => {
   const data = JSON.stringify(logs);
-  await getClientBase().set(`connector-${connectorId}-logs`, data, 'EX', FIVE_MINUTES);
+  await getClientBase().set(`connector-${connectorId}-logs`, data);
 };
 export const redisGetConnectorLogs = async (connectorId: string): Promise<string[]> => {
   const rawLogs = await getClientBase().get(`connector-${connectorId}-logs`);

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/redis-test.js
@@ -11,8 +11,10 @@ import {
   getRedisVersion,
   lockResource,
   PLAYBOOK_EXECUTIONS_MAX_LENGTH,
+  redisAddIngestionHistory,
   redisClearTelemetry,
   redisGetForgotPasswordOtp,
+  redisGetIngestionHistory,
   redisGetTelemetry,
   redisGetXtmAgentResponse,
   redisInit,
@@ -23,6 +25,8 @@ import {
   setEditContext,
 } from '../../../src/database/redis';
 import { OPENCTI_ADMIN_UUID } from '../../../src/schema/general';
+
+const ingestionHistoryKey = (feedId) => `ingestion-${feedId}-history`;
 
 describe('Redis basic and utils', () => {
   it('should redis in correct version', async () => {
@@ -234,5 +238,82 @@ describe('Redis XTM agent response cache', () => {
       const cached = await redisGetXtmAgentResponse(cacheKey);
       expect(cached, `payload ${payload} should be rejected`).toBeNull();
     }
+  });
+});
+
+describe('Redis ingestion history', () => {
+  it('should add and read ingestion history', async () => {
+    const feedId = `feed-${uuid()}`;
+    const log = { timestamp: new Date().toISOString(), status: 'success', messages: ['first-log'] };
+
+    await getClientBase().del(ingestionHistoryKey(feedId));
+    await redisAddIngestionHistory(feedId, log);
+    const history = await redisGetIngestionHistory(feedId);
+
+    expect(history).toHaveLength(1);
+    expect(history[0].status).toBe('success');
+    expect(history[0].messages).toEqual(['first-log']);
+  });
+
+  it('should deduplicate consecutive identical logs and increment count', async () => {
+    const feedId = `feed-${uuid()}`;
+    const firstTimestamp = '2026-07-06T10:00:00.000Z';
+    const secondTimestamp = '2026-07-06T10:01:00.000Z';
+
+    await getClientBase().del(ingestionHistoryKey(feedId));
+    await redisAddIngestionHistory(feedId, {
+      timestamp: firstTimestamp,
+      status: 'error',
+      messages: ['same-error'],
+    });
+    await redisAddIngestionHistory(feedId, {
+      timestamp: secondTimestamp,
+      status: 'error',
+      messages: ['same-error'],
+    });
+
+    const history = await redisGetIngestionHistory(feedId);
+    expect(history).toHaveLength(1);
+    expect(history[0].count).toBe(2);
+    expect(history[0].timestamp).toBe(secondTimestamp);
+  });
+
+  it('should push a new entry when status or message changes', async () => {
+    const feedId = `feed-${uuid()}`;
+
+    await getClientBase().del(ingestionHistoryKey(feedId));
+    await redisAddIngestionHistory(feedId, {
+      timestamp: '2026-07-06T10:00:00.000Z',
+      status: 'success',
+      messages: ['ok'],
+    });
+    await redisAddIngestionHistory(feedId, {
+      timestamp: '2026-07-06T10:01:00.000Z',
+      status: 'error',
+      messages: ['ko'],
+    });
+
+    const history = await redisGetIngestionHistory(feedId);
+    expect(history).toHaveLength(2);
+    expect(history[0].status).toBe('error');
+    expect(history[1].status).toBe('success');
+  });
+
+  it('should keep only the latest 20 ingestion history entries', async () => {
+    const feedId = `feed-${uuid()}`;
+
+    await getClientBase().del(ingestionHistoryKey(feedId));
+    for (let i = 0; i < 25; i += 1) {
+      await redisAddIngestionHistory(feedId, {
+        timestamp: `2026-07-06T10:${String(i).padStart(2, '0')}:00.000Z`,
+        status: 'success',
+        messages: [`msg-${i}`],
+      });
+    }
+
+    const history = await redisGetIngestionHistory(feedId);
+    expect(history).toHaveLength(20);
+    expect(history[0].messages).toEqual(['msg-24']);
+    expect(history[19].messages).toEqual(['msg-5']);
   });
 });


### PR DESCRIPTION


<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Added Redis TTL (5 minutes) on connector transient logs written by updateConnectorLogs, to avoid keeping stale logs indefinitely in memory.
- Added ingestion history foundation in Redis:
     - FeedLog structure
     - bounded list storage (latest 20 entries)
     - deduplication on latest entry (status + messages) with count increment (capped at 100)
     - history read helper
- Scope intentionally limited to backend Redis layer only (no GraphQL schema/front exposure in this PR).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #8920

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
