### PR TITLE
feat(client-python): add fetch_opencti_file_by_id method (#13520)

### DIFF
--- a/client-python/examples/upload_and_export_external_reference_file.py
+++ b/client-python/examples/upload_and_export_external_reference_file.py
@@ -61,9 +61,12 @@ for stix_object in bundle["objects"]:
         if exported_external_reference.get("source_name") != "debug-fetch-by-id-source":
             continue
         exported_files = exported_external_reference.get("x_opencti_files", [])
+        if not exported_files:
+            continue
         # the external reference may be reused across script runs (dedup on
-        # source_name + url), so pick the most recently uploaded file
-        latest_file = sorted(exported_files, key=lambda f: f["version"])[-1]
+        # source_name + url), so pick the most recently uploaded file;
+        # "version" may be missing/None, so fall back to "" for sorting
+        latest_file = max(exported_files, key=lambda f: f.get("version") or "")
         exported_data = latest_file["data"]
 
 assert exported_data is not None, "file not found in exported bundle"

--- a/client-python/examples/upload_and_export_external_reference_file.py
+++ b/client-python/examples/upload_and_export_external_reference_file.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+import base64
+import os
+import tempfile
+
+from pycti import OpenCTIApiClient
+
+# Variables
+api_url = os.getenv("OPENCTI_API_URL", "http://localhost:4000")
+api_token = os.getenv("OPENCTI_API_TOKEN", "bfa014e0-e02e-4aa6-a42b-603b19dcf159")
+
+# OpenCTI initialization
+opencti_api_client = OpenCTIApiClient(api_url, api_token)
+
+# Content used to verify round-tripping later on
+file_content = b"debug fetch_opencti_file_by_id - sample content"
+
+with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as tmp_file:
+    tmp_file.write(file_content)
+    tmp_file_path = tmp_file.name
+
+print("== Step 1: create an External Reference ==")
+external_reference = opencti_api_client.external_reference.create(
+    source_name="debug-fetch-by-id-source",
+    url="https://example.com/debug-fetch-by-id",
+    description="Created by upload_and_export_external_reference_file.py",
+)
+print(external_reference)
+
+print("\n== Step 2: upload a file to the External Reference ==")
+upload_response = opencti_api_client.external_reference.add_file(
+    id=external_reference["id"],
+    file_name=tmp_file_path,
+)
+print(upload_response)
+# add_file() returns the raw GraphQL response, not a flattened dict
+uploaded_file = upload_response["data"]["externalReferenceEdit"]["importPush"]
+
+print("\n== Step 3: create a Report referencing the External Reference ==")
+report = opencti_api_client.report.create(
+    name="Debug fetch_opencti_file_by_id Report",
+    published="2024-01-01T00:00:00Z",
+    description="Created by upload_and_export_external_reference_file.py",
+    externalReferences=[external_reference["id"]],
+)
+print(report)
+
+print("\n== Step 4: export the Report to STIX2 (triggers fetch_opencti_file_by_id) ==")
+bundle = opencti_api_client.stix2.get_stix_bundle_or_object_from_entity_id(
+    entity_type="Report",
+    entity_id=report["id"],
+    mode="full",
+    only_entity=False,
+)
+
+exported_data = None
+for stix_object in bundle["objects"]:
+    if stix_object.get("type") != "report":
+        continue
+    for exported_external_reference in stix_object.get("external_references", []):
+        if exported_external_reference.get("source_name") != "debug-fetch-by-id-source":
+            continue
+        exported_files = exported_external_reference.get("x_opencti_files", [])
+        # the external reference may be reused across script runs (dedup on
+        # source_name + url), so pick the most recently uploaded file
+        latest_file = sorted(exported_files, key=lambda f: f["version"])[-1]
+        exported_data = latest_file["data"]
+
+assert exported_data is not None, "file not found in exported bundle"
+decoded_from_export = base64.b64decode(exported_data)
+print(f"Decoded content from export: {decoded_from_export!r}")
+assert decoded_from_export == file_content, "content mismatch after export round-trip!"
+print("OK: exported file content matches the uploaded content")
+
+print(
+    "\n== Step 5: compare fetch_opencti_file (url-based) vs fetch_opencti_file_by_id =="
+)
+file_id = uploaded_file["id"]
+storage_url = api_url.rstrip("/") + "/storage/get/" + file_id
+data_via_url = opencti_api_client.fetch_opencti_file(
+    storage_url, binary=True, serialize=True
+)
+data_via_id = opencti_api_client.fetch_opencti_file_by_id(
+    file_id, binary=True, serialize=True
+)
+print(f"fetch_opencti_file (url):     {data_via_url!r}")
+print(f"fetch_opencti_file_by_id:     {data_via_id!r}")
+assert (
+    data_via_url == data_via_id
+), "url-based and id-based fetch returned different data!"
+print("OK: both methods return identical content")
+
+print("\n== Cleanup ==")
+opencti_api_client.stix_domain_object.delete(id=report["id"])
+opencti_api_client.external_reference.delete(id=external_reference["id"])
+os.remove(tmp_file_path)
+print("Done.")

--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -249,7 +249,8 @@ class OpenCTIApiClient:
 
         # Define API
         self.api_token = token
-        self.api_url = url.rstrip("/") + "/graphql"
+        self.base_url = url.rstrip("/")
+        self.api_url = self.base_url + "/graphql"
         if provider is not None:
             provider_pattern_checker = re.compile(
                 r"^[A-Za-z]+\/\d+(?:\.[a-z]*\d+){0,}$"
@@ -792,6 +793,24 @@ class OpenCTIApiClient:
                 "Error fetching file", {"uri": fetch_uri, "error": str(e)}
             )
             return None
+
+    def fetch_opencti_file_by_id(self, file_id, binary=False, serialize=False):
+        """Get file from the OpenCTI API using its file id.
+
+        Builds the download URL from the platform base URL, avoiding the need
+        for callers to craft the storage URL themselves.
+
+        :param file_id: id of the file to fetch (e.g. an importFiles entry id)
+        :type file_id: str
+        :param binary: if True, returns raw bytes; if False, returns text, defaults to False
+        :type binary: bool, optional
+        :param serialize: if True, returns base64-encoded content, defaults to False
+        :type serialize: bool, optional
+        :return: returns either the file content as text, bytes, base64-encoded string, or None on failure
+        :rtype: str, bytes, or None
+        """
+        fetch_uri = f"{self.base_url}/storage/get/{file_id}"
+        return self.fetch_opencti_file(fetch_uri, binary=binary, serialize=serialize)
 
     def health_check(self):
         """Submit an example request to the OpenCTI API.

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2022,12 +2022,8 @@ class OpenCTIStix2:
                 ):
                     external_reference["x_opencti_files"] = []
                     for file in entity_external_reference["importFiles"]:
-                        url = (
-                            self.opencti.api_url.replace("graphql", "storage/get/")
-                            + file["id"]
-                        )
-                        data = self.opencti.fetch_opencti_file(
-                            url, binary=True, serialize=True
+                        data = self.opencti.fetch_opencti_file_by_id(
+                            file["id"], binary=True, serialize=True
                         )
                         external_reference["x_opencti_files"].append(
                             {
@@ -2395,19 +2391,19 @@ class OpenCTIStix2:
             del entity["attribute_date"]
         # Artifact
         if entity["type"] == "artifact" and "importFiles" in entity:
-            first_file = entity["importFiles"][0]["id"]
-            url = self.opencti.api_url.replace("graphql", "storage/get/") + first_file
-            file = self.opencti.fetch_opencti_file(url, binary=True, serialize=True)
+            first_file_id = entity["importFiles"][0]["id"]
+            file = self.opencti.fetch_opencti_file_by_id(
+                first_file_id, binary=True, serialize=True
+            )
             if file:
                 entity["payload_bin"] = file
         # Files
         if "importFiles" in entity and len(entity["importFiles"]) > 0:
             entity["x_opencti_files"] = []
             for file in entity["importFiles"]:
-                url = (
-                    self.opencti.api_url.replace("graphql", "storage/get/") + file["id"]
+                data = self.opencti.fetch_opencti_file_by_id(
+                    file["id"], binary=True, serialize=True
                 )
-                data = self.opencti.fetch_opencti_file(url, binary=True, serialize=True)
                 x_opencti_file = {
                     "name": file["name"],
                     "data": data,

--- a/client-python/tests/01-unit/api/test_opencti_api_client_fetch_file.py
+++ b/client-python/tests/01-unit/api/test_opencti_api_client_fetch_file.py
@@ -1,0 +1,97 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pycti import OpenCTIApiClient
+
+
+class TestFetchOpenctiFileById:
+    """Test OpenCTIApiClient.fetch_opencti_file_by_id functionality."""
+
+    @pytest.fixture
+    def api_client(self):
+        """Create an API client instance without performing health check."""
+        with patch.object(OpenCTIApiClient, "_setup_proxy_certificates"):
+            client = OpenCTIApiClient(
+                url="http://localhost:4000",
+                token="test-token",
+                ssl_verify=False,
+                perform_health_check=False,
+            )
+            client.app_logger = MagicMock()
+            return client
+
+    def test_builds_url_from_base_url_and_file_id(self, api_client):
+        """The storage URL should be derived from base_url, not api_url string replace."""
+        captured_calls = []
+
+        def fake_fetch_opencti_file(fetch_uri, binary=False, serialize=False):
+            captured_calls.append((fetch_uri, binary, serialize))
+            return "content"
+
+        with patch.object(
+            api_client, "fetch_opencti_file", side_effect=fake_fetch_opencti_file
+        ):
+            result = api_client.fetch_opencti_file_by_id("file-id-123")
+
+        assert result == "content"
+        assert captured_calls == [
+            ("http://localhost:4000/storage/get/file-id-123", False, False)
+        ]
+
+    def test_passes_binary_and_serialize_flags_through(self, api_client):
+        """binary and serialize flags must be forwarded unchanged."""
+        with patch.object(
+            api_client, "fetch_opencti_file", return_value="Zm9v"
+        ) as mocked_fetch:
+            result = api_client.fetch_opencti_file_by_id(
+                "file-id-123", binary=True, serialize=True
+            )
+
+        assert result == "Zm9v"
+        mocked_fetch.assert_called_once_with(
+            "http://localhost:4000/storage/get/file-id-123",
+            binary=True,
+            serialize=True,
+        )
+
+    def test_returns_none_on_failed_fetch(self, api_client):
+        """When the underlying fetch fails, None is propagated as-is."""
+        with patch.object(api_client, "fetch_opencti_file", return_value=None):
+            result = api_client.fetch_opencti_file_by_id("missing-file-id")
+
+        assert result is None
+
+    def test_uses_real_http_layer_and_honors_response_status(self, api_client):
+        """End-to-end (mocking only session.get) to verify delegation to fetch_opencti_file."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.content = b"binary-data"
+        mock_response.text = "text-data"
+
+        with patch.object(
+            api_client.session, "get", return_value=mock_response
+        ) as mocked_get:
+            result = api_client.fetch_opencti_file_by_id("file-id-456")
+
+        assert result == "text-data"
+        called_url = mocked_get.call_args[0][0]
+        assert called_url == "http://localhost:4000/storage/get/file-id-456"
+
+    def test_uses_real_http_layer_on_failed_response(self, api_client):
+        """A non-ok HTTP response should result in None and a warning log."""
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.status_code = 404
+
+        with patch.object(api_client.session, "get", return_value=mock_response):
+            result = api_client.fetch_opencti_file_by_id("missing-file-id")
+
+        assert result is None
+        api_client.app_logger.warning.assert_called_with(
+            "Failed to fetch file",
+            {
+                "uri": "http://localhost:4000/storage/get/missing-file-id",
+                "status_code": 404,
+            },
+        )

--- a/client-python/tests/01-unit/api/test_opencti_api_client_fetch_file.py
+++ b/client-python/tests/01-unit/api/test_opencti_api_client_fetch_file.py
@@ -95,3 +95,74 @@ class TestFetchOpenctiFileById:
                 "status_code": 404,
             },
         )
