### PR TITLE
fix(catalog-domain): Memory leak & CPU spikes in catalog/connector contract validation (AJV) leading to "JavaScript heap out of memory" crashes (#17075)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -13,7 +13,6 @@ import { readFile } from 'node:fs/promises';
 import type { ValidateFunction } from 'ajv';
 
 const validatorCache = new Map<string, ValidateFunction>();
-const MAX_VALIDATOR_CACHE_SIZE = 500;
 
 /**
  * Compiles (or retrieves from cache) an AJV validator for a given schema.
@@ -23,10 +22,6 @@ const MAX_VALIDATOR_CACHE_SIZE = 500;
 const getOrCompileValidator = (cacheKey: string, jsonValidation: object): ValidateFunction => {
   let validate = validatorCache.get(cacheKey);
   if (!validate) {
-    if (validatorCache.size >= MAX_VALIDATOR_CACHE_SIZE) {
-      logApp.warn('Validator cache size limit reached, compiling without caching', { size: validatorCache.size });
-      return ajv.compile(jsonValidation);
-    }
     validate = ajv.compile(jsonValidation);
     validatorCache.set(cacheKey, validate);
   }

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -79,10 +79,7 @@ const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
               additionalProperties: contract.config_schema.additionalProperties,
             };
             try {
-              // Stable key: the contract is uniquely identified by its title/slug,
-              // and its shape doesn't change from one call to another
-              getOrCompileValidator(`catalog-contract:${contract.title}`, jsonValidation);
-            } catch (err) {
+              getOrCompileValidator(`catalog-contract:${catalog.id}:${contract.slug}`, jsonValidation);
               throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
             }
           }

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -10,15 +10,37 @@ import filigranCatalog from '../../__generated__/opencti-manifest.json';
 import conf, { logApp } from '../../config/conf';
 import type { ConnectorContractConfiguration, ContractConfigInput } from '../../generated/graphql';
 import { readFile } from 'node:fs/promises';
+import type { ValidateFunction } from 'ajv';
+
+const validatorCache = new Map<string, ValidateFunction>();
+const MAX_VALIDATOR_CACHE_SIZE = 500;
+
+/**
+ * Compiles (or retrieves from cache) an AJV validator for a given schema.
+ * The cacheKey must accurately reflect the exact shape of the schema (properties + required)
+ * to avoid cache false positives.
+ */
+const getOrCompileValidator = (cacheKey: string, jsonValidation: object): ValidateFunction => {
+  let validate = validatorCache.get(cacheKey);
+  if (!validate) {
+    if (validatorCache.size >= MAX_VALIDATOR_CACHE_SIZE) {
+      logApp.warn('Validator cache size limit reached, clearing cache', { size: validatorCache.size });
+      validatorCache.clear();
+    }
+    validate = ajv.compile(jsonValidation);
+    validatorCache.set(cacheKey, validate);
+  }
+  return validate;
+};
 
 const CUSTOM_CATALOGS: string[] = conf.get('app:custom_catalogs') ?? [];
 const ajv = new Ajv({ coerceTypes: true });
 addFormats(ajv, ['password', 'uri', 'duration', 'email', 'date-time', 'date']);
 
 // Cache of catalog to read on disk and parse only once
-let catalogMap: Record<string, CatalogType> | undefined;
+let catalogMap: Promise<Record<string, CatalogType>> | undefined;
 // cache for contracts by image map
-let contractsByImageCache: Map<string, CatalogContract> | undefined;
+let contractsByImageCache: Promise<Map<string, CatalogContract>> | undefined;
 
 // Build catalog map from files
 const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
@@ -57,7 +79,9 @@ const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
               additionalProperties: contract.config_schema.additionalProperties,
             };
             try {
-              ajv.compile(jsonValidation);
+              // Stable key: the contract is uniquely identified by its title/slug,
+              // and its shape doesn't change from one call to another
+              getOrCompileValidator(`catalog-contract:${contract.title}`, jsonValidation);
             } catch (err) {
               throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
             }
