### PR TITLE
feat(opencti-mcp): add OpenCTI MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@
 # NodeJS
 node_modules/
 
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+
 # Yarn
 .yarn/
 opencti-platform/opencti-front/.yarnrc.yml

--- a/opencti-mcp/.env.example
+++ b/opencti-mcp/.env.example
@@ -1,0 +1,12 @@
+# Required
+OPENCTI_ADMIN_TOKEN=change-me-to-a-uuid-v4-token
+MCP_API_KEY=change-me-to-a-random-mcp-bearer-token
+
+# Optional overrides (defaults shown)
+# OPENCTI_VERSION=latest
+# OPENCTI_ADMIN_EMAIL=admin@opencti.io
+# OPENCTI_ADMIN_PASSWORD=ChangeMe
+# MINIO_ROOT_USER=ChangeMe
+# MINIO_ROOT_PASSWORD=ChangeMe
+# LOG_LEVEL=info
+# APP__BASE_URL=http://localhost:4000

--- a/opencti-mcp/Dockerfile
+++ b/opencti-mcp/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 
 # Copy package metadata first for better layer caching
 COPY pyproject.toml ./
+COPY README.md requirements.txt ./
 COPY src/ ./src/
 
 # Install the package (no dev extras needed at runtime)

--- a/opencti-mcp/Dockerfile
+++ b/opencti-mcp/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1
+# Build the OpenCTI MCP server image.
+#
+# Usage:
+#   docker build -t opencti-mcp .
+#   docker run --rm \
+#     -e OPENCTI_URL=http://opencti:4000 \
+#     -e OPENCTI_TOKEN=<token> \
+#     -e MCP_TRANSPORT=sse \
+#     -e MCP_SSE_HOST=0.0.0.0 \
+#     -e MCP_SSE_PORT=8000 \
+#     -e MCP_API_KEY=<mcp-bearer-token> \
+#     -p 8000:8000 \
+#     opencti-mcp
+
+FROM python:3.12.7-slim
+
+WORKDIR /app
+
+# Copy package metadata first for better layer caching
+COPY pyproject.toml ./
+COPY src/ ./src/
+
+# Install the package (no dev extras needed at runtime)
+RUN pip install --no-cache-dir .
+
+# Run as non-root for security
+RUN useradd --no-create-home --shell /bin/false mcp
+USER mcp
+
+ENV MCP_TRANSPORT=sse \
+    MCP_SSE_HOST=0.0.0.0 \
+    MCP_SSE_PORT=8000
+
+EXPOSE 8000
+
+# Health check: open an HTTP connection to the SSE endpoint. 200 means the
+# endpoint accepted the request, and 401 means the authenticated endpoint is
+# up but the health check did not send a bearer token.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD python -c "\
+import http.client, sys; \
+try: \
+    c = http.client.HTTPConnection('localhost', 8000, timeout=5); \
+    c.request('GET', '/sse'); \
+    sys.exit(0 if c.getresponse().status in (200, 401) else 1); \
+except Exception: \
+    sys.exit(1)"
+
+CMD ["opencti-mcp"]

--- a/opencti-mcp/README.md
+++ b/opencti-mcp/README.md
@@ -8,8 +8,8 @@ the OpenCTI GraphQL API.
 
 | Category | Tools |
 | --- | --- |
-| Indicators | `lookup_indicator`, `list_indicators`, `get_indicator`, `add_indicator`, `update_indicator`, `promote_observable_to_indicator`, `get_indicator_relationships` |
-| Observables | `lookup_observable`, `list_observables`, `get_observable`, `add_observable`, `enrich_observable`, `get_observable_indicators`, `get_observable_relationships` |
+| Indicators | `list_indicators`, `get_indicator`, `add_indicator`, `update_indicator`, `promote_observable_to_indicator`, `get_indicator_relationships` |
+| Observables | `list_observables`, `get_observable`, `add_observable`, `enrich_observable`, `get_observable_indicators`, `get_observable_relationships` |
 | Reports | `lookup_report`, `list_reports`, `create_report`, `add_object_to_report`, `get_report_objects`, `export_report_stix` |
 | Cases | `create_incident_case`, `create_rfi`, `lookup_case`, `list_cases`, `add_object_to_case`, `update_case_status` |
 | Tasks | `create_task`, `complete_task` |
@@ -48,7 +48,7 @@ For development:
 cd opencti-mcp
 pip install -r requirements.txt
 pip install -r test-requirements.txt
-pip install -e ".[dev]"
+pip install -e .
 ```
 
 ## Configuration
@@ -196,7 +196,7 @@ docker compose down -v
 cd opencti-mcp
 pip install -r requirements.txt
 pip install -r test-requirements.txt
-pip install -e ".[dev]"
+pip install -e .
 ```
 
 Run checks:

--- a/opencti-mcp/README.md
+++ b/opencti-mcp/README.md
@@ -1,0 +1,247 @@
+# OpenCTI MCP Server
+
+The OpenCTI MCP server exposes OpenCTI threat-intelligence operations through
+the Model Context Protocol (MCP). It uses the official `pycti` client to call
+the OpenCTI GraphQL API.
+
+## Features
+
+| Category | Tools |
+| --- | --- |
+| Indicators | `lookup_indicator`, `list_indicators`, `get_indicator`, `add_indicator`, `update_indicator`, `promote_observable_to_indicator`, `get_indicator_relationships` |
+| Observables | `lookup_observable`, `list_observables`, `get_observable`, `add_observable`, `enrich_observable`, `get_observable_indicators`, `get_observable_relationships` |
+| Reports | `lookup_report`, `list_reports`, `create_report`, `add_object_to_report`, `get_report_objects`, `export_report_stix` |
+| Cases | `create_incident_case`, `create_rfi`, `lookup_case`, `list_cases`, `add_object_to_case`, `update_case_status` |
+| Tasks | `create_task`, `complete_task` |
+| Investigations | `create_investigation`, `get_investigation`, `list_investigations`, `add_to_investigation`, `export_investigation_as_report`, `start_investigation_from_container` |
+| Enrichment | `list_enrichment_connectors`, `enrich_entity`, `get_enrichment_status`, `get_entity_connectors` |
+| Relationships | `create_relationship`, `lookup_relationships`, `create_sighting` |
+| Search | `global_search`, `find_by_stix_id`, `find_by_external_reference` |
+
+## Resources
+
+| URI template | Description |
+| --- | --- |
+| `opencti://indicator/{id}` | Indicator details |
+| `opencti://observable/{id}` | Observable details with related indicators |
+| `opencti://report/{id}` | Report details with contained objects |
+| `opencti://case/{id}` | Incident, RFI, or RFT case details |
+| `opencti://investigation/{id}` | Investigation exported as a STIX 2.1 bundle |
+
+## Requirements
+
+- Python 3.10 or later
+- A running OpenCTI instance
+- An OpenCTI API token with the permissions required by the tools you enable
+
+## Installation
+
+From the repository root:
+
+```bash
+pip install -e ./opencti-mcp
+```
+
+For development:
+
+```bash
+cd opencti-mcp
+pip install -r requirements.txt
+pip install -r test-requirements.txt
+pip install -e ".[dev]"
+```
+
+## Configuration
+
+The server reads configuration from environment variables. A `.env` file in the
+working directory is also supported.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `OPENCTI_URL` | Yes |  | Base URL of the OpenCTI instance, for example `http://localhost:4000` |
+| `OPENCTI_TOKEN` | Yes |  | OpenCTI API bearer token |
+| `OPENCTI_SSL_VERIFY` | No | `true` | `true`, `false`, or a CA bundle path |
+| `LOG_LEVEL` | No | `info` | Python log level |
+| `MCP_TRANSPORT` | No | `stdio` | `stdio` or `sse` |
+| `MCP_SSE_HOST` | No | `127.0.0.1` | Bind host for SSE transport |
+| `MCP_SSE_PORT` | No | `8000` | Bind port for SSE transport |
+| `MCP_API_KEY` | Required for SSE unless explicitly disabled |  | Bearer token required for SSE HTTP requests |
+| `MCP_ALLOW_UNAUTHENTICATED_SSE` | No | `false` | Development-only opt-in for unauthenticated SSE |
+| `MCP_MAX_BODY_BYTES` | No | `1048576` | Maximum SSE HTTP request body size |
+| `MCP_MAX_CONCURRENT` | No | `20` | Maximum concurrent SSE HTTP requests |
+| `MCP_RATE_LIMIT_PER_MINUTE` | No | `60` | Maximum SSE HTTP requests per client per minute |
+
+## Usage
+
+### stdio transport
+
+Use `stdio` when an MCP client launches the server process directly:
+
+```bash
+OPENCTI_URL=http://localhost:4000 \
+OPENCTI_TOKEN=<opencti-token> \
+opencti-mcp
+```
+
+Example MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "opencti": {
+      "command": "opencti-mcp",
+      "env": {
+        "OPENCTI_URL": "http://localhost:4000",
+        "OPENCTI_TOKEN": "<opencti-token>"
+      }
+    }
+  }
+}
+```
+
+### SSE transport
+
+Use `sse` when exposing the server as an HTTP endpoint. SSE requires
+`MCP_API_KEY` by default.
+
+```bash
+MCP_TRANSPORT=sse \
+MCP_SSE_HOST=127.0.0.1 \
+MCP_SSE_PORT=8000 \
+MCP_API_KEY=<mcp-bearer-token> \
+OPENCTI_URL=http://localhost:4000 \
+OPENCTI_TOKEN=<opencti-token> \
+opencti-mcp
+```
+
+Configure MCP clients to use:
+
+```text
+http://localhost:8000/sse
+```
+
+Clients must send:
+
+```text
+Authorization: Bearer <mcp-bearer-token>
+```
+
+## Docker
+
+Build the MCP server image from `opencti-mcp/`:
+
+```bash
+cd opencti-mcp
+docker build -t opencti-mcp .
+```
+
+Run it against an existing OpenCTI instance:
+
+```bash
+docker run --rm \
+  -e OPENCTI_URL=http://opencti:4000 \
+  -e OPENCTI_TOKEN=<opencti-token> \
+  -e MCP_TRANSPORT=sse \
+  -e MCP_SSE_HOST=0.0.0.0 \
+  -e MCP_SSE_PORT=8000 \
+  -e MCP_API_KEY=<mcp-bearer-token> \
+  -p 8000:8000 \
+  opencti-mcp
+```
+
+## Docker Compose
+
+The `docker-compose.yml` in this directory starts OpenCTI and the MCP server
+for local testing.
+
+```bash
+cd opencti-mcp
+cp .env.example .env
+```
+
+Edit `.env` and set:
+
+- `OPENCTI_ADMIN_TOKEN` to a UUID v4 value
+- `MCP_API_KEY` to a random bearer token for MCP clients
+
+Elasticsearch requires a higher virtual-memory limit on Linux and WSL2:
+
+```bash
+sudo sysctl -w vm.max_map_count=262144
+```
+
+Start the stack:
+
+```bash
+docker compose up -d
+```
+
+Default endpoints:
+
+| Service | URL |
+| --- | --- |
+| OpenCTI UI | `http://localhost:4000` |
+| MCP SSE endpoint | `http://localhost:8000/sse` |
+| RabbitMQ management | `http://localhost:15672` |
+
+Stop and remove local volumes:
+
+```bash
+docker compose down -v
+```
+
+## Development
+
+```bash
+cd opencti-mcp
+pip install -r requirements.txt
+pip install -r test-requirements.txt
+pip install -e ".[dev]"
+```
+
+Run checks:
+
+```bash
+pytest tests/ -v
+black --check src/ tests/
+isort --check-only src/ tests/
+flake8 src/ tests/ --ignore E,W
+mypy src/
+```
+
+## Security
+
+- Use a dedicated OpenCTI API token with least-privilege permissions.
+- Do not expose SSE without `MCP_API_KEY` unless running an isolated local
+  development environment.
+- Bind SSE to `127.0.0.1` unless a reverse proxy provides TLS, authentication,
+  request limits, and access controls.
+- Keep `OPENCTI_SSL_VERIFY=true` in production. Use a CA bundle path for
+  private certificate authorities.
+- Tool and resource handlers return sanitized errors to MCP clients and log
+  detailed exceptions server-side.
+- The SSE app enforces process-local request body, rate, and concurrency
+  limits. These controls are not a replacement for reverse-proxy limits in
+  shared or internet-facing deployments.
+
+## Architecture
+
+```text
+MCP client
+    |
+    | MCP protocol (stdio or SSE)
+    v
+opencti_mcp.server
+    |
+    | registers tools and resources
+    v
+opencti_mcp.tools / opencti_mcp.resources
+    |
+    | pycti
+    v
+OpenCTI GraphQL API
+```
+
+The server is designed for a single OpenCTI tenant per process. The pycti
+client is initialized once at startup and shared by tool and resource handlers.
+Run separate server processes for separate OpenCTI tenants.

