### PR TITLE
feat(custom-views): Add custom views to the security coverage (#16525)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsCustomAttributes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsCustomAttributes.tsx
@@ -505,6 +505,13 @@ export const stixCoreObjectsCustomAttributesQuery = graphql`
         updated_at
         revoked
         x_opencti_reliability
+        coverage_valid_from
+        coverage_valid_to
+        coverage_last_result
+        coverage_information {
+          coverage_name
+          coverage_score
+        }
         objectCovered {
           id
           entity_type
@@ -540,12 +547,14 @@ interface StixCoreObjectsCustomAttributesContentProps {
   queryRef: PreloadedQuery<StixCoreObjectsCustomAttributesQuery>;
   columns: readonly WidgetColumn[];
   layout: WidgetColumnsLayout;
+  host?: WidgetHost;
 }
 
 const StixCoreObjectsCustomAttributesContent = ({
   queryRef,
   columns,
   layout,
+  host,
 }: StixCoreObjectsCustomAttributesContentProps) => {
   const data = usePreloadedQuery(stixCoreObjectsCustomAttributesQuery, queryRef);
 
@@ -556,6 +565,7 @@ const StixCoreObjectsCustomAttributesContent = ({
       data={data.stixCoreObject}
       columns={columns}
       layout={layout}
+      host={host}
     />
   );
 };
@@ -621,6 +631,7 @@ const StixCoreObjectsCustomAttributes = ({
                     queryRef={queryRef}
                     columns={columns}
                     layout={layout}
+                    host={host}
                   />
                 </React.Suspense>
               )

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsCustomAttributes.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsCustomAttributes.tsx
@@ -498,6 +498,21 @@ export const stixCoreObjectsCustomAttributesQuery = graphql`
         mime_type
         payload_bin
       }
+      ... on SecurityCoverage {
+        name
+        description
+        created_at
+        updated_at
+        revoked
+        x_opencti_reliability
+        objectCovered {
+          id
+          entity_type
+          representative {
+            main
+          }
+        }
+      }
       createdBy {
         ... on Identity {
           id

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttribute.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttribute.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import Grid from '@mui/material/Grid';
-import type { WidgetColumn } from '../../../utils/widget/widget';
+import type { WidgetColumn, WidgetHost } from '../../../utils/widget/widget';
 import type { WidgetColumnsLayout } from './WidgetCustomAttributesColumnsInput';
 import WidgetCustomAttributesCard, { StixCoreObject } from './WidgetCustomAttributesCard';
 
@@ -8,12 +8,14 @@ interface WidgetCustomAttributesProps {
   data: StixCoreObject | null | undefined;
   columns: readonly WidgetColumn[];
   layout?: WidgetColumnsLayout;
+  host?: WidgetHost;
 }
 
 const WidgetCustomAttributes: FunctionComponent<WidgetCustomAttributesProps> = ({
   data,
   columns,
   layout = '1',
+  host,
 }) => {
   const col1 = layout === '2' ? columns.filter((_, i) => i % 2 === 0) : columns;
   const col2 = layout === '2' ? columns.filter((_, i) => i % 2 === 1) : [];
@@ -26,6 +28,7 @@ const WidgetCustomAttributes: FunctionComponent<WidgetCustomAttributesProps> = (
             key={column.attribute}
             column={column}
             data={data}
+            host={host}
           />
         ))}
       </Grid>
@@ -36,6 +39,7 @@ const WidgetCustomAttributes: FunctionComponent<WidgetCustomAttributesProps> = (
               key={column.attribute}
               column={column}
               data={data}
+              host={host}
             />
           ))}
         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttributesCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttributesCard.tsx
@@ -23,6 +23,8 @@ import { entityTypeRenderers } from 'src/utils/widget/widgetCustomAttributesRend
 import ListItemText from '@mui/material/ListItemText';
 import { openVocabListRenderers, openVocabSingleRenderers } from 'src/utils/widget/widgetOpenVocabRendererUtils';
 import { EMPTY_VALUE } from 'src/utils/String';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ItemIcon from 'src/components/ItemIcon';
 
 export type StixCoreObject = NonNullable<StixCoreObjectsCustomAttributesQuery$data['stixCoreObject']>;
 
