### PR TITLE
fix(security/groups): update skeleton loading to only render if password_valid_until is defined (#17131)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/UserLine.tsx
@@ -250,17 +250,20 @@ export const UserLineDummy: React.FC<Pick<UserLineComponentProps, 'dataColumns'>
                 height="100%"
               />
             </div>
-            <div
-              className={classes.bodyItem}
-              style={{ width: dataColumns.password_valid_until.width }}
-            >
-              <Skeleton
-                animation="wave"
-                variant="rectangular"
-                width={100}
-                height="100%"
-              />
-            </div>
+            {dataColumns.password_valid_until
+              && (
+                <div
+                  className={classes.bodyItem}
+                  style={{ width: dataColumns.password_valid_until.width }}
+                >
+                  <Skeleton
+                    animation="wave"
+                    variant="rectangular"
+                    width={100}
+                    height="100%"
+                  />
+                </div>
+              )}
             <div
               className={classes.bodyItem}
               style={{ width: dataColumns.created_at.width }}


### PR DESCRIPTION

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* update skeleton loading to only render if password_valid_until is defined

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* fixes #17131

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

- with FORCE_PASSWORD_CHANGE not enabled, confirm group details pages load 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
