### PR TITLE
chore(musl): move musl rolling build to GitHub workflow (#17146)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@6.1.3
 jobs:
-  # Client-python steps
+# Client-python steps
 
   build_pycti:
     working_directory: ~/repo
@@ -73,7 +73,7 @@ jobs:
           branch_pattern: master
           event: fail
           template: basic_fail_1
-  # opencti steps
+# opencti steps
   build_frontend:
     working_directory: ~/opencti
     docker:
@@ -118,7 +118,7 @@ jobs:
     docker:
       - image: nikolaik/python-nodejs:python3.11-nodejs22
     resource_class: medium+
-    steps:
+    steps:  
       - run:
           command: apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev curl g++ make python3 python3-dev
       - run:
@@ -131,35 +131,6 @@ jobs:
       - run:
           working_directory: ~/opencti/opencti-platform/opencti-graphql
           command: TAG_VERSION=${CIRCLE_TAG} yarn build
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - opencti
-
-  build_platform_rolling:
-    working_directory: ~/opencti
-    docker:
-      - image: nikolaik/python-nodejs:python3.11-nodejs22
-    resource_class: medium+
-    steps:
-      - run:
-          command: apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev curl g++ make python3 python3-dev
-      - run:
-          command: npm install -g node-gyp
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti@master#subdirectory=client-python|' -i {} \;
-      - run:
-          working_directory: ~/opencti/opencti-platform/opencti-graphql
-          command: yarn install
-      - run:
-          working_directory: ~/opencti/opencti-platform/opencti-graphql
-          command: yarn build
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -208,7 +179,7 @@ jobs:
           at: ~/
       - run:
           name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;          
       - run:
           working_directory: ~/opencti_musl/opencti-platform/opencti-graphql
           command: yarn install
@@ -248,32 +219,6 @@ jobs:
           event: fail
           template: basic_fail_1
 
-  package_rolling:
-    working_directory: ~/opencti
-    docker:
-      - image: circleci/node:current
-    resource_class: medium+
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run: mkdir release
-      - run: rm -Rf ./opencti-platform/opencti-graphql/.yarn/cache
-      - run: cp -a ./opencti-platform/opencti-graphql release/opencti
-      - run: cp -a ./opencti-platform/.yarnrc.yml release/opencti/
-      - run: cp -a ./opencti-worker/src release/opencti/worker
-      - run: cd release/opencti && git clone https://github.com/OpenCTI-Platform/docker
-      - run: cd release/opencti && git clone https://github.com/OpenCTI-Platform/connectors
-      - run:
-          working_directory: ~/opencti/release
-          command: tar -zcvf "opencti-$(date '+%Y%m%d').tar.gz" opencti
-      - run:
-          working_directory: ~/opencti/release
-          command: curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T opencti-$(date '+%Y%m%d').tar.gz "https://filigran.jfrog.io/artifactory/opencti/opencti-$(date '+%Y%m%d').tar.gz"
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
   package_rolling_musl:
     working_directory: ~/opencti_musl
     docker:
@@ -294,9 +239,6 @@ jobs:
       - run:
           working_directory: ~/opencti_musl/release
           command: tar -zcvf "opencti-$(date '+%Y%m%d')_musl.tar.gz" opencti
-      - run:
-          working_directory: ~/opencti_musl/release
-          command: curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T opencti-$(date '+%Y%m%d')_musl.tar.gz "https://filigran.jfrog.io/artifactory/opencti/opencti-$(date '+%Y%m%d')_musl.tar.gz"
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -465,7 +407,7 @@ jobs:
           no_output_timeout: 30m
       - slack/notify:
           event: fail
-          template: basic_fail_1
+          template: basic_fail_1      
 
   docker_build_worker_fips:
     working_directory: ~/opencti_docker
@@ -606,305 +548,6 @@ jobs:
           event: fail
           template: basic_fail_1
 
-  docker_build_platform_rolling:
-    working_directory: ~/opencti_docker
-    machine:
-      image: ubuntu-2004:202111-02
-      resource_class: large
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-            mkdir -p ~/.docker/cli-plugins
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-            docker buildx create --name mybuilder --use
-      - run:
-          name: Login to docker hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - run:
-          working_directory: ~/opencti_docker/opencti-platform
-          name: Build Docker image opencti/platform
-          command: |
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile -t opencti/platform:rolling --push .
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile -t ghcr.io/opencti-platform/opencti/platform:rolling --push .
-          no_output_timeout: 30m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  docker_build_worker_rolling:
-    working_directory: ~/opencti_docker
-    machine:
-      image: ubuntu-2004:202111-02
-      resource_class: large
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-            mkdir -p ~/.docker/cli-plugins
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-            docker buildx create --name mybuilder --use
-      - run:
-          name: Login to docker hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - run:
-          working_directory: ~/opencti_docker/opencti-worker
-          name: Build Docker image opencti/worker
-          command: |
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -t opencti/worker:rolling --push .
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -t ghcr.io/opencti-platform/opencti/worker:rolling --push .
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  docker_build_platform_fips_rolling:
-    working_directory: ~/opencti_docker
-    machine:
-      image: ubuntu-2004:202111-02
-      resource_class: large
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-            mkdir -p ~/.docker/cli-plugins
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-            docker buildx create --name mybuilder --use
-      - run:
-          name: Login to docker hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - run:
-          working_directory: ~/opencti_docker/opencti-platform
-          name: Build Docker image opencti/platform
-          command: |
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_fips -t opencti/platform:rolling-fips --push .
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_fips -t ghcr.io/opencti-platform/opencti/platform:rolling-fips --push .
-          no_output_timeout: 30m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  docker_build_worker_fips_rolling:
-    working_directory: ~/opencti_docker
-    machine:
-      image: ubuntu-2004:202111-02
-      resource_class: large
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-            mkdir -p ~/.docker/cli-plugins
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-            docker buildx create --name mybuilder --use
-      - run:
-          name: Login to docker hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - run:
-          working_directory: ~/opencti_docker/opencti-worker
-          name: Build Docker image opencti/worker
-          command: |
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_fips -t opencti/worker:rolling-fips --push .
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_fips -t ghcr.io/opencti-platform/opencti/worker:rolling-fips --push .
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  docker_build_platform_ubi9_rolling:
-    working_directory: ~/opencti_docker
-    machine:
-      image: ubuntu-2004:202111-02
-      resource_class: large
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-            mkdir -p ~/.docker/cli-plugins
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-            docker buildx create --name mybuilder --use
-      - run:
-          name: Login to docker hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - run:
-          working_directory: ~/opencti_docker/opencti-platform
-          name: Build Docker image opencti/platform (UBI9 rolling)
-          command: |
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_ubi9 -t opencti/platform:rolling-ubi9 --push .
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_ubi9 -t ghcr.io/opencti-platform/opencti/platform:rolling-ubi9 --push .
-          no_output_timeout: 30m
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  docker_build_worker_ubi9_rolling:
-    working_directory: ~/opencti_docker
-    machine:
-      image: ubuntu-2004:202111-02
-      resource_class: large
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
-      - run:
-          name: Install buildx
-          command: |
-            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
-            curl --output docker-buildx \
-              --silent --show-error --location --fail --retry 3 \
-              "$BUILDX_BINARY_URL"
-            mkdir -p ~/.docker/cli-plugins
-            mv docker-buildx ~/.docker/cli-plugins/
-            chmod a+x ~/.docker/cli-plugins/docker-buildx
-            docker buildx install
-            # Run binfmt
-            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
-            docker buildx create --name mybuilder --use
-      - run:
-          name: Login to docker hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-      - run:
-          working_directory: ~/opencti_docker/opencti-worker
-          name: Build Docker image opencti/worker (UBI9 rolling)
-          command: |
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_ubi9 -t opencti/worker:rolling-ubi9 --push .
-            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_ubi9 -t ghcr.io/opencti-platform/opencti/worker:rolling-ubi9 --push .
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  deploy_testing:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - kubernetes/install-kubectl
-      - run:
-          name: Restart to redeploy the new rolling image and latest XTM Composer
-          command: |
-            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n customer-testing-octi rollout restart deployment -l app=opencti
-            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n customer-testing-octi rollout restart deployment -l app=xtm-composer
-
-  deploy_master-ff:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - kubernetes/install-kubectl
-      - run:
-          name: Restart to redeploy the new rolling image and latest XTM Composer
-          command: |
-            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_MASTER_FF -n customer-master-ff-octi rollout restart deployment -l app=opencti
-            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_MASTER_FF -n customer-master-ff-octi rollout restart deployment -l app=xtm-composer
-
-  notify_rolling:
-    docker:
-      - image: "cimg/base:stable"
-    steps:
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - slack/notify:
-          event: pass
-          template: basic_success_1
   notify:
     docker:
       - image: "cimg/base:stable"
@@ -917,7 +560,7 @@ jobs:
 workflows:
   opencti:
     jobs:
-      # Prepare and deploy client-python before building opencti
+# Prepare and deploy client-python before building opencti
       - build_pycti:
           filters:
             tags:
@@ -932,11 +575,14 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
-      # Build opencti
+# Build opencti
       - build_frontend:
           filters:
             tags:
               only: /.*/
+            branches:
+              only:
+                - master
       - wait_for_connector_release:
           filters:
             tags:
@@ -953,13 +599,6 @@ workflows:
             - build_frontend
             - build_pycti
             - wait_for_connector_release
-      - build_platform_rolling:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - build_frontend
       - build_platform_musl:
           filters:
             tags:
@@ -976,20 +615,13 @@ workflows:
                 - master
           requires:
             - build_frontend
-      - package_rolling:
-          requires:
-            - build_platform_rolling
-          filters:
-            branches:
-              only:
-                - master
       - package_rolling_musl:
           requires:
             - build_platform_musl_rolling
           filters:
             branches:
               only:
-                - master
+                - master                
       - tag_package:
           requires:
             - build_platform
@@ -1006,48 +638,7 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
-      - docker_build_platform_rolling:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              only:
-                - master
-      - docker_build_worker_rolling:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              only:
-                - master
-      - docker_build_platform_fips_rolling:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              only:
-                - master
-      - docker_build_worker_fips_rolling:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              only:
-                - master
-      - docker_build_platform_ubi9_rolling:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              only:
-                - master
-      - docker_build_worker_ubi9_rolling:
-          requires:
-            - build_frontend
-          filters:
-            branches:
-              only:
-                - master
+
       - docker_build_platform:
           requires:
             - build_frontend
@@ -1102,24 +693,7 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
-      - deploy_testing:
-          requires:
-            - docker_build_platform_rolling
-            - docker_build_worker_rolling
-      - deploy_master-ff:
-          requires:
-            - docker_build_platform_rolling
-            - docker_build_worker_rolling
-      - notify_rolling:
-          requires:
-            - deploy_testing
-            - deploy_master-ff
-            - docker_build_platform_fips_rolling
-            - docker_build_worker_fips_rolling
-            - docker_build_platform_ubi9_rolling
-            - docker_build_worker_ubi9_rolling
-            - package_rolling
-            - package_rolling_musl
+
       - notify:
           requires:
             - docker_build_platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,35 +165,6 @@ jobs:
           paths:
             - opencti_musl
 
-  build_platform_musl_rolling:
-    working_directory: ~/opencti_musl
-    docker:
-      - image: nikolaik/python-nodejs:python3.11-nodejs22-alpine
-    resource_class: medium+
-    steps:
-      - run:
-          command: apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libmagic libffi-dev curl
-      - run:
-          command: npm install -g node-gyp
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;          
-      - run:
-          working_directory: ~/opencti_musl/opencti-platform/opencti-graphql
-          command: yarn install
-      - run:
-          working_directory: ~/opencti_musl/opencti-platform/opencti-graphql
-          command: yarn build
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-      - persist_to_workspace:
-          root: ~/
-          paths:
-            - opencti_musl
-
   tag_package:
     working_directory: ~/opencti
     docker:
@@ -215,30 +186,6 @@ jobs:
       - run:
           working_directory: ~/opencti/release
           command: curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T opencti-${CIRCLE_TAG}.tar.gz "https://filigran.jfrog.io/artifactory/opencti/opencti-${CIRCLE_TAG}.tar.gz"
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-
-  package_rolling_musl:
-    working_directory: ~/opencti_musl
-    docker:
-      - image: circleci/node:current
-    resource_class: medium+
-    steps:
-      - attach_workspace:
-          at: ~/
-      - add_ssh_keys
-      - run: sudo apt-get update -qq && sudo apt install curl
-      - run: mkdir release
-      - run: rm -Rf ./opencti-platform/opencti-graphql/.yarn/cache
-      - run: cp -a ./opencti-platform/opencti-graphql release/opencti
-      - run: cp -a ./opencti-platform/.yarnrc.yml release/opencti/
-      - run: cp -a ./opencti-worker/src release/opencti/worker
-      - run: cd release/opencti && git clone https://github.com/OpenCTI-Platform/docker
-      - run: cd release/opencti && git clone https://github.com/OpenCTI-Platform/connectors
-      - run:
-          working_directory: ~/opencti_musl/release
-          command: tar -zcvf "opencti-$(date '+%Y%m%d')_musl.tar.gz" opencti
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -608,20 +555,6 @@ workflows:
           requires:
             - build_frontend
             - wait_for_connector_release
-      - build_platform_musl_rolling:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - build_frontend
-      - package_rolling_musl:
-          requires:
-            - build_platform_musl_rolling
-          filters:
-            branches:
-              only:
-                - master                
       - tag_package:
           requires:
             - build_platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@6.1.3
 jobs:
-# Client-python steps
+  # Client-python steps
 
   build_pycti:
     working_directory: ~/repo
@@ -73,7 +73,7 @@ jobs:
           branch_pattern: master
           event: fail
           template: basic_fail_1
-# opencti steps
+  # opencti steps
   build_frontend:
     working_directory: ~/opencti
     docker:
@@ -118,7 +118,7 @@ jobs:
     docker:
       - image: nikolaik/python-nodejs:python3.11-nodejs22
     resource_class: medium+
-    steps:  
+    steps:
       - run:
           command: apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev curl g++ make python3 python3-dev
       - run:
@@ -131,6 +131,35 @@ jobs:
       - run:
           working_directory: ~/opencti/opencti-platform/opencti-graphql
           command: TAG_VERSION=${CIRCLE_TAG} yarn build
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - opencti
+
+  build_platform_rolling:
+    working_directory: ~/opencti
+    docker:
+      - image: nikolaik/python-nodejs:python3.11-nodejs22
+    resource_class: medium+
+    steps:
+      - run:
+          command: apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev curl g++ make python3 python3-dev
+      - run:
+          command: npm install -g node-gyp
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti@master#subdirectory=client-python|' -i {} \;
+      - run:
+          working_directory: ~/opencti/opencti-platform/opencti-graphql
+          command: yarn install
+      - run:
+          working_directory: ~/opencti/opencti-platform/opencti-graphql
+          command: yarn build
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -179,7 +208,7 @@ jobs:
           at: ~/
       - run:
           name: Replace pycti requirement of stable version with latest master branch code
-          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;          
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
       - run:
           working_directory: ~/opencti_musl/opencti-platform/opencti-graphql
           command: yarn install
@@ -215,6 +244,32 @@ jobs:
       - run:
           working_directory: ~/opencti/release
           command: curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T opencti-${CIRCLE_TAG}.tar.gz "https://filigran.jfrog.io/artifactory/opencti/opencti-${CIRCLE_TAG}.tar.gz"
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  package_rolling:
+    working_directory: ~/opencti
+    docker:
+      - image: circleci/node:current
+    resource_class: medium+
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run: mkdir release
+      - run: rm -Rf ./opencti-platform/opencti-graphql/.yarn/cache
+      - run: cp -a ./opencti-platform/opencti-graphql release/opencti
+      - run: cp -a ./opencti-platform/.yarnrc.yml release/opencti/
+      - run: cp -a ./opencti-worker/src release/opencti/worker
+      - run: cd release/opencti && git clone https://github.com/OpenCTI-Platform/docker
+      - run: cd release/opencti && git clone https://github.com/OpenCTI-Platform/connectors
+      - run:
+          working_directory: ~/opencti/release
+          command: tar -zcvf "opencti-$(date '+%Y%m%d').tar.gz" opencti
+      - run:
+          working_directory: ~/opencti/release
+          command: curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T opencti-$(date '+%Y%m%d').tar.gz "https://filigran.jfrog.io/artifactory/opencti/opencti-$(date '+%Y%m%d').tar.gz"
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -410,7 +465,7 @@ jobs:
           no_output_timeout: 30m
       - slack/notify:
           event: fail
-          template: basic_fail_1      
+          template: basic_fail_1
 
   docker_build_worker_fips:
     working_directory: ~/opencti_docker
@@ -551,6 +606,305 @@ jobs:
           event: fail
           template: basic_fail_1
 
+  docker_build_platform_rolling:
+    working_directory: ~/opencti_docker
+    machine:
+      image: ubuntu-2004:202111-02
+      resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+            docker buildx create --name mybuilder --use
+      - run:
+          name: Login to docker hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+      - run:
+          working_directory: ~/opencti_docker/opencti-platform
+          name: Build Docker image opencti/platform
+          command: |
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile -t opencti/platform:rolling --push .
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile -t ghcr.io/opencti-platform/opencti/platform:rolling --push .
+          no_output_timeout: 30m
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  docker_build_worker_rolling:
+    working_directory: ~/opencti_docker
+    machine:
+      image: ubuntu-2004:202111-02
+      resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+            docker buildx create --name mybuilder --use
+      - run:
+          name: Login to docker hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+      - run:
+          working_directory: ~/opencti_docker/opencti-worker
+          name: Build Docker image opencti/worker
+          command: |
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -t opencti/worker:rolling --push .
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -t ghcr.io/opencti-platform/opencti/worker:rolling --push .
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  docker_build_platform_fips_rolling:
+    working_directory: ~/opencti_docker
+    machine:
+      image: ubuntu-2004:202111-02
+      resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+            docker buildx create --name mybuilder --use
+      - run:
+          name: Login to docker hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+      - run:
+          working_directory: ~/opencti_docker/opencti-platform
+          name: Build Docker image opencti/platform
+          command: |
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_fips -t opencti/platform:rolling-fips --push .
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_fips -t ghcr.io/opencti-platform/opencti/platform:rolling-fips --push .
+          no_output_timeout: 30m
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  docker_build_worker_fips_rolling:
+    working_directory: ~/opencti_docker
+    machine:
+      image: ubuntu-2004:202111-02
+      resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+            docker buildx create --name mybuilder --use
+      - run:
+          name: Login to docker hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+      - run:
+          working_directory: ~/opencti_docker/opencti-worker
+          name: Build Docker image opencti/worker
+          command: |
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_fips -t opencti/worker:rolling-fips --push .
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_fips -t ghcr.io/opencti-platform/opencti/worker:rolling-fips --push .
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  docker_build_platform_ubi9_rolling:
+    working_directory: ~/opencti_docker
+    machine:
+      image: ubuntu-2004:202111-02
+      resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+            docker buildx create --name mybuilder --use
+      - run:
+          name: Login to docker hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+      - run:
+          working_directory: ~/opencti_docker/opencti-platform
+          name: Build Docker image opencti/platform (UBI9 rolling)
+          command: |
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_ubi9 -t opencti/platform:rolling-ubi9 --push .
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_ubi9 -t ghcr.io/opencti-platform/opencti/platform:rolling-ubi9 --push .
+          no_output_timeout: 30m
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  docker_build_worker_ubi9_rolling:
+    working_directory: ~/opencti_docker
+    machine:
+      image: ubuntu-2004:202111-02
+      resource_class: large
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - run:
+          name: Replace pycti requirement of stable version with latest master branch code
+          command: find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@master#subdirectory=client-python|' -i {} \;
+      - run:
+          name: Install buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.8.2/buildx-v0.8.2.linux-amd64"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
+            docker buildx create --name mybuilder --use
+      - run:
+          name: Login to docker hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$GHCR_PASS" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
+      - run:
+          working_directory: ~/opencti_docker/opencti-worker
+          name: Build Docker image opencti/worker (UBI9 rolling)
+          command: |
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_ubi9 -t opencti/worker:rolling-ubi9 --push .
+            docker buildx build --pull --progress=plain --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_ubi9 -t ghcr.io/opencti-platform/opencti/worker:rolling-ubi9 --push .
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+
+  deploy_testing:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
+      - run:
+          name: Restart to redeploy the new rolling image and latest XTM Composer
+          command: |
+            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n customer-testing-octi rollout restart deployment -l app=opencti
+            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN -n customer-testing-octi rollout restart deployment -l app=xtm-composer
+
+  deploy_master-ff:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - kubernetes/install-kubectl
+      - run:
+          name: Restart to redeploy the new rolling image and latest XTM Composer
+          command: |
+            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_MASTER_FF -n customer-master-ff-octi rollout restart deployment -l app=opencti
+            kubectl --server=https://api.staging.eu-west.filigran.io --token=$K8S_TOKEN_MASTER_FF -n customer-master-ff-octi rollout restart deployment -l app=xtm-composer
+
+  notify_rolling:
+    docker:
+      - image: "cimg/base:stable"
+    steps:
+      - run: sudo apt-get update -qq && sudo apt install curl
+      - slack/notify:
+          event: pass
+          template: basic_success_1
   notify:
     docker:
       - image: "cimg/base:stable"
@@ -563,7 +917,7 @@ jobs:
 workflows:
   opencti:
     jobs:
-# Prepare and deploy client-python before building opencti
+      # Prepare and deploy client-python before building opencti
       - build_pycti:
           filters:
             tags:
@@ -578,14 +932,11 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
-# Build opencti
+      # Build opencti
       - build_frontend:
           filters:
             tags:
               only: /.*/
-            branches:
-              only:
-                - master
       - wait_for_connector_release:
           filters:
             tags:
@@ -602,6 +953,13 @@ workflows:
             - build_frontend
             - build_pycti
             - wait_for_connector_release
+      - build_platform_rolling:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build_frontend
       - build_platform_musl:
           filters:
             tags:
@@ -618,13 +976,20 @@ workflows:
                 - master
           requires:
             - build_frontend
+      - package_rolling:
+          requires:
+            - build_platform_rolling
+          filters:
+            branches:
+              only:
+                - master
       - package_rolling_musl:
           requires:
             - build_platform_musl_rolling
           filters:
             branches:
               only:
-                - master                
+                - master
       - tag_package:
           requires:
             - build_platform
@@ -641,7 +1006,48 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
-
+      - docker_build_platform_rolling:
+          requires:
+            - build_frontend
+          filters:
+            branches:
+              only:
+                - master
+      - docker_build_worker_rolling:
+          requires:
+            - build_frontend
+          filters:
+            branches:
+              only:
+                - master
+      - docker_build_platform_fips_rolling:
+          requires:
+            - build_frontend
+          filters:
+            branches:
+              only:
+                - master
+      - docker_build_worker_fips_rolling:
+          requires:
+            - build_frontend
+          filters:
+            branches:
+              only:
+                - master
+      - docker_build_platform_ubi9_rolling:
+          requires:
+            - build_frontend
+          filters:
+            branches:
+              only:
+                - master
+      - docker_build_worker_ubi9_rolling:
+          requires:
+            - build_frontend
+          filters:
+            branches:
+              only:
+                - master
       - docker_build_platform:
           requires:
             - build_frontend
@@ -696,7 +1102,24 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+(-lts\.[0-9]+)?$/
             branches:
               ignore: /.*/
-
+      - deploy_testing:
+          requires:
+            - docker_build_platform_rolling
+            - docker_build_worker_rolling
+      - deploy_master-ff:
+          requires:
+            - docker_build_platform_rolling
+            - docker_build_worker_rolling
+      - notify_rolling:
+          requires:
+            - deploy_testing
+            - deploy_master-ff
+            - docker_build_platform_fips_rolling
+            - docker_build_worker_fips_rolling
+            - docker_build_platform_ubi9_rolling
+            - docker_build_worker_ubi9_rolling
+            - package_rolling
+            - package_rolling_musl
       - notify:
           requires:
             - docker_build_platform

--- a/.github/actions/build-platform-musl/action.yml
+++ b/.github/actions/build-platform-musl/action.yml
@@ -1,0 +1,57 @@
+name: build-platform-musl
+description: Build the opencti platform with musl (Alpine) and produce a tar.gz artifact
+
+inputs:
+  checkout_ref:
+    description: "Reference of the branch or commit sha"
+    default: ${{ github.sha }}
+  client_python_local:
+    description: "Use client python from the same commit"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.checkout_ref }}
+
+    - name: Use client-python in OpenCTI from same branch
+      shell: bash
+      if: ${{ inputs.client_python_local == 'true' }}
+      run: |
+        find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@${{ inputs.checkout_ref }}#subdirectory=client-python|' -i {} \;
+
+    - name: Build platform (musl) and package tar.gz
+      shell: bash
+      run: |
+        docker run --rm \
+          -v "${{ github.workspace }}:/workspace" \
+          -w /workspace \
+          nikolaik/python-nodejs:python3.11-nodejs22-alpine \
+          sh -c '
+            apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libmagic libffi-dev curl &&
+            npm install -g node-gyp &&
+            cd /workspace/opencti-platform/opencti-graphql &&
+            yarn install &&
+            yarn build
+          '
+
+    - name: Package musl tar.gz
+      shell: bash
+      run: |
+        mkdir -p release
+        rm -rf ./opencti-platform/opencti-graphql/.yarn/cache
+        cp -a ./opencti-platform/opencti-graphql release/opencti
+        cp -a ./opencti-platform/.yarnrc.yml release/opencti/
+        cp -a ./opencti-worker/src release/opencti/worker
+        cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
+
+    - name: Upload musl tar artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: opencti-platform-musl
+        path: /tmp/opencti-musl.tar.gz
+        retention-days: 7
+

