### PR TITLE
fix(decay-rules): change decay excluded indicator creation (#13752)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/indicator/indicator-domain.ts
@@ -52,7 +52,7 @@ import {
   checkDecayRules,
 } from '../decayRule/decayRule-domain';
 import { stixDomainObjectEditField } from '../../domain/stixDomainObject';
-import { checkScore, prepareDate, utcDate } from '../../utils/format';
+import { checkScore, prepareDate, UNTIL_END_STR, utcDate } from '../../utils/format';
 import { checkObservableValue, isCacheEmpty } from '../../database/exclusionListCache';
 import { stixHashesToInput } from '../../schema/fieldDataAdapter';
 import { REVOKED, VALID_FROM, VALID_UNTIL, X_DETECTION, X_SCORE } from '../../schema/identifier';
@@ -309,7 +309,9 @@ export const addIndicator = async (context: AuthContext, user: AuthUser, indicat
 
   if (isDecayActivated && exclusionRule) {
     finalIndicatorToCreate = {
-      ...indicatorToCreate,
+      valid_until: UNTIL_END_STR,
+      ...resolvedIndicator,
+      valid_from: validFrom.toISOString(),
       decay_exclusion_applied_rule: {
         decay_exclusion_id: exclusionRule.id,
         decay_exclusion_name: exclusionRule.name,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request makes a targeted adjustment to the indicator creation logic, specifically when a decay rule exclusion is applied. The main change ensures that the `valid_until` field is set to a special constant value and updates the order and source of certain indicator properties for consistency.

Key changes:

**Indicator creation logic:**
* When a decay rule exclusion is applied, the `valid_until` field is now explicitly set to `UNTIL_END_STR`, and the indicator's properties are merged from `resolvedIndicator` instead of the previous object. Additionally, `valid_from` is set using `toISOString()` for consistency.

**Imports update:**
* The `UNTIL_END_STR` constant is imported from `../../utils/format` to support the new logic for `valid_until`.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #13752

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
