### PR TITLE
build(vite): update Vite configuration to target build for Widely Available baseline on 2026-01-01 rather than deprecated chrome58 target (#17050)

### DIFF
--- a/opencti-platform/opencti-front/vite.config.ts
+++ b/opencti-platform/opencti-front/vite.config.ts
@@ -17,7 +17,6 @@ const backProxy = (ws = false) => ({
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    target: ['chrome58'],
     sourcemap: true,
   },
 


### PR DESCRIPTION
### Proposed changes

Updates the OpenCTI frontend Vite build configuration to stop targeting the deprecated chrome58 output and instead rely on Vite’s default browser target ([the Baseline “Widely Available on 2026-01-01” set](https://web-platform-dx.github.io/supported-browsers/?widelyAvailableOnDate=2026-01-01)), aligning the build with modern browser support expectations.

### Related issues
* closes #17050

### How to test this PR
* smoke test on UI with various supported browsers

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality
