### PR TITLE
fix(widget): prevent importing wordcloud widget to crash (#16930)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetWordCloud.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useTheme } from '@mui/styles';
 import ReactWordcloud, { Props } from 'react-wordcloud';
 import type { Theme } from '../Theme';
 import { colors } from '../../utils/Charts';
 import useDistributionGraphData from '../../utils/hooks/useDistributionGraphData';
+import useResizeObserver from '../../utils/hooks/useResizeObserver';
+import WidgetNoData from './WidgetNoData';
 
 interface WidgetWordCloudProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,13 +13,24 @@ interface WidgetWordCloudProps {
   groupBy: string;
 }
 
+// Imported widgets can mount before the layout settles; avoid rendering on tiny/unstable boxes.
+const MIN_RENDER_SIZE = 10;
+
 const WidgetWordCloud = ({ data, groupBy }: WidgetWordCloudProps) => {
   const theme = useTheme<Theme>();
   const { buildWidgetWordCloudOption } = useDistributionGraphData();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { width, height } = useResizeObserver(containerRef);
 
   const wordCloudData = useMemo(
     () => buildWidgetWordCloudOption(data, groupBy),
     [data, groupBy],
+  );
+
+  const sanitizedWords = useMemo(
+    // Log scale requires strictly positive finite values; 0/NaN can crash d3-wordcloud internals.
+    () => wordCloudData.filter((w) => Number.isFinite(w.value) && w.value > 0),
+    [wordCloudData],
   );
 
   const options: Props['options'] = useMemo(() => {
@@ -34,12 +47,26 @@ const WidgetWordCloud = ({ data, groupBy }: WidgetWordCloudProps) => {
     };
   }, [theme]);
 
+  const isContainerReady = width > MIN_RENDER_SIZE && height > MIN_RENDER_SIZE;
+  const hasRenderableWords = sanitizedWords.length > 0;
+  // Imported widgets can briefly mount with zero-size container or non-positive values.
+  // With d3 log scale, those transient inputs can produce invalid domains and crash wordcloud layout.
+  const shouldRenderWordCloud = isContainerReady && hasRenderableWords;
+  const shouldRenderEmptyState = isContainerReady && !hasRenderableWords;
+
   return (
-    <ReactWordcloud
-      words={wordCloudData}
-      minSize={[1, 1]}
-      options={options}
-    />
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+      {shouldRenderWordCloud && (
+        <ReactWordcloud
+          words={sanitizedWords}
+          minSize={[1, 1]}
+          options={options}
+        />
+      )}
+      {shouldRenderEmptyState && (
+        <WidgetNoData />
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* prevent rendering the react-wordcloud when size is equal to 0
* add some guard if words are equal to 0

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16930 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
