### PR TITLE
ci(fork): change trigger in check commit workflow (#13735)

### DIFF
--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -3,8 +3,7 @@ name: PR conventions checks
 # It avoids jobs that require elevated write permissions/secrets on fork PRs; PR-write operations should live in a separate workflow.
 
 on:
-  #pull_request_target:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, ready_for_review, synchronize]
 
 permissions: {}

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "If you need to sign commits, Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
       - name: Check signed commits in PR on fail see above information.
-        uses: 1Password/check-signed-commits-action@v1
+        uses: 1Password/check-signed-commits-action@ed2885f3ed2577a4f5d3c3fe895432a557d23d52
         with:
           comment: |
             Thank you for your contribution, but we need you to sign your commits. Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -3,7 +3,7 @@ name: PR conventions checks
 # It avoids jobs that require elevated write permissions/secrets on fork PRs; PR-write operations should live in a separate workflow.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, ready_for_review, synchronize]
 jobs:
   check-pr-title-convention:

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -3,7 +3,8 @@ name: PR conventions checks
 # It avoids jobs that require elevated write permissions/secrets on fork PRs; PR-write operations should live in a separate workflow.
 
 on:
-  pull_request_target:
+  #pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, ready_for_review, synchronize]
 
 permissions: {}

--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -5,6 +5,9 @@ name: PR conventions checks
 on:
   pull_request_target:
     types: [opened, edited, reopened, ready_for_review, synchronize]
+
+permissions: {}
+
 jobs:
   check-pr-title-convention:
     name: Check that PR title follows convention
@@ -24,14 +27,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
-      - name: Information about how to sign commits see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
-        # "with comment" below does not work for forks.
+      - name: Check signed commits in PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "If you need to sign commits, Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
-      - name: Check signed commits in PR on fail see above information.
-        uses: 1Password/check-signed-commits-action@ed2885f3ed2577a4f5d3c3fe895432a557d23d52
-        with:
-          comment: |
-            Thank you for your contribution, but we need you to sign your commits. Please see https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+          UNSIGNED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits \
+            --jq '[.[] | select(.commit.verification.verified != true)] | length')
+          if [ "$UNSIGNED" -gt 0 ]; then
+            echo "::error::Found $UNSIGNED unsigned commit(s). Please sign your commits: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+            exit 1
+          fi
+          echo "All commits are signed."


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* changing pull_request to pull_request_target should made it trigger automatically on forks.
* remove write permission
* use gh cli instead of an external lib to check that commit are signed

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #13735 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

See "Testing" commit =>
Run with "pull_request" to be trigger on pull request itself here (pull_request_target is only trigger from master):
- https://github.com/OpenCTI-Platform/opencti/actions/runs/29577970667/job/87876692580

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
