### PR TITLE
fix(playbook): validate AI agent intent binding as the run-as user (#16945)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -177,8 +177,11 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
     // covers saves that go through the schema resolver — a crafted
     // playbook update or an agent that was unbound after save would
     // otherwise let us run an arbitrary XTM One agent under the
-    // platform automation identity.
-    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_TRANSFORM_INTENT, agent_slug))) {
+    // configured run-as identity. The check runs as the SAME identity
+    // as the agent call so the per-user XTM One catalog visibility
+    // matches what the call will actually see.
+    const runAsUserId = resolveRunAsUserId(run_as);
+    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_TRANSFORM_INTENT, agent_slug, runAsUserId))) {
       logApp.warn('[PLAYBOOK AI AGENT] Configured agent is not bound to the transformer intent, returning bundle unmodified', {
         agentSlug: agent_slug,
         intent: PLAYBOOK_AI_AGENT_TRANSFORM_INTENT,
@@ -186,7 +189,7 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
       return { output_port: 'unmodified', bundle };
     }
     const content = buildAgentMessageContent(bundle, prompt);
-    const rawResponse = await callXtmAgent(agent_slug, content, resolveRunAsUserId(run_as));
+    const rawResponse = await callXtmAgent(agent_slug, content, runAsUserId);
     if (rawResponse === null) {
       return { output_port: 'unmodified', bundle };
     }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -18,7 +18,7 @@ import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveAgentJwtUser, resolveRunAsUserId } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, isXtmOneConfigured, resolveAgentJwtUser, resolveRunAsUserId } from './ai-agent-shared';
 
 // Canonical STIX 2.1 ID shape: `<type>--<uuid>` where the UUID is the
 // 8-4-4-4-12 hex layout. Stricter than the loose `[\w-]{36}` pattern in
@@ -170,6 +170,15 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
     const { agent_slug, prompt, run_as } = playbookNode.configuration;
     if (!agent_slug) {
       logApp.warn('[PLAYBOOK AI AGENT] No agent configured, returning bundle unmodified');
+      return { output_port: 'unmodified', bundle };
+    }
+    // Without an XTM One configuration the step can never run: skip it
+    // before resolving the JWT identity so no user lookup is performed
+    // and no misleading identity-resolution warning is logged.
+    if (!isXtmOneConfigured()) {
+      logApp.warn('[PLAYBOOK AI AGENT] XTM One is not configured, returning bundle unmodified', {
+        agentSlug: agent_slug,
+      });
       return { output_port: 'unmodified', bundle };
     }
     // Resolve the XTM One identity ONCE (run-as user, defaulting to the

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -18,7 +18,7 @@ import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import type { StixBundle, StixObject } from '../../../types/stix-2-1-common';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveRunAsUserId } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveAgentJwtUser, resolveRunAsUserId } from './ai-agent-shared';
 
 // Canonical STIX 2.1 ID shape: `<type>--<uuid>` where the UUID is the
 // 8-4-4-4-12 hex layout. Stricter than the loose `[\w-]{36}` pattern in
@@ -172,6 +172,11 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
       logApp.warn('[PLAYBOOK AI AGENT] No agent configured, returning bundle unmodified');
       return { output_port: 'unmodified', bundle };
     }
+    // Resolve the XTM One identity ONCE (run-as user, defaulting to the
+    // seeded platform admin) and share it between the binding check and
+    // the agent call: both are guaranteed to run as the same identity
+    // with a single user lookup.
+    const jwtUser = await resolveAgentJwtUser(resolveRunAsUserId(run_as));
     // Defense in depth: re-check that the configured slug is currently
     // bound to the transformer intent. AJV `oneOf` validation only
     // covers saves that go through the schema resolver — a crafted
@@ -180,8 +185,7 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
     // configured run-as identity. The check runs as the SAME identity
     // as the agent call so the per-user XTM One catalog visibility
     // matches what the call will actually see.
-    const runAsUserId = resolveRunAsUserId(run_as);
-    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_TRANSFORM_INTENT, agent_slug, runAsUserId))) {
+    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_TRANSFORM_INTENT, agent_slug, jwtUser))) {
       logApp.warn('[PLAYBOOK AI AGENT] Configured agent is not bound to the transformer intent, returning bundle unmodified', {
         agentSlug: agent_slug,
         intent: PLAYBOOK_AI_AGENT_TRANSFORM_INTENT,
@@ -189,7 +193,7 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
       return { output_port: 'unmodified', bundle };
     }
     const content = buildAgentMessageContent(bundle, prompt);
-    const rawResponse = await callXtmAgent(agent_slug, content, runAsUserId);
+    const rawResponse = await callXtmAgent(agent_slug, content, jwtUser);
     if (rawResponse === null) {
       return { output_port: 'unmodified', bundle };
     }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-component.ts
@@ -177,6 +177,15 @@ export const PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT: PlaybookComponent<AiAgentTra
     // the agent call: both are guaranteed to run as the same identity
     // with a single user lookup.
     const jwtUser = await resolveAgentJwtUser(resolveRunAsUserId(run_as));
+    if (!jwtUser) {
+      // No resolvable JWT identity: neither the binding check nor the
+      // agent call could run — skip both with an accurate log instead
+      // of a misleading "agent not bound" warning.
+      logApp.warn('[PLAYBOOK AI AGENT] No resolvable JWT identity for the agent call, returning bundle unmodified', {
+        agentSlug: agent_slug,
+      });
+      return { output_port: 'unmodified', bundle };
+    }
     // Defense in depth: re-check that the configured slug is currently
     // bound to the transformer intent. AJV `oneOf` validation only
     // covers saves that go through the schema resolver — a crafted

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -17,7 +17,7 @@ import * as R from 'ramda';
 import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveRunAsUserId } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveAgentJwtUser, resolveRunAsUserId } from './ai-agent-shared';
 
 interface AiAgentSendConfiguration {
   agent_slug: string;
@@ -98,6 +98,11 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
       logApp.warn('[PLAYBOOK AI AGENT SEND] No agent configured, dropping playbook step', { playbookId });
       return { output_port: undefined, bundle, forceBundleTracking: true };
     }
+    // Resolve the XTM One identity ONCE (run-as user, defaulting to the
+    // seeded platform admin) and share it between the binding check and
+    // the agent call: both are guaranteed to run as the same identity
+    // with a single user lookup.
+    const jwtUser = await resolveAgentJwtUser(resolveRunAsUserId(run_as));
     // Defense in depth: re-check that the configured slug is currently
     // bound to the consumer intent before invoking it. AJV `oneOf`
     // validation only covers saves that go through the schema resolver
@@ -106,8 +111,7 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
     // the configured run-as identity. The check runs as the SAME
     // identity as the agent call so the per-user XTM One catalog
     // visibility matches what the call will actually see.
-    const runAsUserId = resolveRunAsUserId(run_as);
-    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_SEND_INTENT, agent_slug, runAsUserId))) {
+    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_SEND_INTENT, agent_slug, jwtUser))) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] Configured agent is not bound to the consumer intent, dropping playbook step', {
         playbookId,
         agentSlug: agent_slug,
@@ -116,7 +120,7 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
       return { output_port: undefined, bundle, forceBundleTracking: true };
     }
     const content = buildAgentMessageContent(bundle, prompt);
-    const rawResponse = await callXtmAgent(agent_slug, content, runAsUserId);
+    const rawResponse = await callXtmAgent(agent_slug, content, jwtUser);
     if (rawResponse === null) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] Agent call did not complete', {
         playbookId,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -17,7 +17,7 @@ import * as R from 'ramda';
 import type { JSONSchemaType } from 'ajv';
 import type { PlaybookComponent } from '../playbook-types';
 import { logApp } from '../../../config/conf';
-import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, resolveAgentJwtUser, resolveRunAsUserId } from './ai-agent-shared';
+import { buildAgentMessageContent, buildAgentSlugOneOf, callXtmAgent, isAgentBoundToIntent, isXtmOneConfigured, resolveAgentJwtUser, resolveRunAsUserId } from './ai-agent-shared';
 
 interface AiAgentSendConfiguration {
   agent_slug: string;
@@ -96,6 +96,16 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
     const { agent_slug, prompt, run_as } = playbookNode.configuration;
     if (!agent_slug) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] No agent configured, dropping playbook step', { playbookId });
