### PR TITLE
fix(managers): add request timeouts to sync and publisher manager http clients (#17088)

### DIFF
--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -313,12 +313,14 @@
     "lock_key": "publisher_manager_lock",
     "interval": 10000,
     "enable_buffering": true,
-    "buffering_seconds": 60
+    "buffering_seconds": 60,
+    "webhook_timeout": 300000
   },
   "sync_manager": {
     "enabled": true,
     "lock_key": "sync_manager_lock",
-    "interval": 10000
+    "interval": 10000,
+    "file_fetch_timeout": 300000
   },
   "ingestion_manager": {
     "enabled": true,

--- a/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/publisherManager.ts
@@ -49,6 +49,7 @@ const DOC_URI = 'https://docs.opencti.io';
 const PUBLISHER_ENGINE_KEY = conf.get('publisher_manager:lock_key');
 const PUBLISHER_ENABLE_BUFFERING = conf.get('publisher_manager:enable_buffering');
 const PUBLISHER_BUFFERING_SECONDS = conf.get('publisher_manager:buffering_seconds');
+const WEBHOOK_TIMEOUT = conf.get('publisher_manager:webhook_timeout') || 300_000;
 const PUBLISHER_MANAGER_NAME = 'publisher_manager';
 const STREAM_SCHEDULE_TIME = 10000;
 
@@ -229,7 +230,7 @@ export async function handleWebhookNotification(configurationString: string | un
   const headersObject = Object.fromEntries((headers ?? []).map((header) => [header.attribute, header.value]));
   const paramsObject = Object.fromEntries((params ?? []).map((param) => [param.attribute, param.value]));
 
-  const httpClientOptions: GetHttpClient = { responseType: 'json', headers: headersObject };
+  const httpClientOptions: GetHttpClient = { responseType: 'json', headers: headersObject, timeout: WEBHOOK_TIMEOUT };
   const httpClient = getHttpClient(httpClientOptions);
 
   await httpClient.call({ url, method: verb, params: paramsObject, data: webhookPayload });

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -9,14 +9,14 @@ import { patchSync } from '../domain/connector';
 import { lockResources } from '../lock/master-lock';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import { utcDate } from '../utils/format';
-import { topEntitiesList, storeLoadById } from '../database/middleware-loader';
+import { storeLoadById, topEntitiesList } from '../database/middleware-loader';
 import { isEmptyField, wait } from '../database/utils';
 import { pushToWorkerForConnector } from '../database/rabbitmq';
 import { OPENCTI_SYSTEM_UUID } from '../schema/general';
 import { getHttpClient } from '../utils/http-client';
 import { createSyncHttpUri, httpBase } from '../domain/connector-utils';
 import { EVENT_CURRENT_VERSION } from '../database/stream/stream-utils';
-import { storeSyncConsumerMetrics, clearSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
+import { clearSyncConsumerMetrics, storeSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
 import { createParser } from 'eventsource-parser';
 import { InterruptibleTimer } from './interruptible-timer';
 import {
@@ -30,6 +30,7 @@ import {
 const SYNC_MANAGER_KEY = conf.get('sync_manager:lock_key') || 'sync_manager_lock';
 const SCHEDULE_TIME = conf.get('sync_manager:interval') || 10000;
 const WAIT_TIME_ACTION = 2000;
+const FILE_FETCH_TIMEOUT = conf.get('sync_manager:file_fetch_timeout') || 300_000;
 
 const waitLoopTimer = new InterruptibleTimer();
 
@@ -266,7 +267,12 @@ const syncManagerInstance = (syncId) => {
       const { ssl_verify: ssl = false } = sync;
       const token = await decryptSynchronizerCredential(sync.token);
       const headers = !isEmptyField(token) ? { authorization: `Bearer ${token}` } : undefined;
-      const httpClientOptions = { headers, rejectUnauthorized: ssl, responseType: 'arraybuffer' };
+      const httpClientOptions = {
+        headers: headers,
+        rejectUnauthorized: ssl,
+        responseType: 'arraybuffer',
+        timeout: FILE_FETCH_TIMEOUT,
+      };
       const httpClient = getHttpClient(httpClientOptions);
       lastState = sync.current_state_date;
       lastEventDate = sync.current_state_date;

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/publisherManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/publisherManager-test.ts
@@ -4,26 +4,26 @@ import { handleWebhookNotification } from '../../../src/manager/publisherManager
 
 describe('handleWebhookNotification', () => {
   const mockedAxiosInstance = vi.fn();
-  
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(axios, 'create').mockReturnValue(mockedAxiosInstance as unknown as AxiosInstance);
   });
-  
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   it('should intercept the axios.create call and use a mock instance', async () => {
-    const configurationString = JSON.stringify({ 
-      url: 'https://my-webhook-endpoint.com/test', 
-      verb: 'POST', 
-      template: '{}' 
+    const configurationString = JSON.stringify({
+      url: 'https://my-webhook-endpoint.com/test',
+      verb: 'POST',
+      template: '{}',
     });
     mockedAxiosInstance.mockResolvedValue({ status: 200, data: 'success from spy' });
-    
+
     await handleWebhookNotification(configurationString, {});
-    
+
     expect(axios.create).toHaveBeenCalledTimes(1);
     expect(mockedAxiosInstance).toHaveBeenCalledOnce();
     const axiosCallArgs = mockedAxiosInstance.mock.calls[0][0];
@@ -55,11 +55,11 @@ describe('handleWebhookNotification', () => {
       settings: {},
       data: [],
     };
-    
+
     mockedAxiosInstance.mockResolvedValue({ status: 200, data: 'OK' });
-    
+
     await handleWebhookNotification(configurationString, templateData);
-    
+
     expect(axios.create).toHaveBeenCalledTimes(1);
     expect(axios.create).toHaveBeenCalledWith(expect.objectContaining({
       headers: {
@@ -69,7 +69,7 @@ describe('handleWebhookNotification', () => {
       },
     }));
     expect(mockedAxiosInstance).toHaveBeenCalledTimes(1);
-    
+
     const axiosCallArgs = mockedAxiosInstance.mock.calls[0][0];
     expect(axiosCallArgs.url).toBe(webhookConfiguration.url);
     expect(axiosCallArgs.method).toBe('POST');
@@ -77,11 +77,11 @@ describe('handleWebhookNotification', () => {
       source: 'opencti-platform',
       type: 'notification',
     });
-    
+
     // Verify that the template has been rendered with expected data
-    const expectedData = { 
-      message: 'Update on Stix-Object-Cyber-Tigrou by test-admin', 
-      source_id: 'trigger-id-abcde' 
+    const expectedData = {
+      message: 'Update on Stix-Object-Cyber-Tigrou by test-admin',
+      source_id: 'trigger-id-abcde',
     };
     expect(axiosCallArgs.data).toEqual(expectedData);
   });
@@ -94,15 +94,15 @@ describe('handleWebhookNotification', () => {
     };
     const configurationString = JSON.stringify(webhookConfiguration);
     const templateDataWithNewline = {
-      description: 'Line 1\nLine 2'
+      description: 'Line 1\nLine 2',
     };
-    
+
     mockedAxiosInstance.mockResolvedValue({ status: 200 });
-    
+
     await handleWebhookNotification(configurationString, templateDataWithNewline);
-    
+
     expect(mockedAxiosInstance).toHaveBeenCalledOnce();
-    
+
     const axiosCallArgs = mockedAxiosInstance.mock.calls[0][0];
     // Ensure the template rendering produce valid JSON
     expect(axiosCallArgs.data).toHaveProperty('description');
@@ -123,35 +123,52 @@ describe('handleWebhookNotification', () => {
         title: 'Quarterly\nReport',
         author: {
           name: 'John Doe',
-          bio: 'Cybersecurity expert.\nAuthor of several publications.'
+          bio: 'Cybersecurity expert.\nAuthor of several publications.',
         },
         events: [
           { id: 'evt-1', message: 'First alert:\nsuspicious connection.' },
-          { id: 'evt-2', message: 'Second alert, no line break.' }
+          { id: 'evt-2', message: 'Second alert, no line break.' },
         ],
         tags: ['urgent', 'review\nneeded'],
         is_published: true,
         version: 2,
-      }
+      },
     };
-    
+
     mockedAxiosInstance.mockResolvedValue({ status: 200 });
-    
+
     await handleWebhookNotification(configurationString, templateDataWithNesting);
-    
+
     expect(mockedAxiosInstance).toHaveBeenCalledOnce();
-    
+
     const axiosCallArgs = mockedAxiosInstance.mock.calls[0][0];
     // Check imbricated properties are correctly rendered
     expect(axiosCallArgs.data).toHaveProperty('title');
     expect(axiosCallArgs.data).toHaveProperty('author_bio');
     expect(axiosCallArgs.data).toHaveProperty('first_event_message');
-    
+
     // Ensure new lines are correctly rendered
     expect(axiosCallArgs.data.title).toContain('Quarterly');
     expect(axiosCallArgs.data.title).toContain('Report');
     expect(axiosCallArgs.data.author_bio).toContain('Cybersecurity expert');
     expect(axiosCallArgs.data.first_event_message).toContain('First alert');
+  });
+
+  it('should set a request timeout on the webhook http client to prevent indefinite hangs', async () => {
+    const configurationString = JSON.stringify({
+      url: 'https://my-webhook-endpoint.com/test',
+      verb: 'POST',
+      template: '{}',
+    });
+    mockedAxiosInstance.mockResolvedValue({ status: 200, data: 'success' });
+
+    await handleWebhookNotification(configurationString, {});
+
+    expect(axios.create).toHaveBeenCalledWith(expect.objectContaining({ timeout: 300_000 }));
+    const axiosCreateArgs = (axios.create as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // A falsy timeout (0/undefined) means axios waits forever; guard against ever regressing to that.
+    expect(axiosCreateArgs.timeout).toBeTypeOf('number');
+    expect(axiosCreateArgs.timeout).toBeGreaterThan(0);
   });
 
   it('should correctly handle forward slashes in template data', async () => {
@@ -162,15 +179,15 @@ describe('handleWebhookNotification', () => {
     };
     const configurationString = JSON.stringify(webhookConfiguration);
     const templateDataWithSlash = {
-      description: 'This is a path: /home/user/file.txt'
+      description: 'This is a path: /home/user/file.txt',
     };
-    
+
     mockedAxiosInstance.mockResolvedValue({ status: 200 });
-    
+
     await handleWebhookNotification(configurationString, templateDataWithSlash);
-    
+
     expect(mockedAxiosInstance).toHaveBeenCalledOnce();
-    
+
     const axiosCallArgs = mockedAxiosInstance.mock.calls[0][0];
     expect(axiosCallArgs.data).toHaveProperty('description');
     expect(axiosCallArgs.data.description).toBe('This is a path: /home/user/file.txt');

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/publisherManager-webhook-timeout-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/publisherManager-webhook-timeout-test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios, { type AxiosInstance } from 'axios';
+
+// WEBHOOK_TIMEOUT is computed once at module import time from conf.get(...), so the override
+// must be in place before publisherManager.ts is imported (vi.mock is hoisted above imports).
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/conf')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: (key: string) => (key === 'publisher_manager:webhook_timeout' ? 9999 : actual.default.get(key)),
+    },
+  };
+});
+
+// Import after the mock so the module picks up the overridden config value.
+const { handleWebhookNotification } = await import('../../../src/manager/publisherManager');
+
+describe('handleWebhookNotification webhook timeout configuration', () => {
+  const mockedAxiosInstance = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(axios, 'create').mockReturnValue(mockedAxiosInstance as unknown as AxiosInstance);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should use the timeout configured via publisher_manager:webhook_timeout instead of the hardcoded default', async () => {
+    const configurationString = JSON.stringify({
+      url: 'https://my-webhook-endpoint.com/test',
+      verb: 'POST',
+      template: '{}',
+    });
+    mockedAxiosInstance.mockResolvedValue({ status: 200, data: 'success' });
+
+    await handleWebhookNotification(configurationString, {});
+
+    expect(axios.create).toHaveBeenCalledWith(expect.objectContaining({ timeout: 9999 }));
+  });
+});


### PR DESCRIPTION
### Proposed changes

* add configurable `timeout` to the sync manager's storage/embedded-image fetch http client
* add configurable `timeout` to the publisher manager's webhook http client
* both default to 300000ms (5 minutes), overridable via `sync_manager:file_fetch_timeout` and `publisher_manager:webhook_timeout`

### Related issues
* closes #17088

### How to test this PR

Run the added unit tests:

yarn test:unit tests/01-unit/manager/publisherManager-test.ts tests/01-unit/manager/publisherManager-webhook-timeout-test.ts


Manual repro (matches the ticket's steps):
1. Start the platform with short timeouts to speed up testing, e.g. `SYNC_MANAGER__FILE_FETCH_TIMEOUT=10000 PUBLISHER_MANAGER__WEBHOOK_TIMEOUT=10000 yarn start`
2. Create a webhook Notifier pointing at an endpoint that never responds, use its "Test" dialog — it now fails with a timeout error instead of hanging
3. Create a Sync pointing at a stream whose storage/embedded-image endpoint never responds, create a Note with an embedded image — the sync logs a timeout warning and keeps running instead of hanging

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Follow-up to #17038/#17066, which fixed the same class of hang in `ingestionManager`. Both clients previously had no timeout at all (axios defaults to infinite), so a stalled remote endpoint could hang the connector indefinitely. `syncManager` has no automated test coverage since the relevant logic isn't exported as standalone functions, adding that would require a refactor, left out of scope for this PR.