+
+    def test_builds_url_without_double_slash_when_url_has_trailing_slash(self):
+        """A trailing slash on the platform url must not produce a double slash
+        in the generated storage url."""
+        with patch.object(OpenCTIApiClient, "_setup_proxy_certificates"):
+            client = OpenCTIApiClient(
+                url="http://localhost:4000/",
+                token="test-token",
+                ssl_verify=False,
+                perform_health_check=False,
+            )
+            client.app_logger = MagicMock()
+
+        with patch.object(
+            client, "fetch_opencti_file", return_value="content"
+        ) as mocked_fetch:
+            client.fetch_opencti_file_by_id("file-id-123")
+
+        mocked_fetch.assert_called_once_with(
+            "http://localhost:4000/storage/get/file-id-123",
+            binary=False,
+            serialize=False,
+        )
+
+    def test_passes_file_id_with_special_characters_unchanged(self, api_client):
+        """A file id that looks like a path (with spaces/subfolders) must be
+        forwarded as-is, with no accidental encoding."""
+        file_id = "import/Artifact/some-id/my file (v2).bin"
+
+        with patch.object(
+            api_client, "fetch_opencti_file", return_value="content"
+        ) as mocked_fetch:
+            api_client.fetch_opencti_file_by_id(file_id, binary=True, serialize=True)
+
+        mocked_fetch.assert_called_once_with(
+            f"http://localhost:4000/storage/get/{file_id}",
+            binary=True,
+            serialize=True,
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:4000",
+            "https://opencti.example.com",
+            "http://192.168.1.10:4000",
+        ],
+    )
+    def test_url_equivalent_to_legacy_replace_based_construction(self, url):
+        """Characterization test: the new base_url-based storage url must be
+        byte-identical to the old api_url.replace("graphql", "storage/get/")
+        construction it replaces at the opencti_stix2.py call sites."""
+        with patch.object(OpenCTIApiClient, "_setup_proxy_certificates"):
+            client = OpenCTIApiClient(
+                url=url,
+                token="test-token",
+                ssl_verify=False,
+                perform_health_check=False,
+            )
+            client.app_logger = MagicMock()
+
+        file_id = "some-file-id"
+        legacy_url = client.api_url.replace("graphql", "storage/get/") + file_id
+
+        with patch.object(
+            client, "fetch_opencti_file", return_value="content"
+        ) as mocked_fetch:
+            client.fetch_opencti_file_by_id(file_id)
+
+        new_url = mocked_fetch.call_args[0][0]
+        assert new_url == legacy_url

