### PR TITLE
feat(telemetry): add TELEMETRY_TAGS deployment dimensions and active connectors by catalog identity (#16956)

### DIFF
--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -36,6 +36,7 @@ Here is an exhaustive list of the collected metrics:
 - The platform unique identifier
 - The platform creation date
 - The number of nodes in the cluster
+- The deployment tags, when configured by the operator (`telemetry_manager:tags` / `TELEMETRY_MANAGER__TAGS` - comma-separated freeform tags such as `saas,eu-west`, normalized to lowercase and sorted before export)
 
 ### Users and accounts
 
@@ -55,6 +56,7 @@ Here is an exhaustive list of the collected metrics:
 
 - The number of active connectors
 - The number of connectors deployed via composer
+- The active connectors broken down by catalog identity: for composer-managed connectors, the catalog contract slug (resolved from the deployed container image); for manually registered connectors, the registered connector name - together with the connector type and a managed/manual flag. No connector configuration is ever collected.
 
 ### Drafts
 

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -276,7 +276,8 @@
     "interval": 10000
   },
   "telemetry_manager": {
-    "lock_key": "telemetry_manager_lock"
+    "lock_key": "telemetry_manager_lock",
+    "tags": ""
   },
   "playbook_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -5,7 +5,7 @@ import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import conf, { DEV_MODE, logApp, PLATFORM_VERSION } from '../config/conf';
 import { executionContext, SYSTEM_USER, TELEMETRY_MANAGER_USER } from '../utils/access';
 import { getClusterInformation } from '../database/cluster-module';
-import { TELEMETRY_SERVICE_NAME, TelemetryMeterManager } from '../telemetry/TelemetryMeterManager';
+import { normalizeTelemetryTags, TELEMETRY_SERVICE_NAME, TelemetryMeterManager, type DimensionalGaugeItem } from '../telemetry/TelemetryMeterManager';
 import type { HandlerInput, ManagerDefinition } from './managerModule';
 import { registerManager } from './managerModule';
 import { MetricFileExporter } from '../telemetry/MetricFileExporter';