--- a/.github/actions/build-platform-musl/action.yml
+++ b/.github/actions/build-platform-musl/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.checkout_ref }}
 
@@ -49,7 +49,7 @@ runs:
         cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
 
     - name: Upload musl tar artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: opencti-platform-musl
         path: /tmp/opencti-musl.tar.gz

--- a/.github/actions/docker-build-builder/action.yml
+++ b/.github/actions/docker-build-builder/action.yml
@@ -56,5 +56,5 @@ runs:
       with:
         name: docker-image-opencti-builder${{ inputs.docker_image_suffix }}
         path: /tmp/opencti-builder${{ inputs.docker_image_suffix }}.tar
-        retention-days: 7
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/actions/docker-build-builder/action.yml
+++ b/.github/actions/docker-build-builder/action.yml
@@ -56,5 +56,5 @@ runs:
       with:
         name: docker-image-opencti-builder${{ inputs.docker_image_suffix }}
         path: /tmp/opencti-builder${{ inputs.docker_image_suffix }}.tar
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 

--- a/.github/actions/docker-build-platform/action.yml
+++ b/.github/actions/docker-build-platform/action.yml
@@ -56,4 +56,4 @@ runs:
       with:
         name: docker-image-opencti-platform${{ inputs.docker_image_suffix }}
         path: /tmp/opencti-platform${{ inputs.docker_image_suffix }}.tar
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10

