### PR TITLE
fix(form_intake): remove content from listed ov (#16918)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormUtils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertFormBuilderDataToSchema, normalizeDraftAuthorizedMembersDefaults } from './FormUtils';
+import { convertFormBuilderDataToSchema, getAttributesForEntityType, getInitialMandatoryFields, normalizeDraftAuthorizedMembersDefaults } from './FormUtils';
 import type { FormBuilderData } from './Form.d';
 import type { AuthorizedMemberOption } from '../../../../utils/authorizedMembers';
 
@@ -262,5 +262,39 @@ describe('convertFormBuilderDataToSchema', () => {
       ],
     });
     expect(schema.fields[0].isReadOnly).toBe(false);
+  });
+});
+
+describe('container content attribute mapping', () => {
+  const t_i18n = (key: string) => key;
+
+  const entityTypes = [
+    {
+      value: 'Case-Incident',
+      label: 'Case Incident',
+      attributes: [
+        {
+          value: 'content',
+          name: 'content',
+          label: 'Content',
+          type: 'markdown',
+          mandatory: true,
+        },
+      ],
+    },
+  ];
+
+  it('should not expose content as an open vocabulary attribute', () => {
+    const openVocabAttributes = getAttributesForEntityType('Case-Incident', 'openvocab', entityTypes as any, t_i18n);
+
+    expect(openVocabAttributes).toEqual([]);
+  });
+
+  it('should keep mandatory content field as textarea', () => {
+    const mandatoryFields = getInitialMandatoryFields('Case-Incident', entityTypes as any, t_i18n);
+
+    expect(mandatoryFields).toHaveLength(1);
+    expect(mandatoryFields[0].attributeMapping.attributeName).toBe('content');
+    expect(mandatoryFields[0].type).toBe('textarea');
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormUtils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormUtils.test.ts
@@ -285,13 +285,13 @@ describe('container content attribute mapping', () => {
   ];
 
   it('should not expose content as an open vocabulary attribute', () => {
-    const openVocabAttributes = getAttributesForEntityType('Case-Incident', 'openvocab', entityTypes as any, t_i18n);
+    const openVocabAttributes = getAttributesForEntityType('Case-Incident', 'openvocab', entityTypes, t_i18n);
 
     expect(openVocabAttributes).toEqual([]);
   });
 
   it('should keep mandatory content field as textarea', () => {
-    const mandatoryFields = getInitialMandatoryFields('Case-Incident', entityTypes as any, t_i18n);
+    const mandatoryFields = getInitialMandatoryFields('Case-Incident', entityTypes, t_i18n);
 
     expect(mandatoryFields).toHaveLength(1);
     expect(mandatoryFields[0].attributeMapping.attributeName).toBe('content');

--- a/opencti-platform/opencti-front/src/utils/vocabularyMapping.ts
+++ b/opencti-platform/opencti-front/src/utils/vocabularyMapping.ts
@@ -92,9 +92,6 @@ export const OPENVOCAB_FIELD_MAPPINGS: VocabularyMapping[] = [
 
   // Ingestion RSS attributes
   { attribute: 'ingestion_running', vocabularyType: 'ingestion_running_ov', label: 'Ingestion running', multiple: false },
-
-  // Container attributes
-  { attribute: 'content', vocabularyType: 'content_ov', label: 'Content', multiple: false },
 ];
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request updates the handling of the `content` attribute for container entity types, specifically ensuring that it is not treated as an open vocabulary field but remains a mandatory textarea field. It also removes the open vocabulary mapping for `content` from the global vocabulary mappings.

The most important changes are:

**Test updates and validation:**
* Added tests in `FormUtils.test.ts` to verify that the `content` attribute for `Case-Incident` is not exposed as an open vocabulary attribute and remains a mandatory textarea field.

**Vocabulary mapping adjustments:**
* Removed the `content` attribute from the `OPENVOCAB_FIELD_MAPPINGS` in `vocabularyMapping.ts`, so it is no longer treated as an open vocabulary field globally.

**Test utilities:**
* Updated imports in `FormUtils.test.ts` to include the new utility functions used in the tests.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16918

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
