### PR TITLE
feat(workflows): prevent workflow used status removal (#16811)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/domain/workflow-domain.ts
@@ -7,7 +7,7 @@ import { loadAssignees, loadParticipants } from '../../../database/members';
 import { fullEntitiesList, internalLoadById, storeLoadById } from '../../../database/middleware-loader';
 import { resolveUserById } from '../../../domain/user';
 import { createListTask } from '../../../domain/backgroundTask-common';
-import { type EditInput, FilterMode } from '../../../generated/graphql';
+import { type EditInput, FilterMode, FilterOperator } from '../../../generated/graphql';
 import { RELATION_HAS_WORKFLOW } from '../../../schema/internalRelationship';
 import { addWorkflowPublishCount } from '../../../manager/telemetryManager';
 import type { BasicStoreEntity } from '../../../types/store';
@@ -34,7 +34,7 @@ import {
   type WorkflowSerializedTransition,
   type WorkflowValidationError,
 } from '../types/workflow-types';
-import { validateWorkflowDefinitionData } from '../workflow-validation';
+import { validateWorkflowDefinitionData, extractAllStatesFromDefinition } from '../workflow-validation';
 import { checkEnterpriseEdition } from '../../../enterprise-edition/ee';
 
 // EE-only action types – conditions on transitions and onEnter/onExit state actions.
@@ -569,6 +569,64 @@ export const publishWorkflowDefinition = async (
       entityType,
       errorCount: draftVersion.validation_errors.length,
     });
+  }
+
+  // Re-check at publish time: ensure the draft does not remove non-ending states that still have
+  // active workflow instances. The validation_errors on the draft were computed at save time and
+  // may be stale (instances may have moved into those states since the draft was saved).
+  if (workflowDefinitionEntity.published_version) {
+    let oldDef: any;
+    let newDef: any;
+    try {
+      const rawOld = workflowDefinitionEntity.published_version.content;
+      oldDef = typeof rawOld === 'string' ? JSON.parse(rawOld) : rawOld;
+      const rawNew = draftVersion.content;
+      newDef = typeof rawNew === 'string' ? JSON.parse(rawNew) : rawNew;
+    } catch (_) {
+      oldDef = null;
+      newDef = null;
+    }
+
+    if (oldDef && newDef) {
+      const oldStates = extractAllStatesFromDefinition(oldDef);
+      const newStates = extractAllStatesFromDefinition(newDef);
+      const removedStates = [...oldStates].filter((s) => !newStates.has(s));
+
+      if (removedStates.length > 0) {
+        // Ending states (no outgoing transitions) are safe to remove even with active instances.
+        const statesWithOutgoingTransitions = new Set<string>();
+        for (const transition of (oldDef.transitions ?? [])) {
+          const fromStates = Array.isArray(transition.from) ? transition.from : [transition.from];
+          for (const s of fromStates) {
+            if (s && s !== '*') statesWithOutgoingTransitions.add(s);
+          }
+        }
+        const nonEndingRemovedStates = removedStates.filter((s) => statesWithOutgoingTransitions.has(s));
+
+        if (nonEndingRemovedStates.length > 0) {
+          // Note: 'workflow_id' is a reserved special filter key (WORKFLOW_FILTER) in OpenCTI that maps to
+          // entity workflow status (x_opencti_workflow_id). We cannot use it as a raw ES filter key.
+          // Instead, we filter by currentState in ES and post-filter by workflow_id.
+          const instancesInRemovedStates = await fullEntitiesList<any>(executionContext, executionUser, [ENTITY_TYPE_WORKFLOW_INSTANCE], {
+            filters: {
+              mode: FilterMode.And,
+              filters: [
+                { key: ['currentState'], values: nonEndingRemovedStates, operator: FilterOperator.Eq, mode: FilterMode.Or },
+              ],
+              filterGroups: [],
+            },
+          });
+          const conflictingInstances = instancesInRemovedStates.filter((inst: any) => inst.workflow_id === workflowDefinitionEntity.id);
+
+          if (conflictingInstances.length > 0) {
+            throw FunctionalError(
+              'Cannot publish workflow: the following statuses are in use and cannot be removed. Move all items out of those statuses first.',
+              { removedStates: nonEndingRemovedStates, entityType },
+            );
+          }
+        }
+      }
+    }
   }
 
   // Validate consistency BEFORE publishing

--- a/opencti-platform/opencti-graphql/src/modules/workflow/workflow-validation.ts
+++ b/opencti-platform/opencti-graphql/src/modules/workflow/workflow-validation.ts
@@ -62,7 +62,7 @@ export const workflowDefinitionSchema = z.object({
   transitions: z.array(workflowSerializedTransitionSchema),
 });
 
