### PR TITLE
feat(custom-views): Allow date range configuration directly within Custom Views on entity pages (#16533)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomView.tsx
@@ -1,12 +1,15 @@
-import { Suspense, useMemo } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { ErrorBoundary } from '@components/Error';
-import { MESSAGING$ } from '../../../relay/environment';
+import { MESSAGING$ } from 'src/relay/environment';
 import Loader from '../../../components/Loader';
 import useQueryLoading from '../../../utils/hooks/useQueryLoading';
 import useDashboard from '../../../components/dashboard/useDashboard';
 import DashboardContent from '../../../components/dashboard/DashboardContent';
 import { CustomView_Query } from './__generated__/CustomView_Query.graphql';
+import { DashboardConfig } from 'src/components/dashboard/dashboard-types';
+import DashboardTimeFilters from 'src/components/dashboard/DashboardTimeFilters';
+import { Stack } from '@mui/material';
 
 const customViewQuery = graphql`
   query CustomView_Query($id: ID!) {
@@ -35,18 +38,41 @@ const CustomViewComponent = ({ queryRef, entityId, entityType }: CustomViewCompo
   }
 
   const helpers = useDashboard({ entity: customView });
+
+  const [dateOverride, setDateOverride] = useState<DashboardConfig | null>(null);
+  const effectiveConfig = dateOverride ?? helpers.config;
+
+  const handleDateChange = (
+    type: 'startDate' | 'endDate' | 'relativeDate',
+    value: string | null,
+  ) => {
+    setDateOverride({
+      startDate: effectiveConfig?.startDate ?? null,
+      endDate: effectiveConfig?.endDate ?? null,
+      relativeDate: effectiveConfig?.relativeDate ?? null,
+      [type]: value,
+    });
+  };
+
   const host = useMemo(() => ({
     kind: 'custom-view' as const,
     customViewTargetEntityType: entityType,
     customViewTargetEntityId: entityId,
   }), [entityType]);
+
   return (
-    <DashboardContent
-      helpers={helpers}
-      isEditable={false}
-      entity={customView}
-      host={host}
-    />
+    <Stack gap={2}>
+      <DashboardTimeFilters
+        config={effectiveConfig}
+        handleDateChange={handleDateChange}
+      />
+      <DashboardContent
+        helpers={{ ...helpers, config: effectiveConfig }}
+        isEditable={false}
+        entity={customView}
+        host={host}
+      />
+    </Stack>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/custom_views/CustomView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/custom_views/CustomView.tsx
@@ -46,11 +46,26 @@ const CustomViewComponent = ({ queryRef, entityId, entityType }: CustomViewCompo
     type: 'startDate' | 'endDate' | 'relativeDate',
     value: string | null,
   ) => {
-    setDateOverride({
-      startDate: effectiveConfig?.startDate ?? null,
-      endDate: effectiveConfig?.endDate ?? null,
-      relativeDate: effectiveConfig?.relativeDate ?? null,
-      [type]: value,
+    setDateOverride((prev) => {
+      const base = prev ?? helpers.config;
+      const normalizedValue = value === 'none' ? null : value;
+
+      let nextConfig: DashboardConfig = {
+        startDate: base?.startDate ?? null,
+        endDate: base?.endDate ?? null,
+        relativeDate: base?.relativeDate ?? null,
+        [type]: normalizedValue,
+      };
+
+      if (type === 'relativeDate' && value !== 'none') {
+        nextConfig = {
+          ...nextConfig,
+          startDate: null,
+          endDate: null,
+        };
+      }
+
+      return nextConfig;
     });
   };
 


### PR DESCRIPTION
### Proposed changes

* Add component of date filters
* Add a state to store the value in react 

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/16533

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
Set a default date/time filter value in customization of a custom view, then go back to your entity, check if the default value is set.
The default value should be set, and you can be able to modify it, but NOT save it. If you reload the page, only the default value set in customization should be displayed.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