--- a/.github/actions/docker-build-platform/action.yml
+++ b/.github/actions/docker-build-platform/action.yml
@@ -56,4 +56,4 @@ runs:
       with:
         name: docker-image-opencti-platform${{ inputs.docker_image_suffix }}
         path: /tmp/opencti-platform${{ inputs.docker_image_suffix }}.tar
-        retention-days: 1
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}

--- a/.github/actions/docker-build-worker/action.yml
+++ b/.github/actions/docker-build-worker/action.yml
@@ -56,4 +56,4 @@ runs:
       with:
         name: docker-image-opencti-worker${{ inputs.docker_image_suffix }}
         path: /tmp/opencti-worker${{ inputs.docker_image_suffix }}.tar
-        retention-days: 1
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}

--- a/.github/actions/docker-build-worker/action.yml
+++ b/.github/actions/docker-build-worker/action.yml
@@ -56,4 +56,4 @@ runs:
       with:
         name: docker-image-opencti-worker${{ inputs.docker_image_suffix }}
         path: /tmp/opencti-worker${{ inputs.docker_image_suffix }}.tar
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -102,5 +102,5 @@ runs:
         name: sbom-${{  inputs.sbom_name || inputs.artifact_name || inputs.image_name }}
         path: "*.cdx.json"
         overwrite: ${{ inputs.overwrite }}
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -102,5 +102,5 @@ runs:
         name: sbom-${{  inputs.sbom_name || inputs.artifact_name || inputs.image_name }}
         path: "*.cdx.json"
         overwrite: ${{ inputs.overwrite }}