@@ -17,7 +17,8 @@ import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { elCount } from '../database/engine';
-import { READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
+import { isNotEmptyField, READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
+import { getSupportedContractsByImage } from '../modules/catalog/catalog-domain';
 import { FilterMode } from '../generated/graphql';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../database/redis';
 import type { AuthUser } from '../types/user';
@@ -227,12 +228,21 @@ const telemetryInitializer = async (): Promise<HandlerInput> => {
   // Meter Provider creation
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   const platformId = settings.id;
-  const filigranResource = resourceFromAttributes({
+  const filigranResourceAttributes: Record<string, string> = {
     [ATTR_SERVICE_NAME]: TELEMETRY_SERVICE_NAME,
     [ATTR_SERVICE_VERSION]: PLATFORM_VERSION,
     [ATTR_SERVICE_INSTANCE_ID]: platformId,
     'service.instance.creation': settings.created_at as unknown as string,
-  });
+  };
+  // Optional deployment tags (telemetry_manager:tags / TELEMETRY_MANAGER__TAGS,
+  // normalized to a canonical sorted/lowercased comma string). One resource
+  // attribute on every export so analytics can slice any metric by deployment
+  // dimension (e.g. "saas,eu-west"). Omitted entirely when not configured.
+  const telemetryTags = normalizeTelemetryTags(conf.get('telemetry_manager:tags'));
+  if (telemetryTags.length > 0) {
+    filigranResourceAttributes['filigran.telemetry.tags'] = telemetryTags;
+  }
+  const filigranResource = resourceFromAttributes(filigranResourceAttributes);
   const resource = defaultResource().merge(filigranResource);
   const filigranMeterProvider = new MeterProvider(({ resource, readers: filigranMetricReaders }));
   const filigranTelemetryMeterManager = new TelemetryMeterManager(filigranMeterProvider);
@@ -265,6 +275,31 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     const connectors = await getEntitiesListFromCache<BasicStoreEntityConnector>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_CONNECTOR);
     const activeConnectors = connectors.filter((c) => c.active);
     manager.setActiveConnectorsCount(activeConnectors.length);
+    // Breakdown by catalog identity: composer-managed connectors resolve to
+    // the catalog contract slug through their stored container image (the
+    // user-set connector name is irrelevant); manually registered connectors
+    // have no catalog reference in database, so their registered name is the
+    // best available identity, flagged managed=false.
+    const contractsByImage = await getSupportedContractsByImage();
+    const connectorsByIdentity = new Map<string, DimensionalGaugeItem>();
+    activeConnectors.forEach((connector) => {
+      const isManaged = isNotEmptyField(connector.catalog_id);
+      const slug = isManaged
+        ? (contractsByImage.get(connector.manager_contract_image ?? '')?.slug ?? connector.manager_contract_image ?? '')
+        : (connector.name ?? '').trim().toLowerCase();
+      if (slug.length === 0) {
+        return;
+      }
+      const attributes = { slug, managed: isManaged ? 'true' : 'false', type: connector.connector_type ?? '' };
+      const identityKey = `${attributes.slug}|${attributes.managed}|${attributes.type}`;
+      const existingItem = connectorsByIdentity.get(identityKey);
+      if (existingItem) {
+        existingItem.value += 1;
+      } else {
+        connectorsByIdentity.set(identityKey, { value: 1, attributes });
+      }
+    });
+    manager.setActiveConnectorsByIdentity(Array.from(connectorsByIdentity.values()));
     // endregion
 
     // region Roles with draft capability information

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -5,7 +5,7 @@ import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import conf, { DEV_MODE, logApp, PLATFORM_VERSION } from '../config/conf';
 import { executionContext, SYSTEM_USER, TELEMETRY_MANAGER_USER } from '../utils/access';
 import { getClusterInformation } from '../database/cluster-module';
-import { normalizeTelemetryTags, TELEMETRY_SERVICE_NAME, TelemetryMeterManager, type DimensionalGaugeItem } from '../telemetry/TelemetryMeterManager';
+import { computeActiveConnectorsByIdentity, normalizeTelemetryTags, TELEMETRY_SERVICE_NAME, TelemetryMeterManager } from '../telemetry/TelemetryMeterManager';
 import type { HandlerInput, ManagerDefinition } from './managerModule';
 import { registerManager } from './managerModule';
 import { MetricFileExporter } from '../telemetry/MetricFileExporter';
@@ -17,7 +17,7 @@ import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { elCount } from '../database/engine';
-import { isNotEmptyField, READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
+import { READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
 import { getSupportedContractsByImage } from '../modules/catalog/catalog-domain';
 import { FilterMode } from '../generated/graphql';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../database/redis';
@@ -275,31 +275,12 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     const connectors = await getEntitiesListFromCache<BasicStoreEntityConnector>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_CONNECTOR);
     const activeConnectors = connectors.filter((c) => c.active);
     manager.setActiveConnectorsCount(activeConnectors.length);
-    // Breakdown by catalog identity: composer-managed connectors resolve to
-    // the catalog contract slug through their stored container image (the
-    // user-set connector name is irrelevant); manually registered connectors
-    // have no catalog reference in database, so their registered name is the
-    // best available identity, flagged managed=false.
+    // Breakdown by catalog identity (see computeActiveConnectorsByIdentity):
+    // composer-managed connectors resolve to the catalog contract slug
+    // through their stored container image; manually registered connectors
+    // fall back to their registered name, flagged managed=false.
     const contractsByImage = await getSupportedContractsByImage();
-    const connectorsByIdentity = new Map<string, DimensionalGaugeItem>();
-    activeConnectors.forEach((connector) => {
-      const isManaged = isNotEmptyField(connector.catalog_id);
-      const slug = isManaged
-        ? (contractsByImage.get(connector.manager_contract_image ?? '')?.slug ?? connector.manager_contract_image ?? '')
-        : (connector.name ?? '').trim().toLowerCase();
-      if (slug.length === 0) {
-        return;
-      }
-      const attributes = { slug, managed: isManaged ? 'true' : 'false', type: connector.connector_type ?? '' };
-      const identityKey = `${attributes.slug}|${attributes.managed}|${attributes.type}`;
-      const existingItem = connectorsByIdentity.get(identityKey);
-      if (existingItem) {
-        existingItem.value += 1;
-      } else {
-        connectorsByIdentity.set(identityKey, { value: 1, attributes });
-      }
-    });
-    manager.setActiveConnectorsByIdentity(Array.from(connectorsByIdentity.values()));
+    manager.setActiveConnectorsByIdentity(computeActiveConnectorsByIdentity(activeConnectors, contractsByImage));
     // endregion
 
     // region Roles with draft capability information

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -59,7 +59,9 @@ export const computeActiveConnectorsByIdentity = (
       return;
     }
     const attributes = { slug, managed: isManaged ? 'true' : 'false', type: connector.connector_type ?? '' };
-    const identityKey = `${attributes.slug}|${attributes.managed}|${attributes.type}`;
+    // JSON-encode the key components: manual connector names are freeform, so
+    // a naive separator-joined key could collide across identities.
+    const identityKey = JSON.stringify([attributes.slug, attributes.managed, attributes.type]);
     const existingItem = connectorsByIdentity.get(identityKey);
     if (existingItem) {
       existingItem.value += 1;
@@ -434,10 +436,14 @@ export class TelemetryMeterManager {
     const gaugeOptions = { description, unit: opts.unit ?? 'count', valueType: opts.valueType ?? ValueType.INT };
     const dimensionalGauge = meter.createObservableGauge(`opencti_${name}`, gaugeOptions);
     dimensionalGauge.addCallback((observableResult: ObservableResult) => {
-      /* eslint-disable @typescript-eslint/ban-ts-comment */
-      // @ts-ignore
-      const items = this[observer] as DimensionalGaugeItem[];
-      items.forEach((item) => observableResult.observe(item.value, item.attributes));
+      const items = (this as unknown as Record<string, unknown>)[observer];
+      // Guard against a mis-registered observer (unset property or scalar
+      // field): observing nothing is better than throwing inside the OTLP
+      // collection callback and breaking the whole export cycle.
+      if (!Array.isArray(items)) {
+        return;
+      }
+      (items as DimensionalGaugeItem[]).forEach((item) => observableResult.observe(item.value, item.attributes));
     });
   }
 

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -4,6 +4,28 @@ import { ValueType } from '@opentelemetry/api';
 
 export const TELEMETRY_SERVICE_NAME = 'opencti-telemetry';
 
+// One datapoint of a multi-dimensional gauge: a value observed with a set of
+// OTLP datapoint attributes (labels).
+export interface DimensionalGaugeItem {
+  value: number;
+  attributes: Record<string, string>;
+}
+
+// Normalize the deployment tags configured via telemetry_manager:tags
+// (TELEMETRY_MANAGER__TAGS): split on ",", trim, lowercase, drop empties,
+// dedupe, sort, re-join. Shared Filigran contract (same normalization in
+// XTM One and OpenAEV) so an identical tag set always produces the identical
+// string in the analytics warehouse.
+export const normalizeTelemetryTags = (rawTags: string | null | undefined): string => {
+  const tags = new Set(
+    (rawTags ?? '')
+      .split(',')
+      .map((tag) => tag.trim().toLowerCase())
+      .filter((tag) => tag.length > 0),
+  );
+  return Array.from(tags).sort().join(',');
+};
+
 export class TelemetryMeterManager {
   meterProvider: MeterProvider;
 
@@ -21,6 +43,11 @@ export class TelemetryMeterManager {
 
   // Number of active connectors
   activeConnectorsCount = 0;
+
+  // Active connectors broken down by catalog identity (slug, managed, type).
+  // Composer-managed connectors carry the exact catalog contract slug; manual
+  // connectors fall back to their registered name (managed=false).
+  activeConnectorsByIdentity: DimensionalGaugeItem[] = [];
 
   disseminationCount = 0;
 
@@ -202,6 +229,10 @@ export class TelemetryMeterManager {
     this.activeConnectorsCount = n;
   }
 
+  setActiveConnectorsByIdentity(items: DimensionalGaugeItem[]) {
+    this.activeConnectorsByIdentity = items;
+  }
+
   setDisseminationCount(n: number) {
     this.disseminationCount = n;
   }
@@ -348,6 +379,24 @@ export class TelemetryMeterManager {
     });
   }
 
+  // Multi-dimensional gauge: the observed property holds a list of
+  // DimensionalGaugeItem, each exported as one datapoint with its own OTLP
+  // attributes (labels).
+  registerDimensionalGauge(name: string, description: string, observer: string, opts: {
+    unit?: string;
+    valueType?: ValueType;
+  } = {}) {
+    const meter = this.meterProvider.getMeter(TELEMETRY_SERVICE_NAME);
+    const gaugeOptions = { description, unit: opts.unit ?? 'count', valueType: opts.valueType ?? ValueType.INT };
+    const dimensionalGauge = meter.createObservableGauge(`opencti_${name}`, gaugeOptions);
+    dimensionalGauge.addCallback((observableResult: ObservableResult) => {
+      /* eslint-disable @typescript-eslint/ban-ts-comment */
+      // @ts-ignore
+      const items = this[observer] as DimensionalGaugeItem[];
+      items.forEach((item) => observableResult.observe(item.value, item.attributes));
+    });
+  }
+
   registerFiligranTelemetry() {
     // This kind of gauge count be synchronous, waiting for opentelemetry-js 3668
     // https://github.com/open-telemetry/opentelemetry-js/issues/3668
@@ -355,6 +404,7 @@ export class TelemetryMeterManager {
     this.registerGauge('total_service_account_count', 'number of service account', 'serviceAccountCount');
     this.registerGauge('total_instances_count', 'cluster number of instances', 'instancesCount');
     this.registerGauge('active_connectors_count', 'number of active connectors', 'activeConnectorsCount');
+    this.registerDimensionalGauge('active_connectors_by_identity', 'active connectors broken down by catalog identity (slug, managed, type)', 'activeConnectorsByIdentity');
     this.registerGauge('is_enterprise_edition', 'enterprise Edition is activated', 'isEEActivated', { unit: 'boolean' });
     this.registerGauge('call_dissemination', 'dissemination feature usage', 'disseminationCount');
     this.registerGauge('roles_with_capability_in_draft_count', 'number of roles with capability in draft', 'rolesWithCapabilityInDraftCount');

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -26,6 +26,50 @@ export const normalizeTelemetryTags = (rawTags: string | null | undefined): stri
   return Array.from(tags).sort().join(',');
 };
 
+// The connector fields the identity breakdown relies on (structural subset of
+// BasicStoreEntityConnector, kept minimal so the pure computation stays
+// unit-testable without the store type transitive closure).
+export interface ConnectorIdentitySource {
+  catalog_id?: string | null;
+  manager_contract_image?: string | null;
+  name?: string | null;
+  connector_type?: string | null;
+}
+
+// Breakdown of active connectors by catalog identity: composer-managed
+// connectors resolve to the exact catalog contract slug through their stored
+// container image (the user-set connector name is irrelevant). When the
+// stored image is not in the catalog (e.g. removed contract), the datapoint
+// is SKIPPED rather than exporting the raw image string, which could carry a
+// private registry hostname - only catalog slugs ever leave the platform for
+// managed connectors. Manually registered connectors have no catalog
+// reference, so their trimmed/lowercased registered name is the best
+// available identity, flagged managed=false.
+export const computeActiveConnectorsByIdentity = (
+  activeConnectors: ConnectorIdentitySource[],
+  contractsByImage: ReadonlyMap<string, { slug: string }>,
+): DimensionalGaugeItem[] => {
+  const connectorsByIdentity = new Map<string, DimensionalGaugeItem>();
+  activeConnectors.forEach((connector) => {
+    const isManaged = (connector.catalog_id ?? '').length > 0;
+    const slug = isManaged
+      ? (contractsByImage.get(connector.manager_contract_image ?? '')?.slug ?? '')
+      : (connector.name ?? '').trim().toLowerCase();
+    if (slug.length === 0) {
+      return;
+    }
+    const attributes = { slug, managed: isManaged ? 'true' : 'false', type: connector.connector_type ?? '' };
+    const identityKey = `${attributes.slug}|${attributes.managed}|${attributes.type}`;
+    const existingItem = connectorsByIdentity.get(identityKey);
+    if (existingItem) {
+      existingItem.value += 1;
+    } else {
+      connectorsByIdentity.set(identityKey, { value: 1, attributes });
+    }
+  });
+  return Array.from(connectorsByIdentity.values());
+};
+
 export class TelemetryMeterManager {
   meterProvider: MeterProvider;
 

--- a/opencti-platform/opencti-graphql/src/types/connector.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/connector.d.ts
@@ -24,6 +24,10 @@ export interface BasicStoreEntityConnector extends StoreEntity {
   connector_info: ConnectorInfo;
   playbook_compatible: boolean;
   xtm_one_intent: string | null;
+  // region composer (set only on composer-managed connectors)
+  catalog_id?: string;
+  manager_contract_image?: string;
+  // endregion
 }
 export interface BasicStoreEntityConnectorManager extends BasicStoreEntity {
   public_key: string;

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
@@ -67,6 +67,17 @@ describe('Active connectors by catalog identity', () => {
     expect(computeActiveConnectorsByIdentity([manual(''), manual('   '), manual(null), manual(undefined)], CONTRACTS)).toEqual([]);
   });
 
+  it('should not collide identities when a freeform manual name contains separator-like characters', () => {
+    // Under a naive 'slug|managed|type' string key these two would merge.
+    const items = computeActiveConnectorsByIdentity(
+      [manual('a|false', 't'), manual('a', 'false|t')],
+      CONTRACTS,
+    );
+    expect(items).toHaveLength(2);
+    expect(items).toContainEqual({ value: 1, attributes: { slug: 'a|false', managed: 'false', type: 't' } });
+    expect(items).toContainEqual({ value: 1, attributes: { slug: 'a', managed: 'false', type: 'false|t' } });
+  });
+
   it('should aggregate connectors sharing the same identity and keep distinct types apart', () => {
     const items = computeActiveConnectorsByIdentity(
       [

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeTelemetryTags } from '../../../src/telemetry/TelemetryMeterManager';
+
+describe('Telemetry tags normalization', () => {
+  it('should return an empty string when no tags are configured', () => {
+    expect(normalizeTelemetryTags(undefined)).toEqual('');
+    expect(normalizeTelemetryTags(null)).toEqual('');
+    expect(normalizeTelemetryTags('')).toEqual('');
+    expect(normalizeTelemetryTags('   ')).toEqual('');
+    expect(normalizeTelemetryTags(' , ,, ')).toEqual('');
+  });
+  it('should trim, lowercase, dedupe and sort tags into a canonical string', () => {
+    expect(normalizeTelemetryTags('saas')).toEqual('saas');
+    expect(normalizeTelemetryTags('saas,eu-west')).toEqual('eu-west,saas');
+    expect(normalizeTelemetryTags('  EU-West ,SAAS, saas,, ')).toEqual('eu-west,saas');
+    expect(normalizeTelemetryTags('b,a,c,a')).toEqual('a,b,c');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeTelemetryTags } from '../../../src/telemetry/TelemetryMeterManager';
+import { computeActiveConnectorsByIdentity, normalizeTelemetryTags, type ConnectorIdentitySource } from '../../../src/telemetry/TelemetryMeterManager';
 
 describe('Telemetry tags normalization', () => {
   it('should return an empty string when no tags are configured', () => {
@@ -14,5 +14,73 @@ describe('Telemetry tags normalization', () => {
     expect(normalizeTelemetryTags('saas,eu-west')).toEqual('eu-west,saas');
     expect(normalizeTelemetryTags('  EU-West ,SAAS, saas,, ')).toEqual('eu-west,saas');
     expect(normalizeTelemetryTags('b,a,c,a')).toEqual('a,b,c');
+  });
+});
+
+describe('Active connectors by catalog identity', () => {
+  const CONTRACTS = new Map([
+    ['opencti/connector-mitre', { slug: 'mitre-att-ck' }],
+    ['opencti/connector-misp', { slug: 'misp' }],
+  ]);
+
+  const managed = (image: string, type = 'EXTERNAL_IMPORT'): ConnectorIdentitySource => ({
+    catalog_id: 'catalog-1',
+    manager_contract_image: image,
+    name: 'User Renamed Me',
+    connector_type: type,
+  });
+
+  const manual = (name: string | null | undefined, type = 'EXTERNAL_IMPORT'): ConnectorIdentitySource => ({
+    name,
+    connector_type: type,
+  });
+
+  it('should return no datapoint for an empty connector list', () => {
+    expect(computeActiveConnectorsByIdentity([], CONTRACTS)).toEqual([]);
+  });
+
+  it('should resolve managed connectors to the catalog contract slug, ignoring the user-set name', () => {
+    const items = computeActiveConnectorsByIdentity([managed('opencti/connector-mitre')], CONTRACTS);
+    expect(items).toEqual([
+      { value: 1, attributes: { slug: 'mitre-att-ck', managed: 'true', type: 'EXTERNAL_IMPORT' } },
+    ]);
+  });
+
+  it('should SKIP managed connectors whose image is not in the catalog (never export raw image strings)', () => {
+    const items = computeActiveConnectorsByIdentity(
+      [managed('registry.private.corp/team/custom-connector'), managed('opencti/connector-misp')],
+      CONTRACTS,
+    );
+    expect(items).toEqual([
+      { value: 1, attributes: { slug: 'misp', managed: 'true', type: 'EXTERNAL_IMPORT' } },
+    ]);
+  });
+
+  it('should fall back to the trimmed/lowercased registered name for manual connectors', () => {
+    const items = computeActiveConnectorsByIdentity([manual('  My Custom Feed ')], CONTRACTS);
+    expect(items).toEqual([
+      { value: 1, attributes: { slug: 'my custom feed', managed: 'false', type: 'EXTERNAL_IMPORT' } },
+    ]);
+  });
+
+  it('should skip manual connectors without a usable name', () => {
+    expect(computeActiveConnectorsByIdentity([manual(''), manual('   '), manual(null), manual(undefined)], CONTRACTS)).toEqual([]);
+  });
+
+  it('should aggregate connectors sharing the same identity and keep distinct types apart', () => {
+    const items = computeActiveConnectorsByIdentity(
+      [
+        managed('opencti/connector-mitre'),
+        managed('opencti/connector-mitre'),
+        managed('opencti/connector-mitre', 'INTERNAL_ENRICHMENT'),
+        manual('mitre-att-ck'),
+      ],
+      CONTRACTS,
+    );
+    expect(items).toContainEqual({ value: 2, attributes: { slug: 'mitre-att-ck', managed: 'true', type: 'EXTERNAL_IMPORT' } });
+    expect(items).toContainEqual({ value: 1, attributes: { slug: 'mitre-att-ck', managed: 'true', type: 'INTERNAL_ENRICHMENT' } });
+    // The manual connector with the same name stays distinct through managed=false.
+    expect(items).toContainEqual({ value: 1, attributes: { slug: 'mitre-att-ck', managed: 'false', type: 'EXTERNAL_IMPORT' } });
+    expect(items).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Summary

Closes #16956. Part of the cross-product TELEMETRY_TAGS effort (XTM One, OpenAEV, enterprise-data-platform, helm-xtm-suite companion PRs).

### 1. TELEMETRY_TAGS deployment dimensions

- New config key `telemetry_manager:tags` (env `TELEMETRY_MANAGER__TAGS`, default empty in `config/default.json`): comma-separated freeform deployment tags, e.g. `saas,eu-west`.
- `normalizeTelemetryTags()` in `TelemetryMeterManager.ts`: trim, lowercase, drop empties, dedupe, sort, re-join - the shared Filigran normalization contract (same in XTM One / OpenAEV) so an identical tag set always produces the identical string in the analytics warehouse.
- Exported as one OTLP resource attribute `filigran.telemetry.tags` on every metric export (omitted entirely when not configured) - zero per-gauge changes; the enterprise data platform lands it as a `tags` column on every telemetry row.

### 2. Active connectors by catalog identity

New multi-dimensional gauge `opencti_active_connectors_by_identity`: one datapoint per active connector identity with attributes:

- `slug`: composer-managed connectors resolve to the catalog contract slug through their stored `manager_contract_image` (`getSupportedContractsByImage()` lookup) - exact catalog truth, independent of the user-set connector name. When the stored image has no catalog match (e.g. removed contract), the datapoint is SKIPPED rather than exporting the raw image string, so a private registry hostname can never leave the platform. Manually registered connectors (no catalog reference in database) fall back to the trimmed/lowercased registered name;
- `managed`: `true` / `false` so analytics can tell exact catalog identity from best-effort names;
- `type`: EXTERNAL_IMPORT / INTERNAL_ENRICHMENT / ...

Implementation notes:

- The breakdown is computed by the pure `computeActiveConnectorsByIdentity()` helper in `TelemetryMeterManager.ts` (unit-testable without the store/cache transitive closure) and fed by the connector entity cache already loaded by `fetchTelemetryData()` - zero extra queries.
- New `registerDimensionalGauge()` on `TelemetryMeterManager` (the existing `registerGauge()` only supports single-scalar class fields): observes one datapoint per `DimensionalGaugeItem` with its own OTLP attributes.
- `catalog_id` / `manager_contract_image` added to `BasicStoreEntityConnector` (stored but previously untyped).
- Anonymous only: catalog slugs / registered names and counts - no connector configuration, no container images.

### Docs

`docs/docs/reference/usage-telemetry.md` updated (per `.github/instructions/telemetry.instructions.md`): deployment tags under Platform information, the identity breakdown under Connectors.

## Test plan

- [x] `yarn vitest run tests/01-unit/manager/telemetryTags-test.ts` - 8 passed (tag normalization table + identity breakdown: managed slug resolution, unmatched-image skip with a private-registry fixture, manual name fallback, empty-name skip, aggregation across identical identities and distinct types)
- [x] `yarn check-ts` - no errors in touched files (only the pre-existing `re2` native module resolution error on Windows, unrelated)
- [x] `yarn lint` - clean