+      return { output_port: undefined, bundle, forceBundleTracking: true };
+    }
+    // Without an XTM One configuration the step can never run: skip it
+    // before resolving the JWT identity so no user lookup is performed
+    // and no misleading identity-resolution warning is logged.
+    if (!isXtmOneConfigured()) {
+      logApp.warn('[PLAYBOOK AI AGENT SEND] XTM One is not configured, dropping playbook step', {
+        playbookId,
+        agentSlug: agent_slug,
+      });
       return { output_port: undefined, bundle, forceBundleTracking: true };
     }
     // Resolve the XTM One identity ONCE (run-as user, defaulting to the

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -103,8 +103,11 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
     // validation only covers saves that go through the schema resolver
     // — a crafted playbook update or an agent that was unbound after
     // save would otherwise let us run an arbitrary XTM One agent under
-    // the platform automation identity.
-    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_SEND_INTENT, agent_slug))) {
+    // the configured run-as identity. The check runs as the SAME
+    // identity as the agent call so the per-user XTM One catalog
+    // visibility matches what the call will actually see.
+    const runAsUserId = resolveRunAsUserId(run_as);
+    if (!(await isAgentBoundToIntent(PLAYBOOK_AI_AGENT_SEND_INTENT, agent_slug, runAsUserId))) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] Configured agent is not bound to the consumer intent, dropping playbook step', {
         playbookId,
         agentSlug: agent_slug,
@@ -113,7 +116,7 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
       return { output_port: undefined, bundle, forceBundleTracking: true };
     }
     const content = buildAgentMessageContent(bundle, prompt);
-    const rawResponse = await callXtmAgent(agent_slug, content, resolveRunAsUserId(run_as));
+    const rawResponse = await callXtmAgent(agent_slug, content, runAsUserId);
     if (rawResponse === null) {
       logApp.warn('[PLAYBOOK AI AGENT SEND] Agent call did not complete', {
         playbookId,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-send-component.ts
@@ -103,6 +103,16 @@ export const PLAYBOOK_AI_AGENT_SEND_COMPONENT: PlaybookComponent<AiAgentSendConf
     // the agent call: both are guaranteed to run as the same identity
     // with a single user lookup.
     const jwtUser = await resolveAgentJwtUser(resolveRunAsUserId(run_as));
+    if (!jwtUser) {
+      // No resolvable JWT identity: neither the binding check nor the
+      // agent call could run — skip both with an accurate log instead
+      // of a misleading "agent not bound" warning.
+      logApp.warn('[PLAYBOOK AI AGENT SEND] No resolvable JWT identity for the agent call, dropping playbook step', {
+        playbookId,
+        agentSlug: agent_slug,
+      });
+      return { output_port: undefined, bundle, forceBundleTracking: true };
+    }
     // Defense in depth: re-check that the configured slug is currently
     // bound to the consumer intent before invoking it. AJV `oneOf`
     // validation only covers saves that go through the schema resolver

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -149,11 +149,20 @@ export const resolveAgentJwtUser = async (
       });
     }
   }
-  logApp.error('[PLAYBOOK AI AGENT] No resolvable JWT identity (seeded admin cannot be loaded), skipping XTM One interaction', {
+  logApp.error('[PLAYBOOK AI AGENT] No resolvable JWT identity (no candidate user with a usable email), skipping XTM One interaction', {
     runAsUserId,
   });
   return null;
 };
+
+/**
+ * True when the platform is wired to an XTM One instance (url + token).
+ * Executors check this FIRST so a missing configuration skips the whole
+ * agent step — including the user lookup performed by
+ * ``resolveAgentJwtUser`` — without touching the database or logging
+ * misleading identity-resolution warnings.
+ */
+export const isXtmOneConfigured = (): boolean => !!nconf.get('xtm:xtm_one_url') && xtmOneClient.isConfigured();
 
 /**
  * Runtime defense in depth: re-check that ``slug`` is currently bound to

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -168,10 +168,11 @@ export const resolveAgentJwtUser = async (
  * for agents that are bound to the intent but only visible to the
  * run-as user (e.g. group-shared, non-company-managed agents).
  *
- * Returns ``false`` (and logs a warning) on catalog failure / unknown
- * slug / unresolvable identity (``jwtUser`` null), so the executor
- * falls through to its safe terminal branch (``unmodified`` /
- * fire-and-wait) instead of calling the agent.
+ * Returns ``false`` on catalog failure (logged here as a warning),
+ * unknown slug, or unresolvable identity (``jwtUser`` null — already
+ * logged by ``resolveAgentJwtUser``). In every case the executor logs
+ * the skip and falls through to its safe terminal branch
+ * (``unmodified`` / fire-and-wait) instead of calling the agent.
  */
 export const isAgentBoundToIntent = async (
   intent: string,
@@ -198,7 +199,7 @@ export const isAgentBoundToIntent = async (
     logApp.warn('[PLAYBOOK AI AGENT] Failed to validate agent intent binding', {
       intent,
       slug,
-      cause: (e as Error).message,
+      cause: e instanceof Error ? e.message : String(e),
     });
     return false;
   }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -136,11 +136,11 @@ export const resolveAgentJwtUser = async (
       if (user?.user_email) {
         return { id: user.id, user_email: user.user_email };
       }
-      logApp.warn('[PLAYBOOK AI AGENT] JWT user not found, trying next fallback', { targetUserId });
+      logApp.warn('[PLAYBOOK AI AGENT] JWT user not found or has no resolvable email, trying next fallback', { targetUserId, userFound: !!user });
     } catch (e: unknown) {
       logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve JWT user, trying next fallback', {
         targetUserId,
-        cause: (e as Error).message,
+        cause: e instanceof Error ? e.message : String(e),
       });
     }
   }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -90,14 +90,18 @@ export const buildAgentSlugOneOf = async (
  * matching local account and any write-back to OpenCTI is attributed to
  * a real, well-known user.
  *
- * When no run-as user is configured, it defaults to the seeded platform
- * admin (``OPENCTI_ADMIN_UUID``) - a real, indexed account with a
- * resolvable email - rather than the in-memory ``AUTOMATION_MANAGER_USER``,
- * whose placeholder email cannot be resolved on the XTM One side.
+ * When no run-as user is configured — or the run-as user cannot be
+ * loaded — it falls back to the seeded platform admin
+ * (``OPENCTI_ADMIN_UUID``), a real account that is always present in
+ * the database with a resolvable email. The in-memory
+ * ``AUTOMATION_MANAGER_USER`` / ``SYSTEM_USER`` identities are NOT
+ * valid fallbacks: their placeholder emails ("AUTOMATION MANAGER" /
+ * "SYSTEM") can never be resolved to an account on the XTM One side,
+ * so a JWT minted for them is guaranteed to be useless.
  *
- * ``AUTOMATION_MANAGER_USER`` remains the last-resort fallback when the
- * target user (explicit run-as or seeded admin) cannot be loaded, so the
- * component degrades gracefully instead of failing.
+ * Returns ``null`` when no resolvable identity exists at all (the
+ * seeded admin itself cannot be loaded) so callers skip the XTM One
+ * interaction instead of sending a dead JWT.
  *
  * Shared by both the agent call itself (``callXtmAgent``) and the
  * intent-binding pre-check (``isAgentBoundToIntent``) so the catalog
@@ -106,27 +110,34 @@ export const buildAgentSlugOneOf = async (
  */
 const resolveAgentJwtUser = async (
   runAsUserId?: string,
-): Promise<{ id: string; user_email: string }> => {
-  const targetUserId = runAsUserId || OPENCTI_ADMIN_UUID;
-  try {
-    const context = executionContext('playbook_components');
-    const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
-      context,
-      SYSTEM_USER,
-      targetUserId,
-      { type: ENTITY_TYPE_USER },
-    );
-    if (user?.user_email) {
-      return { id: user.id, user_email: user.user_email };
+): Promise<{ id: string; user_email: string } | null> => {
+  const candidateIds = runAsUserId && runAsUserId !== OPENCTI_ADMIN_UUID
+    ? [runAsUserId, OPENCTI_ADMIN_UUID]
+    : [OPENCTI_ADMIN_UUID];
+  const context = executionContext('playbook_components');
+  for (const targetUserId of candidateIds) {
+    try {
+      const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
+        context,
+        SYSTEM_USER,
+        targetUserId,
+        { type: ENTITY_TYPE_USER },
+      );
+      if (user?.user_email) {
+        return { id: user.id, user_email: user.user_email };
+      }
+      logApp.warn('[PLAYBOOK AI AGENT] JWT user not found, trying next fallback', { targetUserId });
+    } catch (e: unknown) {
+      logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve JWT user, trying next fallback', {
+        targetUserId,
+        cause: (e as Error).message,
+      });
     }
-    logApp.warn('[PLAYBOOK AI AGENT] Run-as user not found, falling back to automation user', { runAsUserId: targetUserId });
-  } catch (e: unknown) {
-    logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve run-as user, falling back to automation user', {
-      runAsUserId: targetUserId,
-      cause: (e as Error).message,
-    });
   }
