### PR TITLE
feat(telemetry): export registry-stripped identity for managed connectors absent from the catalog (#16959)

### DIFF
--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -56,7 +56,7 @@ Here is an exhaustive list of the collected metrics:
 
 - The number of active connectors
 - The number of connectors deployed via composer
-- The active connectors broken down by catalog identity: for composer-managed connectors, the catalog contract slug (resolved from the deployed container image); for manually registered connectors, the registered connector name - together with the connector type and a managed/manual flag. No connector configuration is ever collected.
+- The active connectors broken down by catalog identity: for composer-managed connectors, the catalog contract slug (resolved from the deployed container image), or the image repository path with the registry hostname stripped when the image is not part of the catalog; for manually registered connectors, the registered connector name - together with the connector type and a managed/manual flag. No connector configuration and no registry hostname is ever collected.
 
 ### Drafts
 

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -36,13 +36,38 @@ export interface ConnectorIdentitySource {
   connector_type?: string | null;
 }
 
+// Reduce a container image reference to its repository path: drop any digest
+// (@sha256:...), any tag (":x" after the last "/") and the registry hostname.
+// Per the Docker reference grammar the first path component is a registry
+// host iff it contains "." or ":" or is exactly "localhost" - bare Docker Hub
+// namespaces (e.g. "opencti/connector-mitre") are therefore preserved. The
+// registry hostname is the only deployment-infrastructure detail in an image
+// reference, so stripping it keeps the connector identity exportable without
+// leaking where the image is hosted.
+export const stripImageToRepositoryPath = (imageReference: string | null | undefined): string => {
+  const reference = (imageReference ?? '').trim().toLowerCase();
+  if (reference.length === 0) {
+    return '';
+  }
+  const withoutDigest = reference.split('@')[0];
+  const lastSlash = withoutDigest.lastIndexOf('/');
+  const lastColon = withoutDigest.lastIndexOf(':');
+  const withoutTag = lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
+  const segments = withoutTag.split('/').filter((segment) => segment.length > 0);
+  if (segments.length > 1 && (segments[0].includes('.') || segments[0].includes(':') || segments[0] === 'localhost')) {
+    segments.shift();
+  }
+  return segments.join('/');
+};
+
 // Breakdown of active connectors by catalog identity: composer-managed
 // connectors resolve to the exact catalog contract slug through their stored
 // container image (the user-set connector name is irrelevant). When the
-// stored image is not in the catalog (e.g. removed contract), the datapoint
-// is SKIPPED rather than exporting the raw image string, which could carry a
-// private registry hostname - only catalog slugs ever leave the platform for
-// managed connectors. Manually registered connectors have no catalog
+// stored image is not in the catalog (custom contract, removed contract,
+// private catalog on an on-premise deployment), the registry-stripped
+// repository path of the image is exported instead so those deployments stay
+// visible - the raw reference (and thus a private registry hostname) never
+// leaves the platform. Manually registered connectors have no catalog
 // reference, so their trimmed/lowercased registered name is the best
 // available identity, flagged managed=false.
 export const computeActiveConnectorsByIdentity = (
@@ -53,7 +78,7 @@ export const computeActiveConnectorsByIdentity = (
   activeConnectors.forEach((connector) => {
     const isManaged = (connector.catalog_id ?? '').length > 0;
     const slug = isManaged
-      ? (contractsByImage.get(connector.manager_contract_image ?? '')?.slug ?? '')
+      ? (contractsByImage.get(connector.manager_contract_image ?? '')?.slug ?? stripImageToRepositoryPath(connector.manager_contract_image))
       : (connector.name ?? '').trim().toLowerCase();
     if (slug.length === 0) {
       return;

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -54,7 +54,10 @@ export const stripImageToRepositoryPath = (imageReference: string | null | undef
   const lastColon = withoutDigest.lastIndexOf(':');
   const withoutTag = lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
   const segments = withoutTag.split('/').filter((segment) => segment.length > 0);
-  if (segments.length > 1 && (segments[0].includes('.') || segments[0].includes(':') || segments[0] === 'localhost')) {
+  // Strip the registry host even when it is the ONLY segment (host-only,
+  // repository-less reference): returning it would leak the hostname the
+  // whole helper exists to withhold. Callers treat '' as "no usable identity".
+  if (segments.length > 0 && (segments[0].includes('.') || segments[0].includes(':') || segments[0] === 'localhost')) {
     segments.shift();
   }
   return segments.join('/');

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
@@ -37,6 +37,14 @@ describe('Container image repository path stripping', () => {
     expect(stripImageToRepositoryPath('custom-connector')).toEqual('custom-connector');
   });
 
+  it('should return an empty string for host-only references (never export a bare registry hostname)', () => {
+    expect(stripImageToRepositoryPath('registry.private.corp')).toEqual('');
+    expect(stripImageToRepositoryPath('registry.private.corp:5000')).toEqual('');
+    expect(stripImageToRepositoryPath('localhost')).toEqual('');
+    expect(stripImageToRepositoryPath('localhost:5000')).toEqual('');
+    expect(stripImageToRepositoryPath('registry.private.corp/')).toEqual('');
+  });
+
   it('should strip tags and digests', () => {
     expect(stripImageToRepositoryPath('opencti/connector-mitre:6.0.0')).toEqual('opencti/connector-mitre');
     expect(stripImageToRepositoryPath('custom-connector:latest')).toEqual('custom-connector');

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/telemetryTags-test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeActiveConnectorsByIdentity, normalizeTelemetryTags, type ConnectorIdentitySource } from '../../../src/telemetry/TelemetryMeterManager';
+import { computeActiveConnectorsByIdentity, normalizeTelemetryTags, stripImageToRepositoryPath, type ConnectorIdentitySource } from '../../../src/telemetry/TelemetryMeterManager';
 
 describe('Telemetry tags normalization', () => {
   it('should return an empty string when no tags are configured', () => {
@@ -14,6 +14,39 @@ describe('Telemetry tags normalization', () => {
     expect(normalizeTelemetryTags('saas,eu-west')).toEqual('eu-west,saas');
     expect(normalizeTelemetryTags('  EU-West ,SAAS, saas,, ')).toEqual('eu-west,saas');
     expect(normalizeTelemetryTags('b,a,c,a')).toEqual('a,b,c');
+  });
+});
+
+describe('Container image repository path stripping', () => {
+  it('should return an empty string for empty references', () => {
+    expect(stripImageToRepositoryPath(undefined)).toEqual('');
+    expect(stripImageToRepositoryPath(null)).toEqual('');
+    expect(stripImageToRepositoryPath('')).toEqual('');
+    expect(stripImageToRepositoryPath('   ')).toEqual('');
+  });
+
+  it('should strip private registry hostnames (with or without port) but keep the repository path', () => {
+    expect(stripImageToRepositoryPath('registry.private.corp/team/custom-connector')).toEqual('team/custom-connector');
+    expect(stripImageToRepositoryPath('registry.private.corp:5000/team/custom-connector')).toEqual('team/custom-connector');
+    expect(stripImageToRepositoryPath('localhost/team/custom-connector')).toEqual('team/custom-connector');
+    expect(stripImageToRepositoryPath('localhost:5000/custom-connector')).toEqual('custom-connector');
+  });
+
+  it('should keep Docker Hub namespaces (not registry hosts) intact', () => {
+    expect(stripImageToRepositoryPath('opencti/connector-mitre')).toEqual('opencti/connector-mitre');
+    expect(stripImageToRepositoryPath('custom-connector')).toEqual('custom-connector');
+  });
+
+  it('should strip tags and digests', () => {
+    expect(stripImageToRepositoryPath('opencti/connector-mitre:6.0.0')).toEqual('opencti/connector-mitre');
+    expect(stripImageToRepositoryPath('custom-connector:latest')).toEqual('custom-connector');
+    expect(stripImageToRepositoryPath('registry.private.corp:5000/team/custom-connector:1.2.3')).toEqual('team/custom-connector');
+    expect(stripImageToRepositoryPath('opencti/connector-mitre@sha256:abcdef0123456789')).toEqual('opencti/connector-mitre');
+    expect(stripImageToRepositoryPath('registry.private.corp/team/conn:1.0@sha256:abcdef0123456789')).toEqual('team/conn');
+  });
+
+  it('should trim and lowercase the reference', () => {
+    expect(stripImageToRepositoryPath('  Registry.Private.Corp/Team/Custom-Connector:V1  ')).toEqual('team/custom-connector');
   });
 });
 
@@ -46,14 +79,24 @@ describe('Active connectors by catalog identity', () => {
     ]);
   });
 
-  it('should SKIP managed connectors whose image is not in the catalog (never export raw image strings)', () => {
+  it('should export the registry-stripped repository path for managed connectors whose image is not in the catalog', () => {
     const items = computeActiveConnectorsByIdentity(
-      [managed('registry.private.corp/team/custom-connector'), managed('opencti/connector-misp')],
+      [managed('registry.private.corp:5000/team/custom-connector:1.2.3'), managed('opencti/connector-misp')],
       CONTRACTS,
     );
-    expect(items).toEqual([
-      { value: 1, attributes: { slug: 'misp', managed: 'true', type: 'EXTERNAL_IMPORT' } },
-    ]);
+    expect(items).toHaveLength(2);
+    // The datapoint stays visible, but the private registry hostname is stripped.
+    expect(items).toContainEqual({ value: 1, attributes: { slug: 'team/custom-connector', managed: 'true', type: 'EXTERNAL_IMPORT' } });
+    expect(items).toContainEqual({ value: 1, attributes: { slug: 'misp', managed: 'true', type: 'EXTERNAL_IMPORT' } });
+    // The raw reference (hostname, tag) never appears in any exported slug.
+    items.forEach((item) => {
+      expect(item.attributes.slug).not.toContain('registry.private.corp');
+      expect(item.attributes.slug).not.toContain(':');
+    });
+  });
+
+  it('should still skip managed connectors without any usable image reference', () => {
+    expect(computeActiveConnectorsByIdentity([managed(''), managed('   ')], CONTRACTS)).toEqual([]);
   });
 
   it('should fall back to the trimmed/lowercased registered name for manual connectors', () => {


### PR DESCRIPTION
## Summary

Closes #16959. Follow-up to #16957: the `opencti_active_connectors_by_identity` gauge skipped composer-managed connectors whose stored `manager_contract_image` has no catalog match, which removed all telemetry visibility on on-premise / custom-catalog deployments. We need visibility on ALL kinds of deployments - the datapoint must exist, only the registry hostname must stay private.

### Behavior change

- **Catalog match (unchanged):** managed connectors still export the exact catalog contract slug.
- **No catalog match (new):** instead of dropping the datapoint, the slug now carries the registry-stripped repository path of the image, computed by the new pure `stripImageToRepositoryPath()` helper: digest (`@sha256:...`) and tag are removed, and the leading path component is stripped iff it is a registry host per the Docker reference grammar (contains `.` or `:`, or is exactly `localhost`) - including when it is the ONLY segment, so a host-only reference resolves to an empty string and is skipped rather than exporting a bare hostname. Example: `registry.private.corp:5000/team/custom-connector:1.2.3` -> `team/custom-connector`. Docker Hub namespaces such as `opencti/connector-mitre` are preserved as-is.
- **Manual connectors (unchanged):** registered name, `managed=false`.

The registry hostname - the only deployment-infrastructure detail in an image reference - still never leaves the platform, and the anonymous-only guarantee (no connector configuration) is untouched.

### Docs

`docs/docs/reference/usage-telemetry.md` updated: the Connectors section now documents the registry-stripped fallback and states that no registry hostname is ever collected.

## Test plan

- [x] `yarn vitest run tests/01-unit/manager/telemetryTags-test.ts` - 16 passed (7 new: registry/port/localhost stripping, host-only references resolving to empty, Docker Hub namespace preservation, tag + digest stripping, trim/lowercase, unmatched-managed fallback exporting the stripped path with an explicit no-hostname assertion, empty-image skip)
- [x] `yarn check-ts` - no errors in touched files (only the pre-existing Windows-only `re2` resolution error)
- [x] `yarn lint` - clean