--- a/opencti-mcp/docker-compose.yml
+++ b/opencti-mcp/docker-compose.yml
@@ -1,0 +1,160 @@
+# Docker Compose stack: OpenCTI platform + MCP server (SSE transport)
+#
+# Prerequisites:
+#   sudo sysctl -w vm.max_map_count=262144   # required by Elasticsearch
+#
+# Quick start:
+#   cp .env.example .env        # then fill in OPENCTI_ADMIN_TOKEN and MCP_API_KEY
+#   docker compose up -d
+#   # Wait ~2 minutes for the platform to initialise, then:
+#   # MCP SSE endpoint: http://localhost:8000/sse
+#   # OpenCTI UI:       http://localhost:4000  (admin / ChangeMe)
+
+services:
+  # --------------------------------------------------------------------------
+  # Infrastructure
+  # --------------------------------------------------------------------------
+  redis:
+    image: redis:8.6.2
+    container_name: opencti-mcp-redis
+    restart: unless-stopped
+    networks:
+      - opencti
+
+  elasticsearch:
+    image: elasticsearch:8.19.14
+    container_name: opencti-mcp-elasticsearch
+    restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.ml.enabled=false
+      - ES_JAVA_OPTS=-Xms1G -Xmx1G
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - opencti
+
+  minio:
+    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
+    container_name: opencti-mcp-minio
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-ChangeMe}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-ChangeMe}
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    volumes:
+      - s3data:/data
+    networks:
+      - opencti
+
+  rabbitmq:
+    image: rabbitmq:4.2.5-management
+    container_name: opencti-mcp-rabbitmq
+    restart: unless-stopped
+    volumes:
+      - amqpdata:/var/lib/rabbitmq
+    networks:
+      - opencti
+
+  # --------------------------------------------------------------------------
+  # OpenCTI platform
+  # --------------------------------------------------------------------------
+  opencti:
+    image: filigran/platform:${OPENCTI_VERSION:-6.6}
+    container_name: opencti-mcp-platform
+    restart: unless-stopped
+    environment:
+      NODE_OPTIONS: --max-old-space-size=8096
+      APP__PORT: 4000
+      APP__BASE_URL: ${APP__BASE_URL:-http://localhost:4000}
+      APP__ADMIN__EMAIL: ${OPENCTI_ADMIN_EMAIL:-admin@opencti.io}
+      APP__ADMIN__PASSWORD: ${OPENCTI_ADMIN_PASSWORD:-ChangeMe}
+      APP__ADMIN__TOKEN: ${OPENCTI_ADMIN_TOKEN:?OPENCTI_ADMIN_TOKEN is required}
+      APP__APP_LOGS__LOGS_LEVEL: error
+      REDIS__HOSTNAME: redis
+      ELASTICSEARCH__URL: http://elasticsearch:9200
+      MINIO__ENDPOINT: minio
+      MINIO__PORT: 9000
+      MINIO__USE_SSL: "false"
+      MINIO__ACCESS_KEY: ${MINIO_ROOT_USER:-ChangeMe}
+      MINIO__SECRET_KEY: ${MINIO_ROOT_PASSWORD:-ChangeMe}
+      RABBITMQ__HOSTNAME: rabbitmq
+      RABBITMQ__PORT: 5672
+      RABBITMQ__PORT_MANAGEMENT: 15672
+      RABBITMQ__MANAGEMENT_SSL: "false"
+      RABBITMQ__USERNAME: ${RABBITMQ_DEFAULT_USER:-guest}
+      RABBITMQ__PASSWORD: ${RABBITMQ_DEFAULT_PASS:-guest}
+      SMTP__HOSTNAME: localhost
+      SMTP__PORT: 25
+    ports:
+      - "4000:4000"
+    depends_on:
+      - redis
+      - elasticsearch
+      - minio
+      - rabbitmq
+    networks:
+      - opencti
+
+  # --------------------------------------------------------------------------
+  # OpenCTI worker
+  # --------------------------------------------------------------------------
+  worker:
+    image: filigran/worker:${OPENCTI_VERSION:-6.6}
+    container_name: opencti-mcp-worker
+    restart: unless-stopped
+    environment:
+      OPENCTI_URL: http://opencti:4000
+      OPENCTI_TOKEN: ${OPENCTI_ADMIN_TOKEN:?OPENCTI_ADMIN_TOKEN is required}
+      WORKER_LOG_LEVEL: info
+    depends_on:
+      - opencti
+    networks:
+      - opencti
+
+  # --------------------------------------------------------------------------
+  # MCP server (SSE transport)
+  # --------------------------------------------------------------------------
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: opencti-mcp:local
+    container_name: opencti-mcp-server
+    restart: unless-stopped
+    environment:
+      OPENCTI_URL: http://opencti:4000
+      OPENCTI_TOKEN: ${OPENCTI_ADMIN_TOKEN:?OPENCTI_ADMIN_TOKEN is required}
+      MCP_TRANSPORT: sse
+      MCP_SSE_HOST: 0.0.0.0
+      MCP_SSE_PORT: 8000
+      MCP_API_KEY: ${MCP_API_KEY:?MCP_API_KEY is required}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "8000:8000"
+    depends_on:
+      - opencti
+    networks:
+      - opencti
+
+networks:
+  opencti:
+    driver: bridge
+
+volumes:
+  esdata:
+  s3data:
+  amqpdata:

--- a/opencti-mcp/pyproject.toml
+++ b/opencti-mcp/pyproject.toml
@@ -9,7 +9,7 @@ description = "MCP server exposing OpenCTI threat-intelligence capabilities to A
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
-dynamic = ["dependencies", "optional-dependencies"]
+dynamic = ["dependencies"]
 keywords = ["opencti", "mcp", "threat-intelligence", "stix", "cti"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -30,9 +30,6 @@ where = ["src"]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
-
-[tool.setuptools.dynamic.optional-dependencies]
-dev = { file = ["test-requirements.txt"] }
 
 [tool.black]
 target-version = ["py310"]

--- a/opencti-mcp/pyproject.toml
+++ b/opencti-mcp/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "opencti-mcp"
+version = "0.1.0"
+description = "MCP server exposing OpenCTI threat-intelligence capabilities to AI assistants"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dynamic = ["dependencies", "optional-dependencies"]
+keywords = ["opencti", "mcp", "threat-intelligence", "stix", "cti"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+]
+
+[project.scripts]
+opencti-mcp = "opencti_mcp.server:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools.dynamic.optional-dependencies]
+dev = { file = ["test-requirements.txt"] }
+
+[tool.black]
+target-version = ["py310"]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = ["pycti"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["opencti_mcp"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false

--- a/opencti-mcp/requirements.txt
+++ b/opencti-mcp/requirements.txt
@@ -1,0 +1,5 @@
+mcp>=1.0
+pycti>=6.0.0
+python-dotenv>=1.0
+starlette>=0.27
+uvicorn>=0.20

--- a/opencti-mcp/src/opencti_mcp/__init__.py
+++ b/opencti-mcp/src/opencti_mcp/__init__.py
@@ -1,0 +1,4 @@
+# coding: utf-8
+"""OpenCTI MCP Server — exposes OpenCTI threat-intelligence capabilities via MCP."""
+
+__version__ = "0.1.0"

--- a/opencti-mcp/src/opencti_mcp/client.py
+++ b/opencti-mcp/src/opencti_mcp/client.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+"""Singleton OpenCTIApiClient accessor.
+
+Call :func:`get_client` anywhere inside tool/resource handlers to obtain the
+shared pycti client that was initialised at server start-up.
+"""
+
+from __future__ import annotations
+
+from pycti import OpenCTIApiClient
+
+from opencti_mcp.config import Config
+
+_client: OpenCTIApiClient | None = None
+
+
+def init_client(cfg: Config) -> OpenCTIApiClient:
+    """Initialise the module-level pycti client from *cfg*.
+
+    This must be called once before :func:`get_client` is used.  Calling it
+    again replaces the existing singleton (useful in tests).
+
+    :param cfg: runtime configuration.
+    :return: the newly created :class:`~pycti.OpenCTIApiClient` instance.
+    """
+    global _client
+    _client = OpenCTIApiClient(
+        url=cfg.opencti_url,
+        token=cfg.opencti_token,
+        log_level=cfg.log_level,
+        ssl_verify=cfg.ssl_verify,
+        perform_health_check=False,
+    )
+    return _client
+
+
+def get_client() -> OpenCTIApiClient:
+    """Return the shared pycti client.
+
+    :raises RuntimeError: if :func:`init_client` has not been called yet.
+    :return: the shared :class:`~pycti.OpenCTIApiClient` instance.
+    """
+    if _client is None:
+        raise RuntimeError("OpenCTI client has not been initialised — call init_client() first")
+    return _client

--- a/opencti-mcp/src/opencti_mcp/config.py
+++ b/opencti-mcp/src/opencti_mcp/config.py
@@ -1,0 +1,122 @@
+# coding: utf-8
+"""Configuration loader for the OpenCTI MCP server.
+
+Reads connection settings from environment variables or a .env file.
+"""
+
+import os
+from dataclasses import dataclass
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+@dataclass
+class Config:
+    """Runtime configuration derived from environment variables."""
+
+    opencti_url: str
+    opencti_token: str
+    ssl_verify: bool | str
+    log_level: str
+    transport: str  # "stdio" | "sse"
+    sse_host: str
+    sse_port: int
+    api_key: str  # empty string means no SSE authentication required
+    allow_unauthenticated_sse: bool
+    max_request_body_bytes: int
+    max_concurrent_requests: int
+    rate_limit_per_minute: int
+
+
+def load_config() -> Config:
+    """Load and validate configuration from the environment.
+
+    Required environment variables:
+        OPENCTI_URL   — base URL of the OpenCTI instance (e.g. ``http://localhost:4000``)
+        OPENCTI_TOKEN — API bearer token
+
+    Optional environment variables:
+        OPENCTI_SSL_VERIFY  — ``"true"``/``"false"`` or path to CA bundle (default: ``"true"``)
+        LOG_LEVEL           — Python log level name (default: ``"info"``)
+        MCP_TRANSPORT       — ``"stdio"`` (default) or ``"sse"``
+        MCP_SSE_HOST        — bind host for SSE transport (default: ``"127.0.0.1"``)
+        MCP_SSE_PORT        — bind port for SSE transport (default: ``8000``)
+        MCP_API_KEY         — bearer token required on every SSE request (default: unset/disabled)
+        MCP_MAX_BODY_BYTES  — maximum SSE HTTP request body size (default: ``1048576``)
+        MCP_MAX_CONCURRENT  — maximum concurrent SSE HTTP requests (default: ``20``)
+        MCP_RATE_LIMIT_PER_MINUTE — maximum SSE HTTP requests per client/minute (default: ``60``)
+
+    :raises ValueError: if a required variable is missing.
+    :return: populated :class:`Config` instance.
+    """
+    opencti_url = os.getenv("OPENCTI_URL", "").strip()
+    if not opencti_url:
+        raise ValueError("OPENCTI_URL environment variable is required")
+
+    opencti_token = os.getenv("OPENCTI_TOKEN", "").strip()
+    if not opencti_token:
+        raise ValueError("OPENCTI_TOKEN environment variable is required")
+
+    # Preserve the original value for the CA-bundle path case; only lowercase
+    # for the boolean comparison so that file-system paths are not corrupted.
+    ssl_raw = os.getenv("OPENCTI_SSL_VERIFY", "true").strip()
+    ssl_lower = ssl_raw.lower()
+    if ssl_lower in ("false", "0", "no"):
+        ssl_verify: bool | str = False
+    elif ssl_lower in ("true", "1", "yes"):
+        ssl_verify = True
+    else:
+        # Treat as a path to a CA bundle file — preserve original case
+        ssl_verify = ssl_raw
+
+    transport = os.getenv("MCP_TRANSPORT", "stdio").lower().strip()
+    if transport not in {"stdio", "sse"}:
+        raise ValueError("MCP_TRANSPORT must be either 'stdio' or 'sse'")
+
+    sse_port_raw = os.getenv("MCP_SSE_PORT", "8000").strip()
+    try:
+        sse_port = int(sse_port_raw)
+    except ValueError as exc:
+        raise ValueError("MCP_SSE_PORT must be an integer") from exc
+    if not (1 <= sse_port <= 65535):
+        raise ValueError("MCP_SSE_PORT must be in range 1..65535")
+
+    allow_unauthenticated_sse = os.getenv(
+        "MCP_ALLOW_UNAUTHENTICATED_SSE", "false"
+    ).strip().lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+    max_request_body_bytes = _positive_int_env("MCP_MAX_BODY_BYTES", 1_048_576)
+    max_concurrent_requests = _positive_int_env("MCP_MAX_CONCURRENT", 20)
+    rate_limit_per_minute = _positive_int_env("MCP_RATE_LIMIT_PER_MINUTE", 60)
+
+    return Config(
+        opencti_url=opencti_url,
+        opencti_token=opencti_token,
+        ssl_verify=ssl_verify,
+        log_level=os.getenv("LOG_LEVEL", "info"),
+        transport=transport,
+        sse_host=os.getenv("MCP_SSE_HOST", "127.0.0.1"),
+        sse_port=sse_port,
+        api_key=os.getenv("MCP_API_KEY", ""),
+        allow_unauthenticated_sse=allow_unauthenticated_sse,
+        max_request_body_bytes=max_request_body_bytes,
+        max_concurrent_requests=max_concurrent_requests,
+        rate_limit_per_minute=rate_limit_per_minute,
+    )
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name, str(default)).strip()
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < 1:
+        raise ValueError(f"{name} must be greater than 0")
+    return value

--- a/opencti-mcp/src/opencti_mcp/errors.py
+++ b/opencti-mcp/src/opencti_mcp/errors.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+"""Error handling helpers for MCP tool/resource responses."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+
+def safe_error_response(logger: logging.Logger, operation: str, exc: Exception) -> str:
+    """Return a sanitized error payload and log full exception server-side."""
+    logger.exception("%s failed", operation, exc_info=exc)
+    return json.dumps(
+        {
+            "error": {
+                "code": "internal_error",
+                "message": "Request failed. Check server logs for details.",
+                "operation": operation,
+            }
+        }
+    )

--- a/opencti-mcp/src/opencti_mcp/resources/__init__.py
+++ b/opencti-mcp/src/opencti_mcp/resources/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+"""Resources package initialiser."""

--- a/opencti-mcp/src/opencti_mcp/resources/stix_export.py
+++ b/opencti-mcp/src/opencti_mcp/resources/stix_export.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+"""MCP resources (read-only context) for STIX object export."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register MCP resources for read-only STIX object context."""
+
+    @mcp.resource("opencti://indicator/{indicator_id}")
+    def indicator_resource(indicator_id: str) -> str:
+        """Full indicator details including decay score and pattern.
+
+        :param indicator_id: OpenCTI ID or STIX standard ID.
+        :return: JSON-encoded indicator object.
+        """
+        client = get_client()
+        try:
+            result = client.indicator.read(id=indicator_id)
+            return json.dumps(result, default=str) if result else json.dumps({"error": "Not found"})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.resource("opencti://observable/{observable_id}")
+    def observable_resource(observable_id: str) -> str:
+        """Full observable details including related indicators and sightings.
+
+        :param observable_id: OpenCTI ID or STIX standard ID.
+        :return: JSON-encoded observable object.
+        """
+        client = get_client()
+        try:
+            result = client.stix_cyber_observable.read(id=observable_id)
+            return json.dumps(result, default=str) if result else json.dumps({"error": "Not found"})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.resource("opencti://report/{report_id}")
+    def report_resource(report_id: str) -> str:
+        """Full report with all contained objects.
+
+        :param report_id: OpenCTI ID or STIX standard ID.
+        :return: JSON-encoded report object.
+        """
+        client = get_client()
+        try:
+            result = client.report.read(id=report_id)
+            return json.dumps(result, default=str) if result else json.dumps({"error": "Not found"})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.resource("opencti://case/{case_id}")
+    def case_resource(case_id: str) -> str:
+        """Full case (Incident/RFI/RFT) details including tasks and objects.
+
+        :param case_id: OpenCTI ID or STIX standard ID.
+        :return: JSON-encoded case object.
+        """
+        client = get_client()
+        for reader in (
+            client.case_incident.read,
+            client.case_rfi.read,
+            client.case_rft.read,
+        ):
+            try:
+                result = reader(id=case_id)
+                if result:
+                    return json.dumps(result, default=str)
+            except Exception:
+                logger.debug("case_resource: reader attempt failed", exc_info=True)
+        return json.dumps({"error": "Case not found"})
+
+    @mcp.resource("opencti://investigation/{investigation_id}")
+    def investigation_resource(investigation_id: str) -> str:
+        """Investigation workspace as a STIX 2.1 bundle.
+
+        :param investigation_id: OpenCTI workspace ID.
+        :return: STIX 2.1 bundle JSON string.
+        """
+        client = get_client()
+        try:
+            bundle = client.workspace.to_stix_bundle(id=investigation_id)
+            return bundle if bundle else json.dumps({"error": "Export failed"})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/server.py
+++ b/opencti-mcp/src/opencti_mcp/server.py
@@ -1,0 +1,218 @@
+# coding: utf-8
+"""OpenCTI MCP server entrypoint.
+
+Starts the Model Context Protocol server and registers all tools and resources.
+Supports both ``stdio`` (for direct LLM tool use) and ``sse`` (HTTP/SSE for
+remote deployment) transports, controlled by the ``MCP_TRANSPORT`` environment
+variable.
+
+Usage::
+
+    # stdio (default, launched directly by an MCP client):
+    OPENCTI_URL=http://localhost:4000 OPENCTI_TOKEN=<token> python -m opencti_mcp.server
+
+    # SSE / HTTP (for remote deployment):
+    MCP_TRANSPORT=sse MCP_SSE_HOST=0.0.0.0 MCP_SSE_PORT=8000 \\
+        OPENCTI_URL=http://opencti:4000 OPENCTI_TOKEN=<token> \\
+        python -m opencti_mcp.server
+
+    # SSE with Bearer token authentication:
+    MCP_TRANSPORT=sse MCP_API_KEY=<secret> ... python -m opencti_mcp.server
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from secrets import compare_digest
+from time import monotonic
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import init_client
+from opencti_mcp.config import Config, load_config
+from opencti_mcp.resources import stix_export
+from opencti_mcp.tools import (
+    cases,
+    enrichment,
+    indicators,
+    investigations,
+    observables,
+    relationships,
+    reports,
+    search,
+)
+
+# ---------------------------------------------------------------------------
+# Logging — write structured output to stderr so it does not pollute the
+# MCP stdio protocol stream.
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    stream=sys.stderr,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger("opencti_mcp")
+
+
+def _add_sse_request_controls(app: Any, cfg: Config) -> None:
+    """Add process-local request guards for the SSE HTTP app."""
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import Response
+
+    semaphore = asyncio.Semaphore(cfg.max_concurrent_requests)
+    request_windows: dict[str, list[float]] = {}
+
+    class _RequestControlsMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request: Any, call_next: Any) -> Any:
+            content_length = request.headers.get("content-length")
+            if content_length is not None:
+                try:
+                    body_size = int(content_length)
+                except ValueError:
+                    return Response("Invalid Content-Length", status_code=400)
+                if body_size > cfg.max_request_body_bytes:
+                    return Response("Request body too large", status_code=413)
+
+            client_host = request.client.host if request.client else "unknown"
+            now = monotonic()
+            window_start = now - 60
+            timestamps = [ts for ts in request_windows.get(client_host, []) if ts > window_start]
+            if len(timestamps) >= cfg.rate_limit_per_minute:
+                request_windows[client_host] = timestamps
+                return Response("Rate limit exceeded", status_code=429)
+            timestamps.append(now)
+            request_windows[client_host] = timestamps
+
+            if semaphore.locked():
+                return Response("Too many concurrent requests", status_code=503)
+            await semaphore.acquire()
+            try:
+                return await call_next(request)
+            finally:
+                semaphore.release()
+
+    app.add_middleware(_RequestControlsMiddleware)
+
+
+def _run_sse(mcp: FastMCP, cfg: Config) -> None:
+    """Start SSE transport, optionally with Bearer token authentication.
+
+    When ``MCP_API_KEY`` is set every incoming SSE request must carry an
+    ``Authorization: Bearer <key>`` header; requests without it are rejected
+    with HTTP 401.
+
+    Falls back to the built-in ``mcp.run`` runner only for explicitly
+    unauthenticated development mode on older mcp library versions.
+    """
+    try:
+        app = mcp.sse_app()
+    except AttributeError:
+        if cfg.api_key:
+            raise RuntimeError(
+                "MCP_API_KEY is set but cannot be enforced: mcp.sse_app() is unavailable"
+            )
+        if not cfg.allow_unauthenticated_sse:
+            raise RuntimeError(
+                "Refusing unauthenticated SSE: set MCP_API_KEY or MCP_ALLOW_UNAUTHENTICATED_SSE=true"
+            )
+        logger.warning(
+            "Running unauthenticated SSE due to legacy mcp library and explicit override"
+        )
+        mcp.run(transport="sse")
+        return
+
+    _add_sse_request_controls(app, cfg)
+
+    import uvicorn
+
+    if cfg.api_key:
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import Response
+
+        _key = cfg.api_key
+
+        class _BearerAuthMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request: Any, call_next: Any) -> Any:
+                auth = request.headers.get("Authorization", "")
+                if not (auth.startswith("Bearer ") and compare_digest(auth[7:], _key)):
+                    return Response(
+                        content="Unauthorized",
+                        status_code=401,
+                        media_type="text/plain",
+                    )
+                return await call_next(request)
+
+        app.add_middleware(_BearerAuthMiddleware)
+        logger.info("SSE transport: Bearer token authentication enabled")
+        uvicorn.run(app, host=cfg.sse_host, port=cfg.sse_port, log_level="warning")
+    else:
+        if not cfg.allow_unauthenticated_sse:
+            raise RuntimeError(
+                "Refusing unauthenticated SSE: set MCP_API_KEY or MCP_ALLOW_UNAUTHENTICATED_SSE=true"
+            )
+        logger.warning(
+            "SSE transport: running unauthenticated because MCP_ALLOW_UNAUTHENTICATED_SSE=true"
+        )
+        uvicorn.run(app, host=cfg.sse_host, port=cfg.sse_port, log_level="warning")
+
+
+def build_server() -> tuple[FastMCP, Config]:
+    """Construct and configure the MCP server.
+
+    Loads config, initialises the pycti client, and registers all tools and
+    resources.  Returns the configured :class:`FastMCP` instance and the
+    :class:`Config` so that the transport can be selected.
+
+    :return: ``(mcp, cfg)`` tuple.
+    :raises ValueError: if required environment variables are missing.
+    """
+    cfg = load_config()
+    logger.setLevel(cfg.log_level.upper())
+    logger.info("Initialising OpenCTI MCP server")
+
+    init_client(cfg)
+
+    mcp = FastMCP(
+        "OpenCTI",
+        instructions=(
+            "You are connected to an OpenCTI threat-intelligence platform. "
+            "Use the available tools to look up, create, and enrich indicators, "
+            "observables, reports, cases (incident response, RFIs), and "
+            "investigation workspaces.  All objects follow the STIX 2.1 standard."
+        ),
+    )
+
+    # Register tools
+    search.register(mcp)
+    indicators.register(mcp)
+    observables.register(mcp)
+    reports.register(mcp)
+    cases.register(mcp)
+    investigations.register(mcp)
+    enrichment.register(mcp)
+    relationships.register(mcp)
+
+    # Register resources (read-only context)
+    stix_export.register(mcp)
+
+    logger.info("OpenCTI MCP server ready")
+    return mcp, cfg
+
+
+def main() -> None:
+    """Start the MCP server using the transport specified in the environment."""
+    mcp, cfg = build_server()
+
+    if cfg.transport == "sse":
+        logger.info("Starting SSE transport on %s:%s", cfg.sse_host, cfg.sse_port)
+        _run_sse(mcp, cfg)
+    else:
+        logger.info("Starting stdio transport")
+        mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/opencti-mcp/src/opencti_mcp/server.py
+++ b/opencti-mcp/src/opencti_mcp/server.py
@@ -62,6 +62,37 @@ def _add_sse_request_controls(app: Any, cfg: Config) -> None:
     from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import Response
 
+    class _BodySizeLimitMiddleware:
+        def __init__(self, app: Any) -> None:
+            self.app = app
+
+        async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+            if scope["type"] != "http":
+                await self.app(scope, receive, send)
+                return
+
+            messages = []
+            body_size = 0
+            more_body = True
+            while more_body:
+                message = await receive()
+                messages.append(message)
+                if message["type"] != "http.request":
+                    continue
+                body_size += len(message.get("body", b""))
+                if body_size > cfg.max_request_body_bytes:
+                    response = Response("Request body too large", status_code=413)
+                    await response(scope, receive, send)
+                    return
+                more_body = message.get("more_body", False)
+
+            async def replay_receive() -> Any:
+                if messages:
+                    return messages.pop(0)
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            await self.app(scope, replay_receive, send)
+
     semaphore = asyncio.Semaphore(cfg.max_concurrent_requests)
     request_windows: dict[str, list[float]] = {}
 
@@ -95,6 +126,7 @@ def _add_sse_request_controls(app: Any, cfg: Config) -> None:
                 semaphore.release()
 
     app.add_middleware(_RequestControlsMiddleware)
+    app.add_middleware(_BodySizeLimitMiddleware)
 
 
 def _run_sse(mcp: FastMCP, cfg: Config) -> None:

--- a/opencti-mcp/src/opencti_mcp/tools/__init__.py
+++ b/opencti-mcp/src/opencti_mcp/tools/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+"""Tools package initialiser."""

--- a/opencti-mcp/src/opencti_mcp/tools/cases.py
+++ b/opencti-mcp/src/opencti_mcp/tools/cases.py
@@ -193,7 +193,6 @@ def register(mcp: FastMCP) -> None:
         :return: JSON with ``{"success": true}`` or ``{"error": …}``.
         """
         client = get_client()
-        last_error: str = ""
         for adder_type in (client.case_incident, client.case_rfi, client.case_rft):
             try:
                 adder_type.add_stix_object_or_stix_relationship(
@@ -202,15 +201,9 @@ def register(mcp: FastMCP) -> None:
                 )
                 return json.dumps({"success": True})
             except Exception:
-                last_error = "Failed to link object to case"
                 logger.debug("add_object_to_case: attempt failed", exc_info=True)
         return json.dumps(
-            {
-                "error": (
-                    f"Could not add object to case — case ID may be invalid or inaccessible"
-                    f" (last error: {last_error})"
-                )
-            }
+            {"error": "Could not add object to case: case ID may be invalid or inaccessible"}
         )
 
     @mcp.tool()
@@ -281,7 +274,7 @@ def register(mcp: FastMCP) -> None:
         try:
             result = client.task.update_field(
                 id=task_id,
-                input=[{"key": "completed", "value": ["true"]}],
+                input=[{"key": "completed", "value": [True]}],
             )
             return json.dumps(result, default=str)
         except Exception as exc:

--- a/opencti-mcp/src/opencti_mcp/tools/cases.py
+++ b/opencti-mcp/src/opencti_mcp/tools/cases.py
@@ -1,0 +1,288 @@
+# coding: utf-8
+"""Case management tools (incident response, RFIs, RFTs, tasks) for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all case tools onto *mcp*."""
+
+    # -------------------------------------------------------------------------
+    # Incident cases
+    # -------------------------------------------------------------------------
+
+    @mcp.tool()
+    def create_incident_case(
+        name: str,
+        severity: str = "low",
+        priority: str = "P4",
+        description: str | None = None,
+        labels: list[str] | None = None,
+        markings: list[str] | None = None,
+        assignees: list[str] | None = None,
+        object_ids: list[str] | None = None,
+    ) -> str:
+        """Create a new Incident Response case in OpenCTI.
+
+        :param name: case name / title.
+        :param severity: severity level — one of ``"low"``, ``"medium"``,
+            ``"high"``, ``"critical"`` (default ``"low"``).
+        :param priority: priority level — one of ``"P1"``, ``"P2"``, ``"P3"``,
+            ``"P4"`` (default ``"P4"``).
+        :param description: optional free-text description.
+        :param labels: list of label IDs.
+        :param markings: list of TLP marking definition IDs.
+        :param assignees: list of user IDs to assign to the case.
+        :param object_ids: list of entity IDs to link to the case at creation
+            time.
+        :return: JSON-encoded created case object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.case_incident.create(
+                name=name,
+                severity=severity,
+                priority=priority,
+                description=description,
+                objectLabel=labels,
+                objectMarking=markings,
+                objectAssignee=assignees,
+                objects=object_ids,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    # -------------------------------------------------------------------------
+    # Request for Information (RFI)
+    # -------------------------------------------------------------------------
+
+    @mcp.tool()
+    def create_rfi(
+        name: str,
+        priority: str = "P4",
+        description: str | None = None,
+        information_types: list[str] | None = None,
+        labels: list[str] | None = None,
+        markings: list[str] | None = None,
+        assignees: list[str] | None = None,
+    ) -> str:
+        """Create a new Request for Information (RFI) case.
+
+        :param name: RFI title.
+        :param priority: priority level — ``"P1"``–``"P4"`` (default ``"P4"``).
+        :param description: optional description of the information requested.
+        :param information_types: list of information-type labels (e.g.
+            ``["indicators", "ttps"]``).
+        :param labels: list of label IDs.
+        :param markings: list of TLP marking definition IDs.
+        :param assignees: list of user IDs to assign.
+        :return: JSON-encoded created RFI object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.case_rfi.create(
+                name=name,
+                priority=priority,
+                description=description,
+                information_types=information_types,
+                objectLabel=labels,
+                objectMarking=markings,
+                objectAssignee=assignees,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    # -------------------------------------------------------------------------
+    # Generic case operations
+    # -------------------------------------------------------------------------
+
+    @mcp.tool()
+    def lookup_case(name_or_id: str, limit: int = 10) -> str:
+        """Find any case (Incident / RFI / RFT) by name or ID.
+
+        First attempts exact ID look-ups across all case types; falls back to
+        free-text search.
+
+        :param name_or_id: OpenCTI/STIX ID or name/keyword.
+        :param limit: maximum results on keyword search (default 10).
+        :return: JSON-encoded case object (ID match) or list of matching cases.
+        """
+        client = get_client()
+        # Try incident
+        for reader in (
+            client.case_incident.read,
+            client.case_rfi.read,
+            client.case_rft.read,
+        ):
+            try:
+                result = reader(id=name_or_id)
+                if result is not None:
+                    return json.dumps(result, default=str)
+            except Exception:
+                logger.debug("lookup_case: ID read attempt failed", exc_info=True)
+
+        # Fall back to search across all types
+        results: list[Any] = []
+        for lister in (
+            client.case_incident.list,
+            client.case_rfi.list,
+            client.case_rft.list,
+        ):
+            try:
+                found = lister(search=name_or_id, first=limit)
+                results.extend(found or [])
+            except Exception:
+                logger.debug("lookup_case: search attempt failed", exc_info=True)
+        return json.dumps(results[:limit], default=str)
+
+    @mcp.tool()
+    def list_cases(
+        case_type: str = "all",
+        search: str | None = None,
+        limit: int = 50,
+    ) -> str:
+        """List cases with optional type and keyword filters.
+
+        :param case_type: ``"incident"``, ``"rfi"``, ``"rft"``, or ``"all"``
+            (default ``"all"``).
+        :param search: optional free-text search keyword.
+        :param limit: maximum results per case type (1–200, default 50).
+        :return: JSON-encoded list of case objects.
+        """
+        client = get_client()
+        limit = max(1, min(limit, 200))
+        results: list[Any] = []
+        mapping = {
+            "incident": [client.case_incident.list],
+            "rfi": [client.case_rfi.list],
+            "rft": [client.case_rft.list],
+            "all": [client.case_incident.list, client.case_rfi.list, client.case_rft.list],
+        }
+        listers = mapping.get(case_type.lower(), mapping["all"])
+        for lister in listers:
+            try:
+                found = lister(search=search, first=limit)
+                results.extend(found or [])
+            except Exception:
+                logger.debug("list_cases: lister call failed", exc_info=True)
+        return json.dumps(results[:limit], default=str)
+
+    @mcp.tool()
+    def add_object_to_case(case_id: str, object_id: str) -> str:
+        """Link a STIX object or relationship to a case.
+
+        The case type (incident / RFI / RFT) is detected automatically by
+        trying each case API in turn.
+
+        :param case_id: OpenCTI internal ID or STIX standard ID of the case.
+        :param object_id: OpenCTI internal ID or STIX standard ID of the
+            entity/relationship to add.
+        :return: JSON with ``{"success": true}`` or ``{"error": …}``.
+        """
+        client = get_client()
+        last_error: str = ""
+        for adder_type in (client.case_incident, client.case_rfi, client.case_rft):
+            try:
+                adder_type.add_stix_object_or_stix_relationship(
+                    id=case_id,
+                    stixObjectOrStixRelationshipId=object_id,
+                )
+                return json.dumps({"success": True})
+            except Exception:
+                last_error = "Failed to link object to case"
+                logger.debug("add_object_to_case: attempt failed", exc_info=True)
+        return json.dumps(
+            {
+                "error": (
+                    f"Could not add object to case — case ID may be invalid or inaccessible"
+                    f" (last error: {last_error})"
+                )
+            }
+        )
+
+    @mcp.tool()
+    def update_case_status(case_id: str, status_id: str) -> str:
+        """Update the workflow status of a case.
+
+        Retrieve available status IDs from the OpenCTI platform's workflow
+        configuration.  The status must already exist in the workflow for the
+        relevant case type.
+
+        :param case_id: OpenCTI internal ID.
+        :param status_id: target workflow status ID.
+        :return: JSON-encoded updated case object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.stix_domain_object.update_field(
+                id=case_id,
+                input=[{"key": "x_opencti_workflow_id", "value": [status_id]}],
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    # -------------------------------------------------------------------------
+    # Tasks
+    # -------------------------------------------------------------------------
+
+    @mcp.tool()
+    def create_task(
+        name: str,
+        case_id: str | None = None,
+        description: str | None = None,
+        assignees: list[str] | None = None,
+        due_date: str | None = None,
+    ) -> str:
+        """Create a task, optionally linked to a case.
+
+        :param name: task name.
+        :param case_id: optional OpenCTI ID of the case to attach the task to.
+        :param description: optional free-text description.
+        :param assignees: list of user IDs to assign.
+        :param due_date: ISO-8601 due date string (e.g.
+            ``"2024-07-01T00:00:00Z"``).
+        :return: JSON-encoded created task object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.task.create(
+                name=name,
+                description=description,
+                objectAssignee=assignees,
+                due_date=due_date,
+                objects=[case_id] if case_id else None,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def complete_task(task_id: str) -> str:
+        """Mark a task as completed.
+
+        :param task_id: OpenCTI internal ID of the task.
+        :return: JSON-encoded updated task object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.task.update_field(
+                id=task_id,
+                input=[{"key": "completed", "value": ["true"]}],
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/enrichment.py
+++ b/opencti-mcp/src/opencti_mcp/tools/enrichment.py
@@ -1,0 +1,157 @@
+# coding: utf-8
+"""Enrichment tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+# GraphQL query used to retrieve recent works associated with a specific entity.
+_ENRICHMENT_WORKS_QUERY = """
+query EnrichmentWorks($filters: FilterGroup) {
+    works(first: 50, filters: $filters, orderBy: timestamp, orderMode: desc) {
+        edges {
+            node {
+                id
+                name
+                status
+                timestamp
+                completed_time
+                tracking {
+                    import_expected_number
+                    import_processed_number
+                }
+                errors {
+                    timestamp
+                    message
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all enrichment tools onto *mcp*."""
+
+    @mcp.tool()
+    def list_enrichment_connectors(entity_type: str | None = None) -> str:
+        """List active enrichment connectors available in this OpenCTI instance.
+
+        :param entity_type: optional STIX type to filter connectors by scope
+            (e.g. ``"IPv4-Addr"``, ``"Domain-Name"``).  When omitted all
+            active enrichment connectors are returned.
+        :return: JSON-encoded list of connector summaries (id, name,
+            connector_scope, active).
+        """
+        client = get_client()
+        try:
+            all_connectors = client.connector.list()
+            enrichment = [
+                c
+                for c in (all_connectors or [])
+                if c.get("connector_type") == "INTERNAL_ENRICHMENT" and c.get("active", False)
+            ]
+            if entity_type:
+                entity_type_lower = entity_type.lower()
+                enrichment = [
+                    c
+                    for c in enrichment
+                    if any(s.lower() == entity_type_lower for s in (c.get("connector_scope") or []))
+                ]
+            summaries = [
+                {
+                    "id": c.get("id"),
+                    "name": c.get("name"),
+                    "connector_scope": c.get("connector_scope"),
+                    "active": c.get("active"),
+                    "auto": c.get("auto"),
+                }
+                for c in enrichment
+            ]
+            return json.dumps(summaries, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def enrich_entity(entity_id: str, connector_id: str | None = None) -> str:
+        """Trigger enrichment connectors for a STIX cyber observable.
+
+        This tool operates on **STIX Cyber Observables** (SCOs) only — e.g.
+        IP addresses, domain names, file hashes, URLs.  To enrich other
+        entity types (Malware, Threat Actor, etc.) use the enrichment
+        connectors' native interfaces.
+
+        When *connector_id* is omitted all compatible enrichment connectors
+        for the observable's type are triggered automatically.
+
+        :param entity_id: OpenCTI internal ID or STIX standard ID of the
+            STIX Cyber Observable to enrich.
+        :param connector_id: optional ID of a specific connector.  Use
+            ``list_enrichment_connectors`` to discover valid IDs.
+        :return: JSON object with ``work_id`` returned by the enrichment
+            request, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            work_id = client.stix_cyber_observable.ask_for_enrichment(
+                id=entity_id,
+                connector_id=connector_id,
+            )
+            return json.dumps({"work_id": work_id}, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_enrichment_status(work_id: str) -> str:
+        """Poll the status of an enrichment work job.
+
+        :param work_id: work ID returned by ``enrich_entity`` or
+            ``enrich_observable``.
+        :return: JSON-encoded work status object with fields ``id``,
+            ``status``, ``tracking`` (counts), ``messages``, and ``errors``;
+            or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.work.get_work(work_id=work_id)
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_entity_connectors(entity_id: str) -> str:
+        """List enrichment connectors that have run on a specific entity.
+
+        Returns connector works associated with the entity, showing which
+        connectors have processed it and their completion status.
+
+        :param entity_id: OpenCTI internal ID or STIX standard ID.
+        :return: JSON-encoded list of work objects, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            entity = client.stix_core_object.read(id=entity_id)
+            if entity is None:
+                return json.dumps({"error": "Entity not found"})
+            # Fetch recent works filtered to this entity's standard_id
+            standard_id = entity.get("standard_id") or entity_id
+            filters = {
+                "mode": "and",
+                "filters": [{"key": "event_source_id", "values": [standard_id]}],
+                "filterGroups": [],
+            }
+            result = client.query(_ENRICHMENT_WORKS_QUERY, {"filters": filters})
+            edges = result.get("data", {}).get("works", {}).get("edges", [])
+            works = [e["node"] for e in edges]
+            return json.dumps(works, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/indicators.py
+++ b/opencti-mcp/src/opencti_mcp/tools/indicators.py
@@ -1,0 +1,206 @@
+# coding: utf-8
+"""Indicator tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all indicator tools onto *mcp*."""
+
+    @mcp.tool()
+    def list_indicators(
+        search: str | None = None,
+        pattern_type: str | None = None,
+        limit: int = 50,
+    ) -> str:
+        """Search and list indicators with optional filtering.
+
+        Covers all use cases from a simple value look-up to a filtered list.
+
+        :param search: optional free-text search keyword — can be an IP,
+            domain, hash, URL, indicator name, or any partial STIX pattern
+            fragment.
+        :param pattern_type: optional filter on pattern type (e.g. ``"stix"``,
+            ``"sigma"``, ``"yara"``).
+        :param limit: maximum number of results to return (1–200, default 50).
+        :return: JSON-encoded list of indicator objects.
+        """
+        client = get_client()
+        limit = max(1, min(limit, 200))
+        filters: dict[str, Any] | None = None
+        if pattern_type:
+            filters = {
+                "mode": "and",
+                "filters": [{"key": "pattern_type", "values": [pattern_type]}],
+                "filterGroups": [],
+            }
+        try:
+            results = client.indicator.list(
+                search=search,
+                filters=filters,
+                first=limit,
+            )
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_indicator(indicator_id: str) -> str:
+        """Get full details of a single indicator by its OpenCTI or STIX ID.
+
+        :param indicator_id: OpenCTI internal ID or STIX standard ID of the
+            indicator (e.g. ``"indicator--4e11b23f-…"``).
+        :return: JSON-encoded indicator object, or ``{"error": …}`` if not found.
+        """
+        client = get_client()
+        try:
+            result = client.indicator.read(id=indicator_id)
+            if result is None:
+                return json.dumps({"error": "Indicator not found"})
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def add_indicator(
+        name: str,
+        pattern: str,
+        pattern_type: str,
+        main_observable_type: str,
+        valid_from: str | None = None,
+        valid_until: str | None = None,
+        score: int = 50,
+        description: str | None = None,
+        labels: list[str] | None = None,
+        markings: list[str] | None = None,
+    ) -> str:
+        """Create a new STIX indicator in OpenCTI.
+
+        :param name: human-readable name for the indicator.
+        :param pattern: STIX pattern string (e.g.
+            ``"[ipv4-addr:value = '1.2.3.4']"``).
+        :param pattern_type: pattern language — one of ``"stix"``, ``"sigma"``,
+            ``"yara"``, ``"snort"``, ``"tanium-signal"``, ``"spl"``.
+        :param main_observable_type: the primary observable type this indicator
+            represents (e.g. ``"IPv4-Addr"``, ``"Domain-Name"``,
+            ``"StixFile"``).
+        :param valid_from: ISO-8601 datetime string when the indicator becomes
+            valid (e.g. ``"2024-01-01T00:00:00Z"``).  Defaults to now.
+        :param valid_until: ISO-8601 datetime string when the indicator expires.
+        :param score: threat score 0–100 (default 50).
+        :param description: optional free-text description.
+        :param labels: list of label IDs to attach.
+        :param markings: list of TLP marking definition IDs to attach.
+        :return: JSON-encoded created indicator object, or ``{"error": …}``
+            on failure.
+        """
+        client = get_client()
+        try:
+            result = client.indicator.create(
+                name=name,
+                pattern=pattern,
+                pattern_type=pattern_type,
+                x_opencti_main_observable_type=main_observable_type,
+                valid_from=valid_from,
+                valid_until=valid_until,
+                x_opencti_score=score,
+                description=description,
+                objectLabel=labels,
+                objectMarking=markings,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def update_indicator(
+        indicator_id: str,
+        score: int | None = None,
+        valid_until: str | None = None,
+        revoked: bool | None = None,
+        description: str | None = None,
+    ) -> str:
+        """Update one or more fields of an existing indicator.
+
+        Only the fields you supply will be changed; omitted fields are left
+        unchanged.
+
+        :param indicator_id: OpenCTI internal ID or STIX standard ID.
+        :param score: new threat score (0–100).
+        :param valid_until: new expiry date as an ISO-8601 string.
+        :param revoked: set to ``True`` to revoke the indicator.
+        :param description: updated description text.
+        :return: JSON-encoded updated indicator object, or ``{"error": …}``.
+        """
+        client = get_client()
+        inputs: list[dict[str, Any]] = []
+        if score is not None:
+            inputs.append({"key": "x_opencti_score", "value": [str(score)]})
+        if valid_until is not None:
+            inputs.append({"key": "valid_until", "value": [valid_until]})
+        if revoked is not None:
+            # Pass the Python bool directly — do NOT convert to a string.
+            inputs.append({"key": "revoked", "value": [revoked]})
+        if description is not None:
+            inputs.append({"key": "description", "value": [description]})
+        if not inputs:
+            return json.dumps({"error": "No fields to update were provided"})
+        try:
+            result = client.indicator.update_field(
+                id=indicator_id,
+                input=inputs,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def promote_observable_to_indicator(observable_id: str) -> str:
+        """Promote an existing STIX cyber observable to a full indicator.
+
+        OpenCTI will automatically create the corresponding STIX pattern and
+        link the new indicator back to the observable via a ``based-on``
+        relationship.
+
+        :param observable_id: OpenCTI internal ID or STIX standard ID of the
+            observable to promote.
+        :return: JSON-encoded new indicator object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.stix_cyber_observable.promote_to_indicator_v2(id=observable_id)
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_indicator_relationships(indicator_id: str, limit: int = 50) -> str:
+        """Fetch the relationships attached to an indicator.
+
+        Typically returns ``indicates`` and ``based-on`` relationships, but
+        all relationship types are included.
+
+        :param indicator_id: OpenCTI internal ID or STIX standard ID.
+        :param limit: maximum relationships to return (default 50).
+        :return: JSON-encoded list of relationship objects.
+        """
+        client = get_client()
+        try:
+            results = client.stix_core_relationship.list(
+                fromId=indicator_id,
+                first=limit,
+            )
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/investigations.py
+++ b/opencti-mcp/src/opencti_mcp/tools/investigations.py
@@ -1,0 +1,140 @@
+# coding: utf-8
+"""Investigation (workspace) tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all investigation tools onto *mcp*."""
+
+    @mcp.tool()
+    def create_investigation(
+        name: str,
+        object_ids: list[str] | None = None,
+        description: str | None = None,
+    ) -> str:
+        """Create a new Investigation workspace in OpenCTI.
+
+        An investigation is a visual canvas that lets analysts map and link
+        threat-intelligence entities interactively.
+
+        :param name: investigation title.
+        :param object_ids: list of entity IDs to pre-populate the canvas with.
+        :param description: optional description.
+        :return: JSON-encoded created workspace object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.workspace.create(
+                type="investigation",
+                name=name,
+                description=description,
+                investigated_entities_ids=object_ids or [],
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_investigation(investigation_id: str) -> str:
+        """Retrieve details of an investigation workspace.
+
+        :param investigation_id: OpenCTI internal ID of the workspace.
+        :return: JSON-encoded workspace object including the list of
+            investigated entity IDs, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.workspace.read(id=investigation_id)
+            if result is None:
+                return json.dumps({"error": "Investigation not found"})
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def list_investigations(search: str | None = None, limit: int = 50) -> str:
+        """List investigation workspaces.
+
+        :param search: optional free-text search keyword applied to workspace
+            names.
+        :param limit: maximum number of results (1–200, default 50).
+        :return: JSON-encoded list of workspace objects.
+        """
+        client = get_client()
+        limit = max(1, min(limit, 200))
+        try:
+            results = client.workspace.list(
+                type="investigation",
+                search=search,
+                first=limit,
+            )
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def add_to_investigation(investigation_id: str, object_id: str) -> str:
+        """Add an entity to an investigation workspace canvas.
+
+        :param investigation_id: OpenCTI internal ID of the workspace.
+        :param object_id: OpenCTI internal ID or STIX standard ID of the
+            entity to add.
+        :return: JSON with ``{"success": true}`` or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            client.workspace.add_investigated_entity(
+                id=investigation_id,
+                entity_id=object_id,
+            )
+            return json.dumps({"success": True})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def export_investigation_as_report(investigation_id: str) -> str:
+        """Export an investigation workspace as a STIX 2.1 Report bundle.
+
+        The bundle contains a STIX Report object with all investigated
+        entities included as object references, along with the full STIX
+        representation of each entity.
+
+        :param investigation_id: OpenCTI internal ID of the workspace.
+        :return: STIX 2.1 bundle JSON string, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            bundle = client.workspace.to_stix_bundle(id=investigation_id)
+            return bundle if bundle else json.dumps({"error": "Export failed"})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def start_investigation_from_container(container_id: str) -> str:
+        """Create a new investigation by pivoting from an existing container.
+
+        Supported container types are Reports, Cases (Incident/RFI/RFT),
+        and Groupings.  All objects from the container are copied into the
+        new investigation's canvas.
+
+        :param container_id: OpenCTI internal ID or STIX standard ID of the
+            source container.
+        :return: JSON-encoded new workspace object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.workspace.add_from_container(id=container_id)
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/observables.py
+++ b/opencti-mcp/src/opencti_mcp/tools/observables.py
@@ -1,0 +1,184 @@
+# coding: utf-8
+"""Observable (IoC) tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all observable tools onto *mcp*."""
+
+    @mcp.tool()
+    def list_observables(
+        search: str | None = None,
+        observable_type: str | None = None,
+        limit: int = 50,
+    ) -> str:
+        """Search and list STIX cyber observables with optional filtering.
+
+        Covers all observable types: IP addresses, domain names, URLs, file
+        hashes, email addresses, hostnames, cryptocurrency wallets, and more.
+
+        :param search: optional free-text search keyword — can be an IP,
+            domain, hash, URL, or any observable value fragment.
+        :param observable_type: optional STIX type filter (e.g.
+            ``"IPv4-Addr"``, ``"Domain-Name"``, ``"StixFile"``,
+            ``"Email-Addr"``).  When omitted all types are searched.
+        :param limit: maximum number of results to return (1–200, default 50).
+        :return: JSON-encoded list of observable objects.
+        """
+        client = get_client()
+        limit = max(1, min(limit, 200))
+        try:
+            results = client.stix_cyber_observable.list(
+                types=[observable_type] if observable_type else None,
+                search=search,
+                first=limit,
+            )
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_observable(observable_id: str) -> str:
+        """Get full details of a single STIX cyber observable by its ID.
+
+        :param observable_id: OpenCTI internal ID or STIX standard ID.
+        :return: JSON-encoded observable object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.stix_cyber_observable.read(id=observable_id)
+            if result is None:
+                return json.dumps({"error": "Observable not found"})
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def add_observable(
+        observable_key: str,
+        observable_value: str,
+        score: int = 50,
+        description: str | None = None,
+        labels: list[str] | None = None,
+        markings: list[str] | None = None,
+        create_indicator: bool = False,
+    ) -> str:
+        """Create a new STIX cyber observable in OpenCTI.
+
+        Use the ``<Type>.<field>`` key format, e.g.:
+
+        * ``"IPv4-Addr.value"`` / ``"1.2.3.4"``
+        * ``"Domain-Name.value"`` / ``"evil.example.com"``
+        * ``"Url.value"`` / ``"https://evil.example.com/payload"``
+        * ``"Email-Addr.value"`` / ``"attacker@evil.com"``
+        * ``"File.hashes.SHA-256"`` / ``"<sha256 hex>"``
+        * ``"File.hashes.MD5"`` / ``"<md5 hex>"``
+        * ``"File.name"`` / ``"malware.exe"``
+        * ``"StixFile.name"`` — same as ``File.name``
+
+        :param observable_key: STIX property key in ``<Type>.<field>`` format.
+        :param observable_value: the raw observable value.
+        :param score: threat score 0–100 (default 50).
+        :param description: optional free-text description.
+        :param labels: list of label IDs to attach.
+        :param markings: list of TLP marking definition IDs.
+        :param create_indicator: when ``True`` an indicator is automatically
+            created and linked to this observable (default ``False``).
+        :return: JSON-encoded created observable object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.stix_cyber_observable.create(
+                simple_observable_key=observable_key,
+                simple_observable_value=observable_value,
+                simple_observable_description=description,
+                x_opencti_score=score,
+                objectLabel=labels,
+                objectMarking=markings,
+                createIndicator=create_indicator,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def enrich_observable(observable_id: str, connector_id: str | None = None) -> str:
+        """Trigger enrichment connectors for a STIX cyber observable.
+
+        When *connector_id* is omitted all active enrichment connectors
+        compatible with the observable's type are triggered automatically.
+
+        :param observable_id: OpenCTI internal ID or STIX standard ID.
+        :param connector_id: optional ID of a specific enrichment connector to
+            use.  List connectors with the ``list_enrichment_connectors`` tool.
+        :return: JSON object with ``work_id`` (or list of work IDs) that can be
+            polled with ``get_enrichment_status``, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            work_id = client.stix_cyber_observable.ask_for_enrichment(
+                id=observable_id,
+                connector_id=connector_id,
+            )
+            return json.dumps({"work_id": work_id}, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_observable_indicators(observable_id: str, limit: int = 50) -> str:
+        """List indicators that are based on a specific observable.
+
+        Returns all indicators linked to this observable via ``based-on``
+        relationships.
+
+        :param observable_id: OpenCTI internal ID or STIX standard ID.
+        :param limit: maximum number of results to return (default 50).
+        :return: JSON-encoded list of indicator objects.
+        """
+        client = get_client()
+        try:
+            results = client.stix_core_relationship.list(
+                toId=observable_id,
+                relationship_type="based-on",
+                first=limit,
+            )
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_observable_relationships(
+        observable_id: str,
+        limit: int = 50,
+    ) -> str:
+        """List all relationships attached to a STIX cyber observable.
+
+        The *limit* applies independently to each direction (from / to), so
+        the response may contain up to ``2 × limit`` relationships in total.
+
+        :param observable_id: OpenCTI internal ID or STIX standard ID.
+        :param limit: maximum number of relationships per direction (default 50).
+        :return: JSON-encoded list of relationship objects.
+        """
+        client = get_client()
+        try:
+            from_rels = client.stix_core_relationship.list(fromId=observable_id, first=limit)
+            to_rels = client.stix_core_relationship.list(toId=observable_id, first=limit)
+            combined: list[Any] = []
+            combined.extend(from_rels or [])
+            combined.extend(to_rels or [])
+            return json.dumps(combined, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/relationships.py
+++ b/opencti-mcp/src/opencti_mcp/tools/relationships.py
@@ -1,0 +1,152 @@
+# coding: utf-8
+"""Relationship tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all relationship tools onto *mcp*."""
+
+    @mcp.tool()
+    def create_relationship(
+        from_id: str,
+        relationship_type: str,
+        to_id: str,
+        description: str | None = None,
+        start_time: str | None = None,
+        stop_time: str | None = None,
+        confidence: int | None = None,
+        markings: list[str] | None = None,
+    ) -> str:
+        """Create a STIX core relationship between two entities.
+
+        Common relationship types include:
+        ``"uses"``, ``"indicates"``, ``"attributed-to"``,
+        ``"targets"``, ``"mitigates"``, ``"related-to"``,
+        ``"impersonates"``, ``"based-on"``.
+
+        :param from_id: OpenCTI internal ID or STIX standard ID of the source
+            entity.
+        :param relationship_type: STIX relationship type string.
+        :param to_id: OpenCTI internal ID or STIX standard ID of the target
+            entity.
+        :param description: optional description of the relationship.
+        :param start_time: ISO-8601 start time (e.g. ``"2024-01-01T00:00:00Z"``).
+        :param stop_time: ISO-8601 stop time.
+        :param confidence: confidence level 0–100.
+        :param markings: list of TLP marking definition IDs.
+        :return: JSON-encoded created relationship object, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.stix_core_relationship.create(
+                fromId=from_id,
+                toId=to_id,
+                relationship_type=relationship_type,
+                description=description,
+                start_time=start_time,
+                stop_time=stop_time,
+                confidence=confidence,
+                objectMarking=markings,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def lookup_relationships(
+        entity_id: str,
+        relationship_type: str | None = None,
+        direction: str = "both",
+        limit: int = 50,
+    ) -> str:
+        """List relationships attached to an entity.
+
+        The *limit* applies independently per direction, so up to
+        ``2 × limit`` relationships may be returned when *direction* is
+        ``"both"``.
+
+        :param entity_id: OpenCTI internal ID or STIX standard ID.
+        :param relationship_type: optional filter on relationship type (e.g.
+            ``"uses"``, ``"indicates"``).
+        :param direction: ``"from"`` (entity is source), ``"to"`` (entity is
+            target), or ``"both"`` (default).
+        :param limit: maximum relationships per direction (default 50).
+        :return: JSON-encoded list of relationship objects.
+        """
+        client = get_client()
+        results: list[Any] = []
+        try:
+            if direction in ("from", "both"):
+                from_rels = client.stix_core_relationship.list(
+                    fromId=entity_id,
+                    relationship_type=relationship_type,
+                    first=limit,
+                )
+                results.extend(from_rels or [])
+            if direction in ("to", "both"):
+                to_rels = client.stix_core_relationship.list(
+                    toId=entity_id,
+                    relationship_type=relationship_type,
+                    first=limit,
+                )
+                results.extend(to_rels or [])
+            return json.dumps(results, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def create_sighting(
+        observable_id: str,
+        target_id: str,
+        first_seen: str | None = None,
+        last_seen: str | None = None,
+        count: int = 1,
+        confidence: int | None = None,
+        description: str | None = None,
+        markings: list[str] | None = None,
+    ) -> str:
+        """Record a STIX sighting relationship between an observable and a target.
+
+        A sighting asserts that an observable was seen at a specific location
+        (identity, sector, region, etc.).
+
+        :param observable_id: OpenCTI internal ID or STIX standard ID of the
+            observable or indicator that was sighted.
+        :param target_id: OpenCTI internal ID or STIX standard ID of the
+            target entity where the sighting occurred (e.g. an Organization or
+            Identity).
+        :param first_seen: ISO-8601 datetime when first observed.
+        :param last_seen: ISO-8601 datetime when last observed.
+        :param count: number of times the observable was sighted (default 1).
+        :param confidence: confidence level 0–100.
+        :param description: optional description.
+        :param markings: list of TLP marking definition IDs.
+        :return: JSON-encoded created sighting relationship, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.stix_sighting_relationship.create(
+                fromId=observable_id,
+                toId=target_id,
+                first_seen=first_seen,
+                last_seen=last_seen,
+                attribute_count=count,
+                confidence=confidence,
+                description=description,
+                objectMarking=markings,
+            )
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/reports.py
+++ b/opencti-mcp/src/opencti_mcp/tools/reports.py
@@ -1,0 +1,192 @@
+# coding: utf-8
+"""Report tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all report tools onto *mcp*."""
+
+    @mcp.tool()
+    def lookup_report(name_or_id: str, limit: int = 10) -> str:
+        """Find a report by its name, ID, or a keyword search.
+
+        First attempts an exact ID look-up; falls back to a free-text search
+        against report names and descriptions.
+
+        :param name_or_id: OpenCTI/STIX ID or a name / keyword.
+        :param limit: maximum search results when falling back (default 10).
+        :return: JSON-encoded report object (ID look-up) or list of matching
+            report objects (search), or ``{"error": …}``.
+        """
+        client = get_client()
+        # Try direct ID read first
+        try:
+            result = client.report.read(id=name_or_id)
+            if result is not None:
+                return json.dumps(result, default=str)
+        except Exception:
+            logger.debug("lookup_report: ID read failed, falling back to search", exc_info=True)
+        # Fall back to free-text search
+        try:
+            results = client.report.list(search=name_or_id, first=limit)
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def list_reports(
+        search: str | None = None,
+        report_class: str | None = None,
+        limit: int = 50,
+    ) -> str:
+        """List threat-intelligence reports with optional filtering.
+
+        :param search: optional free-text search keyword.
+        :param report_class: optional report type/class filter (e.g.
+            ``"Threat Report"``, ``"Internal Report"``,
+            ``"Malware Analysis"``).
+        :param limit: maximum number of results (1–200, default 50).
+        :return: JSON-encoded list of report objects.
+        """
+        client = get_client()
+        limit = max(1, min(limit, 200))
+        filters = None
+        if report_class:
+            filters = {
+                "mode": "and",
+                "filters": [{"key": "report_types", "values": [report_class]}],
+                "filterGroups": [],
+            }
+        try:
+            results = client.report.list(
+                search=search,
+                filters=filters,
+                first=limit,
+            )
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def create_report(
+        name: str,
+        published: str,
+        description: str | None = None,
+        report_types: list[str] | None = None,
+        labels: list[str] | None = None,
+        markings: list[str] | None = None,
+        author_id: str | None = None,
+        object_ids: list[str] | None = None,
+    ) -> str:
+        """Create a new threat-intelligence report in OpenCTI.
+
+        :param name: report title.
+        :param published: publication date as ISO-8601 string (e.g.
+            ``"2024-06-15T00:00:00Z"``).
+        :param description: optional free-text description / executive summary.
+        :param report_types: list of report type labels (e.g.
+            ``["threat-report"]``, ``["internal-report"]``).
+        :param labels: list of label IDs to attach.
+        :param markings: list of TLP marking definition IDs.
+        :param author_id: OpenCTI ID of the authoring identity.
+        :param object_ids: list of entity IDs to include in the report's
+            object list from the start.
+        :return: JSON-encoded created report object (with a ``failed_objects``
+            key listing any IDs that could not be linked), or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            result = client.report.create(
+                name=name,
+                published=published,
+                description=description,
+                report_types=report_types,
+                objectLabel=labels,
+                objectMarking=markings,
+                createdBy=author_id,
+            )
+            failed_objects: list[str] = []
+            if result and object_ids:
+                for oid in object_ids:
+                    try:
+                        client.report.add_stix_object_or_stix_relationship(
+                            id=result["id"],
+                            stixObjectOrStixRelationshipId=oid,
+                        )
+                    except Exception:
+                        logger.debug(
+                            f'"create_report: failed to add object {oid!r}"', exc_info=True
+                        )
+                        failed_objects.append(oid)
+            if failed_objects:
+                result = dict(result or {})
+                result["failed_objects"] = failed_objects
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def add_object_to_report(report_id: str, object_id: str) -> str:
+        """Link an existing STIX object or relationship to a report.
+
+        :param report_id: OpenCTI internal ID or STIX standard ID of the
+            report.
+        :param object_id: OpenCTI internal ID or STIX standard ID of the
+            entity/relationship to add.
+        :return: JSON with ``{"success": true}`` or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            client.report.add_stix_object_or_stix_relationship(
+                id=report_id,
+                stixObjectOrStixRelationshipId=object_id,
+            )
+            return json.dumps({"success": True})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def get_report_objects(report_id: str) -> str:
+        """Return all STIX objects and relationships contained in a report.
+
+        :param report_id: OpenCTI internal ID or STIX standard ID.
+        :return: JSON-encoded list of contained objects (id, entity_type,
+            name/observable_value), or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            report = client.report.read(id=report_id)
+            if report is None:
+                return json.dumps({"error": "Report not found"})
+            objects = report.get("objects", [])
+            return json.dumps(objects, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def export_report_stix(report_id: str) -> str:
+        """Export a report as a STIX 2.1 bundle JSON string.
+
+        The bundle includes the report object and all its referenced STIX
+        objects.
+
+        :param report_id: OpenCTI internal ID or STIX standard ID.
+        :return: STIX 2.1 bundle JSON string, or ``{"error": …}``.
+        """
+        client = get_client()
+        try:
+            stix = client.report.to_stix2(id=report_id)
+            return stix if stix else json.dumps({"error": "Export failed"})
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/src/opencti_mcp/tools/search.py
+++ b/opencti-mcp/src/opencti_mcp/tools/search.py
@@ -1,0 +1,123 @@
+# coding: utf-8
+"""Cross-entity search tools for the OpenCTI MCP server."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from opencti_mcp.client import get_client
+from opencti_mcp.errors import safe_error_response
+
+logger = logging.getLogger(__name__)
+
+# Minimal attribute set for summary search results; keeps responses concise.
+_SEARCH_CUSTOM_ATTRIBUTES = (
+    "id standard_id entity_type "
+    "... on StixDomainObject { name } "
+    "... on StixCyberObservable { observable_value }"
+)
+
+
+def register(mcp: FastMCP) -> None:
+    """Register all search tools onto *mcp*."""
+
+    @mcp.tool()
+    def global_search(query: str, types: list[str] | None = None, limit: int = 20) -> str:
+        """Free-text search across all STIX entity types in OpenCTI.
+
+        Use this to find any threat-intelligence object when you only have a
+        keyword or partial name.  Returns a JSON list of matching entities with
+        their id, entity_type, name/observable_value, and standard_id.
+
+        :param query: search keyword or phrase.
+        :param types: optional list of STIX type names to restrict the search
+            (e.g. ``["Indicator", "Malware", "Report"]``).  When omitted all
+            types are searched.
+        :param limit: maximum number of results to return (1–200, default 20).
+            When *types* is provided the budget is distributed evenly across
+            each type so the combined result does not exceed *limit*.
+        :return: JSON-encoded list of matching entity summaries.
+        """
+        client = get_client()
+        limit = max(1, min(limit, 200))
+        results: list[dict[str, Any]] = []
+
+        if types:
+            # Distribute the result budget evenly so total ≤ limit.
+            per_type = max(1, limit // len(types))
+            for entity_type in types:
+                try:
+                    raw = client.stix_core_object.list(
+                        types=[entity_type],
+                        search=query,
+                        first=per_type,
+                        customAttributes=_SEARCH_CUSTOM_ATTRIBUTES,
+                    )
+                    results.extend(raw or [])
+                except Exception:
+                    logger.debug(
+                        f'"global_search: failed for type {entity_type!r}"',
+                        exc_info=True,
+                    )
+        else:
+            try:
+                raw = client.stix_core_object.list(
+                    search=query,
+                    first=limit,
+                    customAttributes=_SEARCH_CUSTOM_ATTRIBUTES,
+                )
+                results.extend(raw or [])
+            except Exception:
+                logger.debug("global_search: list call failed", exc_info=True)
+
+        return json.dumps(results[:limit], default=str)
+
+    @mcp.tool()
+    def find_by_stix_id(stix_id: str) -> str:
+        """Retrieve any OpenCTI entity by its STIX standard ID.
+
+        Works for any STIX object type (indicators, observables, reports,
+        cases, relationships, etc.).
+
+        :param stix_id: STIX 2.1 standard ID (e.g.
+            ``"indicator--4e11b23f-…"``).
+        :return: JSON-encoded entity dict, or ``{"error": "Not found"}`` if the
+            entity does not exist or is not accessible.
+        """
+        client = get_client()
+        try:
+            result = client.stix_core_object.read(id=stix_id)
+            if result is None:
+                return json.dumps({"error": "Not found"})
+            return json.dumps(result, default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)
+
+    @mcp.tool()
+    def find_by_external_reference(source_name: str, external_id: str) -> str:
+        """Look up an entity by external reference (e.g. a CVE ID or MITRE ATT&CK ID).
+
+        :param source_name: the source system name (e.g. ``"MITRE ATT&CK"`` or
+            ``"NVD"``)
+        :param external_id: the identifier in the external system (e.g.
+            ``"T1059"`` or ``"CVE-2024-1234"``).
+        :return: JSON-encoded list of matching entities.
+        """
+        client = get_client()
+        try:
+            filters = {
+                "mode": "and",
+                "filters": [
+                    {"key": "externalReferences.source_name", "values": [source_name]},
+                    {"key": "externalReferences.external_id", "values": [external_id]},
+                ],
+                "filterGroups": [],
+            }
+            results = client.stix_core_object.list(filters=filters, first=50)
+            return json.dumps(results or [], default=str)
+        except Exception as exc:
+            return safe_error_response(logger, __name__, exc)

--- a/opencti-mcp/test-requirements.txt
+++ b/opencti-mcp/test-requirements.txt
@@ -1,0 +1,8 @@
+black
+flake8
+isort
+mypy
+pytest
+pytest-asyncio
+pytest-cov
+pytest-mock

--- a/opencti-mcp/tests/__init__.py
+++ b/opencti-mcp/tests/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/opencti-mcp/tests/conftest.py
+++ b/opencti-mcp/tests/conftest.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+"""Shared pytest fixtures for the OpenCTI MCP test suite."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import opencti_mcp.client as client_module
+
+
+@pytest.fixture()
+def mock_client() -> MagicMock:
+    """Return a MagicMock pre-wired with common client attributes.
+
+    The mock is patched into ``opencti_mcp.client._client`` for the duration
+    of each test.  Individual tests can override specific return values as
+    needed before calling tool functions.
+    """
+    mock = MagicMock()
+    with patch.object(client_module, "_client", mock):
+        yield mock
+
+
+def make_mcp():
+    """Create a fresh FastMCP instance for tool registration."""
+    from mcp.server.fastmcp import FastMCP
+
+    return FastMCP("test")
+
+
+def get_tool(mcp, name: str):
+    """Return the raw callable for a registered tool by name."""
+    return mcp._tool_manager._tools[name].fn

--- a/opencti-mcp/tests/test_cases.py
+++ b/opencti-mcp/tests/test_cases.py
@@ -123,6 +123,28 @@ class TestLookupCase:
             assert isinstance(data, list)
 
 
+class TestAddObjectToCase:
+    def test_returns_simple_error_when_all_case_types_fail(self) -> None:
+        mock = _mock_client()
+        for case_api in (mock.case_incident, mock.case_rfi, mock.case_rft):
+            case_api.add_stix_object_or_stix_relationship.side_effect = ValueError("api failure")
+
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["add_object_to_case"].fn
+            result = tool_fn(
+                case_id="case-incident--abc123",
+                object_id="indicator--abc123",
+            )
+            data = json.loads(result)
+            assert data == {
+                "error": "Could not add object to case: case ID may be invalid or inaccessible"
+            }
+
+
 class TestCreateTask:
     def test_creates_task(self) -> None:
         mock = _mock_client()
@@ -150,3 +172,5 @@ class TestCompleteTask:
             data = json.loads(result)
             assert "error" not in data
             mock.task.update_field.assert_called_once()
+            _, kwargs = mock.task.update_field.call_args
+            assert kwargs["input"] == [{"key": "completed", "value": [True]}]

--- a/opencti-mcp/tests/test_cases.py
+++ b/opencti-mcp/tests/test_cases.py
@@ -1,0 +1,152 @@
+# coding: utf-8
+"""Tests for case management tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import cases
+
+MOCK_CASE = {
+    "id": "case-incident--abc123",
+    "standard_id": "case-incident--abc123",
+    "entity_type": "Case-Incident",
+    "name": "Test incident",
+    "severity": "high",
+    "priority": "P2",
+}
+
+MOCK_RFI = {
+    "id": "case-rfi--def456",
+    "standard_id": "case-rfi--def456",
+    "entity_type": "Case-Rfi",
+    "name": "RFI: Investigate domain",
+    "priority": "P3",
+}
+
+MOCK_TASK = {
+    "id": "task--ghi789",
+    "standard_id": "task--ghi789",
+    "entity_type": "Task",
+    "name": "Triage logs",
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.case_incident.create.return_value = MOCK_CASE
+    mock.case_incident.read.return_value = MOCK_CASE
+    mock.case_incident.list.return_value = [MOCK_CASE]
+    mock.case_rfi.create.return_value = MOCK_RFI
+    mock.case_rfi.read.return_value = None
+    mock.case_rfi.list.return_value = []
+    mock.case_rft.read.return_value = None
+    mock.case_rft.list.return_value = []
+    mock.task.create.return_value = MOCK_TASK
+    mock.task.update_field.return_value = MOCK_TASK
+    mock.stix_domain_object.update_field.return_value = MOCK_CASE
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestCreateIncidentCase:
+    def test_creates_case(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_incident_case"].fn
+            result = tool_fn(name="Test incident", severity="high", priority="P2")
+            data = json.loads(result)
+            assert data["id"] == "case-incident--abc123"
+
+    def test_error_propagated(self) -> None:
+        mock = _mock_client()
+        mock.case_incident.create.side_effect = ValueError("API error")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_incident_case"].fn
+            result = tool_fn(name="Bad case")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestCreateRfi:
+    def test_creates_rfi(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_rfi"].fn
+            result = tool_fn(name="RFI: Investigate domain", priority="P3")
+            data = json.loads(result)
+            assert data["entity_type"] == "Case-Rfi"
+
+
+class TestLookupCase:
+    def test_finds_by_id(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_case"].fn
+            result = tool_fn(name_or_id="case-incident--abc123")
+            data = json.loads(result)
+            assert data["id"] == "case-incident--abc123"
+
+    def test_falls_back_to_search(self) -> None:
+        mock = _mock_client()
+        mock.case_incident.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_case"].fn
+            result = tool_fn(name_or_id="Test incident")
+            data = json.loads(result)
+            assert isinstance(data, list)
+
+
+class TestCreateTask:
+    def test_creates_task(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_task"].fn
+            result = tool_fn(name="Triage logs", case_id="case-incident--abc123")
+            data = json.loads(result)
+            assert data["entity_type"] == "Task"
+
+
+class TestCompleteTask:
+    def test_marks_complete(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            cases.register(mcp)
+            tool_fn = mcp._tool_manager._tools["complete_task"].fn
+            result = tool_fn(task_id="task--ghi789")
+            data = json.loads(result)
+            assert "error" not in data
+            mock.task.update_field.assert_called_once()

--- a/opencti-mcp/tests/test_config.py
+++ b/opencti-mcp/tests/test_config.py
@@ -1,0 +1,138 @@
+# coding: utf-8
+"""Tests for Config loading (config.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from opencti_mcp.config import load_config
+
+
+class TestSslVerifyParsing:
+    """Verify that ssl_verify is parsed correctly for all input forms."""
+
+    def test_true_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("OPENCTI_SSL_VERIFY", "true")
+        cfg = load_config()
+        assert cfg.ssl_verify is True
+
+    def test_false_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("OPENCTI_SSL_VERIFY", "false")
+        cfg = load_config()
+        assert cfg.ssl_verify is False
+
+    def test_zero_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("OPENCTI_SSL_VERIFY", "0")
+        cfg = load_config()
+        assert cfg.ssl_verify is False
+
+    def test_one_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("OPENCTI_SSL_VERIFY", "1")
+        cfg = load_config()
+        assert cfg.ssl_verify is True
+
+    def test_ca_bundle_path_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CA bundle path must NOT be lowercased."""
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("OPENCTI_SSL_VERIFY", "/etc/pki/tls/certs/CA-bundle.crt")
+        cfg = load_config()
+        # Path must be returned exactly as supplied — lowercasing would break cert loading
+        assert cfg.ssl_verify == "/etc/pki/tls/certs/CA-bundle.crt"
+
+    def test_uppercase_true_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("OPENCTI_SSL_VERIFY", "TRUE")
+        cfg = load_config()
+        assert cfg.ssl_verify is True
+
+    def test_default_is_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.delenv("OPENCTI_SSL_VERIFY", raising=False)
+        cfg = load_config()
+        assert cfg.ssl_verify is True
+
+
+class TestRequiredVariables:
+    def test_missing_url_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENCTI_URL", raising=False)
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        with pytest.raises(ValueError, match="OPENCTI_URL"):
+            load_config()
+
+    def test_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.delenv("OPENCTI_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="OPENCTI_TOKEN"):
+            load_config()
+
+
+class TestApiKey:
+    def test_api_key_populated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("MCP_API_KEY", "supersecret")
+        cfg = load_config()
+        assert cfg.api_key == "supersecret"
+
+    def test_api_key_defaults_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.delenv("MCP_API_KEY", raising=False)
+        cfg = load_config()
+        assert cfg.api_key == ""
+
+
+class TestTransportValidation:
+    def test_invalid_transport_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("MCP_TRANSPORT", "http")
+        with pytest.raises(ValueError, match="MCP_TRANSPORT"):
+            load_config()
+
+    def test_invalid_port_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("MCP_SSE_PORT", "invalid")
+        with pytest.raises(ValueError, match="MCP_SSE_PORT"):
+            load_config()
+
+    def test_port_out_of_range_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("MCP_SSE_PORT", "70000")
+        with pytest.raises(ValueError, match="MCP_SSE_PORT"):
+            load_config()
+
+    def test_unauthenticated_sse_flag_defaults_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.delenv("MCP_ALLOW_UNAUTHENTICATED_SSE", raising=False)
+        cfg = load_config()
+        assert cfg.allow_unauthenticated_sse is False
+
+    def test_request_control_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        cfg = load_config()
+        assert cfg.max_request_body_bytes == 1_048_576
+        assert cfg.max_concurrent_requests == 20
+        assert cfg.rate_limit_per_minute == 60
+
+    def test_invalid_request_control_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENCTI_URL", "http://localhost:4000")
+        monkeypatch.setenv("OPENCTI_TOKEN", "tok")
+        monkeypatch.setenv("MCP_RATE_LIMIT_PER_MINUTE", "0")
+        with pytest.raises(ValueError, match="MCP_RATE_LIMIT_PER_MINUTE"):
+            load_config()

--- a/opencti-mcp/tests/test_enrichment.py
+++ b/opencti-mcp/tests/test_enrichment.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+"""Tests for enrichment tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import enrichment
+
+MOCK_CONNECTORS = [
+    {
+        "id": "conn--1",
+        "name": "AbuseIPDB",
+        "connector_type": "INTERNAL_ENRICHMENT",
+        "connector_scope": ["IPv4-Addr"],
+        "active": True,
+        "auto": True,
+    },
+    {
+        "id": "conn--2",
+        "name": "VirusTotal",
+        "connector_type": "INTERNAL_ENRICHMENT",
+        "connector_scope": ["StixFile", "IPv4-Addr", "Domain-Name"],
+        "active": True,
+        "auto": False,
+    },
+    {
+        "id": "conn--3",
+        "name": "ImportReport",
+        "connector_type": "INTERNAL_IMPORT_FILE",
+        "connector_scope": ["application/pdf"],
+        "active": True,
+        "auto": False,
+    },
+]
+
+MOCK_WORK = {
+    "id": "work--xyz",
+    "name": "Enrichment (ipv4-addr--abc)",
+    "status": "complete",
+    "timestamp": "2024-01-01T00:00:00Z",
+    "completed_time": "2024-01-01T00:01:00Z",
+    "tracking": {"import_expected_number": 1, "import_processed_number": 1},
+    "messages": [],
+    "errors": [],
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.connector.list.return_value = MOCK_CONNECTORS
+    mock.stix_cyber_observable.ask_for_enrichment.return_value = "work--xyz"
+    mock.work.get_work.return_value = MOCK_WORK
+    mock.stix_core_object.read.return_value = {
+        "id": "ipv4-addr--abc",
+        "standard_id": "ipv4-addr--abc",
+        "entity_type": "IPv4-Addr",
+    }
+    mock.query.return_value = {"data": {"works": {"edges": [{"node": MOCK_WORK}]}}}
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestListEnrichmentConnectors:
+    def test_returns_enrichment_connectors_only(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            enrichment.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_enrichment_connectors"].fn
+            result = tool_fn()
+            data = json.loads(result)
+            assert isinstance(data, list)
+            # ImportReport connector should be excluded
+            names = [c["name"] for c in data]
+            assert "ImportReport" not in names
+            assert "AbuseIPDB" in names
+
+    def test_filters_by_entity_type(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            enrichment.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_enrichment_connectors"].fn
+            result = tool_fn(entity_type="StixFile")
+            data = json.loads(result)
+            names = [c["name"] for c in data]
+            assert "VirusTotal" in names
+            assert "AbuseIPDB" not in names
+
+
+class TestEnrichEntity:
+    def test_returns_work_id(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            enrichment.register(mcp)
+            tool_fn = mcp._tool_manager._tools["enrich_entity"].fn
+            result = tool_fn(entity_id="ipv4-addr--abc", connector_id="conn--1")
+            data = json.loads(result)
+            assert data.get("work_id") == "work--xyz"
+
+    def test_error_returned_as_json(self) -> None:
+        mock = _mock_client()
+        mock.stix_cyber_observable.ask_for_enrichment.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            enrichment.register(mcp)
+            tool_fn = mcp._tool_manager._tools["enrich_entity"].fn
+            result = tool_fn(entity_id="ipv4-addr--abc")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestGetEnrichmentStatus:
+    def test_returns_work_status(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            enrichment.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_enrichment_status"].fn
+            result = tool_fn(work_id="work--xyz")
+            data = json.loads(result)
+            assert data["status"] == "complete"
+
+
+class TestGetEntityConnectors:
+    def test_returns_works_for_entity(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            enrichment.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_entity_connectors"].fn
+            result = tool_fn(entity_id="ipv4-addr--abc")
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data[0]["status"] == "complete"

--- a/opencti-mcp/tests/test_indicators.py
+++ b/opencti-mcp/tests/test_indicators.py
@@ -1,0 +1,217 @@
+# coding: utf-8
+"""Tests for indicator tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import indicators
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MOCK_INDICATOR = {
+    "id": "indicator--abc123",
+    "standard_id": "indicator--abc123",
+    "entity_type": "Indicator",
+    "name": "[ipv4-addr:value = '1.2.3.4']",
+    "pattern": "[ipv4-addr:value = '1.2.3.4']",
+    "pattern_type": "stix",
+    "x_opencti_score": 75,
+    "valid_from": "2024-01-01T00:00:00Z",
+    "valid_until": "2025-01-01T00:00:00Z",
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.indicator.list.return_value = [MOCK_INDICATOR]
+    mock.indicator.read.return_value = MOCK_INDICATOR
+    mock.indicator.create.return_value = MOCK_INDICATOR
+    mock.indicator.update_field.return_value = MOCK_INDICATOR
+    mock.stix_cyber_observable.promote_to_indicator_v2.return_value = MOCK_INDICATOR
+    mock.stix_core_relationship.list.return_value = []
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListIndicators:
+    """list_indicators replaces the former lookup_indicator and list_indicators."""
+
+    def test_returns_json_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_indicators"].fn
+            result = tool_fn(search="1.2.3.4")
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data[0]["id"] == "indicator--abc123"
+
+    def test_no_search_returns_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_indicators"].fn
+            result = tool_fn()
+            data = json.loads(result)
+            assert isinstance(data, list)
+
+    def test_clamps_limit(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_indicators"].fn
+            tool_fn(search="test", limit=9999)
+            mock.indicator.list.assert_called_once()
+            _, kwargs = mock.indicator.list.call_args
+            assert kwargs["first"] == 200
+
+    def test_error_returns_json_error(self) -> None:
+        mock = _mock_client()
+        mock.indicator.list.side_effect = RuntimeError("connection failed")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_indicators"].fn
+            result = tool_fn(search="bad")
+            data = json.loads(result)
+            assert "error" in data
+
+    def test_pattern_type_filter_applied(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_indicators"].fn
+            tool_fn(pattern_type="yara")
+            _, kwargs = mock.indicator.list.call_args
+            assert kwargs["filters"] is not None
+
+
+class TestGetIndicator:
+    def test_returns_single_indicator(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_indicator"].fn
+            result = tool_fn(indicator_id="indicator--abc123")
+            data = json.loads(result)
+            assert data["id"] == "indicator--abc123"
+
+    def test_not_found(self) -> None:
+        mock = _mock_client()
+        mock.indicator.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_indicator"].fn
+            result = tool_fn(indicator_id="missing")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestAddIndicator:
+    def test_creates_indicator(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["add_indicator"].fn
+            result = tool_fn(
+                name="Test indicator",
+                pattern="[ipv4-addr:value = '1.2.3.4']",
+                pattern_type="stix",
+                main_observable_type="IPv4-Addr",
+                score=80,
+            )
+            data = json.loads(result)
+            assert data["id"] == "indicator--abc123"
+            mock.indicator.create.assert_called_once()
+
+
+class TestUpdateIndicator:
+    def test_updates_score(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["update_indicator"].fn
+            result = tool_fn(indicator_id="indicator--abc123", score=90)
+            data = json.loads(result)
+            assert "error" not in data
+            mock.indicator.update_field.assert_called_once()
+
+    def test_revoked_passed_as_bool(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["update_indicator"].fn
+            tool_fn(indicator_id="indicator--abc123", revoked=True)
+            _, kwargs = mock.indicator.update_field.call_args
+            revoked_input = next(i for i in kwargs["input"] if i["key"] == "revoked")
+            # Value must be the Python bool True, not the string "true"
+            assert revoked_input["value"] == [True]
+
+    def test_no_fields_returns_error(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["update_indicator"].fn
+            result = tool_fn(indicator_id="indicator--abc123")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestPromoteObservableToIndicator:
+    def test_returns_indicator(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            indicators.register(mcp)
+            tool_fn = mcp._tool_manager._tools["promote_observable_to_indicator"].fn
+            result = tool_fn(observable_id="ipv4-addr--xyz")
+            data = json.loads(result)
+            assert data["entity_type"] == "Indicator"

--- a/opencti-mcp/tests/test_investigations.py
+++ b/opencti-mcp/tests/test_investigations.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+"""Tests for investigation tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import investigations
+
+MOCK_WORKSPACE = {
+    "id": "workspace--w1",
+    "name": "Test Investigation",
+    "type": "investigation",
+    "investigated_entities_ids": [],
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.workspace.create.return_value = MOCK_WORKSPACE
+    mock.workspace.read.return_value = MOCK_WORKSPACE
+    mock.workspace.list.return_value = [MOCK_WORKSPACE]
+    mock.workspace.add_investigated_entity.return_value = None
+    mock.workspace.to_stix_bundle.return_value = '{"type":"bundle","id":"bundle--x"}'
+    mock.workspace.add_from_container.return_value = MOCK_WORKSPACE
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestCreateInvestigation:
+    def test_creates_workspace(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_investigation"].fn
+            result = tool_fn(name="Test Investigation")
+            data = json.loads(result)
+            assert data["id"] == "workspace--w1"
+            mock.workspace.create.assert_called_once()
+
+    def test_error_propagated(self) -> None:
+        mock = _mock_client()
+        mock.workspace.create.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_investigation"].fn
+            result = tool_fn(name="Bad")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestGetInvestigation:
+    def test_returns_workspace(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_investigation"].fn
+            result = tool_fn(investigation_id="workspace--w1")
+            data = json.loads(result)
+            assert data["name"] == "Test Investigation"
+
+    def test_not_found(self) -> None:
+        mock = _mock_client()
+        mock.workspace.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_investigation"].fn
+            result = tool_fn(investigation_id="missing")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestListInvestigations:
+    def test_returns_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_investigations"].fn
+            result = tool_fn()
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data[0]["id"] == "workspace--w1"
+
+
+class TestAddToInvestigation:
+    def test_returns_success(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["add_to_investigation"].fn
+            result = tool_fn(investigation_id="workspace--w1", object_id="malware--m1")
+            data = json.loads(result)
+            assert data.get("success") is True
+
+
+class TestExportInvestigationAsReport:
+    def test_returns_bundle_string(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["export_investigation_as_report"].fn
+            result = tool_fn(investigation_id="workspace--w1")
+            # Should be a raw JSON string (not wrapped in another JSON)
+            assert '"type":"bundle"' in result
+
+    def test_export_failed_returns_error(self) -> None:
+        mock = _mock_client()
+        mock.workspace.to_stix_bundle.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["export_investigation_as_report"].fn
+            result = tool_fn(investigation_id="workspace--w1")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestStartInvestigationFromContainer:
+    def test_creates_from_container(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            investigations.register(mcp)
+            tool_fn = mcp._tool_manager._tools["start_investigation_from_container"].fn
+            result = tool_fn(container_id="report--r1")
+            data = json.loads(result)
+            assert data["id"] == "workspace--w1"

--- a/opencti-mcp/tests/test_observables.py
+++ b/opencti-mcp/tests/test_observables.py
@@ -1,0 +1,166 @@
+# coding: utf-8
+"""Tests for observable tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import observables
+
+MOCK_OBSERVABLE = {
+    "id": "ipv4-addr--abc123",
+    "standard_id": "ipv4-addr--abc123",
+    "entity_type": "IPv4-Addr",
+    "observable_value": "1.2.3.4",
+}
+
+MOCK_REL = {
+    "id": "relationship--r1",
+    "entity_type": "stix-core-relationship",
+    "relationship_type": "related-to",
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.stix_cyber_observable.list.return_value = [MOCK_OBSERVABLE]
+    mock.stix_cyber_observable.read.return_value = MOCK_OBSERVABLE
+    mock.stix_cyber_observable.create.return_value = MOCK_OBSERVABLE
+    mock.stix_cyber_observable.ask_for_enrichment.return_value = "work--xyz"
+    mock.stix_core_relationship.list.return_value = [MOCK_REL]
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestListObservables:
+    def test_returns_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_observables"].fn
+            result = tool_fn(search="1.2.3.4")
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data[0]["observable_value"] == "1.2.3.4"
+
+    def test_no_args_returns_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_observables"].fn
+            result = tool_fn()
+            data = json.loads(result)
+            assert isinstance(data, list)
+
+    def test_type_filter_applied(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_observables"].fn
+            tool_fn(observable_type="IPv4-Addr")
+            _, kwargs = mock.stix_cyber_observable.list.call_args
+            assert kwargs["types"] == ["IPv4-Addr"]
+
+    def test_clamps_limit(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_observables"].fn
+            tool_fn(limit=9999)
+            _, kwargs = mock.stix_cyber_observable.list.call_args
+            assert kwargs["first"] == 200
+
+    def test_error_returns_json(self) -> None:
+        mock = _mock_client()
+        mock.stix_cyber_observable.list.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["list_observables"].fn
+            result = tool_fn(search="bad")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestGetObservable:
+    def test_returns_observable(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_observable"].fn
+            result = tool_fn(observable_id="ipv4-addr--abc123")
+            data = json.loads(result)
+            assert data["id"] == "ipv4-addr--abc123"
+
+    def test_not_found(self) -> None:
+        mock = _mock_client()
+        mock.stix_cyber_observable.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_observable"].fn
+            result = tool_fn(observable_id="missing")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestAddObservable:
+    def test_creates_observable(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["add_observable"].fn
+            result = tool_fn(observable_key="IPv4-Addr.value", observable_value="1.2.3.4")
+            data = json.loads(result)
+            assert data["id"] == "ipv4-addr--abc123"
+            mock.stix_cyber_observable.create.assert_called_once()
+
+
+class TestGetObservableRelationships:
+    def test_returns_combined_both_directions(self) -> None:
+        """Relationships from both directions are returned without truncation."""
+        mock = _mock_client()
+        from_rel = dict(MOCK_REL, id="relationship--from")
+        to_rel = dict(MOCK_REL, id="relationship--to")
+        mock.stix_core_relationship.list.side_effect = [[from_rel], [to_rel]]
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            observables.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_observable_relationships"].fn
+            result = tool_fn(observable_id="ipv4-addr--abc123", limit=1)
+            data = json.loads(result)
+            # Both directions are included — total may exceed the per-direction limit
+            assert len(data) == 2
+            ids = {r["id"] for r in data}
+            assert "relationship--from" in ids
+            assert "relationship--to" in ids

--- a/opencti-mcp/tests/test_relationships.py
+++ b/opencti-mcp/tests/test_relationships.py
@@ -1,0 +1,144 @@
+# coding: utf-8
+"""Tests for relationship tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import relationships
+
+MOCK_REL = {
+    "id": "relationship--r1",
+    "entity_type": "stix-core-relationship",
+    "relationship_type": "uses",
+    "fromId": "threat-actor--ta1",
+    "toId": "malware--m1",
+}
+
+MOCK_SIGHTING = {
+    "id": "sighting--s1",
+    "entity_type": "stix-sighting-relationship",
+    "attribute_count": 3,
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.stix_core_relationship.create.return_value = MOCK_REL
+    mock.stix_core_relationship.list.return_value = [MOCK_REL]
+    mock.stix_sighting_relationship.create.return_value = MOCK_SIGHTING
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestCreateRelationship:
+    def test_creates_and_returns(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_relationship"].fn
+            result = tool_fn(
+                from_id="threat-actor--ta1",
+                relationship_type="uses",
+                to_id="malware--m1",
+            )
+            data = json.loads(result)
+            assert data["id"] == "relationship--r1"
+
+    def test_error_returned(self) -> None:
+        mock = _mock_client()
+        mock.stix_core_relationship.create.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_relationship"].fn
+            result = tool_fn(from_id="a", relationship_type="uses", to_id="b")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestLookupRelationships:
+    def test_direction_both_returns_all(self) -> None:
+        """With direction='both', results from both sides are included without truncation."""
+        mock = _mock_client()
+        from_rel = dict(MOCK_REL, id="relationship--from")
+        to_rel = dict(MOCK_REL, id="relationship--to")
+        mock.stix_core_relationship.list.side_effect = [[from_rel], [to_rel]]
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_relationships"].fn
+            result = tool_fn(entity_id="threat-actor--ta1", limit=1)
+            data = json.loads(result)
+            # Both relationships must be present — limit applies per-direction
+            ids = {r["id"] for r in data}
+            assert "relationship--from" in ids
+            assert "relationship--to" in ids
+
+    def test_direction_from(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_relationships"].fn
+            tool_fn(entity_id="threat-actor--ta1", direction="from")
+            # Only one call (fromId)
+            assert mock.stix_core_relationship.list.call_count == 1
+
+    def test_direction_to(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_relationships"].fn
+            tool_fn(entity_id="malware--m1", direction="to")
+            assert mock.stix_core_relationship.list.call_count == 1
+
+    def test_error_returns_json(self) -> None:
+        mock = _mock_client()
+        mock.stix_core_relationship.list.side_effect = RuntimeError("network error")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_relationships"].fn
+            result = tool_fn(entity_id="ta1")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestCreateSighting:
+    def test_creates_sighting(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            relationships.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_sighting"].fn
+            result = tool_fn(
+                observable_id="ipv4-addr--abc",
+                target_id="identity--org1",
+                count=3,
+            )
+            data = json.loads(result)
+            assert data["id"] == "sighting--s1"
+            mock.stix_sighting_relationship.create.assert_called_once()

--- a/opencti-mcp/tests/test_reports.py
+++ b/opencti-mcp/tests/test_reports.py
@@ -1,0 +1,167 @@
+# coding: utf-8
+"""Tests for report tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import reports
+
+MOCK_REPORT = {
+    "id": "report--r1",
+    "standard_id": "report--r1",
+    "entity_type": "Report",
+    "name": "Threat Report Alpha",
+    "published": "2024-01-15T00:00:00Z",
+    "objects": [{"id": "malware--m1", "entity_type": "Malware", "name": "Foo"}],
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.report.read.return_value = MOCK_REPORT
+    mock.report.list.return_value = [MOCK_REPORT]
+    mock.report.create.return_value = MOCK_REPORT
+    mock.report.add_stix_object_or_stix_relationship.return_value = None
+    mock.report.to_stix2.return_value = '{"type":"bundle","id":"bundle--x"}'
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestLookupReport:
+    def test_finds_by_id(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_report"].fn
+            result = tool_fn(name_or_id="report--r1")
+            data = json.loads(result)
+            assert data["id"] == "report--r1"
+
+    def test_falls_back_to_search(self) -> None:
+        mock = _mock_client()
+        mock.report.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["lookup_report"].fn
+            result = tool_fn(name_or_id="Threat Report Alpha")
+            data = json.loads(result)
+            assert isinstance(data, list)
+
+
+class TestCreateReport:
+    def test_creates_report(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_report"].fn
+            result = tool_fn(name="New Report", published="2024-06-01T00:00:00Z")
+            data = json.loads(result)
+            assert data["id"] == "report--r1"
+
+    def test_failed_objects_reported(self) -> None:
+        """Object link failures must be listed in failed_objects, not silently dropped."""
+        mock = _mock_client()
+        mock.report.add_stix_object_or_stix_relationship.side_effect = RuntimeError("link failed")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_report"].fn
+            result = tool_fn(
+                name="New Report",
+                published="2024-06-01T00:00:00Z",
+                object_ids=["malware--m1", "indicator--i1"],
+            )
+            data = json.loads(result)
+            assert "failed_objects" in data
+            assert "malware--m1" in data["failed_objects"]
+            assert "indicator--i1" in data["failed_objects"]
+
+    def test_no_failed_objects_key_on_success(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["create_report"].fn
+            result = tool_fn(
+                name="New Report",
+                published="2024-06-01T00:00:00Z",
+                object_ids=["malware--m1"],
+            )
+            data = json.loads(result)
+            # No failures → failed_objects key absent (or empty list)
+            assert data.get("failed_objects", []) == []
+
+
+class TestAddObjectToReport:
+    def test_success(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["add_object_to_report"].fn
+            result = tool_fn(report_id="report--r1", object_id="malware--m1")
+            data = json.loads(result)
+            assert data.get("success") is True
+
+    def test_error_returned(self) -> None:
+        mock = _mock_client()
+        mock.report.add_stix_object_or_stix_relationship.side_effect = RuntimeError("bad")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["add_object_to_report"].fn
+            result = tool_fn(report_id="report--r1", object_id="malware--m1")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestGetReportObjects:
+    def test_returns_objects(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_report_objects"].fn
+            result = tool_fn(report_id="report--r1")
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data[0]["entity_type"] == "Malware"
+
+    def test_not_found(self) -> None:
+        mock = _mock_client()
+        mock.report.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            reports.register(mcp)
+            tool_fn = mcp._tool_manager._tools["get_report_objects"].fn
+            result = tool_fn(report_id="missing")
+            data = json.loads(result)
+            assert "error" in data

--- a/opencti-mcp/tests/test_search.py
+++ b/opencti-mcp/tests/test_search.py
@@ -1,0 +1,156 @@
+# coding: utf-8
+"""Tests for search tools."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.tools import search
+
+MOCK_ENTITY = {
+    "id": "malware--abc",
+    "standard_id": "malware--abc",
+    "entity_type": "Malware",
+    "name": "TestMalware",
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.stix_core_object.list.return_value = [MOCK_ENTITY]
+    mock.stix_core_object.read.return_value = MOCK_ENTITY
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestGlobalSearch:
+    def test_returns_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["global_search"].fn
+            result = tool_fn(query="TestMalware")
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data[0]["id"] == "malware--abc"
+
+    def test_with_types_distributes_limit(self) -> None:
+        """When types are specified limit should be distributed per type."""
+        mock = _mock_client()
+        mock.stix_core_object.list.return_value = []
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["global_search"].fn
+            tool_fn(query="x", types=["Malware", "Indicator"], limit=20)
+            # Each type call should use per_type = 20 // 2 = 10
+            for c in mock.stix_core_object.list.call_args_list:
+                _, kwargs = c
+                assert kwargs["first"] == 10
+
+    def test_with_types_total_capped(self) -> None:
+        """Combined results from multiple types must not exceed limit."""
+        mock = _mock_client()
+        # Return 10 items per type
+        mock.stix_core_object.list.return_value = [MOCK_ENTITY] * 10
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["global_search"].fn
+            result = tool_fn(query="x", types=["Malware", "Indicator"], limit=10)
+            data = json.loads(result)
+            assert len(data) <= 10
+
+    def test_clamps_limit(self) -> None:
+        mock = _mock_client()
+        mock.stix_core_object.list.return_value = []
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["global_search"].fn
+            tool_fn(query="x", limit=9999)
+            _, kwargs = mock.stix_core_object.list.call_args
+            assert kwargs["first"] == 200
+
+    def test_api_error_returns_empty_list(self) -> None:
+        mock = _mock_client()
+        mock.stix_core_object.list.side_effect = RuntimeError("network error")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["global_search"].fn
+            result = tool_fn(query="x")
+            data = json.loads(result)
+            assert isinstance(data, list)
+            assert data == []
+
+
+class TestFindByStixId:
+    def test_returns_entity(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["find_by_stix_id"].fn
+            result = tool_fn(stix_id="malware--abc")
+            data = json.loads(result)
+            assert data["id"] == "malware--abc"
+
+    def test_not_found_returns_error(self) -> None:
+        mock = _mock_client()
+        mock.stix_core_object.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["find_by_stix_id"].fn
+            result = tool_fn(stix_id="malware--missing")
+            data = json.loads(result)
+            assert "error" in data
+
+    def test_api_error_returns_json_error(self) -> None:
+        mock = _mock_client()
+        mock.stix_core_object.read.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["find_by_stix_id"].fn
+            result = tool_fn(stix_id="malware--abc")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestFindByExternalReference:
+    def test_returns_list(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            search.register(mcp)
+            tool_fn = mcp._tool_manager._tools["find_by_external_reference"].fn
+            result = tool_fn(source_name="MITRE ATT&CK", external_id="T1059")
+            data = json.loads(result)
+            assert isinstance(data, list)

--- a/opencti-mcp/tests/test_server.py
+++ b/opencti-mcp/tests/test_server.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+"""Tests for MCP server transport helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.responses import Response
+from starlette.routing import Route
+from starlette.types import Message
+
+from opencti_mcp.config import Config
+from opencti_mcp.server import _add_sse_request_controls
+
+
+def _config(**overrides: Any) -> Config:
+    values = {
+        "opencti_url": "http://localhost:4000",
+        "opencti_token": "token",
+        "ssl_verify": True,
+        "log_level": "info",
+        "transport": "sse",
+        "sse_host": "127.0.0.1",
+        "sse_port": 8000,
+        "api_key": "mcp-key",
+        "allow_unauthenticated_sse": False,
+        "max_request_body_bytes": 4,
+        "max_concurrent_requests": 20,
+        "rate_limit_per_minute": 60,
+    }
+    values.update(overrides)
+    return Config(**values)
+
+
+async def test_body_limit_rejects_chunked_request_without_content_length() -> None:
+    from starlette.applications import Starlette
+
+    called = False
+
+    async def endpoint(request: Any) -> Response:
+        nonlocal called
+        called = True
+        return Response("ok")
+
+    app = Starlette(routes=[Route("/", endpoint, methods=["POST"])])
+    _add_sse_request_controls(app, _config())
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+    messages: list[Message] = [
+        {"type": "http.request", "body": b"123", "more_body": True},
+        {"type": "http.request", "body": b"45", "more_body": False},
+    ]
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        return messages.pop(0)
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    await app(scope, receive, send)
+
+    assert called is False
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 413

--- a/opencti-mcp/tests/test_stix_export.py
+++ b/opencti-mcp/tests/test_stix_export.py
@@ -1,0 +1,177 @@
+# coding: utf-8
+"""Tests for STIX export resources."""
+
+from __future__ import annotations
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import opencti_mcp.client as client_module
+from opencti_mcp.resources import stix_export
+
+MOCK_INDICATOR = {
+    "id": "indicator--abc",
+    "entity_type": "Indicator",
+    "pattern": "[ipv4-addr:value = '1.2.3.4']",
+}
+
+MOCK_OBSERVABLE = {
+    "id": "ipv4-addr--abc",
+    "entity_type": "IPv4-Addr",
+    "observable_value": "1.2.3.4",
+}
+
+MOCK_REPORT = {
+    "id": "report--r1",
+    "entity_type": "Report",
+    "name": "Alpha",
+    "objects": [],
+}
+
+MOCK_CASE = {
+    "id": "case-incident--c1",
+    "entity_type": "Case-Incident",
+    "name": "Incident Alpha",
+}
+
+
+def _mock_client() -> MagicMock:
+    mock = MagicMock()
+    mock.indicator.read.return_value = MOCK_INDICATOR
+    mock.stix_cyber_observable.read.return_value = MOCK_OBSERVABLE
+    mock.report.read.return_value = MOCK_REPORT
+    mock.case_incident.read.return_value = MOCK_CASE
+    mock.case_rfi.read.return_value = None
+    mock.case_rft.read.return_value = None
+    mock.workspace.to_stix_bundle.return_value = '{"type":"bundle","id":"bundle--x"}'
+    return mock
+
+
+def _patch_client(mock: MagicMock) -> AbstractContextManager[None]:
+    return patch.object(client_module, "_client", mock)
+
+
+class TestIndicatorResource:
+    def test_returns_json(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://indicator/{indicator_id}"].fn
+            result = resource_fn(indicator_id="indicator--abc")
+            data = json.loads(result)
+            assert data["id"] == "indicator--abc"
+
+    def test_not_found(self) -> None:
+        mock = _mock_client()
+        mock.indicator.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://indicator/{indicator_id}"].fn
+            result = resource_fn(indicator_id="missing")
+            data = json.loads(result)
+            assert "error" in data
+
+    def test_api_error_returns_json_error(self) -> None:
+        mock = _mock_client()
+        mock.indicator.read.side_effect = RuntimeError("API down")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://indicator/{indicator_id}"].fn
+            result = resource_fn(indicator_id="indicator--abc")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestObservableResource:
+    def test_returns_json(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates[
+                "opencti://observable/{observable_id}"
+            ].fn
+            result = resource_fn(observable_id="ipv4-addr--abc")
+            data = json.loads(result)
+            assert data["id"] == "ipv4-addr--abc"
+
+    def test_api_error_returns_json_error(self) -> None:
+        mock = _mock_client()
+        mock.stix_cyber_observable.read.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates[
+                "opencti://observable/{observable_id}"
+            ].fn
+            result = resource_fn(observable_id="ipv4-addr--abc")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestReportResource:
+    def test_returns_json(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://report/{report_id}"].fn
+            result = resource_fn(report_id="report--r1")
+            data = json.loads(result)
+            assert data["id"] == "report--r1"
+
+    def test_api_error_returns_json_error(self) -> None:
+        mock = _mock_client()
+        mock.report.read.side_effect = RuntimeError("fail")
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://report/{report_id}"].fn
+            result = resource_fn(report_id="report--r1")
+            data = json.loads(result)
+            assert "error" in data
+
+
+class TestCaseResource:
+    def test_returns_incident(self) -> None:
+        mock = _mock_client()
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://case/{case_id}"].fn
+            result = resource_fn(case_id="case-incident--c1")
+            data = json.loads(result)
+            assert data["id"] == "case-incident--c1"
+
+    def test_not_found_returns_error(self) -> None:
+        mock = _mock_client()
+        mock.case_incident.read.return_value = None
+        with _patch_client(mock):
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("test")
+            stix_export.register(mcp)
+            resource_fn = mcp._resource_manager._templates["opencti://case/{case_id}"].fn
+            result = resource_fn(case_id="missing")
+            data = json.loads(result)
+            assert "error" in data


### PR DESCRIPTION
### Proposed changes

* Add a new `opencti-mcp` Python package that exposes OpenCTI capabilities through the Model Context Protocol (MCP).
* Implement MCP tools and resources for indicators, observables, reports, cases, investigations, enrichment, relationships, search, and STIX export.
* Add stdio and SSE transports, with SSE authentication, request size limits, rate limiting, and concurrency controls.
* Add Dockerfile and Docker Compose support for local MCP/OpenCTI testing.
* Add unit tests covering configuration, tool behavior, resource behavior, and error handling.
* Add README documentation for installation, configuration, Docker usage, development, and security considerations.

### Related issues

* closes

### How to test this PR

From the repository root:

```bash
cd opencti-mcp
pip install -r requirements.txt
pip install -r test-requirements.txt
pip install -e ".[dev]"
pytest tests -q
black --check src tests
isort --check-only src tests
flake8 src tests --ignore E,W
mypy src
```

To smoke test against a local OpenCTI instance:

```bash
cd opencti-mcp
cp .env.example .env
# Set OPENCTI_ADMIN_TOKEN and MCP_API_KEY in .env
docker compose up -d
```

Then configure an MCP client to connect to:

```text
http://localhost:8000/sse
```

using:

```text
Authorization: Bearer <MCP_API_KEY>
```

### Checklist

- [ x] I consider the submitted work as finished
- [ x] I tested the code for its functionality
- [ x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ x] Where necessary, I refactored code to improve the overall quality

### Further comments

This PR introduces MCP support as a separate package under `opencti-mcp` to keep the integration isolated from the existing platform, worker, and Python client code. The server delegates OpenCTI API behavior to pycti, while MCP-specific concerns such as transport selection, authentication, request limits, and sanitized error responses remain in the MCP package.