### PR TITLE
fix(telemetry): widen dev-mode export window from 2 minutes to 3 hours (#16965)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -36,13 +36,17 @@ const FILIGRAN_OTLP_TELEMETRY = DEV_MODE
   ? 'https://telemetry.staging.filigran.io/v1/metrics' : 'https://telemetry.filigran.io/v1/metrics';
 
 const ONE_MINUTE = 60 * 1000;
-const TWO_MINUTE = 2 * ONE_MINUTE;
 const ONE_HOUR = 60 * ONE_MINUTE;
+const THREE_HOUR = 3 * ONE_HOUR;
 const SIX_HOUR = 6 * ONE_HOUR;
 // Collect data period, corresponds to data point collection
 const TELEMETRY_COLLECT_INTERVAL = DEV_MODE ? ONE_MINUTE : ONE_HOUR;
-// Export data period, sending information to files, console and otlp
-const TELEMETRY_EXPORT_INTERVAL = DEV_MODE ? TWO_MINUTE : SIX_HOUR;
+// Export data period, sending information to files, console and otlp.
+// Dev mode uses a 3h window instead of the production 6h: tight-enough to
+// observe a full cycle in a working day, without flooding the staging
+// collector (one object per export per instance) when many dev instances
+// run at once.
+const TELEMETRY_EXPORT_INTERVAL = DEV_MODE ? THREE_HOUR : SIX_HOUR;
 // Manager schedule, data point generation
 const COMPUTE_SCHEDULE_TIME = DEV_MODE ? ONE_MINUTE / 2 : ONE_HOUR / 2;
 


### PR DESCRIPTION
## Summary

Widens the telemetry dev-mode export window from 2 minutes to 3 hours. Closes #16965.

The staging collector persists one object per export per instance, so the 2-minute dev cadence floods the staging bucket whenever several long-lived dev-mode instances export at once. This happened on XTM Hub on 2026-07-04: within an hour of the feature landing, 6 dev-mode environments were producing ~180 objects/hour. A 3-hour window is still tight enough to observe full export cycles within a working day without that failure mode.

Production stays at 6 hours; refresh/collect cadence and endpoints are unchanged. Cross-product alignment: same change applied to the sibling platforms (XTM Hub additionally gates gauge telemetry to production/staging environments in FiligranHQ/xtm-hub#2762).

## Test plan

- [x] Constant-only change; existing telemetry tests reference the constants symbolically and stay green.