-  return AUTOMATION_MANAGER_USER;
+  logApp.error('[PLAYBOOK AI AGENT] No resolvable JWT identity (seeded admin cannot be loaded), skipping XTM One interaction', {
+    runAsUserId,
+  });
+  return null;
 };
 
 /**
@@ -158,6 +169,11 @@ export const isAgentBoundToIntent = async (
   if (!slug) return false;
   try {
     const jwtUser = await resolveAgentJwtUser(runAsUserId);
+    if (!jwtUser) {
+      // No resolvable identity — the agent call itself could not run
+      // either, so fail closed without hitting XTM One.
+      return false;
+    }
     // The context user is only used to mint the outbound JWT — spread the
     // automation user to satisfy the AuthUser shape, but carry the resolved
     // identity so the catalog lookup matches the subsequent agent call.
@@ -348,6 +364,9 @@ export const sanitizeDefinitionRunAs = async (
  * ``resolveAgentJwtUser``) so XTM One - and any subsequent write-back to
  * OpenCTI - sees the agent call as coming from that real account. When no
  * run-as user is configured it defaults to the seeded platform admin.
+ * When no resolvable identity exists at all, the call is skipped (a JWT
+ * minted for an in-memory placeholder user can never be resolved by
+ * XTM One anyway).
  */
 export const callXtmAgent = async (
   agentSlug: string,
@@ -361,6 +380,9 @@ export const callXtmAgent = async (
   }
   try {
     const jwtUser = await resolveAgentJwtUser(runAsUserId);
+    if (!jwtUser) {
+      return null;
+    }
     const jwt = await issueXtmJwt(jwtUser, xtmOneUrl);
     const httpClient = getHttpClient({
       baseURL: xtmOneUrl,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -84,13 +84,67 @@ export const buildAgentSlugOneOf = async (
 };
 
 /**
+ * Resolve the identity whose email is embedded in the cross-platform JWT
+ * sent to XTM One. When the component is configured with an explicit
+ * ``run_as`` user, the JWT is minted for that user so XTM One resolves a
+ * matching local account and any write-back to OpenCTI is attributed to
+ * a real, well-known user.
+ *
+ * When no run-as user is configured, it defaults to the seeded platform
+ * admin (``OPENCTI_ADMIN_UUID``) - a real, indexed account with a
+ * resolvable email - rather than the in-memory ``AUTOMATION_MANAGER_USER``,
+ * whose placeholder email cannot be resolved on the XTM One side.
+ *
+ * ``AUTOMATION_MANAGER_USER`` remains the last-resort fallback when the
+ * target user (explicit run-as or seeded admin) cannot be loaded, so the
+ * component degrades gracefully instead of failing.
+ *
+ * Shared by both the agent call itself (``callXtmAgent``) and the
+ * intent-binding pre-check (``isAgentBoundToIntent``) so the catalog
+ * visibility check and the actual invocation always run as the SAME
+ * XTM One identity.
+ */
+const resolveAgentJwtUser = async (
+  runAsUserId?: string,
+): Promise<{ id: string; user_email: string }> => {
+  const targetUserId = runAsUserId || OPENCTI_ADMIN_UUID;
+  try {
+    const context = executionContext('playbook_components');
+    const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
+      context,
+      SYSTEM_USER,
+      targetUserId,
+      { type: ENTITY_TYPE_USER },
+    );
+    if (user?.user_email) {
+      return { id: user.id, user_email: user.user_email };
+    }
+    logApp.warn('[PLAYBOOK AI AGENT] Run-as user not found, falling back to automation user', { runAsUserId: targetUserId });
+  } catch (e: unknown) {
+    logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve run-as user, falling back to automation user', {
+      runAsUserId: targetUserId,
+      cause: (e as Error).message,
+    });
+  }
+  return AUTOMATION_MANAGER_USER;
+};
+
+/**
  * Runtime defense in depth: re-check that ``slug`` is currently bound to
  * the expected ``intent`` in the XTM One catalog before the executor
  * actually invokes the agent. AJV validation at playbook save time only
  * guards saves that go through the schema resolver — direct DB writes,
  * future bulk-import paths, or an agent that gets unbound from the
  * intent after save would otherwise let the executor run an arbitrary
- * agent under the platform-internal ``AUTOMATION_MANAGER_USER`` JWT.
+ * agent under the caller's JWT.
+ *
+ * The catalog lookup runs as the SAME identity that ``callXtmAgent``
+ * will mint the JWT for (resolved run-as user, defaulting to the seeded
+ * platform admin — see ``resolveAgentJwtUser``). The XTM One catalog is
+ * scoped per user, so checking with any other identity (previously the
+ * placeholder ``AUTOMATION_MANAGER_USER``) makes the check fail closed
+ * for agents that are bound to the intent but only visible to the
+ * run-as user (e.g. group-shared, non-company-managed agents).
  *
  * Returns ``false`` (and logs a warning) on catalog failure / unknown
  * slug, so the executor falls through to its safe terminal branch
@@ -99,10 +153,19 @@ export const buildAgentSlugOneOf = async (
 export const isAgentBoundToIntent = async (
   intent: string,
   slug: string,
+  runAsUserId?: string,
 ): Promise<boolean> => {
   if (!slug) return false;
   try {
-    const agents = await xtmOneClient.listAgentsForIntent(buildPlaybookAutomationContext(), intent);
+    const jwtUser = await resolveAgentJwtUser(runAsUserId);
+    // The context user is only used to mint the outbound JWT — spread the
+    // automation user to satisfy the AuthUser shape, but carry the resolved
+    // identity so the catalog lookup matches the subsequent agent call.
+    const context: AuthContext = {
+      ...buildPlaybookAutomationContext(),
+      user: { ...AUTOMATION_MANAGER_USER, id: jwtUser.id, user_email: jwtUser.user_email },
+    };
+    const agents = await xtmOneClient.listAgentsForIntent(context, intent);
     return (agents ?? []).some((a) => a.agent_slug === slug);
   } catch (e: unknown) {
     logApp.warn('[PLAYBOOK AI AGENT] Failed to validate agent intent binding', {
@@ -271,47 +334,6 @@ export const sanitizeDefinitionRunAs = async (
     return true;
   }));
   return mutations.some((changed) => changed) ? JSON.stringify(definition) : playbookDefinition;
-};
-
-/**
- * Resolve the identity whose email is embedded in the cross-platform JWT
- * sent to XTM One. When the component is configured with an explicit
- * ``run_as`` user, the JWT is minted for that user so XTM One resolves a
- * matching local account and any write-back to OpenCTI is attributed to
- * a real, well-known user.
- *
- * When no run-as user is configured, it defaults to the seeded platform
- * admin (``OPENCTI_ADMIN_UUID``) - a real, indexed account with a
- * resolvable email - rather than the in-memory ``AUTOMATION_MANAGER_USER``,
- * whose placeholder email cannot be resolved on the XTM One side.
- *
- * ``AUTOMATION_MANAGER_USER`` remains the last-resort fallback when the
- * target user (explicit run-as or seeded admin) cannot be loaded, so the
- * component degrades gracefully instead of failing.
- */
-const resolveAgentJwtUser = async (
-  runAsUserId?: string,
-): Promise<{ id: string; user_email: string }> => {
-  const targetUserId = runAsUserId || OPENCTI_ADMIN_UUID;
-  try {
-    const context = executionContext('playbook_components');
-    const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
-      context,
-      SYSTEM_USER,
-      targetUserId,
-      { type: ENTITY_TYPE_USER },
-    );
-    if (user?.user_email) {
-      return { id: user.id, user_email: user.user_email };
-    }
-    logApp.warn('[PLAYBOOK AI AGENT] Run-as user not found, falling back to automation user', { runAsUserId: targetUserId });
-  } catch (e: unknown) {
-    logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve run-as user, falling back to automation user', {
-      runAsUserId: targetUserId,
-      cause: (e as Error).message,
-    });
-  }
-  return AUTOMATION_MANAGER_USER;
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -84,6 +84,15 @@ export const buildAgentSlugOneOf = async (
 };
 
 /**
+ * Identity whose email is embedded in the cross-platform JWT sent to
+ * XTM One — the minimal shape required by ``issueXtmJwt``.
+ */
+export interface AgentJwtUser {
+  id: string;
+  user_email: string;
+}
+
+/**
  * Resolve the identity whose email is embedded in the cross-platform JWT
  * sent to XTM One. When the component is configured with an explicit
  * ``run_as`` user, the JWT is minted for that user so XTM One resolves a
@@ -103,14 +112,15 @@ export const buildAgentSlugOneOf = async (
  * seeded admin itself cannot be loaded) so callers skip the XTM One
  * interaction instead of sending a dead JWT.
  *
- * Shared by both the agent call itself (``callXtmAgent``) and the
- * intent-binding pre-check (``isAgentBoundToIntent``) so the catalog
- * visibility check and the actual invocation always run as the SAME
- * XTM One identity.
+ * Executors call this ONCE and hand the resolved identity to both the
+ * intent-binding pre-check (``isAgentBoundToIntent``) and the agent
+ * call itself (``callXtmAgent``), so the catalog visibility check and
+ * the actual invocation are guaranteed to run as the SAME XTM One
+ * identity and the user is only looked up once per playbook step.
  */