-        retention-days: 3
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/actions/tar-platform-musl/action.yml
+++ b/.github/actions/tar-platform-musl/action.yml
@@ -54,7 +54,7 @@ runs:
     - name: Upload musl tar artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
-        name: opencti-platform-musl
+        name: tar-opencti-platform-musl
         path: /tmp/opencti-musl.tar.gz
         retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/actions/tar-platform-musl/action.yml
+++ b/.github/actions/tar-platform-musl/action.yml
@@ -41,14 +41,18 @@ runs:
     - name: Package musl tar.gz
       shell: bash
       run: |
+        set -eux
         mkdir -p release
+        ls -lart
         rm -rf ./opencti-platform/opencti-graphql/.yarn/cache
         cp -a ./opencti-platform/opencti-graphql release/opencti
         cp -a ./opencti-platform/.yarnrc.yml release/opencti/
         cp -a ./opencti-worker/src release/opencti/worker
-        cd release/opencti/
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker release/docker
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors release/connectors
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker release/opencti/docker
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors release/opencti/connectors
+        ls -lart release
+        pwd
+        ls -lart
         cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
 
     - name: Upload musl tar artifact

--- a/.github/actions/tar-platform-musl/action.yml
+++ b/.github/actions/tar-platform-musl/action.yml
@@ -47,8 +47,8 @@ runs:
         cp -a ./opencti-platform/.yarnrc.yml release/opencti/
         cp -a ./opencti-worker/src release/opencti/worker
         cd release/opencti/
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker release/docker
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors release/connectors
         cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
 
     - name: Upload musl tar artifact