@@ -118,6 +120,21 @@ const renderByAttributeType = (
         <FieldOrEmpty source={list}>
           <TextList list={list} />
         </FieldOrEmpty>
+      );
+    }
+
+    case 'entity_ref': {
+      const value = getField<{ id: string; entity_type: string; representative?: { main?: string } }>(data, attribute);
+      if (!value?.representative?.main) return empty();
+      return (
+        <List sx={{ py: 0 }}>
+          <ListItem dense divider>
+            <ListItemIcon>
+              <ItemIcon type={value.entity_type} />
+            </ListItemIcon>
+            <ListItemText primary={value.representative.main} />
+          </ListItem>
+        </List>
       );
     }
 

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttributesCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttributesCard.tsx
@@ -3,7 +3,7 @@ import { Box, List, ListItem, Stack, Typography } from '@mui/material';
 import { useTheme } from '@mui/styles';
 import type { Theme } from 'src/components/Theme';
 import { useFormatter } from 'src/components/i18n';
-import type { WidgetColumn } from 'src/utils/widget/widget';
+import type { WidgetColumn, WidgetHost } from 'src/utils/widget/widget';
 import ItemMarkings from '../../../components/ItemMarkings';
 import ItemAuthor from '../../../components/ItemAuthor';
 import ItemConfidence from '../../../components/ItemConfidence';
@@ -23,8 +23,6 @@ import { entityTypeRenderers } from 'src/utils/widget/widgetCustomAttributesRend
 import ListItemText from '@mui/material/ListItemText';
 import { openVocabListRenderers, openVocabSingleRenderers } from 'src/utils/widget/widgetOpenVocabRendererUtils';
 import { EMPTY_VALUE } from 'src/utils/String';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ItemIcon from 'src/components/ItemIcon';
 
 export type StixCoreObject = NonNullable<StixCoreObjectsCustomAttributesQuery$data['stixCoreObject']>;
 
@@ -32,6 +30,7 @@ interface WidgetCustomAttributesCardProps {
   column: WidgetColumn;
   data: StixCoreObject | null | undefined;
   isCustomViewReadOnly?: boolean;
+  host?: WidgetHost;
 }
 
 const isString = (v: unknown): v is string => typeof v === 'string';
@@ -123,21 +122,6 @@ const renderByAttributeType = (
       );
     }
 
