### PR TITLE
fix(workflows): no admin required in transition AMs (#16919)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -627,6 +627,7 @@ export const draftWorkspaceEditAuthorizedMembers = async (
   user: AuthUser,
   workspaceId: string,
   input: MemberAccessInput[] | undefined | null,
+  options?: { skipAdminValidation?: boolean },
 ) => {
   const args = {
     entityId: workspaceId,
@@ -634,6 +635,7 @@ export const draftWorkspaceEditAuthorizedMembers = async (
     requiredCapabilities: [KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS],
     entityType: ENTITY_TYPE_DRAFT_WORKSPACE,
     busTopicKey: ENTITY_TYPE_DRAFT_WORKSPACE,
+    skipAdminValidation: options?.skipAdminValidation,
   };
   // @ts-expect-error TODO improve busTopicKey types to avoid this
   return editAuthorizedMembers(context, user, args);

--- a/opencti-platform/opencti-graphql/src/modules/workflow/registry/workflow-actions.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/registry/workflow-actions.ts
@@ -92,13 +92,14 @@ export const ActionRegistry: Record<string, ActionFunction> = {
     const resolvedMembers = resolveDynamicAuthorizedMembers(entity, rawMembers);
 
     if (entity?.entity_type === 'DraftWorkspace') {
-      await draftWorkspaceEditAuthorizedMembers(context, user, entity.id, resolvedMembers);
+      await draftWorkspaceEditAuthorizedMembers(context, user, entity.id, resolvedMembers, { skipAdminValidation: true });
     } else {
       await editAuthorizedMembers(context, user, {
         entityId: entity.id ?? entity.internal_id,
         input: resolvedMembers,
         requiredCapabilities: [KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS],
         entityType: entity.entity_type,
+        skipAdminValidation: true,
       });
     }
   },

--- a/opencti-platform/opencti-graphql/src/utils/authorizedMembers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/authorizedMembers.ts
@@ -159,9 +159,10 @@ export const buildRestrictedMembers = async (
     input: MemberAccessInput[] | undefined | null;
     requiredCapabilities: string[];
     entityType: string;
+    skipAdminValidation?: boolean;
   },
 ): Promise<null | AuthorizedMember[]> => {
-  const { entityId, input, requiredCapabilities, entityType } = args;
+  const { entityId, input, requiredCapabilities, entityType, skipAdminValidation } = args;
 
   // Allow authorized members edition only on draft type but not for other entity types in draft
   const draftId = getDraftContext(context, user);
@@ -174,13 +175,15 @@ export const buildRestrictedMembers = async (
     if (filteredInput.some(({ id }) => id === MEMBER_ACCESS_ALL) && settings.platform_organization && !isInternalObject(entityType)) {
       throw FunctionalError('You can\'t grant access to everyone in an organization sharing context');
     }
-    const hasValidAdmin = await containsValidAdmin(
-      context,
-      filteredInput,
-      requiredCapabilities,
-    );
-    if (!hasValidAdmin) {
-      throw FunctionalError('It should have at least one valid member with admin access');
+    if (!skipAdminValidation) {
+      const hasValidAdmin = await containsValidAdmin(
+        context,
+        filteredInput,
+        requiredCapabilities,
+      );
+      if (!hasValidAdmin) {
+        throw FunctionalError('It should have at least one valid member with admin access');
+      }
     }
     restricted_members = filteredInput.map(({ id, access_right, groups_restriction_ids }) => {
       const member = { id, access_right, groups_restriction_ids };
@@ -202,15 +205,17 @@ export const editAuthorizedMembers = async (
     requiredCapabilities: string[];
     entityType: string;
     busTopicKey?: keyof typeof BUS_TOPICS; // TODO improve busTopicKey types
+    skipAdminValidation?: boolean;
   },
 ) => {
-  const { entityId, input, requiredCapabilities, entityType, busTopicKey } = args;
+  const { entityId, input, requiredCapabilities, entityType, busTopicKey, skipAdminValidation } = args;
 
   const restricted_members = await buildRestrictedMembers(context, user, {
     entityId,
     input,
     requiredCapabilities,
     entityType,
+    skipAdminValidation,
   });
 
   const patch = { restricted_members };

--- a/opencti-platform/opencti-graphql/src/utils/authorizedMembers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/authorizedMembers.ts
@@ -24,6 +24,7 @@ import type { AuthContext, AuthUser } from '../types/user';
 import {
   AccessOperation,
   type AuthorizedMember,
+  BYPASS,
   isUserHasCapabilities,
   isValidMemberAccessRight,
   MEMBER_ACCESS_ALL,
@@ -175,7 +176,11 @@ export const buildRestrictedMembers = async (
     if (filteredInput.some(({ id }) => id === MEMBER_ACCESS_ALL) && settings.platform_organization && !isInternalObject(entityType)) {
       throw FunctionalError('You can\'t grant access to everyone in an organization sharing context');
     }
-    if (!skipAdminValidation) {
+    // Skip the admin presence check only when explicitly requested by a privileged
+    // system actor (one with BYPASS capability, e.g. WORKFLOW_MANAGER_USER).
+    // This prevents accidental misuse of the flag by regular callers.
+    const bypassAllowed = skipAdminValidation && isUserHasCapabilities(user, [BYPASS]);
+    if (!bypassAllowed) {
       const hasValidAdmin = await containsValidAdmin(
         context,
         filteredInput,

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-actions-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-actions-test.ts
@@ -556,3 +556,74 @@ describe('ActionRegistry.validateDraft', () => {
     await expect(freshRegistry.validateDraft(ctx)).rejects.toThrow('Validation failed');
   });
 });
+
+// ---------------------------------------------------------------------------
+// updateAuthorizedMembers — skipAdminValidation bypass
+// ---------------------------------------------------------------------------
+
+describe('ActionRegistry.updateAuthorizedMembers (skipAdminValidation)', () => {
+  let freshRegistry: Record<string, (ctx: any, params?: any) => Promise<void>>;
+  let mockEditAuthorizedMembers: ReturnType<typeof vi.fn>;
+  let mockDraftWorkspaceEditAuthorizedMembers: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockEditAuthorizedMembers = vi.fn().mockResolvedValue(undefined);
+    mockDraftWorkspaceEditAuthorizedMembers = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('../../../src/utils/authorizedMembers', () => ({ editAuthorizedMembers: mockEditAuthorizedMembers }));
+    vi.doMock('../../../src/modules/draftWorkspace/draftWorkspace-domain', () => ({
+      validateDraftWorkspace: vi.fn(),
+      draftWorkspaceEditAuthorizedMembers: mockDraftWorkspaceEditAuthorizedMembers,
+    }));
+    vi.doMock('../../../src/config/conf', async () => {
+      const actual = await import('../../../src/config/conf');
+      return { ...actual, logApp: { info: vi.fn(), error: vi.fn(), warn: vi.fn() } };
+    });
+    vi.doMock('../../../src/schema/identifier', () => ({ generateInternalId: vi.fn() }));
+    vi.doMock('../../../src/utils/access', () => ({ KNOWLEDGE_KNUPDATE_KNMANAGEAUTHMEMBERS: 'KNMANAGEAUTHMEMBERS' }));
+    vi.doMock('../../../src/schema/stixRefRelationship', () => ({
+      RELATION_CREATED_BY: 'created-by',
+      RELATION_OBJECT_ASSIGNEE: 'object-assignee',
+      RELATION_OBJECT_PARTICIPANT: 'object-participant',
+    }));
+    const mod = await import('../../../src/modules/workflow/registry/workflow-actions');
+    freshRegistry = mod.ActionRegistry as any;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('passes skipAdminValidation: true when members list has no admin (non-draft entity)', async () => {
+    const ctx = {
+      user: { id: 'user-id' },
+      entity: { id: 'entity-id', internal_id: 'entity-id', entity_type: 'Incident' },
+      context: {},
+    };
+    await freshRegistry.updateAuthorizedMembers(ctx, {
+      authorized_members: [{ id: 'some-user', access_right: 'view' }],
+    });
+    expect(mockEditAuthorizedMembers).toHaveBeenCalledWith(
+      ctx.context, ctx.user,
+      expect.objectContaining({ skipAdminValidation: true }),
+    );
+  });
+
+  it('passes skipAdminValidation: true when members list has no admin (DraftWorkspace)', async () => {
+    const ctx = {
+      user: { id: 'user-id' },
+      entity: { id: 'draft-id', internal_id: 'draft-id', entity_type: 'DraftWorkspace' },
+      context: {},
+    };
+    await freshRegistry.updateAuthorizedMembers(ctx, {
+      authorized_members: [{ id: 'some-user', access_right: 'view' }],
+    });
+    expect(mockDraftWorkspaceEditAuthorizedMembers).toHaveBeenCalledWith(
+      ctx.context, ctx.user,
+      'draft-id',
+      expect.any(Array),
+      { skipAdminValidation: true },
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* allow to configure workflow transitions with authorized members configuration that doesn't contain any admin user

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16919

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

1. Go to Settings → Customization → Draft and add a workflow transition with an Update authorized members action. Configure the action's member list with no admin — for example, add a user with no bypass and remove all other accesses.

2. Publish the workflow.

3. Create a Draft and trigger that transition from its workflow panel.

**Before this fix:** the transition fails with "It should have at least one valid member with admin access"
**After this fix:** the transition succeeds and the draft's authorized members are updated as configured.

4. open the draft with your admin user, open its authorized members settings and try to save a configuration with no admin member (your not-bypass user with just can edit/can view for example). It should still be rejected with "It should have at least one valid member with admin access", confirming the bypass is scoped to workflow engine execution only.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