-const extractAllStatesFromDefinition = (definition: z.infer<typeof workflowDefinitionSchema>): Set<string> => {
+export const extractAllStatesFromDefinition = (definition: z.infer<typeof workflowDefinitionSchema>): Set<string> => {
   const stateIds = new Set<string>();
 
   if (definition.initialState !== '*') {
@@ -324,26 +324,39 @@ export const validateWorkflowDefinitionData = async (
         const newStates = extractAllStatesFromDefinition(validationResult.data);
         const removedStates = [...oldStates].filter((s) => !newStates.has(s));
         if (removedStates.length > 0) {
-          // Note: 'workflow_id' is a reserved special filter key (WORKFLOW_FILTER) in OpenCTI that maps to
-          // entity workflow status (x_opencti_workflow_id). We cannot use it as a raw ES filter key.
-          // Instead, we filter by currentState in ES and post-filter by workflow_id.
-          const instancesInRemovedStates = await fullEntitiesList<any>(context, user, [ENTITY_TYPE_WORKFLOW_INSTANCE], {
-            filters: {
-              mode: FilterMode.And,
-              filters: [
-                { key: ['currentState'], values: removedStates, operator: FilterOperator.Eq, mode: FilterMode.Or },
-              ],
-              filterGroups: [],
-            },
-          });
-          const conflictingInstances = instancesInRemovedStates.filter((inst: any) => inst.workflow_id === existingWorkflowId);
+          // Ending states (no outgoing transitions in the old workflow) are safe to remove even when
+          // instances are in them — those instances are terminal and cannot progress anyway.
+          const statesWithOutgoingTransitions = new Set<string>();
+          for (const transition of oldValidation.data.transitions) {
+            const fromStates = Array.isArray(transition.from) ? transition.from : [transition.from];
+            for (const s of fromStates) {
+              if (s && s !== '*') statesWithOutgoingTransitions.add(s);
+            }
+          }
+          const nonEndingRemovedStates = removedStates.filter((s) => statesWithOutgoingTransitions.has(s));
 
-          if (conflictingInstances.length > 0) {
-            errors.push({
-              type: 'STATE_IN_USE',
-              message: `Cannot remove states ${removedStates.join(', ')} that are currently in use by workflow instances`,
-              path: conflictingInstances.map((i: any) => ({ id: i.id, entity_type: ENTITY_TYPE_WORKFLOW_INSTANCE })),
+          if (nonEndingRemovedStates.length > 0) {
+            // Note: 'workflow_id' is a reserved special filter key (WORKFLOW_FILTER) in OpenCTI that maps to
+            // entity workflow status (x_opencti_workflow_id). We cannot use it as a raw ES filter key.
+            // Instead, we filter by currentState in ES and post-filter by workflow_id.
+            const instancesInRemovedStates = await fullEntitiesList<any>(context, user, [ENTITY_TYPE_WORKFLOW_INSTANCE], {
+              filters: {
+                mode: FilterMode.And,
+                filters: [
+                  { key: ['currentState'], values: nonEndingRemovedStates, operator: FilterOperator.Eq, mode: FilterMode.Or },
+                ],
+                filterGroups: [],
+              },
             });
+            const conflictingInstances = instancesInRemovedStates.filter((inst: any) => inst.workflow_id === existingWorkflowId);
+
+            if (conflictingInstances.length > 0) {
+              errors.push({
+                type: 'STATE_IN_USE',
+                message: `Cannot remove states ${nonEndingRemovedStates.join(', ')} that are currently in use by workflow instances`,
+                path: conflictingInstances.map((i: any) => ({ id: i.id, entity_type: ENTITY_TYPE_WORKFLOW_INSTANCE })),
+              });
+            }
           }
         }
       }

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-domain-test.ts
@@ -48,9 +48,13 @@ vi.mock('../../../src/utils/draftContext', () => ({
   bypassDraftContext: vi.fn((context) => context),
 }));
 
-vi.mock('../../../src/modules/workflow/workflow-validation', () => ({
-  validateWorkflowDefinitionData: vi.fn().mockResolvedValue({}),
-}));
+vi.mock('../../../src/modules/workflow/workflow-validation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/modules/workflow/workflow-validation')>();
+  return {
+    ...actual,
+    validateWorkflowDefinitionData: vi.fn().mockResolvedValue([]),
+  };
+});
 
 vi.mock('../../../src/modules/workflow/engine/workflow-factory', () => ({
   WorkflowFactory: {
@@ -497,6 +501,109 @@ describe('Workflow Domain', () => {
         { key: 'draft_version', value: [] },
       ],
     );
+  });
+
+  it('should throw when publishing removes a non-ending state currently in use', async () => {
+    // Published version: state-a → state-b → state-c (state-b has outgoing transition → non-ending)
+    const publishedVersion = {
+      id: 'pub-1',
+      timestamp: '2024-01-01T00:00:00Z',
+      createdBy: 'user-1',
+      content: JSON.stringify({
+        initialState: 'state-a',
+        states: [{ statusId: 'state-a' }, { statusId: 'state-b' }, { statusId: 'state-c' }],
+        transitions: [
+          { from: 'state-a', to: 'state-b', event: 'proceed' },
+          { from: 'state-b', to: 'state-c', event: 'complete' },
+        ],
+      }),
+      validation_errors: [],
+    };
+    // Draft version: removes state-b (jumps state-a → state-c directly)
+    const draftVersion = {
+      id: 'draft-1',
+      timestamp: '2024-01-02T00:00:00Z',
+      createdBy: 'user-1',
+      content: JSON.stringify({
+        initialState: 'state-a',
+        states: [{ statusId: 'state-a' }, { statusId: 'state-c' }],
+        transitions: [
+          { from: 'state-a', to: 'state-c', event: 'skip' },
+        ],
+      }),
+      validation_errors: [],
+    };
+
+    (findByType as any).mockResolvedValue({ id: 'entity-setting-id', workflow_id: 'workflow-id' });
+    (storeLoadById as any).mockResolvedValue({
+      id: 'workflow-id',
+      name: 'Test Workflow',
+      published_version: publishedVersion,
+      draft_version: draftVersion,
+      all_versions: [draftVersion, publishedVersion],
+    });
+
+    // An instance is currently in state-b (the removed non-ending state)
+    (fullEntitiesList as any).mockResolvedValue([
+      { id: 'instance-1', workflow_id: 'workflow-id', currentState: 'state-b' },
+    ]);
+
+    await expect(publishWorkflowDefinition(mockContext, mockUser, 'Incident'))
+      .rejects.toThrow('Cannot publish workflow: the following statuses are in use and cannot be removed');
+  });
+
+  it('should allow publishing when removed state is an ending state', async () => {
+    // Published version: state-a → state-b (state-b is terminal, no outgoing transitions)
+    const publishedVersion = {
+      id: 'pub-1',
+      timestamp: '2024-01-01T00:00:00Z',
+      createdBy: 'user-1',
+      content: JSON.stringify({
+        initialState: 'state-a',
+        states: [{ statusId: 'state-a' }, { statusId: 'state-b' }],
+        transitions: [
+          { from: 'state-a', to: 'state-b', event: 'finish' },
+        ],
+      }),
+      validation_errors: [],
+    };
+    // Draft version: removes state-b entirely
+    const draftVersion = {
+      id: 'draft-1',
+      timestamp: '2024-01-02T00:00:00Z',
+      createdBy: 'user-1',
+      content: JSON.stringify({
+        initialState: 'state-a',
+        states: [{ statusId: 'state-a' }],
+        transitions: [],
+      }),
+      validation_errors: [],
+    };
+
+    (findByType as any).mockResolvedValue({ id: 'entity-setting-id', workflow_id: 'workflow-id' });
+    (storeLoadById as any)
+      .mockResolvedValueOnce({
+        id: 'workflow-id',
+        name: 'Test Workflow',
+        published_version: publishedVersion,
+        draft_version: draftVersion,
+        all_versions: [draftVersion, publishedVersion],
+      })
+      .mockResolvedValueOnce({
+        id: 'workflow-id',
+        name: 'Test Workflow',
+        published_version: draftVersion,
+        draft_version: null,
+        all_versions: [draftVersion, publishedVersion],
+      });
+
+    // An instance is in the ending state state-b, but that should not block publication
+    (fullEntitiesList as any).mockResolvedValue([
+      { id: 'instance-1', workflow_id: 'workflow-id', currentState: 'state-b' },
+    ]);
+
+    const result = await publishWorkflowDefinition(mockContext, mockUser, 'Incident');
+    expect(result.published).toBe(true);
   });
 
   it('should update workflow with different draft and published versions', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-validation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/workflow-validation-test.ts
@@ -442,12 +442,12 @@ describe('Workflow Validation', () => {
     expect(errors).toEqual([]);
   });
 
-  it('should return error for state in use when removing states', async () => {
+  it('should return error for state in use when removing a non-ending state', async () => {
     // Reset mocks for this test
     vi.mocked(middlewareLoader.storeLoadById).mockReset();
     vi.mocked(middlewareLoader.fullEntitiesList).mockReset();
 
-    // Mock existing workflow with states
+    // Old workflow: state-a → state-b → state-c. state-b has an outgoing transition → non-ending.
     vi.mocked(middlewareLoader.storeLoadById).mockResolvedValue({
       id: 'existing-workflow',
       draft_version: {
@@ -457,9 +457,11 @@ describe('Workflow Validation', () => {
           states: [
             { statusId: 'state-a' },
             { statusId: 'state-b' },
+            { statusId: 'state-c' },
           ],
           transitions: [
             { from: 'state-a', to: 'state-b', event: 'proceed' },
+            { from: 'state-b', to: 'state-c', event: 'complete' },
           ],
         }),
         validation_errors: [],
@@ -483,10 +485,11 @@ describe('Workflow Validation', () => {
       },
     );
 
+    // New workflow: remove state-b (non-ending state currently in use)
     const updated = {
       initialState: 'state-a',
-      states: [{ statusId: 'state-a' }], // Removing state-b
-      transitions: [],
+      states: [{ statusId: 'state-a' }, { statusId: 'state-c' }],
+      transitions: [{ from: 'state-a', to: 'state-c', event: 'skip' }],
     };
 
     const errors = await validateWorkflowDefinitionData(
@@ -499,6 +502,60 @@ describe('Workflow Validation', () => {
 
     expect(errors.length).toBeGreaterThan(0);
     expect(errors.some((e) => e.type === 'STATE_IN_USE')).toBe(true);
+  });
+
+  it('should allow removing an ending state even if instances are in it', async () => {
+    // Reset mocks for this test
+    vi.mocked(middlewareLoader.storeLoadById).mockReset();
+    vi.mocked(middlewareLoader.fullEntitiesList).mockReset();
+
+    // Old workflow: state-a → state-b. state-b has NO outgoing transitions → ending/terminal state.
+    vi.mocked(middlewareLoader.storeLoadById).mockResolvedValue({
+      id: 'existing-workflow',
+      draft_version: {
+        id: 'v1', timestamp: '', createdBy: '',
+        content: JSON.stringify({
+          initialState: 'state-a',
+          states: [
+            { statusId: 'state-a' },
+            { statusId: 'state-b' },
+          ],
+          transitions: [
+            { from: 'state-a', to: 'state-b', event: 'finish' },
+          ],
+        }),
+        validation_errors: [],
+      },
+    } as any);
+
+    vi.mocked(middlewareLoader.fullEntitiesList).mockImplementation(
+      async (_context: any, _user: any, entityTypes: any): Promise<any> => {
+        if (entityTypes.includes('WorkflowDefinition')) return [];
+        // There IS an instance stuck in the ending state
+        if (entityTypes.includes('WorkflowInstance')) {
+          return [{ id: 'instance-1', workflow_id: 'existing-workflow', currentState: 'state-b' }];
+        }
+        return [];
+      },
+    );
+
+    // New workflow: remove state-b (ending state)
+    const updated = {
+      initialState: 'state-a',
+      states: [{ statusId: 'state-a' }],
+      transitions: [],
+    };
+
+    const errors = await validateWorkflowDefinitionData(
+      mockContext,
+      mockUser,
+      JSON.stringify(updated),
+      'Incident',
+      'existing-workflow',
+    );
+
+    // Ending states can be removed even when instances are in them
+    expect(errors.some((e) => e.type === 'STATE_IN_USE')).toBe(false);
   });
 
   it('should allow removing states not in use', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* prevent submitting a workflow definition that removes a non-ending status that is currently used by an entity. Non-ending means a status that can transition to other statuses → removing terminal/ending states should be allowed.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16811

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Scenario 1 — Publication is blocked when a non-ending state is in use

1. Go to **Settings → Customization ** for the Draft entity type.
2. Create and publish a workflow: `New → In Review → Validated`. (you will need to add the validateDraft action to the second transition)
3. Create a draft, open it and make it progress to the **In Review** status.
4. Edit the workflow draft: remove `In Review` (connect directly from initial state to `Validated`).
5. **Expected**: publication is rejected with an error: *"Cannot publish workflow: the following statuses are in use and cannot be removed"*.
6. Move the draft out of `In Review` to another status.
7. Try to **Publish** again.
8. **Expected**: publication succeeds.

---

### Scenario 2 — Publication is allowed when only a terminal (ending) state is removed

1. Use the workflow: `New → In Review → Validated` (and publish it). `Validated` has no outgoing transitions — it is a terminal state.
2. Move a draft to **Validated**.
3. Edit the workflow draft: remove the `Validated` state, making `In Review` the new terminal state.
4. **Publish** the workflow draft.
5. **Expected**: publication succeeds — the draft stuck in `Validated` does not block publication since it was already in a terminal state.

---

### Scenario 3 — Stale draft does not bypass the publish-time guard

1. With the workflow `New → In Review → Validated` published, draft a version that removes `In Review` (edit the workflow without clicking the publish button, it's auto-saved).
2. Move a draft into `In Review`.
4. **Publish** the workflow draft.
5. **Expected**: publication is rejected even though the draft was saved without errors — the guard re-checks at publish time.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
