### PR TITLE
feat(security-coverage): drawer to display instances URL (#17043)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "Übergeordnete Beziehungen ausgewählter Knoten auswählen (zu)",
   "Select Relationships of Selected Nodes": "Wählen Sie Beziehungen ausgewählter Knoten aus",
   "Select saved filter": "Gespeicherten Filter auswählen",
+  "Select the OpenAEV instance": "Wählen Sie die OpenAEV-Instanz aus",
   "Select the organizations to share the draft content with during this transition.": "Wählen Sie die Organisationen aus, für die der Inhaltsentwurf während dieses Übergangs freigegeben werden soll.",
   "Select the organizations to unshare the draft content from during this transition.": "Wählen Sie die Organisationen aus, für die Sie die Freigabe des Inhaltsentwurfs während dieses Übergangs aufheben möchten.",
   "Select your file": "Wählen Sie Ihre Datei",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "Select Parent Relationships of Selected Nodes (To)",
   "Select Relationships of Selected Nodes": "Select Relationships of Selected Nodes",
   "Select saved filter": "Select saved filter",
+  "Select the OpenAEV instance": "Select the OpenAEV instance",
   "Select the organizations to share the draft content with during this transition.": "Select the organizations to share the draft content with during this transition.",
   "Select the organizations to unshare the draft content from during this transition.": "Select the organizations to unshare the draft content from during this transition.",
   "Select your file": "Select your file",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "Seleccionar relaciones principales de nodos seleccionados (A)",
   "Select Relationships of Selected Nodes": "Seleccionar relaciones de nodos seleccionados",
   "Select saved filter": "Seleccionar filtro guardado",
+  "Select the OpenAEV instance": "Selecciona la instancia de OpenAEV",
   "Select the organizations to share the draft content with during this transition.": "Seleccione las organizaciones con las que compartir el borrador de contenido durante esta transición.",
   "Select the organizations to unshare the draft content from during this transition.": "Seleccione las organizaciones de las que desea retirar el contenido del borrador durante esta transición.",
   "Select your file": "Seleccionar otro fichero",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "Sélectionner les relations parentales des nœuds sélectionnés (vers)",
   "Select Relationships of Selected Nodes": "Sélectionner les relations des nœuds sélectionnés",
   "Select saved filter": "Sélectionner un filtre sauvegardé",
+  "Select the OpenAEV instance": "Sélectionnez l'instance OpenAEV",
   "Select the organizations to share the draft content with during this transition.": "Sélectionner les organisations avec lesquelles partager le projet de contenu pendant cette transition.",
   "Select the organizations to unshare the draft content from during this transition.": "Sélectionnez les organisations à partir desquelles le projet de contenu ne sera plus partagé pendant cette transition.",
   "Select your file": "Selectionner votre fichier",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "Seleziona le relazioni genitore dei nodi selezionati (A)",
   "Select Relationships of Selected Nodes": "Seleziona le relazioni dei nodi selezionati",
   "Select saved filter": "Seleziona il filtro salvato",
+  "Select the OpenAEV instance": "Seleziona l'istanza di OpenAEV",
   "Select the organizations to share the draft content with during this transition.": "Selezionare le organizzazioni con cui condividere la bozza di contenuto durante questa transizione.",
   "Select the organizations to unshare the draft content from during this transition.": "Selezionare le organizzazioni da cui non condividere la bozza di contenuto durante questa transizione.",
   "Select your file": "Seleziona il tuo file",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "選択したノードの親関係を選択",
   "Select Relationships of Selected Nodes": "選択したノードの関係を選択",
   "Select saved filter": "保存したフィルタを選択",
+  "Select the OpenAEV instance": "OpenAEVインスタンスを選択してください",
   "Select the organizations to share the draft content with during this transition.": "この移行期間中にドラフトコンテンツを共有する組織を選択します。",
   "Select the organizations to unshare the draft content from during this transition.": "この移行期間中にドラフトコンテンツの共有を解除する組織を選択します。",
   "Select your file": "ファイルを選択してください",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "선택한 노드의 상위 관계 선택(대상)",
   "Select Relationships of Selected Nodes": "선택한 노드의 관계 선택",
   "Select saved filter": "저장된 필터 선택",
+  "Select the OpenAEV instance": "OpenAEV 인스턴스를 선택하십시오",
   "Select the organizations to share the draft content with during this transition.": "이 전환 중에 초안 콘텐츠를 공유할 조직을 선택합니다.",
   "Select the organizations to unshare the draft content from during this transition.": "이 전환 중에 초안 콘텐츠의 공유를 해제할 조직을 선택하세요.",
   "Select your file": "파일 선택",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "Выбрать родительские отношения выбранных узлов (To)",
   "Select Relationships of Selected Nodes": "Выбор отношений выбранных узлов",
   "Select saved filter": "Выберите сохраненный фильтр",
+  "Select the OpenAEV instance": "Выберите экземпляр OpenAEV",
   "Select the organizations to share the draft content with during this transition.": "Выберите организации, с которыми нужно поделиться черновым содержимым во время этого перехода.",
   "Select the organizations to unshare the draft content from during this transition.": "Выберите организации, с которыми необходимо снять доступ к черновому содержимому во время этого перехода.",
   "Select your file": "Выберите свой файл",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -4007,6 +4007,7 @@
   "Select Parent Relationships of Selected Nodes (To)": "选择所选节点的父关系",
   "Select Relationships of Selected Nodes": "选择选定节点的关系",
   "Select saved filter": "选择已保存的筛选器",
+  "Select the OpenAEV instance": "选择 OpenAEV 实例",
   "Select the organizations to share the draft content with during this transition.": "选择在此过渡期间要与之共享草稿内容的组织。",
   "Select the organizations to unshare the draft content from during this transition.": "选择要在此过渡期间取消共享草案内容的组织。",
   "Select your file": "选择你的文件",

--- a/opencti-platform/opencti-front/src/components/ExternalLinkPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/ExternalLinkPopover.tsx
@@ -10,6 +10,7 @@ interface ExternalLinkPopoverProps {
   externalLink: string | URL | undefined;
   setDisplayExternalLink: (value: boolean) => void;
   setExternalLink?: (value: string | URL | undefined) => void;
+  onConfirm?: () => void;
 }
 
 const ExternalLinkPopover: FunctionComponent<ExternalLinkPopoverProps> = ({
@@ -17,6 +18,7 @@ const ExternalLinkPopover: FunctionComponent<ExternalLinkPopoverProps> = ({
   externalLink,
   setDisplayExternalLink,
   setExternalLink,
+  onConfirm,
 }) => {
   const { t_i18n } = useFormatter();
   const handleCloseExternalLink = () => {
@@ -26,6 +28,7 @@ const ExternalLinkPopover: FunctionComponent<ExternalLinkPopoverProps> = ({
   const handleBrowseExternalLink = () => {
     window.open(externalLink, '_blank');
     setDisplayExternalLink(false);
+    onConfirm?.();
     setExternalLink?.(undefined);
   };
 

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/GoToOpenAEVDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/GoToOpenAEVDrawer.tsx
@@ -1,0 +1,83 @@
+import Button from '../../../../components/common/button/Button';
+import { graphql, useFragment } from 'react-relay';
+import { GoToOpenAEVDrawerFragment$key } from './__generated__/GoToOpenAEVDrawerFragment.graphql';
+import { OaevLogo } from '../../../../static/images/logo_oaev';
+import { useFormatter } from '../../../../components/i18n';
+import { useState } from 'react';
+import Drawer from '../../common/drawer/Drawer';
+import { Stack, Typography } from '@mui/material';
+import { OpenInNewOutlined } from '@mui/icons-material';
+import ExternalLinkPopover from '../../../../components/ExternalLinkPopover';
+
+const fragment = graphql`
+  fragment GoToOpenAEVDrawerFragment on SecurityCoverage {
+    results {
+      name
+      external_uri
+    }
+  }
+`;
+
+interface GoToOpenAEVDrawerProps {
+  data: GoToOpenAEVDrawerFragment$key;
+}
+
+const GoToOpenAEVDrawer = ({ data }: GoToOpenAEVDrawerProps) => {
+  const { t_i18n } = useFormatter();
+  const [open, setOpen] = useState(false);
+  const [selectedLink, setSelectedLink] = useState<string>();
+
+  const { results } = useFragment(fragment, data);
+  const instances = (results ?? []).filter((r) => !!r.external_uri);
+  const disabled = instances.length === 0;
+
+  return (
+    <>
+      <Button
+        disabled={disabled}
+        startIcon={<OaevLogo />}
+        onClick={() => setOpen(true)}
+        variant="tertiary"
+        size="small"
+        sx={{ mt: 2 }}
+      >
+        {t_i18n('Go to OpenAEV')}
+      </Button>
+
+      <Drawer
+        open={open}
+        onClose={() => setOpen(false)}
+        title={t_i18n('Select the OpenAEV instance')}
+      >
+        <Stack>
+          {instances.map((instance) => (
+            <Stack direction="row" key={instance.external_uri}>
+              <div style={{ flex: 1 }}>
+                <Typography>{instance.name}</Typography>
+                <Typography variant="body2">{instance.external_uri}</Typography>
+              </div>
+              <Button
+                onClick={() => setSelectedLink(instance.external_uri!)}
+                startIcon={<OpenInNewOutlined fontSize="small" />}
+              >
+                {t_i18n('Browse the link')}
+              </Button>
+            </Stack>
+          ))}
+        </Stack>
+      </Drawer>
+
+      <ExternalLinkPopover
+        externalLink={selectedLink}
+        displayExternalLink={!!selectedLink}
+        setDisplayExternalLink={() => setSelectedLink('')}
+        onConfirm={() => {
+          setSelectedLink('');
+          setOpen(false);
+        }}
+      />
+    </>
+  );
+};
+
+export default GoToOpenAEVDrawer;

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/GoToOpenAEVDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/GoToOpenAEVDrawer.tsx
@@ -49,7 +49,7 @@ const GoToOpenAEVDrawer = ({ data }: GoToOpenAEVDrawerProps) => {
         onClose={() => setOpen(false)}
         title={t_i18n('Select the OpenAEV instance')}
       >
-        <Stack>
+        <Stack spacing={2}>
           {instances.map((instance) => (
             <Stack direction="row" key={instance.external_uri}>
               <div style={{ flex: 1 }}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/GoToOpenAEVDrawer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/GoToOpenAEVDrawer.tsx
@@ -7,7 +7,6 @@ import { useState } from 'react';
 import Drawer from '../../common/drawer/Drawer';
 import { Stack, Typography } from '@mui/material';
 import { OpenInNewOutlined } from '@mui/icons-material';
-import ExternalLinkPopover from '../../../../components/ExternalLinkPopover';
 
 const fragment = graphql`
   fragment GoToOpenAEVDrawerFragment on SecurityCoverage {
@@ -25,11 +24,15 @@ interface GoToOpenAEVDrawerProps {
 const GoToOpenAEVDrawer = ({ data }: GoToOpenAEVDrawerProps) => {
   const { t_i18n } = useFormatter();
   const [open, setOpen] = useState(false);
-  const [selectedLink, setSelectedLink] = useState<string>();
 
   const { results } = useFragment(fragment, data);
   const instances = (results ?? []).filter((r) => !!r.external_uri);
   const disabled = instances.length === 0;
+
+  const handleBrowseLink = (externalUri: string) => {
+    window.open(externalUri, '_blank');
+    setOpen(false);
+  };
 
   return (
     <>
@@ -57,7 +60,7 @@ const GoToOpenAEVDrawer = ({ data }: GoToOpenAEVDrawerProps) => {
                 <Typography variant="body2">{instance.external_uri}</Typography>
               </div>
               <Button
-                onClick={() => setSelectedLink(instance.external_uri!)}
+                onClick={() => handleBrowseLink(instance.external_uri!)}
                 startIcon={<OpenInNewOutlined fontSize="small" />}
               >
                 {t_i18n('Browse the link')}
@@ -66,16 +69,6 @@ const GoToOpenAEVDrawer = ({ data }: GoToOpenAEVDrawerProps) => {
           ))}
         </Stack>
       </Drawer>
-
-      <ExternalLinkPopover
-        externalLink={selectedLink}
-        displayExternalLink={!!selectedLink}
-        setDisplayExternalLink={() => setSelectedLink('')}
-        onConfirm={() => {
-          setSelectedLink('');
-          setOpen(false);
-        }}
-      />
     </>
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo, useState } from 'react';
+import { Suspense, useMemo } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useSubscription } from 'react-relay';
 import { Route, useLocation, useParams } from 'react-router-dom';
 import Security from 'src/utils/Security';
@@ -16,16 +16,14 @@ import ErrorNotFound from '../../../../components/ErrorNotFound';
 import Breadcrumbs from '../../../../components/Breadcrumbs';
 import { useFormatter } from '../../../../components/i18n';
 import { KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNUPDATE_KNDELETE } from '../../../../utils/hooks/useGranted';
-import { getPaddingRight, isNotEmptyField } from '../../../../utils/utils';
+import { getPaddingRight } from '../../../../utils/utils';
 import SecurityCoverageEdition from './SecurityCoverageEdition';
 import SecurityCoverageDeletion from './SecurityCoverageDeletion';
 import useQueryLoading from '../../../../utils/hooks/useQueryLoading';
-import Button from '@common/button/Button';
-import { OaevLogo } from '../../../../static/images/logo_oaev';
-import ExternalLinkPopover from '../../../../components/ExternalLinkPopover';
 import { RootSecurityCoverageSubscription } from '@components/analyses/security_coverages/__generated__/RootSecurityCoverageSubscription.graphql';
 import SecurityCoverageResult from '@components/analyses/security_coverages/SecurityCoverageResult';
 import { PATH_SECURITY_COVERAGE, PATH_SECURITY_COVERAGES } from '@components/common/routes/paths';
+import GoToOpenAEVDrawer from './GoToOpenAEVDrawer';
 
 const subscription = graphql`
     subscription RootSecurityCoverageSubscription($id: ID!) {
@@ -58,6 +56,7 @@ const securityCoverageQuery = graphql`
       ...WorkbenchFileViewer_entity
       ...StixCoreObjectContent_stixCoreObject
       ...StixCoreObjectSharingListFragment
+      ...GoToOpenAEVDrawerFragment
     }
     connectorsForImport {
       ...FileManager_connectorsImport
@@ -89,11 +88,10 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
 
   useSubscription<RootSecurityCoverageSubscription>(subConfig);
 
-  const [displayExternalLink, setDisplayExternalLink] = useState(false);
-  const hasExternalUri = isNotEmptyField(securityCoverage?.external_uri);
   const basePath = PATH_SECURITY_COVERAGE(securityCoverageId);
   const paddingRight = getPaddingRight(location.pathname, basePath, false);
   const isContent = location.pathname.includes('content');
+
   return (
     <>
       {securityCoverage ? (
@@ -150,24 +148,7 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
               ),
             }}
             extraActions={!isContent && (
-              <>
-                <Button
-                  disabled={!hasExternalUri}
-                  startIcon={<OaevLogo />}
-                  onClick={() => setDisplayExternalLink(true)}
-                  title={hasExternalUri ? securityCoverage.external_uri : undefined}
-                  variant="tertiary"
-                  size="small"
-                  sx={{ mt: 2 }}
-                >
-                  {hasExternalUri ? `${t_i18n('Go to OpenAEV')}` : `${t_i18n('Provisioning OpenAEV')}`}
-                </Button>
-                <ExternalLinkPopover
-                  externalLink={hasExternalUri ? securityCoverage.external_uri : undefined}
-                  displayExternalLink={displayExternalLink}
-                  setDisplayExternalLink={setDisplayExternalLink}
-                />
-              </>
+              <GoToOpenAEVDrawer data={securityCoverage} />
             )}
             extraRoutes={(
               <>

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -15893,6 +15893,7 @@ type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & Sti
   objectCovered: StixDomainObject
   toStixBundle: String
   security_platform_type: String
+  results: [SecurityCoverageResult!]
 }
 
 enum SecurityCoverageOrdering {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -29797,6 +29797,7 @@ export type SecurityCoverage = BasicObject & StixCoreObject & StixDomainObject &
   refreshed_at?: Maybe<Scalars['DateTime']['output']>;
   reports?: Maybe<ReportConnection>;
   representative: Representative;
+  results?: Maybe<Array<SecurityCoverageResult>>;
   revoked: Scalars['Boolean']['output'];
   roles?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   security_platform_type?: Maybe<Scalars['String']['output']>;
@@ -50760,6 +50761,7 @@ export type SecurityCoverageResolvers<ContextType = any, ParentType extends Reso
   refreshed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   reports?: Resolver<Maybe<ResolversTypes['ReportConnection']>, ParentType, ContextType, Partial<SecurityCoverageReportsArgs>>;
   representative?: Resolver<ResolversTypes['Representative'], ParentType, ContextType>;
+  results?: Resolver<Maybe<Array<ResolversTypes['SecurityCoverageResult']>>, ParentType, ContextType>;
   revoked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   roles?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   security_platform_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -193,6 +193,14 @@ export const securityCoverageDelete = async (context: AuthContext, user: AuthUse
 };
 // endregion
 
+export const getSecurityCoverageResults = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverage: BasicStoreEntitySecurityCoverage,
+) => {
+  return loadThroughDenormalized(context, user, securityCoverage, INPUT_RESULT_OF);
+};
+
 export const getSecurityCoverageResultProperty = async (
   context: AuthContext,
   user: AuthUser,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -8,6 +8,7 @@ import {
   getSecurityCoverageResultProperty,
   averageCoverageInformation,
   mostRecentLastCoverageResult,
+  getSecurityCoverageResults,
 } from './securityCoverage-domain';
 import {
   stixDomainObjectAddRelation,
@@ -32,6 +33,7 @@ const SecurityCoverageResolvers: Resolvers = {
   SecurityCoverage: {
     objectCovered: (securityCoverage, _, context) => objectCovered<any>(context, context.user, securityCoverage.id),
     toStixBundle: (securityCoverage, _, context) => securityCoverageStixBundle(context, context.user, securityCoverage.id),
+    results: (securityCoverage, _, context) => getSecurityCoverageResults(context, context.user, securityCoverage),
     // security coverage result info
     coverage_last_result: (securityCoverage, _, context) => mostRecentLastCoverageResult(context, context.user, securityCoverage),
     coverage_valid_from: (securityCoverage, _, context) => getSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_from'),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.graphql
@@ -202,6 +202,7 @@ type SecurityCoverage implements BasicObject & StixObject & StixCoreObject & Sti
   objectCovered: StixDomainObject
   toStixBundle: String
   security_platform_type: String
+  results: [SecurityCoverageResult!]
 }
 
 # Ordering

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { addSecurityCoverage, securityCoverageDelete } from '../../../../src/modules/securityCoverage/securityCoverage-domain';
+import { addSecurityCoverage, getSecurityCoverageResults, securityCoverageDelete } from '../../../../src/modules/securityCoverage/securityCoverage-domain';
 import { ADMIN_USER, testContext } from '../../../utils/testQuery';
 import { addReport, reportDeleteWithElements } from '../../../../src/domain/report';
 import type { StoreEntityReport } from '../../../../src/types/store';
@@ -62,6 +62,37 @@ describe('SecurityCoverage domain', () => {
       };
       const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
       const results = await loadThroughDenormalized(testContext, ADMIN_USER, securityCoverage, INPUT_RESULT_OF);
+      expect(results.length).toEqual(0);
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+    });
+  });
+
+  describe('Function getSecurityCoverageResults()', () => {
+    it('should return the same results as the denormalized results loader', async () => {
+      const externalUri = 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a133';
+      const input = {
+        ...BASE_INPUT(),
+        name: 'sc for getSecurityCoverageResults',
+        coverage_information: [{
+          coverage_name: 'prevention',
+          coverage_score: 10,
+        }],
+        external_uri: externalUri,
+      };
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
+      const results = await getSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage);
+      expect(results.length).toEqual(1);
+      expect(results[0].name).toEqual(externalUri);
+      expect(results[0].external_uri).toEqual(externalUri);
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+    });
+
+    it('should return an empty array when the security coverage has no result', async () => {
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, {
+        ...BASE_INPUT(),
+        name: 'sc without result',
+      });
+      const results = await getSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage);
       expect(results.length).toEqual(0);
       await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
     });


### PR DESCRIPTION
### Proposed changes

* Add resolver returning results of a SC in backend
* Add a drawer to display the list of instances

### Related issues

* closes #17043
* #14716

### How to test this PR

Create a SC
Create some SCR for this SC that contain a external_uri

Also make a test with some SCR but none containing external_uri -> button disabled

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality