### PR TITLE
fix(client-python): run _data_handler in thread pool and add /health endpoint (#16928)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -814,7 +814,7 @@ class ListenQueue(threading.Thread):
                 content={"error": "Invalid JSON payload"},
             )
         try:
-            self._data_handler(data)
+            await asyncio.to_thread(self._data_handler, data)
         except Exception as e:
             self.helper.connector_logger.error(
                 "Error processing message", {"cause": str(e)}
@@ -894,6 +894,14 @@ class ListenQueue(threading.Thread):
                     time.sleep(10)
         elif self.listen_protocol == "API":
             self.helper.connector_logger.info("Starting Listen HTTP thread")
+
+            # Health endpoint for load balancer health checks.
+            # Registered separately from the callback route so it responds
+            # even while _data_handler is processing in a background thread.
+            @app.get("/health")
+            async def _health():
+                return JSONResponse(content={"status": "ok"}, status_code=200)
+
             app.add_api_route(
                 self.listen_protocol_api_path,
                 self._http_process_callback,

--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -64,6 +64,15 @@ FALSY: List[str] = ["no", "false", "False"]
 app = FastAPI()
 
 
+# Health endpoint for load balancer / orchestrator health checks. Registered once
+# at module import (not inside ListenQueue.run()) so it is defined exactly once
+# regardless of how many times a listener is started. It stays responsive even
+# while a callback is processing, because _data_handler runs off the event loop.
+@app.get("/health")
+async def _health() -> JSONResponse:
+    return JSONResponse(content={"status": "ok"}, status_code=200)
+
+
 def killProgramHook(etype, value, tb) -> None:
     """Exception hook to terminate the program on unhandled exceptions.
 
@@ -532,6 +541,9 @@ class ListenQueue(threading.Thread):
         self.queue_name = connector_config["listen"]
         self.exit_event = threading.Event()
         self.thread = None
+        # Serializes API-listen callback processing (see _http_process_callback).
+        # Created lazily inside the running event loop.
+        self._callback_lock = None
 
     # noinspection PyUnusedLocal
     def _process_message(self, channel, method, properties, body) -> None:
@@ -814,7 +826,14 @@ class ListenQueue(threading.Thread):
                 content={"error": "Invalid JSON payload"},
             )
         try:
-            await asyncio.to_thread(self._data_handler, data)
+            # Serialize callback processing: _data_handler mutates shared connector
+            # state (work_id, draft/playbook context), so at most one may run at a
+            # time. It still runs in a worker thread so the event loop stays free to
+            # answer /health and accept (not concurrently execute) further callbacks.
+            if self._callback_lock is None:
+                self._callback_lock = asyncio.Lock()
+            async with self._callback_lock:
+                await asyncio.to_thread(self._data_handler, data)
         except Exception as e:
             self.helper.connector_logger.error(
                 "Error processing message", {"cause": str(e)}
@@ -894,14 +913,6 @@ class ListenQueue(threading.Thread):
                     time.sleep(10)
         elif self.listen_protocol == "API":
             self.helper.connector_logger.info("Starting Listen HTTP thread")
-
-            # Health endpoint for load balancer health checks.
-            # Registered separately from the callback route so it responds
-            # even while _data_handler is processing in a background thread.
-            @app.get("/health")
-            async def _health():
-                return JSONResponse(content={"status": "ok"}, status_code=200)
-
             app.add_api_route(
                 self.listen_protocol_api_path,
                 self._http_process_callback,

--- a/client-python/tests/01-unit/connector_helper/test_api_listen_protocol.py
+++ b/client-python/tests/01-unit/connector_helper/test_api_listen_protocol.py
@@ -59,9 +59,7 @@ class TestApiListenProtocol(IsolatedAsyncioTestCase):
     async def test_health_route_registered_once(self):
         # Registered at module import; must appear exactly once even though
         # ListenQueue.run() may be entered multiple times in a process.
-        health_routes = [
-            r for r in app.routes if getattr(r, "path", None) == "/health"
-        ]
+        health_routes = [r for r in app.routes if getattr(r, "path", None) == "/health"]
         self.assertEqual(len(health_routes), 1)
 
     async def test_callbacks_are_serialized(self):

--- a/client-python/tests/01-unit/connector_helper/test_api_listen_protocol.py
+++ b/client-python/tests/01-unit/connector_helper/test_api_listen_protocol.py
@@ -1,0 +1,124 @@
+import asyncio
+import json
+import threading
+import time
+from unittest import IsolatedAsyncioTestCase
+
+from pycti.connector.opencti_connector_helper import ListenQueue, _health, app
+
+
+class DummyLogger:
+    def info(self, message, data=None):
+        pass
+
+    def debug(self, message, data=None):
+        pass
+
+    def warning(self, message, data=None):
+        pass
+
+    def error(self, message, data=None):
+        pass
+
+
+class DummyHelper:
+    def __init__(self):
+        self.connector_logger = DummyLogger()
+
+
+class FakeRequest:
+    """Minimal stand-in for a FastAPI Request for the API listen callback."""
+
+    def __init__(self, payload, token="valid-token"):
+        self.headers = {"Authorization": f"Bearer {token}"}
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+def _make_listen_queue(data_handler):
+    """Build a minimal ListenQueue without running the heavy __init__.
+
+    Only the attributes used by _http_process_callback are set.
+    """
+    lq = ListenQueue.__new__(ListenQueue)
+    lq.helper = DummyHelper()
+    lq._callback_lock = None
+    lq.is_token_valid = lambda token: True
+    lq._data_handler = data_handler
+    return lq
+
+
+class TestApiListenProtocol(IsolatedAsyncioTestCase):
+    async def test_health_endpoint_returns_200(self):
+        response = await _health()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.body), {"status": "ok"})
+
+    async def test_health_route_registered_once(self):
+        # Registered at module import; must appear exactly once even though
+        # ListenQueue.run() may be entered multiple times in a process.
+        health_routes = [
+            r for r in app.routes if getattr(r, "path", None) == "/health"
+        ]
+        self.assertEqual(len(health_routes), 1)
+
+    async def test_callbacks_are_serialized(self):
+        """Concurrent POST callbacks must not run _data_handler concurrently.
+
+        _data_handler mutates shared connector state, so the async lock must
+        serialize it even though it now runs in a worker thread.
+        """
+        state = {"current": 0, "max": 0}
+        counter_lock = threading.Lock()
+
+        def data_handler(_data):
+            with counter_lock:
+                state["current"] += 1
+                state["max"] = max(state["max"], state["current"])
+            time.sleep(0.05)
+            with counter_lock:
+                state["current"] -= 1
+
+        lq = _make_listen_queue(data_handler)
+        responses = await asyncio.gather(
+            lq._http_process_callback(FakeRequest({"a": 1})),
+            lq._http_process_callback(FakeRequest({"b": 2})),
+            lq._http_process_callback(FakeRequest({"c": 3})),
+        )
+        self.assertEqual(state["max"], 1)
+        self.assertTrue(all(r.status_code == 202 for r in responses))
+
+    async def test_event_loop_not_blocked_during_processing(self):
+        """A long _data_handler must not block the event loop.
+
+        A concurrent lightweight coroutine (standing in for /health) should
+        complete while _data_handler is still processing in a worker thread.
+        """
+        order = []
+
+        def slow_handler(_data):
+            time.sleep(0.2)
+            order.append("handler_done")
+
+        lq = _make_listen_queue(slow_handler)
+
+        async def quick_task():
+            await asyncio.sleep(0.05)
+            order.append("quick_done")
+
+        await asyncio.gather(
+            lq._http_process_callback(FakeRequest({"x": 1})),
+            quick_task(),
+        )
+        self.assertEqual(order[0], "quick_done")
+
+    async def test_invalid_token_returns_401_without_running_handler(self):
+        def data_handler(_data):
+            raise AssertionError("handler must not run for an invalid token")
+
+        lq = _make_listen_queue(data_handler)
+        lq.is_token_valid = lambda token: False
+        response = await lq._http_process_callback(FakeRequest({"a": 1}))
+        self.assertEqual(response.status_code, 401)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
Problem: 
`_http_process_callback` calls `_data_handler()` synchronously inside an async FastAPI handler, blocking the entire Uvicorn event loop. During heavy STIX bundle processing (e.g. large imports), the server cannot respond to health checks, new requests, or graceful shutdown signals. Load balancers (ALB, NLB, k8s) mark the target unhealthy and the container orchestrator kills it mid-work.
Deployment Context: 
We run the OpenCTi platform and its connectors on AWS ECS (Fargate). Each internal enrichment connectors using CONNECTOR_LISTEN_PROTOCOL=api is fronte dby an Application Load Balancer, whose target group performs periodic HTTP health checks against the connector's listener. When `__data_handlers()` blocks the event loop while processing a large bundle, the connector stops answerig the ALB health check wihtin the timeout windows. The target is marekd unhealthy and ECS replaces the task. That both drops the in-flight works and under sustained load, produces a restart loop. The platform itslef (also ECS behind an ALB) exhibits the same class of problem for any long synchronous handler. 

Fix: 
1. Wrap `_data_handler()` with `asyncio.to_thread()` so it runs in the default thread pool executor, freeing the event loop for concurrent requests and health checks.
2. Add `GET /health` endpoint that returns {"status": "ok"} with 200, registered before the callback route so load balancers have a dedicated lightweight health check path.

Both changes are backwards-compatible. asyncio.to_thread() behaves identically to a synchronous call from the caller's perspective. Connectors using AMQP protocol are unaffected.

### Related issues
Fixes #16928


### How to test this PR
1. Run any internal_enrichment connecotr with connector_listen_protocol=api. 
2. Trigger enrichment with a large payload so _data_handler() runs for several seconds. 
3. While it's procesisng, hit the listener from another shell 'curl -sic http://<connector>:7070/ - the request hangs until _data_handler finishes, because the event loop is blocked. Behind a load balancer, the health check exceeds its timeout and the target is marked unhealthy. 
4. WIth this fix, `GET /health` returns {status:ok} with 200 immediately
5. Repeat the large payload enrichment. The Get helath still respond promptly, the handler now runs in a thread pool executor via asyncio.to_thread(), so the event loops stays free. 
6. Confirm the enrichment still completes and results are written back as before. 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