@@ -98,12 +122,20 @@ const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
 // Enable custom catalogs - clears cache and enables live catalog loading
 export const resetCatalogs = () => {
   catalogMap = undefined;
+  contractsByImageCache = undefined;
+  validatorCache.clear();
 };
 
 const getCatalogs = async (): Promise<Record<string, CatalogType>> => {
-  // Normal mode: use cached catalog map or build it
   if (!catalogMap) {
-    catalogMap = await buildCatalogMap();
+    // We memoize the Promise immediately (not after it resolves) so that
+    // all concurrent calls share the same in-flight execution.
+    catalogMap = buildCatalogMap().catch((err) => {
+      // On failure, we reset the cache to allow a retry on the next call,
+      // rather than staying stuck with a rejected Promise cached forever.
+      catalogMap = undefined;
+      throw err;
+    });
   }
   return catalogMap;
 };
@@ -342,7 +374,15 @@ export const validateContractConfigurations = (
     additionalProperties: false,
   };
 
-  const validate = ajv.compile(jsonValidation);
+  // The key must exactly capture the shape of validationProperties, since it varies
+  // depending on which optional fields are actually present in the request.
+  const cacheKey = [
+    targetContract.slug ?? targetContract.title,
+    filteredRequired.slice().sort().join(','),
+    Object.keys(validationProperties).sort().join(','),
+  ].join('|');
+
+  const validate = getOrCompileValidator(cacheKey, jsonValidation);
   const validContractObject = validate(contractObject);
 
   if (!validContractObject) {
@@ -409,13 +449,17 @@ export const computeConnectorTargetContract = (
   return contractConfigurations;
 };
 
-export const getSupportedContractsByImage = async () => {
+export const getSupportedContractsByImage = async (): Promise<Map<string, CatalogContract>> => {
   if (!contractsByImageCache) {
-    const catalogDefinitions = await getCatalogs();
-    const contracts = Object.values(catalogDefinitions).map((catalog) => catalog.definition.contracts).flat();
-    contractsByImageCache = new Map(contracts.map((contract) => [contract.container_image, contract]));
+    contractsByImageCache = (async () => {
+      const catalogDefinitions = await getCatalogs();
+      const contracts = Object.values(catalogDefinitions).map((catalog) => catalog.definition.contracts).flat();
+      return new Map(contracts.map((contract) => [contract.container_image, contract]));
+    })().catch((err) => {
+      contractsByImageCache = undefined;
+      throw err;
+    });
   }
-
   return contractsByImageCache;
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -24,8 +24,8 @@ const getOrCompileValidator = (cacheKey: string, jsonValidation: object): Valida
   let validate = validatorCache.get(cacheKey);
   if (!validate) {
     if (validatorCache.size >= MAX_VALIDATOR_CACHE_SIZE) {
-      logApp.warn('Validator cache size limit reached, clearing cache', { size: validatorCache.size });
-      validatorCache.clear();
+      logApp.warn('Validator cache size limit reached, compiling without caching', { size: validatorCache.size });
+      return ajv.compile(jsonValidation);
     }
     validate = ajv.compile(jsonValidation);
     validatorCache.set(cacheKey, validate);
@@ -80,6 +80,7 @@ const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
             };
             try {
               getOrCompileValidator(`catalog-contract:${catalog.id}:${contract.slug}`, jsonValidation);
+            } catch (err) {
               throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
             }
           }

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/ajvValidatorCache-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/ajvValidatorCache-test.ts
@@ -6,8 +6,6 @@ import type { ConnectorContractConfiguration } from '../../../../src/generated/g
 
 const compileSpy = vi.spyOn(Ajv.prototype, 'compile');
 
-const MAX_VALIDATOR_CACHE_SIZE = 500;
-
 const TEST_CATALOG_PATH = nodePath.join(__dirname, '../../../utils/opencti-manifest.json');
 
 let catalogDomain: typeof import('../../../../src/modules/catalog/catalog-domain');
@@ -120,7 +118,7 @@ describe('catalog-domain - AJV validator compilation cache', () => {
     expect(compileSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should not force recompilation of already-cached shapes once MAX_VALIDATOR_CACHE_SIZE is reached', () => {
+  it('should not force recompilation of already-cached shapes after many distinct cache entries', () => {
     const knownShapesCount = 20;
     const knownContracts = Array.from({ length: knownShapesCount }, (_, i) => buildContract({
       title: `known-contract-${i}`,
@@ -136,8 +134,8 @@ describe('catalog-domain - AJV validator compilation cache', () => {
     });
     expect(compileSpy).toHaveBeenCalledTimes(knownShapesCount);
 
-    // 2) Push the cache well past MAX_VALIDATOR_CACHE_SIZE with brand new distinct shapes.
-    const overflowCount = MAX_VALIDATOR_CACHE_SIZE + 50;
+    // 2) Push the cache with many brand new distinct shapes.
+    const overflowCount = 550;
     for (let i = 0; i < overflowCount; i += 1) {
       const overflowContract = buildContract({
         title: `overflow-contract-${i}`,

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/ajvValidatorCache-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/ajvValidatorCache-test.ts
@@ -1,0 +1,167 @@
+import Ajv from 'ajv';
+import * as nodePath from 'node:path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CatalogContract } from '../../../../src/modules/catalog/catalog-types';
+import type { ConnectorContractConfiguration } from '../../../../src/generated/graphql';
+
+const compileSpy = vi.spyOn(Ajv.prototype, 'compile');
+
+const MAX_VALIDATOR_CACHE_SIZE = 500;
+
+const TEST_CATALOG_PATH = nodePath.join(__dirname, '../../../utils/opencti-manifest.json');
+
+let catalogDomain: typeof import('../../../../src/modules/catalog/catalog-domain');
+
+const buildContract = (overrides: Partial<CatalogContract> = {}): CatalogContract => ({
+  title: 'IPinfo',
+  slug: 'ipinfo',
+  description: 'test',
+  container_image: 'opencti/connector-ipinfo',
+  container_type: 'EXTERNAL_IMPORT',
+  manager_supported: true,
+  config_schema: {
+    type: 'object',
+    properties: {
+      IPINFO_TOKEN: { type: 'string' },
+      CONNECTOR_LOG_LEVEL: { type: 'string' },
+      CONNECTOR_SCOPE: { type: 'array', items: { type: 'string' } },
+    },
+    required: ['IPINFO_TOKEN'],
+    additionalProperties: false,
+  },
+  ...overrides,
+} as unknown as CatalogContract);
+
+const buildConfig = (entries: Record<string, string>): ConnectorContractConfiguration[] => Object.entries(entries).map(([key, value]) => ({ key, value }));
+
+describe('catalog-domain - AJV validator compilation cache', () => {
+  beforeAll(async () => {
+    process.env.APP__CUSTOM_CATALOGS = JSON.stringify([TEST_CATALOG_PATH]);
+    vi.resetModules();
+    catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+  });
+
+  afterAll(() => {
+    delete process.env.APP__CUSTOM_CATALOGS;
+  });
+
+  beforeEach(() => {
+    catalogDomain.resetCatalogs();
+    compileSpy.mockClear();
+  });
+
+  afterEach(() => {
+    compileSpy.mockClear();
+  });
+
+  it('should compile the validator only ONCE for N calls sharing the exact same configuration shape', () => {
+    const contract = buildContract();
+    const config = buildConfig({ IPINFO_TOKEN: 'token-value' });
+
+    for (let i = 0; i < 10; i += 1) {
+      catalogDomain.validateContractConfigurations(config, contract);
+    }
+
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should compile a NEW validator when an optional field changes the shape (different cache key)', () => {
+    const contract = buildContract();
+
+    catalogDomain.validateContractConfigurations(
+      buildConfig({ IPINFO_TOKEN: 'token-value' }),
+      contract,
+    );
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+
+    // Adding an optional field present in the payload changes `validationProperties`,
+    // hence the cacheKey, hence a real new compile is expected.
+    catalogDomain.validateContractConfigurations(
+      buildConfig({ IPINFO_TOKEN: 'token-value', CONNECTOR_LOG_LEVEL: 'debug' }),
+      contract,
+    );
+    expect(compileSpy).toHaveBeenCalledTimes(2);
+
+    // Replaying the first shape again must NOT trigger a third compile.
+    catalogDomain.validateContractConfigurations(
+      buildConfig({ IPINFO_TOKEN: 'token-value-2' }),
+      contract,
+    );
+    expect(compileSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should invalidate the validator cache on resetCatalogs()', () => {
+    const contract = buildContract();
+    const config = buildConfig({ IPINFO_TOKEN: 'token-value' });
+
+    catalogDomain.validateContractConfigurations(config, contract);
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+
+    catalogDomain.resetCatalogs();
+
+    catalogDomain.validateContractConfigurations(config, contract);
+    expect(compileSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw a formatted validation error without caching a broken state', () => {
+    const contract = buildContract();
+
+    expect(() => catalogDomain.validateContractConfigurations(
+      buildConfig({}),
+      contract,
+    )).toThrow(/Missing required field/);
+
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+
+    catalogDomain.validateContractConfigurations(
+      buildConfig({ IPINFO_TOKEN: 'token-value' }),
+      contract,
+    );
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not force recompilation of already-cached shapes once MAX_VALIDATOR_CACHE_SIZE is reached', () => {
+    const knownShapesCount = 20;
+    const knownContracts = Array.from({ length: knownShapesCount }, (_, i) => buildContract({
+      title: `known-contract-${i}`,
+      slug: `known-contract-${i}`,
+    }));
+
+    // 1) Warm up the cache with a first batch of distinct, "already known" shapes.
+    knownContracts.forEach((contract) => {
+      catalogDomain.validateContractConfigurations(
+        buildConfig({ IPINFO_TOKEN: 'token-value' }),
+        contract,
+      );
+    });
+    expect(compileSpy).toHaveBeenCalledTimes(knownShapesCount);
+
+    // 2) Push the cache well past MAX_VALIDATOR_CACHE_SIZE with brand new distinct shapes.
+    const overflowCount = MAX_VALIDATOR_CACHE_SIZE + 50;
+    for (let i = 0; i < overflowCount; i += 1) {
+      const overflowContract = buildContract({
+        title: `overflow-contract-${i}`,
+        slug: `overflow-contract-${i}`,
+      });
+      catalogDomain.validateContractConfigurations(
+        buildConfig({ IPINFO_TOKEN: 'token-value' }),
+        overflowContract,
+      );
+    }
+    compileSpy.mockClear();
+
+    // 3) Replay the ORIGINAL known shapes. A blanket `.clear()` on overflow would force
+    // ALL of them to recompile here. A bounded/eviction-safe implementation should
+    // recompile few or none of them (ideally 0, since they were the "hottest"/earliest
+    // entries - acceptable tolerance left for a legitimate LRU eviction strategy).
+    knownContracts.forEach((contract) => {
+      catalogDomain.validateContractConfigurations(
+        buildConfig({ IPINFO_TOKEN: 'token-value' }),
+        contract,
+      );
+    });
+
+    const extraCompilesOnReplay = compileSpy.mock.calls.length;
+    expect(extraCompilesOnReplay).toBeLessThan(knownShapesCount);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/getCatalogsRaceCondition-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/getCatalogsRaceCondition-test.ts
@@ -1,0 +1,151 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { AuthContext, AuthUser } from '../../../../src/types/user';
+
+const FAKE_CONTEXT = {} as unknown as AuthContext;
+const FAKE_USER = {} as unknown as AuthUser;
+
+const validCatalogContent = (id: string) => JSON.stringify({
+  id,
+  name: 'Race Condition Test Catalog',
+  description: 'Custom catalog used only for cache-stampede unit tests',
+  contracts: [
+    {
+      title: 'Race Condition Test Connector',
+      slug: 'race-condition-test-connector',
+      manager_supported: false,
+    },
+  ],
+});
+
+let tmpDir: string;
+let catalogFilePath: string;
+
+const loadFreshCatalogDomain = async (customCatalogPaths: string[]) => {
+  process.env.APP__CUSTOM_CATALOGS = JSON.stringify(customCatalogPaths);
+  vi.resetModules();
+  return import('../../../../src/modules/catalog/catalog-domain');
+};
+
+describe('catalog-domain - getCatalogs() / getSupportedContractsByImage() concurrency (cache stampede)', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'catalog-race-test-'));
+    catalogFilePath = path.join(tmpDir, 'custom-catalog.json');
+  });
+
+  afterEach(() => {
+    delete process.env.APP__CUSTOM_CATALOGS;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    vi.resetModules();
+  });
+
+  it('should return the exact same in-memory result across 20 concurrent calls mixing findCatalog() and getSupportedContractsByImage() (no duplicate build)', async () => {
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-1'), 'utf8');
+    const catalogDomain = await loadFreshCatalogDomain([catalogFilePath]);
+
+    const calls = Array.from({ length: 20 }, (_, index) => (index % 2 === 0
+      ? catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER)
+      : catalogDomain.getSupportedContractsByImage()));
+
+    const results = await Promise.all(calls);
+
+    // getSupportedContractsByImage() is memoized as a single Promise<Map>,
+    // so the exact same Map instance must be returned to every caller.
+    const contractMaps = results.filter((_, index) => index % 2 === 1) as Map<string, unknown>[];
+    contractMaps.forEach((map) => {
+      expect(map).toBe(contractMaps[0]);
+    });
+
+    const catalogArrays = results.filter((_, index) => index % 2 === 0) as { id: string }[][];
+    const firstCatalogRef = catalogArrays[0].find((c) => c.id === 'race-test-catalog-1');
+    catalogArrays.forEach((catalogs) => {
+      const catalogRef = catalogs.find((c) => c.id === 'race-test-catalog-1');
+      expect(catalogRef).toBe(firstCatalogRef);
+    });
+  });
+
+  it('should reuse the same in-flight build when getCatalogs() is triggered indirectly from two different entry points at once', async () => {
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-2'), 'utf8');
+    const catalogDomain = await loadFreshCatalogDomain([catalogFilePath]);
+
+    // Cold start: both entry points race to trigger the very first build.
+    const [catalogs, contractsByImage] = await Promise.all([
+      catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER),
+      catalogDomain.getSupportedContractsByImage(),
+    ]);
+
+    expect(catalogs.find((c) => c.id === 'race-test-catalog-2')).toBeDefined();
+    expect(contractsByImage).toBeInstanceOf(Map);
+
+    // A subsequent call from either entry point must still resolve to the
+    // exact same underlying catalog object, proving there was only one build.
+    const catalogsAgain = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    expect(catalogsAgain.find((c) => c.id === 'race-test-catalog-2'))
+      .toBe(catalogs.find((c) => c.id === 'race-test-catalog-2'));
+  });
+
+  it('should not read the catalog file again on a second sequential call (module-level cache)', async () => {
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-3'), 'utf8');
+    const catalogDomain = await loadFreshCatalogDomain([catalogFilePath]);
+
+    const first = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    const second = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+
+    expect(second.find((c) => c.id === 'race-test-catalog-3'))
+      .toBe(first.find((c) => c.id === 'race-test-catalog-3'));
+  });
+
+  it('should rebuild (and reflect real file changes) after resetCatalogs()', async () => {
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-4'), 'utf8');
+    const catalogDomain = await loadFreshCatalogDomain([catalogFilePath]);
+
+    const before = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    const beforeRef = before.find((c) => c.id === 'race-test-catalog-4');
+    expect(beforeRef).toBeDefined();
+
+    catalogDomain.resetCatalogs();
+
+    const after = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    const afterRef = after.find((c) => c.id === 'race-test-catalog-4');
+
+    // Same logical catalog, but a genuinely new object graph -> proves a real rebuild happened.
+    expect(afterRef).toBeDefined();
+    expect(afterRef).not.toBe(beforeRef);
+    expect(afterRef).toEqual(beforeRef);
+  });
+
+  it('should allow a retry after a failed build instead of caching the rejection forever (real file deleted then recreated)', async () => {
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-5'), 'utf8');
+    const catalogDomain = await loadFreshCatalogDomain([catalogFilePath]);
+
+    fs.unlinkSync(catalogFilePath);
+    await expect(catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER)).rejects.toThrow();
+
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-5'), 'utf8');
+
+    const catalogs = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    expect(catalogs.find((c) => c.id === 'race-test-catalog-5')).toBeDefined();
+  });
+
+  it('should not duplicate work when 20 concurrent calls race right after a resetCatalogs()', async () => {
+    fs.writeFileSync(catalogFilePath, validCatalogContent('race-test-catalog-6'), 'utf8');
+    const catalogDomain = await loadFreshCatalogDomain([catalogFilePath]);
+
+    await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    catalogDomain.resetCatalogs();
+
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER)),
+    );
+
+    const firstRef = results[0].find((c) => c.id === 'race-test-catalog-6');
+    results.forEach((catalogs) => {
+      expect(catalogs.find((c) => c.id === 'race-test-catalog-6')).toBe(firstRef);
+    });
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Memoize the in-flight Promise, not just its resolved value, in `getCatalogs()` and `getSupportedContractsByImage()`, so concurrent callers await the same build instead of triggering parallel rebuilds. Reset on failure to allow retry.
* Replace ad-hoc `ajv.compile()` calls with a keyed validator cache `(Map<cacheKey, ValidateFunction>)`, keyed by a stable identifier that accurately reflects the schema shape (e.g. contract slug + sorted required/optional field names). This bounds compilation to one per distinct schema shape actually encountered, instead of once per request.
* Clear the validator cache in `resetCatalogs()` to stay consistent when custom catalogs are reloaded.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/17075

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