-const resolveAgentJwtUser = async (
+export const resolveAgentJwtUser = async (
   runAsUserId?: string,
-): Promise<{ id: string; user_email: string } | null> => {
+): Promise<AgentJwtUser | null> => {
   const candidateIds = runAsUserId && runAsUserId !== OPENCTI_ADMIN_UUID
     ? [runAsUserId, OPENCTI_ADMIN_UUID]
     : [OPENCTI_ADMIN_UUID];
@@ -150,30 +160,31 @@ const resolveAgentJwtUser = async (
  * agent under the caller's JWT.
  *
  * The catalog lookup runs as the SAME identity that ``callXtmAgent``
- * will mint the JWT for (resolved run-as user, defaulting to the seeded
- * platform admin — see ``resolveAgentJwtUser``). The XTM One catalog is
+ * will mint the JWT for: the executor resolves it once with
+ * ``resolveAgentJwtUser`` (run-as user, defaulting to the seeded
+ * platform admin) and passes it to both calls. The XTM One catalog is
  * scoped per user, so checking with any other identity (previously the
  * placeholder ``AUTOMATION_MANAGER_USER``) makes the check fail closed
  * for agents that are bound to the intent but only visible to the
  * run-as user (e.g. group-shared, non-company-managed agents).
  *
  * Returns ``false`` (and logs a warning) on catalog failure / unknown
- * slug, so the executor falls through to its safe terminal branch
- * (``unmodified`` / fire-and-wait) instead of calling the agent.
+ * slug / unresolvable identity (``jwtUser`` null), so the executor
+ * falls through to its safe terminal branch (``unmodified`` /
+ * fire-and-wait) instead of calling the agent.
  */
 export const isAgentBoundToIntent = async (
   intent: string,
   slug: string,
-  runAsUserId?: string,
+  jwtUser: AgentJwtUser | null,
 ): Promise<boolean> => {
   if (!slug) return false;
+  if (!jwtUser) {
+    // No resolvable identity — the agent call itself could not run
+    // either, so fail closed without hitting XTM One.
+    return false;
+  }
   try {
-    const jwtUser = await resolveAgentJwtUser(runAsUserId);
-    if (!jwtUser) {
-      // No resolvable identity — the agent call itself could not run
-      // either, so fail closed without hitting XTM One.
-      return false;
-    }
     // The context user is only used to mint the outbound JWT — spread the
     // automation user to satisfy the AuthUser shape, but carry the resolved
     // identity so the catalog lookup matches the subsequent agent call.
@@ -360,29 +371,30 @@ export const sanitizeDefinitionRunAs = async (
  * deciding how to react (route to ``unmodified``, swallow at the end
  * of a chain, etc.) instead of crashing the whole run.
  *
- * The JWT is minted on behalf of the configured ``run_as`` user (see
- * ``resolveAgentJwtUser``) so XTM One - and any subsequent write-back to
- * OpenCTI - sees the agent call as coming from that real account. When no
- * run-as user is configured it defaults to the seeded platform admin.
- * When no resolvable identity exists at all, the call is skipped (a JWT
- * minted for an in-memory placeholder user can never be resolved by
- * XTM One anyway).
+ * The JWT is minted for the identity the executor resolved once with
+ * ``resolveAgentJwtUser`` (configured ``run_as`` user, defaulting to the
+ * seeded platform admin) — the same identity the intent-binding
+ * pre-check ran as — so XTM One, and any subsequent write-back to
+ * OpenCTI, sees the agent call as coming from that real account. When
+ * no resolvable identity exists at all (``jwtUser`` null), the call is
+ * skipped (a JWT minted for an in-memory placeholder user can never be
+ * resolved by XTM One anyway).
  */
 export const callXtmAgent = async (
   agentSlug: string,
   content: string,
-  runAsUserId?: string,
+  jwtUser: AgentJwtUser | null,
 ): Promise<string | null> => {
   const xtmOneUrl = nconf.get('xtm:xtm_one_url');
   if (!xtmOneUrl || !xtmOneClient.isConfigured()) {
     logApp.warn('[PLAYBOOK AI AGENT] XTM One is not configured, skipping agent call');
     return null;
   }
+  if (!jwtUser) {
+    // resolveAgentJwtUser already logged why no identity could be resolved.
+    return null;
+  }
   try {
-    const jwtUser = await resolveAgentJwtUser(runAsUserId);
-    if (!jwtUser) {
-      return null;
-    }
     const jwt = await issueXtmJwt(jwtUser, xtmOneUrl);
     const httpClient = getHttpClient({
       baseURL: xtmOneUrl,

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -125,7 +125,11 @@ export const resolveAgentJwtUser = async (
     ? [runAsUserId, OPENCTI_ADMIN_UUID]
     : [OPENCTI_ADMIN_UUID];
   const context = executionContext('playbook_components');
-  for (const targetUserId of candidateIds) {
+  for (let candidateIndex = 0; candidateIndex < candidateIds.length; candidateIndex += 1) {
+    const targetUserId = candidateIds[candidateIndex];
+    // Keep the message static for log aggregation; whether another
+    // candidate remains is carried as a structured attribute.
+    const hasNextFallback = candidateIndex < candidateIds.length - 1;
     try {
       const user = await internalLoadById<BasicStoreEntity & { user_email?: string }>(
         context,
@@ -136,10 +140,11 @@ export const resolveAgentJwtUser = async (
       if (user?.user_email) {
         return { id: user.id, user_email: user.user_email };
       }
-      logApp.warn('[PLAYBOOK AI AGENT] JWT user not found or has no resolvable email, trying next fallback', { targetUserId, userFound: !!user });
+      logApp.warn('[PLAYBOOK AI AGENT] JWT user not found or has no resolvable email', { targetUserId, userFound: !!user, hasNextFallback });
     } catch (e: unknown) {
-      logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve JWT user, trying next fallback', {
+      logApp.warn('[PLAYBOOK AI AGENT] Failed to resolve JWT user', {
         targetUserId,
+        hasNextFallback,
         cause: e instanceof Error ? e.message : String(e),
       });
     }

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -7,6 +7,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
   isAgentBoundToIntent: vi.fn(),
+  isXtmOneConfigured: vi.fn(),
   resolveAgentJwtUser: vi.fn(),
   resolveRunAsUserId: vi.fn(),
 }));
@@ -23,6 +24,7 @@ import {
   buildAgentSlugOneOf,
   callXtmAgent,
   isAgentBoundToIntent,
+  isXtmOneConfigured,
   resolveAgentJwtUser,
   resolveRunAsUserId,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
@@ -77,6 +79,8 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+    // XTM One configured by default; the unconfigured test overrides this.
+    vi.mocked(isXtmOneConfigured).mockReturnValue(true);
     // No run-as user configured by default; tests that need it override this.
     vi.mocked(resolveRunAsUserId).mockReturnValue(undefined);
     // The executor resolves the JWT identity once and forwards it to both
@@ -134,6 +138,20 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: '' }),
       );
 
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
+    it('should route to `unmodified` without any user lookup or XTM One call when XTM One is not configured', async () => {
+      vi.mocked(isXtmOneConfigured).mockReturnValue(false);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(resolveAgentJwtUser).not.toHaveBeenCalled();
+      expect(isAgentBoundToIntent).not.toHaveBeenCalled();
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -7,6 +7,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
   isAgentBoundToIntent: vi.fn(),
+  resolveAgentJwtUser: vi.fn(),
   resolveRunAsUserId: vi.fn(),
 }));
 
@@ -22,6 +23,7 @@ import {
   buildAgentSlugOneOf,
   callXtmAgent,
   isAgentBoundToIntent,
+  resolveAgentJwtUser,
   resolveRunAsUserId,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
@@ -45,6 +47,10 @@ const ORIGINAL_BUNDLE: StixBundle = {
 };
 
 const TRANSFORMED_BUNDLE_OBJECT = { id: TRANSFORMED_INDICATOR_ID, type: 'indicator', spec_version: '2.1' };
+
+// Identity resolved once by the executor and shared between the binding
+// check and the agent call.
+const JWT_USER = { id: 'jwt-user-id', user_email: 'jwt-user@org.test' };
 
 const buildExecutorParams = (
   configuration: { agent_slug: string; prompt?: string },
@@ -73,6 +79,9 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
     // No run-as user configured by default; tests that need it override this.
     vi.mocked(resolveRunAsUserId).mockReturnValue(undefined);
+    // The executor resolves the JWT identity once and forwards it to both
+    // the binding check and the agent call.
+    vi.mocked(resolveAgentJwtUser).mockResolvedValue(JWT_USER);
     // Default to "agent slug is bound to the right intent" so existing
     // tests exercise the live agent-call path; tests that need the
     // negative branch override this explicitly.
@@ -137,7 +146,7 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-not-bound-to-transformer' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-not-bound-to-transformer', undefined);
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-not-bound-to-transformer', JWT_USER);
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
@@ -150,7 +159,7 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x', undefined);
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x', JWT_USER);
     });
 
     it('should route to `unmodified` when XTM One call fails (callXtmAgent returns null)', async () => {
@@ -160,12 +169,12 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', undefined);
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', JWT_USER);
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
     });
 
-    it('should resolve the configured run-as user and forward it to both the binding check and the agent call', async () => {
+    it('should resolve the JWT identity ONCE from the configured run-as user and forward it to both the binding check and the agent call', async () => {
       vi.mocked(resolveRunAsUserId).mockReturnValue('run-as-user-id');
       vi.mocked(callXtmAgent).mockResolvedValue(null);
 
@@ -173,8 +182,10 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x', 'run-as-user-id');
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', 'run-as-user-id');
+      expect(resolveAgentJwtUser).toHaveBeenCalledTimes(1);
+      expect(resolveAgentJwtUser).toHaveBeenCalledWith('run-as-user-id');
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x', JWT_USER);
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', JWT_USER);
     });
 
     it('should accept a raw JSON STIX bundle response and emit a new bundle preserving the original envelope', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -137,7 +137,7 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-not-bound-to-transformer' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-not-bound-to-transformer');
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-not-bound-to-transformer', undefined);
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBe('unmodified');
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
@@ -150,7 +150,7 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x');
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x', undefined);
     });
 
     it('should route to `unmodified` when XTM One call fails (callXtmAgent returns null)', async () => {
@@ -165,7 +165,7 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
     });
 
-    it('should resolve the configured run-as user and forward it to the agent call', async () => {
+    it('should resolve the configured run-as user and forward it to both the binding check and the agent call', async () => {
       vi.mocked(resolveRunAsUserId).mockReturnValue('run-as-user-id');
       vi.mocked(callXtmAgent).mockResolvedValue(null);
 
@@ -173,6 +173,7 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_transformer', 'agent-x', 'run-as-user-id');
       expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', 'run-as-user-id');
     });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-component-test.ts
@@ -139,6 +139,19 @@ describe('PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT', () => {
       expect(result.bundle).toBe(ORIGINAL_BUNDLE);
     });
 
+    it('should route to `unmodified` and skip both the binding check and the agent call when no JWT identity can be resolved', async () => {
+      vi.mocked(resolveAgentJwtUser).mockResolvedValue(null);
+
+      const result = await PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(isAgentBoundToIntent).not.toHaveBeenCalled();
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBe('unmodified');
+      expect(result.bundle).toBe(ORIGINAL_BUNDLE);
+    });
+
     it('should route to `unmodified` and not call XTM One when the slug is not bound to the cti.stix_transformer intent (defense in depth)', async () => {
       vi.mocked(isAgentBoundToIntent).mockResolvedValue(false);
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -115,6 +115,20 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
       expect(result.forceBundleTracking).toBe(true);
     });
 
+    it('should drop the step (no binding check, no agent call) when no JWT identity can be resolved', async () => {
+      vi.mocked(resolveAgentJwtUser).mockResolvedValue(null);
+
+      const result = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(isAgentBoundToIntent).not.toHaveBeenCalled();
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBeUndefined();
+      expect(result.bundle).toBe(BUNDLE);
+      expect(result.forceBundleTracking).toBe(true);
+    });
+
     it('should drop the step (no agent call) when the slug is not bound to the cti.stix_consumer intent (defense in depth)', async () => {
       vi.mocked(isAgentBoundToIntent).mockResolvedValue(false);
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -113,7 +113,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-not-bound-to-consumer' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-not-bound-to-consumer');
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-not-bound-to-consumer', undefined);
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
@@ -127,7 +127,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x');
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x', undefined);
     });
 
     it('should call the agent and still terminate cleanly (bundle tracked) when the agent responds', async () => {
@@ -157,7 +157,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
       expect(result.forceBundleTracking).toBe(true);
     });
 
-    it('should resolve the configured run-as user and forward it to the agent call', async () => {
+    it('should resolve the configured run-as user and forward it to both the binding check and the agent call', async () => {
       vi.mocked(resolveRunAsUserId).mockReturnValue('run-as-user-id');
       vi.mocked(callXtmAgent).mockResolvedValue('reply');
 
@@ -165,6 +165,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x', 'run-as-user-id');
       expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', 'run-as-user-id');
     });
   });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -7,6 +7,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
   isAgentBoundToIntent: vi.fn(),
+  isXtmOneConfigured: vi.fn(),
   resolveAgentJwtUser: vi.fn(),
   resolveRunAsUserId: vi.fn(),
 }));
@@ -23,6 +24,7 @@ import {
   buildAgentSlugOneOf,
   callXtmAgent,
   isAgentBoundToIntent,
+  isXtmOneConfigured,
   resolveAgentJwtUser,
   resolveRunAsUserId,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
@@ -64,6 +66,8 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
+    // XTM One configured by default; the unconfigured test overrides this.
+    vi.mocked(isXtmOneConfigured).mockReturnValue(true);
     // No run-as user configured by default; tests that need it override this.
     vi.mocked(resolveRunAsUserId).mockReturnValue(undefined);
     // The executor resolves the JWT identity once and forwards it to both
@@ -109,6 +113,21 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: '' }),
       );
 
+      expect(callXtmAgent).not.toHaveBeenCalled();
+      expect(result.output_port).toBeUndefined();
+      expect(result.bundle).toBe(BUNDLE);
+      expect(result.forceBundleTracking).toBe(true);
+    });
+
+    it('should drop the step without any user lookup or XTM One call when XTM One is not configured', async () => {
+      vi.mocked(isXtmOneConfigured).mockReturnValue(false);
+
+      const result = await PLAYBOOK_AI_AGENT_SEND_COMPONENT.executor(
+        buildExecutorParams({ agent_slug: 'agent-x' }),
+      );
+
+      expect(resolveAgentJwtUser).not.toHaveBeenCalled();
+      expect(isAgentBoundToIntent).not.toHaveBeenCalled();
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-send-component-test.ts
@@ -7,6 +7,7 @@ vi.mock('../../../../../src/modules/playbook/components/ai-agent-shared', () => 
   buildAgentSlugOneOf: vi.fn(),
   callXtmAgent: vi.fn(),
   isAgentBoundToIntent: vi.fn(),
+  resolveAgentJwtUser: vi.fn(),
   resolveRunAsUserId: vi.fn(),
 }));
 
@@ -22,6 +23,7 @@ import {
   buildAgentSlugOneOf,
   callXtmAgent,
   isAgentBoundToIntent,
+  resolveAgentJwtUser,
   resolveRunAsUserId,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
 import type { StixBundle } from '../../../../../src/types/stix-2-1-common';
@@ -35,6 +37,10 @@ const BUNDLE: StixBundle = {
   type: 'bundle',
   objects: [],
 };
+
+// Identity resolved once by the executor and shared between the binding
+// check and the agent call.
+const JWT_USER = { id: 'jwt-user-id', user_email: 'jwt-user@org.test' };
 
 const buildExecutorParams = (configuration: { agent_slug: string; prompt?: string }) => ({
   eventId: 'event-id',
@@ -60,6 +66,9 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
     vi.mocked(buildAgentMessageContent).mockReturnValue('built content');
     // No run-as user configured by default; tests that need it override this.
     vi.mocked(resolveRunAsUserId).mockReturnValue(undefined);
+    // The executor resolves the JWT identity once and forwards it to both
+    // the binding check and the agent call.
+    vi.mocked(resolveAgentJwtUser).mockResolvedValue(JWT_USER);
     // Default to "agent slug is bound to the consumer intent" so the
     // existing tests exercise the live path; tests that need the
     // negative branch override this explicitly.
@@ -113,7 +122,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-not-bound-to-consumer' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-not-bound-to-consumer', undefined);
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-not-bound-to-consumer', JWT_USER);
       expect(callXtmAgent).not.toHaveBeenCalled();
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
@@ -127,7 +136,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x', undefined);
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x', JWT_USER);
     });
 
     it('should call the agent and still terminate cleanly (bundle tracked) when the agent responds', async () => {
@@ -138,7 +147,7 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
       );
 
       expect(buildAgentMessageContent).toHaveBeenCalledWith(BUNDLE, 'do something');
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', undefined);
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', JWT_USER);
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
       expect(result.forceBundleTracking).toBe(true);
@@ -151,13 +160,13 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', undefined);
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', JWT_USER);
       expect(result.output_port).toBeUndefined();
       expect(result.bundle).toBe(BUNDLE);
       expect(result.forceBundleTracking).toBe(true);
     });
 
-    it('should resolve the configured run-as user and forward it to both the binding check and the agent call', async () => {
+    it('should resolve the JWT identity ONCE from the configured run-as user and forward it to both the binding check and the agent call', async () => {
       vi.mocked(resolveRunAsUserId).mockReturnValue('run-as-user-id');
       vi.mocked(callXtmAgent).mockResolvedValue('reply');
 
@@ -165,8 +174,10 @@ describe('PLAYBOOK_AI_AGENT_SEND_COMPONENT', () => {
         buildExecutorParams({ agent_slug: 'agent-x' }),
       );
 
-      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x', 'run-as-user-id');
-      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', 'run-as-user-id');
+      expect(resolveAgentJwtUser).toHaveBeenCalledTimes(1);
+      expect(resolveAgentJwtUser).toHaveBeenCalledWith('run-as-user-id');
+      expect(isAgentBoundToIntent).toHaveBeenCalledWith('cti.stix_consumer', 'agent-x', JWT_USER);
+      expect(callXtmAgent).toHaveBeenCalledWith('agent-x', 'built content', JWT_USER);
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -65,6 +65,7 @@ import {
   callXtmAgent,
   isAgentBoundToIntent,
   isRunAsUserAllowed,
+  isXtmOneConfigured,
   resolveAgentJwtUser,
   resolveRunAsUserId,
   sanitizeDefinitionRunAs,
@@ -161,6 +162,21 @@ describe('ai-agent-shared', () => {
       const result = await buildAgentSlugOneOf('cti.stix_transformer');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('isXtmOneConfigured', () => {
+    it('should be true only when both the XTM One URL and the client token are configured', () => {
+      vi.mocked(nconf.get).mockReturnValue('https://xtm-one.test');
+      vi.mocked(xtmOneClient.isConfigured).mockReturnValue(true);
+      expect(isXtmOneConfigured()).toBe(true);
+
+      vi.mocked(nconf.get).mockReturnValue(undefined);
+      expect(isXtmOneConfigured()).toBe(false);
+
+      vi.mocked(nconf.get).mockReturnValue('https://xtm-one.test');
+      vi.mocked(xtmOneClient.isConfigured).mockReturnValue(false);
+      expect(isXtmOneConfigured()).toBe(false);
     });
   });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -65,6 +65,7 @@ import {
   callXtmAgent,
   isAgentBoundToIntent,
   isRunAsUserAllowed,
+  resolveAgentJwtUser,
   resolveRunAsUserId,
   sanitizeDefinitionRunAs,
 } from '../../../../../src/modules/playbook/components/ai-agent-shared';
@@ -163,16 +164,97 @@ describe('ai-agent-shared', () => {
     });
   });
 
+  describe('resolveAgentJwtUser', () => {
+    const ADMIN_JWT_USER = { id: OPENCTI_ADMIN_UUID, user_email: 'admin@opencti.io' };
+
+    it('should resolve the seeded admin (single lookup) when no run-as user is configured', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(ADMIN_JWT_USER as any);
+
+      const result = await resolveAgentJwtUser(undefined);
+
+      expect(result).toEqual(ADMIN_JWT_USER);
+      expect(internalLoadById).toHaveBeenCalledTimes(1);
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        OPENCTI_ADMIN_UUID,
+        { type: ENTITY_TYPE_USER },
+      );
+    });
+
+    it('should resolve the run-as user (single lookup) when a runAsUserId is provided', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-7', user_email: 'analyst@org.test' } as any);
+
+      const result = await resolveAgentJwtUser('user-7');
+
+      expect(result).toEqual({ id: 'user-7', user_email: 'analyst@org.test' });
+      expect(internalLoadById).toHaveBeenCalledTimes(1);
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        'user-7',
+        { type: ENTITY_TYPE_USER },
+      );
+    });
+
+    it('should fall back to the seeded admin when the run-as user cannot be loaded', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        return null;
+      }) as any);
+
+      await expect(resolveAgentJwtUser('missing-user')).resolves.toEqual(ADMIN_JWT_USER);
+    });
+
+    it('should fall back to the seeded admin when the resolved run-as user has no email', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        return { id: 'user-9' };
+      }) as any);
+
+      await expect(resolveAgentJwtUser('user-9')).resolves.toEqual(ADMIN_JWT_USER);
+    });
+
+    it('should fall back to the seeded admin when resolving the run-as user throws', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        throw new Error('ES down');
+      }) as any);
+
+      await expect(resolveAgentJwtUser('user-x')).resolves.toEqual(ADMIN_JWT_USER);
+    });
+
+    it('should not look the seeded admin up twice when the run-as user IS the seeded admin', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+
+      const result = await resolveAgentJwtUser(OPENCTI_ADMIN_UUID);
+
+      expect(result).toBeNull();
+      expect(internalLoadById).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return null when neither the run-as user nor the seeded admin can be resolved', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+
+      const result = await resolveAgentJwtUser('missing-user');
+
+      expect(result).toBeNull();
+      expect(internalLoadById).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('isAgentBoundToIntent', () => {
     const ADMIN_JWT_USER = { id: OPENCTI_ADMIN_UUID, user_email: 'admin@opencti.io' };
 
-    beforeEach(() => {
-      // No run-as user configured by default -> the seeded admin is resolved.
-      vi.mocked(internalLoadById).mockResolvedValue(ADMIN_JWT_USER as any);
+    it('should return false (without calling XTM One) when the slug is empty', async () => {
+      const result = await isAgentBoundToIntent('cti.stix_transformer', '', ADMIN_JWT_USER);
+      expect(result).toBe(false);
+      expect(xtmOneClient.listAgentsForIntent).not.toHaveBeenCalled();
     });
 
-    it('should return false (without calling XTM One) when the slug is empty', async () => {
-      const result = await isAgentBoundToIntent('cti.stix_transformer', '');
+    it('should fail closed (no catalog call) when no JWT identity could be resolved (jwtUser null)', async () => {
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', null);
+
       expect(result).toBe(false);
       expect(xtmOneClient.listAgentsForIntent).not.toHaveBeenCalled();
     });
@@ -183,68 +265,24 @@ describe('ai-agent-shared', () => {
         { agent_id: '2', agent_name: 'B', agent_slug: 'agent-b', agent_description: null, priority: 0 },
       ]);
 
-      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-b');
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-b', ADMIN_JWT_USER);
 
       expect(result).toBe(true);
     });
 
-    it('should query the catalog as the seeded admin when no run-as user is configured (same identity as the agent call)', async () => {
-      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([]);
-
-      await isAgentBoundToIntent('cti.stix_transformer', 'agent-a');
-
-      expect(internalLoadById).toHaveBeenCalledWith(
-        expect.anything(),
-        SYSTEM_USER,
-        OPENCTI_ADMIN_UUID,
-        { type: ENTITY_TYPE_USER },
-      );
-      const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
-      expect(passedContext.user?.id).toBe(OPENCTI_ADMIN_UUID);
-      expect(passedContext.user?.user_email).toBe('admin@opencti.io');
-    });
-
-    it('should query the catalog as the resolved run-as user when a runAsUserId is provided', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-7', user_email: 'analyst@org.test' } as any);
+    it('should query the catalog as the passed JWT identity (same identity as the agent call), without a user lookup', async () => {
       vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([
         { agent_id: '1', agent_name: 'A', agent_slug: 'agent-a', agent_description: null, priority: 0 },
       ]);
 
-      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'user-7');
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', { id: 'user-7', user_email: 'analyst@org.test' });
 
       expect(result).toBe(true);
-      expect(internalLoadById).toHaveBeenCalledWith(
-        expect.anything(),
-        SYSTEM_USER,
-        'user-7',
-        { type: ENTITY_TYPE_USER },
-      );
+      // The identity was resolved once by the executor — no lookup here.
+      expect(internalLoadById).not.toHaveBeenCalled();
       const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
       expect(passedContext.user?.id).toBe('user-7');
       expect(passedContext.user?.user_email).toBe('analyst@org.test');
-    });
-
-    it('should fall back to the seeded admin when the run-as user cannot be loaded', async () => {
-      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
-        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
-        return null;
-      }) as any);
-      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([]);
-
-      await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'missing-user');
-
-      const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
-      expect(passedContext.user?.id).toBe(OPENCTI_ADMIN_UUID);
-      expect(passedContext.user?.user_email).toBe('admin@opencti.io');
-    });
-
-    it('should fail closed (no catalog call) when neither the run-as user nor the seeded admin can be resolved', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue(null as any);
-
-      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'missing-user');
-
-      expect(result).toBe(false);
-      expect(xtmOneClient.listAgentsForIntent).not.toHaveBeenCalled();
     });
 
     it('should return false when the slug is NOT in the intent catalog (defense-in-depth check fails closed)', async () => {
@@ -252,7 +290,7 @@ describe('ai-agent-shared', () => {
         { agent_id: '1', agent_name: 'A', agent_slug: 'agent-a', agent_description: null, priority: 0 },
       ]);
 
-      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-not-bound');
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-not-bound', ADMIN_JWT_USER);
 
       expect(result).toBe(false);
     });
