### PR TITLE
feat(telemetry): add full AI and product adoption telemetry coverage (#16969)

### DIFF
--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -92,7 +92,7 @@ All AI usage counters are backend-agnostic: the same counter is incremented whet
 - The number of playbook AI agent component runs
 - Whether the built-in LLM configuration is enabled, with the provider type as dimension (`mistralai`, `openai`, `azureopenai`, `other`, or `none` when disabled)
 - Whether XTM One is configured (URL and token)
-- Whether the Filigran chatbot AI CGU have been accepted
+- Whether the Filigran chatbot AI CGU has been accepted
 
 ### Product adoption
 

--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -81,6 +81,41 @@ Here is an exhaustive list of the collected metrics:
 - The number of custom views created
 - The number of custom views enabled
 
+### AI features
+
+All AI usage counters are backend-agnostic: the same counter is incremented whether the feature is served by the legacy backend or by XTM One, and no counter carries a legacy/XTM One dimension.
+
+- The number of chatbot messages sent
+- The number of AI Insights requests, broken down by cache state (`hit`, `miss`)
+- The number of Ask AI queries, broken down by feature (`fix_spelling`, `make_shorter`, `make_longer`, `change_tone`, `summarize`, `explain`, `container_report`, `summarize_files`, `convert_files_to_stix`, `activity`, `forecast`, `history`, `container_summary`)
+- The number of direct XTM One agent calls, broken down by channel (`direct`, `direct_files`)
+- The number of playbook AI agent component runs
+- Whether the built-in LLM configuration is enabled, with the provider type as dimension (`mistralai`, `openai`, `azureopenai`, `other`, or `none` when disabled)
+- Whether XTM One is configured (URL and token)
+- Whether the Filigran chatbot AI CGU have been accepted
+
+### Product adoption
+
+- The number of knowledge objects, broken down by a curated list of entity types (reports, groupings, notes, opinions, cases, tasks, feedbacks, indicators, malware, intrusion sets, threat actors, incidents), plus the total number of observables and the total number of relationships. No knowledge content is ever collected, only counts.
+- The number of built-in ingesters, broken down by type (`rss`, `taxii`, `taxii-collection`, `csv`, `json`) and running state
+- The number of OpenCTI-to-OpenCTI synchronizers
+- The number of data sharing surfaces, broken down by type (`live_stream`, `feed`, `taxii_collection`, `public_dashboard`) and public (anonymous access) state
+- The number of playbooks, broken down by running state
+- The number of playbook executions started
+- The number of activated inference rules
+- The number of notification triggers, broken down by type (`live`, `digest`)
+- The number of notifiers, broken down by connector (`email`, `webhook`, `ui`, `other`)
+- The number of notifications sent, broken down by channel (`email`, `webhook`, `ui`)
+- The number of export generations requested
+- The number of objects processed by completed import works (ingestion volume proxy)
+- The number of groups
+- The number of roles
+- The number of organizations
+- Whether organization segregation is configured
+- Whether the file indexing manager is running
+- The number of indexed files
+- Whether the platform is registered on XTM Hub
+
 ### Email and notifications
 
 - The number of emails sent from the platform

--- a/opencti-platform/opencti-graphql/src/database/ai-llm.ts
+++ b/opencti-platform/opencti-graphql/src/database/ai-llm.ts
@@ -13,7 +13,6 @@ import type { AuthUser } from '../types/user';
 import { truncate } from '../utils/format';
 import { notify } from './redis';
 import { isEmptyField } from './utils';
-import { addNlqQueryCount } from '../manager/telemetryManager';
 
 const AI_ENABLED = conf.get('ai:enabled');
 const AI_TYPE = conf.get('ai:type');
@@ -205,7 +204,8 @@ export const queryNLQAi = async (promptValue: ChatPromptValueInterface) => {
     throw badAiConfigError;
   }
 
-  await addNlqQueryCount();
+  // NLQ usage telemetry is counted at the feature entry point
+  // (generateNLQresponse in ai-domain) so it stays backend-agnostic.
 
   logApp.info('[NLQ] Querying AI model for structured output');
   try {

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -534,6 +534,16 @@ export const redisInitializeWork = async (workId: string, isMultiPartWork: boole
     });
   });
 };
