### PR TITLE
fix(live-stream): keep emptyFilter in normalizeFilterGroupForBackend (#17132)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -710,6 +710,17 @@ describe('Function findFilterFromKey: should return the filters of the specified
 });
 
 describe('Function normalizeFilterGroupForBackend', () => {
+  it('should not return null/undefined when an empty filter group is used as input', () => {
+    const result = normalizeFilterGroupForBackend(emptyFilterGroup);
+    expect(result).not.toBeNull();
+    expect(result).not.toBeUndefined();
+    expect(result).toStrictEqual({
+      mode: 'and',
+      filters: [],
+      filterGroups: [],
+    });
+  });
+
   it('should convert string keys to arrays', () => {
     const input: FilterGroup = {
       mode: 'and',

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -524,7 +524,7 @@ export function normalizeFilterGroupForBackend(filterGroup?: FilterGroup | null)
 export function normalizeFilterGroupForBackend(
   filterGroup?: FilterGroup | null,
 ): GqlFilterGroup | undefined {
-  if (!filterGroup || !isFilterGroupNotEmpty(filterGroup)) {
+  if (!filterGroup) {
     return undefined;
   }
   return {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request makes a small change to the `normalizeFilterGroupForBackend` function in `filtersUtils.tsx`. The check for whether the filter group is empty using `isFilterGroupNotEmpty` was removed, so the function now only checks if `filterGroup` is present before proceeding.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17132

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