--- a/.github/actions/tar-platform-musl/action.yml
+++ b/.github/actions/tar-platform-musl/action.yml
@@ -34,7 +34,7 @@ runs:
             apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libmagic libffi-dev curl &&
             npm install -g node-gyp &&
             cd /workspace/opencti-platform/opencti-graphql &&
-            yarn install &&
+            yarn install --immutable &&
             yarn build
           '
 

--- a/.github/actions/tar-platform-musl/action.yml
+++ b/.github/actions/tar-platform-musl/action.yml
@@ -56,5 +56,5 @@ runs:
       with:
         name: tar-opencti-platform-musl
         path: /tmp/opencti-musl.tar.gz
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 

--- a/.github/actions/tar-platform-musl/action.yml
+++ b/.github/actions/tar-platform-musl/action.yml
@@ -46,6 +46,9 @@ runs:
         cp -a ./opencti-platform/opencti-graphql release/opencti
         cp -a ./opencti-platform/.yarnrc.yml release/opencti/
         cp -a ./opencti-worker/src release/opencti/worker
+        cd release/opencti/
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors
         cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
 
     - name: Upload musl tar artifact
@@ -53,5 +56,5 @@ runs:
       with:
         name: opencti-platform-musl
         path: /tmp/opencti-musl.tar.gz
