### PR TITLE
fix(frontend): fix infinite PDF loading loop (#16828)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.jsx
@@ -27,6 +27,7 @@ import { RichTextEditor } from '@filigran/rich-text-editor';
 import { htmlToPdf } from '../../../../utils/htmlToPdf/htmlToPdf';
 import HtmlDisplay from '../../../../components/HtmlDisplay';
 import useAttributes from '../../../../utils/hooks/useAttributes';
+import { isPdfPasswordError } from './StixCoreObjectContentPdfUtils';
 
 import '../../../../utils/pdfWorker-setup';
 
@@ -247,6 +248,7 @@ class StixCoreObjectContentComponent extends Component {
       changed: false,
       isLoading,
       onProgressExportFileName,
+      blockedPdfPreviewFileId: null,
     };
   }
 
@@ -346,6 +348,7 @@ class StixCoreObjectContentComponent extends Component {
       currentFileId: null,
       changed: false,
       contentSelected: true,
+      blockedPdfPreviewFileId: null,
       currentContent: stixCoreObject.contentField ?? t('Write something awesome...'),
     }, () => {
       this.props.setMappingHeaderDisabled(false);
@@ -355,7 +358,12 @@ class StixCoreObjectContentComponent extends Component {
   }
 
   handleSelectFile(fileId) {
-    this.setState({ currentFileId: fileId, changed: false, contentSelected: false }, () => {
+    this.setState({
+      currentFileId: fileId,
+      changed: false,
+      contentSelected: false,
+      blockedPdfPreviewFileId: null,
+    }, () => {
       this.props.setMappingHeaderDisabled(true);
       this.loadFileContent();
       this.saveView();
@@ -371,14 +379,36 @@ class StixCoreObjectContentComponent extends Component {
       this.setState({
         currentFileId: null,
         contentSelected: isContainerWithContent(stixCoreObject.entity_type),
+        blockedPdfPreviewFileId: null,
         currentContent: isContainerWithContent(stixCoreObject.entity_type) ? stixCoreObject.contentField ?? t('Write something awesome...') : '',
       }, () => this.saveView());
     } else if (fileName && !isDelete) {
-      this.setState({ currentFileId: fileName, contentSelected: false }, () => {
+      this.setState({
+        currentFileId: fileName,
+        contentSelected: false,
+        blockedPdfPreviewFileId: null,
+      }, () => {
         this.loadFileContent();
         this.saveView();
       });
     }
+  }
+
+  handlePdfLoadError(error) {
+    if (!isPdfPasswordError(error)) {
+      return;
+    }
+    this.setState({ blockedPdfPreviewFileId: this.state.currentFileId });
+  }
+
+  handlePdfPasswordRequest(updatePassword) {
+    const { t } = this.props;
+    const password = window.prompt(t('This PDF is password protected. Enter password to preview it.'));
+    if (password === null) {
+      this.setState({ blockedPdfPreviewFileId: this.state.currentFileId });
+      return;
+    }
+    updatePassword(password);
   }
 
   // PDF SECTION
@@ -475,6 +505,7 @@ class StixCoreObjectContentComponent extends Component {
       navOpen,
       changed,
       contentSelected,
+      blockedPdfPreviewFileId,
     } = this.state;
     const files = getFiles(stixCoreObject);
     const exportFiles = getExportFiles(stixCoreObject);
@@ -484,6 +515,7 @@ class StixCoreObjectContentComponent extends Component {
     const currentFile = currentFileId
       && [...files, ...exportFiles, ...filesFromTemplate].find((n) => n.id === currentFileId);
     const currentFileType = currentFile && currentFile.metaData.mimetype;
+    const isBlockedPdfPreview = currentFileType === 'application/pdf' && currentFileId === blockedPdfPreviewFileId;
     const { innerHeight } = window;
     const height = innerHeight - 320;
     const isContentCompatible = isContainerWithContent(stixCoreObject.entity_type);
@@ -672,7 +704,7 @@ class StixCoreObjectContentComponent extends Component {
                 </div>
               </>
             )}
-            {currentFileType === 'application/pdf' && (
+            {currentFileType === 'application/pdf' && !isBlockedPdfPreview && (
               <>
                 <StixCoreObjectContentBar
                   handleZoomIn={this.handleZoomIn.bind(this)}
@@ -689,6 +721,8 @@ class StixCoreObjectContentComponent extends Component {
                 >
                   <Document
                     onLoadSuccess={this.onDocumentLoadSuccess.bind(this)}
+                    onLoadError={this.handlePdfLoadError.bind(this)}
+                    onPassword={this.handlePdfPasswordRequest.bind(this)}
                     loading={<Loader variant="inElement" />}
                     file={currentUrl}
                   >
@@ -703,6 +737,33 @@ class StixCoreObjectContentComponent extends Component {
                   </Document>
                 </div>
               </>
+            )}
+            {isBlockedPdfPreview && (
+              <div
+                className={
+                  navOpen
+                    ? classes.adjustedContainerNavOpen
+                    : classes.adjustedContainer
+                }
+              >
+                <div
+                  style={{
+                    display: 'table',
+                    height: '100%',
+                    width: '100%',
+                  }}
+                >
+                  <span
+                    style={{
+                      display: 'table-cell',
+                      verticalAlign: 'middle',
+                      textAlign: 'center',
+                    }}
+                  >
+                    {t('Unable to preview this PDF. It may be password protected. Select another file to continue.')}
+                  </span>
+                </div>
+              </div>
             )}
             {!currentFile && !contentSelected && (
               <div

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isPdfPasswordError } from './StixCoreObjectContentPdfUtils';
+
+describe('isPdfPasswordError', () => {
+  it('returns true when error name indicates password issue', () => {
+    expect(isPdfPasswordError({ name: 'PasswordException' })).toBe(true);
+  });
+
+  it('returns true when error message indicates missing password', () => {
+    expect(isPdfPasswordError({ message: 'No password given' })).toBe(true);
+  });
+
+  it('returns false for non-password errors', () => {
+    expect(isPdfPasswordError({ name: 'AbortException', message: 'The operation was aborted.' })).toBe(false);
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentPdfUtils.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentPdfUtils.ts
@@ -1,0 +1,8 @@
+export const isPdfPasswordError = (error: { name?: string; message?: string } | undefined | null) => {
+  if (!error) return false;
+  const errorName = (error.name ?? '').toLowerCase();
+  const errorMessage = (error.message ?? '').toLowerCase();
+  return errorName.includes('password')
+    || errorMessage.includes('password')
+    || errorMessage.includes('no password given');
+};


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request adds support for handling password-protected PDF files in the `StixCoreObjectContent` component. The main changes introduce logic to detect when a PDF cannot be previewed due to password protection, prompt the user for a password, and gracefully handle errors when previewing such files. Additionally, new utility functions and tests are included to support and verify this behavior.

**PDF password protection handling:**

* Added the `isPdfPasswordError` utility function in `StixCoreObjectContentPdfUtils.ts` to detect errors related to password-protected PDFs.
* Updated `StixCoreObjectContent.jsx` to track blocked PDF previews using a new `blockedPdfPreviewFileId` state, display an appropriate message when a PDF cannot be previewed, and prompt the user for a password if needed. 
* Integrated the new utility function and handlers into the PDF preview logic, including error and password request handling in the PDF viewer. 

**Testing:**

* Added unit tests for the `isPdfPasswordError` utility to ensure correct detection of password-related PDF errors.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16828

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
