### PR TITLE
feat(authentication): logout based on websocket connection (#17081)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpServer.js
+++ b/opencti-platform/opencti-graphql/src/http/httpServer.js
@@ -24,7 +24,7 @@ import { createAuthenticatedContext } from './httpAuthenticatedContext';
 import { getSettings } from '../domain/settings';
 import { isWorkAlive } from '../domain/work';
 import { computeLoaders } from './httpAuthenticatedContext';
-import { buildRateLimiterOptions } from './httpUtils';
+import { buildRateLimiterOptions, logOutUser } from './httpUtils';
 import { checkDraftInContext } from './httpServer-draft';
 import ipWhitelistMiddleware from './ipWhitelistMiddleware';
 
@@ -118,11 +118,44 @@ const createHttpServer = async () => {
     server: httpServer,
     path: `${basePath}/graphql`,
   });
+  const userConnections = new Map();
   wsServer.on('error', (e) => {
     throw e;
   });
+  const trackConnections = async (user, activity, timeoutId) => {
+    const userId = user.id;
+    if (activity === 'connection') {
+      if (!userConnections.has(userId)) {
+        userConnections.set(userId, 1);
+      } else {
+        userConnections.set(userId, userConnections.get(userId) + 1);
+      }
+    } else {
+      const userConnectionCount = userConnections.get(userId);
+      if (userConnectionCount === 1) {
+        await logOutUser(user);
+        userConnections.delete(userId);
+      } else if (userConnectionCount > 1) {
+        userConnections.set(userId, userConnections.get(userId) - 1);
+      }
+    }
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  };
   const serverCleanup = useServer({
     schema,
+    onConnect: async (ctx) => {
+      const session = await extractWsSessionContext(ctx);
+      await trackConnections(session.user, 'connection');
+    },
+    onDisconnect: async (ctx) => {
+      // timeout to prevent logouts due to refresh or network issues
+      const timeoutId = setTimeout(async () => {
+        const session = await extractWsSessionContext(ctx);
+        await trackConnections(session.user, 'disconnection', timeoutId);
+      }, 4000);
+    },
     context: extractWsSessionContext,
   }, wsServer);
 

--- a/opencti-platform/opencti-graphql/src/http/httpUtils.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpUtils.ts
@@ -16,6 +16,10 @@ import {
 import type { HelmetOptions } from 'helmet';
 import { type Options, ipKeyGenerator } from 'express-rate-limit';
 import { BlockList } from 'node:net';
+import type { AuthUser } from '../types/user';
+import { publishUserAction } from '../listener/UserActionListener';
+import { delUserContext } from '../database/redis';
+import { killUserSessions } from '../database/session';
 
 export const setCookieError = (res: Response, message: string) => {
   // Map error messages to safe, non-sensitive codes exposed to the client.
@@ -285,4 +289,22 @@ export const buildRateLimiterOptions = (): Options => {
     },
   };
   return rateLimitOptions as Options;
+};
+
+export const logOutUser = async (user: AuthUser) => {
+  try {
+    if (user) {
+      await publishUserAction({
+        user: { ...user, origin: { socket: 'query', user_id: user.id } },
+        event_type: 'authentication',
+        event_access: 'administration',
+        event_scope: 'logout',
+        context_data: undefined,
+      });
+      await delUserContext(user);
+      await killUserSessions(user.id);
+    }
+  } catch (e) {
+    logApp.error('Error logout', { cause: e });
+  }
 };


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add on connection listener to record when a user is connected to the application. Log each connection and track how many connections each connected user has
* Add on disconnection listener to track when a user disconnects from the websocket connection. 
* When a disconnection occurs for a user, wait 4sec before continuing to ensure it was an intentional disconnect. 
* Remove the the connection from the users connection count. When all connections are removed for a user, trigger a log out function to record the logout activity, clear the redis user context, and kill all active sessions.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17081 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

Test that user is logged out upon tab closure
- login as a user then close the browser tab. 
- The login screen should be presented when navigating back to the application

Test multiple tab/window handling
- login and open multiple tabs
- The user should be able to close tabs and not be logged out until the last tab is closed

Test multiple session handling
- Login using an incognito window and a regular browser window to trigger a single user having multiple sessions
- Close one of the windows
- The user should be able to remain active for the remaining window
- Close the final window and the login screen should be presented when navigating back to the application

Test activity logging
- Review the activity page for logout activity for the previous test cases and confirm that logs were recorded for the test cases

### Checklist
<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