-        retention-days: 7
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/actions/tar-platform/action.yml
+++ b/.github/actions/tar-platform/action.yml
@@ -1,0 +1,60 @@
+name: build-platform-musl
+description: Build the opencti platform and produce a tar.gz artifact
+
+inputs:
+  checkout_ref:
+    description: "Reference of the branch or commit sha"
+    default: ${{ github.sha }}
+  client_python_local:
+    description: "Use client python from the same commit"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ inputs.checkout_ref }}
+
+    - name: Use client-python in OpenCTI from same branch
+      shell: bash
+      if: ${{ inputs.client_python_local == 'true' }}
+      run: |
+        find . -name requirements.txt -exec sed 's|^pycti==.*$|pycti @ git+https://github.com/OpenCTI-Platform/opencti.git@${{ inputs.checkout_ref }}#subdirectory=client-python|' -i {} \;
+
+    - name: Build platform and package tar.gz
+      shell: bash
+      run: |
+        docker run --rm \
+          -v "${{ github.workspace }}:/workspace" \
+          -w /workspace \
+          nikolaik/python-nodejs:python3.11-nodejs22 \
+          sh -c '
+            apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev curl g++ make python3 python3-dev &&
+            npm install -g node-gyp &&
+            cd /workspace/opencti-platform/opencti-graphql &&
+            yarn install &&
+            yarn build
+          '
+
+    - name: Package musl tar.gz
+      shell: bash
+      run: |
+        mkdir -p release
+        rm -rf ./opencti-platform/opencti-graphql/.yarn/cache
+        cp -a ./opencti-platform/opencti-graphql release/opencti
+        cp -a ./opencti-platform/.yarnrc.yml release/opencti/
+        cp -a ./opencti-worker/src release/opencti/worker
+        cd release/opencti/
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors
+        cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
+
+    - name: Upload musl tar artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+      with:
+        name: opencti-platform-musl
+        path: /tmp/opencti-musl.tar.gz
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+

--- a/.github/actions/tar-platform/action.yml
+++ b/.github/actions/tar-platform/action.yml
@@ -46,9 +46,8 @@ runs:
         cp -a ./opencti-platform/opencti-graphql release/opencti
         cp -a ./opencti-platform/.yarnrc.yml release/opencti/
         cp -a ./opencti-worker/src release/opencti/worker
-        cd release/opencti/
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker release/docker
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors release/connectors
         cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
 
     - name: Upload tar artifact

--- a/.github/actions/tar-platform/action.yml
+++ b/.github/actions/tar-platform/action.yml
@@ -1,4 +1,4 @@
-name: build-platform-musl
+name: build-platform-tar
 description: Build the opencti platform and produce a tar.gz artifact
 
 inputs:
@@ -31,10 +31,10 @@ runs:
           -w /workspace \
           nikolaik/python-nodejs:python3.11-nodejs22 \
           sh -c '
