### PR TITLE
feat(security-coverage): compute average score and most recent result across coverage results (#16989)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10738,6 +10738,8 @@ type Mutation {
   securityCoverageRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): SecurityCoverage
   securityCoverageResultAdd(input: SecurityCoverageResultAddInput!): SecurityCoverageResult
   securityCoverageResultDelete(id: ID!): ID
+  securityCoverageResultRelationAdd(id: ID!, input: StixRefRelationshipAddInput!): StixRefRelationship
+  securityCoverageResultRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): SecurityCoverage
   askSendOtp(input: AskSendOtpInput!): String
   verifyOtp(input: VerifyOtpInput!): VerifyOtp
   verifyMfa(input: VerifyMfaInput!): Boolean

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17369,6 +17369,8 @@ export type Mutation = {
   securityCoverageRelationDelete?: Maybe<SecurityCoverage>;
   securityCoverageResultAdd?: Maybe<SecurityCoverageResult>;
   securityCoverageResultDelete?: Maybe<Scalars['ID']['output']>;
+  securityCoverageResultRelationAdd?: Maybe<StixRefRelationship>;
+  securityCoverageResultRelationDelete?: Maybe<SecurityCoverage>;
   securityPlatformAdd?: Maybe<SecurityPlatform>;
   securityPlatformContextClean?: Maybe<SecurityPlatform>;
   securityPlatformContextPatch?: Maybe<SecurityPlatform>;
@@ -19444,6 +19446,19 @@ export type MutationSecurityCoverageResultAddArgs = {
 
 export type MutationSecurityCoverageResultDeleteArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationSecurityCoverageResultRelationAddArgs = {
+  id: Scalars['ID']['input'];
+  input: StixRefRelationshipAddInput;
+};
+
+
+export type MutationSecurityCoverageResultRelationDeleteArgs = {
+  id: Scalars['ID']['input'];
+  relationship_type: Scalars['String']['input'];
+  toId: Scalars['StixRef']['input'];
 };
 
 
@@ -48103,6 +48118,8 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   securityCoverageRelationDelete?: Resolver<Maybe<ResolversTypes['SecurityCoverage']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageRelationDeleteArgs, 'id' | 'relationship_type' | 'toId'>>;
   securityCoverageResultAdd?: Resolver<Maybe<ResolversTypes['SecurityCoverageResult']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageResultAddArgs, 'input'>>;
   securityCoverageResultDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageResultDeleteArgs, 'id'>>;
+  securityCoverageResultRelationAdd?: Resolver<Maybe<ResolversTypes['StixRefRelationship']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageResultRelationAddArgs, 'id' | 'input'>>;
+  securityCoverageResultRelationDelete?: Resolver<Maybe<ResolversTypes['SecurityCoverage']>, ParentType, ContextType, RequireFields<MutationSecurityCoverageResultRelationDeleteArgs, 'id' | 'relationship_type' | 'toId'>>;
   securityPlatformAdd?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<MutationSecurityPlatformAddArgs, 'input'>>;
   securityPlatformContextClean?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<MutationSecurityPlatformContextCleanArgs, 'id'>>;
   securityPlatformContextPatch?: Resolver<Maybe<ResolversTypes['SecurityPlatform']>, ParentType, ContextType, RequireFields<MutationSecurityPlatformContextPatchArgs, 'id' | 'input'>>;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -200,11 +200,7 @@ export const getSecurityCoverageResultProperty = async (
   property: keyof BasicStoreEntitySecurityCoverageResult,
 ) => {
   const results = await loadThroughDenormalized(context, user, securityCoverage, INPUT_RESULT_OF);
-
-  if (!results[0]) {
-    return undefined;
-  }
-
+  if (results.length !== 1) return undefined;
   return results[0][property];
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -23,8 +23,14 @@ import {
 import { ENTITY_TYPE_CONTAINER_CASE_INCIDENT } from '../case/case-incident/case-incident-types';
 import { ENTITY_TYPE_CONTAINER_GROUPING } from '../grouping/grouping-types';
 import { deleteSecurityCoverageResultsByResultOf } from './securityCoverageResult/securityCoverageResult-domain';
-import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, INPUT_RESULT_OF, type BasicStoreEntitySecurityCoverageResult } from './securityCoverageResult/securityCoverageResult-types';
+import {
+  ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  INPUT_RESULT_OF,
+  type BasicStoreEntitySecurityCoverageResult,
+  type StoreEntitySecurityCoverageResult,
+} from './securityCoverageResult/securityCoverageResult-types';
 import { loadThroughDenormalized } from '../../resolvers/stix';
+import { getAverageCoverageInformation, getMostRecentLastCoverageResult } from './securityCoverageResult/securityCoverageResult-utils';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -200,4 +206,32 @@ export const getSecurityCoverageResultProperty = async (
   }
 
   return results[0][property];
+};
+
+export const mostRecentLastCoverageResult = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverage: BasicStoreEntitySecurityCoverage,
+) => {
+  const results: StoreEntitySecurityCoverageResult[] = await loadThroughDenormalized(
+    context,
+    user,
+    securityCoverage,
+    INPUT_RESULT_OF,
+  );
+  return getMostRecentLastCoverageResult(results);
+};
+
+export const averageCoverageInformation = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverage: BasicStoreEntitySecurityCoverage,
+) => {
+  const results = await loadThroughDenormalized(
+    context,
+    user,
+    securityCoverage,
+    INPUT_RESULT_OF,
+  );
+  return getAverageCoverageInformation(results);
 };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -6,6 +6,8 @@ import {
   securityCoverageStixBundle,
   objectCovered,
   getSecurityCoverageResultProperty,
+  averageCoverageInformation,
+  mostRecentLastCoverageResult,
 } from './securityCoverage-domain';
 import {
   stixDomainObjectAddRelation,
@@ -31,11 +33,10 @@ const SecurityCoverageResolvers: Resolvers = {
     objectCovered: (securityCoverage, _, context) => objectCovered<any>(context, context.user, securityCoverage.id),
     toStixBundle: (securityCoverage, _, context) => securityCoverageStixBundle(context, context.user, securityCoverage.id),
     // security coverage result info
-    coverage_last_result: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_last_result'),
+    coverage_last_result: (securityCoverage, _, context) => mostRecentLastCoverageResult(context, context.user, securityCoverage),
     coverage_valid_from: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_from'),
     coverage_valid_to: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_to'),
-    coverage_information: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_information'),
-    external_uri: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'external_uri'),
+    coverage_information: (securityCoverage, _, context) => averageCoverageInformation(context, context.user, securityCoverage),
     coveredEntitiesDistribution: (securityCoverage, args, context) =>
       distributionRelations(context, context.user, { ...args, fromOrToId: securityCoverage[RELATION_RESULT_OF] } as any),
     stixCoreRelationshipsFromResults: (securityCoverage, args, context) => stixCoreRelationshipsPaginated(context, context.user, securityCoverage[RELATION_RESULT_OF], args),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
@@ -1,3 +1,4 @@
+import { stixDomainObjectAddRelation, stixDomainObjectDeleteRelation } from '../../../domain/stixDomainObject';
 import type { Resolvers } from '../../../generated/graphql';
 import { addSecurityCoverageResult, deleteSecurityCoverageResult, findById, findSecurityCoverageResultPaginated } from './securityCoverageResult-domain';
 
@@ -9,6 +10,8 @@ const SecurityCoverageResultResolvers: Resolvers = {
   Mutation: {
     securityCoverageResultAdd: (_, { input }, context) => addSecurityCoverageResult(context, context.user, input),
     securityCoverageResultDelete: (_, { id }, context) => deleteSecurityCoverageResult(context, context.user, id),
+    securityCoverageResultRelationAdd: (_, { id, input }, context) => stixDomainObjectAddRelation(context, context.user, id, input),
+    securityCoverageResultRelationDelete: (_, { id, toId, relationship_type }, context) => stixDomainObjectDeleteRelation(context, context.user, id, toId, relationship_type),
   },
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -19,7 +19,7 @@ export const getAverageCoverageInformation = async (results: StoreEntitySecurity
   });
   return Array.from(mapOfScores, ([coverage_name, scores]) => ({
     coverage_name,
-    coverage_score: scores.reduce((sum, num) => sum + num, 0) / scores.length,
+    coverage_score: Math.round(scores.reduce((sum, num) => sum + num, 0) / scores.length),
   }));
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -9,7 +9,6 @@ import type { StoreEntitySecurityCoverageResult } from './securityCoverageResult
 export const getAverageCoverageInformation = async (results: StoreEntitySecurityCoverageResult[]) => {
   const mapOfScores = new Map<string, number[]>();
   results.forEach(({ coverage_information }) => {
-    console.log(coverage_information);
     (coverage_information ?? []).forEach(({ coverage_name, coverage_score }) => {
       if (mapOfScores.has(coverage_name)) {
         mapOfScores.get(coverage_name)!.push(coverage_score);
@@ -18,7 +17,6 @@ export const getAverageCoverageInformation = async (results: StoreEntitySecurity
       }
     });
   });
-  console.log(mapOfScores);
   return Array.from(mapOfScores, ([coverage_name, scores]) => ({
     coverage_name,
     coverage_score: scores.reduce((sum, num) => sum + num, 0) / scores.length,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -1,0 +1,38 @@
+import type { StoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
+
+/**
+ * Compute the average coverage information of an array of securityCoverageResult.
+ *
+ * @param results Array of results to compute the average coverage.
+ * @returns Average coverage information.
+ */
+export const getAverageCoverageInformation = async (results: StoreEntitySecurityCoverageResult[]) => {
+  const mapOfScores = new Map<string, number[]>();
+  results.forEach(({ coverage_information }) => {
+    console.log(coverage_information);
+    (coverage_information ?? []).forEach(({ coverage_name, coverage_score }) => {
+      if (mapOfScores.has(coverage_name)) {
+        mapOfScores.get(coverage_name)!.push(coverage_score);
+      } else {
+        mapOfScores.set(coverage_name, [coverage_score]);
+      }
+    });
+  });
+  console.log(mapOfScores);
+  return Array.from(mapOfScores, ([coverage_name, scores]) => ({
+    coverage_name,
+    coverage_score: scores.reduce((sum, num) => sum + num, 0) / scores.length,
+  }));
+};
+
+/**
+ * Get the most recent date of "coverage_last_result" of an array of securityCoverageResult.
+ *
+ * @param results Array of results to get the most recent "coverage_last_result".
+ * @returns Most recent date.
+ */
+export const getMostRecentLastCoverageResult = async (results: StoreEntitySecurityCoverageResult[]) => {
+  const allDates = results.flatMap(({ coverage_last_result }) => coverage_last_result || []);
+  if (allDates.length === 0) return undefined;
+  return new Date(Math.max(...allDates.map((d) => new Date(d).getTime())));
+};

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
@@ -231,4 +231,6 @@ input SecurityCoverageResultAddInput {
 type Mutation {
   securityCoverageResultAdd(input: SecurityCoverageResultAddInput!): SecurityCoverageResult @auth(for: [KNOWLEDGE_KNUPDATE])
   securityCoverageResultDelete(id: ID!): ID @auth(for: [KNOWLEDGE_KNUPDATE_KNDELETE])
+  securityCoverageResultRelationAdd(id: ID!, input: StixRefRelationshipAddInput!): StixRefRelationship @auth(for: [KNOWLEDGE_KNUPDATE])
+  securityCoverageResultRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): SecurityCoverage @auth(for: [KNOWLEDGE_KNUPDATE])
 }

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
@@ -1,10 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { addSecurityCoverage, securityCoverageDelete } from '../../../src/modules/securityCoverage/securityCoverage-domain';
-import { ADMIN_USER, testContext } from '../../utils/testQuery';
-import { addReport, reportDeleteWithElements } from '../../../src/domain/report';
-import type { StoreEntityReport } from '../../../src/types/store';
-import { loadThroughDenormalized } from '../../../src/resolvers/stix';
-import { INPUT_RESULT_OF } from '../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
+import { addSecurityCoverage, securityCoverageDelete } from '../../../../src/modules/securityCoverage/securityCoverage-domain';
+import { ADMIN_USER, testContext } from '../../../utils/testQuery';
+import { addReport, reportDeleteWithElements } from '../../../../src/domain/report';
+import type { StoreEntityReport } from '../../../../src/types/store';
+import { loadThroughDenormalized } from '../../../../src/resolvers/stix';
+import { INPUT_RESULT_OF } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 
 describe('SecurityCoverage domain', () => {
   let report: StoreEntityReport;

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverageResult-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverageResult-utils-test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { getAverageCoverageInformation, getMostRecentLastCoverageResult } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils';
+import type { StoreEntitySecurityCoverageResult } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
+
+describe('Function getMostRecentLastCoverageResult()', () => {
+  it('should result undefined if array is empty', async () => {
+    expect(await getMostRecentLastCoverageResult([])).toBeUndefined();
+  });
+
+  it('should result undefined if no result contains last_result date', async () => {
+    const results = [
+      { name: 'result 1' },
+      { name: 'result 2' },
+      { name: 'result 3' },
+    ] as StoreEntitySecurityCoverageResult[];
+    expect(await getMostRecentLastCoverageResult(results)).toBeUndefined();
+  });
+
+  it('should return the only last_result date', async () => {
+    const results = [
+      { name: 'result 1' },
+      { name: 'result 2', coverage_last_result: '2026-07-07T15:16:08.223Z' },
+      { name: 'result 3' },
+    ] as StoreEntitySecurityCoverageResult[];
+    expect(await getMostRecentLastCoverageResult(results)).toEqual(new Date('2026-07-07T15:16:08.223Z'));
+  });
+
+  it('should return the most recent last_result date', async () => {
+    const results = [
+      { name: 'result 1', coverage_last_result: '2026-07-07T15:16:08.223Z' },
+      { name: 'result 2', coverage_last_result: '2026-07-06T15:16:08.223Z' },
+      { name: 'result 3', coverage_last_result: '2026-07-05T15:16:08.223Z' },
+    ] as StoreEntitySecurityCoverageResult[];
+    expect(await getMostRecentLastCoverageResult(results)).toEqual(new Date('2026-07-07T15:16:08.223Z'));
+  });
+});
+
+describe('Function getAverageCoverageInformation()', () => {
+  it('should an empty array if no results', async () => {
+    expect(await getAverageCoverageInformation([])).toEqual([]);
+  });
+
+  it('should an empty array if no coverage info', async () => {
+    const results = [
+      { name: 'result 1' },
+      { name: 'result 2' },
+      { name: 'result 3' },
+    ] as StoreEntitySecurityCoverageResult[];
+    expect(await getAverageCoverageInformation(results)).toEqual([]);
+  });
+
+  it('should return the only coverage_information', async () => {
+    const results = [
+      { name: 'result 1' },
+      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 40 }] },
+      { name: 'result 3' },
+    ] as StoreEntitySecurityCoverageResult[];
+    expect(await getAverageCoverageInformation(results))
+      .toEqual([{ coverage_name: 'vulnerability', score: 40 }]);
+  });
+
+  it('should return the average coverage_information', async () => {
+    const results = [
+      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 60 }, { coverage_name: 'detection', coverage_score: 60 }] },
+      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 40 }] },
+      { name: 'result 3' },
+    ] as StoreEntitySecurityCoverageResult[];
+    expect(await getAverageCoverageInformation(results)).toEqual([
+      { coverage_name: 'vulnerability', score: 50 },
+      { coverage_name: 'detection', score: 40 },
+    ]);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverageResult-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverageResult-utils-test.ts
@@ -56,18 +56,18 @@ describe('Function getAverageCoverageInformation()', () => {
       { name: 'result 3' },
     ] as StoreEntitySecurityCoverageResult[];
     expect(await getAverageCoverageInformation(results))
-      .toEqual([{ coverage_name: 'vulnerability', score: 40 }]);
+      .toEqual([{ coverage_name: 'vulnerability', coverage_score: 40 }]);
   });
 
   it('should return the average coverage_information', async () => {
     const results = [
-      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 60 }, { coverage_name: 'detection', coverage_score: 60 }] },
-      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 40 }] },
+      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 60 }, { coverage_name: 'detection', coverage_score: 15 }] },
+      { coverage_information: [{ coverage_name: 'vulnerability', coverage_score: 40 }, { coverage_name: 'detection', coverage_score: 20 }] },
       { name: 'result 3' },
     ] as StoreEntitySecurityCoverageResult[];
     expect(await getAverageCoverageInformation(results)).toEqual([
-      { coverage_name: 'vulnerability', score: 50 },
-      { coverage_name: 'detection', score: 40 },
+      { coverage_name: 'vulnerability', coverage_score: 50 },
+      { coverage_name: 'detection', coverage_score: 18 },
     ]);
   });
 });


### PR DESCRIPTION
### Proposed changes

* Update SecurityCoverage resolver to prepare data correctly
* Add tests

### Related issues

* closes #16989
* https://github.com/OpenCTI-Platform/opencti/issues/14716

### How to test this PR

Create a new SecurityCoverage

Create two SecurityCoverageResults linked to this SC
```graphql
mutation AddSecurityCoverageResult {
  securityCoverageResultAdd(input:  {
     resultOf: "security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f",
     external_uri: "/analyses/reports/1528eb8c-7f8e-4d1a-a9bf-4eb03207b339/overview",
     coverage_last_result: "2026-07-07T13:00:17.823Z",
     coverage_information: [{
        coverage_name: "detection",
        coverage_score: 80
     }]
  }) {
    id
  }
}
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality