### PR TITLE
fix(lts): add missing platform id in LTS license agreement dialog (#17039)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -290,6 +290,7 @@
   "Analytics": "Analytik",
   "AND": "AND",
   "and ... more": "und {count} mehr.",
+  "and provide your platform identifier.": "und geben Sie Ihre Plattformkennung an.",
   "And many more features...": "Und viele weitere Funktionen...",
   "API access": "API-Zugang",
   "API key": "API-Schlüssel",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -290,6 +290,7 @@
   "Analytics": "Analytics",
   "AND": "AND",
   "and ... more": "and {count} more.",
+  "and provide your platform identifier.": "and provide your platform identifier.",
   "And many more features...": "And many more features...",
   "API access": "API access",
   "API key": "API key",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -290,6 +290,7 @@
   "Analytics": "Análisis",
   "AND": "Y",
   "and ... more": "y {count} más.",
+  "and provide your platform identifier.": "y proporcione el identificador de su plataforma.",
   "And many more features...": "Y muchas más funciones...",
   "API access": "Acceso a la API",
   "API key": "Clave de API",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -290,6 +290,7 @@
   "Analytics": "Analytique",
   "AND": "ET",
   "and ... more": "et {count} de plus.",
+  "and provide your platform identifier.": "et fournissez votre identifiant de plateforme.",
   "And many more features...": "Et bien d'autres fonctionnalités...",
   "API access": "Accès à l'API",
   "API key": "Clé d'API",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -290,6 +290,7 @@
   "Analytics": "Analitica",
   "AND": "E",
   "and ... more": "e {count} altro",
+  "and provide your platform identifier.": "e fornisci l'identificatore della tua piattaforma.",
   "And many more features...": "E molte altre funzionalità...",
   "API access": "Accesso API",
   "API key": "Chiave API",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -296,6 +296,7 @@
   "Analyze this indicator": "このインジケーターを分析する",
   "AND": "そして",
   "and ... more": "および{count}以上です。",
+  "and provide your platform identifier.": "プラットフォーム識別子をお知らせください。",
   "And many more features...": "その他多くの機能...",
   "API access": "APIアクセス",
   "API key": "APIキー",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -290,6 +290,7 @@
   "Analytics": "분석",
   "AND": "그리고",
   "and ... more": "외 {count}개",
+  "and provide your platform identifier.": "플랫폼 식별자를 제공해 주세요.",
   "And many more features...": "그리고 더 많은 기능...",
   "API access": "API 접근",
   "API key": "API 키",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -290,6 +290,7 @@
   "Analytics": "Аналитика",
   "AND": "И",
   "and ... more": "и ... подробнее",
+  "and provide your platform identifier.": "и укажите идентификатор вашей платформы.",
   "And many more features...": "И многие другие возможности...",
   "API access": "Доступ к API",
   "API key": "Ключ API",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -290,6 +290,7 @@
   "Analytics": "分析系统",
   "AND": "和",
   "and ... more": "和{count}更多。",
+  "and provide your platform identifier.": "并提供您的平台标识符。",
   "And many more features...": "还有更多功能...",
   "API access": "API访问",
   "API key": "API 密钥",

--- a/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
@@ -24,6 +24,7 @@ import TextField from '@mui/material/TextField';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
+import Box from "@mui/material/Box";
 import { LtsLicenseRootQuery, LtsLicenseRootQuery$data } from '@components/__generated__/LtsLicenseRootQuery.graphql';
 import { ConnectedThemeProvider } from '../../components/AppThemeProvider';
 import { ConnectedIntlProvider } from '../../components/AppIntlProvider';
@@ -34,6 +35,7 @@ import { useFormatter } from '../../components/i18n';
 import useApiMutation from '../../utils/hooks/useApiMutation';
 import Message from '../../components/Message';
 import { isEmptyField } from '../../utils/utils';
+import ItemCopy from "../../components/ItemCopy";
 
 const useStyles = makeStyles<Theme>(() => ({
   container: {
@@ -109,7 +111,11 @@ const LicenseComponent: FunctionComponent<LicenseProps> = ({ settings }) => {
           <Alert severity="info" style={{ marginTop: 15 }}>
             {t_i18n('OpenCTI LTS Edition requires a license key to be enabled. Filigran provides a free-to-use license for development and research purposes as well as for charity organizations.')}
             <br /><br />
-            {t_i18n('To obtain a license, please')} <a href="https://filigran.io/contact/" target="_blank" rel="noreferrer">{t_i18n('reach out to the Filigran team')}</a>.
+            {t_i18n('To obtain a license, please')} <a href="https://filigran.io/contact/" target="_blank" rel="noreferrer">{t_i18n('reach out to the Filigran team')}</a> {t_i18n('and provide your platform identifier.')}
+            <br /><br />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              {t_i18n('Platform identifier')}:<ItemCopy content={settings.id} variant="inLine" />
+            </Box>
           </Alert>
           {isNoLicenseByConfig ? (
             <FormGroup style={{ marginTop: 15 }}>

--- a/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
@@ -24,7 +24,7 @@ import TextField from '@mui/material/TextField';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
-import Box from "@mui/material/Box";
+import Box from '@mui/material/Box';
 import { LtsLicenseRootQuery, LtsLicenseRootQuery$data } from '@components/__generated__/LtsLicenseRootQuery.graphql';
 import { ConnectedThemeProvider } from '../../components/AppThemeProvider';
 import { ConnectedIntlProvider } from '../../components/AppIntlProvider';
@@ -35,7 +35,7 @@ import { useFormatter } from '../../components/i18n';
 import useApiMutation from '../../utils/hooks/useApiMutation';
 import Message from '../../components/Message';
 import { isEmptyField } from '../../utils/utils';
-import ItemCopy from "../../components/ItemCopy";
+import ItemCopy from '../../components/ItemCopy';
 
 const useStyles = makeStyles<Theme>(() => ({
   container: {
@@ -114,7 +114,8 @@ const LicenseComponent: FunctionComponent<LicenseProps> = ({ settings }) => {
             {t_i18n('To obtain a license, please')} <a href="https://filigran.io/contact/" target="_blank" rel="noreferrer">{t_i18n('reach out to the Filigran team')}</a> {t_i18n('and provide your platform identifier.')}
             <br /><br />
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              {t_i18n('Platform identifier')}:<ItemCopy content={settings.id} variant="inLine" />
+              {t_i18n('Platform identifier')}
+              <ItemCopy content={settings.id} variant="inLine" />
             </Box>
           </Alert>
           {isNoLicenseByConfig ? (


### PR DESCRIPTION
### Proposed changes

* add platform identifier with handy copy-paste button in the LTS license gate screen

<img width="995" height="663" alt="image" src="https://github.com/user-attachments/assets/b1432736-be74-4fd1-98ef-e937e8af7a2b" />


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17039 

### How to test this PR

Start the app on the LTS branch, without an LTS license enabled. 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