@@ -260,7 +298,7 @@ describe('ai-agent-shared', () => {
     it('should fail closed (return false) when the catalog call throws', async () => {
       vi.mocked(xtmOneClient.listAgentsForIntent).mockRejectedValue(new Error('XTM One down'));
 
-      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a');
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', ADMIN_JWT_USER);
 
       expect(result).toBe(false);
     });
@@ -447,34 +485,27 @@ describe('ai-agent-shared', () => {
       vi.mocked(issueXtmJwt).mockResolvedValue('signed.jwt');
       vi.mocked(xtmOneClient.isConfigured).mockReturnValue(true);
       vi.mocked(nconf.get).mockReturnValue('https://xtm-one.test');
-      // No run-as user configured by default -> the seeded admin is resolved.
-      vi.mocked(internalLoadById).mockResolvedValue(ADMIN_JWT_USER as any);
     });
 
     it('should return null and not call the HTTP client when XTM One is not configured', async () => {
       vi.mocked(nconf.get).mockReturnValue(undefined);
       vi.mocked(xtmOneClient.isConfigured).mockReturnValue(false);
 
-      const result = await callXtmAgent('any-agent', 'content');
+      const result = await callXtmAgent('any-agent', 'content', ADMIN_JWT_USER);
 
       expect(result).toBeNull();
       expect(getHttpClient).not.toHaveBeenCalled();
     });
 
-    it('should default to the seeded admin and POST a non-streaming chat message', async () => {
+    it('should mint the JWT for the passed identity (no extra lookup) and POST a non-streaming chat message', async () => {
       const post = vi.fn().mockResolvedValue({ data: { content: 'agent reply' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
-      const result = await callXtmAgent('agent-slug', 'hello world');
+      const result = await callXtmAgent('agent-slug', 'hello world', ADMIN_JWT_USER);
 
       expect(result).toBe('agent reply');
-      // No run-as user -> resolve the seeded admin by its fixed UUID.
-      expect(internalLoadById).toHaveBeenCalledWith(
-        expect.anything(),
-        SYSTEM_USER,
-        OPENCTI_ADMIN_UUID,
-        { type: ENTITY_TYPE_USER },
-      );
+      // The identity was resolved once by the executor — no lookup here.
+      expect(internalLoadById).not.toHaveBeenCalled();
       expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
       expect(getHttpClient).toHaveBeenCalledTimes(1);
       const headers = vi.mocked(getHttpClient).mock.calls[0][0].headers as Record<string, string>;
@@ -487,68 +518,21 @@ describe('ai-agent-shared', () => {
       );
     });
 
-    it('should mint the JWT for the resolved run-as user when a runAsUserId is provided', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-7', user_email: 'analyst@org.test' } as any);
+    it('should mint the JWT for a run-as identity exactly as passed', async () => {
       const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
-      const result = await callXtmAgent('agent-slug', 'content', 'user-7');
+      const result = await callXtmAgent('agent-slug', 'content', { id: 'user-7', user_email: 'analyst@org.test' });
 
       expect(result).toBe('ok');
-      expect(internalLoadById).toHaveBeenCalledWith(
-        expect.anything(),
-        SYSTEM_USER,
-        'user-7',
-        { type: ENTITY_TYPE_USER },
-      );
       expect(issueXtmJwt).toHaveBeenCalledWith({ id: 'user-7', user_email: 'analyst@org.test' }, 'https://xtm-one.test');
     });
 
-    it('should fall back to the seeded admin when the run-as user cannot be loaded', async () => {
-      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
-        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
-        return null;
-      }) as any);
+    it('should skip the call (return null, no JWT minted) when no JWT identity could be resolved (jwtUser null)', async () => {
       const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
-      await callXtmAgent('agent-slug', 'content', 'missing-user');
-
-      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
-    });
-
-    it('should fall back to the seeded admin when the resolved user has no email', async () => {
-      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
-        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
-        return { id: 'user-9' };
-      }) as any);
-      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
-      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
-
-      await callXtmAgent('agent-slug', 'content', 'user-9');
-
-      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
-    });
-
-    it('should fall back to the seeded admin when resolving the run-as user throws', async () => {
-      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
-        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
-        throw new Error('ES down');
-      }) as any);
-      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
-      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
-
-      await callXtmAgent('agent-slug', 'content', 'user-x');
-
-      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
-    });
-
-    it('should skip the call (return null, no JWT minted) when neither the run-as user nor the seeded admin can be resolved', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue(null as any);
-      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
-      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
-
-      const result = await callXtmAgent('agent-slug', 'content', 'missing-user');
+      const result = await callXtmAgent('agent-slug', 'content', null);
 
       expect(result).toBeNull();
       expect(issueXtmJwt).not.toHaveBeenCalled();
@@ -559,7 +543,7 @@ describe('ai-agent-shared', () => {
       const post = vi.fn().mockResolvedValue({ data: {} });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
-      const result = await callXtmAgent('agent-slug', 'content');
+      const result = await callXtmAgent('agent-slug', 'content', ADMIN_JWT_USER);
 
       expect(result).toBeNull();
     });
@@ -568,7 +552,7 @@ describe('ai-agent-shared', () => {
       const post = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
-      const result = await callXtmAgent('agent-slug', 'content');
+      const result = await callXtmAgent('agent-slug', 'content', ADMIN_JWT_USER);
 
       expect(result).toBeNull();
     });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -164,6 +164,13 @@ describe('ai-agent-shared', () => {
   });
 
   describe('isAgentBoundToIntent', () => {
+    const ADMIN_JWT_USER = { id: OPENCTI_ADMIN_UUID, user_email: 'admin@opencti.io' };
+
+    beforeEach(() => {
+      // No run-as user configured by default -> the seeded admin is resolved.
+      vi.mocked(internalLoadById).mockResolvedValue(ADMIN_JWT_USER as any);
+    });
+
     it('should return false (without calling XTM One) when the slug is empty', async () => {
       const result = await isAgentBoundToIntent('cti.stix_transformer', '');
       expect(result).toBe(false);
@@ -179,8 +186,53 @@ describe('ai-agent-shared', () => {
       const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-b');
 
       expect(result).toBe(true);
+    });
+
+    it('should query the catalog as the seeded admin when no run-as user is configured (same identity as the agent call)', async () => {
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([]);
+
+      await isAgentBoundToIntent('cti.stix_transformer', 'agent-a');
+
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        OPENCTI_ADMIN_UUID,
+        { type: ENTITY_TYPE_USER },
+      );
       const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
-      expect(passedContext.user).toBe(AUTOMATION_MANAGER_USER);
+      expect(passedContext.user?.id).toBe(OPENCTI_ADMIN_UUID);
+      expect(passedContext.user?.user_email).toBe('admin@opencti.io');
+    });
+
+    it('should query the catalog as the resolved run-as user when a runAsUserId is provided', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-7', user_email: 'analyst@org.test' } as any);
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([
+        { agent_id: '1', agent_name: 'A', agent_slug: 'agent-a', agent_description: null, priority: 0 },
+      ]);
+
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'user-7');
+
+      expect(result).toBe(true);
+      expect(internalLoadById).toHaveBeenCalledWith(
+        expect.anything(),
+        SYSTEM_USER,
+        'user-7',
+        { type: ENTITY_TYPE_USER },
+      );
+      const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
+      expect(passedContext.user?.id).toBe('user-7');
+      expect(passedContext.user?.user_email).toBe('analyst@org.test');
+    });
+
+    it('should fall back to AUTOMATION_MANAGER_USER when the run-as user cannot be loaded', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+      vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([]);
+
+      await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'missing-user');
+
+      const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
+      expect(passedContext.user?.id).toBe(AUTOMATION_MANAGER_USER.id);
+      expect(passedContext.user?.user_email).toBe(AUTOMATION_MANAGER_USER.user_email);
     });
 
     it('should return false when the slug is NOT in the intent catalog (defense-in-depth check fails closed)', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -224,15 +224,27 @@ describe('ai-agent-shared', () => {
       expect(passedContext.user?.user_email).toBe('analyst@org.test');
     });
 
-    it('should fall back to AUTOMATION_MANAGER_USER when the run-as user cannot be loaded', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+    it('should fall back to the seeded admin when the run-as user cannot be loaded', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        return null;
+      }) as any);
       vi.mocked(xtmOneClient.listAgentsForIntent).mockResolvedValue([]);
 
       await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'missing-user');
 
       const passedContext = vi.mocked(xtmOneClient.listAgentsForIntent).mock.calls[0][0];
-      expect(passedContext.user?.id).toBe(AUTOMATION_MANAGER_USER.id);
-      expect(passedContext.user?.user_email).toBe(AUTOMATION_MANAGER_USER.user_email);
+      expect(passedContext.user?.id).toBe(OPENCTI_ADMIN_UUID);
+      expect(passedContext.user?.user_email).toBe('admin@opencti.io');
+    });
+
+    it('should fail closed (no catalog call) when neither the run-as user nor the seeded admin can be resolved', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+
+      const result = await isAgentBoundToIntent('cti.stix_transformer', 'agent-a', 'missing-user');
+
+      expect(result).toBe(false);
+      expect(xtmOneClient.listAgentsForIntent).not.toHaveBeenCalled();
     });
 
     it('should return false when the slug is NOT in the intent catalog (defense-in-depth check fails closed)', async () => {
@@ -492,34 +504,55 @@ describe('ai-agent-shared', () => {
       expect(issueXtmJwt).toHaveBeenCalledWith({ id: 'user-7', user_email: 'analyst@org.test' }, 'https://xtm-one.test');
     });
 
-    it('should fall back to AUTOMATION_MANAGER_USER when the run-as user cannot be loaded', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+    it('should fall back to the seeded admin when the run-as user cannot be loaded', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        return null;
+      }) as any);
       const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
       await callXtmAgent('agent-slug', 'content', 'missing-user');
 
-      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
     });
 
-    it('should fall back to AUTOMATION_MANAGER_USER when the resolved user has no email', async () => {
-      vi.mocked(internalLoadById).mockResolvedValue({ id: 'user-9' } as any);
+    it('should fall back to the seeded admin when the resolved user has no email', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        return { id: 'user-9' };
+      }) as any);
       const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
       await callXtmAgent('agent-slug', 'content', 'user-9');
 
-      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
     });
 
-    it('should fall back to AUTOMATION_MANAGER_USER when resolving the run-as user throws', async () => {
-      vi.mocked(internalLoadById).mockRejectedValue(new Error('ES down'));
+    it('should fall back to the seeded admin when resolving the run-as user throws', async () => {
+      vi.mocked(internalLoadById).mockImplementation((async (_context: any, _user: any, id: string) => {
+        if (id === OPENCTI_ADMIN_UUID) return ADMIN_JWT_USER;
+        throw new Error('ES down');
+      }) as any);
       const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
       vi.mocked(getHttpClient).mockReturnValue({ post } as any);
 
       await callXtmAgent('agent-slug', 'content', 'user-x');
 
-      expect(issueXtmJwt).toHaveBeenCalledWith(AUTOMATION_MANAGER_USER, 'https://xtm-one.test');
+      expect(issueXtmJwt).toHaveBeenCalledWith(ADMIN_JWT_USER, 'https://xtm-one.test');
+    });
+
+    it('should skip the call (return null, no JWT minted) when neither the run-as user nor the seeded admin can be resolved', async () => {
+      vi.mocked(internalLoadById).mockResolvedValue(null as any);
+      const post = vi.fn().mockResolvedValue({ data: { content: 'ok' } });
+      vi.mocked(getHttpClient).mockReturnValue({ post } as any);
+
+      const result = await callXtmAgent('agent-slug', 'content', 'missing-user');
+
+      expect(result).toBeNull();
+      expect(issueXtmJwt).not.toHaveBeenCalled();
+      expect(post).not.toHaveBeenCalled();
     });
 
     it('should return null when the assistant content field is missing', async () => {


### PR DESCRIPTION
## Proposed changes

- Fix the runtime intent-binding check of both AI agent playbook components (Transform with AI agent / Send to AI agent): `isAgentBoundToIntent()` now queries the XTM One intent catalog as the SAME identity that `callXtmAgent()` mints the cross-platform JWT for (resolved `run_as` user, defaulting to the seeded platform admin).
- Previously the check always ran as `AUTOMATION_MANAGER_USER` (placeholder email "AUTOMATION MANAGER"), which resolves to a minimal non-admin, group-less user on the XTM One side. Since the XTM One catalog is scoped per user, agents that ARE bound to the intent but only group-shared (not company-managed) were invisible to the check, so the step was skipped with "[PLAYBOOK AI AGENT] Configured agent is not bound to the transformer intent, returning bundle unmodified" even though the run-as user could see and invoke the agent.
- The identity is resolved exactly ONCE per playbook step: the executor calls the now-exported `resolveAgentJwtUser()` and passes the resolved `AgentJwtUser | null` object to both `isAgentBoundToIntent()` and `callXtmAgent()`. Neither helper performs its own user lookup anymore, so the visibility check and the actual invocation are structurally guaranteed to run as the same identity, with a single `internalLoadById` call per step (addresses the Copilot review remark about duplicate lookups / possible divergence).
- Drop the `AUTOMATION_MANAGER_USER` last-resort JWT fallback entirely: its placeholder email can never be resolved to an account on the XTM One side, so a JWT minted for it is guaranteed dead. `resolveAgentJwtUser()` falls back from the run-as user to the seeded platform admin (`OPENCTI_ADMIN_UUID`, always present in the database), and when even that cannot be loaded it returns null.
- When no JWT identity can be resolved, both executors early-return with a dedicated "no resolvable JWT identity" warning (accurate troubleshooting signal) instead of falling through to a misleading "agent is not bound to the intent" message; the shared helpers additionally fail closed if ever handed a null identity.
- Both executors check the XTM One configuration FIRST (new shared `isXtmOneConfigured()` predicate): on a misconfigured platform the step is skipped with a dedicated warning before any `internalLoadById` lookup, so no DB/ES query and no identity-resolution log noise occur.
- Unit tests updated/extended: `resolveAgentJwtUser()` is now tested directly (seeded admin default, explicit run-as, run-as -> admin fallback, no-email and throwing lookups, no double lookup when run_as IS the admin, null when nothing resolvable); `isAgentBoundToIntent()` / `callXtmAgent()` are tested with the pre-resolved identity (including the fail-closed null path); both component executor tests assert the identity is resolved once, forwarded to both calls, and that the null-identity early return skips the binding check and the agent call.

## Related issues

- Fixes #16945

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (unit tests: 95 passed; tsc + eslint clean)
- [x] I added/update the relevant documentation (comments updated in-code)
- [x] Where necessary I refactored code to improve the overall quality