-    case 'entity_ref': {
-      const value = getField<{ id: string; entity_type: string; representative?: { main?: string } }>(data, attribute);
-      if (!value?.representative?.main) return empty();
-      return (
-        <List sx={{ py: 0 }}>
-          <ListItem dense divider>
-            <ListItemIcon>
-              <ItemIcon type={value.entity_type} />
-            </ListItemIcon>
-            <ListItemText primary={value.representative.main} />
-          </ListItem>
-        </List>
-      );
-    }
-
     case 'markdown': {
       const value = getField(data, attribute, isString);
       if (!value) return empty();
@@ -186,6 +170,7 @@ const renderAttributeValue = (
   data: StixCoreObject | null | undefined,
   t_i18n: (s: string) => string,
   fldt: (s: unknown) => string,
+  host?: WidgetHost,
 ) => {
   const { attribute } = column;
   if (!attribute) return null;
@@ -205,7 +190,7 @@ const renderAttributeValue = (
       ?? (isSCO ? entityTypeRenderers['Stix-Cyber-Observable']?.[attribute] : undefined);
 
   if (specificRenderer) {
-    return specificRenderer(data, t_i18n, fldt);
+    return specificRenderer(data, t_i18n, fldt, host);
   }
 
   const byType = renderByAttributeType(column, data, t_i18n, fldt);
@@ -317,6 +302,7 @@ const renderAttributeValue = (
 const WidgetCustomAttributesCard: FunctionComponent<WidgetCustomAttributesCardProps> = ({
   column,
   data,
+  host,
 }) => {
   const theme = useTheme<Theme>();
   const { t_i18n, fldt } = useFormatter();
@@ -327,7 +313,7 @@ const WidgetCustomAttributesCard: FunctionComponent<WidgetCustomAttributesCardPr
       <Typography variant="h4" sx={{ marginBottom: theme.spacing(0.5) }}>
         {t_i18n(label)}
       </Typography>
-      {renderAttributeValue(column, data, t_i18n, fldt)}
+      {renderAttributeValue(column, data, t_i18n, fldt, host)}
     </Box>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetListsDefaultColumns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetListsDefaultColumns.tsx
@@ -361,7 +361,11 @@ const customAttributesTypeColumns: Record<string, WidgetColumn[]> = {
     { attribute: 'longitude', label: 'Longitude' },
   ],
   'Security-Coverage': [
-    { attribute: 'objectCovered', label: 'Covered entity', attributeType: 'entity_ref' },
+    { attribute: 'objectCovered', label: 'Covered entity' },
+    { attribute: 'coverage_valid_from', label: 'Valid from', attributeType: 'date' },
+    { attribute: 'coverage_valid_to', label: 'Valid until', attributeType: 'date' },
+    { attribute: 'coverage_last_result', label: 'Last result', attributeType: 'date' },
+    { attribute: 'coverage_information', label: 'Detection' },
   ],
 };
 

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetListsDefaultColumns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetListsDefaultColumns.tsx
@@ -360,6 +360,9 @@ const customAttributesTypeColumns: Record<string, WidgetColumn[]> = {
     { attribute: 'latitude', label: 'Latitude' },
     { attribute: 'longitude', label: 'Longitude' },
   ],
+  'Security-Coverage': [
+    { attribute: 'objectCovered', label: 'Covered entity', attributeType: 'entity_ref' },
+  ],
 };
 
 const customAttributesExtraColumns: WidgetColumn[] = [

--- a/opencti-platform/opencti-front/src/utils/widget/widget.d.ts
+++ b/opencti-platform/opencti-front/src/utils/widget/widget.d.ts
@@ -32,7 +32,8 @@ export type WidgetColumnAttributeType
     | 'cvss_score'
     | 'open_vocab'
     | 'open_vocab_list'
-    | 'copy';
+    | 'copy'
+    | 'entity_ref';
 
 interface WidgetColumn {
   attribute: string | null;

--- a/opencti-platform/opencti-front/src/utils/widget/widgetCustomAttributesRendererUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetCustomAttributesRendererUtils.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { StixCoreObject } from '@components/widgets/WidgetCustomAttributesCard';
 import FieldOrEmpty from '../../components/FieldOrEmpty';
-import { List, ListItem, Stack, Typography } from '@mui/material';
+import { List, ListItem, ListItemButton, ListItemIcon, Stack, Typography } from '@mui/material';
 import ItemCopy from '../../components/ItemCopy';
 import ListItemText from '@mui/material/ListItemText';
 import ExpandablePre from '../../components/ExpandablePre';
@@ -10,11 +10,16 @@ import ItemSeverity from 'src/components/ItemSeverity';
 import TextList from '@common/text/TextList';
 import ItemOpenVocab from 'src/components/ItemOpenVocab';
 import { EMPTY_VALUE } from 'src/utils/String';
+import SecurityCoverageScores from '@components/analyses/security_coverages/SecurityCoverageScores';
+import ItemIcon from '../../components/ItemIcon';
+import { Link } from 'react-router-dom';
+import { WidgetHost } from 'src/utils/widget/widget';
 
 type AttributeRenderer = (
   data: StixCoreObject,
   t_i18n: (s: string) => string,
   fldt: (s: unknown) => string,
+  host?: WidgetHost,
 ) => ReactNode;
 
 type EntityRenderers = Partial<Record<string, AttributeRenderer>>;
@@ -209,6 +214,61 @@ const artifactRenderers: EntityRenderers = {
   hash_sha512: makeHashRenderer('SHA-512'),
 };
 
+const securityCoverageRenderers: EntityRenderers = {
+  objectCovered: (data, _t_i18n, _fldt, host) => {
+    const covered = getField<{
+      id: string;
+      entity_type: string;
+      representative?: { main?: string };
+    }>(data, 'objectCovered');
+
+    const isPreview = host?.kind === 'custom-view'
+      && Boolean(host.customViewTargetEntityId)
+      && host.previewMode === true;
+    const isClickable = !isPreview;
+
+    return (
+      <FieldOrEmpty source={covered}>
+        {covered && (
+          <List sx={{ py: 0 }}>
+            <ListItem dense divider disablePadding={isClickable}>
+              {isClickable ? (
+                <ListItemButton component={Link} to={`/dashboard/id/${covered.id}`}>
+                  <ListItemIcon>
+                    <ItemIcon type={covered.entity_type} />
+                  </ListItemIcon>
+                  <ListItemText primary={covered.representative?.main} />
+                </ListItemButton>
+              ) : (
+                <>
+                  <ListItemIcon>
+                    <ItemIcon type={covered.entity_type} />
+                  </ListItemIcon>
+                  <ListItemText primary={covered.representative?.main} />
+                </>
+              )}
+            </ListItem>
+          </List>
+        )}
+      </FieldOrEmpty>
+    );
+  },
+
+  coverage_information: (data) => {
+    const coverageInformation = getField<ReadonlyArray<{
+      coverage_name: string;
+      coverage_score: number;
+    }>>(data, 'coverage_information');
+
+    return (
+      <SecurityCoverageScores
+        coverage_information={coverageInformation ?? []}
+        variant="details"
+      />
+    );
+  },
+};
+
 export const entityTypeRenderers: Record<string, EntityRenderers> = {
   Indicator: indicatorRenderers,
   'Threat-Actor-Individual': threatActorIndividualRenderers,
@@ -216,4 +276,5 @@ export const entityTypeRenderers: Record<string, EntityRenderers> = {
   Vulnerability: vulnerabilityRenderers,
   'Stix-Cyber-Observable': stixCyberObservableRenderers,
   Artifact: artifactRenderers,
+  'Security-Coverage': securityCoverageRenderers,
 };

--- a/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/customView/customView-domain.ts
@@ -21,7 +21,6 @@ import {
   ENTITY_TYPE_DATA_COMPONENT,
   ENTITY_TYPE_DATA_SOURCE,
 } from '../../schema/stixDomainObject';
-import { ENTITY_TYPE_SECURITY_COVERAGE } from '../securityCoverage/securityCoverage-types';
 import { ENTITY_TYPE_CONTAINER_TASK } from '../task/task-types';
 import { ENTITY_TYPE_CONTAINER_FEEDBACK } from '../case/feedback/feedback-types';
 import { ABSTRACT_STIX_CORE_RELATIONSHIP, ABSTRACT_STIX_CYBER_OBSERVABLE, ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
@@ -48,7 +47,6 @@ const ENTITY_TYPES_WITHOUT_CUSTOM_VIEWS = [
   ENTITY_TYPE_COURSE_OF_ACTION,
   ENTITY_TYPE_DATA_COMPONENT,
   ENTITY_TYPE_DATA_SOURCE,
-  ENTITY_TYPE_SECURITY_COVERAGE,
 ];
 
 /**
@@ -363,7 +361,7 @@ export async function duplicateCustomView(
     );
   }
   return duplicate;
-};
+}
 
 export const deleteCustomView = async (
   context: AuthContext,


### PR DESCRIPTION
### Proposed changes

* Add custom view to security coverage
* Add attribute for widget attribute related to security coverage

Only one file is related to the feature (the `custom-view-domain.ts`) , the others are made for the widget "attributes" in the custom view. As security coverage as a special field "covered object", to be sure it will not be missing in the future I've added it already.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/16525

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
Add a custom view to security coverage in Settings -> Customization -> Security Coverage -> Custom View
Check if everything works well here.
Then enable the view.
Check the custom view in Security Coverage overview

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
