### PR TITLE
fix(security): modify default value for armor_protection cost_limit (#16760)

### DIFF
--- a/.github/workflows/ci-test-frontend.yml
+++ b/.github/workflows/ci-test-frontend.yml
@@ -97,6 +97,7 @@ jobs:
           -e APP__APP_LOG__EXTENDED_ERROR_MESSAGE=true \
           -e APP__SESSION_TIMEOUT=3600000 \
           -e APP__HEALTH_ACCESS_KEY=cihealthkey \
+          -e APP__GRAPHQL__ARMOR_PROTECTION__DISABLED=false \
           -e REDIS__HOSTNAME=redis \
           -e REDIS__NAMESPACE=e2e-start \
           -e ELASTICSEARCH__URL=http://elasticsearch:9200 \

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -55,7 +55,7 @@
         "max_depth": 20,
         "max_directives": 20,
         "max_tokens": 100000,
-        "cost_limit": 3000000,
+        "cost_limit": 30000000,
         "block_field_suggestion": true
       },
       "batching_protection": {

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -55,7 +55,7 @@
         "max_depth": 20,
         "max_directives": 20,
         "max_tokens": 100000,
-        "cost_limit": 30000000,
+        "cost_limit": 50000000,
         "block_field_suggestion": true
       },
       "batching_protection": {

--- a/opencti-platform/opencti-graphql/src/graphql/graphql.js
+++ b/opencti-platform/opencti-graphql/src/graphql/graphql.js
@@ -47,7 +47,7 @@ const createApolloServer = () => {
         enabled: conf.get('app:graphql:armor_protection:block_field_suggestion') ?? true,
       },
       costLimit: { // Limit the complexity of a GraphQL document.
-        maxCost: conf.get('app:graphql:armor_protection:cost_limit') ?? 30000000,
+        maxCost: conf.get('app:graphql:armor_protection:cost_limit') ?? 50000000,
       },
       maxDepth: { // maxDepth: Limit the depth of a document.
         n: conf.get('app:graphql:armor_protection:max_depth') ?? 20,

--- a/opencti-platform/opencti-graphql/src/graphql/graphql.js
+++ b/opencti-platform/opencti-graphql/src/graphql/graphql.js
@@ -47,7 +47,7 @@ const createApolloServer = () => {
         enabled: conf.get('app:graphql:armor_protection:block_field_suggestion') ?? true,
       },
       costLimit: { // Limit the complexity of a GraphQL document.
-        maxCost: conf.get('app:graphql:armor_protection:cost_limit') ?? 3000000,
+        maxCost: conf.get('app:graphql:armor_protection:cost_limit') ?? 30000000,
       },
       maxDepth: { // maxDepth: Limit the depth of a document.
         n: conf.get('app:graphql:armor_protection:max_depth') ?? 20,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request introduces updates to the GraphQL configuration and the frontend CI workflow, focusing on enhancing security settings and increasing operational limits.

**GraphQL configuration changes:**

* Increased the `cost_limit` for GraphQL queries from 3,000,000 to 50,000,000 in `opencti-platform/opencti-graphql/config/default.json`, allowing for more complex or larger queries.

**Frontend CI workflow updates:**

* Added the environment variable `APP__GRAPHQL__ARMOR_PROTECTION__DISABLED=false` to the frontend CI workflow in `.github/workflows/ci-test-frontend.yml`, ensuring that GraphQL armor protection remains enabled during tests.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16760

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
