### PR TITLE
fix(engine): apply retryElOperations to elIndex (#16979)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4030,15 +4030,17 @@ export const elIndex = async (
   if (pipeline) {
     indexParams = { ...indexParams, pipeline };
   }
-  if (engine instanceof ElkClient) {
-    await engine.index(indexParams).catch((err: any) => {
-      throw DatabaseError('Simple indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
-    });
-  } else {
-    await engine.index(indexParams).catch((err: any) => {
-      throw DatabaseError('Simple indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
-    });
-  }
+  const indexOperation = async () => {
+    // Branching kept to please tsc
+    if (engine instanceof ElkClient) {
+      return await engine.index(indexParams);
+    } else {
+      return await engine.index(indexParams);
+    }
+  };
+  await retryElOperations(indexOperation).catch((err: any) => {
+    throw DatabaseError('Simple indexing fail', { cause: err, documentId, entityType, ...extendedErrors({ documentBody }) });
+  });
 
   return documentBody;
 };

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -556,7 +556,7 @@ export const retryElOperations = async (operation: () => Promise<any>): Promise<
     } catch (error) {
       if (attempt < BULK_MAX_RETRIES && isTransitoryError(error)) {
         const delayMs = BULK_INITIAL_DELAY_MS * (2 ** attempt);
-        logApp.warn(`[SEARCH] Bulk request transitory error, retrying in ${delayMs}ms (attempt ${attempt + 1}/${BULK_MAX_RETRIES})`, { cause: error });
+        logApp.warn(`[SEARCH] Engine transitory error, retrying in ${delayMs}ms (attempt ${attempt + 1}/${BULK_MAX_RETRIES})`, { cause: error });
         await wait(delayMs);
       } else {
         throw error;

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-retry-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-retry-test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const testMocks = vi.hoisted(() => ({
+  index: vi.fn(),
   update: vi.fn(),
   delete: vi.fn(),
   reindex: vi.fn(),
@@ -20,6 +21,8 @@ vi.mock('@elastic/elasticsearch', () => {
     public delete = testMocks.delete;
 
     public reindex = testMocks.reindex;
+
+    public index = testMocks.index;
 
     // eslint-disable-next-line no-useless-constructor
     constructor(_config: unknown) {}
@@ -79,7 +82,7 @@ vi.mock('../../../src/config/conf', async (importOriginal) => {
   };
 });
 
-import { elDelete, elReindexElements, elUpdate, searchEngineInit } from '../../../src/database/engine';
+import { elDelete, elIndex, elReindexElements, elUpdate, searchEngineInit } from '../../../src/database/engine';
 
 const TRANSIENT_ERROR = new Error('circuit_breaking_exception: data too large');
 const MAX_RETRY_ATTEMPTS = 6;
@@ -122,6 +125,32 @@ describe('engine retries on circuit breaking exception', () => {
       await vi.runAllTimersAsync();
       await rejectionAssertion;
       expect(testMocks.update).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS);
+    });
+  });
+
+  describe('elIndex', () => {
+    it('retries after circuit_breaking_exception', async () => {
+      vi.useFakeTimers();
+      testMocks.index
+        .mockRejectedValueOnce(TRANSIENT_ERROR)
+        .mockResolvedValueOnce({});
+      const indexPromise = elIndex('entities', { internal_id: 'entity-1', entity_type: 'Report' });
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(indexPromise).resolves.toMatchObject({ internal_id: 'entity-1' });
+      expect(testMocks.index).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws higher level exception when retries are exhausted', async () => {
+      vi.useFakeTimers();
+      testMocks.index.mockRejectedValue(TRANSIENT_ERROR);
+      const indexPromise = elIndex('entities', { internal_id: 'entity-1', entity_type: 'Report' });
+      const rejectionAssertion = expect(indexPromise).rejects.toMatchObject({
+        message: 'Simple indexing fail',
+        extensions: { code: 'DATABASE_ERROR' },
+      });
+      await vi.runAllTimersAsync();
+      await rejectionAssertion;
+      expect(testMocks.index).toHaveBeenCalledTimes(MAX_RETRY_ATTEMPTS);
     });
   });
 


### PR DESCRIPTION
### Description

We've noticed during on-call that `elIndex` does not currently benefit from the retry mechanism and thus can lead to circuit breaking errors on the first attempt. This PR attempts to apply that retry mechanism.

### Proposed changes

* Wrapped primitive ES call in `retryElOperations`
* Updated unit tests suite

### Related issues

* closes #16979 

### How to test this PR

Run unit test suite.
Kinda super tricky trying to reproduce in a real application case.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
