### PR TITLE
fix(engine): avoid wrapping inner ES operations when calling retryElOperations (#16978)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -529,44 +529,22 @@ const elExecuteWithAbortSignal = async (
 const BULK_MAX_RETRIES = 5;
 const BULK_INITIAL_DELAY_MS = 500;
 
-const collectErrorCandidates = (error: any): any[] => {
-  const candidates: any[] = [];
-  const queue: any[] = [error];
-  const visited = new Set<any>();
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current || visited.has(current)) {
-      continue;
-    }
-    visited.add(current);
-    candidates.push(current);
-    queue.push(current?.cause);
-    queue.push(current?.originalError);
-    queue.push(current?.extensions?.data?.cause);
-  }
-  return candidates;
-};
-
 const isTransitoryError = (error: any): boolean => {
-  const errorsToInspect = collectErrorCandidates(error);
-  for (let index = 0; index < errorsToInspect.length; index += 1) {
-    const currentError = errorsToInspect[index];
-    const statusCode = currentError?.statusCode ?? currentError?.meta?.statusCode ?? currentError?.status;
-    // 429: Too many requests, 503: Service unavailable, both can be transient and should be retried
-    if (statusCode === 429 || statusCode === 503) {
-      return true;
-    }
-    const errorCode = currentError?.code;
-    // All these error codes are commonly associated with transient issues that can occur in network communication
-    // or when the search engine is under heavy load, and thus are good candidates for retrying the operation.
-    if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN'].includes(errorCode)) {
-      return true;
-    }
-    const errorMessage = currentError?.message ?? '';
-    // All these error messages are commonly associated with transient issues that can occur when the search engine is under heavy load
-    if (/circuit_breaking_exception|es_rejected_execution|too_many_requests|service_unavailable/i.test(errorMessage)) {
-      return true;
-    }
+  const statusCode = error?.statusCode ?? error?.meta?.statusCode ?? error?.status;
+  // 429: Too many requests, 503: Service unavailable, both can be transient and should be retried
+  if (statusCode === 429 || statusCode === 503) {
+    return true;
+  }
+  const errorCode = error?.code ?? error?.cause?.code;
+  // All these error codes are commonly associated with transient issues that can occur in network communication
+  // or when the search engine is under heavy load, and thus are good candidates for retrying the operation.
+  if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN'].includes(errorCode)) {
+    return true;
+  }
+  const errorMessage = error?.message ?? '';
+  // All these error messages are commonly associated with transient issues that can occur when the search engine is under heavy load
+  if (/circuit_breaking_exception|es_rejected_execution|too_many_requests|service_unavailable/i.test(errorMessage)) {
+    return true;
   }
   return false;
 };

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4050,27 +4050,25 @@ export const elUpdate = async (
   documentBody: any,
   retry = ES_RETRY_ON_CONFLICT,
 ) => {
-  const updateOperation = async () => {
-    const entityType = documentBody.entity_type ? documentBody.entity_type : '';
-    const updateRequest = {
-      id: documentId,
-      index: indexName,
-      retry_on_conflict: retry,
-      timeout: BULK_TIMEOUT,
-      refresh: true,
-      body: documentBody,
-    };
-    try {
-      return await elExecuteWithAbortSignal(
-        context?.requestAbortSignal,
-        (opts) => (engine as ElkClient).update(updateRequest, opts),
-        () => (engine as OpenClient).update(updateRequest),
-      );
-    } catch (err: any) {
-      throw DatabaseError('Update indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
-    }
+  const entityType = documentBody.entity_type ? documentBody.entity_type : '';
+  const updateRequest = {
+    id: documentId,
+    index: indexName,
+    retry_on_conflict: retry,
+    timeout: BULK_TIMEOUT,
+    refresh: true,
+    body: documentBody,
   };
-  return retryElOperations(updateOperation);
+  const updateOperation = async () => {
+    return await elExecuteWithAbortSignal(
+      context?.requestAbortSignal,
+      (opts) => (engine as ElkClient).update(updateRequest, opts),
+      () => (engine as OpenClient).update(updateRequest),
+    );
+  };
+  return retryElOperations(updateOperation).catch((err: any) => {
+    throw DatabaseError('Update indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
+  });
 };
 export const elReplace = async (
   context: AuthContext,
@@ -4096,23 +4094,21 @@ export const elReplace = async (
   });
 };
 export const elDelete = (indexName: string, documentId: string) => {
-  const deleteOperation = async () => {
-    const deleteRequest = {
-      id: documentId,
-      index: indexName,
-      timeout: BULK_TIMEOUT,
-      refresh: true,
-    };
-    try {
-      if (engine instanceof ElkClient) {
-        return await engine.delete(deleteRequest);
-      }
-      return await engine.delete(deleteRequest);
-    } catch (err: any) {
-      throw DatabaseError('Deleting indexing fail', { cause: err, documentId });
-    }
+  const deleteRequest = {
+    id: documentId,
+    index: indexName,
+    timeout: BULK_TIMEOUT,
+    refresh: true,
   };
-  return retryElOperations(deleteOperation);
+  const deleteOperation = async () => {
+    if (engine instanceof ElkClient) {
+      return await engine.delete(deleteRequest);
+    }
+    return await engine.delete(deleteRequest);
+  };
+  return retryElOperations(deleteOperation).catch((err: any) => {
+    throw DatabaseError('Deleting indexing fail', { cause: err, documentId });
+  });
 };
 const getRelatedRelations = async (
   context: AuthContext,
@@ -4325,54 +4321,52 @@ export const elReindexElements = async (
   destIndex: string,
   opts: { dbId?: string; sourceUpdate?: any } = {},
 ) => {
-  const reindexOperation = async () => {
-    const { dbId, sourceUpdate = {} } = opts;
-    const sourceCleanupScript = "ctx._source.remove('fromType'); ctx._source.remove('toType'); "
-      + "ctx._source.remove('spec_version'); ctx._source.remove('representative'); ctx._source.remove('objectOrganization'); "
-      + "ctx._source.remove('rel_has-reference'); ctx._source.remove('rel_has-reference.internal_id'); "
-      + "ctx._source.remove('i_valid_from_day'); ctx._source.remove('i_valid_until_day'); "
-      + "ctx._source.remove('i_valid_from_month'); ctx._source.remove('i_valid_until_month'); "
-      + "ctx._source.remove('i_valid_from_year'); ctx._source.remove('i_valid_until_year'); "
-      + "ctx._source.remove('i_stop_time_year'); ctx._source.remove('i_start_time_year'); "
-      + "ctx._source.remove('i_start_time_month'); ctx._source.remove('i_stop_time_month'); "
-      + "ctx._source.remove('i_start_time_day'); ctx._source.remove('i_stop_time_day'); "
-      + "ctx._source.remove('i_created_at_year'); ctx._source.remove('i_created_at_month'); ctx._source.remove('i_created_at_day'); "
-      + "ctx._source.remove('rel_can-share'); ctx._source.remove('rel_can-share.internal_id');"
-      + "ctx._source.remove('x_opencti_cvss_vector'); ctx._source.remove('x_opencti_cvss_v2_vector'); ctx._source.remove('x_opencti_cvss_v4_vector');"
-      + "ctx._source.remove('authorized_members');"; // after renaming authorized_members to restricted_members
-    const idReplaceScript = 'if (params.replaceId) { ctx._id = params.newId }';
-    const sourceUpdateScript = 'for (change in params.changes.entrySet()) { ctx._source[change.getKey()] = change.getValue() }';
-    const source = `${sourceCleanupScript} ${idReplaceScript} ${sourceUpdateScript}`;
-    const reindexParams = {
-      body: {
-        source: {
-          index: sourceIndex,
-          query: {
-            ids: {
-              values: ids,
-            },
+  const { dbId, sourceUpdate = {} } = opts;
+  const sourceCleanupScript = "ctx._source.remove('fromType'); ctx._source.remove('toType'); "
+    + "ctx._source.remove('spec_version'); ctx._source.remove('representative'); ctx._source.remove('objectOrganization'); "
+    + "ctx._source.remove('rel_has-reference'); ctx._source.remove('rel_has-reference.internal_id'); "
+    + "ctx._source.remove('i_valid_from_day'); ctx._source.remove('i_valid_until_day'); "
+    + "ctx._source.remove('i_valid_from_month'); ctx._source.remove('i_valid_until_month'); "
+    + "ctx._source.remove('i_valid_from_year'); ctx._source.remove('i_valid_until_year'); "
+    + "ctx._source.remove('i_stop_time_year'); ctx._source.remove('i_start_time_year'); "
+    + "ctx._source.remove('i_start_time_month'); ctx._source.remove('i_stop_time_month'); "
+    + "ctx._source.remove('i_start_time_day'); ctx._source.remove('i_stop_time_day'); "
+    + "ctx._source.remove('i_created_at_year'); ctx._source.remove('i_created_at_month'); ctx._source.remove('i_created_at_day'); "
+    + "ctx._source.remove('rel_can-share'); ctx._source.remove('rel_can-share.internal_id');"
+    + "ctx._source.remove('x_opencti_cvss_vector'); ctx._source.remove('x_opencti_cvss_v2_vector'); ctx._source.remove('x_opencti_cvss_v4_vector');"
+    + "ctx._source.remove('authorized_members');"; // after renaming authorized_members to restricted_members
+  const idReplaceScript = 'if (params.replaceId) { ctx._id = params.newId }';
+  const sourceUpdateScript = 'for (change in params.changes.entrySet()) { ctx._source[change.getKey()] = change.getValue() }';
+  const source = `${sourceCleanupScript} ${idReplaceScript} ${sourceUpdateScript}`;
+  const reindexParams = {
+    body: {
+      source: {
+        index: sourceIndex,
+        query: {
+          ids: {
+            values: ids,
           },
         },
-        dest: {
-          index: destIndex,
-        },
-        script: { // remove old fields that are not mapped anymore but can be present in DB
-          params: { changes: sourceUpdate, replaceId: !!dbId, newId: dbId },
-          source,
-        },
       },
-      refresh: true,
-    };
-    try {
-      if (engine instanceof ElkClient) {
-        return await engine.reindex(reindexParams);
-      }
-      return await engine.reindex(reindexParams);
-    } catch (err: any) {
-      throw DatabaseError(`Reindexing fail from ${sourceIndex} to ${destIndex}`, { cause: err, body: reindexParams.body });
-    }
+      dest: {
+        index: destIndex,
+      },
+      script: { // remove old fields that are not mapped anymore but can be present in DB
+        params: { changes: sourceUpdate, replaceId: !!dbId, newId: dbId },
+        source,
+      },
+    },
+    refresh: true,
   };
-  return retryElOperations(reindexOperation);
+  const reindexOperation = async () => {
+    if (engine instanceof ElkClient) {
+      return await engine.reindex(reindexParams);
+    }
+    return await engine.reindex(reindexParams);
+  };
+  return retryElOperations(reindexOperation).catch((err: any) => {
+    throw DatabaseError(`Reindexing fail from ${sourceIndex} to ${destIndex}`, { cause: err, body: reindexParams.body });
+  });
 };
 
 export const elRemoveDraftIdFromElements = async (

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -529,22 +529,44 @@ const elExecuteWithAbortSignal = async (
 const BULK_MAX_RETRIES = 5;
 const BULK_INITIAL_DELAY_MS = 500;
 
+const collectErrorCandidates = (error: any): any[] => {
+  const candidates: any[] = [];
+  const queue: any[] = [error];
+  const visited = new Set<any>();
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    candidates.push(current);
+    queue.push(current?.cause);
+    queue.push(current?.originalError);
+    queue.push(current?.extensions?.data?.cause);
+  }
+  return candidates;
+};
+
 const isTransitoryError = (error: any): boolean => {
-  const statusCode = error?.statusCode ?? error?.meta?.statusCode ?? error?.status;
-  // 429: Too many requests, 503: Service unavailable, both can be transient and should be retried
-  if (statusCode === 429 || statusCode === 503) {
-    return true;
-  }
-  const errorCode = error?.code ?? error?.cause?.code;
-  // All these error codes are commonly associated with transient issues that can occur in network communication
-  // or when the search engine is under heavy load, and thus are good candidates for retrying the operation.
-  if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN'].includes(errorCode)) {
-    return true;
-  }
-  const errorMessage = error?.message ?? '';
-  // All these error messages are commonly associated with transient issues that can occur when the search engine is under heavy load
-  if (/circuit_breaking_exception|es_rejected_execution|too_many_requests|service_unavailable/i.test(errorMessage)) {
-    return true;
+  const errorsToInspect = collectErrorCandidates(error);
+  for (let index = 0; index < errorsToInspect.length; index += 1) {
+    const currentError = errorsToInspect[index];
+    const statusCode = currentError?.statusCode ?? currentError?.meta?.statusCode ?? currentError?.status;
+    // 429: Too many requests, 503: Service unavailable, both can be transient and should be retried
+    if (statusCode === 429 || statusCode === 503) {
+      return true;
+    }
+    const errorCode = currentError?.code;
+    // All these error codes are commonly associated with transient issues that can occur in network communication
+    // or when the search engine is under heavy load, and thus are good candidates for retrying the operation.
+    if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN'].includes(errorCode)) {
+      return true;
+    }
+    const errorMessage = currentError?.message ?? '';
+    // All these error messages are commonly associated with transient issues that can occur when the search engine is under heavy load
+    if (/circuit_breaking_exception|es_rejected_execution|too_many_requests|service_unavailable/i.test(errorMessage)) {
+      return true;
+    }
   }
   return false;
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-retry-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-retry-test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testMocks = vi.hoisted(() => ({
+  update: vi.fn(),
+  delete: vi.fn(),
+  reindex: vi.fn(),
+  info: vi.fn(),
+  putPipeline: vi.fn(),
+  confGet: vi.fn(),
+}));
+
+vi.mock('@elastic/elasticsearch', () => {
+  class MockElkClient {
+    public ingest = { putPipeline: testMocks.putPipeline };
+
+    public info = testMocks.info;
+
+    public update = testMocks.update;
+
+    public delete = testMocks.delete;
+
+    public reindex = testMocks.reindex;
+
+    // eslint-disable-next-line no-useless-constructor
+    constructor(_config: unknown) {}
+  }
+  return { Client: MockElkClient };
+});
+
+vi.mock('@opensearch-project/opensearch', () => {
+  class MockOpenClient {
+    // eslint-disable-next-line no-useless-constructor
+    constructor(_config: unknown) {}
+  }
+  return { Client: MockOpenClient };
+});
+
+vi.mock('@opensearch-project/opensearch/aws', () => ({
+  AwsSigv4Signer: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../../src/config/credentials', () => ({
+  enrichWithRemoteCredentials: vi.fn(async (_provider, auth) => auth),
+}));
+
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/conf')>();
+  const confGet = vi.fn((key: string) => {
+    if (key === 'elasticsearch:engine_selector') {
+      return 'elk';
+    }
+    if (key === 'elasticsearch:engine_check') {
+      return false;
+    }
+    return actual.default.get(key);
+  });
+  testMocks.confGet.mockImplementation(confGet);
+  return {
+    ...actual,
+    default: { ...actual.default, get: confGet },
+    booleanConf: vi.fn((key: string, defaultValue: boolean) => {
+      if (key === 'elasticsearch:engine_check') {
+        return false;
+      }
+      return defaultValue;
+    }),
+    extendedErrors: vi.fn(() => ({})),
+    loadCert: vi.fn(() => null),
+    logApp: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+    logMigration: {
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+import { elDelete, elReindexElements, elUpdate, searchEngineInit } from '../../../src/database/engine';
+
+const TRANSIENT_ERROR = new Error('circuit_breaking_exception: data too large');
+const MAX_RETRY_ATTEMPTS = 6;
+
+describe('engine retries on circuit breaking exception', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    testMocks.info.mockResolvedValue({
+      version: { number: '8.19.1' },
+      tagline: 'You Know, for Search',
+    });
+    testMocks.putPipeline.mockResolvedValue({});
+    await searchEngineInit();
+  });
+
+  describe('elUpdate', () => {
+    it('retries after circuit_breaking_exception', async () => {
+      vi.useFakeTimers();
+      testMocks.update
+        .mockRejectedValueOnce(TRANSIENT_ERROR)
+        .mockResolvedValueOnce({});
+      const updatePromise = elUpdate({} as any, 'entities', 'entity-1', { entity_type: 'Report' });
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(updatePromise).resolves.toEqual({});
+      expect(testMocks.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws higher level exception when retries are exhausted', async () => {
+      vi.useFakeTimers();
+      testMocks.update.mockRejectedValue(TRANSIENT_ERROR);
+      const updatePromise = elUpdate({} as any, 'entities', 'entity-1', { entity_type: 'Report' });
+      const rejectionAssertion = expect(updatePromise).rejects.toMatchObject({
+        message: 'Update indexing fail',
+        extensions: { code: 'DATABASE_ERROR' },
+      });
+      await vi.runAllTimersAsync();
+      await rejectionAssertion;
+      expect(testMocks.update).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS);
+    });
+  });
+
+  describe('elDelete', () => {
+    it('retries after circuit_breaking_exception', async () => {
+      vi.useFakeTimers();
+      testMocks.delete
+        .mockRejectedValueOnce(TRANSIENT_ERROR)
+        .mockResolvedValueOnce({});
+      const deletePromise = elDelete('entities', 'entity-1');
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(deletePromise).resolves.toEqual({});
+      expect(testMocks.delete).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws higher level exception when retries are exhausted', async () => {
+      vi.useFakeTimers();
+      testMocks.delete.mockRejectedValue(TRANSIENT_ERROR);
+      const deletePromise = elDelete('entities', 'entity-1');
+      const rejectionAssertion = expect(deletePromise).rejects.toMatchObject({
+        message: 'Deleting indexing fail',
+        extensions: { code: 'DATABASE_ERROR' },
+      });
+      await vi.runAllTimersAsync();
+      await rejectionAssertion;
+      expect(testMocks.delete).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS);
+    });
+  });
+
+  describe('elReindexElements', () => {
+    it('retries after circuit_breaking_exception', async () => {
+      vi.useFakeTimers();
+      testMocks.reindex
+        .mockRejectedValueOnce(TRANSIENT_ERROR)
+        .mockResolvedValueOnce({});
+      const reindexPromise = elReindexElements({} as any, {} as any, ['entity-1'], 'src_entities', 'dest_entities');
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(reindexPromise).resolves.toEqual({});
+      expect(testMocks.reindex).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws higher level exception when retries are exhausted', async () => {
+      vi.useFakeTimers();
+      testMocks.reindex.mockRejectedValue(TRANSIENT_ERROR);
+      const reindexPromise = elReindexElements({} as any, {} as any, ['entity-1'], 'src_entities', 'dest_entities');
+      const rejectionAssertion = expect(reindexPromise).rejects.toMatchObject({
+        message: 'Reindexing fail from src_entities to dest_entities',
+        extensions: { code: 'DATABASE_ERROR' },
+      });
+      await vi.runAllTimersAsync();
+      await rejectionAssertion;
+      expect(testMocks.reindex).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS);
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildLocalMustFilter, prepareElementForIndexing } from '../../../src/database/engine';
+import { buildLocalMustFilter, prepareElementForIndexing, retryElOperations } from '../../../src/database/engine';
+import { DatabaseError } from '../../../src/config/errors';
 import * as engineConfig from '../../../src/database/engine-config';
 
 describe('prepareElementForIndexing testing', () => {
@@ -110,6 +111,24 @@ describe('buildLocalMustFilter testing', () => {
           },
         ],
       },
+    });
+  });
+
+  describe('retryElOperations testing', () => {
+    it('should retry when transient error is wrapped in DatabaseError', async () => {
+      vi.useFakeTimers();
+      try {
+        const operation = vi
+          .fn()
+          .mockRejectedValueOnce(DatabaseError('Update indexing fail', { cause: { statusCode: 429 } }))
+          .mockResolvedValueOnce('ok');
+        const retryPromise = retryElOperations(operation);
+        await vi.advanceTimersByTimeAsync(500);
+        await expect(retryPromise).resolves.toBe('ok');
+        expect(operation).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-test.js
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildLocalMustFilter, prepareElementForIndexing, retryElOperations } from '../../../src/database/engine';
-import { DatabaseError } from '../../../src/config/errors';
+import { buildLocalMustFilter, prepareElementForIndexing } from '../../../src/database/engine';
 import * as engineConfig from '../../../src/database/engine-config';
 
 describe('prepareElementForIndexing testing', () => {
@@ -111,24 +110,6 @@ describe('buildLocalMustFilter testing', () => {
           },
         ],
       },
-    });
-  });
-
-  describe('retryElOperations testing', () => {
-    it('should retry when transient error is wrapped in DatabaseError', async () => {
-      vi.useFakeTimers();
-      try {
-        const operation = vi
-          .fn()
-          .mockRejectedValueOnce(DatabaseError('Update indexing fail', { cause: { statusCode: 429 } }))
-          .mockResolvedValueOnce('ok');
-        const retryPromise = retryElOperations(operation);
-        await vi.advanceTimersByTimeAsync(500);
-        await expect(retryPromise).resolves.toBe('ok');
-        expect(operation).toHaveBeenCalledTimes(2);
-      } finally {
-        vi.useRealTimers();
-      }
     });
   });
 });


### PR DESCRIPTION
### Descrption

During on-call we've spotted some circuit breaking alerts triggered on `elUpdate` without the retry mechanism being effective even though the code seems to indicate it should be in place.

### Proposed changes

Modifies engine primitives that call `retryElOperations` after wrapping the ES operation in a try/catch block to rethrow a higher-level applicative Exception like `DatabaseError` as this makes `retryElOperations` ineffective. Instead, include the call to `retryElOperations` inside the try.

### Related issues

* closes https://github.com/OpenCTI-Platform/opencti/issues/16978

### How to test this PR

Run unit test suite.
Kinda super tricky trying to reproduce in a real application case.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
