### PR TITLE
fix(engine): retry failed bulk items selectively on partial failures (#17134)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4040,14 +4040,14 @@ export const elAttributeValues = async (
 };
 // endregion
 
-// Per-item errors considered transient: the engine refused the item under load or contention,
+// The list of per-item errors considered transient: elasticsearch refused the item under load or contention,
 // the operation was NOT applied and can be resubmitted as-is.
 const BULK_ITEM_TRANSIENT_ERRORS = [
   'es_rejected_execution_exception',
   'circuit_breaking_exception',
   'too_many_requests',
   'unavailable_shards_exception',
-  'version_conflict_engine_exception', // only surfaces after retry_on_conflict is exhausted
+  'version_conflict_engine_exception', // only after retry_on_conflict is exhausted
 ];
 const isTransientBulkItemError = (itemResult: any): boolean => {
   return itemResult.status === 429 || BULK_ITEM_TRANSIENT_ERRORS.includes(itemResult.error?.type);
@@ -4059,12 +4059,16 @@ export const elBulk = async (context: AuthContext, args: any) => {
   if (!data.errors) {
     return data;
   }
-  // Partial failure (HTTP 200, per-item errors): succeeded items are already applied and must not
-  // be resubmitted; failed items are guaranteed not applied. Retry only the failed transient ones.
+  // So, from here, we have a partial failure (HTTP 200 fot the top HTTP response, but with per-item errors).
+  // We need to retry the failed items, but only the transient ones. Permanent errors will be reported.
+  // -> Succeeded items are already applied and must not be resubmitted;
+  // -> Failed items are guaranteed not applied on Elasticsearch side. So we retry only the failed transient ones.
+
   const { body, ...bulkArgs } = args;
   const operations: Array<{ lines: any[]; index: number }> = [];
   for (let i = 0; i < body.length; i += 1) {
-    // A bulk operation is one action line plus, except for delete, one source line
+    // We need to group the bulk lines into operations, because the bulk API is a sequence of action lines and source lines.
+    // And for that we need to know if the action is a delete or not, because delete has no source line.
     const isDelete = body[i].delete !== undefined;
     const lines = isDelete ? [body[i]] : [body[i], body[i + 1]];
     operations.push({ lines, index: operations.length });
@@ -4074,6 +4078,8 @@ export const elBulk = async (context: AuthContext, args: any) => {
   const finalItems: any[] = new Array(operations.length);
   let pending = operations;
   let response = data;
+
+  // Start the retry loop, with exponential backoff.
   for (let attempt = 0; attempt <= BULK_MAX_RETRIES; attempt += 1) {
     if (attempt > 0) {
       response = await elRawBulk(context, { ...bulkArgs, body: pending.flatMap((operation) => operation.lines) });
@@ -4088,9 +4094,12 @@ export const elBulk = async (context: AuthContext, args: any) => {
       const itemResult = bulkItemResult(items[k]);
       const error = itemResult?.error;
       if (!error || error.type === DOCUMENT_MISSING_EXCEPTION) {
-        continue; // success, or tolerated update of an already deleted document
+        // We skip this case of missing document,
+        // because it is a tolerated update of an already deleted document (the document is not there, but the operation is considered successful).
+        continue;
       }
       if (isTransientBulkItemError(itemResult)) {
+        // This is a transient error, we will retry this operation in the next loop iteration.
         retryable.push(operation);
         transientErrors.push(error);
       } else {
@@ -4098,6 +4107,7 @@ export const elBulk = async (context: AuthContext, args: any) => {
       }
     }
     if (permanentErrors.length > 0) {
+      // So here we have permanent errors, we cannot continue, we need to throw an error with the details of the permanent errors.
       throw DatabaseError('Bulk indexing fail', { bulkId, attempts: attempt + 1, errors: permanentErrors });
     }
     if (retryable.length === 0) {
@@ -4107,6 +4117,7 @@ export const elBulk = async (context: AuthContext, args: any) => {
       return { ...response, items: finalItems, errors: finalItems.some((item) => item && bulkItemResult(item)?.error !== undefined) };
     }
     if (attempt === BULK_MAX_RETRIES) {
+      // We have exhausted the maximum number of retries, we need to throw an error with the details of the transient errors.
       throw DatabaseError('Bulk indexing fail', { bulkId, attempts: attempt + 1, errors: transientErrors });
     }
     const delayMs = BULK_INITIAL_DELAY_MS * (2 ** attempt);

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4059,7 +4059,7 @@ export const elBulk = async (context: AuthContext, args: any) => {
   if (!data.errors) {
     return data;
   }
-  // So, from here, we have a partial failure (HTTP 200 fot the top HTTP response, but with per-item errors).
+  // So, from here, we have a partial failure (HTTP 200 for the top-level HTTP response, but with per-item errors).
   // We need to retry the failed items, but only the transient ones. Permanent errors will be reported.
   // -> Succeeded items are already applied and must not be resubmitted;
   // -> Failed items are guaranteed not applied on Elasticsearch side. So we retry only the failed transient ones.

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -4040,16 +4040,91 @@ export const elAttributeValues = async (
 };
 // endregion
 
+// Per-item errors considered transient: the engine refused the item under load or contention,
+// the operation was NOT applied and can be resubmitted as-is.
+const BULK_ITEM_TRANSIENT_ERRORS = [
+  'es_rejected_execution_exception',
+  'circuit_breaking_exception',
+  'too_many_requests',
+  'unavailable_shards_exception',
+  'version_conflict_engine_exception', // only surfaces after retry_on_conflict is exhausted
+];
+const isTransientBulkItemError = (itemResult: any): boolean => {
+  return itemResult.status === 429 || BULK_ITEM_TRANSIENT_ERRORS.includes(itemResult.error?.type);
+};
+const bulkItemResult = (item: any) => item.index ?? item.update ?? item.delete ?? item.create;
+
 export const elBulk = async (context: AuthContext, args: any) => {
-  return elRawBulk(context, args).then((data) => {
-    if (data.errors) {
-      const errors = data.items.map((i: any) => i.index?.error || i.update?.error).filter((f: any) => f !== undefined);
-      if (errors.filter((err: any) => err.type !== DOCUMENT_MISSING_EXCEPTION).length > 0) {
-        throw DatabaseError('Bulk indexing fail', { errors });
+  const data = await elRawBulk(context, args);
+  if (!data.errors) {
+    return data;
+  }
+  // Partial failure (HTTP 200, per-item errors): succeeded items are already applied and must not
+  // be resubmitted; failed items are guaranteed not applied. Retry only the failed transient ones.
+  const { body, ...bulkArgs } = args;
+  const operations: Array<{ lines: any[]; index: number }> = [];
+  for (let i = 0; i < body.length; i += 1) {
+    // A bulk operation is one action line plus, except for delete, one source line
+    const isDelete = body[i].delete !== undefined;
+    const lines = isDelete ? [body[i]] : [body[i], body[i + 1]];
+    operations.push({ lines, index: operations.length });
+    i += lines.length - 1;
+  }
+  const bulkId = generateInternalId().substring(0, 8);
+  const finalItems: any[] = new Array(operations.length);
+  let pending = operations;
+  let response = data;
+  for (let attempt = 0; attempt <= BULK_MAX_RETRIES; attempt += 1) {
+    if (attempt > 0) {
+      response = await elRawBulk(context, { ...bulkArgs, body: pending.flatMap((operation) => operation.lines) });
+    }
+    const items = response.items ?? [];
+    const retryable: typeof pending = [];
+    const transientErrors: any[] = [];
+    const permanentErrors: any[] = [];
+    for (let k = 0; k < items.length; k += 1) {
+      const operation = pending[k];
+      finalItems[operation.index] = items[k];
+      const itemResult = bulkItemResult(items[k]);
+      const error = itemResult?.error;
+      if (!error || error.type === DOCUMENT_MISSING_EXCEPTION) {
+        continue; // success, or tolerated update of an already deleted document
+      }
+      if (isTransientBulkItemError(itemResult)) {
+        retryable.push(operation);
+        transientErrors.push(error);
+      } else {
+        permanentErrors.push(error);
       }
     }
-    return data;
-  });
+    if (permanentErrors.length > 0) {
+      throw DatabaseError('Bulk indexing fail', { bulkId, attempts: attempt + 1, errors: permanentErrors });
+    }
+    if (retryable.length === 0) {
+      if (attempt > 0) {
+        logApp.info('[SEARCH] Bulk recovered after partial failures', { bulkId, attempts: attempt + 1, opsTotal: operations.length });
+      }
+      return { ...response, items: finalItems, errors: finalItems.some((item) => item && bulkItemResult(item)?.error !== undefined) };
+    }
+    if (attempt === BULK_MAX_RETRIES) {
+      throw DatabaseError('Bulk indexing fail', { bulkId, attempts: attempt + 1, errors: transientErrors });
+    }
+    const delayMs = BULK_INITIAL_DELAY_MS * (2 ** attempt);
+    const errorTypes: Record<string, number> = {};
+    transientErrors.forEach((error) => {
+      errorTypes[error.type] = (errorTypes[error.type] ?? 0) + 1;
+    });
+    logApp.warn(`[SEARCH] Bulk partial failure, retrying failed items in ${delayMs}ms (attempt ${attempt + 1}/${BULK_MAX_RETRIES})`, {
+      bulkId,
+      opsTotal: operations.length,
+      opsOk: operations.length - retryable.length,
+      opsRetrying: retryable.length,
+      errorTypes,
+    });
+    await wait(delayMs);
+    pending = retryable;
+  }
+  return response;
 };
 /* v8 ignore next */
 export const elIndex = async (

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/engine-bulk-partial-retry-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/engine-bulk-partial-retry-test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testMocks = vi.hoisted(() => ({
+  bulk: vi.fn(),
+  info: vi.fn(),
+  putPipeline: vi.fn(),
+  confGet: vi.fn(),
+}));
+
+vi.mock('@elastic/elasticsearch', () => {
+  class MockElkClient {
+    public ingest = { putPipeline: testMocks.putPipeline };
+
+    public info = testMocks.info;
+
+    public bulk = testMocks.bulk;
+
+    // eslint-disable-next-line no-useless-constructor
+    constructor(_config: unknown) {}
+  }
+  return { Client: MockElkClient };
+});
+
+vi.mock('@opensearch-project/opensearch', () => {
+  class MockOpenClient {
+    // eslint-disable-next-line no-useless-constructor
+    constructor(_config: unknown) {}
+  }
+  return { Client: MockOpenClient };
+});
+
+vi.mock('@opensearch-project/opensearch/aws', () => ({
+  AwsSigv4Signer: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../../src/config/credentials', () => ({
+  enrichWithRemoteCredentials: vi.fn(async (_provider, auth) => auth),
+}));
+
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/conf')>();
+  const confGet = vi.fn((key: string) => {
+    if (key === 'elasticsearch:engine_selector') {
+      return 'elk';
+    }
+    if (key === 'elasticsearch:engine_check') {
+      return false;
+    }
+    return actual.default.get(key);
+  });
+  testMocks.confGet.mockImplementation(confGet);
+  return {
+    ...actual,
+    default: { ...actual.default, get: confGet },
+    booleanConf: vi.fn((key: string, defaultValue: boolean) => {
+      if (key === 'elasticsearch:engine_check') {
+        return false;
+      }
+      return defaultValue;
+    }),
+    extendedErrors: vi.fn(() => ({})),
+    loadCert: vi.fn(() => null),
+    logApp: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+    logMigration: {
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+import { logApp } from '../../../src/config/conf';
+import { elBulk, searchEngineInit } from '../../../src/database/engine';
+
+const MAX_ATTEMPTS = 6; // 1 initial + BULK_MAX_RETRIES
+
+const indexOp = (id: string) => [{ index: { _index: 'test-index', _id: id } }, { value: id }];
+const updateOp = (id: string) => [{ update: { _index: 'test-index', _id: id } }, { script: { source: 'noop' } }];
+const deleteOp = (id: string) => [{ delete: { _index: 'test-index', _id: id } }];
+
+const okItem = (action: string, id: string) => ({ [action]: { _id: id, status: action === 'index' ? 201 : 200 } });
+const errorItem = (action: string, id: string, status: number, type: string) => ({ [action]: { _id: id, status, error: { type, reason: `${type} on ${id}` } } });
+
+describe('elBulk selective retry on partial (per-item) failures', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    testMocks.info.mockResolvedValue({
+      version: { number: '8.19.1' },
+      tagline: 'You Know, for Search',
+    });
+    testMocks.putPipeline.mockResolvedValue({});
+    await searchEngineInit();
+  });
+
+  it('passes through clean responses without any extra work', async () => {
+    const data = { took: 1, errors: false, items: [okItem('index', 'a')] };
+    testMocks.bulk.mockResolvedValue(data);
+    await expect(elBulk({} as any, { refresh: true, body: indexOp('a') })).resolves.toEqual(data);
+    expect(testMocks.bulk).toHaveBeenCalledTimes(1);
+  });
+
+  it('resubmits only the failed transient items and merges the results', async () => {
+    vi.useFakeTimers();
+    const body = [...indexOp('a'), ...updateOp('b'), ...deleteOp('c')];
+    testMocks.bulk
+      .mockResolvedValueOnce({
+        took: 1,
+        errors: true,
+        items: [okItem('index', 'a'), errorItem('update', 'b', 429, 'es_rejected_execution_exception'), okItem('delete', 'c')],
+      })
+      .mockResolvedValueOnce({ took: 1, errors: false, items: [okItem('update', 'b')] });
+    const bulkPromise = elBulk({} as any, { refresh: true, timeout: '1h', body });
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await bulkPromise;
+    expect(testMocks.bulk).toHaveBeenCalledTimes(2);
+    // The second bulk carries ONLY the failed update operation (action line + source line)
+    expect(testMocks.bulk.mock.calls[1][0].body).toEqual(updateOp('b'));
+    expect(testMocks.bulk.mock.calls[1][0].refresh).toBe(true);
+    // The merged response keeps the original item order and clears the errors flag
+    expect(result.errors).toBe(false);
+    expect(result.items.map((i: any) => (i.index ?? i.update ?? i.delete)._id)).toEqual(['a', 'b', 'c']);
+    expect(logApp.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Bulk partial failure, retrying failed items'),
+      expect.objectContaining({ opsTotal: 3, opsOk: 2, opsRetrying: 1, errorTypes: { es_rejected_execution_exception: 1 } }),
+    );
+    expect(logApp.info).toHaveBeenCalledWith(
+      expect.stringContaining('Bulk recovered after partial failures'),
+      expect.objectContaining({ attempts: 2, opsTotal: 3 }),
+    );
+  });
+
+  it('detects and retries failed DELETE items (previously swallowed)', async () => {
+    vi.useFakeTimers();
+    const body = [...deleteOp('a'), ...deleteOp('b')];
+    testMocks.bulk
+      .mockResolvedValueOnce({
+        took: 1,
+        errors: true,
+        items: [okItem('delete', 'a'), errorItem('delete', 'b', 429, 'es_rejected_execution_exception')],
+      })
+      .mockResolvedValueOnce({ took: 1, errors: false, items: [okItem('delete', 'b')] });
+    const bulkPromise = elBulk({} as any, { refresh: true, body });
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await bulkPromise;
+    expect(testMocks.bulk).toHaveBeenCalledTimes(2);
+    // Delete operations have no source line
+    expect(testMocks.bulk.mock.calls[1][0].body).toEqual(deleteOp('b'));
+    expect(result.errors).toBe(false);
+  });
+
+  it('retries version conflicts surviving retry_on_conflict (hot document contention)', async () => {
+    vi.useFakeTimers();
+    testMocks.bulk
+      .mockResolvedValueOnce({
+        took: 1,
+        errors: true,
+        items: [errorItem('update', 'hot', 409, 'version_conflict_engine_exception')],
+      })
+      .mockResolvedValueOnce({ took: 1, errors: false, items: [okItem('update', 'hot')] });
+    const bulkPromise = elBulk({} as any, { body: updateOp('hot') });
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(bulkPromise).resolves.toMatchObject({ errors: false });
+    expect(testMocks.bulk).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails fast on permanent item errors, without retrying', async () => {
+    testMocks.bulk.mockResolvedValue({
+      took: 1,
+      errors: true,
+      items: [okItem('index', 'a'), errorItem('index', 'b', 400, 'mapper_parsing_exception')],
+    });
+    const bulkPromise = elBulk({} as any, { body: [...indexOp('a'), ...indexOp('b')] });
+    await expect(bulkPromise).rejects.toMatchObject({
+      message: 'Bulk indexing fail',
+      extensions: { code: 'DATABASE_ERROR', data: expect.objectContaining({ attempts: 1, bulkId: expect.any(String) }) },
+    });
+    expect(testMocks.bulk).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails fast when transient and permanent errors are mixed', async () => {
+    testMocks.bulk.mockResolvedValue({
+      took: 1,
+      errors: true,
+      items: [errorItem('update', 'a', 429, 'es_rejected_execution_exception'), errorItem('index', 'b', 400, 'strict_dynamic_mapping_exception')],
+    });
+    await expect(elBulk({} as any, { body: [...updateOp('a'), ...indexOp('b')] })).rejects.toMatchObject({ message: 'Bulk indexing fail' });
+    expect(testMocks.bulk).toHaveBeenCalledTimes(1);
+  });
+
+  it('still tolerates document_missing_exception on update without retrying', async () => {
+    testMocks.bulk.mockResolvedValue({
+      took: 1,
+      errors: true,
+      items: [errorItem('update', 'gone', 404, 'document_missing_exception')],
+    });
+    const result = await elBulk({} as any, { body: updateOp('gone') });
+    expect(testMocks.bulk).toHaveBeenCalledTimes(1);
+    // The tolerated error stays visible in the response items
+    expect(result.errors).toBe(true);
+  });
+
+  it('gives up after the retry budget and reports the remaining errors with the bulkId', async () => {
+    vi.useFakeTimers();
+    testMocks.bulk.mockResolvedValue({
+      took: 1,
+      errors: true,
+      items: [errorItem('update', 'a', 429, 'circuit_breaking_exception')],
+    });
+    const bulkPromise = elBulk({} as any, { body: updateOp('a') });
+    const rejection = expect(bulkPromise).rejects.toMatchObject({
+      message: 'Bulk indexing fail',
+      extensions: {
+        code: 'DATABASE_ERROR',
+        data: expect.objectContaining({
+          attempts: MAX_ATTEMPTS,
+          bulkId: expect.any(String),
+          errors: [expect.objectContaining({ type: 'circuit_breaking_exception' })],
+        }),
+      },
+    });
+    await vi.runAllTimersAsync();
+    await rejection;
+    expect(testMocks.bulk).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+  });
+
+  it('keeps the request-level (transport) retry behavior of elRawBulk', async () => {
+    vi.useFakeTimers();
+    testMocks.bulk
+      .mockRejectedValueOnce(new Error('circuit_breaking_exception: data too large'))
+      .mockResolvedValueOnce({ took: 1, errors: false, items: [] });
+    const bulkPromise = elBulk({} as any, { body: [] });
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(bulkPromise).resolves.toMatchObject({ errors: false });
+    expect(testMocks.bulk).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Description

A `_bulk` request can succeed (HTTP 200) while some of its items fail, with a per-item error
detail. The Elasticsearch/OpenSearch client does not throw in that case, so `retryElOperations`
(which only sees request-level failures) never triggers: `elBulk` detected the per-item errors
afterwards and threw `DatabaseError('Bulk indexing fail')` on the first response, dropping items
that failed with the exact transient overload errors the retry mechanism targets
(`es_rejected_execution_exception`, per-item `circuit_breaking_exception`, version conflicts
surviving `retry_on_conflict`). Per-item **delete** errors were even silently swallowed (`elBulk`
only collected `index`/`update` item errors). Since succeeded items stay applied (bulk is not
transactional), this produced durable partial writes. Full analysis in #17134.

### Proposed changes

* `elBulk` now classifies per-item errors on `errors: true` responses:
  * **transient** (status 429, `es_rejected_execution_exception`, `circuit_breaking_exception`,
    `too_many_requests`, `unavailable_shards_exception`, `version_conflict_engine_exception`):
    **only the failed action/source pairs are resubmitted**, with the same exponential backoff and
    budget as `retryElOperations` (500 ms × 2^n, 5 retries); item results are merged across
    attempts so callers still see one aggregate response;
  * **tolerated**: `document_missing_exception` on update, behavior unchanged;
  * **permanent** (mapping violations, script errors, ...): fail fast, no useless retries.
* Item errors are now collected for **all** operation types (`index`/`update`/`delete`/`create`),
  fixing the silent partial-delete case.
* Every bulk gets a short `bulkId`; each retry logs an accounting line
  (`opsTotal` / `opsOk` / `opsRetrying` / `errorTypes` / delay) and the `bulkId` is carried in the
  final `DatabaseError` data, so the platform error log, the worker log and the work error
  correlate on one id.
* The terminal contract is unchanged: after budget exhaustion (or on permanent errors), the same
  `DatabaseError('Bulk indexing fail')` is thrown, so upstream behavior (GraphQL error, worker
  handling) is identical to today. Safe by construction: failed items are guaranteed not applied,
  so resubmitting them cannot double-apply anything, and resending only the failed subset is
  strictly lighter for Elasticsearch than the full-batch replay already performed for
  request-level errors.

### Related issues

* closes #17134
* complementary to #16978 / #16979 (PRs #16981 / #16986), which cover the request-level failure
  mode

### How to test this PR

* Unit suite: `tests/01-unit/database/engine-bulk-partial-retry-test.ts` (selective resubmission,
  delete-error detection, permanent fail-fast, tolerance, budget exhaustion, transport-retry
  control).
* Manual, reproduced end-to-end: start Elasticsearch with a tiny write queue
  (`thread_pool.write.queue_size=1`), flood it with concurrent raw bulks while creating entities
  through the API. Mutations that previously failed with `Bulk indexing fail` now succeed; the
  platform logs `[SEARCH] Bulk partial failure, retrying failed items ...`
  (`bulkId`, `opsOk`/`opsRetrying`, error types) then `[SEARCH] Bulk recovered after partial
  failures`. In a 45 s flood run: 40/40 mutations OK, 19 partial failures all recovered on first
  retry.
* Delete case: set `index.blocks.read_only: true` on an entity index and delete an entity through
  the API: the failure is now surfaced as a `DATABASE_ERROR` carrying the per-item
  `cluster_block_exception` (previously reported as success while the document remained).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

The retry sits in `elBulk`, next to the Elasticsearch call, so every producer (ingestion, mass
deletes, merges, drafts, background tasks, migrations) benefits without modification. An invariant
worth stating: bulk bodies carry at most one operation per document id (true for all current
producers), so selective resubmission cannot reorder operations targeting the same document. The
alternative of retrying at business level (or in pycti) was rejected: it replays whole mutations,
re-runs non-idempotent denormalization scripts, and loses the per-item information.