--- a/client-python/tests/01-unit/utils/test_opencti_stix2.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2.py
@@ -632,12 +632,12 @@ def test_prepare_export_fetches_artifact_payload_bin_by_id(
     assert len(result) == 1
     assert result[0]["payload_bin"] == "Zm9v"
     # An artifact entity with importFiles goes through both the "Artifact"
-    # (payload_bin) and generic "Files" (x_opencti_files) branches, so the
-    # same file id is fetched twice.
-    assert fetch_by_id_calls == [
-        ("import/Artifact/internal-artifact-id/sample.bin", True, True),
-        ("import/Artifact/internal-artifact-id/sample.bin", True, True),
-    ]
+    # (payload_bin) and generic "Files" (x_opencti_files) branches. Assert on
+    # the fetched file id/flags rather than the exact call count, so this
+    # test doesn't lock in that implementation detail.
+    assert len(fetch_by_id_calls) >= 1
+    for call in fetch_by_id_calls:
+        assert call == ("import/Artifact/internal-artifact-id/sample.bin", True, True)
 
 
 def test_prepare_export_fetches_generic_import_files_by_id(

--- a/client-python/tests/01-unit/utils/test_opencti_stix2.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2.py
@@ -532,3 +532,158 @@ def test_prepare_export_keeps_non_embedded_markdown_image_uri(
     assert len(result) == 1
     assert result[0]["description"] == "desc ![img](/storage/get/import/global/a.png)"
     assert len(fetch_calls) == 0
+
+
+def test_generate_export_fetches_external_reference_files_by_id(
+    opencti_stix2: OpenCTIStix2, monkeypatch
+):
+    """External reference importFiles must be fetched via fetch_opencti_file_by_id,
+    passing the raw file id rather than a manually crafted storage URL."""
+    fetch_by_id_calls = []
+
+    def fake_fetch_by_id(file_id, binary=False, serialize=False):
+        fetch_by_id_calls.append((file_id, binary, serialize))
+        return "Zm9v"
+
+    monkeypatch.setattr(
+        opencti_stix2.opencti, "fetch_opencti_file_by_id", fake_fetch_by_id
+    )
+
+    entity = {
+        "id": "internal-report-id-ext-ref",
+        "standard_id": "report--33333333-3333-4333-8333-333333333333",
+        "entity_type": "Report",
+        "parent_types": ["Stix-Domain-Object"],
+        "externalReferencesIds": ["ext-ref-id"],
+        "externalReferences": [
+            {
+                "source_name": "acme-source",
+                "description": "",
+                "url": "https://example.com/report",
+                "hash": "",
+                "external_id": "",
+                "importFiles": [
+                    {
+                        "id": "import/External-Reference/ext-ref-id/report.pdf",
+                        "name": "report.pdf",
+                        "metaData": {"mimetype": "application/pdf", "version": "v1"},
+                    }
+                ],
+            }
+        ],
+    }
+
+    result = opencti_stix2.generate_export(entity=entity)
+
+    assert len(fetch_by_id_calls) == 1
+    assert fetch_by_id_calls[0] == (
+        "import/External-Reference/ext-ref-id/report.pdf",
+        True,
+        True,
+    )
+    x_opencti_files = result["external_references"][0]["x_opencti_files"]
+    assert x_opencti_files == [
+        {
+            "name": "report.pdf",
+            "data": "Zm9v",
+            "mime_type": "application/pdf",
+            "version": "v1",
+        }
+    ]
+
+
+def test_prepare_export_fetches_artifact_payload_bin_by_id(
+    opencti_stix2: OpenCTIStix2, monkeypatch
+):
+    """Artifact payload_bin must be fetched via fetch_opencti_file_by_id using the
+    first importFiles entry's id, not a manually crafted storage URL."""
+    monkeypatch.setattr(
+        opencti_stix2.opencti.stix_nested_ref_relationship,
+        "list",
+        lambda **kwargs: [],
+    )
+
+    fetch_by_id_calls = []
+
+    def fake_fetch_by_id(file_id, binary=False, serialize=False):
+        fetch_by_id_calls.append((file_id, binary, serialize))
+        return "Zm9v"
+
+    monkeypatch.setattr(
+        opencti_stix2.opencti, "fetch_opencti_file_by_id", fake_fetch_by_id
+    )
+
+    entity = {
+        "id": "artifact--44444444-4444-4444-8444-444444444444",
+        "type": "artifact",
+        "x_opencti_id": "internal-artifact-id",
+        "importFilesIds": ["import/Artifact/internal-artifact-id/sample.bin"],
+        "importFiles": [
+            {
+                "id": "import/Artifact/internal-artifact-id/sample.bin",
+                "name": "sample.bin",
+                "metaData": {"mimetype": "application/octet-stream", "version": None},
+            }
+        ],
+    }
+
+    result = opencti_stix2.prepare_export(entity=entity, mode="simple")
+
+    assert len(result) == 1
+    assert result[0]["payload_bin"] == "Zm9v"
+    # An artifact entity with importFiles goes through both the "Artifact"
+    # (payload_bin) and generic "Files" (x_opencti_files) branches, so the
+    # same file id is fetched twice.
+    assert fetch_by_id_calls == [
+        ("import/Artifact/internal-artifact-id/sample.bin", True, True),
+        ("import/Artifact/internal-artifact-id/sample.bin", True, True),
+    ]
+
+
+def test_prepare_export_fetches_generic_import_files_by_id(
+    opencti_stix2: OpenCTIStix2, monkeypatch
+):
+    """Generic entity importFiles (x_opencti_files) must be fetched via
+    fetch_opencti_file_by_id, not a manually crafted storage URL."""
+    monkeypatch.setattr(
+        opencti_stix2.opencti.stix_nested_ref_relationship,
+        "list",
+        lambda **kwargs: [],
+    )
+
+    fetch_by_id_calls = []
+
+    def fake_fetch_by_id(file_id, binary=False, serialize=False):
+        fetch_by_id_calls.append((file_id, binary, serialize))
+        return "Zm9v"
+
+    monkeypatch.setattr(
+        opencti_stix2.opencti, "fetch_opencti_file_by_id", fake_fetch_by_id
+    )
+
+    entity = {
+        "id": "intrusion-set--55555555-5555-4555-8555-555555555555",
+        "type": "intrusion-set",
+        "x_opencti_id": "internal-intrusion-set-id",
+        "importFilesIds": ["import/Intrusion-Set/internal-intrusion-set-id/notes.txt"],
+        "importFiles": [
+            {
+                "id": "import/Intrusion-Set/internal-intrusion-set-id/notes.txt",
+                "name": "notes.txt",
+                "metaData": {"mimetype": "text/plain", "version": "v2"},
+            }
+        ],
+    }
+
+    result = opencti_stix2.prepare_export(entity=entity, mode="simple")
+
+    assert len(result) == 1
+    x_opencti_files = result[0]["x_opencti_files"]
+    assert len(x_opencti_files) == 1
+    assert x_opencti_files[0]["name"] == "notes.txt"
+    assert x_opencti_files[0]["data"] == "Zm9v"
+    assert x_opencti_files[0]["mime_type"] == "text/plain"
+    assert x_opencti_files[0]["version"] == "v2"
+    assert fetch_by_id_calls == [
+        ("import/Intrusion-Set/internal-intrusion-set-id/notes.txt", True, True)
+    ]


### PR DESCRIPTION
### Proposed changes

* Added `fetch_opencti_file_by_id(file_id, ...)` to `OpenCTIApiClient` that fetches a file straight from its id instead of requiring callers to build the storage URL by hand. `fetch_opencti_file` is untouched, so nothing breaks for anyone already using it.
* Swapped the 3 internal spots in `opencti_stix2.py` that were manually crafting the storage URL to use the new method instead. Left the 2 markdown embedded-image spots alone since those need a path, not just an id.

### Related issues
* closes #13520

### How to test this PR

Run the unit test suite:

```
cd client-python
python3 -m pytest tests/01-unit/api/test_opencti_api_client_fetch_file.py tests/01-unit/utils/test_opencti_stix2.py -v
```


Or run it live against a real instance with `examples/upload_and_export_external_reference_file.py`. it uploads a file, exports it, and checks the old and new fetch methods return identical content.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

`fetch_opencti_file` stays as-is on purpose as `pycti` is a published package other connectors depend on. This is additive at the API level, but a real replacement at the 3 call sites (not just an alternative path left dangling).
