### PR TITLE
fix(workbench): Observable type selector does not apply the selected type (#17126)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/String.test.ts
+++ b/opencti-platform/opencti-front/src/utils/String.test.ts
@@ -171,7 +171,7 @@ describe('String utils', () => {
   describe('uniqWithByFields', () => {
     it('should remove duplicates based on a single field', () => {
       const data = [{ id: '1', name: 'a' }, { id: '2', name: 'b' }, { id: '1', name: 'c' }];
-      const result = uniqWithByFields<typeof data[0]>(['id'])(data);
+      const result = uniqWithByFields<typeof data[0]>(['id'], data);
       expect(result).toEqual([{ id: '1', name: 'a' }, { id: '2', name: 'b' }]);
     });
 
@@ -181,7 +181,7 @@ describe('String utils', () => {
         { x: 1, y: 2, z: 'b' },
         { x: 1, y: 3, z: 'c' },
       ];
-      const result = uniqWithByFields<typeof data[0]>(['x', 'y'])(data);
+      const result = uniqWithByFields<typeof data[0]>(['x', 'y'], data);
       expect(result).toEqual([
         { x: 1, y: 2, z: 'a' },
         { x: 1, y: 3, z: 'c' },
@@ -189,7 +189,7 @@ describe('String utils', () => {
     });
 
     it('should return empty array for empty input', () => {
-      expect(uniqWithByFields(['id'])([])).toEqual([]);
+      expect(uniqWithByFields(['id'], [])).toEqual([]);
     });
 
     it('should handle deep equality for object fields', () => {
@@ -198,7 +198,7 @@ describe('String utils', () => {
         { id: '2', meta: { a: 1 } },
         { id: '3', meta: { a: 2 } },
       ];
-      const result = uniqWithByFields<typeof data[0]>(['meta'])(data);
+      const result = uniqWithByFields<typeof data[0]>(['meta'], data);
       expect(result).toEqual([
         { id: '1', meta: { a: 1 } },
         { id: '3', meta: { a: 2 } },

--- a/opencti-platform/opencti-front/src/utils/String.tsx
+++ b/opencti-platform/opencti-front/src/utils/String.tsx
@@ -138,7 +138,7 @@ const areSameByFields = <T extends Record<string, unknown>>(
   fields.every((f) => JSON.stringify(a[f]) === JSON.stringify(b[f]));
 
 /** Deduplicate an array by keeping only the first occurrence of each unique combination of the given fields. */
-export const uniqWithByFields = <T extends Record<string, unknown>>(fields: (keyof T)[]) => (data: T[]): T[] => {
+export const uniqWithByFields = <T extends Record<string, unknown>>(fields: (keyof T)[], data: T[]): T[] => {
   return data.filter((item, index) =>
     data.findIndex((other) =>
       areSameByFields(fields as string[], item, other),


### PR DESCRIPTION
### Proposed changes
- Fix observable type switching in Workbench
- Fix the signature of the string utils function uniqWithByFields (due to a refacto of string utils)
- Update the tests of uniqWithByFields

<img width="1680" height="536" alt="image" src="https://github.com/user-attachments/assets/2822a8c9-fa7c-4f1b-bc63-841ddedf319d" />


### Related issues
fixes #17126