### PR TITLE
fix(ingestion-manager): set default timeout for feed requests (#17038)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -326,7 +326,7 @@
     "interval": 30000,
     "uri_deny_list": [],
     "feed": {
-      "request_timeout": 30000
+      "request_timeout": 300000
     },
     "taxii_feed": {
       "limit_per_request": 0

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -325,6 +325,9 @@
     "lock_key": "ingestion_manager_lock",
     "interval": 30000,
     "uri_deny_list": [],
+    "feed": {
+      "request_timeout": 30000
+    },
     "taxii_feed": {
       "limit_per_request": 0
     },

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -206,6 +206,7 @@ export const rssDataParser = async (turndownService: TurndownService, data: conv
 };
 
 const rssDataHandler = async (context: AuthContext, httpRssGet: Getter, turndownService: TurndownService, ingestion: BasicStoreEntityIngestionRss) => {
+  logApp.info(`[OPENCTI-MODULE] Executing Rss ingestion for ${ingestion.name}`);
   const data = await httpRssGet(ingestion.uri);
   const items = await rssDataParser(turndownService, data, ingestion.current_state_date);
   // Build Stix bundle from items
@@ -455,6 +456,7 @@ export const processTaxiiResponse = async (context: AuthContext, ingestion: Basi
 };
 
 const taxiiV21DataHandler: TaxiiHandlerFn = async (context: AuthContext, ingestion: BasicStoreEntityIngestionTaxii) => {
+  logApp.info(`[OPENCTI-MODULE] Executing Taxii ingestion for ${ingestion.name}`);
   const taxiResponse = await taxiiHttpGet(ingestion);
   await processTaxiiResponse(context, ingestion, taxiResponse);
 };
@@ -547,6 +549,7 @@ const csvDataHandler = async (context: AuthContext, ingestion: BasicStoreEntityI
   const csvMapperParsed = parseCsvMapper(csvMapper);
   csvMapperParsed.user_chosen_markings = ingestion.markings ?? [];
   try {
+    logApp.info(`[OPENCTI-MODULE] Executing CSV ingestion for ${ingestion.name}`);
     const { csvLines, addedLast } = await fetchCsvFromUrl(csvMapperParsed, ingestion, { timeout: FEED_REQUEST_TIMEOUT });
     await processCsvLines(context, ingestion, csvMapperParsed, csvLines, addedLast);
   } catch (e: any) {
@@ -621,10 +624,11 @@ export const jsonExecutor = async (context: AuthContext) => {
     if (isMustExecuteIteration(ingestion.last_execution_date, ingestion.scheduling_period)) {
       const { messages_number, messages_size } = await queueDetails(connectorIdFromIngestId(ingestion.id));
       if (messages_number === 0) { // If no more ingestion to do
+        logApp.info(`[OPENCTI-MODULE] Executing Json ingestion for ${ingestion.name}`);
         const { objects, variables, nextExecutionState } = await executeJsonQuery(context, ingestion, {
           timeout: FEED_REQUEST_TIMEOUT,
         });
-        logApp.info('pushBundleToConnectorQueue', objects.length);
+        logApp.info(`[OPENCTI-MODULE] Json ingestion execution for ${objects.length} items`);
         // Push the bundle to absorption queue if required
         if (objects.length > 0) {
           const bundle: StixBundle = {

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -621,7 +621,9 @@ export const jsonExecutor = async (context: AuthContext) => {
     if (isMustExecuteIteration(ingestion.last_execution_date, ingestion.scheduling_period)) {
       const { messages_number, messages_size } = await queueDetails(connectorIdFromIngestId(ingestion.id));
       if (messages_number === 0) { // If no more ingestion to do
-        const { objects, variables, nextExecutionState } = await executeJsonQuery(context, ingestion);
+        const { objects, variables, nextExecutionState } = await executeJsonQuery(context, ingestion, {
+          timeout: FEED_REQUEST_TIMEOUT,
+        });
         logApp.info('pushBundleToConnectorQueue', objects.length);
         // Push the bundle to absorption queue if required
         if (objects.length > 0) {

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -52,6 +52,7 @@ const INGESTION_MANAGER_KEY = conf.get('ingestion_manager:lock_key') || 'ingesti
 const INGESTION_MANAGER_TAXII_FEED_LIMIT_PER_REQUEST = conf.get('ingestion_manager:taxii_feed:limit_per_request') || 0;
 const RSS_FEED_MIN_INTERVAL_MINUTES = conf.get('ingestion_manager:rss_feed:min_interval_minutes') || 5;
 const RSS_FEED_USER_AGENT = conf.get('ingestion_manager:rss_feed:user_agent') || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0';
+const FEED_REQUEST_TIMEOUT = conf.get('ingestion_manager:feed:request_timeout') || 30000;
 const CSV_FEED_MIN_INTERVAL_MINUTES = conf.get('ingestion_manager:csv_feed:min_interval_minutes') || 5;
 
 let running = false;
@@ -166,6 +167,7 @@ export const rssHttpClientOptions = (ingestion: BasicStoreEntityIngestionRss) =>
   const httpClientOptions: GetHttpClient = {
     responseType: 'text',
     headers: { 'User-Agent': RSS_FEED_USER_AGENT },
+    timeout: FEED_REQUEST_TIMEOUT,
     rejectUnauthorized: ingestion.ssl_verify ?? false,
   };
   return httpClientOptions;
@@ -345,7 +347,13 @@ export const buildTaxiiHttpClientOptions = async (ingestion: BasicStoreEntityIng
     certificates = { cert: decryptedAuthValue.split(':')[0], key: decryptedAuthValue.split(':')[1], ca: decryptedAuthValue.split(':')[2] };
   }
 
-  const httpClientOptions: GetHttpClient = { headers: octiHeaders, rejectUnauthorized: ingestion.ssl_verify ?? false, responseType: 'json', certificates };
+  const httpClientOptions: GetHttpClient = {
+    headers: octiHeaders,
+    rejectUnauthorized: ingestion.ssl_verify ?? false,
+    timeout: FEED_REQUEST_TIMEOUT,
+    responseType: 'json',
+    certificates,
+  };
   return httpClientOptions;
 };
 
@@ -539,7 +547,7 @@ const csvDataHandler = async (context: AuthContext, ingestion: BasicStoreEntityI
   const csvMapperParsed = parseCsvMapper(csvMapper);
   csvMapperParsed.user_chosen_markings = ingestion.markings ?? [];
   try {
-    const { csvLines, addedLast } = await fetchCsvFromUrl(csvMapperParsed, ingestion);
+    const { csvLines, addedLast } = await fetchCsvFromUrl(csvMapperParsed, ingestion, { timeout: FEED_REQUEST_TIMEOUT });
     await processCsvLines(context, ingestion, csvMapperParsed, csvLines, addedLast);
   } catch (e: any) {
     throw UnknownError(e, { ingestionName: ingestion.name, ingestionId: ingestion.id });

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -52,7 +52,7 @@ const INGESTION_MANAGER_KEY = conf.get('ingestion_manager:lock_key') || 'ingesti
 const INGESTION_MANAGER_TAXII_FEED_LIMIT_PER_REQUEST = conf.get('ingestion_manager:taxii_feed:limit_per_request') || 0;
 const RSS_FEED_MIN_INTERVAL_MINUTES = conf.get('ingestion_manager:rss_feed:min_interval_minutes') || 5;
 const RSS_FEED_USER_AGENT = conf.get('ingestion_manager:rss_feed:user_agent') || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0';
-const FEED_REQUEST_TIMEOUT = conf.get('ingestion_manager:feed:request_timeout') || 30000;
+const FEED_REQUEST_TIMEOUT = conf.get('ingestion_manager:feed:request_timeout') || 300000;
 const CSV_FEED_MIN_INTERVAL_MINUTES = conf.get('ingestion_manager:csv_feed:min_interval_minutes') || 5;
 
 let running = false;

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -554,7 +554,7 @@ const csvDataHandler = async (context: AuthContext, ingestion: BasicStoreEntityI
   }
 };
 
-const csvExecutor = async (context: AuthContext) => {
+export const csvExecutor = async (context: AuthContext) => {
   const filters = {
     mode: 'and',
     filters: [{ key: 'ingestion_running', values: [true] }],

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
@@ -14,7 +14,7 @@ import {
   IngestionCsvMapperType,
 } from '../../generated/graphql';
 import { notify } from '../../database/redis';
-import { BUS_TOPICS, PLATFORM_VERSION } from '../../config/conf';
+import conf, { BUS_TOPICS, PLATFORM_VERSION } from '../../config/conf';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
 import {
   type BasicStoreEntityCsvMapper,
@@ -40,6 +40,7 @@ import { createOnTheFlyUser } from '../user/user-domain';
 import { findDefaultIngestionGroups } from '../../domain/group';
 
 const MINIMAL_CSV_FEED_COMPATIBLE_VERSION = '6.6.0';
+const DEFAULT_FEED_REQUEST_TIMEOUT = conf.get('ingestion_manager:feed:request_timeout') || 300000;
 
 export const findById = async (context: AuthContext, user: AuthUser, ingestionId: string) => {
   return storeLoadById<BasicStoreEntityIngestionCsv>(context, user, ingestionId, ENTITY_TYPE_INGESTION_CSV);
@@ -248,7 +249,7 @@ export const fetchCsvFromUrl = async (
   ingestion: BasicStoreEntityIngestionCsv,
   opts: { limit?: number; timeout?: number } = {},
 ): Promise<CsvResponseData> => {
-  const { limit = undefined, timeout = undefined } = opts;
+  const { limit = undefined, timeout = DEFAULT_FEED_REQUEST_TIMEOUT } = opts;
   const headers = new OpenCTIHeaders();
   headers.Accept = 'application/csv';
   const decryptedAuthValue = await decryptIngestionCredential(ingestion.authentication_value);

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-domain.ts
@@ -243,8 +243,12 @@ interface CsvResponseData {
   addedLast: string | undefined | null;
 }
 
-export const fetchCsvFromUrl = async (csvMapper: CsvMapperParsed, ingestion: BasicStoreEntityIngestionCsv, opts: { limit?: number } = {}): Promise<CsvResponseData> => {
-  const { limit = undefined } = opts;
+export const fetchCsvFromUrl = async (
+  csvMapper: CsvMapperParsed,
+  ingestion: BasicStoreEntityIngestionCsv,
+  opts: { limit?: number; timeout?: number } = {},
+): Promise<CsvResponseData> => {
+  const { limit = undefined, timeout = undefined } = opts;
   const headers = new OpenCTIHeaders();
   headers.Accept = 'application/csv';
   const decryptedAuthValue = await decryptIngestionCredential(ingestion.authentication_value);
@@ -261,7 +265,13 @@ export const fetchCsvFromUrl = async (csvMapper: CsvMapperParsed, ingestion: Bas
     const [cert, key, ca] = (decryptedAuthValue || '').split(':');
     certificates = { cert, key, ca };
   }
-  const httpClientOptions: GetHttpClient = { headers, rejectUnauthorized: ingestion.ssl_verify ?? false, responseType: 'arraybuffer', certificates };
+  const httpClientOptions: GetHttpClient = {
+    headers,
+    rejectUnauthorized: ingestion.ssl_verify ?? false,
+    timeout,
+    responseType: 'arraybuffer',
+    certificates,
+  };
   const httpClient = getHttpClient(httpClientOptions);
   const { data, headers: resultHeaders } = await httpClient.get(ingestion.uri);
   const dataLines = data.toString().split(/\r?\n/);

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -24,7 +24,7 @@ import { publishUserAction } from '../../listener/UserActionListener';
 import { type BasicStoreEntityJsonMapper, ENTITY_TYPE_JSON_MAPPER, type JsonMapperParsed } from '../internal/jsonMapper/jsonMapper-types';
 import { type EditInput, IngestionAuthType, type IngestionJsonAddInput, type JsonMapperTestResult } from '../../generated/graphql';
 import { notify } from '../../database/redis';
-import { BUS_TOPICS, logApp } from '../../config/conf';
+import conf, { BUS_TOPICS, logApp } from '../../config/conf';
 import { ABSTRACT_INTERNAL_OBJECT } from '../../schema/general';
 import { getHttpClient, type GetHttpClient, OpenCTIHeaders } from '../../utils/http-client';
 import { isEmptyField, isNotEmptyField, wait } from '../../database/utils';
@@ -40,6 +40,8 @@ interface JsonQueryFetchOpts {
   maxResults?: number;
   timeout?: number;
 }
+
+const DEFAULT_FEED_REQUEST_TIMEOUT = conf.get('ingestion_manager:feed:request_timeout') || 300000;
 
 const getValueFromPath = (path: string, json: any) => {
   return JSONPath.JSONPath({ path, json, wrap: false, flatten: true });
@@ -93,7 +95,7 @@ const filterVariablesForAttributes = (attributes: Array<DataParam>, variables: R
 };
 
 export const executeJsonQuery = async (context: AuthContext, ingestion: BasicStoreEntityIngestionJson, opts: JsonQueryFetchOpts = {}) => {
-  const { maxResults = 0, timeout = undefined } = opts;
+  const { maxResults = 0, timeout = DEFAULT_FEED_REQUEST_TIMEOUT } = opts;
   let certificates;
   const headers = new OpenCTIHeaders();
   headers.Accept = 'application/json';

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -38,6 +38,7 @@ import { encryptIngestionCredential, decryptIngestionCredential } from './ingest
 
 interface JsonQueryFetchOpts {
   maxResults?: number;
+  timeout?: number;
 }
 
 const getValueFromPath = (path: string, json: any) => {
@@ -92,7 +93,7 @@ const filterVariablesForAttributes = (attributes: Array<DataParam>, variables: R
 };
 
 export const executeJsonQuery = async (context: AuthContext, ingestion: BasicStoreEntityIngestionJson, opts: JsonQueryFetchOpts = {}) => {
-  const { maxResults = 0 } = opts;
+  const { maxResults = 0, timeout = undefined } = opts;
   let certificates;
   const headers = new OpenCTIHeaders();
   headers.Accept = 'application/json';
@@ -124,7 +125,13 @@ export const executeJsonQuery = async (context: AuthContext, ingestion: BasicSto
       ca: certificateAuthenticationValue.split(':')[2],
     };
   }
-  const httpClientOptions: GetHttpClient = { headers, rejectUnauthorized: ingestion.ssl_verify ?? false, responseType: 'json', certificates };
+  const httpClientOptions: GetHttpClient = {
+    headers,
+    rejectUnauthorized: ingestion.ssl_verify ?? false,
+    timeout,
+    responseType: 'json',
+    certificates,
+  };
   const httpClient = getHttpClient(httpClientOptions);
   // Prepare query params
   const queryVariables = filterVariablesForAttributes(ingestion.query_attributes ?? [], variables, 'query_param');

--- a/opencti-platform/opencti-graphql/src/utils/http-client.ts
+++ b/opencti-platform/opencti-graphql/src/utils/http-client.ts
@@ -16,6 +16,7 @@ export interface Certificates {
 export interface GetHttpClient {
   baseURL?: string;
   rejectUnauthorized?: boolean;
+  timeout?: number;
   responseType: 'json' | 'arraybuffer' | 'text' | 'stream';
   headers?: RawAxiosRequestHeaders | AxiosHeaders | Partial<HeadersDefaults>;
   certificates?: Certificates;
@@ -54,7 +55,7 @@ const buildHttpAgentOpts = (uri: string, baseURL: string | undefined, defaultHtt
     proxy: false, // Disable direct proxy protocol in http adapter
   };
 };
-export const getHttpClient = ({ baseURL, headers, rejectUnauthorized, responseType, certificates, auth }: GetHttpClient) => {
+export const getHttpClient = ({ baseURL, headers, rejectUnauthorized, timeout, responseType, certificates, auth }: GetHttpClient) => {
   // Build a default https agent to force query options if no proxy is setup
   const cert = isNotEmptyField(certificates?.cert) ? fromBase64(certificates?.cert) : undefined;
   const key = isNotEmptyField(certificates?.key) ? fromBase64(certificates?.key) : undefined;
@@ -64,6 +65,7 @@ export const getHttpClient = ({ baseURL, headers, rejectUnauthorized, responseTy
   // Create the default caller
   const caller = axios.create({
     baseURL,
+    timeout,
     responseType,
     headers,
     auth,

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestion-domain-options-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestion-domain-options-test.ts
@@ -23,6 +23,20 @@ vi.mock('../../../../src/utils/http-client', () => ({
   getHttpClient: getHttpClientMock,
 }));
 
+vi.mock('../../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/config/conf')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: (key: string) => {
+        if (key === 'ingestion_manager:feed:request_timeout') return 7777;
+        return actual.default.get(key);
+      },
+    },
+  };
+});
+
 vi.mock('../../../../src/modules/ingestion/ingestion-common', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../../../src/modules/ingestion/ingestion-common')>();
   return {
@@ -77,6 +91,26 @@ describe('Ingestion domain timeout options', () => {
     );
   });
 
+  it('should fallback to configured timeout for csv when timeout option is omitted', async () => {
+    httpGetMock.mockResolvedValue({
+      data: Buffer.from('header\nvalue'),
+      headers: {},
+    });
+
+    const csvMapper = { skipLineChar: '#' } as any;
+    const ingestion = {
+      uri: 'http://localhost/csv',
+      authentication_type: 'none',
+      ssl_verify: false,
+    } as any;
+
+    await fetchCsvFromUrl(csvMapper, ingestion);
+
+    expect(getHttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 7777, responseType: 'arraybuffer' }),
+    );
+  });
+
   it('should pass timeout to json http client options', async () => {
     httpCallMock.mockResolvedValueOnce({
       data: { items: [] },
@@ -108,6 +142,40 @@ describe('Ingestion domain timeout options', () => {
 
     expect(getHttpClientMock).toHaveBeenCalledWith(
       expect.objectContaining({ timeout: 4321, responseType: 'json' }),
+    );
+  });
+
+  it('should fallback to configured timeout for json when timeout option is omitted', async () => {
+    httpCallMock.mockResolvedValueOnce({
+      data: { items: [] },
+      headers: {},
+    });
+    findJsonMapperByIdMock.mockResolvedValue({
+      representations: '[]',
+      variables: '[]',
+    });
+    getEntitiesMapFromCacheMock.mockResolvedValue(new Map());
+    jsonMappingExecutionMock.mockResolvedValue([]);
+
+    const ingestion = {
+      headers: [],
+      ingestion_json_state: null,
+      query_attributes: [],
+      authentication_type: 'none',
+      ssl_verify: false,
+      uri: 'http://localhost/json',
+      body: '{}',
+      verb: 'POST',
+      json_mapper_id: 'json-mapper--1',
+      user_id: null,
+      pagination_with_sub_page: false,
+      pagination_with_sub_page_attribute_path: null,
+    } as any;
+
+    await executeJsonQuery({} as any, ingestion);
+
+    expect(getHttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 7777, responseType: 'json' }),
     );
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestion-domain-options-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestion-domain-options-test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getHttpClientMock,
+  httpGetMock,
+  httpCallMock,
+  decryptIngestionCredentialMock,
+  findJsonMapperByIdMock,
+  getEntitiesMapFromCacheMock,
+  jsonMappingExecutionMock,
+} = vi.hoisted(() => ({
+  getHttpClientMock: vi.fn(),
+  httpGetMock: vi.fn(),
+  httpCallMock: vi.fn(),
+  decryptIngestionCredentialMock: vi.fn(),
+  findJsonMapperByIdMock: vi.fn(),
+  getEntitiesMapFromCacheMock: vi.fn(),
+  jsonMappingExecutionMock: vi.fn(),
+}));
+
+vi.mock('../../../../src/utils/http-client', () => ({
+  OpenCTIHeaders: class OpenCTIHeaders {},
+  getHttpClient: getHttpClientMock,
+}));
+
+vi.mock('../../../../src/modules/ingestion/ingestion-common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/modules/ingestion/ingestion-common')>();
+  return {
+    ...actual,
+    decryptIngestionCredential: decryptIngestionCredentialMock,
+  };
+});
+
+vi.mock('../../../../src/modules/internal/jsonMapper/jsonMapper-domain', () => ({
+  findById: findJsonMapperByIdMock,
+}));
+
+vi.mock('../../../../src/database/cache', () => ({
+  getEntitiesMapFromCache: getEntitiesMapFromCacheMock,
+}));
+
+vi.mock('../../../../src/parser/json-mapper', () => ({
+  default: jsonMappingExecutionMock,
+}));
+
+import { fetchCsvFromUrl } from '../../../../src/modules/ingestion/ingestion-csv-domain';
+import { executeJsonQuery } from '../../../../src/modules/ingestion/ingestion-json-domain';
+
+describe('Ingestion domain timeout options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    decryptIngestionCredentialMock.mockResolvedValue('');
+    getHttpClientMock.mockReturnValue({
+      get: httpGetMock,
+      call: httpCallMock,
+    });
+  });
+
+  it('should pass timeout to csv http client options', async () => {
+    httpGetMock.mockResolvedValue({
+      data: Buffer.from('header\nvalue'),
+      headers: {},
+    });
+
+    const csvMapper = { skipLineChar: '#' } as any;
+    const ingestion = {
+      uri: 'http://localhost/csv',
+      authentication_type: 'none',
+      ssl_verify: false,
+    } as any;
+
+    await fetchCsvFromUrl(csvMapper, ingestion, { timeout: 1234 });
+
+    expect(getHttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 1234, responseType: 'arraybuffer' }),
+    );
+  });
+
+  it('should pass timeout to json http client options', async () => {
+    httpCallMock.mockResolvedValueOnce({
+      data: { items: [] },
+      headers: {},
+    });
+    findJsonMapperByIdMock.mockResolvedValue({
+      representations: '[]',
+      variables: '[]',
+    });
+    getEntitiesMapFromCacheMock.mockResolvedValue(new Map());
+    jsonMappingExecutionMock.mockResolvedValue([]);
+
+    const ingestion = {
+      headers: [],
+      ingestion_json_state: null,
+      query_attributes: [],
+      authentication_type: 'none',
+      ssl_verify: false,
+      uri: 'http://localhost/json',
+      body: '{}',
+      verb: 'POST',
+      json_mapper_id: 'json-mapper--1',
+      user_id: null,
+      pagination_with_sub_page: false,
+      pagination_with_sub_page_attribute_path: null,
+    } as any;
+
+    await executeJsonQuery({} as any, ingestion, { timeout: 4321 });
+
+    expect(getHttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 4321, responseType: 'json' }),
+    );
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestionManager-feed-timeout-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestionManager-feed-timeout-test.ts
@@ -1,0 +1,270 @@
+import { AxiosError } from 'axios';
+import TurndownService from 'turndown';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const findAllRssIngestionMock = vi.fn();
+const patchRssIngestionMock = vi.fn();
+const findAllTaxiiIngestionMock = vi.fn();
+const patchTaxiiIngestionMock = vi.fn();
+const findAllCsvIngestionMock = vi.fn();
+const patchCsvIngestionMock = vi.fn();
+const fetchCsvFromUrlMock = vi.fn();
+const findAllJsonIngestionMock = vi.fn();
+const patchJsonIngestionMock = vi.fn();
+const executeJsonQueryMock = vi.fn();
+const decryptIngestionCredentialMock = vi.fn();
+const queueDetailsMock = vi.fn();
+const getHttpClientMock = vi.fn();
+
+vi.mock('../../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/config/conf')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: (key: string) => {
+        if (key === 'ingestion_manager:feed:request_timeout') return 50;
+        return actual.default.get(key);
+      },
+    },
+    booleanConf: () => false,
+    logApp: {
+      ...actual.logApp,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../../../src/modules/ingestion/ingestion-rss-domain', () => ({
+  findAllRssIngestion: findAllRssIngestionMock,
+  patchRssIngestion: patchRssIngestionMock,
+}));
+
+vi.mock('../../../../src/modules/ingestion/ingestion-taxii-domain', () => ({
+  findAllTaxiiIngestion: findAllTaxiiIngestionMock,
+  patchTaxiiIngestion: patchTaxiiIngestionMock,
+}));
+
+vi.mock('../../../../src/modules/ingestion/ingestion-csv-domain', () => ({
+  findAllCsvIngestion: findAllCsvIngestionMock,
+  patchCsvIngestion: patchCsvIngestionMock,
+  fetchCsvFromUrl: fetchCsvFromUrlMock,
+}));
+
+vi.mock('../../../../src/modules/ingestion/ingestion-json-domain', () => ({
+  findAllJsonIngestion: findAllJsonIngestionMock,
+  patchJsonIngestion: patchJsonIngestionMock,
+  executeJsonQuery: executeJsonQueryMock,
+}));
+
+vi.mock('../../../../src/modules/ingestion/ingestion-common', () => ({
+  decryptIngestionCredential: decryptIngestionCredentialMock,
+}));
+
+vi.mock('../../../../src/domain/connector', () => ({
+  queueDetails: queueDetailsMock,
+  connectorIdFromIngestId: (id: string) => `connector-${id}`,
+}));
+
+vi.mock('../../../../src/manager/ingestionManager/ingestionManagerPushToQueue', () => ({
+  pushBundleToConnectorQueue: vi.fn(),
+  updateBuiltInConnectorInfo: vi.fn(),
+}));
+
+vi.mock('../../../../src/utils/http-client', () => ({
+  OpenCTIHeaders: class OpenCTIHeaders {},
+  getHttpClient: getHttpClientMock,
+}));
+
+const timeoutError = new AxiosError('timeout', 'ECONNABORTED');
+const validRss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test feed</title>
+    <pubDate>Wed, 10 Jul 2024 12:00:00 GMT</pubDate>
+    <item>
+      <title>A working item</title>
+      <link>http://localhost/items/1</link>
+      <description>description</description>
+      <pubDate>Wed, 10 Jul 2024 12:00:00 GMT</pubDate>
+      <category>test</category>
+    </item>
+  </channel>
+</rss>`;
+
+describe('Ingestion manager feed timeout behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    queueDetailsMock.mockResolvedValue({ messages_number: 0, messages_size: 0 });
+    patchRssIngestionMock.mockResolvedValue({});
+    patchTaxiiIngestionMock.mockResolvedValue({ current_state_cursor: undefined, added_after_start: undefined });
+    patchCsvIngestionMock.mockResolvedValue({});
+    patchJsonIngestionMock.mockResolvedValue({});
+    decryptIngestionCredentialMock.mockResolvedValue('');
+    fetchCsvFromUrlMock.mockRejectedValue(timeoutError);
+    executeJsonQueryMock.mockResolvedValue({ objects: [], variables: {}, nextExecutionState: {} });
+
+    getHttpClientMock.mockImplementation(() => ({
+      get: async (uri: string) => {
+        if (uri.includes('hang')) {
+          throw timeoutError;
+        }
+        if (uri.includes('/collections/')) {
+          return {
+            data: { objects: [], more: false, next: undefined },
+            headers: {},
+            status: 200,
+          };
+        }
+        return { data: validRss };
+      },
+    }));
+  });
+
+  it('should continue RSS iteration when one feed times out and another is healthy', async () => {
+    const baseIngestion = {
+      scheduling_period: 'auto',
+      last_execution_date: undefined,
+      ssl_verify: false,
+      created_by_ref: 'identity--1',
+      object_marking_refs: [],
+      report_types: ['threat-report'],
+    };
+
+    const hangingIngestion = {
+      ...baseIngestion,
+      id: 'ingestion--hang',
+      internal_id: 'internal--hang',
+      name: 'Hanging RSS',
+      uri: 'http://localhost/hang',
+    };
+
+    const healthyIngestion = {
+      ...baseIngestion,
+      id: 'ingestion--ok',
+      internal_id: 'internal--ok',
+      name: 'Working RSS',
+      uri: 'http://localhost/feed',
+      user_id: 'user--2',
+    };
+
+    findAllRssIngestionMock.mockResolvedValue([hangingIngestion, healthyIngestion]);
+
+    const { rssExecutor } = await import('../../../../src/manager/ingestionManager');
+
+    // The executor should still resolve: a timeout on one feed must not stop the whole RSS iteration.
+    await expect(rssExecutor({} as any, new TurndownService())).resolves.toBeDefined();
+
+    expect(patchRssIngestionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'internal--hang',
+      expect.objectContaining({ last_execution_date: expect.any(String) }),
+    );
+
+    expect(getHttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 50 }),
+    );
+  });
+
+  it('should continue TAXII iteration when one feed times out and another is healthy', async () => {
+    const baseIngestion = {
+      scheduling_period: 'auto',
+      last_execution_date: undefined,
+      ssl_verify: false,
+      version: 'v21',
+      collection: 'default',
+      authentication_type: 'none',
+      authentication_value: undefined,
+    };
+    const hangingIngestion = {
+      ...baseIngestion,
+      id: 'taxii--hang',
+      internal_id: 'taxii-internal--hang',
+      name: 'Hanging TAXII',
+      uri: 'http://localhost/hang',
+      user_id: 'user--1',
+    };
+    const healthyIngestion = {
+      ...baseIngestion,
+      id: 'taxii--ok',
+      internal_id: 'taxii-internal--ok',
+      name: 'Working TAXII',
+      uri: 'http://localhost/taxii',
+      user_id: 'user--2',
+    };
+    findAllTaxiiIngestionMock.mockResolvedValue([hangingIngestion, healthyIngestion]);
+
+    const { taxiiExecutor } = await import('../../../../src/manager/ingestionManager');
+
+    await expect(taxiiExecutor({} as any)).resolves.toBeDefined();
+
+    expect(patchTaxiiIngestionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'taxii-internal--ok',
+      expect.objectContaining({ last_execution_date: expect.any(String) }),
+    );
+    expect(getHttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 50 }),
+    );
+  });
+
+  it('should catch CSV timeout and update last execution date', async () => {
+    const csvIngestion = {
+      id: 'csv--hang',
+      internal_id: 'csv-internal--hang',
+      name: 'Hanging CSV',
+      user_id: 'user--1',
+      scheduling_period: 'auto',
+      last_execution_date: undefined,
+      csv_mapper_type: 'inline',
+      csv_mapper: '{}',
+      markings: [],
+    };
+    findAllCsvIngestionMock.mockResolvedValue([csvIngestion]);
+
+    const { csvExecutor } = await import('../../../../src/manager/ingestionManager');
+
+    await expect(csvExecutor({} as any)).resolves.toBeDefined();
+
+    expect(fetchCsvFromUrlMock).toHaveBeenCalledWith(
+      expect.anything(),
+      csvIngestion,
+      expect.objectContaining({ timeout: 50 }),
+    );
+    expect(patchCsvIngestionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'csv-internal--hang',
+      expect.objectContaining({ last_execution_date: expect.any(String) }),
+    );
+  });
+
+  it('should pass timeout to JSON query execution', async () => {
+    const jsonIngestion = {
+      id: 'json--ok',
+      internal_id: 'json-internal--ok',
+      name: 'Working JSON',
+      user_id: 'user--1',
+      scheduling_period: 'auto',
+      last_execution_date: undefined,
+      query_attributes: [],
+    };
+    findAllJsonIngestionMock.mockResolvedValue([jsonIngestion]);
+
+    const { jsonExecutor } = await import('../../../../src/manager/ingestionManager');
+
+    await expect(jsonExecutor({} as any)).resolves.toBeUndefined();
+
+    expect(executeJsonQueryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      jsonIngestion,
+      expect.objectContaining({ timeout: 50 }),
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add timeout option in http-client axios param
* Set 30s default timeout on RSS/CSV/TAXII feed http client -> this should prevent the main promise.all to hang and prevent releasing the ingestion_manager_lock on Redis

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17038

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