+// Atomic first-completion marker for a work: SET NX guarantees that exactly
+// one caller wins, whichever completion path (reportExpectation vs
+// updateProcessedTime) and whichever node observes the completion first.
+// A dedicated TTL-bounded key is used instead of a field on the work hash so
+// the marker can never recreate or orphan a deleted work key.
+const WORK_COMPLETION_FLAG_TTL = 86400; // 1 day, works complete well within it
+export const redisAcquireWorkCompletionFlag = async (workId: string): Promise<boolean> => {
+  const result = await getClientBase().set(`work_completion_counted:${workId}`, '1', 'EX', WORK_COMPLETION_FLAG_TTL, 'NX');
+  return result === 'OK';
+};
 // endregion
 // region async calls tracking
 const ASYNC_CALL_TTL = 300;

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -713,22 +713,15 @@ export const redisDelForgotPassword = async (id: string, email: string) => {
 // region - telemetry gauges
 const TELEMETRY_EVENT_KEY = 'telemetry_events';
 /**
- * Increment a gauge by its name
+ * Increment a gauge by its name.
+ * HINCRBY is atomic: concurrent increments (multiple API instances, or
+ * fire-and-forget calls racing on the same node) can never lose updates,
+ * unlike the previous hget + hset read-modify-write.
  * @param gaugeName
  * @param countToAdd 1 or more to be added in count
  */
 export const redisSetTelemetryAdd = async (gaugeName: string, countToAdd: number) => {
-  const currentCountStr = await getClientBase().hget(TELEMETRY_EVENT_KEY, gaugeName);
-  if (currentCountStr) {
-    const currentCount: number = +currentCountStr;
-    if (!Number.isNaN(currentCount) && countToAdd > 0) {
-      await getClientBase().hset(TELEMETRY_EVENT_KEY, gaugeName, currentCount + countToAdd);
-    } else {
-      await getClientBase().hset(TELEMETRY_EVENT_KEY, gaugeName, countToAdd);
-    }
-  } else {
-    await getClientBase().hset(TELEMETRY_EVENT_KEY, gaugeName, countToAdd);
-  }
+  await getClientBase().hincrby(TELEMETRY_EVENT_KEY, gaugeName, countToAdd);
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/domain/container.js
+++ b/opencti-platform/opencti-graphql/src/domain/container.js
@@ -282,7 +282,7 @@ export const containerEditAuthorizedMembers = async (context, user, entityId, in
 
 export const aiSummary = async (context, user, args) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('container_summary');
+  addAskAiQueryCount('container_summary');
 
   const { busId = null, language = 'English', forceRefresh = false } = args;
   const hasTypesArgs = args.types && args.types.length > 0;

--- a/opencti-platform/opencti-graphql/src/domain/container.js
+++ b/opencti-platform/opencti-graphql/src/domain/container.js
@@ -37,6 +37,7 @@ import { notify } from '../database/redis';
 import { AI_BUS } from '../modules/ai/ai-types';
 import { cleanHtmlTags } from '../utils/ai/cleanHtmlTags';
 import { toB64 } from '../utils/base64';
+import { addAskAiQueryCount } from '../manager/telemetryManager';
 
 const AI_INSIGHTS_REFRESH_TIMEOUT = conf.get('ai:insights_refresh_timeout');
 const aiResponseCache = {};
@@ -281,6 +282,7 @@ export const containerEditAuthorizedMembers = async (context, user, entityId, in
 
 export const aiSummary = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('container_summary');
 
   const { busId = null, language = 'English', forceRefresh = false } = args;
   const hasTypesArgs = args.types && args.types.length > 0;

--- a/opencti-platform/opencti-graphql/src/domain/stix.js
+++ b/opencti-platform/opencti-graphql/src/domain/stix.js
@@ -28,6 +28,7 @@ import { ACTION_TYPE_SHARE, ACTION_TYPE_UNSHARE, createListTask } from './backgr
 import { objectOrganization, RELATION_GRANTED_TO } from '../schema/stixRefRelationship';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 import { elFindByIds } from '../database/engine';
+import { addExportGeneratedCount } from '../manager/telemetryManager';
 
 export const stixDelete = async (context, user, id, opts = {}) => {
   const element = await internalLoadById(context, user, id);
@@ -93,6 +94,9 @@ export const askListExport = async (context, user, exportContext, format, select
   if (!exportContext || !exportContext?.entity_type) {
     throw FunctionalError('entity_type is missing from askListExport');
   }
+
+  // Telemetry: one export generation requested (attempts semantics).
+  addExportGeneratedCount();
 
   const connectors = await connectorsForExport(context, user, format, true);
   const markingLevels = await Promise.all(contentMaxMarkings.map(async (id) => {
@@ -174,6 +178,9 @@ export const askListExport = async (context, user, exportContext, format, select
 };
 
 export const askEntityExport = async (context, user, format, entity, type, contentMaxMarkings, fileMarkings) => {
+  // Telemetry: one export generation requested (attempts semantics).
+  addExportGeneratedCount();
+
   const connectors = await connectorsForExport(context, user, format, true);
   const markingLevels = await Promise.all(contentMaxMarkings.map(async (id) => {
     return await findMarkingDefinitionById(context, user, id);

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -114,6 +114,7 @@ import { ENTITY_TYPE_CONTAINER_GROUPING } from '../modules/grouping/grouping-typ
 import { convertStoreToStix_2_1 } from '../database/stix-2-1-converter';
 import { findById as findDraftById } from '../modules/draftWorkspace/draftWorkspace-domain';
 import { buildTranslatedIdsMap } from '../database/data-changes';
+import { addAskAiQueryCount } from '../manager/telemetryManager';
 
 const AI_INSIGHTS_REFRESH_TIMEOUT = conf.get('ai:insights_refresh_timeout');
 const aiResponseCache = {};
@@ -1079,6 +1080,7 @@ export const stixCoreObjectEditContext = async (context, user, stixCoreObjectId,
 // region ai
 export const aiActivity = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('activity');
 
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
@@ -1119,6 +1121,7 @@ export const aiActivity = async (context, user, args) => {
 
 export const aiForecast = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('forecast');
 
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
@@ -1150,6 +1153,7 @@ export const aiForecast = async (context, user, args) => {
 
 export const aiHistory = async (context, user, args) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('history');
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
   const identifier = `${id}-history`;

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreObject.js
@@ -1080,7 +1080,7 @@ export const stixCoreObjectEditContext = async (context, user, stixCoreObjectId,
 // region ai
 export const aiActivity = async (context, user, args) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('activity');
+  addAskAiQueryCount('activity');
 
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
@@ -1121,7 +1121,7 @@ export const aiActivity = async (context, user, args) => {
 
 export const aiForecast = async (context, user, args) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('forecast');
+  addAskAiQueryCount('forecast');
 
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
@@ -1153,7 +1153,7 @@ export const aiForecast = async (context, user, args) => {
 
 export const aiHistory = async (context, user, args) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('history');
+  addAskAiQueryCount('history');
   const { id, language = 'English', forceRefresh = false } = args;
   // Resolve in cache
   const identifier = `${id}-history`;

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -6,6 +6,7 @@ import { IMPORT_CSV_CONNECTOR, IMPORT_CSV_CONNECTOR_ID } from '../connector/impo
 import { elDeleteInstances, elIndex, elLoadById, elPaginate, elRawDeleteByQuery, elUpdate, ES_MINIMUM_FIXED_PAGINATION } from '../database/engine';
 import { internalLoadById } from '../database/middleware-loader';
 import {
+  redisAcquireWorkCompletionFlag,
   redisDeleteWorks,
   redisGetWork,
   redisGetWorkCompletionState,
@@ -301,8 +302,12 @@ const isWorkFinished = (expected, total) => total >= expected;
 
 // Works exist for the whole connector surface (imports, exports, analysis,
 // notifications...). The ingestion volume proxy must only count import-side
-// pipelines, and only on the FIRST transition to complete (reportExpectation
-// and updateProcessedTime can both observe completion for the same work).
+// pipelines, and only ONCE per work: reportExpectation and updateProcessedTime
+// can both observe the completion of the same work concurrently (even from
+// different nodes), so uniqueness is enforced with an atomic Redis SET NX
+// flag - only the caller that acquires it counts. The status check is just a
+// cheap short-circuit for works that are already complete in the index.
+// Fire-and-forget: a telemetry failure must never break the work completion.
 const INGESTION_WORK_EVENT_TYPES = [
   'EXTERNAL_IMPORT', // external connectors, built-in ingesters, form intakes
   'INTERNAL_IMPORT_FILE', // file imports
@@ -310,9 +315,16 @@ const INGESTION_WORK_EVENT_TYPES = [
   'INTERNAL_INGESTION', // draft validation
 ];
 const countIngestionObjectsProcessed = (work, objectsCount) => {
-  if (work && work.status !== 'complete' && INGESTION_WORK_EVENT_TYPES.includes(work.event_type)) {
-    addIngestionObjectsProcessedCount(objectsCount);
+  if (!work || work.status === 'complete' || !INGESTION_WORK_EVENT_TYPES.includes(work.event_type)) {
+    return;
   }
+  redisAcquireWorkCompletionFlag(work.id)
+    .then((isFirstCompletion) => {
+      if (isFirstCompletion) {
+        addIngestionObjectsProcessedCount(objectsCount);
+      }
+    })
+    .catch((reason) => logApp.warn('Error acquiring work completion flag for telemetry', { reason }));
 };
 
 export const reportExpectation = async (context, user, workId, errorData) => {

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -299,6 +299,22 @@ const updateWorkTaskToComplete = async (context, user, work) => {
 
 const isWorkFinished = (expected, total) => total >= expected;
 
+// Works exist for the whole connector surface (imports, exports, analysis,
+// notifications...). The ingestion volume proxy must only count import-side
+// pipelines, and only on the FIRST transition to complete (reportExpectation
+// and updateProcessedTime can both observe completion for the same work).
+const INGESTION_WORK_EVENT_TYPES = [
+  'EXTERNAL_IMPORT', // external connectors, built-in ingesters, form intakes
+  'INTERNAL_IMPORT_FILE', // file imports
+  'INTERNAL_ENRICHMENT', // enrichment results ingested back
+  'INTERNAL_INGESTION', // draft validation
+];
+const countIngestionObjectsProcessed = (work, objectsCount) => {
+  if (work && work.status !== 'complete' && INGESTION_WORK_EVENT_TYPES.includes(work.event_type)) {
+    addIngestionObjectsProcessedCount(objectsCount);
+  }
+};
+
 export const reportExpectation = async (context, user, workId, errorData) => {
   const timestamp = now();
   await redisUpdateWorkFigures(workId);
@@ -325,8 +341,6 @@ export const reportExpectation = async (context, user, workId, errorData) => {
       sourceScript += `ctx._source['status'] = "complete";
       ctx._source['completed_number'] = params.completed_number;
       ctx._source['completed_time'] = params.now;`;
-      // Telemetry: objects processed by this completed work (volume proxy).
-      addIngestionObjectsProcessedCount(total);
     }
     // To avoid maximum string in Elastic and too big memory footprint, arbitrary limit the number of possible errors in a work to 100
     if (errorData) {
@@ -338,6 +352,11 @@ export const reportExpectation = async (context, user, workId, errorData) => {
     // Update elastic
     const currentWork = await loadWorkById(context, user, workId);
     if (currentWork) {
+      if (isComplete) {
+        // Telemetry: objects processed by this completed work (volume proxy,
+        // import-side pipelines only, first completion only).
+        countIngestionObjectsProcessed(currentWork, total);
+      }
       await elUpdate(context, currentWork._index, workId, { script: { source: sourceScript, lang: 'painless', params } });
       // If work is associated to a task, we also need to update work to completed on the task
       if (isComplete) {
@@ -446,8 +465,10 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
                ctx._source['import_expected_number'] = params.completed_number;
                ctx._source['completed_number'] = params.completed_number;
                ctx._source['completed_time'] = params.processed_time;`;
-    // Telemetry: objects processed by this completed work (volume proxy).
-    addIngestionObjectsProcessedCount(params.completed_number);
+    // Telemetry: objects processed by this completed work (volume proxy,
+    // import-side pipelines only, first completion only). Use the real
+    // processed total, not the defaulted-to-1 completed_number.
+    countIngestionObjectsProcessed(currentWork, total);
   }
   if (isNotEmptyField(message)) {
     if (inError) {

--- a/opencti-platform/opencti-graphql/src/domain/work.js
+++ b/opencti-platform/opencti-graphql/src/domain/work.js
@@ -24,6 +24,7 @@ import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_WORK } 
 import { RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
 import { addFilter } from '../utils/filtering/filtering-utils';
 import { now, sinceNowInMinutes } from '../utils/format';
+import { addIngestionObjectsProcessedCount } from '../manager/telemetryManager';
 
 export const workToExportFile = (work) => {
   const lastModifiedSinceMin = sinceNowInMinutes(work.updated_at);
@@ -324,6 +325,8 @@ export const reportExpectation = async (context, user, workId, errorData) => {
       sourceScript += `ctx._source['status'] = "complete";
       ctx._source['completed_number'] = params.completed_number;
       ctx._source['completed_time'] = params.now;`;
+      // Telemetry: objects processed by this completed work (volume proxy).
+      addIngestionObjectsProcessedCount(total);
     }
     // To avoid maximum string in Elastic and too big memory footprint, arbitrary limit the number of possible errors in a work to 100
     if (errorData) {
@@ -443,6 +446,8 @@ export const updateProcessedTime = async (context, user, workId, message, inErro
                ctx._source['import_expected_number'] = params.completed_number;
                ctx._source['completed_number'] = params.completed_number;
                ctx._source['completed_time'] = params.processed_time;`;
+    // Telemetry: objects processed by this completed work (volume proxy).
+    addIngestionObjectsProcessedCount(params.completed_number);
   }
   if (isNotEmptyField(message)) {
     if (inError) {

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -329,8 +329,9 @@ export const postChatbotMessage = async (req: Express.Request, res: Express.Resp
 
     // Telemetry: one chatbot message, backend-agnostic (same counter as the
     // legacy Flowise proxy). Counted before the upstream call (attempts
-    // semantics, consistent with call_nlq).
-    await addChatbotMessageCount();
+    // semantics, consistent with call_nlq). Fire-and-forget: a telemetry
+    // failure must never break the chatbot.
+    addChatbotMessageCount();
 
     const headers = await generateBasicHeaders(req, context);
     const httpClient = getXtmClient('stream', headers);
@@ -599,7 +600,7 @@ export const postAgentMessage = async (req: Express.Request, res: Express.Respon
     const isMultipart = (req.headers['content-type'] ?? '').includes('multipart/form-data');
 
     // Telemetry: direct agent call, split by channel only (json vs multipart).
-    await addXtmAgentCallCount(isMultipart ? 'direct_files' : 'direct');
+    addXtmAgentCallCount(isMultipart ? 'direct_files' : 'direct');
 
     if (isMultipart) {
       // File-based mode: 3-step flow via XTM One chat API
@@ -785,7 +786,7 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       if (cached) {
         logApp.info('Agent response served from cache', { agent_slug });
         // Telemetry: AI Insight served from cache.
-        await addAiInsightRequestCount('hit');
+        addAiInsightRequestCount('hit');
         writeAgentStreamHeaders(res);
         res.write(`data: ${JSON.stringify({
           type: 'done',
@@ -800,7 +801,7 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
 
     // Telemetry: AI Insight requiring a live agent run (cache miss, cache
     // disabled, or explicit force refresh). Counted before the upstream call.
-    await addAiInsightRequestCount('miss');
+    addAiInsightRequestCount('miss');
 
     const headers = await generateBasicHeaders(req, context);
     // Force the upstream `opencti-draft-id` header to match the validated
@@ -942,7 +943,7 @@ export const getLegacyChatbotProxy = async (req: Express.Request, res: Express.R
 
     // Telemetry: one chatbot message, same backend-agnostic counter as the
     // XTM One proxy - the chatbot is one feature whichever backend serves it.
-    await addChatbotMessageCount();
+    addChatbotMessageCount();
 
     const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
     const vars = {

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -17,6 +17,7 @@ import type { AuthContext } from '../types/user';
 import { getHttpClient, getResponseError } from '../utils/http-client';
 import { redisGetXtmAgentResponse, redisSetXtmAgentResponse } from '../database/redis';
 import { checkDraftInContext } from './httpServer-draft';
+import { addAiInsightRequestCount, addChatbotMessageCount, addXtmAgentCallCount } from '../manager/telemetryManager';
 
 const XTM_ONE_URL = nconf.get('xtm:xtm_one_url');
 export const XTM_ONE_CHATBOT_URL = `${XTM_ONE_URL}/chatbot`;
@@ -326,6 +327,11 @@ export const postChatbotMessage = async (req: Express.Request, res: Express.Resp
       return;
     }
 
+    // Telemetry: one chatbot message, backend-agnostic (same counter as the
+    // legacy Flowise proxy). Counted before the upstream call (attempts
+    // semantics, consistent with call_nlq).
+    await addChatbotMessageCount();
+
     const headers = await generateBasicHeaders(req, context);
     const httpClient = getXtmClient('stream', headers);
     const response = await httpClient.post('/api/v1/platform/chat/messages', req.body, {
@@ -592,6 +598,9 @@ export const postAgentMessage = async (req: Express.Request, res: Express.Respon
 
     const isMultipart = (req.headers['content-type'] ?? '').includes('multipart/form-data');
 
+    // Telemetry: direct agent call, split by channel only (json vs multipart).
+    await addXtmAgentCallCount(isMultipart ? 'direct_files' : 'direct');
+
     if (isMultipart) {
       // File-based mode: 3-step flow via XTM One chat API
       // 1. Parse incoming multipart
@@ -775,6 +784,8 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       const cached = await redisGetXtmAgentResponse(cacheKey);
       if (cached) {
         logApp.info('Agent response served from cache', { agent_slug });
+        // Telemetry: AI Insight served from cache.
+        await addAiInsightRequestCount('hit');
         writeAgentStreamHeaders(res);
         res.write(`data: ${JSON.stringify({
           type: 'done',
@@ -786,6 +797,10 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
         return;
       }
     }
+
+    // Telemetry: AI Insight requiring a live agent run (cache miss, cache
+    // disabled, or explicit force refresh). Counted before the upstream call.
+    await addAiInsightRequestCount('miss');
 
     const headers = await generateBasicHeaders(req, context);
     // Force the upstream `opencti-draft-id` header to match the validated
@@ -924,6 +939,10 @@ export const getLegacyChatbotProxy = async (req: Express.Request, res: Express.R
       res.status(400).json({ error: 'Chatbot is not enabled' });
       return;
     }
+
+    // Telemetry: one chatbot message, same backend-agnostic counter as the
+    // XTM One proxy - the chatbot is one feature whichever backend serves it.
+    await addChatbotMessageCount();
 
     const jwt = await issueXtmJwt(context.user, XTM_ONE_URL);
     const vars = {

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookExecutor.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookExecutor.ts
@@ -10,6 +10,7 @@ import { UnsupportedError } from '../../config/errors';
 import { PLAYBOOK_COMPONENTS } from '../../modules/playbook/playbook-components';
 import type { StreamDataEvent } from '../../types/event';
 import { isDebugPlaybook } from './playbookManagerUtils';
+import { addPlaybookExecutionCount } from '../telemetryManager';
 
 // Only way to force the step_literal checking
 // Don't try to understand, just trust
@@ -86,6 +87,13 @@ export const playbookExecutor = async ({
 }: ExecutorFn) => {
   const currentPlaybookInDebug = isDebugPlaybook(playbookId);
   const isExternalCallback = externalCallback !== undefined;
+  // Telemetry: a call with no previous step and no external callback is the
+  // first step of a fresh playbook execution (every trigger path - stream,
+  // cron, manual - starts this way), so count one execution here rather than
+  // at each of the trigger call sites.
+  if (previousStep === null && !isExternalCallback) {
+    addPlaybookExecutionCount();
+  }
   const start = isExternalCallback ? externalCallback.externalStartDate : utcDate();
   const instanceWithConfig = { ...nextStep.instance, configuration: JSON.parse(nextStep.instance.configuration ?? '{}') };
   if (nextStep.component.is_internal || isExternalCallback) {

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -43,6 +43,7 @@ import { sanitizeNotificationData } from '../utils/templateContextSanitizer';
 import { safeRender } from '../utils/safeEjs.client';
 import { NOTIFICATION_STREAM_NAME, type StreamProcessor } from '../database/stream/stream-utils';
 import { InterruptibleTimer } from './interruptible-timer';
+import { addNotificationSentCount } from './telemetryManager';
 
 const DOC_URI = 'https://docs.opencti.io';
 const PUBLISHER_ENGINE_KEY = conf.get('publisher_manager:lock_key');
@@ -259,17 +260,23 @@ export const internalProcessNotification = async (
 
   const assembledTemplateData = assembleTemplateData(content, triggerList, storeSettings, notificationUser, notificationData);
 
+  // Telemetry: notifications sent by channel (attempts semantics, counted
+  // before the delivery call; simplified email counts as email).
   switch (notifierConnectorId) {
     case NOTIFIER_CONNECTOR_UI:
+      addNotificationSentCount('ui');
       await handleUINotification(authContext, notificationName, triggerIds, notificationType, notificationUser, content);
       break;
     case NOTIFIER_CONNECTOR_EMAIL:
+      addNotificationSentCount('email');
       await handleEmailNotification(notificationUser, notifierConfigurationString, assembledTemplateData, triggerIds);
       break;
     case NOTIFIER_CONNECTOR_SIMPLIFIED_EMAIL:
+      addNotificationSentCount('email');
       await handleSimplifiedEmailNotification(notificationUser, notifierConfigurationString, assembledTemplateData, triggerIds);
       break;
     case NOTIFIER_CONNECTOR_WEBHOOK:
+      addNotificationSentCount('webhook');
       await handleWebhookNotification(notifierConfigurationString, assembledTemplateData);
       break;
     default:

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -193,6 +193,10 @@ export const XTM_AGENT_CHANNELS = ['direct', 'direct_files'] as const;
 export type XtmAgentChannel = typeof XTM_AGENT_CHANNELS[number];
 export const NOTIFICATION_CHANNELS = ['email', 'webhook', 'ui'] as const;
 export type NotificationChannel = typeof NOTIFICATION_CHANNELS[number];
+// Providers supported by the built-in LLM configuration (see database/ai-llm.ts).
+// Any other configured value is exported as 'other' to keep the is_ai_enabled
+// type dimension bounded.
+export const AI_PROVIDER_TYPES = ['mistralai', 'openai', 'azureopenai'] as const;
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -288,23 +292,30 @@ export const addWorkflowPublishCount = () => {
     .catch((reason) => logApp.warn('Error adding workflow publish count to telemetry', { reason }));
 };
 
+// All the counters below are fire-and-forget: they are called from feature
+// hot paths (HTTP handlers, domain functions), so a Redis failure must never
+// break the feature itself - it is only logged.
 // One chatbot message sent, whatever the serving backend (legacy Flowise or XTM One).
-export const addChatbotMessageCount = async () => {
-  await redisSetTelemetryAdd(TELEMETRY_GAUGE_CHATBOT_MESSAGE, 1);
+export const addChatbotMessageCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_CHATBOT_MESSAGE, 1)
+    .catch((reason) => logApp.warn('Error adding chatbot message count to telemetry', { reason }));
 };
 
-export const addAiInsightRequestCount = async (cache: AiInsightCacheState) => {
-  await redisSetTelemetryAdd(`${TELEMETRY_GAUGE_AI_INSIGHT_REQUEST}:${cache}`, 1);
+export const addAiInsightRequestCount = (cache: AiInsightCacheState) => {
+  redisSetTelemetryAdd(`${TELEMETRY_GAUGE_AI_INSIGHT_REQUEST}:${cache}`, 1)
+    .catch((reason) => logApp.warn('Error adding AI insight request count to telemetry', { reason }));
 };
 
 // Counted at the feature entry point (domain function), not in the LLM client,
 // so the number does not move if a feature is re-routed to another backend.
-export const addAskAiQueryCount = async (feature: AskAiFeature) => {
-  await redisSetTelemetryAdd(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`, 1);
+export const addAskAiQueryCount = (feature: AskAiFeature) => {
+  redisSetTelemetryAdd(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`, 1)
+    .catch((reason) => logApp.warn('Error adding Ask AI query count to telemetry', { reason }));
 };
 
-export const addXtmAgentCallCount = async (channel: XtmAgentChannel) => {
-  await redisSetTelemetryAdd(`${TELEMETRY_GAUGE_XTM_AGENT_CALL}:${channel}`, 1);
+export const addXtmAgentCallCount = (channel: XtmAgentChannel) => {
+  redisSetTelemetryAdd(`${TELEMETRY_GAUGE_XTM_AGENT_CALL}:${channel}`, 1)
+    .catch((reason) => logApp.warn('Error adding XTM agent call count to telemetry', { reason }));
 };
 
 // Fire-and-forget: a telemetry failure must never break a playbook run.
@@ -435,7 +446,14 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // AI feature adoption before/after an XTM One deployment - usage counters
     // themselves never carry a legacy/xtm_one dimension.
     const aiEnabled = conf.get('ai:enabled') === true || conf.get('ai:enabled') === 'true';
-    const aiType: string = aiEnabled ? (conf.get('ai:type') ?? 'none') : 'none';
+    const configuredAiType: string = conf.get('ai:type') ?? '';
+    // Bounded enum: none when disabled, a known provider, or 'other' for any
+    // unrecognized configured value (misconfiguration must not explode the
+    // dimension cardinality).
+    let aiType = 'none';
+    if (aiEnabled) {
+      aiType = (AI_PROVIDER_TYPES as readonly string[]).includes(configuredAiType) ? configuredAiType : 'other';
+    }
     manager.setIsAiEnabledItems([{ value: aiEnabled ? 1 : 0, attributes: { type: aiType } }]);
     const isXtmOneConfigured = !!(conf.get('xtm:xtm_one_url') && conf.get('xtm:xtm_one_token'));
     manager.setIsXtmOneConfigured(isXtmOneConfigured ? 1 : 0);

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -41,7 +41,6 @@ import {
   READ_INDEX_STIX_CYBER_OBSERVABLES,
   READ_INDEX_STIX_DOMAIN_OBJECTS,
 } from '../database/utils';
-import { fullEntitiesList } from '../database/middleware-loader';
 import type { BasicStoreEntity } from '../types/store';
 import { ENTITY_TYPE_TRIGGER } from '../modules/notification/notification-types';
 import { ENTITY_TYPE_NOTIFIER } from '../modules/notifier/notifier-types';
@@ -92,21 +91,16 @@ const KNOWLEDGE_OBJECT_TYPES = [
   'Incident',
 ];
 
-// Structural subsets used by the snapshot collectors below - kept minimal so
-// the collectors do not depend on each module's full store type.
-type IngesterLike = BasicStoreEntity & { ingestion_running?: boolean };
-type DataShareLike = BasicStoreEntity & { stream_public?: boolean; feed_public?: boolean; taxii_public?: boolean; enabled?: boolean };
+// Structural subset used by the cache-based snapshot collectors below - kept
+// minimal so the collectors do not depend on each module's full store type.
+type DataShareLike = BasicStoreEntity & { stream_public?: boolean; enabled?: boolean };
 
-// Build the two running=true/false datapoints of a dimensional gauge from a
-// list of entities and a predicate. Zero-valued datapoints are kept so that
-// "configured but stopped" adoption states stay visible.
-const buildRunningBreakdown = (type: string, entities: { running: boolean }[]): DimensionalGaugeItem[] => {
-  const runningCount = entities.filter((entity) => entity.running).length;
-  return [
-    { value: runningCount, attributes: { type, running: 'true' } },
-    { value: entities.length - runningCount, attributes: { type, running: 'false' } },
-  ];
-};
+// Filter matching entities whose boolean attribute is true (ES count queries).
+const booleanTrueFilter = (key: string) => ({
+  mode: FilterMode.And,
+  filters: [{ key: [key], values: ['true'] }],
+  filterGroups: [],
+});
 const TELEMETRY_CONSOLE_DEBUG = conf.get('telemetry_manager:console_debug') ?? false;
 const SCHEDULE_TIME = conf.get('telemetry_manager:interval') || 60000; // 1 minute default
 const FILIGRAN_OTLP_TELEMETRY = DEV_MODE
@@ -561,6 +555,10 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region Ingestion adoption
+    // Total/running counts are computed with ES count queries (no document
+    // fetching) and the independent queries run in parallel. Zero-valued
+    // datapoints are kept so "configured but stopped" adoption states stay
+    // visible.
     const ingesterDefinitions: [string, string][] = [
       [ENTITY_TYPE_INGESTION_RSS, 'rss'],
       [ENTITY_TYPE_INGESTION_TAXII, 'taxii'],
@@ -568,33 +566,43 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
       [ENTITY_TYPE_INGESTION_CSV, 'csv'],
       [ENTITY_TYPE_INGESTION_JSON, 'json'],
     ];
-    const ingesterItems: DimensionalGaugeItem[] = [];
-    for (let ingesterIndex = 0; ingesterIndex < ingesterDefinitions.length; ingesterIndex += 1) {
-      const [entityType, label] = ingesterDefinitions[ingesterIndex];
-      const ingesters = await fullEntitiesList<IngesterLike>(context, TELEMETRY_MANAGER_USER, [entityType]);
-      ingesterItems.push(...buildRunningBreakdown(label, ingesters.map((ingester) => ({ running: ingester.ingestion_running === true }))));
-    }
-    manager.setIngestersByType(ingesterItems);
+    const ingesterBreakdowns = await Promise.all(ingesterDefinitions.map(async ([entityType, label]) => {
+      const [totalCount, runningCount] = await Promise.all([
+        elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [entityType] }),
+        elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [entityType], filters: booleanTrueFilter('ingestion_running') }),
+      ]);
+      return [
+        { value: runningCount, attributes: { type: label, running: 'true' } },
+        { value: Math.max(totalCount - runningCount, 0), attributes: { type: label, running: 'false' } },
+      ];
+    }));
+    manager.setIngestersByType(ingesterBreakdowns.flat());
     const synchronizersCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_SYNC] });
     manager.setSynchronizersCount(synchronizersCount);
     // endregion
 
     // region Data sharing adoption
     const dataShareItems: DimensionalGaugeItem[] = [];
-    const buildPublicBreakdown = (type: string, shares: { isPublic: boolean }[]) => {
-      const publicCount = shares.filter((share) => share.isPublic).length;
+    const buildPublicBreakdown = (type: string, totalCount: number, publicCount: number) => {
       dataShareItems.push({ value: publicCount, attributes: { type, public: 'true' } });
-      dataShareItems.push({ value: shares.length - publicCount, attributes: { type, public: 'false' } });
+      dataShareItems.push({ value: Math.max(totalCount - publicCount, 0), attributes: { type, public: 'false' } });
     };
+    // Live streams and public dashboards are already held in the entity cache;
+    // feeds and TAXII collections are counted with ES count queries (they are
+    // not cached and can be numerous on large deployments).
     const liveStreams = await getEntitiesListFromCache<DataShareLike>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_STREAM_COLLECTION);
-    buildPublicBreakdown('live_stream', liveStreams.map((stream) => ({ isPublic: stream.stream_public === true })));
-    const feeds = await fullEntitiesList<DataShareLike>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_FEED]);
-    buildPublicBreakdown('feed', feeds.map((feed) => ({ isPublic: feed.feed_public === true })));
-    const taxiiCollections = await fullEntitiesList<DataShareLike>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_TAXII_COLLECTION]);
-    buildPublicBreakdown('taxii_collection', taxiiCollections.map((collection) => ({ isPublic: collection.taxii_public === true })));
+    buildPublicBreakdown('live_stream', liveStreams.length, liveStreams.filter((stream) => stream.stream_public === true).length);
+    const [feedsCount, publicFeedsCount, taxiiCollectionsCount, publicTaxiiCollectionsCount] = await Promise.all([
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_FEED] }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_FEED], filters: booleanTrueFilter('feed_public') }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_TAXII_COLLECTION] }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_TAXII_COLLECTION], filters: booleanTrueFilter('taxii_public') }),
+    ]);
+    buildPublicBreakdown('feed', feedsCount, publicFeedsCount);
+    buildPublicBreakdown('taxii_collection', taxiiCollectionsCount, publicTaxiiCollectionsCount);
     // Public dashboards are anonymous-access by nature once enabled.
     const publicDashboards = await getEntitiesListFromCache<DataShareLike>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_PUBLIC_DASHBOARD);
-    buildPublicBreakdown('public_dashboard', publicDashboards.map((dashboard) => ({ isPublic: dashboard.enabled === true })));
+    buildPublicBreakdown('public_dashboard', publicDashboards.length, publicDashboards.filter((dashboard) => dashboard.enabled === true).length);
     manager.setDataSharesByType(dataShareItems);
     // endregion
 

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -5,19 +5,58 @@ import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import conf, { DEV_MODE, logApp, PLATFORM_VERSION } from '../config/conf';
 import { executionContext, SYSTEM_USER, TELEMETRY_MANAGER_USER } from '../utils/access';
 import { getClusterInformation } from '../database/cluster-module';
-import { computeActiveConnectorsByIdentity, normalizeTelemetryTags, TELEMETRY_SERVICE_NAME, TelemetryMeterManager } from '../telemetry/TelemetryMeterManager';
+import {
+  computeActiveConnectorsByIdentity,
+  type DimensionalGaugeItem,
+  normalizeTelemetryTags,
+  TELEMETRY_SERVICE_NAME,
+  TelemetryMeterManager,
+} from '../telemetry/TelemetryMeterManager';
 import type { HandlerInput, ManagerDefinition } from './managerModule';
 import { registerManager } from './managerModule';
 import { MetricFileExporter } from '../telemetry/MetricFileExporter';
 import { getEntitiesListFromCache, getEntityFromCache } from '../database/cache';
-import { ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_INTERNAL_FILE, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER } from '../schema/internalObject';
+import {
+  ENTITY_TYPE_CONNECTOR,
+  ENTITY_TYPE_FEED,
+  ENTITY_TYPE_GROUP,
+  ENTITY_TYPE_INTERNAL_FILE,
+  ENTITY_TYPE_ROLE,
+  ENTITY_TYPE_RULE,
+  ENTITY_TYPE_SETTINGS,
+  ENTITY_TYPE_SYNC,
+  ENTITY_TYPE_TAXII_COLLECTION,
+  ENTITY_TYPE_USER,
+} from '../schema/internalObject';
 import { BatchExportingMetricReader } from '../telemetry/BatchExportingMetricReader';
 import type { BasicStoreSettings } from '../types/settings';
 import { getHttpClient } from '../utils/http-client';
 import type { BasicStoreEntityConnector } from '../types/connector';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
-import { elCount } from '../database/engine';
-import { READ_INDEX_INTERNAL_OBJECTS, READ_INDEX_STIX_DOMAIN_OBJECTS } from '../database/utils';
+import { elAggregationCount, elCount } from '../database/engine';
+import {
+  READ_INDEX_FILES,
+  READ_INDEX_INTERNAL_OBJECTS,
+  READ_INDEX_STIX_CORE_RELATIONSHIPS,
+  READ_INDEX_STIX_CYBER_OBSERVABLES,
+  READ_INDEX_STIX_DOMAIN_OBJECTS,
+} from '../database/utils';
+import { fullEntitiesList } from '../database/middleware-loader';
+import type { BasicStoreEntity } from '../types/store';
+import { ENTITY_TYPE_TRIGGER } from '../modules/notification/notification-types';
+import { ENTITY_TYPE_NOTIFIER } from '../modules/notifier/notifier-types';
+import { NOTIFIER_CONNECTOR_EMAIL, NOTIFIER_CONNECTOR_SIMPLIFIED_EMAIL, NOTIFIER_CONNECTOR_UI, NOTIFIER_CONNECTOR_WEBHOOK } from '../modules/notifier/notifier-statics';
+import { ENTITY_TYPE_PLAYBOOK } from '../modules/playbook/playbook-types';
+import { ENTITY_TYPE_PUBLIC_DASHBOARD } from '../modules/publicDashboard/publicDashboard-types';
+import { ENTITY_TYPE_STREAM_COLLECTION } from '../modules/dataSharing/streamCollection-types';
+import {
+  ENTITY_TYPE_INGESTION_CSV,
+  ENTITY_TYPE_INGESTION_JSON,
+  ENTITY_TYPE_INGESTION_RSS,
+  ENTITY_TYPE_INGESTION_TAXII,
+  ENTITY_TYPE_INGESTION_TAXII_COLLECTION,
+} from '../modules/ingestion/ingestion-types';
+import { ENTITY_TYPE_MANAGER_CONFIGURATION } from '../modules/managerConfiguration/managerConfiguration-types';
 import { getSupportedContractsByImage } from '../modules/catalog/catalog-domain';
 import { FilterMode } from '../generated/graphql';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../database/redis';
@@ -30,6 +69,44 @@ import { EnvStrategyType, isStrategyActivated } from '../modules/authenticationP
 import { listRules } from '../modules/retentionRules/retentionRules-domain';
 
 const TELEMETRY_MANAGER_KEY = conf.get('telemetry_manager:lock_key');
+
+// Curated allowlist of knowledge object types exported by the
+// knowledge_objects_by_type gauge (attribute values are the lowercased
+// entity types). Kept bounded on purpose - this is a product adoption
+// signal, not a full data model census.
+const KNOWLEDGE_OBJECT_TYPES = [
+  'Report',
+  'Grouping',
+  'Note',
+  'Opinion',
+  'Case-Incident',
+  'Case-Rfi',
+  'Case-Rft',
+  'Task',
+  'Feedback',
+  'Indicator',
+  'Malware',
+  'Intrusion-Set',
+  'Threat-Actor-Group',
+  'Threat-Actor-Individual',
+  'Incident',
+];
+
+// Structural subsets used by the snapshot collectors below - kept minimal so
+// the collectors do not depend on each module's full store type.
+type IngesterLike = BasicStoreEntity & { ingestion_running?: boolean };
+type DataShareLike = BasicStoreEntity & { stream_public?: boolean; feed_public?: boolean; taxii_public?: boolean; enabled?: boolean };
+
+// Build the two running=true/false datapoints of a dimensional gauge from a
+// list of entities and a predicate. Zero-valued datapoints are kept so that
+// "configured but stopped" adoption states stay visible.
+const buildRunningBreakdown = (type: string, entities: { running: boolean }[]): DimensionalGaugeItem[] => {
+  const runningCount = entities.filter((entity) => entity.running).length;
+  return [
+    { value: runningCount, attributes: { type, running: 'true' } },
+    { value: entities.length - runningCount, attributes: { type, running: 'false' } },
+  ];
+};
 const TELEMETRY_CONSOLE_DEBUG = conf.get('telemetry_manager:console_debug') ?? false;
 const SCHEDULE_TIME = conf.get('telemetry_manager:interval') || 60000; // 1 minute default
 const FILIGRAN_OTLP_TELEMETRY = DEV_MODE
@@ -76,6 +153,46 @@ export const TELEMETRY_GAUGE_DECAY_RULE_CREATION = 'decayRuleCreationCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_CREATED = 'customViewCreatedCount';
 export const TELEMETRY_GAUGE_CUSTOM_VIEW_ENABLED = 'customViewEnabledCount';
 export const TELEMETRY_GAUGE_WORKFLOW_PUBLISH = 'workflowPublishCount';
+// AI usage counters. Backend-agnostic by design: a chatbot message or an Ask AI
+// call is the SAME feature whether it is served by the legacy path or by
+// XTM One, so no counter carries a legacy/xtm_one dimension. The before/after
+// XTM One adoption analysis is done in analytics by segmenting instances on
+// the is_xtm_one_configured gauge.
+export const TELEMETRY_GAUGE_CHATBOT_MESSAGE = 'chatbotMessageCount';
+export const TELEMETRY_GAUGE_AI_INSIGHT_REQUEST = 'aiInsightRequestCount';
+export const TELEMETRY_GAUGE_ASK_AI_QUERY = 'askAiQueryCount';
+export const TELEMETRY_GAUGE_XTM_AGENT_CALL = 'xtmAgentCallCount';
+export const TELEMETRY_GAUGE_PLAYBOOK_AI_AGENT_RUN = 'playbookAiAgentRunCount';
+// Product usage counters
+export const TELEMETRY_GAUGE_PLAYBOOK_EXECUTION = 'playbookExecutionCount';
+export const TELEMETRY_GAUGE_NOTIFICATION_SENT = 'notificationSentCount';
+export const TELEMETRY_GAUGE_EXPORT_GENERATED = 'exportGeneratedCount';
+export const TELEMETRY_GAUGE_INGESTION_OBJECTS_PROCESSED = 'ingestionObjectsProcessedCount';
+
+// Bounded enums for dimensional counters (cardinality discipline: every
+// dimension value set is a closed list, mirrored by the warehouse models).
+export const ASK_AI_FEATURES = [
+  'fix_spelling',
+  'make_shorter',
+  'make_longer',
+  'change_tone',
+  'summarize',
+  'explain',
+  'container_report',
+  'summarize_files',
+  'convert_files_to_stix',
+  'activity',
+  'forecast',
+  'history',
+  'container_summary',
+] as const;
+export type AskAiFeature = typeof ASK_AI_FEATURES[number];
+export const AI_INSIGHT_CACHE_STATES = ['hit', 'miss'] as const;
+export type AiInsightCacheState = typeof AI_INSIGHT_CACHE_STATES[number];
+export const XTM_AGENT_CHANNELS = ['direct', 'direct_files'] as const;
+export type XtmAgentChannel = typeof XTM_AGENT_CHANNELS[number];
+export const NOTIFICATION_CHANNELS = ['email', 'webhook', 'ui'] as const;
+export type NotificationChannel = typeof NOTIFICATION_CHANNELS[number];
 
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
@@ -171,6 +288,55 @@ export const addWorkflowPublishCount = () => {
     .catch((reason) => logApp.warn('Error adding workflow publish count to telemetry', { reason }));
 };
 
+// One chatbot message sent, whatever the serving backend (legacy Flowise or XTM One).
+export const addChatbotMessageCount = async () => {
+  await redisSetTelemetryAdd(TELEMETRY_GAUGE_CHATBOT_MESSAGE, 1);
+};
+
+export const addAiInsightRequestCount = async (cache: AiInsightCacheState) => {
+  await redisSetTelemetryAdd(`${TELEMETRY_GAUGE_AI_INSIGHT_REQUEST}:${cache}`, 1);
+};
+
+// Counted at the feature entry point (domain function), not in the LLM client,
+// so the number does not move if a feature is re-routed to another backend.
+export const addAskAiQueryCount = async (feature: AskAiFeature) => {
+  await redisSetTelemetryAdd(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`, 1);
+};
+
+export const addXtmAgentCallCount = async (channel: XtmAgentChannel) => {
+  await redisSetTelemetryAdd(`${TELEMETRY_GAUGE_XTM_AGENT_CALL}:${channel}`, 1);
+};
+
+// Fire-and-forget: a telemetry failure must never break a playbook run.
+export const addPlaybookAiAgentRunCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_PLAYBOOK_AI_AGENT_RUN, 1)
+    .catch((reason) => logApp.warn('Error adding playbook AI agent run count to telemetry', { reason }));
+};
+
+export const addPlaybookExecutionCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_PLAYBOOK_EXECUTION, 1)
+    .catch((reason) => logApp.warn('Error adding playbook execution count to telemetry', { reason }));
+};
+
+export const addNotificationSentCount = (channel: NotificationChannel) => {
+  redisSetTelemetryAdd(`${TELEMETRY_GAUGE_NOTIFICATION_SENT}:${channel}`, 1)
+    .catch((reason) => logApp.warn('Error adding notification sent count to telemetry', { reason }));
+};
+
+export const addExportGeneratedCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_EXPORT_GENERATED, 1)
+    .catch((reason) => logApp.warn('Error adding export generated count to telemetry', { reason }));
+};
+
+// Volume counter: adds the number of objects processed by a completed work.
+export const addIngestionObjectsProcessedCount = (count: number) => {
+  if (!Number.isFinite(count) || count <= 0) {
+    return;
+  }
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_INGESTION_OBJECTS_PROCESSED, count)
+    .catch((reason) => logApp.warn('Error adding ingestion objects processed count to telemetry', { reason }));
+};
+
 // End Region user event counters
 
 const telemetryInitializer = async (): Promise<HandlerInput> => {
@@ -264,6 +430,20 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setIsEEActivated(isEnterpriseEditionFromSettings(settings) ? 1 : 0);
     // endregion
 
+    // region AI / ecosystem configuration gauges
+    // These booleans are the segmentation keys used by analytics to compare
+    // AI feature adoption before/after an XTM One deployment - usage counters
+    // themselves never carry a legacy/xtm_one dimension.
+    const aiEnabled = conf.get('ai:enabled') === true || conf.get('ai:enabled') === 'true';
+    const aiType: string = aiEnabled ? (conf.get('ai:type') ?? 'none') : 'none';
+    manager.setIsAiEnabledItems([{ value: aiEnabled ? 1 : 0, attributes: { type: aiType } }]);
+    const isXtmOneConfigured = !!(conf.get('xtm:xtm_one_url') && conf.get('xtm:xtm_one_token'));
+    manager.setIsXtmOneConfigured(isXtmOneConfigured ? 1 : 0);
+    manager.setIsChatbotCguAccepted(settings.filigran_chatbot_ai_cgu_status === 'enabled' ? 1 : 0);
+    manager.setIsOrganizationSegregationEnabled(settings.platform_organization ? 1 : 0);
+    manager.setIsXtmHubRegistered(settings.xtm_hub_registration_status === 'registered' ? 1 : 0);
+    // endregion
+
     // region Cluster information
     const clusterInfo = await getClusterInformation();
     manager.setInstancesCount(clusterInfo.info.instances_number);
@@ -345,6 +525,116 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setSecurityCoveragesCount(securityCoveragesCount);
     // endregion
 
+    // region Knowledge graph scale
+    const knowledgeAggregation = await elAggregationCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, {
+      field: 'entity_type',
+      types: KNOWLEDGE_OBJECT_TYPES,
+      normalizeLabel: false,
+    });
+    const knowledgeItems: DimensionalGaugeItem[] = knowledgeAggregation
+      .map(({ label, count }) => ({ value: count, attributes: { type: String(label).toLowerCase() } }));
+    const observablesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CYBER_OBSERVABLES, {});
+    knowledgeItems.push({ value: observablesCount, attributes: { type: 'observable' } });
+    const relationshipsCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CORE_RELATIONSHIPS, {});
+    knowledgeItems.push({ value: relationshipsCount, attributes: { type: 'relationship' } });
+    manager.setKnowledgeObjectsByType(knowledgeItems);
+    // endregion
+
+    // region Ingestion adoption
+    const ingesterDefinitions: [string, string][] = [
+      [ENTITY_TYPE_INGESTION_RSS, 'rss'],
+      [ENTITY_TYPE_INGESTION_TAXII, 'taxii'],
+      [ENTITY_TYPE_INGESTION_TAXII_COLLECTION, 'taxii-collection'],
+      [ENTITY_TYPE_INGESTION_CSV, 'csv'],
+      [ENTITY_TYPE_INGESTION_JSON, 'json'],
+    ];
+    const ingesterItems: DimensionalGaugeItem[] = [];
+    for (let ingesterIndex = 0; ingesterIndex < ingesterDefinitions.length; ingesterIndex += 1) {
+      const [entityType, label] = ingesterDefinitions[ingesterIndex];
+      const ingesters = await fullEntitiesList<IngesterLike>(context, TELEMETRY_MANAGER_USER, [entityType]);
+      ingesterItems.push(...buildRunningBreakdown(label, ingesters.map((ingester) => ({ running: ingester.ingestion_running === true }))));
+    }
+    manager.setIngestersByType(ingesterItems);
+    const synchronizersCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_SYNC] });
+    manager.setSynchronizersCount(synchronizersCount);
+    // endregion
+
+    // region Data sharing adoption
+    const dataShareItems: DimensionalGaugeItem[] = [];
+    const buildPublicBreakdown = (type: string, shares: { isPublic: boolean }[]) => {
+      const publicCount = shares.filter((share) => share.isPublic).length;
+      dataShareItems.push({ value: publicCount, attributes: { type, public: 'true' } });
+      dataShareItems.push({ value: shares.length - publicCount, attributes: { type, public: 'false' } });
+    };
+    const liveStreams = await getEntitiesListFromCache<DataShareLike>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_STREAM_COLLECTION);
+    buildPublicBreakdown('live_stream', liveStreams.map((stream) => ({ isPublic: stream.stream_public === true })));
+    const feeds = await fullEntitiesList<DataShareLike>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_FEED]);
+    buildPublicBreakdown('feed', feeds.map((feed) => ({ isPublic: feed.feed_public === true })));
+    const taxiiCollections = await fullEntitiesList<DataShareLike>(context, TELEMETRY_MANAGER_USER, [ENTITY_TYPE_TAXII_COLLECTION]);
+    buildPublicBreakdown('taxii_collection', taxiiCollections.map((collection) => ({ isPublic: collection.taxii_public === true })));
+    // Public dashboards are anonymous-access by nature once enabled.
+    const publicDashboards = await getEntitiesListFromCache<DataShareLike>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_PUBLIC_DASHBOARD);
+    buildPublicBreakdown('public_dashboard', publicDashboards.map((dashboard) => ({ isPublic: dashboard.enabled === true })));
+    manager.setDataSharesByType(dataShareItems);
+    // endregion
+
+    // region Automation adoption (playbooks and inference rules)
+    // The entity cache only holds RUNNING playbooks; the total comes from the
+    // index so the stopped count is total minus running.
+    const runningPlaybooks = await getEntitiesListFromCache(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_PLAYBOOK);
+    const totalPlaybooksCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_PLAYBOOK] });
+    manager.setPlaybooksItems([
+      { value: runningPlaybooks.length, attributes: { running: 'true' } },
+      { value: Math.max(totalPlaybooksCount - runningPlaybooks.length, 0), attributes: { running: 'false' } },
+    ]);
+    const rules = await getEntitiesListFromCache<BasicStoreEntity & { active?: boolean }>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_RULE);
+    manager.setInferenceRulesActiveCount(rules.filter((rule) => rule.active === true).length);
+    // endregion
+
+    // region Notifications adoption
+    const triggers = await getEntitiesListFromCache<BasicStoreEntity & { trigger_type?: string }>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_TRIGGER);
+    const liveTriggersCount = triggers.filter((trigger) => trigger.trigger_type === 'live').length;
+    manager.setTriggersByType([
+      { value: liveTriggersCount, attributes: { type: 'live' } },
+      { value: triggers.length - liveTriggersCount, attributes: { type: 'digest' } },
+    ]);
+    const notifiers = await getEntitiesListFromCache<BasicStoreEntity & { notifier_connector_id?: string }>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_NOTIFIER);
+    const notifierConnectorLabel = (connectorId?: string) => {
+      if (connectorId === NOTIFIER_CONNECTOR_EMAIL || connectorId === NOTIFIER_CONNECTOR_SIMPLIFIED_EMAIL) return 'email';
+      if (connectorId === NOTIFIER_CONNECTOR_WEBHOOK) return 'webhook';
+      if (connectorId === NOTIFIER_CONNECTOR_UI) return 'ui';
+      return 'other';
+    };
+    const notifierItems = new Map<string, DimensionalGaugeItem>();
+    ['email', 'webhook', 'ui', 'other'].forEach((connector) => notifierItems.set(connector, { value: 0, attributes: { connector } }));
+    notifiers.forEach((notifier) => {
+      const item = notifierItems.get(notifierConnectorLabel(notifier.notifier_connector_id));
+      if (item) item.value += 1;
+    });
+    manager.setNotifiersByConnector(Array.from(notifierItems.values()));
+    // endregion
+
+    // region RBAC scale
+    const groupsCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_GROUP] });
+    manager.setGroupsCount(groupsCount);
+    const rolesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_ROLE] });
+    manager.setRolesCount(rolesCount);
+    const organizationsCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, { types: ['Organization'] });
+    manager.setOrganizationsCount(organizationsCount);
+    // endregion
+
+    // region File indexing
+    const managerConfigurations = await getEntitiesListFromCache<BasicStoreEntity & { manager_id?: string; manager_running?: boolean }>(
+      context,
+      TELEMETRY_MANAGER_USER,
+      ENTITY_TYPE_MANAGER_CONFIGURATION,
+    );
+    const fileIndexConfiguration = managerConfigurations.find((configuration) => configuration.manager_id === 'FILE_INDEX_MANAGER');
+    manager.setIsFileIndexingEnabled(fileIndexConfiguration?.manager_running === true ? 1 : 0);
+    const indexedFilesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_FILES, {});
+    manager.setIndexedFilesCount(indexedFilesCount);
+    // endregion
+
     // region Telemetry user events
     const disseminationCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_DISSEMINATION);
     manager.setDisseminationCount(disseminationCountInRedis);
@@ -396,6 +686,44 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     manager.setCustomViewEnabledCount(customViewEnabledCountInRedis);
     const workflowPublishCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_WORKFLOW_PUBLISH);
     manager.setWorkflowPublishCount(workflowPublishCountInRedis);
+    const chatbotMessageCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_CHATBOT_MESSAGE);
+    manager.setChatbotMessageCount(chatbotMessageCountInRedis);
+    const aiInsightItems: DimensionalGaugeItem[] = [];
+    for (let cacheIndex = 0; cacheIndex < AI_INSIGHT_CACHE_STATES.length; cacheIndex += 1) {
+      const cache = AI_INSIGHT_CACHE_STATES[cacheIndex];
+      const value = await redisGetTelemetry(`${TELEMETRY_GAUGE_AI_INSIGHT_REQUEST}:${cache}`);
+      aiInsightItems.push({ value, attributes: { cache } });
+    }
+    manager.setAiInsightRequestItems(aiInsightItems);
+    const askAiItems: DimensionalGaugeItem[] = [];
+    for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
+      const feature = ASK_AI_FEATURES[featureIndex];
+      const value = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`);
+      askAiItems.push({ value, attributes: { feature } });
+    }
+    manager.setAskAiQueryItems(askAiItems);
+    const xtmAgentItems: DimensionalGaugeItem[] = [];
+    for (let channelIndex = 0; channelIndex < XTM_AGENT_CHANNELS.length; channelIndex += 1) {
+      const channel = XTM_AGENT_CHANNELS[channelIndex];
+      const value = await redisGetTelemetry(`${TELEMETRY_GAUGE_XTM_AGENT_CALL}:${channel}`);
+      xtmAgentItems.push({ value, attributes: { channel } });
+    }
+    manager.setXtmAgentCallItems(xtmAgentItems);
+    const playbookAiAgentRunCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_PLAYBOOK_AI_AGENT_RUN);
+    manager.setPlaybookAiAgentRunCount(playbookAiAgentRunCountInRedis);
+    const playbookExecutionCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_PLAYBOOK_EXECUTION);
+    manager.setPlaybookExecutionCount(playbookExecutionCountInRedis);
+    const notificationSentItems: DimensionalGaugeItem[] = [];
+    for (let channelIndex = 0; channelIndex < NOTIFICATION_CHANNELS.length; channelIndex += 1) {
+      const channel = NOTIFICATION_CHANNELS[channelIndex];
+      const value = await redisGetTelemetry(`${TELEMETRY_GAUGE_NOTIFICATION_SENT}:${channel}`);
+      notificationSentItems.push({ value, attributes: { channel } });
+    }
+    manager.setNotificationSentItems(notificationSentItems);
+    const exportGeneratedCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
+    manager.setExportGeneratedCount(exportGeneratedCountInRedis);
+    const ingestionObjectsProcessedCountInRedis = await redisGetTelemetry(TELEMETRY_GAUGE_INGESTION_OBJECTS_PROCESSED);
+    manager.setIngestionObjectsProcessedCount(ingestionObjectsProcessedCountInRedis);
     // end region Telemetry user events
 
     logApp.debug(`[TELEMETRY] Fetching telemetry data successfully in ${new Date().getTime() - startTime} ms`);

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -341,10 +341,12 @@ export const addExportGeneratedCount = () => {
 
 // Volume counter: adds the number of objects processed by a completed work.
 export const addIngestionObjectsProcessedCount = (count: number) => {
-  if (!Number.isFinite(count) || count <= 0) {
+  // Floored because the Redis accumulation relies on the integer-only HINCRBY.
+  const objectsCount = Math.floor(count);
+  if (!Number.isFinite(objectsCount) || objectsCount <= 0) {
     return;
   }
-  redisSetTelemetryAdd(TELEMETRY_GAUGE_INGESTION_OBJECTS_PROCESSED, count)
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_INGESTION_OBJECTS_PROCESSED, objectsCount)
     .catch((reason) => logApp.warn('Error adding ingestion objects processed count to telemetry', { reason }));
 };
 

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -543,16 +543,19 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region Knowledge graph scale
-    const knowledgeAggregation = await elAggregationCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, {
-      field: 'entity_type',
-      types: KNOWLEDGE_OBJECT_TYPES,
-      normalizeLabel: false,
-    });
+    // The three independent ES queries run in parallel.
+    const [knowledgeAggregation, observablesCount, relationshipsCount] = await Promise.all([
+      elAggregationCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, {
+        field: 'entity_type',
+        types: KNOWLEDGE_OBJECT_TYPES,
+        normalizeLabel: false,
+      }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CYBER_OBSERVABLES, {}),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CORE_RELATIONSHIPS, {}),
+    ]);
     const knowledgeItems: DimensionalGaugeItem[] = knowledgeAggregation
       .map(({ label, count }) => ({ value: count, attributes: { type: String(label).toLowerCase() } }));
-    const observablesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CYBER_OBSERVABLES, {});
     knowledgeItems.push({ value: observablesCount, attributes: { type: 'observable' } });
-    const relationshipsCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CORE_RELATIONSHIPS, {});
     knowledgeItems.push({ value: relationshipsCount, attributes: { type: 'relationship' } });
     manager.setKnowledgeObjectsByType(knowledgeItems);
     // endregion
@@ -646,11 +649,14 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion
 
     // region RBAC scale
-    const groupsCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_GROUP] });
+    // The three independent ES count queries run in parallel.
+    const [groupsCount, rolesCount, organizationsCount] = await Promise.all([
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_GROUP] }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_ROLE] }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, { types: ['Organization'] }),
+    ]);
     manager.setGroupsCount(groupsCount);
-    const rolesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_INTERNAL_OBJECTS, { types: [ENTITY_TYPE_ROLE] });
     manager.setRolesCount(rolesCount);
-    const organizationsCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, { types: ['Organization'] });
     manager.setOrganizationsCount(organizationsCount);
     // endregion
 

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -195,8 +195,11 @@ export const AI_PROVIDER_TYPES = ['mistralai', 'openai', 'azureopenai'] as const
 export const addDisseminationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, 1);
 };
-export const addNlqQueryCount = async () => {
-  await redisSetTelemetryAdd(TELEMETRY_GAUGE_NLQ, 1);
+// Fire-and-forget (like the other feature counters below): a telemetry
+// failure must never break the NLQ feature.
+export const addNlqQueryCount = () => {
+  redisSetTelemetryAdd(TELEMETRY_GAUGE_NLQ, 1)
+    .catch((reason) => logApp.warn('Error adding NLQ query count to telemetry', { reason }));
 };
 export const addRequestAccessCreationCount = async () => {
   await redisSetTelemetryAdd(TELEMETRY_GAUGE_REQUEST_ACCESS, 1);

--- a/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
@@ -422,8 +422,7 @@ export const generateNLQresponse = async (context: AuthContext, user: AuthUser, 
   await checkEnterpriseEdition(context);
   // Counted here (feature entry point) rather than in the LLM client so the
   // metric stays backend-agnostic if NLQ is ever served by XTM One.
-  // Fire-and-forget: a telemetry failure must never break the NLQ feature.
-  addNlqQueryCount().catch((reason) => logApp.warn('Error adding NLQ query count to telemetry', { reason }));
+  addNlqQueryCount();
   const { search } = args;
   const promptValue = await NLQPromptTemplate.formatPromptValue({ text: search });
 

--- a/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
@@ -49,11 +49,13 @@ import { paginatedForPathWithEnrichment } from '../internal/document/document-do
 import type { BasicStoreEntityDocument } from '../internal/document/document-types';
 import { NLQPromptTemplate } from './ai-nlq-utils';
 import { callWithTimeout, TimeoutError } from '../../utils/promiseUtils';
+import { addAskAiQueryCount, addNlqQueryCount } from '../../manager/telemetryManager';
 
 const SYSTEM_PROMPT = 'You are an assistant helping cyber threat intelligence analysts to generate text about cyber threat intelligence information or from a cyber threat intelligence knowledge graph based on the STIX 2.1 model.';
 
 export const fixSpelling = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('fix_spelling');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -74,6 +76,7 @@ export const fixSpelling = async (context: AuthContext, user: AuthUser, id: stri
 
 export const makeShorter = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('make_shorter');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -94,6 +97,7 @@ export const makeShorter = async (context: AuthContext, user: AuthUser, id: stri
 
 export const makeLonger = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('make_longer');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -116,6 +120,7 @@ export const makeLonger = async (context: AuthContext, user: AuthUser, id: strin
 // eslint-disable-next-line max-len
 export const changeTone = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text, tone: InputMaybe<Tone> = Tone.Tactical) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('change_tone');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -136,6 +141,7 @@ export const changeTone = async (context: AuthContext, user: AuthUser, id: strin
 
 export const summarize = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('summarize');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -155,6 +161,7 @@ export const summarize = async (context: AuthContext, user: AuthUser, id: string
 
 export const explain = async (context: AuthContext, user: AuthUser, id: string, content: string) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('explain');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -174,6 +181,7 @@ export const explain = async (context: AuthContext, user: AuthUser, id: string, 
 
 export const generateContainerReport = async (context: AuthContext, user: AuthUser, args: MutationAiContainerGenerateReportArgs) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('container_report');
   const { id, containerId, paragraphs = 10, tone = 'technical', format = 'HTML', language = 'en-us' } = args;
   const paragraphsNumber = !paragraphs || paragraphs > 20 ? 20 : paragraphs;
   const container = await storeLoadById(context, user, containerId, ENTITY_TYPE_CONTAINER) as BasicStoreEntity;
@@ -215,6 +223,7 @@ export const generateContainerReport = async (context: AuthContext, user: AuthUs
 // TODO This function is deprecated (AI Insights)
 export const summarizeFiles = async (context: AuthContext, user: AuthUser, args: MutationAiSummarizeFilesArgs) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('summarize_files');
   const { id, elementId, paragraphs = 10, fileIds, tone = 'technical', format = 'HTML', language = 'en-us' } = args;
   const paragraphsNumber = !paragraphs || paragraphs > 20 ? 20 : paragraphs;
   const stixCoreObject = await storeLoadById(context, user, elementId, ABSTRACT_STIX_CORE_OBJECT) as BasicStoreEntity;
@@ -274,6 +283,7 @@ export const summarizeFiles = async (context: AuthContext, user: AuthUser, args:
 // TODO This function is deprecated (NLP)
 export const convertFilesToStix = async (context: AuthContext, user: AuthUser, args: MutationAiSummarizeFilesArgs) => {
   await checkEnterpriseEdition(context);
+  await addAskAiQueryCount('convert_files_to_stix');
   const { id, elementId, fileIds } = args;
   const stixCoreObject = await storeLoadById(context, user, elementId, ABSTRACT_STIX_CORE_OBJECT) as BasicStoreEntity;
   let finalFilesIds = fileIds;
@@ -410,6 +420,9 @@ export const filtersEntityIdsMapping = async (context: AuthContext, user: AuthUs
 
 export const generateNLQresponse = async (context: AuthContext, user: AuthUser, args: MutationAiNlqArgs) => {
   await checkEnterpriseEdition(context);
+  // Counted here (feature entry point) rather than in the LLM client so the
+  // metric stays backend-agnostic if NLQ is ever served by XTM One.
+  await addNlqQueryCount();
   const { search } = args;
   const promptValue = await NLQPromptTemplate.formatPromptValue({ text: search });
 

--- a/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ai/ai-domain.ts
@@ -55,7 +55,7 @@ const SYSTEM_PROMPT = 'You are an assistant helping cyber threat intelligence an
 
 export const fixSpelling = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('fix_spelling');
+  addAskAiQueryCount('fix_spelling');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -76,7 +76,7 @@ export const fixSpelling = async (context: AuthContext, user: AuthUser, id: stri
 
 export const makeShorter = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('make_shorter');
+  addAskAiQueryCount('make_shorter');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -97,7 +97,7 @@ export const makeShorter = async (context: AuthContext, user: AuthUser, id: stri
 
 export const makeLonger = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('make_longer');
+  addAskAiQueryCount('make_longer');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -120,7 +120,7 @@ export const makeLonger = async (context: AuthContext, user: AuthUser, id: strin
 // eslint-disable-next-line max-len
 export const changeTone = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text, tone: InputMaybe<Tone> = Tone.Tactical) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('change_tone');
+  addAskAiQueryCount('change_tone');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -141,7 +141,7 @@ export const changeTone = async (context: AuthContext, user: AuthUser, id: strin
 
 export const summarize = async (context: AuthContext, user: AuthUser, id: string, content: string, format: InputMaybe<Format> = Format.Text) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('summarize');
+  addAskAiQueryCount('summarize');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -161,7 +161,7 @@ export const summarize = async (context: AuthContext, user: AuthUser, id: string
 
 export const explain = async (context: AuthContext, user: AuthUser, id: string, content: string) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('explain');
+  addAskAiQueryCount('explain');
   if (content.length < 5) {
     return `Content is too short (${content.length})`;
   }
@@ -181,7 +181,7 @@ export const explain = async (context: AuthContext, user: AuthUser, id: string, 
 
 export const generateContainerReport = async (context: AuthContext, user: AuthUser, args: MutationAiContainerGenerateReportArgs) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('container_report');
+  addAskAiQueryCount('container_report');
   const { id, containerId, paragraphs = 10, tone = 'technical', format = 'HTML', language = 'en-us' } = args;
   const paragraphsNumber = !paragraphs || paragraphs > 20 ? 20 : paragraphs;
   const container = await storeLoadById(context, user, containerId, ENTITY_TYPE_CONTAINER) as BasicStoreEntity;
@@ -223,7 +223,7 @@ export const generateContainerReport = async (context: AuthContext, user: AuthUs
 // TODO This function is deprecated (AI Insights)
 export const summarizeFiles = async (context: AuthContext, user: AuthUser, args: MutationAiSummarizeFilesArgs) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('summarize_files');
+  addAskAiQueryCount('summarize_files');
   const { id, elementId, paragraphs = 10, fileIds, tone = 'technical', format = 'HTML', language = 'en-us' } = args;
   const paragraphsNumber = !paragraphs || paragraphs > 20 ? 20 : paragraphs;
   const stixCoreObject = await storeLoadById(context, user, elementId, ABSTRACT_STIX_CORE_OBJECT) as BasicStoreEntity;
@@ -283,7 +283,7 @@ export const summarizeFiles = async (context: AuthContext, user: AuthUser, args:
 // TODO This function is deprecated (NLP)
 export const convertFilesToStix = async (context: AuthContext, user: AuthUser, args: MutationAiSummarizeFilesArgs) => {
   await checkEnterpriseEdition(context);
-  await addAskAiQueryCount('convert_files_to_stix');
+  addAskAiQueryCount('convert_files_to_stix');
   const { id, elementId, fileIds } = args;
   const stixCoreObject = await storeLoadById(context, user, elementId, ABSTRACT_STIX_CORE_OBJECT) as BasicStoreEntity;
   let finalFilesIds = fileIds;
@@ -422,7 +422,8 @@ export const generateNLQresponse = async (context: AuthContext, user: AuthUser, 
   await checkEnterpriseEdition(context);
   // Counted here (feature entry point) rather than in the LLM client so the
   // metric stays backend-agnostic if NLQ is ever served by XTM One.
-  await addNlqQueryCount();
+  // Fire-and-forget: a telemetry failure must never break the NLQ feature.
+  addNlqQueryCount().catch((reason) => logApp.warn('Error adding NLQ query count to telemetry', { reason }));
   const { search } = args;
   const promptValue = await NLQPromptTemplate.formatPromptValue({ text: search });
 

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/ai-agent-shared.ts
@@ -27,6 +27,7 @@ import type { AuthContext, AuthUser } from '../../../types/user';
 import type { BasicStoreEntity } from '../../../types/store';
 import type { StixBundle } from '../../../types/stix-2-1-common';
 import type { ComponentDefinition } from '../playbook-types';
+import { addPlaybookAiAgentRunCount } from '../../../manager/telemetryManager';
 
 // 5 minutes — agent runs may take a while when the LLM has to materialise
 // a large STIX bundle or call multiple tools. Keep well above the default
@@ -409,6 +410,10 @@ export const callXtmAgent = async (
     // resolveAgentJwtUser already logged why no identity could be resolved.
     return null;
   }
+  // Telemetry: one playbook AI agent run (attempts semantics, counted before
+  // the upstream call). Fire-and-forget so a telemetry failure never breaks
+  // the playbook execution.
+  addPlaybookAiAgentRunCount();
   try {
     const jwt = await issueXtmJwt(jwtUser, xtmOneUrl);
     const httpClient = getHttpClient({

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -235,6 +235,88 @@ export class TelemetryMeterManager {
 
   // endregion providers usage
 
+  // region AI usage (backend-agnostic: no legacy/xtm_one dimension anywhere)
+  // Number of chatbot messages sent (legacy Flowise and XTM One combined)
+  chatbotMessageCount = 0;
+
+  // AI Insights requests broken down by cache state (hit | miss)
+  aiInsightRequestItems: DimensionalGaugeItem[] = [];
+
+  // Ask AI queries broken down by feature (fix_spelling, summarize, ...)
+  askAiQueryItems: DimensionalGaugeItem[] = [];
+
+  // Direct XTM One agent calls broken down by channel (direct | direct_files)
+  xtmAgentCallItems: DimensionalGaugeItem[] = [];
+
+  // Number of playbook AI agent component runs
+  playbookAiAgentRunCount = 0;
+
+  // Built-in LLM configuration state, with the provider type as dimension
+  isAiEnabledItems: DimensionalGaugeItem[] = [];
+
+  // Segmentation keys for before/after XTM One adoption analysis
+  isXtmOneConfigured = 0;
+
+  isChatbotCguAccepted = 0;
+  // endregion AI usage
+
+  // region Product adoption
+  // Knowledge graph scale broken down by curated entity type
+  knowledgeObjectsByType: DimensionalGaugeItem[] = [];
+
+  // Built-in ingesters broken down by type (rss | taxii | ...) and running state
+  ingestersByType: DimensionalGaugeItem[] = [];
+
+  // Data sharing surfaces broken down by type and public (anonymous) state
+  dataSharesByType: DimensionalGaugeItem[] = [];
+
+  // Playbooks broken down by running state (EE)
+  playbooksItems: DimensionalGaugeItem[] = [];
+
+  // Number of activated inference rules
+  inferenceRulesActiveCount = 0;
+
+  // Notification triggers broken down by type (live | digest)
+  triggersByType: DimensionalGaugeItem[] = [];
+
+  // Notifiers broken down by connector (email | webhook | ui | other)
+  notifiersByConnector: DimensionalGaugeItem[] = [];
+
+  // RBAC scale
+  groupsCount = 0;
+
+  rolesCount = 0;
+
+  organizationsCount = 0;
+
+  // Number of OpenCTI-to-OpenCTI synchronizers
+  synchronizersCount = 0;
+
+  // Whether organization segregation is configured (EE)
+  isOrganizationSegregationEnabled = 0;
+
+  // Whether the file indexing manager is running
+  isFileIndexingEnabled = 0;
+
+  // Whether the platform is registered on XTM Hub
+  isXtmHubRegistered = 0;
+
+  // Number of indexed files
+  indexedFilesCount = 0;
+
+  // Number of playbook executions started
+  playbookExecutionCount = 0;
+
+  // Notifications sent broken down by channel (email | webhook | ui)
+  notificationSentItems: DimensionalGaugeItem[] = [];
+
+  // Number of export generations requested
+  exportGeneratedCount = 0;
+
+  // Number of objects processed by completed works (ingestion volume proxy)
+  ingestionObjectsProcessedCount = 0;
+  // endregion Product adoption
+
   constructor(meterProvider: MeterProvider) {
     this.meterProvider = meterProvider;
   }
@@ -439,6 +521,114 @@ export class TelemetryMeterManager {
     this.workflowPublishCount = n;
   }
 
+  setChatbotMessageCount(n: number) {
+    this.chatbotMessageCount = n;
+  }
+
+  setAiInsightRequestItems(items: DimensionalGaugeItem[]) {
+    this.aiInsightRequestItems = items;
+  }
+
+  setAskAiQueryItems(items: DimensionalGaugeItem[]) {
+    this.askAiQueryItems = items;
+  }
+
+  setXtmAgentCallItems(items: DimensionalGaugeItem[]) {
+    this.xtmAgentCallItems = items;
+  }
+
+  setPlaybookAiAgentRunCount(n: number) {
+    this.playbookAiAgentRunCount = n;
+  }
+
+  setIsAiEnabledItems(items: DimensionalGaugeItem[]) {
+    this.isAiEnabledItems = items;
+  }
+
+  setIsXtmOneConfigured(n: number) {
+    this.isXtmOneConfigured = n;
+  }
+
+  setIsChatbotCguAccepted(n: number) {
+    this.isChatbotCguAccepted = n;
+  }
+
+  setKnowledgeObjectsByType(items: DimensionalGaugeItem[]) {
+    this.knowledgeObjectsByType = items;
+  }
+
+  setIngestersByType(items: DimensionalGaugeItem[]) {
+    this.ingestersByType = items;
+  }
+
+  setDataSharesByType(items: DimensionalGaugeItem[]) {
+    this.dataSharesByType = items;
+  }
+
+  setPlaybooksItems(items: DimensionalGaugeItem[]) {
+    this.playbooksItems = items;
+  }
+
+  setInferenceRulesActiveCount(n: number) {
+    this.inferenceRulesActiveCount = n;
+  }
+
+  setTriggersByType(items: DimensionalGaugeItem[]) {
+    this.triggersByType = items;
+  }
+
+  setNotifiersByConnector(items: DimensionalGaugeItem[]) {
+    this.notifiersByConnector = items;
+  }
+
+  setGroupsCount(n: number) {
+    this.groupsCount = n;
+  }
+
+  setRolesCount(n: number) {
+    this.rolesCount = n;
+  }
+
+  setOrganizationsCount(n: number) {
+    this.organizationsCount = n;
+  }
+
+  setSynchronizersCount(n: number) {
+    this.synchronizersCount = n;
+  }
+
+  setIsOrganizationSegregationEnabled(n: number) {
+    this.isOrganizationSegregationEnabled = n;
+  }
+
+  setIsFileIndexingEnabled(n: number) {
+    this.isFileIndexingEnabled = n;
+  }
+
+  setIsXtmHubRegistered(n: number) {
+    this.isXtmHubRegistered = n;
+  }
+
+  setIndexedFilesCount(n: number) {
+    this.indexedFilesCount = n;
+  }
+
+  setPlaybookExecutionCount(n: number) {
+    this.playbookExecutionCount = n;
+  }
+
+  setNotificationSentItems(items: DimensionalGaugeItem[]) {
+    this.notificationSentItems = items;
+  }
+
+  setExportGeneratedCount(n: number) {
+    this.exportGeneratedCount = n;
+  }
+
+  setIngestionObjectsProcessedCount(n: number) {
+    this.ingestionObjectsProcessedCount = n;
+  }
+
   registerGauge(name: string, description: string, observer: string, opts: {
     unit?: string;
     valueType?: ValueType;
@@ -527,5 +717,36 @@ export class TelemetryMeterManager {
     this.registerGauge('custom_view_created_count', 'Number of custom views created', 'customViewCreatedCount');
     this.registerGauge('custom_view_enabled_count', 'Number of custom views enabled', 'customViewEnabledCount');
     this.registerGauge('workflow_publish_count', 'Number of workflow definitions published', 'workflowPublishCount');
+    // region AI usage (backend-agnostic counters, see telemetryManager)
+    this.registerGauge('chatbot_message_count', 'Number of chatbot messages sent (legacy and XTM One combined)', 'chatbotMessageCount');
+    this.registerDimensionalGauge('ai_insight_request_count', 'AI Insights requests broken down by cache state (hit, miss)', 'aiInsightRequestItems');
+    this.registerDimensionalGauge('ask_ai_query_count', 'Ask AI queries broken down by feature', 'askAiQueryItems');
+    this.registerDimensionalGauge('xtm_agent_call_count', 'Direct XTM One agent calls broken down by channel (direct, direct_files)', 'xtmAgentCallItems');
+    this.registerGauge('playbook_ai_agent_run_count', 'Number of playbook AI agent component runs', 'playbookAiAgentRunCount');
+    this.registerDimensionalGauge('is_ai_enabled', 'Built-in LLM configuration state with provider type dimension', 'isAiEnabledItems', { unit: 'boolean' });
+    this.registerGauge('is_xtm_one_configured', 'XTM One is configured (url and token)', 'isXtmOneConfigured', { unit: 'boolean' });
+    this.registerGauge('is_chatbot_cgu_accepted', 'Filigran chatbot AI CGU accepted', 'isChatbotCguAccepted', { unit: 'boolean' });
+    // endregion
+    // region Product adoption
+    this.registerDimensionalGauge('knowledge_objects_by_type', 'knowledge graph scale broken down by curated entity type', 'knowledgeObjectsByType');
+    this.registerDimensionalGauge('ingesters_by_type', 'built-in ingesters broken down by type and running state', 'ingestersByType');
+    this.registerDimensionalGauge('data_shares_by_type', 'data sharing surfaces broken down by type and public state', 'dataSharesByType');
+    this.registerDimensionalGauge('playbooks_count', 'playbooks broken down by running state', 'playbooksItems');
+    this.registerGauge('inference_rules_active_count', 'number of activated inference rules', 'inferenceRulesActiveCount');
+    this.registerDimensionalGauge('triggers_by_type', 'notification triggers broken down by type (live, digest)', 'triggersByType');
+    this.registerDimensionalGauge('notifiers_count', 'notifiers broken down by connector (email, webhook, ui, other)', 'notifiersByConnector');
+    this.registerGauge('groups_count', 'number of groups', 'groupsCount');
+    this.registerGauge('roles_count', 'number of roles', 'rolesCount');
+    this.registerGauge('organizations_count', 'number of organizations', 'organizationsCount');
+    this.registerGauge('synchronizers_count', 'number of OpenCTI synchronizers', 'synchronizersCount');
+    this.registerGauge('is_organization_segregation_enabled', 'organization segregation is configured', 'isOrganizationSegregationEnabled', { unit: 'boolean' });
+    this.registerGauge('is_file_indexing_enabled', 'file indexing manager is running', 'isFileIndexingEnabled', { unit: 'boolean' });
+    this.registerGauge('is_xtm_hub_registered', 'platform is registered on XTM Hub', 'isXtmHubRegistered', { unit: 'boolean' });
+    this.registerGauge('indexed_files_count', 'number of indexed files', 'indexedFilesCount');
+    this.registerGauge('playbook_execution_count', 'number of playbook executions started', 'playbookExecutionCount');
+    this.registerDimensionalGauge('notification_sent_count', 'notifications sent broken down by channel (email, webhook, ui)', 'notificationSentItems');
+    this.registerGauge('export_generated_count', 'number of export generations requested', 'exportGeneratedCount');
+    this.registerGauge('ingestion_objects_processed_count', 'number of objects processed by completed works', 'ingestionObjectsProcessedCount');
+    // endregion
   }
 }

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -111,6 +111,14 @@ vi.mock('../../../src/modules/xtm/one/xtm-one-client', () => ({
   default: { isConfigured: vi.fn(() => true) },
 }));
 
+// Telemetry counters are fire-and-forget side effects; mocking the manager
+// also keeps its heavy transitive dependency graph out of this unit test.
+vi.mock('../../../src/manager/telemetryManager', () => ({
+  addChatbotMessageCount: vi.fn(),
+  addAiInsightRequestCount: vi.fn(),
+  addXtmAgentCallCount: vi.fn(),
+}));
+
 // Mock getHttpClient — the core HTTP abstraction
 const mockPost = vi.fn();
 const mockGet = vi.fn();

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/components/ai-agent-shared-test.ts
@@ -45,6 +45,12 @@ vi.mock('../../../../../src/schema/general', () => ({
   OPENCTI_ADMIN_UUID: 'admin-uuid',
 }));
 
+// Telemetry counters are fire-and-forget side effects; mocking the manager
+// also keeps its heavy transitive dependency graph out of this unit test.
+vi.mock('../../../../../src/manager/telemetryManager', () => ({
+  addPlaybookAiAgentRunCount: vi.fn(),
+}));
+
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import nconf from 'nconf';

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -4,7 +4,18 @@ import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { ATTR_SERVICE_INSTANCE_ID, ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { TELEMETRY_SERVICE_NAME, TelemetryMeterManager } from '../../../src/telemetry/TelemetryMeterManager';
 import { PLATFORM_VERSION } from '../../../src/config/conf';
-import { addDisseminationCount, fetchTelemetryData, TELEMETRY_GAUGE_DISSEMINATION, TELEMETRY_GAUGE_DRAFT_CREATION } from '../../../src/manager/telemetryManager';
+import {
+  addAskAiQueryCount,
+  addChatbotMessageCount,
+  addDisseminationCount,
+  addNotificationSentCount,
+  fetchTelemetryData,
+  TELEMETRY_GAUGE_ASK_AI_QUERY,
+  TELEMETRY_GAUGE_CHATBOT_MESSAGE,
+  TELEMETRY_GAUGE_DISSEMINATION,
+  TELEMETRY_GAUGE_DRAFT_CREATION,
+  TELEMETRY_GAUGE_NOTIFICATION_SENT,
+} from '../../../src/manager/telemetryManager';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../../../src/database/redis';
 import { waitInSec } from '../../../src/database/utils';
 
@@ -39,12 +50,33 @@ describe('Telemetry manager test coverage', () => {
     // AND GIVEN some "user event" from another node (simulated by a direct redis update)
     await redisSetTelemetryAdd(TELEMETRY_GAUGE_DISSEMINATION, DISSEMINATION_EVENT_NODE2);
 
+    // AND GIVEN some AI / product events counted through the fire-and-forget
+    // helpers (scalar key + dimensional "key:attribute" formats)
+    const CHATBOT_MESSAGE_EVENTS = 4;
+    const ASK_AI_SUMMARIZE_EVENTS = 2;
+    const NOTIFICATION_EMAIL_EVENTS = 3;
+    for (let i = 0; i < CHATBOT_MESSAGE_EVENTS; i += 1) {
+      addChatbotMessageCount();
+    }
+    for (let i = 0; i < ASK_AI_SUMMARIZE_EVENTS; i += 1) {
+      addAskAiQueryCount('summarize');
+    }
+    for (let i = 0; i < NOTIFICATION_EMAIL_EVENTS; i += 1) {
+      addNotificationSentCount('email');
+    }
+
     const loopCount = 3; // 3' max
     let loopCurrent = 0;
 
     const isRedisUpdatedCallback = async () => {
       const disseminationGaugeValue = await redisGetTelemetry(TELEMETRY_GAUGE_DISSEMINATION);
-      return disseminationGaugeValue === (DISSEMINATION_EVENT_NODE1 + DISSEMINATION_EVENT_NODE2);
+      const chatbotGaugeValue = await redisGetTelemetry(TELEMETRY_GAUGE_CHATBOT_MESSAGE);
+      const askAiGaugeValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:summarize`);
+      const notificationGaugeValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_NOTIFICATION_SENT}:email`);
+      return disseminationGaugeValue === (DISSEMINATION_EVENT_NODE1 + DISSEMINATION_EVENT_NODE2)
+        && chatbotGaugeValue === CHATBOT_MESSAGE_EVENTS
+        && askAiGaugeValue === ASK_AI_SUMMARIZE_EVENTS
+        && notificationGaugeValue === NOTIFICATION_EMAIL_EVENTS;
     };
     let isRedisUpdated = await isRedisUpdatedCallback();
     while (!isRedisUpdated && loopCurrent < loopCount) {
@@ -63,6 +95,17 @@ describe('Telemetry manager test coverage', () => {
     expect(filigranTelemetryMeterManager.disseminationCount).toBe(DISSEMINATION_EVENT_NODE1 + DISSEMINATION_EVENT_NODE2);
     expect(filigranTelemetryMeterManager.instancesCount).toBe(1);
     expect(filigranTelemetryMeterManager.isEEActivated).toBe(1); // 1 mean true
+    // AND the new AI / product Redis counters are wired with the right key
+    // formats and dimensional attributes
+    expect(filigranTelemetryMeterManager.chatbotMessageCount).toBe(CHATBOT_MESSAGE_EVENTS);
+    const summarizeItem = filigranTelemetryMeterManager.askAiQueryItems.find((item) => item.attributes.feature === 'summarize');
+    expect(summarizeItem?.value).toBe(ASK_AI_SUMMARIZE_EVENTS);
+    const fixSpellingItem = filigranTelemetryMeterManager.askAiQueryItems.find((item) => item.attributes.feature === 'fix_spelling');
+    expect(fixSpellingItem?.value).toBe(0); // zero-valued datapoints are kept
+    const emailItem = filigranTelemetryMeterManager.notificationSentItems.find((item) => item.attributes.channel === 'email');
+    expect(emailItem?.value).toBe(NOTIFICATION_EMAIL_EVENTS);
+    const webhookItem = filigranTelemetryMeterManager.notificationSentItems.find((item) => item.attributes.channel === 'webhook');
+    expect(webhookItem?.value).toBe(0);
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/telemetryManager-test.ts
@@ -9,15 +9,34 @@ import {
   addChatbotMessageCount,
   addDisseminationCount,
   addNotificationSentCount,
+  ASK_AI_FEATURES,
   fetchTelemetryData,
   TELEMETRY_GAUGE_ASK_AI_QUERY,
   TELEMETRY_GAUGE_CHATBOT_MESSAGE,
   TELEMETRY_GAUGE_DISSEMINATION,
   TELEMETRY_GAUGE_DRAFT_CREATION,
+  TELEMETRY_GAUGE_EXPORT_GENERATED,
+  TELEMETRY_GAUGE_NLQ,
   TELEMETRY_GAUGE_NOTIFICATION_SENT,
 } from '../../../src/manager/telemetryManager';
 import { redisClearTelemetry, redisGetTelemetry, redisSetTelemetryAdd } from '../../../src/database/redis';
 import { waitInSec } from '../../../src/database/utils';
+import {
+  changeTone,
+  convertFilesToStix,
+  explain,
+  fixSpelling,
+  generateContainerReport,
+  generateNLQresponse,
+  makeLonger,
+  makeShorter,
+  summarize,
+  summarizeFiles,
+} from '../../../src/modules/ai/ai-domain';
+import { aiActivity, aiForecast, aiHistory } from '../../../src/domain/stixCoreObject';
+import { aiSummary } from '../../../src/domain/container';
+import { askEntityExport, askListExport } from '../../../src/domain/stix';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
 
 describe('Telemetry manager test coverage', () => {
   test('Verify that metrics get collected from both elastic and redis', async () => {
@@ -109,5 +128,69 @@ describe('Telemetry manager test coverage', () => {
     // filigranTelemetryMeterManager.activeConnectorsCount : count cannot be verified since there are many ways to create internal connectors.
     // expect(filigranTelemetryMeterManager.draftCount).toBe(getCounterTotal(ENTITY_TYPE_DRAFT_WORKSPACE));
     // expect(filigranTelemetryMeterManager.workbenchCount).toBe(getCounterTotal(ENTITY_TYPE_WORKSPACE));
+  });
+
+  test('AI and export feature entry points increment the usage counters', async () => {
+    // GIVEN a clean telemetry state in redis
+    await redisClearTelemetry();
+
+    // WHEN the text-based Ask AI features are called with a too-short content,
+    // they short-circuit before any LLM call but still count the attempt
+    expect(await fixSpelling(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await makeShorter(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await makeLonger(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await changeTone(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await summarize(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+    expect(await explain(testContext, ADMIN_USER, 'test-bus-id', 'abc')).toBe('Content is too short (3)');
+
+    // AND WHEN the other feature entry points are called without any AI/XTM One
+    // configuration, they fail downstream but the counters keep the attempts
+    // semantics (incremented at the entry point, before the upstream call)
+    const attempt = async (fn: () => Promise<unknown>) => {
+      try {
+        await fn();
+      } catch {
+        // Expected without an AI configuration in the test platform.
+      }
+    };
+    await attempt(() => generateContainerReport(testContext, ADMIN_USER, { containerId: 'unknown-container-id' } as never));
+    await attempt(() => summarizeFiles(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
+    await attempt(() => convertFilesToStix(testContext, ADMIN_USER, { elementId: 'unknown-element-id' } as never));
+    await attempt(() => generateNLQresponse(testContext, ADMIN_USER, { search: 'malware targeting the energy sector' } as never));
+    await attempt(() => aiActivity(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+    await attempt(() => aiForecast(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+    await attempt(() => aiHistory(testContext, ADMIN_USER, { id: 'unknown-entity-id' }));
+    await attempt(() => aiSummary(testContext, ADMIN_USER, { first: 1 }));
+
+    // AND WHEN export generations are requested (no export connector registered:
+    // the calls resolve or fail downstream, the attempts are counted either way)
+    await attempt(() => askListExport(testContext, ADMIN_USER, { entity_type: 'Report' }, 'application/json', [], {}, 'simple', [], []));
+    await attempt(() => askEntityExport(testContext, ADMIN_USER, 'application/json', { id: 'unknown-entity-id', entity_type: 'Report', name: 'unknown' }, 'simple', [], []));
+
+    // THEN every Ask AI feature has been counted exactly once under its
+    // dimensional key, and the scalar NLQ / export counters as well.
+    // The counters are fire-and-forget, so poll until the writes land.
+    const allCountersUpdated = async () => {
+      for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
+        const featureValue = await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${ASK_AI_FEATURES[featureIndex]}`);
+        if (featureValue !== 1) return false;
+      }
+      const nlqValue = await redisGetTelemetry(TELEMETRY_GAUGE_NLQ);
+      const exportValue = await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED);
+      return nlqValue === 1 && exportValue === 2;
+    };
+    let countersUpdated = await allCountersUpdated();
+    let pollCurrent = 0;
+    while (!countersUpdated && pollCurrent < 3) {
+      await waitInSec(1);
+      countersUpdated = await allCountersUpdated();
+      pollCurrent += 1;
+    }
+    for (let featureIndex = 0; featureIndex < ASK_AI_FEATURES.length; featureIndex += 1) {
+      const feature = ASK_AI_FEATURES[featureIndex];
+      expect(await redisGetTelemetry(`${TELEMETRY_GAUGE_ASK_AI_QUERY}:${feature}`), `feature ${feature} should be counted once`).toBe(1);
+    }
+    expect(await redisGetTelemetry(TELEMETRY_GAUGE_NLQ)).toBe(1);
+    expect(await redisGetTelemetry(TELEMETRY_GAUGE_EXPORT_GENERATED)).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Closes #16969.

Extends the Filigran product telemetry from a single AI metric (`opencti_call_nlq`) to full coverage of AI capabilities and the product adoption metrics needed by product management and leadership.

Measurement principles:

- No legacy-vs-XTM One dimension on any usage metric: a chatbot message or an NLQ query is the same feature whichever backend serves it. Counters are hooked at the feature entry point, never inside the LLM or agent client. The before/after XTM One adoption analysis is done in analytics by segmenting instances on the `is_xtm_one_configured` gauge.
- All dimensional attributes are bounded enums. No existing metric is renamed or removed.
- Event counters keep the attempts semantics (increment before the upstream call), are accumulated in Redis like the existing counters, and are fire-and-forget: a Redis failure is logged and never breaks the serving feature.

## New AI metrics

- `chatbot_message_count` (scalar, counted in both the XTM One proxy and the legacy Flowise proxy)
- `ai_insight_request_count{cache=hit|miss}`
- `ask_ai_query_count{feature}` (13 bounded features, counted in each domain function)
- `xtm_agent_call_count{channel=direct|direct_files}`
- `playbook_ai_agent_run_count`
- `is_ai_enabled{type=mistralai|openai|azureopenai|other|none}` (bounded to the supported provider allowlist), `is_xtm_one_configured`, `is_chatbot_cgu_accepted`
- `call_nlq` unchanged in name; the increment moved from the LLM client (`queryNLQAi`) to the feature entry point (`generateNLQresponse`) so it stays backend-agnostic

## New product adoption metrics

Snapshot gauges: `knowledge_objects_by_type{type}` (curated 15-type allowlist + observable + relationship), `ingesters_by_type{type,running}`, `data_shares_by_type{type,public}`, `playbooks_count{running}`, `inference_rules_active_count`, `triggers_by_type{type}`, `notifiers_count{connector=email|webhook|ui|other}`, `groups_count`, `roles_count`, `organizations_count`, `synchronizers_count`, `is_organization_segregation_enabled`, `is_file_indexing_enabled`, `is_xtm_hub_registered`, `indexed_files_count`.

Redis event counters: `playbook_execution_count` (counted once per fresh execution in the playbook executor), `notification_sent_count{channel=email|webhook|ui}` (publisher manager), `export_generated_count` (askListExport / askEntityExport), `ingestion_objects_processed_count` (work completion volume proxy, restricted to import-side work types - EXTERNAL_IMPORT, INTERNAL_IMPORT_FILE, INTERNAL_ENRICHMENT, INTERNAL_INGESTION - and deduplicated with an atomic Redis SET NX first-completion marker per workId so exports/analysis/notification works never inflate it and the two completion paths cannot double count, even across nodes).

## Documentation and tests

- All new metrics are documented in `docs/docs/reference/usage-telemetry.md` (new "AI features" and "Product adoption" sections).
- `tests/03-integration/04-manager/telemetryManager-test.ts` now asserts the new Redis counters end to end (scalar key, dimensional `key:attribute` formats, kept zero datapoints).

## Notes

- The plan listed a separate `is_xtm_one_registered` ecosystem boolean; it would be strictly identical to `is_xtm_one_configured` (the registration manager is enabled by exactly that config), so only the latter is emitted.
- `notifiers_count` includes an explicit `other` bucket so deployments using custom notifier connectors stay visible; the value set remains a closed list.
- Threat actors are exported as the two concrete entity types (`threat-actor-group`, `threat-actor-individual`); OpenCTI has no concrete `Threat-Actor` type.
- Warehouse models (dbt sources + intermediates + marts) are handled in a companion PR on FiligranHQ/enterprise-data-platform; OpenAEV parity in a companion PR on OpenAEV-Platform/openaev.

## Test plan

- [x] `yarn check-ts` (only pre-existing unrelated `re2` module resolution error in this environment)
- [x] `yarn lint` on all touched files
- [x] `yarn vitest run tests/01-unit/manager/telemetryTags-test.ts` (16 passed)
- [ ] CI full suite

