### PR TITLE
fix(lts): add missing platform id in LTS license agreement dialog (#17039)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "Analysieren Sie diesen Indikator",
   "AND": "AND",
   "and ... more": "und {count} mehr.",
+  "and provide your platform identifier.": "und geben Sie Ihre Plattformkennung an.",
   "And many more features...": "Und viele weitere Funktionen...",
   "API access": "API-Zugang",
   "API key": "API-Schlüssel",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "Analyze this indicator",
   "AND": "AND",
   "and ... more": "and {count} more.",
+  "and provide your platform identifier.": "and provide your platform identifier.",
   "And many more features...": "And many more features...",
   "API access": "API access",
   "API key": "API key",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "Analizar este indicador",
   "AND": "Y",
   "and ... more": "y {count} más.",
+  "and provide your platform identifier.": "y proporcione el identificador de su plataforma.",
   "And many more features...": "Y muchas más funciones...",
   "API access": "Acceso a la API",
   "API key": "Clave de API",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "Analyser cet indicateur",
   "AND": "ET",
   "and ... more": "et {count} de plus.",
+  "and provide your platform identifier.": "et fournissez votre identifiant de plateforme.",
   "And many more features...": "Et bien d'autres fonctionnalités...",
   "API access": "Accès à l'API",
   "API key": "Clé d'API",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "Analizzare questo indicatore",
   "AND": "E",
   "and ... more": "e {count} altro",
+  "and provide your platform identifier.": "e fornisci l'identificatore della tua piattaforma.",
   "And many more features...": "E molte altre funzionalità...",
   "API access": "Accesso API",
   "API key": "Chiave API",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "このインジケーターを分析する",
   "AND": "そして",
   "and ... more": "および{count}以上です。",
+  "and provide your platform identifier.": "プラットフォーム識別子をお知らせください。",
   "And many more features...": "その他多くの機能...",
   "API access": "APIアクセス",
   "API key": "APIキー",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "이 지표를 분석하세요",
   "AND": "그리고",
   "and ... more": "외 {count}개",
+  "and provide your platform identifier.": "플랫폼 식별자를 제공해 주세요.",
   "And many more features...": "그리고 더 많은 기능...",
   "API access": "API 접근",
   "API key": "API 키",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "Проанализируйте этот показатель",
   "AND": "И",
   "and ... more": "и ... подробнее",
+  "and provide your platform identifier.": "и укажите идентификатор вашей платформы.",
   "And many more features...": "И многие другие возможности...",
   "API access": "Доступ к API",
   "API key": "Ключ API",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -326,6 +326,7 @@
   "Analyze this indicator": "分析该指标",
   "AND": "和",
   "and ... more": "和{count}更多。",
+  "and provide your platform identifier.": "并提供您的平台标识符。",
   "And many more features...": "还有更多功能...",
   "API access": "API访问",
   "API key": "API 密钥",

--- a/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
@@ -24,6 +24,7 @@ import TextField from '@mui/material/TextField';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
+import Box from '@mui/material/Box';
 import { LtsLicenseRootQuery, LtsLicenseRootQuery$data } from '@components/__generated__/LtsLicenseRootQuery.graphql';
 import { ConnectedThemeProvider } from '../../components/AppThemeProvider';
 import { ConnectedIntlProvider } from '../../components/AppIntlProvider';
@@ -34,6 +35,7 @@ import { useFormatter } from '../../components/i18n';
 import useApiMutation from '../../utils/hooks/useApiMutation';
 import Message from '../../components/Message';
 import { isEmptyField } from '../../utils/utils';
+import ItemCopy from '../../components/ItemCopy';
 
 const useStyles = makeStyles<Theme>(() => ({
   container: {
@@ -109,7 +111,12 @@ const LicenseComponent: FunctionComponent<LicenseProps> = ({ settings }) => {
           <Alert severity="info" style={{ marginTop: 15 }}>
             {t_i18n('OpenCTI LTS Edition requires a license key to be enabled. Filigran provides a free-to-use license for development and research purposes as well as for charity organizations.')}
             <br /><br />
-            {t_i18n('To obtain a license, please')} <a href="https://filigran.io/contact/" target="_blank" rel="noreferrer">{t_i18n('reach out to the Filigran team')}</a>.
+            {t_i18n('To obtain a license, please')} <a href="https://filigran.io/contact/" target="_blank" rel="noreferrer">{t_i18n('reach out to the Filigran team')}</a> {t_i18n('and provide your platform identifier.')}
+            <br /><br />
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              {t_i18n('Platform identifier')}
+              <ItemCopy content={settings.id} variant="inLine" />
+            </Box>
           </Alert>
           {isNoLicenseByConfig ? (
             <FormGroup style={{ marginTop: 15 }}>


### PR DESCRIPTION
### Proposed changes

* add platform id to LTS license screen, with handy copy-paste button.


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17039 