-            apt-get update --allow-insecure-repositories --allow-unauthenticated && apt-get install -y build-essential libffi-dev curl g++ make python3 python3-dev &&
+            apt-get update && apt-get install -y --no-install-recommends build-essential libffi-dev curl g++ make python3 python3-dev && rm -rf /var/lib/apt/lists/* &&
             npm install -g node-gyp &&
             cd /workspace/opencti-platform/opencti-graphql &&
-            yarn install &&
+            yarn install --immutable &&
             yarn build
           '
 

--- a/.github/actions/tar-platform/action.yml
+++ b/.github/actions/tar-platform/action.yml
@@ -38,7 +38,7 @@ runs:
             yarn build
           '
 
-    - name: Package musl tar.gz
+    - name: Package tar.gz
       shell: bash
       run: |
         mkdir -p release
@@ -51,10 +51,10 @@ runs:
         git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors
         cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
 
-    - name: Upload musl tar artifact
+    - name: Upload tar artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
-        name: opencti-platform-musl
-        path: /tmp/opencti-musl.tar.gz
+        name: tar-opencti-platform
+        path: /tmp/opencti.tar.gz
         retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 

--- a/.github/actions/tar-platform/action.yml
+++ b/.github/actions/tar-platform/action.yml
@@ -41,14 +41,19 @@ runs:
     - name: Package tar.gz
       shell: bash
       run: |
+        set -eux
         mkdir -p release
+        ls -lart
         rm -rf ./opencti-platform/opencti-graphql/.yarn/cache
         cp -a ./opencti-platform/opencti-graphql release/opencti
         cp -a ./opencti-platform/.yarnrc.yml release/opencti/
         cp -a ./opencti-worker/src release/opencti/worker
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker release/docker
-        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors release/connectors
-        cd release && tar -zcvf /tmp/opencti-musl.tar.gz opencti
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/docker release/opencti/docker
+        git clone --depth 1 --single-branch --branch master https://github.com/OpenCTI-Platform/connectors release/opencti/connectors
+        ls -lart release
+        pwd
+        ls -lart
+        cd release && tar -zcvf /tmp/opencti.tar.gz opencti
 
     - name: Upload tar artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1

--- a/.github/actions/tar-platform/action.yml
+++ b/.github/actions/tar-platform/action.yml
@@ -56,5 +56,5 @@ runs:
       with:
         name: tar-opencti-platform
         path: /tmp/opencti.tar.gz
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           name: opencti-app-sbom
           path: sbom-staging/
-          retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+          retention-days: 10
 
   # -----------------------
   # Build platform images
@@ -328,7 +328,7 @@ jobs:
           name: sbom-opencti-platform-${{ needs.app-sbom.outputs.app_version }}${{ matrix.suffix }}
           path: sbom-work/sbom-opencti-platform-*.cdx.json
           overwrite: true
-          retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+          retention-days: 10
 
       - name: Validate merged SBOM
         working-directory: sbom-work
@@ -370,4 +370,4 @@ jobs:
         with:
           name: opencti-rolling
           path: artifacts/
-          retention-days: ${{ vars.ROLLING_ARTIFACT_RETENTION_DAYS }}
+          retention-days: 30

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -357,17 +357,26 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           pattern: tar-opencti-platform
-          path: artifacts/
+          path: tar-artifacts/
 
       - name: Download musl tar artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           pattern: tar-opencti-platform-musl
-          path: artifacts/
+          path: tar-artifacts/
 
-      - name: Upload consolidated artifacts
+      # Persist main artifact for longer and other automations
+      # Split in 2 part because tarball are heavy and there is less usage than docker images
+      - name: Upload consolidated artifacts except tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opencti-rolling
           path: artifacts/
+          retention-days: 30
+
+      - name: Upload consolidated tarballs artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tarball-opencti-rolling
+          path: tar-artifacts/
           retention-days: 30

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -1,6 +1,8 @@
 name: OpenCTI CD Rolling
 # This workflow prepare all artifact for the rolling images
 # Build on each merge on master
+#
+# /!\ If you change any name here (artifact or job names), please update releases scripts
 
 on:
   push:
@@ -180,14 +182,24 @@ jobs:
           docker_image_suffix: ${{ matrix.suffix }}
 
   # -----------------------
-  # Build platform musl tar
+  # Build platform tarballs
   # -----------------------
-  build-platform-musl:
-    name: Build platform (musl)
+  build-tar-platform:
+    name: Build platform tarball
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/build-platform-musl
+      - uses: ./.github/actions/tar-platform
+        with:
+          checkout_ref: ${{ github.sha }}
+          client_python_local: true
+
+  build-tar-platform-musl:
+    name: Build platform tarball (musl)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/tar-platform-musl
         with:
           checkout_ref: ${{ github.sha }}
           client_python_local: true
@@ -327,7 +339,7 @@ jobs:
   upload-artifacts:
     name: Upload all artifacts
     runs-on: ubuntu-latest
-    needs: [merge-sbom, build-platform-musl]
+    needs: [merge-sbom, build-tar-platform-musl, build-tar-platform]
     steps:
       - name: Download all SBOM artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -341,10 +353,16 @@ jobs:
           pattern: docker-image-*
           path: artifacts/
 
+      - name: Download tar artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          pattern: tar-opencti-platform
+          path: artifacts/
+
       - name: Download musl tar artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
-          pattern: opencti-platform-musl
+          pattern: tar-opencti-platform-musl
           path: artifacts/
 
       - name: Upload consolidated artifacts

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - lts/*
+      - issue/17146
 
 jobs:
   # -----------------------

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -185,7 +185,7 @@ jobs:
   # Build platform tarballs
   # -----------------------
   build-tar-platform:
-    name: Build platform tarball
+    name: Build platform tarball (standard)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -179,6 +179,19 @@ jobs:
           docker_image_suffix: ${{ matrix.suffix }}
 
   # -----------------------
+  # Build platform musl tar
+  # -----------------------
+  build-platform-musl:
+    name: Build platform (musl)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/build-platform-musl
+        with:
+          checkout_ref: ${{ github.sha }}
+          client_python_local: true
+
+  # -----------------------
   # Generate SBOMs
   # -----------------------
   generate-sbom-platform:
@@ -313,7 +326,7 @@ jobs:
   upload-artifacts:
     name: Upload all artifacts
     runs-on: ubuntu-latest
-    needs: [merge-sbom]
+    needs: [merge-sbom, build-platform-musl]
     steps:
       - name: Download all SBOM artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -325,6 +338,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           pattern: docker-image-*
+          path: artifacts/
+
+      - name: Download musl tar artifact
+        uses: actions/download-artifact@v8
+        with:
+          pattern: opencti-platform-musl
           path: artifacts/
 
       - name: Upload consolidated artifacts

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build builder image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/docker-build-builder
         with:
           checkout_ref: ${{ github.sha }}
@@ -29,7 +29,7 @@ jobs:
     outputs:
       app_version: ${{ steps.version.outputs.app_version }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download builder image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -124,7 +124,7 @@ jobs:
           cp opencti-platform/sbom-parent.cdx.json sbom-staging/
 
       - name: Upload app SBOMs
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opencti-app-sbom
           path: sbom-staging/
@@ -147,7 +147,7 @@ jobs:
           - variant: fips
             suffix: "_fips"
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/docker-build-platform
         with:
           checkout_ref: ${{ github.sha }}
@@ -171,7 +171,7 @@ jobs:
           - variant: fips
             suffix: "_fips"
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/docker-build-worker
         with:
           checkout_ref: ${{ github.sha }}
@@ -185,7 +185,7 @@ jobs:
     name: Build platform (musl)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build-platform-musl
         with:
           checkout_ref: ${{ github.sha }}
@@ -209,7 +209,7 @@ jobs:
           - variant: fips
             suffix: "_fips"
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/generate-sbom
         with:
           tags: '["${{ github.sha }}"]'
@@ -233,7 +233,7 @@ jobs:
           - variant: fips
             suffix: "_fips"
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/generate-sbom
         with:
           tags: '["${{ github.sha }}"]'
@@ -310,7 +310,7 @@ jobs:
 
       - name: Upload merged SBOM
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom-opencti-platform-${{ needs.app-sbom.outputs.app_version }}${{ matrix.suffix }}
           path: sbom-work/sbom-opencti-platform-*.cdx.json
@@ -341,13 +341,13 @@ jobs:
           path: artifacts/
 
       - name: Download musl tar artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           pattern: opencti-platform-musl
           path: artifacts/
 
       - name: Upload consolidated artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: opencti-rolling
           path: artifacts/

--- a/.github/workflows/cd-build-rolling-images-on-merge.yml
+++ b/.github/workflows/cd-build-rolling-images-on-merge.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           name: opencti-app-sbom
           path: sbom-staging/
-          retention-days: 7
+          retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 
   # -----------------------
   # Build platform images
@@ -316,7 +316,7 @@ jobs:
           name: sbom-opencti-platform-${{ needs.app-sbom.outputs.app_version }}${{ matrix.suffix }}
           path: sbom-work/sbom-opencti-platform-*.cdx.json
           overwrite: true
-          retention-days: 7
+          retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 
       - name: Validate merged SBOM
         working-directory: sbom-work
@@ -352,4 +352,4 @@ jobs:
         with:
           name: opencti-rolling
           path: artifacts/
-          retention-days: 10
+          retention-days: ${{ vars.ROLLING_ARTIFACT_RETENTION_DAYS }}

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         name: docker-image-opencti-builder
         path: /tmp/opencti-builder.tar
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 
     - name: Docker meta
       id: meta
@@ -106,7 +106,7 @@ jobs:
       with:
         name: docker-image-opencti-platform
         path: /tmp/opencti-platform.tar
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 
   build-opencti-worker:
     name: Build OpenCTI Worker image
@@ -158,4 +158,4 @@ jobs:
       with:
         name: docker-image-opencti-worker
         path: /tmp/opencti-worker.tar
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10

--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         name: docker-image-opencti-builder
         path: /tmp/opencti-builder.tar
-        retention-days: 7
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 
     - name: Docker meta
       id: meta
@@ -106,7 +106,7 @@ jobs:
       with:
         name: docker-image-opencti-platform
         path: /tmp/opencti-platform.tar
-        retention-days: 7
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 
   build-opencti-worker:
     name: Build OpenCTI Worker image
@@ -158,4 +158,4 @@ jobs:
       with:
         name: docker-image-opencti-worker
         path: /tmp/opencti-worker.tar
-        retention-days: 7
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}

--- a/.github/workflows/ci-test-backend.yml
+++ b/.github/workflows/ci-test-backend.yml
@@ -119,7 +119,7 @@ jobs:
       with:
         name: backend-test-results-integration
         path: ${{ github.workspace }}/opencti-platform/opencti-graphql/test-results
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 
     # Output all logs used during the job
     - name: Log backends (Minio, Elastic, RabbitMQ, Redis)

--- a/.github/workflows/ci-test-backend.yml
+++ b/.github/workflows/ci-test-backend.yml
@@ -119,7 +119,7 @@ jobs:
       with:
         name: backend-test-results-integration
         path: ${{ github.workspace }}/opencti-platform/opencti-graphql/test-results
-        retention-days: 15
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 
     # Output all logs used during the job
     - name: Log backends (Minio, Elastic, RabbitMQ, Redis)

--- a/.github/workflows/ci-test-end-to-end.yml
+++ b/.github/workflows/ci-test-end-to-end.yml
@@ -160,7 +160,7 @@ jobs:
       with:
         name: frontend-test-results${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/frontend-e2e-test/opencti-platform/opencti-front/test-results
-        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
+        retention-days: 10
 
 
     - name: Logs opencti-e2e-start

--- a/.github/workflows/ci-test-end-to-end.yml
+++ b/.github/workflows/ci-test-end-to-end.yml
@@ -160,7 +160,7 @@ jobs:
       with:
         name: frontend-test-results${{ matrix.artifact_suffix }}
         path: ${{ github.workspace }}/frontend-e2e-test/opencti-platform/opencti-front/test-results
-        retention-days: 15
+        retention-days: ${{ vars.CI_ARTIFACT_RETENTION_DAYS }}
 
 
     - name: Logs opencti-e2e-start


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add github action and workflow for musl build.
* Align retention day duration: 10 for all ci (temporary) artifact ; 30 for releases one
* Remove rolling musl from circleci

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17146 

### How to test this PR

- Take a musl tarball and standard tarball from a master build or a release asset
- Compare with the tarball content on this job

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
