### PR TITLE
fix(dashboard): fix VerticalBars widget for time series (#17013)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetVerticalBars.tsx
@@ -34,15 +34,21 @@ const WidgetVerticalBars = ({
       formatter = yd;
     }
 
+    // All intervals are rendered on a 'category' x-axis (isTimeSeries = false) with
+    // tickAmount = 'dataPoints'. A 'datetime' axis (previously used for day/week) aligns its
+    // ticks to calendar boundaries and does not guarantee a tick on the last data point, which
+    // dropped the label of the most recent bar. A category axis labels every bar, including the
+    // most recent one, and the time-series buckets are already gap-filled and evenly spaced by
+    // the backend, so discrete categories render correctly.
     return verticalBarsChartOptions(
       theme,
       formatter,
       simpleNumberFormat,
       false,
-      !interval || ['day', 'week'].includes(interval),
+      false,
       isStacked,
       hasLegend,
-      interval && !['day', 'week'].includes(interval) ? 'dataPoints' : undefined,
+      'dataPoints',
     ) as ApexOptions;
   }, [theme, interval, isStacked, hasLegend]);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request updates the rendering logic for the x-axis in the `WidgetVerticalBars` component to consistently use a 'category' axis for all intervals. This change ensures that every bar, including the most recent one, is labeled correctly, addressing previous issues with missing labels when using a 'datetime' axis.

**Chart rendering improvements:**

* Updated the x-axis configuration in `WidgetVerticalBars.tsx` to always use a 'category' axis with `tickAmount` set to `'dataPoints'`, ensuring that all bars (including the most recent) are labeled, regardless of the interval. Previously, a 'datetime' axis was used for 'day' and 'week' intervals, which could omit the last label due to tick alignment with calendar boundaries.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17013 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
