### PR TITLE
fix(pir): stop pir manager from throwing when enterprise edition is disabled (#16729)

### DIFF
--- a/opencti-platform/opencti-graphql/src/enterprise-edition/ee.ts
+++ b/opencti-platform/opencti-graphql/src/enterprise-edition/ee.ts
@@ -1,14 +1,9 @@
 import type { AuthContext } from '../types/user';
 import { getEntityFromCache } from '../database/cache';
 import type { BasicStoreSettings } from '../types/settings';
-import { executionContext, SYSTEM_USER } from '../utils/access';
+import { SYSTEM_USER } from '../utils/access';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { UnsupportedError } from '../config/errors';
-
-export interface EnterpriseEditionGatedModule {
-  executionContext: string;
-  enterpriseEditionOnly?: boolean;
-}
 
 export const isEnterpriseEdition = async (context: AuthContext) => {
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
@@ -23,11 +18,4 @@ export const checkEnterpriseEdition = async (context: AuthContext) => {
   if (!(await isEnterpriseEdition(context))) {
     throw UnsupportedError('Enterprise edition is not enabled');
   }
-};
-
-export const isEnterpriseEditionAuthorized = async (module: EnterpriseEditionGatedModule): Promise<boolean> => {
-  if (!module.enterpriseEditionOnly) {
-    return true;
-  }
-  return isEnterpriseEdition(executionContext(module.executionContext));
 };

--- a/opencti-platform/opencti-graphql/src/enterprise-edition/ee.ts
+++ b/opencti-platform/opencti-graphql/src/enterprise-edition/ee.ts
@@ -1,9 +1,14 @@
 import type { AuthContext } from '../types/user';
 import { getEntityFromCache } from '../database/cache';
 import type { BasicStoreSettings } from '../types/settings';
-import { SYSTEM_USER } from '../utils/access';
+import { executionContext, SYSTEM_USER } from '../utils/access';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { UnsupportedError } from '../config/errors';
+
+export interface EnterpriseEditionGatedModule {
+  executionContext: string;
+  enterpriseEditionOnly?: boolean;
+}
 
 export const isEnterpriseEdition = async (context: AuthContext) => {
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
@@ -18,4 +23,11 @@ export const checkEnterpriseEdition = async (context: AuthContext) => {
   if (!(await isEnterpriseEdition(context))) {
     throw UnsupportedError('Enterprise edition is not enabled');
   }
+};
+
+export const isEnterpriseEditionAuthorized = async (module: EnterpriseEditionGatedModule): Promise<boolean> => {
+  if (!module.enterpriseEditionOnly) {
+    return true;
+  }
+  return isEnterpriseEdition(executionContext(module.executionContext));
 };

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -9,7 +9,7 @@ import { logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { utcDate } from '../utils/format';
 import type { DataEvent, SseEvent } from '../types/event';
-import { isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { isEnterpriseEditionFromSettings, isEnterpriseEditionAuthorized } from '../enterprise-edition/ee';
 import { InterruptibleTimer } from './interruptible-timer';
 
 export interface HandlerInput {
@@ -61,6 +61,9 @@ const initManager = (manager: ManagerDefinition) => {
 
   const cronHandler = async (cronInputFn?: () => Promise<HandlerInput>) => {
     if (manager.cronSchedulerHandler) {
+      if (!(await isEnterpriseEditionAuthorized(manager))) {
+        return;
+      }
       let lock;
       let cronInput;
       const startDate = utcDate();
@@ -101,6 +104,9 @@ const initManager = (manager: ManagerDefinition) => {
 
   const streamHandler = async () => {
     if (manager.streamSchedulerHandler) {
+      if (!(await isEnterpriseEditionAuthorized(manager))) {
+        return;
+      }
       let lock;
       try {
       // Lock the manager

--- a/opencti-platform/opencti-graphql/src/manager/managerModule.ts
+++ b/opencti-platform/opencti-graphql/src/manager/managerModule.ts
@@ -9,7 +9,8 @@ import { logApp } from '../config/conf';
 import { TYPE_LOCK_ERROR } from '../config/errors';
 import { utcDate } from '../utils/format';
 import type { DataEvent, SseEvent } from '../types/event';
-import { isEnterpriseEditionFromSettings, isEnterpriseEditionAuthorized } from '../enterprise-edition/ee';
+import { isEnterpriseEdition, isEnterpriseEditionFromSettings } from '../enterprise-edition/ee';
+import { executionContext } from '../utils/access';
 import { InterruptibleTimer } from './interruptible-timer';
 
 export interface HandlerInput {
@@ -47,6 +48,13 @@ export interface ManagerDefinition {
   enterpriseEditionOnly?: boolean;
   warning?: () => boolean; // condition to display a warning on manager module (ex: missing configuration, manager can't start)
 }
+
+const isEnterpriseEditionAuthorized = async (manager: ManagerDefinition): Promise<boolean> => {
+  if (!manager.enterpriseEditionOnly) {
+    return true;
+  }
+  return isEnterpriseEdition(executionContext(manager.executionContext));
+};
 
 const initManager = (manager: ManagerDefinition) => {
   const WAIT_TIME_ACTION = 2000;

--- a/opencti-platform/opencti-graphql/src/manager/pirManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/pirManager.ts
@@ -22,6 +22,7 @@ import { STIX_TYPE_RELATION } from '../schema/general';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import type { AuthContext } from '../types/user';
 import { FunctionalError } from '../config/errors';
+import { isEnterpriseEdition } from '../enterprise-edition/ee';
 import { type BasicStoreEntityPir, ENTITY_TYPE_PIR, type ParsedPir, type ParsedPirCriterion, type StoreEntityPir } from '../modules/pir/pir-types';
 import { constructFinalPirFilters, parsePir } from '../modules/pir/pir-utils';
 import { getEntitiesListFromCache } from '../database/cache';
@@ -163,8 +164,12 @@ const processStreamEventsForPir = (context: AuthContext, pir: BasicStoreEntityPi
 /**
  * Handler called every {PIR_MANAGER_INTERVAL} and studying a range of stream events.
  */
-const pirManagerHandler = async () => {
+export const pirManagerHandler = async () => {
   const context = executionContext(PIR_MANAGER_CONTEXT);
+  const isEE = await isEnterpriseEdition(context);
+  if (!isEE) {
+    return;
+  }
   const allPirs = await getEntitiesListFromCache<BasicStoreEntityPir>(context, PIR_MANAGER_USER, ENTITY_TYPE_PIR);
 
   // Loop through all Pirs by group

--- a/opencti-platform/opencti-graphql/src/manager/pirManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/pirManager.ts
@@ -22,7 +22,6 @@ import { STIX_TYPE_RELATION } from '../schema/general';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import type { AuthContext } from '../types/user';
 import { FunctionalError } from '../config/errors';
-import { isEnterpriseEdition } from '../enterprise-edition/ee';
 import { type BasicStoreEntityPir, ENTITY_TYPE_PIR, type ParsedPir, type ParsedPirCriterion, type StoreEntityPir } from '../modules/pir/pir-types';
 import { constructFinalPirFilters, parsePir } from '../modules/pir/pir-utils';
 import { getEntitiesListFromCache } from '../database/cache';
@@ -166,10 +165,6 @@ const processStreamEventsForPir = (context: AuthContext, pir: BasicStoreEntityPi
  */
 export const pirManagerHandler = async () => {
   const context = executionContext(PIR_MANAGER_CONTEXT);
-  const isEE = await isEnterpriseEdition(context);
-  if (!isEE) {
-    return;
-  }
   const allPirs = await getEntitiesListFromCache<BasicStoreEntityPir>(context, PIR_MANAGER_USER, ENTITY_TYPE_PIR);
 
   // Loop through all Pirs by group

--- a/opencti-platform/opencti-graphql/tests/01-unit/enterprise-edition/ee-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/enterprise-edition/ee-test.ts
@@ -1,34 +1,57 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as cache from '../../../src/database/cache';
-import { isEnterpriseEditionAuthorized } from '../../../src/enterprise-edition/ee';
+import { checkEnterpriseEdition, isEnterpriseEdition, isEnterpriseEditionFromSettings } from '../../../src/enterprise-edition/ee';
 
-describe('ee: isEnterpriseEditionAuthorized()', () => {
+describe('ee: isEnterpriseEditionFromSettings()', () => {
+  it('should return true when valid_enterprise_edition is true', () => {
+    expect(isEnterpriseEditionFromSettings({ valid_enterprise_edition: true })).toBe(true);
+  });
+
+  it('should return false when valid_enterprise_edition is false', () => {
+    expect(isEnterpriseEditionFromSettings({ valid_enterprise_edition: false })).toBe(false);
+  });
+
+  it('should return false when settings is undefined', () => {
+    expect(isEnterpriseEditionFromSettings(undefined)).toBe(false);
+  });
+});
+
+describe('ee: isEnterpriseEdition()', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should return true without checking enterprise edition when the module is not enterpriseEditionOnly', async () => {
-    const getEntityFromCacheSpy = vi.spyOn(cache, 'getEntityFromCache');
-
-    const isAuthorized = await isEnterpriseEditionAuthorized({ executionContext: 'test_module' });
-
-    expect(isAuthorized).toBe(true);
-    expect(getEntityFromCacheSpy).not.toHaveBeenCalled();
-  });
-
-  it('should return true when the module is enterpriseEditionOnly and enterprise edition is enabled', async () => {
+  it('should return true when the cached settings have enterprise edition enabled', async () => {
     vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({ valid_enterprise_edition: true } as any);
 
-    const isAuthorized = await isEnterpriseEditionAuthorized({ executionContext: 'test_module', enterpriseEditionOnly: true });
+    const result = await isEnterpriseEdition({} as any);
 
-    expect(isAuthorized).toBe(true);
+    expect(result).toBe(true);
   });
 
-  it('should return false when the module is enterpriseEditionOnly and enterprise edition is disabled', async () => {
+  it('should return false when the cached settings have enterprise edition disabled', async () => {
     vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({ valid_enterprise_edition: false } as any);
 
-    const isAuthorized = await isEnterpriseEditionAuthorized({ executionContext: 'test_module', enterpriseEditionOnly: true });
+    const result = await isEnterpriseEdition({} as any);
 
-    expect(isAuthorized).toBe(false);
+    expect(result).toBe(false);
+  });
+});
+
+describe('ee: checkEnterpriseEdition()', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should not throw when enterprise edition is enabled', async () => {
+    vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({ valid_enterprise_edition: true } as any);
+
+    await expect(checkEnterpriseEdition({} as any)).resolves.toBeUndefined();
+  });
+
+  it('should throw when enterprise edition is disabled', async () => {
+    vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({ valid_enterprise_edition: false } as any);
+
+    await expect(checkEnterpriseEdition({} as any)).rejects.toThrow('Enterprise edition is not enabled');
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/enterprise-edition/ee-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/enterprise-edition/ee-test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as cache from '../../../src/database/cache';
+import { isEnterpriseEditionAuthorized } from '../../../src/enterprise-edition/ee';
+
+describe('ee: isEnterpriseEditionAuthorized()', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return true without checking enterprise edition when the module is not enterpriseEditionOnly', async () => {
+    const getEntityFromCacheSpy = vi.spyOn(cache, 'getEntityFromCache');
+
+    const isAuthorized = await isEnterpriseEditionAuthorized({ executionContext: 'test_module' });
+
+    expect(isAuthorized).toBe(true);
+    expect(getEntityFromCacheSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return true when the module is enterpriseEditionOnly and enterprise edition is enabled', async () => {
+    vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({ valid_enterprise_edition: true } as any);
+
+    const isAuthorized = await isEnterpriseEditionAuthorized({ executionContext: 'test_module', enterpriseEditionOnly: true });
+
+    expect(isAuthorized).toBe(true);
+  });
+
+  it('should return false when the module is enterpriseEditionOnly and enterprise edition is disabled', async () => {
+    vi.spyOn(cache, 'getEntityFromCache').mockResolvedValue({ valid_enterprise_edition: false } as any);
+
+    const isAuthorized = await isEnterpriseEditionAuthorized({ executionContext: 'test_module', enterpriseEditionOnly: true });
+
+    expect(isAuthorized).toBe(false);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-ee-gate-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-ee-gate-test.ts
@@ -38,7 +38,7 @@ describe('Manager module: enterprise edition gate', () => {
 
   it('should not call the handler of an enterpriseEditionOnly manager when EE is disabled', async () => {
     mockLock();
-    vi.spyOn(ee, 'isEnterpriseEditionAuthorized').mockResolvedValue(false);
+    vi.spyOn(ee, 'isEnterpriseEdition').mockResolvedValue(false);
     const handler = vi.fn().mockResolvedValue(undefined);
     const managerDefinition = buildEeOnlyManager('TEST_EE_MANAGER_DISABLED', handler);
     registerManager(managerDefinition);
@@ -53,7 +53,7 @@ describe('Manager module: enterprise edition gate', () => {
 
   it('should call the handler of an enterpriseEditionOnly manager when EE is enabled', async () => {
     mockLock();
-    vi.spyOn(ee, 'isEnterpriseEditionAuthorized').mockResolvedValue(true);
+    vi.spyOn(ee, 'isEnterpriseEdition').mockResolvedValue(true);
     const handler = vi.fn().mockResolvedValue(undefined);
     const managerDefinition = buildEeOnlyManager('TEST_EE_MANAGER_ENABLED', handler);
     registerManager(managerDefinition);

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-ee-gate-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-ee-gate-test.ts
@@ -4,8 +4,6 @@ import { wait } from '../../../../src/database/utils';
 import * as ee from '../../../../src/enterprise-edition/ee';
 import * as masterLock from '../../../../src/lock/master-lock';
 
-// This suite validates that ManagerDefinition.enterpriseEditionOnly is enforced centrally by managerModule,
-// so no manager built on this generic module can forget to check enterprise edition before running (issue #16729).
 describe('Manager module: enterprise edition gate', () => {
   afterEach(async () => {
     vi.restoreAllMocks();

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-ee-gate-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/managerModule/managerModule-ee-gate-test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerManager, getAllEnabledManagers, type ManagerDefinition } from '../../../../src/manager/managerModule';
+import { wait } from '../../../../src/database/utils';
+import * as ee from '../../../../src/enterprise-edition/ee';
+import * as masterLock from '../../../../src/lock/master-lock';
+
+// This suite validates that ManagerDefinition.enterpriseEditionOnly is enforced centrally by managerModule,
+// so no manager built on this generic module can forget to check enterprise edition before running (issue #16729).
+describe('Manager module: enterprise edition gate', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+  });
+
+  const mockLock = () => {
+    vi.spyOn(masterLock, 'lockResources').mockResolvedValue({
+      operation: 'test-op',
+      signal: new AbortController().signal,
+      unlock: vi.fn(),
+    } as any);
+  };
+
+  const buildEeOnlyManager = (id: string, handler: () => Promise<void>): ManagerDefinition => ({
+    id,
+    label: `Test EE manager ${id}`,
+    executionContext: 'test_ee_manager',
+    enterpriseEditionOnly: true,
+    cronSchedulerHandler: {
+      handler,
+      interval: 50,
+      lockKey: `${id}_lock`,
+    },
+    enabledByConfig: true,
+    enabledToStart(): boolean {
+      return this.enabledByConfig;
+    },
+    enabled(): boolean {
+      return this.enabledByConfig;
+    },
+  });
+
+  it('should not call the handler of an enterpriseEditionOnly manager when EE is disabled', async () => {
+    mockLock();
+    vi.spyOn(ee, 'isEnterpriseEditionAuthorized').mockResolvedValue(false);
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const managerDefinition = buildEeOnlyManager('TEST_EE_MANAGER_DISABLED', handler);
+    registerManager(managerDefinition);
+    const registeredManager = getAllEnabledManagers().find((m) => m.manager.id === managerDefinition.id);
+
+    await registeredManager?.start();
+    await wait(200);
+    await registeredManager?.shutdown();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should call the handler of an enterpriseEditionOnly manager when EE is enabled', async () => {
+    mockLock();
+    vi.spyOn(ee, 'isEnterpriseEditionAuthorized').mockResolvedValue(true);
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const managerDefinition = buildEeOnlyManager('TEST_EE_MANAGER_ENABLED', handler);
+    registerManager(managerDefinition);
+    const registeredManager = getAllEnabledManagers().find((m) => m.manager.id === managerDefinition.id);
+
+    await registeredManager?.start();
+    await wait(200);
+    await registeredManager?.shutdown();
+
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('should call the handler of a non-enterpriseEditionOnly manager regardless of EE state', async () => {
+    mockLock();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const managerDefinition: ManagerDefinition = {
+      id: 'TEST_CE_MANAGER',
+      label: 'Test CE manager',
+      executionContext: 'test_ce_manager',
+      cronSchedulerHandler: {
+        handler,
+        interval: 50,
+        lockKey: 'test_ce_manager_lock',
+      },
+      enabledByConfig: true,
+      enabledToStart(): boolean {
+        return this.enabledByConfig;
+      },
+      enabled(): boolean {
+        return this.enabledByConfig;
+      },
+    };
+    registerManager(managerDefinition);
+    const registeredManager = getAllEnabledManagers().find((m) => m.manager.id === managerDefinition.id);
+
+    await registeredManager?.start();
+    await wait(200);
+    await registeredManager?.shutdown();
+
+    expect(handler).toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/pirManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/pirManager-test.ts
@@ -10,9 +10,8 @@ import { STIX_EXT_OCTI } from '../../../src/types/stix-2-1-extensions';
 import * as cache from '../../../src/database/cache';
 import * as streamHandler from '../../../src/database/stream/stream-handler';
 import * as pirDomain from '../../../src/modules/pir/pir-domain';
-import * as ee from '../../../src/enterprise-edition/ee';
 
-// Captured before any vi.spyOn() call so non-Pir cache lookups (e.g. Settings) keep working normally.
+// Captured before any vi.spyOn() call so other cache lookups (e.g. lists of entities other than Pir) keep working normally.
 const originalGetEntitiesListFromCache = cache.getEntitiesListFromCache;
 
 const TEST_PIR_TARGET_1 = 'locations--9b8fd9c3-1ca3-41c2-be13-730f35b166b2';
@@ -133,40 +132,52 @@ describe('pirManager: pirManagerHandler()', () => {
     vi.restoreAllMocks();
   });
 
-  const mockPirCacheAndStream = () => {
+  const mockPirCache = (pirs: any[]) => {
     vi.spyOn(cache, 'getEntitiesListFromCache').mockImplementation(async (context, user, type) => {
       if (type === 'Pir') {
-        return [
-          {
-            id: 'pir-1',
-            internal_id: 'pir-1',
-            lastEventId: '1-0',
-            pir_filters: JSON.stringify({ mode: FilterMode.And, filters: [], filterGroups: [] }),
-            pir_criteria: [],
-          } as any,
-        ];
+        return pirs;
       }
       return originalGetEntitiesListFromCache(context, user, type);
     });
-    vi.spyOn(streamHandler, 'fetchStreamEventsRangeFromEventId').mockResolvedValue({ lastEventId: '2-0' } as any);
   };
 
-  it('should not throw nor try to update Pirs when enterprise edition is disabled', async () => {
-    vi.spyOn(ee, 'isEnterpriseEdition').mockResolvedValue(false);
-    mockPirCacheAndStream();
-    // Simulates the real checkEnterpriseEdition() throwing if it were ever reached.
-    const updatePirSpy = vi.spyOn(pirDomain, 'updatePir').mockRejectedValue(new Error('Enterprise edition is not enabled'));
-
-    await expect(pirManagerHandler()).resolves.toBeUndefined();
-    expect(updatePirSpy).not.toHaveBeenCalled();
+  const buildMockPir = (overrides: Partial<any> = {}) => ({
+    id: 'pir-1',
+    internal_id: 'pir-1',
+    lastEventId: '1-0',
+    pir_filters: JSON.stringify({ mode: FilterMode.And, filters: [], filterGroups: [] }),
+    pir_criteria: [],
+    ...overrides,
   });
 
-  it('should update Pirs normally when enterprise edition is enabled', async () => {
-    vi.spyOn(ee, 'isEnterpriseEdition').mockResolvedValue(true);
-    mockPirCacheAndStream();
+  // Enterprise edition gating is handled centrally by managerModule.ts (see managerModule-ee-gate-test.ts),
+  // so pirManagerHandler itself only needs to be tested for its own business logic.
+  it('should update the Pir lastEventId when the stream advances', async () => {
+    const mockPir = buildMockPir();
+    mockPirCache([mockPir]);
+    vi.spyOn(streamHandler, 'fetchStreamEventsRangeFromEventId').mockResolvedValue({ lastEventId: '2-0' } as any);
     const updatePirSpy = vi.spyOn(pirDomain, 'updatePir').mockResolvedValue({} as any);
 
-    await expect(pirManagerHandler()).resolves.toBeUndefined();
+    await pirManagerHandler();
+
     expect(updatePirSpy).toHaveBeenCalledTimes(1);
+    expect(updatePirSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      mockPir.id,
+      [{ key: 'lastEventId', value: ['2-0'] }],
+      { auditLogEnabled: false },
+    );
+  });
+
+  it('should not update the Pir lastEventId when the stream does not advance', async () => {
+    const mockPir = buildMockPir();
+    mockPirCache([mockPir]);
+    vi.spyOn(streamHandler, 'fetchStreamEventsRangeFromEventId').mockResolvedValue({ lastEventId: mockPir.lastEventId } as any);
+    const updatePirSpy = vi.spyOn(pirDomain, 'updatePir').mockResolvedValue({} as any);
+
+    await pirManagerHandler();
+
+    expect(updatePirSpy).not.toHaveBeenCalled();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/pirManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/pirManager-test.ts
@@ -11,7 +11,6 @@ import * as cache from '../../../src/database/cache';
 import * as streamHandler from '../../../src/database/stream/stream-handler';
 import * as pirDomain from '../../../src/modules/pir/pir-domain';
 
-// Captured before any vi.spyOn() call so other cache lookups (e.g. lists of entities other than Pir) keep working normally.
 const originalGetEntitiesListFromCache = cache.getEntitiesListFromCache;
 
 const TEST_PIR_TARGET_1 = 'locations--9b8fd9c3-1ca3-41c2-be13-730f35b166b2';
@@ -150,8 +149,6 @@ describe('pirManager: pirManagerHandler()', () => {
     ...overrides,
   });
 
-  // Enterprise edition gating is handled centrally by managerModule.ts (see managerModule-ee-gate-test.ts),
-  // so pirManagerHandler itself only needs to be tested for its own business logic.
   it('should update the Pir lastEventId when the stream advances', async () => {
     const mockPir = buildMockPir();
     mockPirCache([mockPir]);

--- a/opencti-platform/opencti-graphql/tests/03-integration/04-manager/pirManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/04-manager/pirManager-test.ts
@@ -1,12 +1,19 @@
-import { beforeAll, describe, it, vi, expect } from 'vitest';
+import { beforeAll, afterEach, describe, it, vi, expect } from 'vitest';
 import type { ParsedPir } from '../../../src/modules/pir/pir-types';
 import { FilterMode, FilterOperator, PirType } from '../../../src/generated/graphql';
 import * as StixFiltering from '../../../src/utils/filtering/filtering-stix/stix-filtering';
 import { isStixMatchFilterGroup_MockableForUnitTests } from '../../../src/utils/filtering/filtering-stix/stix-filtering';
-import { checkEventOnPir } from '../../../src/manager/pirManager';
+import { checkEventOnPir, pirManagerHandler } from '../../../src/manager/pirManager';
 import type { AuthContext } from '../../../src/types/user';
 import type { SseEvent } from '../../../src/types/event';
 import { STIX_EXT_OCTI } from '../../../src/types/stix-2-1-extensions';
+import * as cache from '../../../src/database/cache';
+import * as streamHandler from '../../../src/database/stream/stream-handler';
+import * as pirDomain from '../../../src/modules/pir/pir-domain';
+import * as ee from '../../../src/enterprise-edition/ee';
+
+// Captured before any vi.spyOn() call so non-Pir cache lookups (e.g. Settings) keep working normally.
+const originalGetEntitiesListFromCache = cache.getEntitiesListFromCache;
 
 const TEST_PIR_TARGET_1 = 'locations--9b8fd9c3-1ca3-41c2-be13-730f35b166b2';
 const TEST_PIR_TARGET_2 = 'locations--9b8fd9c3-1ca3-41c2-be13-730f35b166a3';
@@ -20,10 +27,10 @@ const TEST_PIR_CRITERION_1 = {
         key: ['toId'],
         values: [TEST_PIR_TARGET_1],
         operator: FilterOperator.Eq,
-        mode: FilterMode.Or
-      }
-    ]
-  }
+        mode: FilterMode.Or,
+      },
+    ],
+  },
 };
 const TEST_PIR_CRITERION_2 = {
   weight: 1,
@@ -35,10 +42,10 @@ const TEST_PIR_CRITERION_2 = {
         key: ['toId'],
         values: [TEST_PIR_TARGET_2],
         operator: FilterOperator.Eq,
-        mode: FilterMode.Or
-      }
-    ]
-  }
+        mode: FilterMode.Or,
+      },
+    ],
+  },
 };
 
 const TEST_PIR = {
@@ -59,7 +66,7 @@ const TEST_PIR = {
       key: ['confidence'],
       values: [80],
       operator: FilterOperator.Gt,
-      mode: FilterMode.Or
+      mode: FilterMode.Or,
     }],
   },
 } as ParsedPir;
@@ -78,9 +85,9 @@ const buildEvent = ({
       extensions: {
         [STIX_EXT_OCTI]: {
           source_type: 'Malware',
-        }
-      }
-    }
+        },
+      },
+    },
   } as SseEvent<any>;
 };
 
@@ -118,5 +125,48 @@ describe('pirManager: checkEventOnPir()', () => {
     const event = buildEvent({ confidence: 90, target: TEST_PIR_TARGET_2 });
     const matches = await checkEventOnPir(context, event, TEST_PIR);
     expect(matches).toEqual([TEST_PIR_CRITERION_2]);
+  });
+});
+
+describe('pirManager: pirManagerHandler()', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockPirCacheAndStream = () => {
+    vi.spyOn(cache, 'getEntitiesListFromCache').mockImplementation(async (context, user, type) => {
+      if (type === 'Pir') {
+        return [
+          {
+            id: 'pir-1',
+            internal_id: 'pir-1',
+            lastEventId: '1-0',
+            pir_filters: JSON.stringify({ mode: FilterMode.And, filters: [], filterGroups: [] }),
+            pir_criteria: [],
+          } as any,
+        ];
+      }
+      return originalGetEntitiesListFromCache(context, user, type);
+    });
+    vi.spyOn(streamHandler, 'fetchStreamEventsRangeFromEventId').mockResolvedValue({ lastEventId: '2-0' } as any);
+  };
+
+  it('should not throw nor try to update Pirs when enterprise edition is disabled', async () => {
+    vi.spyOn(ee, 'isEnterpriseEdition').mockResolvedValue(false);
+    mockPirCacheAndStream();
+    // Simulates the real checkEnterpriseEdition() throwing if it were ever reached.
+    const updatePirSpy = vi.spyOn(pirDomain, 'updatePir').mockRejectedValue(new Error('Enterprise edition is not enabled'));
+
+    await expect(pirManagerHandler()).resolves.toBeUndefined();
+    expect(updatePirSpy).not.toHaveBeenCalled();
+  });
+
+  it('should update Pirs normally when enterprise edition is enabled', async () => {
+    vi.spyOn(ee, 'isEnterpriseEdition').mockResolvedValue(true);
+    mockPirCacheAndStream();
+    const updatePirSpy = vi.spyOn(pirDomain, 'updatePir').mockResolvedValue({} as any);
+
+    await expect(pirManagerHandler()).resolves.toBeUndefined();
+    expect(updatePirSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Proposed changes

* pir manager kept polling on its cron interval after EE got disabled, hit `updatePir` → `checkEnterpriseEdition` and threw on every tick, spamming error logs
* added an early EE check in `pirManagerHandler` that returns quietly when EE is off, same pattern as `playbookManager.ts`

### Related issues
* closes #16729

### How to test this PR
* disable enterprise edition while the PIR manager is running and confirm no more error logs on each cron tick
* run `yarn test` on `pirManager-test.ts`

### Checklist
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments