### PR TITLE
feat(catalog): decoupling catalog fetch (#16059)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useContext, useEffect } from 'react';
+import React, { Suspense, useCallback, useContext, useEffect, useState } from 'react';
 import IngestionMenu from '@components/data/IngestionMenu';
 import { useQueryLoader } from 'react-relay';
 import IngestionCatalogCard from '@components/data/IngestionCatalog/IngestionCatalogCard';
@@ -29,6 +29,8 @@ import { MESSAGING$ } from '../../../relay/environment';
 import useEnterpriseEdition from '../../../utils/hooks/useEnterpriseEdition';
 import { UserContext } from '../../../utils/hooks/useAuth';
 import { isNotEmptyField } from '../../../utils/utils';
+
+const CATALOG_POLL_INTERVAL_MS = 5000;
 
 interface IngestionCatalogComponentProps {
   catalogsData: IngestionConnectorsCatalogsQuery['response'];
@@ -216,15 +218,37 @@ const IngestionCatalogComponent = ({
 
 const IngestionCatalog = () => {
   const { catalogState, handleOpenDeployDialog, handleCloseDeployDialog, handleCreate } = useConnectorDeployDialog();
+  const [hasCatalogResults, setHasCatalogResults] = useState(false);
 
   const [catalogsRef, loadCatalogs] = useQueryLoader<IngestionConnectorsCatalogsQuery>(ingestionConnectorsCatalogsQuery);
   const [deploymentRef, loadDeployment] = useQueryLoader<IngestionConnectorsQuery>(ingestionConnectorsQuery);
 
+  const handleCatalogsResolved = useCallback((catalogs: IngestionConnectorsCatalogsQuery['response']['catalogs']) => {
+    if ((catalogs?.length ?? 0) > 0) {
+      setHasCatalogResults(true);
+    }
+  }, []);
+
   useEffect(() => {
-    // fetch once the catalogs and use the cache during runtime
+    // Initial bootstrap fetch.
     loadCatalogs({}, { fetchPolicy: 'store-or-network' });
     loadDeployment({}, { fetchPolicy: 'store-and-network' });
-  }, []);
+  }, [loadCatalogs, loadDeployment]);
+
+  useEffect(() => {
+    if (!catalogsRef || hasCatalogResults) {
+      return undefined;
+    }
+
+    // Retry while the catalog manager is still loading and catalogs are empty.
+    const intervalId = setInterval(() => {
+      loadCatalogs({}, { fetchPolicy: 'network-only' });
+    }, CATALOG_POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [catalogsRef, hasCatalogResults, loadCatalogs]);
 
   if (!deploymentRef || !catalogsRef) {
     return <Loader variant={LoaderVariant.container} />;
@@ -235,18 +259,27 @@ const IngestionCatalog = () => {
       <Suspense fallback={<Loader variant={LoaderVariant.container} />}>
         <ConnectorManagerStatusProvider>
           {catalogsRef && (
-            <IngestionConnectorsCatalogs queryRef={catalogsRef}>
-              {({ data: catalogsData }) => (
-                <IngestionConnectors queryRef={deploymentRef}>
-                  {({ data: deploymentData }) => (
-                    <IngestionCatalogComponent
-                      catalogsData={catalogsData}
-                      deploymentData={deploymentData}
-                      onClickDeploy={handleOpenDeployDialog}
-                    />
-                  )}
-                </IngestionConnectors>
-              )}
+            <IngestionConnectorsCatalogs queryRef={catalogsRef} onCatalogsResolved={handleCatalogsResolved}>
+              {({ data: catalogsData }) => {
+                const currentCatalogsCount = catalogsData.catalogs?.length ?? 0;
+                const shouldRenderCatalogLoader = !hasCatalogResults && currentCatalogsCount === 0;
+
+                if (shouldRenderCatalogLoader) {
+                  return <Loader variant={LoaderVariant.container} />;
+                }
+
+                return (
+                  <IngestionConnectors queryRef={deploymentRef}>
+                    {({ data: deploymentData }) => (
+                      <IngestionCatalogComponent
+                        catalogsData={catalogsData}
+                        deploymentData={deploymentData}
+                        onClickDeploy={handleOpenDeployDialog}
+                      />
+                    )}
+                  </IngestionConnectors>
+                );
+              }}
             </IngestionConnectorsCatalogs>
           )}
         </ConnectorManagerStatusProvider>

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useContext, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import IngestionMenu from '@components/data/IngestionMenu';
 import { useQueryLoader } from 'react-relay';
 import IngestionCatalogCard from '@components/data/IngestionCatalog/IngestionCatalogCard';
@@ -267,6 +267,7 @@ const IngestionCatalogComponent = ({
 const IngestionCatalog = () => {
   const { catalogState, handleOpenDeployDialog, handleCloseDeployDialog, handleCreate } = useConnectorDeployDialog();
   const [hasCatalogResults, setHasCatalogResults] = useState(false);
+  const lastSeenCatalogRevision = useRef<string | null | undefined>(undefined);
 
   const [catalogsRef, loadCatalogs] = useQueryLoader<IngestionConnectorsCatalogsQuery>(ingestionConnectorsCatalogsQuery);
   const [deploymentRef, loadDeployment] = useQueryLoader<IngestionConnectorsQuery>(ingestionConnectorsQuery);
@@ -276,6 +277,23 @@ const IngestionCatalog = () => {
       setHasCatalogResults(true);
     }
   }, []);
+
+  const handleCatalogVersionChange = useCallback((revision: string | null) => {
+    if (!revision) {
+      return;
+    }
+
+    // First seen revision establishes baseline and avoids immediate duplicate refetch.
+    if (lastSeenCatalogRevision.current === undefined) {
+      lastSeenCatalogRevision.current = revision;
+      return;
+    }
+
+    if (lastSeenCatalogRevision.current !== revision) {
+      lastSeenCatalogRevision.current = revision;
+      loadCatalogs({}, { fetchPolicy: 'network-only' });
+    }
+  }, [loadCatalogs]);
 
   useEffect(() => {
     // Initial bootstrap fetch.
@@ -305,7 +323,7 @@ const IngestionCatalog = () => {
   return (
     <>
       <Suspense fallback={<IngestionCatalogSkeleton />}>
-        <ConnectorManagerStatusProvider>
+        <ConnectorManagerStatusProvider onCatalogVersionChange={handleCatalogVersionChange}>
           {catalogsRef && (
             <IngestionConnectorsCatalogs queryRef={catalogsRef} onCatalogsResolved={handleCatalogsResolved}>
               {({ data: catalogsData }) => {

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -4,7 +4,7 @@ import { useQueryLoader } from 'react-relay';
 import IngestionCatalogCard from '@components/data/IngestionCatalog/IngestionCatalogCard';
 import useIngestionCatalogFilters from '@components/data/IngestionCatalog/hooks/useIngestionCatalogFilters';
 import { useSearchParams } from 'react-router-dom';
-import { Stack } from '@mui/material';
+import { Skeleton, Stack } from '@mui/material';
 import { Search } from '@mui/icons-material';
 import Grid from '@mui/material/Grid2';
 import { ConnectorManagerStatusProvider, useConnectorManagerStatus } from '@components/data/connectors/ConnectorManagerStatusContext';
@@ -21,7 +21,6 @@ import Breadcrumbs from '../../../components/Breadcrumbs';
 import { useFormatter } from '../../../components/i18n';
 import useConnectedDocumentModifier from '../../../utils/hooks/useConnectedDocumentModifier';
 import PageContainer from '../../../components/PageContainer';
-import Loader, { LoaderVariant } from '../../../components/Loader';
 import Button from '@common/button/Button';
 import IngestionCatalogFilters from './IngestionCatalog/IngestionCatalogFilters';
 import GradientCard from '../../../components/GradientCard';
@@ -131,6 +130,55 @@ const CatalogsEmptyState = () => {
         <BrowseMoreButton />
       </GradientCard>
     </Stack>
+  );
+};
+
+const IngestionCatalogSkeleton = () => {
+  const { t_i18n } = useFormatter();
+
+  return (
+    <div data-testid="catalog-page-skeleton">
+      <IngestionMenu />
+      <PageContainer withRightMenu withGap>
+        <Breadcrumbs elements={[{ label: t_i18n('Data') }, { label: t_i18n('Ingestion') }, { label: t_i18n('Connector catalog'), current: true }]} />
+
+        <Stack flexDirection="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+          <Stack direction="row" spacing={1}>
+            <Skeleton variant="rounded" width={220} height={40} />
+            <Skeleton variant="rounded" width={180} height={40} />
+          </Stack>
+          <Skeleton variant="rounded" width={130} height={40} />
+        </Stack>
+
+        <Grid container spacing={2}>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <Grid
+              key={`skeleton-card-${index}`}
+              size={{ xs: 12, md: 6, lg: 4, xl: 3 }}
+            >
+              <Stack
+                spacing={1.2}
+                sx={{
+                  p: 2,
+                  borderRadius: 2,
+                  border: (theme) => `1px solid ${theme.palette.divider}`,
+                }}
+              >
+                <Skeleton variant="rounded" width="100%" height={120} />
+                <Skeleton variant="text" width="70%" height={34} />
+                <Skeleton variant="text" width="95%" />
+                <Skeleton variant="text" width="90%" />
+                <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
+                  <Skeleton variant="rounded" width={72} height={24} />
+                  <Skeleton variant="rounded" width={84} height={24} />
+                </Stack>
+                <Skeleton variant="rounded" width="100%" height={36} sx={{ mt: 1 }} />
+              </Stack>
+            </Grid>
+          ))}
+        </Grid>
+      </PageContainer>
+    </div>
   );
 };
 
@@ -251,12 +299,12 @@ const IngestionCatalog = () => {
   }, [catalogsRef, hasCatalogResults, loadCatalogs]);
 
   if (!deploymentRef || !catalogsRef) {
-    return <Loader variant={LoaderVariant.container} />;
+    return <IngestionCatalogSkeleton />;
   }
 
   return (
     <>
-      <Suspense fallback={<Loader variant={LoaderVariant.container} />}>
+      <Suspense fallback={<IngestionCatalogSkeleton />}>
         <ConnectorManagerStatusProvider>
           {catalogsRef && (
             <IngestionConnectorsCatalogs queryRef={catalogsRef} onCatalogsResolved={handleCatalogsResolved}>
@@ -265,7 +313,7 @@ const IngestionCatalog = () => {
                 const shouldRenderCatalogLoader = !hasCatalogResults && currentCatalogsCount === 0;
 
                 if (shouldRenderCatalogLoader) {
-                  return <Loader variant={LoaderVariant.container} />;
+                  return <IngestionCatalogSkeleton />;
                 }
 
                 return (

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog.tsx
@@ -279,17 +279,23 @@ const IngestionCatalog = () => {
   }, []);
 
   const handleCatalogVersionChange = useCallback((revision: string | null) => {
+    const prev = lastSeenCatalogRevision.current;
+
+    // Track null revisions so we can detect when the remote catalog first becomes available.
     if (!revision) {
+      lastSeenCatalogRevision.current = null;
       return;
     }
 
-    // First seen revision establishes baseline and avoids immediate duplicate refetch.
-    if (lastSeenCatalogRevision.current === undefined) {
+    // Component just mounted and remote catalog is already available: establish baseline, no refetch.
+    if (prev === undefined) {
       lastSeenCatalogRevision.current = revision;
       return;
     }
 
-    if (lastSeenCatalogRevision.current !== revision) {
+    // Refetch when revision changes OR when remote catalog just became available after loading
+    // (prev === null means we were in loading state and showed the embedded catalog as baseline).
+    if (prev !== revision) {
       lastSeenCatalogRevision.current = revision;
       loadCatalogs({}, { fetchPolicy: 'network-only' });
     }

--- a/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionConnectorsCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/IngestionCatalog/IngestionConnectorsCatalog.tsx
@@ -1,6 +1,6 @@
 import { graphql, usePreloadedQuery } from 'react-relay';
 import type { PreloadedQuery } from 'react-relay';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { IngestionConnectorsCatalogsQuery } from '@components/data/IngestionCatalog/__generated__/IngestionConnectorsCatalogsQuery.graphql';
 
 export const ingestionConnectorsCatalogsQuery = graphql`
@@ -16,11 +16,16 @@ export const ingestionConnectorsCatalogsQuery = graphql`
 
 interface IngestionConnectorsCatalogsProps {
   queryRef: PreloadedQuery<IngestionConnectorsCatalogsQuery>;
+  onCatalogsResolved?: (catalogs: IngestionConnectorsCatalogsQuery['response']['catalogs']) => void;
   children: ({ data }: { data: IngestionConnectorsCatalogsQuery['response'] }) => React.ReactNode;
 }
 
-const IngestionConnectorsCatalogs: React.FC<IngestionConnectorsCatalogsProps> = ({ queryRef, children }) => {
+const IngestionConnectorsCatalogs: React.FC<IngestionConnectorsCatalogsProps> = ({ queryRef, onCatalogsResolved, children }) => {
   const data = usePreloadedQuery(ingestionConnectorsCatalogsQuery, queryRef);
+
+  useEffect(() => {
+    onCatalogsResolved?.(data.catalogs);
+  }, [data.catalogs, onCatalogsResolved]);
 
   return children({ data });
 };

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
@@ -1,7 +1,8 @@
-import React, { createContext, ReactNode, useContext, useEffect } from 'react';
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import React, { createContext, ReactNode, useContext, useEffect, useRef } from 'react';
+import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 import { interval } from 'rxjs';
 import { ConnectorManagerStatusContextQuery } from '@components/data/connectors/__generated__/ConnectorManagerStatusContextQuery.graphql';
+import type { ConnectorManagerStatusContextRefreshCatalogMutation } from '@components/data/connectors/__generated__/ConnectorManagerStatusContextRefreshCatalogMutation.graphql';
 import { FIVE_SECONDS } from '../../../../utils/Time';
 
 export const connectorManagerStatusQuery = graphql`
@@ -16,6 +17,12 @@ export const connectorManagerStatusQuery = graphql`
       revision
       updated_at
     }
+  }
+`;
+
+const refreshCatalogMutation = graphql`
+  mutation ConnectorManagerStatusContextRefreshCatalogMutation {
+    refreshCatalog
   }
 `;
 
@@ -63,7 +70,29 @@ export const ConnectorManagerStatusProvider: React.FC<ConnectorManagerStatusProv
   const connectorManagers = data?.connectorManagers || null;
   const hasRegisteredManagers = connectorManagers ? connectorManagers.length > 0 : false;
   const hasActiveManagers = connectorManagers ? connectorManagers.some((cm) => cm.active) : false;
-  const catalogVersionInfo = data?.catalogVersionInfo ?? null;
+  const rawCatalogVersionInfo = data?.catalogVersionInfo ?? null;
+  const catalogVersionInfo = rawCatalogVersionInfo
+    ? {
+        status: rawCatalogVersionInfo.status,
+        revision: rawCatalogVersionInfo.revision ?? null,
+        updated_at: rawCatalogVersionInfo.updated_at ?? null,
+      }
+    : null;
+
+  const [triggerRefresh] = useMutation<ConnectorManagerStatusContextRefreshCatalogMutation>(refreshCatalogMutation);
+  const hasTriggeredOnDemandRefresh = useRef(false);
+
+  // When the user lands on the catalog page and the catalog is not yet ready
+  // (e.g. the remote server was unavailable at startup), fire a one-shot
+  // on-demand refresh so they don't wait the full scheduled interval.
+  useEffect(() => {
+    if (!catalogVersionInfo) return;
+    if (catalogVersionInfo.status === 'ready') return;
+    if (hasTriggeredOnDemandRefresh.current) return;
+
+    hasTriggeredOnDemandRefresh.current = true;
+    triggerRefresh({ variables: {} });
+  }, [catalogVersionInfo, triggerRefresh]);
 
   useEffect(() => {
     if (!onCatalogVersionChange) {

--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
@@ -11,6 +11,11 @@ export const connectorManagerStatusQuery = graphql`
       active
       last_sync_execution
     }
+    catalogVersionInfo {
+      status
+      revision
+      updated_at
+    }
   }
 `;
 
@@ -18,16 +23,23 @@ interface ConnectorManagerStatusContextValue {
   connectorManagers: readonly { id: string; active: boolean }[] | null;
   hasRegisteredManagers: boolean;
   hasActiveManagers: boolean;
+  catalogVersionInfo: {
+    status: string;
+    revision: string | null;
+    updated_at: string | null;
+  } | null;
 }
 
 const ConnectorManagerStatusContext = createContext<ConnectorManagerStatusContextValue | null>(null);
 
 interface ConnectorManagerStatusProviderProps {
   children: ReactNode;
+  onCatalogVersionChange?: (revision: string | null) => void;
 }
 
 export const ConnectorManagerStatusProvider: React.FC<ConnectorManagerStatusProviderProps> = ({
   children,
+  onCatalogVersionChange,
 }) => {
   const [fetchKey, setFetchKey] = React.useState(0);
 
@@ -51,11 +63,20 @@ export const ConnectorManagerStatusProvider: React.FC<ConnectorManagerStatusProv
   const connectorManagers = data?.connectorManagers || null;
   const hasRegisteredManagers = connectorManagers ? connectorManagers.length > 0 : false;
   const hasActiveManagers = connectorManagers ? connectorManagers.some((cm) => cm.active) : false;
+  const catalogVersionInfo = data?.catalogVersionInfo ?? null;
+
+  useEffect(() => {
+    if (!onCatalogVersionChange) {
+      return;
+    }
+    onCatalogVersionChange(catalogVersionInfo?.revision ?? null);
+  }, [catalogVersionInfo?.revision, onCatalogVersionChange]);
 
   const contextValue: ConnectorManagerStatusContextValue = {
     connectorManagers,
     hasRegisteredManagers,
     hasActiveManagers,
+    catalogVersionInfo,
   };
 
   return (

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -10480,6 +10480,7 @@ type Mutation {
   channelContextClean(id: ID!): Channel
   channelRelationAdd(id: ID!, input: StixRefRelationshipAddInput!): StixRefRelationship
   channelRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): Channel
+  refreshCatalog: Boolean!
   languageAdd(input: LanguageAddInput!): Language
   languageDelete(id: ID!): ID
   languageFieldPatch(id: ID!, input: [EditInput]!, commitMessage: String, references: [String]): Language

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9629,6 +9629,7 @@ type Query {
   channels(first: Int, after: ID, orderBy: ChannelsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): ChannelConnection
   catalog(id: String!): Catalog
   catalogs: [Catalog!]!
+  catalogVersionInfo: CatalogVersionInfo!
   contract(slug: String!): ExtendedContract
   language(id: String!): Language
   languages(first: Int, after: ID, orderBy: LanguagesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): LanguageConnection
@@ -11100,6 +11101,12 @@ type Catalog implements InternalObject & BasicObject {
 type ExtendedContract {
   catalog_id: String!
   contract: String!
+}
+
+type CatalogVersionInfo {
+  status: String!
+  revision: String
+  updated_at: String
 }
 
 enum CatalogsOrdering {

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -148,6 +148,12 @@
     },
     "forgot_password": {
       "otp_ttl_second": 600
+    },
+    "catalog_manager": {
+      "enabled": true,
+      "lock_key": "catalog_manager_lock",
+      "interval": null,
+      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.json.local"
     }
   },
   "demo_mode": false,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -153,7 +153,7 @@
       "enabled": true,
       "lock_key": "catalog_manager_lock",
       "interval": null,
-      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.json.local"
+      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.local.json"
     }
   },
   "demo_mode": false,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -153,6 +153,7 @@
       "enabled": true,
       "lock_key": "catalog_manager_lock",
       "interval": null,
+      "request_timeout": 15000,
       "custom_catalog_refresh_endpoint_uri": "./connector-catalog.local.json"
     }
   },

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -43,6 +43,12 @@
       "password": "admin",
       "token": "d434ce02-e58e-4cac-8b4c-42bf16748e84"
     },
+    "catalog_manager": {
+      "enabled": true,
+      "lock_key": "catalog_manager_lock",
+      "interval": null,
+      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.json.local"
+    },
     "encryption_key": "wbQnxC2ZIoohYzkXW19LiYU2V3lfoCVFkBadFd/dFAY="
   },
   "platform_id": "7992a4b1-128c-4656-bf97-2018b6f1f395",

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -47,6 +47,7 @@
       "enabled": true,
       "lock_key": "catalog_manager_lock",
       "interval": null,
+      "request_timeout": 15000,
       "custom_catalog_refresh_endpoint_uri": "./connector-catalog.json.local"
     },
     "encryption_key": "wbQnxC2ZIoohYzkXW19LiYU2V3lfoCVFkBadFd/dFAY="

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17332,6 +17332,7 @@ export type Mutation = {
   publicDashboardDelete?: Maybe<Scalars['ID']['output']>;
   publicDashboardFieldPatch?: Maybe<PublicDashboard>;
   queryTaskAdd: BackgroundTask;
+  refreshCatalog: Scalars['Boolean']['output'];
   regionAdd?: Maybe<Region>;
   regionEdit?: Maybe<RegionEditMutations>;
   registerConnector?: Maybe<Connector>;
@@ -47796,6 +47797,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   publicDashboardDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationPublicDashboardDeleteArgs, 'id'>>;
   publicDashboardFieldPatch?: Resolver<Maybe<ResolversTypes['PublicDashboard']>, ParentType, ContextType, RequireFields<MutationPublicDashboardFieldPatchArgs, 'id' | 'input'>>;
   queryTaskAdd?: Resolver<ResolversTypes['BackgroundTask'], ParentType, ContextType, RequireFields<MutationQueryTaskAddArgs, 'input'>>;
+  refreshCatalog?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   regionAdd?: Resolver<Maybe<ResolversTypes['Region']>, ParentType, ContextType, RequireFields<MutationRegionAddArgs, 'input'>>;
   regionEdit?: Resolver<Maybe<ResolversTypes['RegionEditMutations']>, ParentType, ContextType, RequireFields<MutationRegionEditArgs, 'id'>>;
   registerConnector?: Resolver<Maybe<ResolversTypes['Connector']>, ParentType, ContextType, Partial<MutationRegisterConnectorArgs>>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3855,6 +3855,13 @@ export type CatalogEdge = {
   node: Catalog;
 };
 
+export type CatalogVersionInfo = {
+  __typename?: 'CatalogVersionInfo';
+  revision?: Maybe<Scalars['String']['output']>;
+  status: Scalars['String']['output'];
+  updated_at?: Maybe<Scalars['String']['output']>;
+};
+
 export enum CatalogsOrdering {
   Score = '_score',
   Name = 'name'
@@ -24432,6 +24439,7 @@ export type Query = {
   caseTemplates?: Maybe<CaseTemplateConnection>;
   cases?: Maybe<CaseConnection>;
   catalog?: Maybe<Catalog>;
+  catalogVersionInfo: CatalogVersionInfo;
   catalogs: Array<Catalog>;
   channel?: Maybe<Channel>;
   channels?: Maybe<ChannelConnection>;
@@ -39653,6 +39661,7 @@ export type ResolversTypes = ResolversObject<{
   Catalog: ResolverTypeWrapper<GraphqlCatalog>;
   CatalogConnection: ResolverTypeWrapper<Omit<CatalogConnection, 'edges'> & { edges: Array<ResolversTypes['CatalogEdge']> }>;
   CatalogEdge: ResolverTypeWrapper<Omit<CatalogEdge, 'node'> & { node: ResolversTypes['Catalog'] }>;
+  CatalogVersionInfo: ResolverTypeWrapper<CatalogVersionInfo>;
   CatalogsOrdering: CatalogsOrdering;
   CertAuthConfig: ResolverTypeWrapper<CertAuthConfig>;
   CertAuthConfigInput: CertAuthConfigInput;
@@ -40786,6 +40795,7 @@ export type ResolversParentTypes = ResolversObject<{
   Catalog: GraphqlCatalog;
   CatalogConnection: Omit<CatalogConnection, 'edges'> & { edges: Array<ResolversParentTypes['CatalogEdge']> };
   CatalogEdge: Omit<CatalogEdge, 'node'> & { node: ResolversParentTypes['Catalog'] };
+  CatalogVersionInfo: CatalogVersionInfo;
   CertAuthConfig: CertAuthConfig;
   CertAuthConfigInput: CertAuthConfigInput;
   ChangePasswordInput: ChangePasswordInput;
@@ -42904,6 +42914,12 @@ export type CatalogConnectionResolvers<ContextType = any, ParentType extends Res
 export type CatalogEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['CatalogEdge'] = ResolversParentTypes['CatalogEdge']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<ResolversTypes['Catalog'], ParentType, ContextType>;
+}>;
+
+export type CatalogVersionInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['CatalogVersionInfo'] = ResolversParentTypes['CatalogVersionInfo']> = ResolversObject<{
+  revision?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type CertAuthConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CertAuthConfig'] = ResolversParentTypes['CertAuthConfig']> = ResolversObject<{
@@ -49396,6 +49412,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   caseTemplates?: Resolver<Maybe<ResolversTypes['CaseTemplateConnection']>, ParentType, ContextType, Partial<QueryCaseTemplatesArgs>>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<QueryCasesArgs>>;
   catalog?: Resolver<Maybe<ResolversTypes['Catalog']>, ParentType, ContextType, RequireFields<QueryCatalogArgs, 'id'>>;
+  catalogVersionInfo?: Resolver<ResolversTypes['CatalogVersionInfo'], ParentType, ContextType>;
   catalogs?: Resolver<Array<ResolversTypes['Catalog']>, ParentType, ContextType>;
   channel?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, RequireFields<QueryChannelArgs, 'id'>>;
   channels?: Resolver<Maybe<ResolversTypes['ChannelConnection']>, ParentType, ContextType, Partial<QueryChannelsArgs>>;
@@ -53450,6 +53467,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   Catalog?: CatalogResolvers<ContextType>;
   CatalogConnection?: CatalogConnectionResolvers<ContextType>;
   CatalogEdge?: CatalogEdgeResolvers<ContextType>;
+  CatalogVersionInfo?: CatalogVersionInfoResolvers<ContextType>;
   CertAuthConfig?: CertAuthConfigResolvers<ContextType>;
   Channel?: ChannelResolvers<ContextType>;
   ChannelConnection?: ChannelConnectionResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -11,12 +11,41 @@ const CATALOG_MANAGER_ENABLED = booleanConf('app:catalog_manager:enabled', true)
 const CATALOG_MANAGER_LOCK_KEY = conf.get('app:catalog_manager:lock_key') || 'catalog_manager_lock';
 const CATALOG_MANAGER_INTERVAL = conf.get('app:catalog_manager:interval');
 const CUSTOM_CATALOG_SOURCE_URI = conf.get('app:catalog_manager:custom_catalog_refresh_endpoint_uri');
+const CATALOG_MANAGER_REQUEST_TIMEOUT = conf.get('app:catalog_manager:request_timeout');
 
 let scheduler: SetIntervalAsyncTimer<[]> | undefined;
 let currentEtag: string | undefined;
 
 const legacyAdapter = new LegacyManifestAdapter();
 const newManifestAdapter = new NewManifestAdapter();
+
+const DEFAULT_CATALOG_MANAGER_REQUEST_TIMEOUT = 15000;
+
+const getCatalogManagerRequestTimeoutMs = (): number => {
+  const timeoutMs = Number(CATALOG_MANAGER_REQUEST_TIMEOUT);
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    return timeoutMs;
+  }
+  return DEFAULT_CATALOG_MANAGER_REQUEST_TIMEOUT;
+};
+
+const createRequestTimeoutSignal = (): AbortSignal => AbortSignal.timeout(getCatalogManagerRequestTimeoutMs());
+
+const isCatalogRequestTimeout = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as { name?: string; message?: string; code?: string };
+  const name = err.name ?? '';
+  const message = (err.message ?? '').toLowerCase();
+  const code = err.code ?? '';
+
+  return name === 'TimeoutError'
+    || (name === 'AbortError' && message.includes('timeout'))
+    || message.includes('timed out')
+    || code === 'ABORT_ERR';
+};
 
 const setCatalogStatusWithoutReplacingSnapshot = (status: CatalogStatus) => {
   updateCatalogManagerInternalCache(undefined, status, true);
@@ -35,7 +64,7 @@ const refreshCatalogInternal = async () => {
   try {
     if (shouldCheckEtag) {
       logApp.info('[OPENCTI-MODULE] Catalog manager checking remote manifest via HEAD', { uri: sourceConfig.uri });
-      const headResponse = await fetch(sourceConfig.uri, { method: 'HEAD' });
+      const headResponse = await fetch(sourceConfig.uri, { method: 'HEAD', signal: createRequestTimeoutSignal() });
       if (headResponse.ok) {
         nextEtag = headResponse.headers.get('etag') ?? undefined;
         if (nextEtag && currentEtag && nextEtag === currentEtag) {
@@ -47,7 +76,7 @@ const refreshCatalogInternal = async () => {
     }
 
     logApp.info(`[OPENCTI-MODULE] Catalog manager fetching manifest from ${sourceConfig.kind} source`, { uri: sourceConfig.uri });
-    const rawManifest = await newManifestAdapter.fetch(sourceConfig);
+    const rawManifest = await newManifestAdapter.fetch(sourceConfig, { signal: createRequestTimeoutSignal() });
 
     if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
       return;
@@ -60,14 +89,23 @@ const refreshCatalogInternal = async () => {
       currentEtag = nextEtag;
     }
   } catch (error) {
+    if (isCatalogRequestTimeout(error)) {
+      logApp.warn('[OPENCTI-MODULE] Catalog manager request timed out', {
+        timeoutMs: getCatalogManagerRequestTimeoutMs(),
+        source: sourceConfig,
+      });
+    }
+
     logApp.warn('[OPENCTI-MODULE] Catalog manager failed to refresh the catalog from configured source', { cause: error });
 
     if (getCatalogManagerInternalCache()) {
+      logApp.info('[OPENCTI-MODULE] Catalog manager keeps existing snapshot; no embedded fallback needed');
       updateCatalogManagerInternalCache(undefined, 'error', true);
       return;
     }
 
     try {
+      logApp.info('[OPENCTI-MODULE] Catalog manager will fallback to embedded legacy manifest');
       logApp.info('[OPENCTI-MODULE] Catalog manager falling back to embedded legacy manifest');
       const legacyRaw = await legacyAdapter.fetch({ kind: 'local', uri: 'embedded' });
       const legacyInternal = legacyAdapter.toInternalCatalog(legacyRaw);

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -99,17 +99,23 @@ const refreshCatalog = async () => {
 
 const isDecouplingEnabled = () => CATALOG_MANAGER_ENABLED && isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS);
 
+const triggerRefreshInBackground = () => {
+  void refreshCatalog().catch((error) => {
+    logApp.warn('[OPENCTI-MODULE] Catalog manager background refresh failed', { cause: error });
+  });
+};
+
 const start = async () => {
   if (!isDecouplingEnabled()) {
     logApp.info('[OPENCTI-MODULE] Catalog manager not started (disabled by configuration or feature flag)');
     return;
   }
 
-  await refreshCatalog();
+  triggerRefreshInBackground();
 
   if (CATALOG_MANAGER_INTERVAL && Number(CATALOG_MANAGER_INTERVAL) > 0) {
     scheduler = setIntervalAsync(async () => {
-      await refreshCatalog();
+      triggerRefreshInBackground();
     }, Number(CATALOG_MANAGER_INTERVAL));
     logApp.info(`[OPENCTI-MODULE] Catalog manager scheduled every ${Number(CATALOG_MANAGER_INTERVAL)}ms`);
   } else {

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -1,0 +1,130 @@
+import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
+import conf, { booleanConf, isFeatureEnabled, logApp } from '../config/conf';
+import { lockResources } from '../lock/master-lock';
+import { TYPE_LOCK_ERROR } from '../config/errors';
+import { LegacyManifestAdapter, NewManifestAdapter, resolveCatalogSource } from '../modules/catalog/catalog-adapters';
+import { getCatalogManagerInternalCache, getCatalogStatus, type CatalogStatus, updateCatalogManagerInternalCache } from '../modules/catalog/catalog-domain';
+
+const DECOUPLING_CONNECTOR_VERSIONS = 'DECOUPLING_CONNECTOR_VERSIONS';
+
+const CATALOG_MANAGER_ENABLED = booleanConf('app:catalog_manager:enabled', true);
+const CATALOG_MANAGER_LOCK_KEY = conf.get('app:catalog_manager:lock_key') || 'catalog_manager_lock';
+const CATALOG_MANAGER_INTERVAL = conf.get('app:catalog_manager:interval');
+const CUSTOM_CATALOG_SOURCE_URI = conf.get('app:catalog_manager:custom_catalog_refresh_endpoint_uri');
+
+let scheduler: SetIntervalAsyncTimer<[]> | undefined;
+let currentEtag: string | undefined;
+
+const legacyAdapter = new LegacyManifestAdapter();
+const newManifestAdapter = new NewManifestAdapter();
+
+const setCatalogStatusWithoutReplacingSnapshot = (status: CatalogStatus) => {
+  updateCatalogManagerInternalCache(undefined, status, true);
+};
+
+const refreshCatalogInternal = async () => {
+  const existingStatus = getCatalogStatus();
+  if (existingStatus !== 'loading') {
+    setCatalogStatusWithoutReplacingSnapshot('loading');
+  }
+
+  const sourceConfig = resolveCatalogSource(CUSTOM_CATALOG_SOURCE_URI).source;
+  const shouldCheckEtag = sourceConfig.kind === 'remote';
+  let nextEtag: string | undefined;
+
+  try {
+    if (shouldCheckEtag) {
+      logApp.info('[OPENCTI-MODULE] Catalog manager checking remote manifest via HEAD', { uri: sourceConfig.uri });
+      const headResponse = await fetch(sourceConfig.uri, { method: 'HEAD' });
+      if (headResponse.ok) {
+        nextEtag = headResponse.headers.get('etag') ?? undefined;
+        if (nextEtag && currentEtag && nextEtag === currentEtag) {
+          logApp.info('[OPENCTI-MODULE] Catalog manager skipping fetch, remote manifest unchanged (ETag match)', { etag: currentEtag });
+          updateCatalogManagerInternalCache(undefined, 'ready', true);
+          return;
+        }
+      }
+    }
+
+    logApp.info(`[OPENCTI-MODULE] Catalog manager fetching manifest from ${sourceConfig.kind} source`, { uri: sourceConfig.uri });
+    const rawManifest = await newManifestAdapter.fetch(sourceConfig);
+
+    if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+      return;
+    }
+
+    const internalCatalog = newManifestAdapter.toInternalCatalog(rawManifest);
+    updateCatalogManagerInternalCache(internalCatalog, 'ready');
+
+    if (shouldCheckEtag && nextEtag) {
+      currentEtag = nextEtag;
+    }
+  } catch (error) {
+    logApp.warn('[OPENCTI-MODULE] Catalog manager failed to refresh the catalog from configured source', { cause: error });
+
+    if (getCatalogManagerInternalCache()) {
+      updateCatalogManagerInternalCache(undefined, 'error', true);
+      return;
+    }
+
+    try {
+      logApp.info('[OPENCTI-MODULE] Catalog manager falling back to embedded legacy manifest');
+      const legacyRaw = await legacyAdapter.fetch({ kind: 'local', uri: 'embedded' });
+      const legacyInternal = legacyAdapter.toInternalCatalog(legacyRaw);
+      updateCatalogManagerInternalCache(legacyInternal, 'ready');
+    } catch (legacyError) {
+      logApp.warn('[OPENCTI-MODULE] Catalog manager failed to load embedded legacy manifest fallback', { cause: legacyError });
+      updateCatalogManagerInternalCache(undefined, 'error');
+    }
+  }
+};
+
+const refreshCatalog = async () => {
+  let lock;
+  try {
+    lock = await lockResources([CATALOG_MANAGER_LOCK_KEY], { retryCount: 0 });
+    await refreshCatalogInternal();
+  } catch (error: any) {
+    if (error?.name === TYPE_LOCK_ERROR) {
+      logApp.debug('[OPENCTI-MODULE] Catalog manager refresh already running on another API');
+      return;
+    }
+    throw error;
+  } finally {
+    if (lock) {
+      await lock.unlock();
+    }
+  }
+};
+
+const isDecouplingEnabled = () => CATALOG_MANAGER_ENABLED && isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS);
+
+const start = async () => {
+  if (!isDecouplingEnabled()) {
+    logApp.info('[OPENCTI-MODULE] Catalog manager not started (disabled by configuration or feature flag)');
+    return;
+  }
+
+  await refreshCatalog();
+
+  if (CATALOG_MANAGER_INTERVAL && Number(CATALOG_MANAGER_INTERVAL) > 0) {
+    scheduler = setIntervalAsync(async () => {
+      await refreshCatalog();
+    }, Number(CATALOG_MANAGER_INTERVAL));
+    logApp.info(`[OPENCTI-MODULE] Catalog manager scheduled every ${Number(CATALOG_MANAGER_INTERVAL)}ms`);
+  } else {
+    logApp.info('[OPENCTI-MODULE] Catalog manager configured for startup-only refresh');
+  }
+};
+
+const shutdown = async () => {
+  if (scheduler) {
+    await clearIntervalAsync(scheduler);
+    scheduler = undefined;
+  }
+};
+
+export default {
+  start,
+  shutdown,
+};

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -1,4 +1,5 @@
 import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
+import { createHash } from 'node:crypto';
 import conf, { booleanConf, isFeatureEnabled, logApp } from '../config/conf';
 import { lockResources } from '../lock/master-lock';
 import { TYPE_LOCK_ERROR } from '../config/errors';
@@ -30,6 +31,13 @@ const getCatalogManagerRequestTimeoutMs = (): number => {
 };
 
 const createRequestTimeoutSignal = (): AbortSignal => AbortSignal.timeout(getCatalogManagerRequestTimeoutMs());
+
+const computeCatalogRevision = (rawManifest: unknown, etag?: string): string => {
+  if (etag) {
+    return etag;
+  }
+  return createHash('sha256').update(JSON.stringify(rawManifest)).digest('hex');
+};
 
 const isCatalogRequestTimeout = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') {
@@ -69,7 +77,7 @@ const refreshCatalogInternal = async () => {
         nextEtag = headResponse.headers.get('etag') ?? undefined;
         if (nextEtag && currentEtag && nextEtag === currentEtag) {
           logApp.info('[OPENCTI-MODULE] Catalog manager skipping fetch, remote manifest unchanged (ETag match)', { etag: currentEtag });
-          updateCatalogManagerInternalCache(undefined, 'ready', true);
+          updateCatalogManagerInternalCache(undefined, 'ready', true, currentEtag);
           return;
         }
       }
@@ -83,7 +91,8 @@ const refreshCatalogInternal = async () => {
     }
 
     const internalCatalog = newManifestAdapter.toInternalCatalog(rawManifest);
-    updateCatalogManagerInternalCache(internalCatalog, 'ready');
+    const revision = computeCatalogRevision(rawManifest, nextEtag);
+    updateCatalogManagerInternalCache(internalCatalog, 'ready', false, revision);
 
     if (shouldCheckEtag && nextEtag) {
       currentEtag = nextEtag;
@@ -109,7 +118,8 @@ const refreshCatalogInternal = async () => {
       logApp.info('[OPENCTI-MODULE] Catalog manager falling back to embedded legacy manifest');
       const legacyRaw = await legacyAdapter.fetch({ kind: 'local', uri: 'embedded' });
       const legacyInternal = legacyAdapter.toInternalCatalog(legacyRaw);
-      updateCatalogManagerInternalCache(legacyInternal, 'ready');
+      const legacyRevision = computeCatalogRevision(legacyRaw);
+      updateCatalogManagerInternalCache(legacyInternal, 'ready', false, legacyRevision);
     } catch (legacyError) {
       logApp.warn('[OPENCTI-MODULE] Catalog manager failed to load embedded legacy manifest fallback', { cause: legacyError });
       updateCatalogManagerInternalCache(undefined, 'error');

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -181,4 +181,5 @@ const shutdown = async () => {
 export default {
   start,
   shutdown,
+  triggerRefreshInBackground,
 };

--- a/opencti-platform/opencti-graphql/src/managers.js
+++ b/opencti-platform/opencti-graphql/src/managers.js
@@ -33,6 +33,7 @@ import { shutdownAllManagers, startAllManagers } from './manager/managerModule';
 import clusterManager from './manager/clusterManager';
 import activityListener from './manager/activityListener';
 import activityManager from './manager/activityManager';
+import catalogManager from './manager/catalogManager';
 import draftValidationConnector from './modules/draftWorkspace/draftWorkspace-connector';
 import authenticationProviderListener from './modules/authenticationProvider/authenticationProvider-listener';
 import supportPackageListener from './modules/support/supportPackage-listener';
@@ -144,6 +145,7 @@ export const startModules = async () => {
   // region Audit
   startingPromises.push(activityListener.start());
   startingPromises.push(activityManager.start());
+  startingPromises.push(catalogManager.start());
   // endregion
 
   startingPromises.push(supportPackageListener.start());
@@ -233,6 +235,7 @@ export const shutdownModules = async () => {
   // region Audit listener
   stoppingPromises.push(activityListener.shutdown());
   stoppingPromises.push(activityManager.shutdown());
+  stoppingPromises.push(catalogManager.shutdown());
   // endregion
   stoppingPromises.push(supportPackageListener.shutdown());
   stoppingPromises.push(authenticationProviderListener.shutdown());

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
@@ -19,7 +19,7 @@ export type CatalogResolutionConfig = {
 export type RawManifest = unknown;
 
 export interface CatalogSourceAdapter {
-  fetch(source: CatalogSourceConfig): Promise<RawManifest>;
+  fetch(source: CatalogSourceConfig, options?: { signal?: AbortSignal }): Promise<RawManifest>;
   toInternalCatalog(raw: RawManifest): InternalCatalog;
 }
 
@@ -158,13 +158,13 @@ export class LegacyManifestAdapter implements CatalogSourceAdapter {
 }
 
 export class NewManifestAdapter implements CatalogSourceAdapter {
-  async fetch(source: CatalogSourceConfig): Promise<RawManifest> {
+  async fetch(source: CatalogSourceConfig, options?: { signal?: AbortSignal }): Promise<RawManifest> {
     if (source.kind === 'local') {
       const content = await readFile(source.uri, { encoding: 'utf8', flag: 'r' });
       return JSON.parse(content);
     }
 
-    const res = await fetch(source.uri);
+    const res = await fetch(source.uri, { signal: options?.signal });
     if (!res.ok) {
       throw UnsupportedError(`Failed to fetch remote catalog (${res.status}) from ${source.uri}`);
     }

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
@@ -95,6 +95,8 @@ const normalizeContractFromNewManifest = (contract: Record<string, any>): Catalo
   const schema = contract.config_schema ?? defaultConfigSchema;
 
   return {
+    id: contract.id ?? null,
+    integration_name: contract.integration_name ?? undefined,
     title: contract.title ?? '',
     slug: contract.slug ?? '',
     description: contract.description ?? '',
@@ -137,6 +139,15 @@ const toCatalogDefinitionsFromNewManifest = (raw: Record<string, any>): CatalogD
   }];
 };
 
+const pickLatestContractsBySlug = (contracts: CatalogContract[]): CatalogContract[] => {
+  // Manifest order defines recency for now: last contract entry for a slug wins.
+  const latestBySlug = new Map<string, CatalogContract>();
+  contracts.forEach((contract) => {
+    latestBySlug.set(contract.slug, contract);
+  });
+  return Array.from(latestBySlug.values());
+};
+
 export class LegacyManifestAdapter implements CatalogSourceAdapter {
   async fetch(_source: CatalogSourceConfig): Promise<RawManifest> {
     const customCatalogs: string[] = conf.get('app:custom_catalogs') ?? [];
@@ -172,7 +183,18 @@ export class NewManifestAdapter implements CatalogSourceAdapter {
   }
 
   toInternalCatalog(raw: RawManifest): InternalCatalog {
-    const normalized = toCatalogDefinitionsFromNewManifest(raw as Record<string, any>);
-    return buildInternalCatalog(normalized);
+    const manifest = raw as Record<string, any>;
+    const normalized = toCatalogDefinitionsFromNewManifest(manifest);
+
+    // Keep all versions for future workflows, but expose latest contract per slug
+    // through current catalog query behavior.
+    const allContracts = normalized[0].contracts;
+    const latestContracts = pickLatestContractsBySlug(allContracts);
+    const latestDefinitions: CatalogDefinition[] = [{
+      ...normalized[0],
+      contracts: latestContracts,
+    }];
+
+    return buildInternalCatalog(latestDefinitions, allContracts);
   }
 }

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
@@ -123,16 +123,6 @@ const normalizeContractFromNewManifest = (contract: Record<string, any>): Catalo
 };
 
 const toCatalogDefinitionsFromNewManifest = (raw: Record<string, any>): CatalogDefinition[] => {
-  const manifestSchemaVersion = String(raw.manifest_schema_version ?? '');
-
-  if (!manifestSchemaVersion) {
-    throw UnsupportedError('Catalog manifest is missing manifest_schema_version');
-  }
-
-  if (!manifestSchemaVersion.startsWith('16')) {
-    throw UnsupportedError(`Unsupported manifest_schema_version: ${manifestSchemaVersion}`);
-  }
-
   if (!raw.id || !Array.isArray(raw.contracts)) {
     throw UnsupportedError('Catalog manifest is missing required fields: id and contracts');
   }

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
@@ -1,0 +1,188 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import conf, { PLATFORM_VERSION } from '../../config/conf';
+import filigranCatalog from '../../__generated__/opencti-manifest.json';
+import type { CatalogContract, CatalogDefinition, IngestionConnectorType } from './catalog-types';
+import { buildInternalCatalog, type InternalCatalog } from './catalog-cache';
+import { UnsupportedError } from '../../config/errors';
+
+export type CatalogSourceConfig = {
+  kind: 'remote' | 'local';
+  uri: string;
+};
+
+export type CatalogResolutionConfig = {
+  source: CatalogSourceConfig;
+  originalUri: string;
+};
+
+export type RawManifest = unknown;
+
+export interface CatalogSourceAdapter {
+  fetch(source: CatalogSourceConfig): Promise<RawManifest>;
+  toInternalCatalog(raw: RawManifest): InternalCatalog;
+}
+
+const CATALOG_PRODUCT = 'opencti';
+const CATALOG_INTEGRATION_TYPE = 'connectors';
+
+const isHttpUri = (value: string) => value.startsWith('http://') || value.startsWith('https://');
+
+export const resolveCatalogSource = (uri?: string | null): CatalogResolutionConfig => {
+  const configuredUri = uri?.trim();
+
+  if (!configuredUri) {
+    const xtmHubUrl = conf.get('xtm:xtmhub_url');
+    const remoteUri = `${xtmHubUrl}/${CATALOG_PRODUCT}/${PLATFORM_VERSION}/${CATALOG_INTEGRATION_TYPE}/manifests/latest`;
+    return {
+      source: { kind: 'remote', uri: remoteUri },
+      originalUri: remoteUri,
+    };
+  }
+
+  if (isHttpUri(configuredUri)) {
+    return {
+      source: { kind: 'remote', uri: configuredUri },
+      originalUri: configuredUri,
+    };
+  }
+
+  if (configuredUri.includes('://') && !configuredUri.startsWith('file://')) {
+    throw UnsupportedError(`Unsupported catalog source URI scheme: ${configuredUri}`);
+  }
+
+  const withoutFilePrefix = configuredUri.startsWith('file://')
+    ? configuredUri.slice('file://'.length)
+    : configuredUri;
+  const localPath = path.isAbsolute(withoutFilePrefix)
+    ? withoutFilePrefix
+    : path.resolve(process.cwd(), withoutFilePrefix);
+
+  return {
+    source: { kind: 'local', uri: localPath },
+    originalUri: configuredUri,
+  };
+};
+
+const toBoolean = (value: unknown, defaultValue = false) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value === 'true';
+  return defaultValue;
+};
+
+const toNumber = (value: unknown, defaultValue: number) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return defaultValue;
+};
+
+const toStringArray = (value: unknown) => (Array.isArray(value) ? value.filter((entry) => typeof entry === 'string') : []);
+
+const defaultConfigSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://filigran.io/opencti/catalog/default_config.schema.json',
+  type: 'object',
+  properties: {},
+  required: [],
+  additionalProperties: true,
+} as CatalogContract['config_schema'];
+
+const normalizeContractFromNewManifest = (contract: Record<string, any>): CatalogContract => {
+  const additional = (contract.additional_properties ?? {}) as Record<string, any>;
+  const schema = contract.config_schema ?? defaultConfigSchema;
+
+  return {
+    title: contract.title ?? '',
+    slug: contract.slug ?? '',
+    description: contract.description ?? '',
+    short_description: contract.short_description ?? '',
+    logo: contract.logo ?? '',
+    use_cases: toStringArray(contract.use_cases),
+    verified: toBoolean(contract.verified, false),
+    last_verified_date: contract.last_verified_date ?? '',
+    playbook_supported: toBoolean(additional.playbook_supported, false),
+    max_confidence_level: toNumber(additional.max_confidence_level, 100),
+    support_version: contract.support_version ?? '',
+    subscription_link: contract.subscription_link ?? '',
+    source_code: contract.source_code ?? '',
+    manager_supported: toBoolean(contract.manager_supported, false),
+    container_version: contract.version ?? '',
+    container_image: contract.image_name ?? contract.container_image ?? '',
+    container_type: (contract.image_type ?? contract.container_type ?? 'EXTERNAL_IMPORT') as IngestionConnectorType,
+    config_schema: {
+      ...defaultConfigSchema,
+      ...schema,
+      properties: schema?.properties ?? {},
+      required: schema?.required ?? [],
+      additionalProperties: schema?.additionalProperties ?? true,
+    },
+  };
+};
+
+const toCatalogDefinitionsFromNewManifest = (raw: Record<string, any>): CatalogDefinition[] => {
+  const manifestSchemaVersion = String(raw.manifest_schema_version ?? '');
+
+  if (!manifestSchemaVersion) {
+    throw UnsupportedError('Catalog manifest is missing manifest_schema_version');
+  }
+
+  if (!manifestSchemaVersion.startsWith('16')) {
+    throw UnsupportedError(`Unsupported manifest_schema_version: ${manifestSchemaVersion}`);
+  }
+
+  if (!raw.id || !Array.isArray(raw.contracts)) {
+    throw UnsupportedError('Catalog manifest is missing required fields: id and contracts');
+  }
+
+  const contracts = raw.contracts.map((contract: Record<string, any>) => normalizeContractFromNewManifest(contract));
+
+  return [{
+    id: String(raw.id),
+    name: String(raw.name ?? 'Connector Catalog'),
+    description: String(raw.description ?? ''),
+    contracts,
+  }];
+};
+
+export class LegacyManifestAdapter implements CatalogSourceAdapter {
+  async fetch(_source: CatalogSourceConfig): Promise<RawManifest> {
+    const customCatalogs: string[] = conf.get('app:custom_catalogs') ?? [];
+    const definitions: CatalogDefinition[] = [filigranCatalog as unknown as CatalogDefinition];
+
+    for (let index = 0; index < customCatalogs.length; index += 1) {
+      const customCatalogPath = customCatalogs[index];
+      const content = await readFile(customCatalogPath, { encoding: 'utf8', flag: 'r' });
+      definitions.push(JSON.parse(content) as CatalogDefinition);
+    }
+
+    return definitions;
+  }
+
+  toInternalCatalog(raw: RawManifest): InternalCatalog {
+    const catalogDefinitions = raw as CatalogDefinition[];
+    return buildInternalCatalog(catalogDefinitions);
+  }
+}
+
+export class NewManifestAdapter implements CatalogSourceAdapter {
+  async fetch(source: CatalogSourceConfig): Promise<RawManifest> {
+    if (source.kind === 'local') {
+      const content = await readFile(source.uri, { encoding: 'utf8', flag: 'r' });
+      return JSON.parse(content);
+    }
+
+    const res = await fetch(source.uri);
+    if (!res.ok) {
+      throw UnsupportedError(`Failed to fetch remote catalog (${res.status}) from ${source.uri}`);
+    }
+    return res.json();
+  }
+
+  toInternalCatalog(raw: RawManifest): InternalCatalog {
+    const normalized = toCatalogDefinitionsFromNewManifest(raw as Record<string, any>);
+    return buildInternalCatalog(normalized);
+  }
+}

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
@@ -1,0 +1,124 @@
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { UnsupportedError } from '../../config/errors';
+import { logApp } from '../../config/conf';
+import type { CatalogContract, CatalogDefinition, CatalogType } from './catalog-types';
+
+type InternalCatalog = {
+  catalogMap: Record<string, CatalogType>;
+  contractsByImage: Map<string, CatalogContract>;
+};
+
+const ajv = new Ajv({ coerceTypes: true });
+addFormats(ajv, ['password', 'uri', 'duration', 'email', 'date-time', 'date']);
+const schemaValidatorCache = new Map<string, ReturnType<typeof ajv.compile>>();
+
+const isEmptyValue = (value: unknown) => value === null || value === undefined || value === '';
+
+const getOrCompileCatalogSchemaValidator = (cacheKey: string, jsonValidation: object) => {
+  let validate = schemaValidatorCache.get(cacheKey);
+  if (!validate) {
+    validate = ajv.compile(jsonValidation);
+    schemaValidatorCache.set(cacheKey, validate);
+  }
+  return validate;
+};
+
+const sanitizeManagerConfigurationSchema = (contract: CatalogContract) => {
+  if (!contract.manager_supported || !contract.config_schema) {
+    return contract;
+  }
+
+  const finalContract = {
+    ...contract,
+    config_schema: {
+      ...contract.config_schema,
+      properties: { ...contract.config_schema.properties },
+      required: [...contract.config_schema.required],
+    },
+  };
+
+  const excludedConfigVars = ['OPENCTI_TOKEN', 'OPENCTI_URL', 'CONNECTOR_TYPE', 'CONNECTOR_RUN_AND_TERMINATE'];
+  for (let i = 0; i < excludedConfigVars.length; i += 1) {
+    delete finalContract.config_schema.properties[excludedConfigVars[i]];
+  }
+  finalContract.config_schema.required = finalContract.config_schema.required
+    .filter((item) => !excludedConfigVars.includes(item));
+
+  return finalContract;
+};
+
+const validateManagerSupportedContract = (catalogId: string, contract: CatalogContract) => {
+  if (!contract.manager_supported) return;
+
+  if (!contract.config_schema) {
+    logApp.warn('A contract has manager_supported=true but is missing config_schema', { contractTitle: contract.title });
+    return;
+  }
+
+  if (isEmptyValue(contract.container_image)) {
+    throw UnsupportedError('Contract must define container_image field', { contractTitle: contract.title });
+  }
+  if (isEmptyValue(contract.container_type)) {
+    throw UnsupportedError('Contract must define container_type field', { contractTitle: contract.title });
+  }
+
+  const jsonValidation = {
+    type: contract.config_schema.type,
+    properties: contract.config_schema.properties,
+    required: contract.config_schema.required,
+    additionalProperties: contract.config_schema.additionalProperties,
+  };
+
+  try {
+    getOrCompileCatalogSchemaValidator(`catalog-contract:${catalogId}:${contract.slug}`, jsonValidation);
+  } catch (err) {
+    throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
+  }
+};
+
+export const clearCatalogCacheValidators = () => {
+  schemaValidatorCache.clear();
+};
+
+export const buildCatalogMapFromDefinitions = (catalogDefinitions: CatalogDefinition[]): Record<string, CatalogType> => {
+  const catalogMap: Record<string, CatalogType> = {};
+
+  for (let index = 0; index < catalogDefinitions.length; index += 1) {
+    const catalog = catalogDefinitions[index];
+
+    for (let contractIndex = 0; contractIndex < catalog.contracts.length; contractIndex += 1) {
+      validateManagerSupportedContract(catalog.id, catalog.contracts[contractIndex]);
+    }
+
+    catalogMap[catalog.id] = {
+      definition: catalog,
+      graphql: {
+        id: catalog.id,
+        entity_type: 'Catalog',
+        parent_types: ['Internal'],
+        standard_id: `catalog--${catalog.id}`,
+        name: catalog.name,
+        description: catalog.description,
+        contracts: catalog.contracts.map((contract) => JSON.stringify(sanitizeManagerConfigurationSchema(contract))),
+      },
+    };
+  }
+
+  return catalogMap;
+};
+
+export const buildContractsByImageCache = (catalogMap: Record<string, CatalogType>): Map<string, CatalogContract> => {
+  const contracts = Object.values(catalogMap)
+    .map((catalog) => catalog.definition.contracts)
+    .flat();
+  return new Map(contracts.map((contract) => [contract.container_image, contract]));
+};
+
+export const buildInternalCatalog = (catalogDefinitions: CatalogDefinition[]): InternalCatalog => {
+  const catalogMap = buildCatalogMapFromDefinitions(catalogDefinitions);
+  const contractsByImage = buildContractsByImageCache(catalogMap);
+  return { catalogMap, contractsByImage };
+};
+
+export type { InternalCatalog };

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
@@ -110,7 +110,7 @@ export const buildCatalogMapFromDefinitions = (catalogDefinitions: CatalogDefini
 
 export const buildContractsByImageCache = (catalogMap: Record<string, CatalogType>): Map<string, CatalogContract> => {
   const contracts = Object.values(catalogMap)
-    .map((catalog) => catalog.definition.contracts)
+    .map((catalog) => catalog.definition.contracts.map((contract) => sanitizeManagerConfigurationSchema(contract)))
     .flat();
   return new Map(contracts.map((contract) => [contract.container_image, contract]));
 };

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
@@ -7,6 +7,12 @@ import type { CatalogContract, CatalogDefinition, CatalogType } from './catalog-
 type InternalCatalog = {
   catalogMap: Record<string, CatalogType>;
   contractsByImage: Map<string, CatalogContract>;
+  /** Flat contracts as they appear in the manifest (all versions retained). */
+  allContracts?: CatalogContract[];
+  /** Grouped contracts by connector slug (all versions retained). */
+  contractsBySlug?: Map<string, CatalogContract[]>;
+  /** Latest contract per connector slug (currently selected as last manifest occurrence). */
+  latestContractsBySlug?: Map<string, CatalogContract>;
 };
 
 const ajv = new Ajv({ coerceTypes: true });
@@ -115,10 +121,42 @@ export const buildContractsByImageCache = (catalogMap: Record<string, CatalogTyp
   return new Map(contracts.map((contract) => [contract.container_image, contract]));
 };
 
-export const buildInternalCatalog = (catalogDefinitions: CatalogDefinition[]): InternalCatalog => {
+export const buildContractsBySlugCache = (allContracts: CatalogContract[]): Map<string, CatalogContract[]> => {
+  const grouped = new Map<string, CatalogContract[]>();
+  allContracts.forEach((contract) => {
+    const current = grouped.get(contract.slug) ?? [];
+    current.push(contract);
+    grouped.set(contract.slug, current);
+  });
+  return grouped;
+};
+
+export const buildLatestContractsBySlugCache = (allContracts: CatalogContract[]): Map<string, CatalogContract> => {
+  // Last contract occurrence for a given slug wins (manifest order driven).
+  const latest = new Map<string, CatalogContract>();
+  allContracts.forEach((contract) => {
+    latest.set(contract.slug, contract);
+  });
+  return latest;
+};
+
+export const buildInternalCatalog = (
+  catalogDefinitions: CatalogDefinition[],
+  allContracts?: CatalogContract[],
+): InternalCatalog => {
   const catalogMap = buildCatalogMapFromDefinitions(catalogDefinitions);
   const contractsByImage = buildContractsByImageCache(catalogMap);
-  return { catalogMap, contractsByImage };
+  const resolvedAllContracts = allContracts ?? Object.values(catalogMap)
+    .flatMap((catalog) => catalog.definition.contracts.map((contract) => sanitizeManagerConfigurationSchema(contract)));
+  const contractsBySlug = buildContractsBySlugCache(resolvedAllContracts);
+  const latestContractsBySlug = buildLatestContractsBySlugCache(resolvedAllContracts);
+  return {
+    catalogMap,
+    contractsByImage,
+    allContracts: resolvedAllContracts,
+    contractsBySlug,
+    latestContractsBySlug,
+  };
 };
 
 export type { InternalCatalog };

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -5,14 +5,18 @@ import type { AuthContext, AuthUser } from '../../types/user';
 import { type CatalogContract, type CatalogDefinition, type CatalogType } from './catalog-types';
 import { isEmptyField } from '../../database/utils';
 import { UnsupportedError } from '../../config/errors';
-import { idGenFromData } from '../../schema/identifier';
 import filigranCatalog from '../../__generated__/opencti-manifest.json';
-import conf, { logApp } from '../../config/conf';
+import conf, { isFeatureEnabled, logApp } from '../../config/conf';
 import type { ConnectorContractConfiguration, ContractConfigInput } from '../../generated/graphql';
 import { readFile } from 'node:fs/promises';
 import type { ValidateFunction } from 'ajv';
+import { buildCatalogMapFromDefinitions, buildContractsByImageCache, clearCatalogCacheValidators, type InternalCatalog } from './catalog-cache';
 
 const validatorCache = new Map<string, ValidateFunction>();
+const MAX_VALIDATOR_CACHE_SIZE = 500;
+const DECOUPLING_CONNECTOR_VERSIONS = 'DECOUPLING_CONNECTOR_VERSIONS';
+
+export type CatalogStatus = 'loading' | 'ready' | 'error';
 
 /**
  * Compiles (or retrieves from cache) an AJV validator for a given schema.
@@ -22,6 +26,10 @@ const validatorCache = new Map<string, ValidateFunction>();
 const getOrCompileValidator = (cacheKey: string, jsonValidation: object): ValidateFunction => {
   let validate = validatorCache.get(cacheKey);
   if (!validate) {
+    if (validatorCache.size >= MAX_VALIDATOR_CACHE_SIZE) {
+      logApp.warn('Validator cache size limit reached, compiling without caching', { size: validatorCache.size });
+      return ajv.compile(jsonValidation);
+    }
     validate = ajv.compile(jsonValidation);
     validatorCache.set(cacheKey, validate);
   }
@@ -36,90 +44,53 @@ addFormats(ajv, ['password', 'uri', 'duration', 'email', 'date-time', 'date']);
 let catalogMap: Promise<Record<string, CatalogType>> | undefined;
 // cache for contracts by image map
 let contractsByImageCache: Promise<Map<string, CatalogContract>> | undefined;
+let managerInternalCatalog: InternalCatalog | undefined;
+let managerCatalogStatus: CatalogStatus = 'loading';
 
 // Build catalog map from files
 const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
-  const newCatalogMap: Record<string, CatalogType> = {};
-  const catalogs = [];
-  catalogs.push(JSON.stringify(filigranCatalog));
+  const catalogDefinitions: CatalogDefinition[] = [filigranCatalog as unknown as CatalogDefinition];
   // Add custom catalogs
   for (let index = 0; index < CUSTOM_CATALOGS.length; index += 1) {
     const customCatalog = CUSTOM_CATALOGS[index];
     const catalog = await readFile(customCatalog, { encoding: 'utf8', flag: 'r' });
-    catalogs.push(catalog);
+    catalogDefinitions.push(JSON.parse(catalog) as CatalogDefinition);
   }
-  // Prepare catalogs map
-  for (let index = 0; index < catalogs.length; index += 1) {
-    const catalogRaw = catalogs[index];
-    const catalog = JSON.parse(catalogRaw) as CatalogDefinition;
-    // Validate each contract
-    for (let contractIndex = 0; contractIndex < catalog.contracts.length; contractIndex += 1) {
-      const contract = catalog.contracts[contractIndex];
-      if (contract.manager_supported) {
-        if (!contract.config_schema) {
-          logApp.warn('A contract has manager_supported=true but is missing config_schema', { contractTitle: contract.title });
-        } else {
-          if (isEmptyField(contract.container_image)) {
-            throw UnsupportedError('Contract must define container_image field', { contractTitle: contract.title });
-          }
-          if (isEmptyField(contract.container_type)) {
-            throw UnsupportedError('Contract must define container_type field', { contractTitle: contract.title });
-          }
 
-          if (contract.config_schema) {
-            const jsonValidation = {
-              type: contract.config_schema.type,
-              properties: contract.config_schema.properties,
-              required: contract.config_schema.required,
-              additionalProperties: contract.config_schema.additionalProperties,
-            };
-            try {
-              getOrCompileValidator(`catalog-contract:${catalog.id}:${contract.slug}`, jsonValidation);
-            } catch (err) {
-              throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
-            }
-          }
-        }
-      }
-    }
-    newCatalogMap[catalog.id] = {
-      definition: catalog,
-      graphql: {
-        id: catalog.id,
-        entity_type: 'Catalog',
-        parent_types: ['Internal'],
-        standard_id: idGenFromData('catalog', { id: catalog.id }),
-        name: catalog.name,
-        description: catalog.description,
-        contracts: catalog.contracts.map((c) => {
-          const finalContract = c;
-          if (finalContract.manager_supported) {
-            if (!finalContract.config_schema) {
-              logApp.warn('A contract has manager_supported=true but is missing config_schema', { contractTitle: finalContract.title });
-            } else {
-              const EXCLUDED_CONFIG_VARS = ['OPENCTI_TOKEN', 'OPENCTI_URL', 'CONNECTOR_TYPE', 'CONNECTOR_RUN_AND_TERMINATE'];
-              EXCLUDED_CONFIG_VARS.forEach((property) => {
-                delete finalContract.config_schema.properties[property];
-              });
-              finalContract.config_schema.required = c.config_schema.required.filter((item) => !EXCLUDED_CONFIG_VARS.includes(item));
-            }
-          }
-          return JSON.stringify(finalContract);
-        }),
-      },
-    };
-  }
-  return newCatalogMap;
+  return buildCatalogMapFromDefinitions(catalogDefinitions);
 };
 
 // Enable custom catalogs - clears cache and enables live catalog loading
 export const resetCatalogs = () => {
   catalogMap = undefined;
   contractsByImageCache = undefined;
+  managerInternalCatalog = undefined;
+  managerCatalogStatus = 'loading';
   validatorCache.clear();
+  clearCatalogCacheValidators();
+};
+
+export const updateCatalogManagerInternalCache = (internalCatalog: InternalCatalog | undefined, status: CatalogStatus, keepExistingSnapshot = false) => {
+  if (!keepExistingSnapshot) {
+    managerInternalCatalog = internalCatalog;
+  }
+  managerCatalogStatus = status;
+};
+
+export const getCatalogManagerInternalCache = () => managerInternalCatalog;
+
+export const getCatalogStatus = (): CatalogStatus => {
+  if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    return 'ready';
+  }
+  return managerCatalogStatus;
 };
 
 const getCatalogs = async (): Promise<Record<string, CatalogType>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog) {
+    return managerInternalCatalog.catalogMap;
+  }
+
   if (!catalogMap) {
     // We memoize the Promise immediately (not after it resolves) so that
     // all concurrent calls share the same in-flight execution.
@@ -443,11 +414,14 @@ export const computeConnectorTargetContract = (
 };
 
 export const getSupportedContractsByImage = async (): Promise<Map<string, CatalogContract>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog) {
+    return managerInternalCatalog.contractsByImage;
+  }
+
   if (!contractsByImageCache) {
     contractsByImageCache = (async () => {
       const catalogDefinitions = await getCatalogs();
-      const contracts = Object.values(catalogDefinitions).map((catalog) => catalog.definition.contracts).flat();
-      return new Map(contracts.map((contract) => [contract.container_image, contract]));
+      return buildContractsByImageCache(catalogDefinitions);
     })().catch((err) => {
       contractsByImageCache = undefined;
       throw err;

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -18,6 +18,12 @@ const DECOUPLING_CONNECTOR_VERSIONS = 'DECOUPLING_CONNECTOR_VERSIONS';
 
 export type CatalogStatus = 'loading' | 'ready' | 'error';
 
+export type CatalogVersionInfo = {
+  status: CatalogStatus;
+  revision: string | null;
+  updated_at: string | null;
+};
+
 /**
  * Compiles (or retrieves from cache) an AJV validator for a given schema.
  * The cacheKey must accurately reflect the exact shape of the schema (properties + required)
@@ -46,6 +52,8 @@ let catalogMap: Promise<Record<string, CatalogType>> | undefined;
 let contractsByImageCache: Promise<Map<string, CatalogContract>> | undefined;
 let managerInternalCatalog: InternalCatalog | undefined;
 let managerCatalogStatus: CatalogStatus = 'loading';
+let managerCatalogRevision: string | null = null;
+let managerCatalogUpdatedAt: string | null = null;
 
 // Build catalog map from files
 const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
@@ -66,18 +74,30 @@ export const resetCatalogs = () => {
   contractsByImageCache = undefined;
   managerInternalCatalog = undefined;
   managerCatalogStatus = 'loading';
+  managerCatalogRevision = null;
+  managerCatalogUpdatedAt = null;
   validatorCache.clear();
   clearCatalogCacheValidators();
 };
 
-export const updateCatalogManagerInternalCache = (internalCatalog: InternalCatalog | undefined, status: CatalogStatus, keepExistingSnapshot = false) => {
+export const updateCatalogManagerInternalCache = (
+  internalCatalog: InternalCatalog | undefined,
+  status: CatalogStatus,
+  keepExistingSnapshot = false,
+  revision?: string | null,
+) => {
   if (!keepExistingSnapshot) {
     managerInternalCatalog = internalCatalog;
   }
+  if (revision !== undefined) {
+    managerCatalogRevision = revision;
+  }
+  managerCatalogUpdatedAt = new Date().toISOString();
   logApp.info('[OPENCTI-MODULE] Updating catalog manager internal cache status', {
     status,
     hasSnapshot: Boolean(managerInternalCatalog),
     keepExistingSnapshot,
+    revision: managerCatalogRevision,
   });
   managerCatalogStatus = status;
 };
@@ -89,6 +109,21 @@ export const getCatalogStatus = (): CatalogStatus => {
     return 'ready';
   }
   return managerCatalogStatus;
+};
+
+export const getCatalogVersionInfo = (): CatalogVersionInfo => {
+  if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    return {
+      status: 'ready',
+      revision: null,
+      updated_at: null,
+    };
+  }
+  return {
+    status: managerCatalogStatus,
+    revision: managerCatalogRevision,
+    updated_at: managerCatalogUpdatedAt,
+  };
 };
 
 const getCatalogs = async (): Promise<Record<string, CatalogType>> => {

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -74,6 +74,11 @@ export const updateCatalogManagerInternalCache = (internalCatalog: InternalCatal
   if (!keepExistingSnapshot) {
     managerInternalCatalog = internalCatalog;
   }
+  logApp.info('[OPENCTI-MODULE] Updating catalog manager internal cache status', {
+    status,
+    hasSnapshot: Boolean(managerInternalCatalog),
+    keepExistingSnapshot,
+  });
   managerCatalogStatus = status;
 };
 
@@ -87,8 +92,15 @@ export const getCatalogStatus = (): CatalogStatus => {
 };
 
 const getCatalogs = async (): Promise<Record<string, CatalogType>> => {
-  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog) {
-    return managerInternalCatalog.catalogMap;
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    if (managerInternalCatalog) {
+      return managerInternalCatalog.catalogMap;
+    }
+
+    // Strict decoupling mode: fallback to legacy sources only after an explicit error.
+    if (managerCatalogStatus !== 'error') {
+      return {};
+    }
   }
 
   if (!catalogMap) {
@@ -414,8 +426,15 @@ export const computeConnectorTargetContract = (
 };
 
 export const getSupportedContractsByImage = async (): Promise<Map<string, CatalogContract>> => {
-  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog) {
-    return managerInternalCatalog.contractsByImage;
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    if (managerInternalCatalog) {
+      return managerInternalCatalog.contractsByImage;
+    }
+
+    // Strict decoupling mode: fallback to legacy sources only after an explicit error.
+    if (managerCatalogStatus !== 'error') {
+      return new Map();
+    }
   }
 
   if (!contractsByImageCache) {

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -513,3 +513,61 @@ export const findContractBySlug = (context: AuthContext, user: AuthUser, contrac
 export const findContractByContainerImage = (context: AuthContext, user: AuthUser, containerImage: string) => {
   return findContract(context, user, (contract) => contract.container_image === containerImage);
 };
+
+// region New multi-version helpers (additive, non-breaking)
+
+/**
+ * Returns all connector contracts from the active catalog snapshot.
+ * For manifest_schema_version 1 with stacked contracts, this includes all versions.
+ */
+export const getAllConnectorContracts = async (): Promise<CatalogContract[]> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog?.allContracts) {
+    return managerInternalCatalog.allContracts;
+  }
+  const catalogs = await getCatalogs();
+  return Object.values(catalogs).flatMap((catalog) => catalog.definition.contracts);
+};
+
+/**
+ * Returns all contracts grouped by connector slug.
+ */
+export const getContractsBySlug = async (): Promise<Map<string, CatalogContract[]>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog?.contractsBySlug) {
+    return managerInternalCatalog.contractsBySlug;
+  }
+  const allContracts = await getAllConnectorContracts();
+  const grouped = new Map<string, CatalogContract[]>();
+  allContracts.forEach((contract) => {
+    const current = grouped.get(contract.slug) ?? [];
+    current.push(contract);
+    grouped.set(contract.slug, current);
+  });
+  return grouped;
+};
+
+/**
+ * Returns the latest contract per connector slug.
+ * Current strategy: last contract occurrence for a slug wins.
+ */
+export const getLatestContractsBySlug = async (): Promise<Map<string, CatalogContract>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog?.latestContractsBySlug) {
+    return managerInternalCatalog.latestContractsBySlug;
+  }
+  const grouped = await getContractsBySlug();
+  const latest = new Map<string, CatalogContract>();
+  grouped.forEach((contracts, slug) => {
+    const last = contracts[contracts.length - 1];
+    if (last) latest.set(slug, last);
+  });
+  return latest;
+};
+
+/**
+ * Finds the latest contract for a connector slug.
+ */
+export const findLatestContractBySlug = async (slug: string): Promise<CatalogContract | undefined> => {
+  const latestBySlug = await getLatestContractsBySlug();
+  return latestBySlug.get(slug);
+};
+
+// endregion

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -131,11 +131,7 @@ const getCatalogs = async (): Promise<Record<string, CatalogType>> => {
     if (managerInternalCatalog) {
       return managerInternalCatalog.catalogMap;
     }
-
-    // Strict decoupling mode: fallback to legacy sources only after an explicit error.
-    if (managerCatalogStatus !== 'error') {
-      return {};
-    }
+    // No remote snapshot yet (loading or error): fall through to embedded catalog as baseline.
   }
 
   if (!catalogMap) {
@@ -465,11 +461,7 @@ export const getSupportedContractsByImage = async (): Promise<Map<string, Catalo
     if (managerInternalCatalog) {
       return managerInternalCatalog.contractsByImage;
     }
-
-    // Strict decoupling mode: fallback to legacy sources only after an explicit error.
-    if (managerCatalogStatus !== 'error') {
-      return new Map();
-    }
+    // No remote snapshot yet (loading or error): fall through to embedded catalog as baseline.
   }
 
   if (!contractsByImageCache) {

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-resolver.ts
@@ -1,4 +1,4 @@
-import { findCatalog, findById, findContractBySlug } from './catalog-domain';
+import { findCatalog, findById, findContractBySlug, getCatalogVersionInfo } from './catalog-domain';
 import type { Resolvers } from '../../generated/graphql';
 
 const catalogResolver: Resolvers = {
@@ -8,6 +8,9 @@ const catalogResolver: Resolvers = {
     },
     catalogs: (_, args, context) => {
       return findCatalog(context, context.user);
+    },
+    catalogVersionInfo: () => {
+      return getCatalogVersionInfo();
     },
     contract: (_, { slug }, context) => {
       return findContractBySlug(context, context.user, slug);

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-resolver.ts
@@ -1,4 +1,5 @@
 import { findCatalog, findById, findContractBySlug, getCatalogVersionInfo } from './catalog-domain';
+import catalogManager from '../../manager/catalogManager';
 import type { Resolvers } from '../../generated/graphql';
 
 const catalogResolver: Resolvers = {
@@ -14,6 +15,12 @@ const catalogResolver: Resolvers = {
     },
     contract: (_, { slug }, context) => {
       return findContractBySlug(context, context.user, slug);
+    },
+  },
+  Mutation: {
+    refreshCatalog: () => {
+      catalogManager.triggerRefreshInBackground();
+      return true;
     },
   },
 };

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-types.ts
@@ -16,6 +16,8 @@ type TypedProperty<K extends keyof TypeMap = keyof TypeMap> = {
 };
 
 export interface CatalogContract {
+  id?: string | null;
+  integration_name?: string;
   title: string;
   slug: string;
   description: string;

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog.graphql
@@ -16,6 +16,12 @@ type ExtendedContract {
   contract: String!
 }
 
+type CatalogVersionInfo {
+  status: String!
+  revision: String
+  updated_at: String
+}
+
 # Ordering
 enum CatalogsOrdering {
   name
@@ -36,5 +42,6 @@ type CatalogEdge {
 type Query {
   catalog(id: String!): Catalog @auth(for: [INGESTION])
   catalogs: [Catalog!]! @auth(for: [INGESTION])
+  catalogVersionInfo: CatalogVersionInfo! @auth(for: [INGESTION])
   contract(slug: String!): ExtendedContract @auth(for: [INGESTION])
 }

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog.graphql
@@ -45,3 +45,8 @@ type Query {
   catalogVersionInfo: CatalogVersionInfo! @auth(for: [INGESTION])
   contract(slug: String!): ExtendedContract @auth(for: [INGESTION])
 }
+
+# Mutations
+type Mutation {
+  refreshCatalog: Boolean! @auth(for: [INGESTION])
+}

--- a/opencti-platform/opencti-graphql/test-ingestion-catalog.js
+++ b/opencti-platform/opencti-graphql/test-ingestion-catalog.js
@@ -1,0 +1,38 @@
+// autocannon-ingestion-catalog.js
+const autocannon = require('autocannon');
+
+const TOKEN = process.env.OPENCTI_TOKEN;
+
+const QUERY = `
+  query IngestionConnectorsCatalogsQuery {
+    catalogs {
+      id
+      name
+      description
+      contracts
+    }
+  }
+`;
+
+const body = JSON.stringify({
+  operationName: 'IngestionConnectorsCatalogsQuery',
+  query: QUERY,
+  variables: {}
+});
+
+autocannon({
+  url: 'http://localhost:4000/graphql',
+  connections: 100,     // concurrency knob — try 50 / 100 / 200
+  pipelining: 1,
+  duration: 120,        // seconds
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'authorization': `Bearer ${TOKEN}`
+  },
+  body
+}, (err, result) => {
+  if (err) return console.error(err);
+  console.log(autocannon.printResult(result));
+  console.log(`\nnon-2xx errors: ${result.non2xx}, timeouts: ${result.timeouts}, errors: ${result.errors}`);
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalog-cache-sanitization-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalog-cache-sanitization-test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { buildInternalCatalog } from '../../../../src/modules/catalog/catalog-cache';
+import type { CatalogContract, CatalogDefinition } from '../../../../src/modules/catalog/catalog-types';
+
+const buildManagerSupportedContract = (): CatalogContract => ({
+  title: 'Manager Supported Connector',
+  slug: 'manager-supported-connector',
+  description: 'Test contract',
+  short_description: 'Test',
+  logo: 'logo.png',
+  use_cases: [],
+  verified: true,
+  last_verified_date: '2026-01-01',
+  playbook_supported: false,
+  max_confidence_level: 100,
+  support_version: '1.0.0',
+  subscription_link: '',
+  source_code: '',
+  manager_supported: true,
+  container_version: '1.0.0',
+  container_image: 'ghcr.io/test/connector:1.0.0',
+  container_type: 'EXTERNAL_IMPORT',
+  config_schema: {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: 'connector-config',
+    type: 'object',
+    properties: {
+      OPENCTI_URL: { type: 'string', description: 'OpenCTI URL', default: '' },
+      OPENCTI_TOKEN: { type: 'string', description: 'OpenCTI token', default: '' },
+      CONNECTOR_TYPE: { type: 'string', description: 'Connector type', default: '' },
+      CONNECTOR_RUN_AND_TERMINATE: { type: 'boolean', description: 'Run and terminate', default: false },
+      api_key: { type: 'string', description: 'API key', default: '' },
+    },
+    required: ['OPENCTI_URL', 'OPENCTI_TOKEN', 'CONNECTOR_TYPE', 'CONNECTOR_RUN_AND_TERMINATE', 'api_key'],
+    additionalProperties: false,
+  },
+});
+
+describe('catalog-cache sanitization for contractsByImage', () => {
+  it('removes excluded OpenCTI runtime variables from manager contract validation schema', () => {
+    const catalogDefinition: CatalogDefinition = {
+      id: 'catalog-test',
+      name: 'Catalog test',
+      description: 'Catalog description',
+      contracts: [buildManagerSupportedContract()],
+    };
+
+    const internalCatalog = buildInternalCatalog([catalogDefinition]);
+    const contract = internalCatalog.contractsByImage.get('ghcr.io/test/connector:1.0.0');
+
+    expect(contract).toBeDefined();
+    expect(contract?.config_schema.properties.OPENCTI_URL).toBeUndefined();
+    expect(contract?.config_schema.properties.OPENCTI_TOKEN).toBeUndefined();
+    expect(contract?.config_schema.properties.CONNECTOR_TYPE).toBeUndefined();
+    expect(contract?.config_schema.properties.CONNECTOR_RUN_AND_TERMINATE).toBeUndefined();
+
+    expect(contract?.config_schema.required).not.toContain('OPENCTI_URL');
+    expect(contract?.config_schema.required).not.toContain('OPENCTI_TOKEN');
+    expect(contract?.config_schema.required).not.toContain('CONNECTOR_TYPE');
+    expect(contract?.config_schema.required).not.toContain('CONNECTOR_RUN_AND_TERMINATE');
+    expect(contract?.config_schema.required).toContain('api_key');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
@@ -121,4 +121,78 @@ describe('catalog-domain decoupling fallback policy', () => {
     expect(info.status).toBe('loading');
     expect(info.revision).toBeNull();
   });
+
+  it('returns latest contract per slug from helper APIs when multiple versions exist', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+    catalogDomain.resetCatalogs();
+
+    const v140 = {
+      id: 'ipinfo-1.4.0',
+      integration_name: 'ipinfo-1.4.0',
+      title: 'IPinfo',
+      slug: 'ipinfo',
+      description: '',
+      short_description: '',
+      logo: '',
+      use_cases: [],
+      verified: false,
+      last_verified_date: '2026-01-01',
+      playbook_supported: false,
+      max_confidence_level: 80,
+      support_version: '>=7.2.0',
+      subscription_link: '',
+      source_code: '',
+      manager_supported: true,
+      container_version: '1.4.0',
+      container_image: 'opencti/connector-ipinfo',
+      container_type: 'EXTERNAL_IMPORT' as const,
+      config_schema: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'ipinfo-1.4.0-config',
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    };
+    const v152 = {
+      ...v140,
+      id: 'ipinfo-1.5.2',
+      integration_name: 'ipinfo-1.5.2',
+      support_version: '>=7.3.0',
+      container_version: '1.5.2',
+    };
+
+    const { buildInternalCatalog } = await import('../../../../src/modules/catalog/catalog-cache');
+    const internalCatalog = buildInternalCatalog([
+      {
+        id: 'stacked-catalog',
+        name: 'Stacked',
+        description: '',
+        contracts: [v152], // current query view: latest only
+      },
+    ], [v140, v152]); // full contracts retained
+
+    catalogDomain.updateCatalogManagerInternalCache(internalCatalog, 'ready', false, 'revision-stacked');
+
+    const allContracts = await catalogDomain.getAllConnectorContracts();
+    expect(allContracts).toHaveLength(2);
+
+    const grouped = await catalogDomain.getContractsBySlug();
+    expect(grouped.get('ipinfo')?.length).toBe(2);
+
+    const latest = await catalogDomain.getLatestContractsBySlug();
+    expect(latest.get('ipinfo')?.container_version).toBe('1.5.2');
+
+    const latestBySlug = await catalogDomain.findLatestContractBySlug('ipinfo');
+    expect(latestBySlug?.container_version).toBe('1.5.2');
+  });
+
+  it('findLatestContractBySlug returns undefined for unknown slug', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+    catalogDomain.resetCatalogs();
+
+    const found = await catalogDomain.findLatestContractBySlug('does-not-exist');
+    expect(found).toBeUndefined();
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
@@ -38,4 +38,84 @@ describe('catalog-domain decoupling fallback policy', () => {
 
     expect(catalogs.length).toBeGreaterThan(0);
   });
+
+  // ── scenario: load → reduced catalog (revision changes) ────────────────────
+  it('returns updated catalog and new revision after manager writes a new snapshot', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+    catalogDomain.resetCatalogs();
+
+    const fakeContract = {
+      title: 'Reduced Connector',
+      slug: 'reduced-connector',
+      description: '',
+      short_description: '',
+      logo: '',
+      use_cases: [],
+      verified: false,
+      last_verified_date: '2026-01-01',
+      playbook_supported: false,
+      max_confidence_level: 100,
+      support_version: '1.0.0',
+      subscription_link: '',
+      source_code: '',
+      manager_supported: true,
+      container_version: '1.0.0',
+      container_image: 'ghcr.io/test/reduced:1.0.0',
+      container_type: 'EXTERNAL_IMPORT',
+      config_schema: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $id: 'reduced-config',
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    };
+
+    const { buildInternalCatalog } = await import('../../../../src/modules/catalog/catalog-cache');
+    const internalCatalog = buildInternalCatalog([{
+      id: 'reduced-catalog',
+      name: 'Reduced',
+      description: '',
+      contracts: [fakeContract],
+    }]);
+
+    catalogDomain.updateCatalogManagerInternalCache(internalCatalog, 'ready', false, 'revision-reduced');
+
+    const versionInfo = catalogDomain.getCatalogVersionInfo();
+    expect(versionInfo.status).toBe('ready');
+    expect(versionInfo.revision).toBe('revision-reduced');
+
+    const contracts = await catalogDomain.getSupportedContractsByImage();
+    expect(contracts.has('ghcr.io/test/reduced:1.0.0')).toBe(true);
+  });
+
+  // ── scenario: error → recover (status and revision update) ─────────────────
+  it('reflects error status then recovers to ready with a new revision', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+    catalogDomain.resetCatalogs();
+
+    // Inject error (keeps existing snapshot = true, so snapshot stays undefined here)
+    catalogDomain.updateCatalogManagerInternalCache(undefined, 'error', true);
+    expect(catalogDomain.getCatalogVersionInfo().status).toBe('error');
+
+    // Recover: write a new catalog
+    const { buildInternalCatalog } = await import('../../../../src/modules/catalog/catalog-cache');
+    const recovered = buildInternalCatalog([{ id: 'r', name: 'R', description: '', contracts: [] }]);
+    catalogDomain.updateCatalogManagerInternalCache(recovered, 'ready', false, 'revision-after-recovery');
+
+    const info = catalogDomain.getCatalogVersionInfo();
+    expect(info.status).toBe('ready');
+    expect(info.revision).toBe('revision-after-recovery');
+  });
+
+  // ── scenario: loading status → empty catalogs ───────────────────────────────
+  it('getCatalogVersionInfo returns loading status before manager first run', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+    catalogDomain.resetCatalogs();
+
+    const info = catalogDomain.getCatalogVersionInfo();
+    expect(info.status).toBe('loading');
+    expect(info.revision).toBeNull();
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthContext, AuthUser } from '../../../../src/types/user';
+
+const FAKE_CONTEXT = {} as unknown as AuthContext;
+const FAKE_USER = {} as unknown as AuthUser;
+
+describe('catalog-domain decoupling fallback policy', () => {
+  beforeEach(() => {
+    process.env.APP__ENABLED_DEV_FEATURES = JSON.stringify(['DECOUPLING_CONNECTOR_VERSIONS']);
+    process.env.APP__CUSTOM_CATALOGS = JSON.stringify([]);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.APP__ENABLED_DEV_FEATURES;
+    delete process.env.APP__CUSTOM_CATALOGS;
+  });
+
+  it('does not fallback to legacy catalog while manager status is loading', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+
+    catalogDomain.resetCatalogs();
+
+    const catalogs = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    const contractsByImage = await catalogDomain.getSupportedContractsByImage();
+
+    expect(catalogs).toEqual([]);
+    expect(contractsByImage.size).toBe(0);
+  });
+
+  it('falls back to legacy catalog only when manager status is error', async () => {
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+
+    catalogDomain.resetCatalogs();
+    catalogDomain.updateCatalogManagerInternalCache(undefined, 'error');
+
+    const catalogs = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+
+    expect(catalogs.length).toBeGreaterThan(0);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
@@ -64,7 +64,7 @@ describe('catalog-domain decoupling fallback policy', () => {
       manager_supported: true,
       container_version: '1.0.0',
       container_image: 'ghcr.io/test/reduced:1.0.0',
-      container_type: 'EXTERNAL_IMPORT',
+      container_type: 'EXTERNAL_IMPORT' as const,
       config_schema: {
         $schema: 'http://json-schema.org/draft-07/schema#',
         $id: 'reduced-config',

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/catalogDomainDecouplingFallback-test.ts
@@ -16,7 +16,7 @@ describe('catalog-domain decoupling fallback policy', () => {
     delete process.env.APP__CUSTOM_CATALOGS;
   });
 
-  it('does not fallback to legacy catalog while manager status is loading', async () => {
+  it('uses embedded catalog as baseline while manager status is loading', async () => {
     const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
 
     catalogDomain.resetCatalogs();
@@ -24,19 +24,22 @@ describe('catalog-domain decoupling fallback policy', () => {
     const catalogs = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
     const contractsByImage = await catalogDomain.getSupportedContractsByImage();
 
-    expect(catalogs).toEqual([]);
-    expect(contractsByImage.size).toBe(0);
+    // Embedded catalog is always the baseline — connectors get data immediately.
+    expect(catalogs.length).toBeGreaterThan(0);
+    expect(contractsByImage.size).toBeGreaterThan(0);
   });
 
-  it('falls back to legacy catalog only when manager status is error', async () => {
+  it('uses embedded catalog as baseline while manager status is error', async () => {
     const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
 
     catalogDomain.resetCatalogs();
     catalogDomain.updateCatalogManagerInternalCache(undefined, 'error');
 
     const catalogs = await catalogDomain.findCatalog(FAKE_CONTEXT, FAKE_USER);
+    const contractsByImage = await catalogDomain.getSupportedContractsByImage();
 
     expect(catalogs.length).toBeGreaterThan(0);
+    expect(contractsByImage.size).toBeGreaterThan(0);
   });
 
   // ── scenario: load → reduced catalog (revision changes) ────────────────────

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/legacyManifestAdapter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/legacyManifestAdapter-test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { LegacyManifestAdapter } from '../../../../../src/modules/catalog/catalog-adapters';
+
+describe('LegacyManifestAdapter', () => {
+  it('returns internal catalog map and image cache matching legacy shape', async () => {
+    const adapter = new LegacyManifestAdapter();
+
+    const raw = await adapter.fetch({ kind: 'local', uri: 'embedded' });
+    const internal = adapter.toInternalCatalog(raw);
+
+    expect(internal.catalogMap).toBeDefined();
+    expect(Object.keys(internal.catalogMap).length).toBeGreaterThan(0);
+    expect(internal.contractsByImage).toBeInstanceOf(Map);
+    expect(internal.contractsByImage.size).toBeGreaterThan(0);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/newManifestAdapter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/newManifestAdapter-test.ts
@@ -104,4 +104,44 @@ describe('NewManifestAdapter', () => {
       expect(Object.keys(internal.catalogMap)).toEqual(['catalog-v2']);
     }
   });
+
+  it('keeps all contracts but exposes latest contract per slug for catalog queries', () => {
+    const adapter = new NewManifestAdapter();
+
+    const manifestWithTwoVersions = {
+      ...fixtureManifest,
+      contracts: [
+        {
+          ...fixtureManifest.contracts[0],
+          id: 'ipinfo-1.4.0',
+          integration_name: 'ipinfo-1.4.0',
+          version: '1.4.0',
+        },
+        {
+          ...fixtureManifest.contracts[0],
+          id: 'ipinfo-1.5.2',
+          integration_name: 'ipinfo-1.5.2',
+          version: '1.5.2',
+          support_version: '>=7.3.0',
+        },
+      ],
+    };
+
+    const internal = adapter.toInternalCatalog(manifestWithTwoVersions);
+    const catalog = internal.catalogMap['catalog-v2'];
+
+    // Latest by slug (last manifest occurrence) is exposed in catalog query view.
+    expect(catalog.definition.contracts).toHaveLength(1);
+    expect(catalog.definition.contracts[0].slug).toBe('ipinfo');
+    expect(catalog.definition.contracts[0].container_version).toBe('1.5.2');
+
+    // All contracts are retained for next workflows.
+    expect(internal.allContracts).toBeDefined();
+    expect(internal.allContracts).toHaveLength(2);
+    expect(internal.latestContractsBySlug?.get('ipinfo')?.container_version).toBe('1.5.2');
+
+    // Metadata from new manifest is preserved.
+    expect(internal.allContracts?.[0].id).toBe('ipinfo-1.4.0');
+    expect(internal.allContracts?.[1].integration_name).toBe('ipinfo-1.5.2');
+  });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/newManifestAdapter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/newManifestAdapter-test.ts
@@ -89,12 +89,19 @@ describe('NewManifestAdapter', () => {
     expect(contract?.manager_supported).toBeTruthy();
   });
 
-  it('rejects unsupported manifest schema versions', () => {
+  it('rejects a manifest missing required top-level fields (id, contracts)', () => {
     const adapter = new NewManifestAdapter();
 
-    expect(() => adapter.toInternalCatalog({
-      ...fixtureManifest,
-      manifest_schema_version: '2.0.0',
-    })).toThrow();
+    expect(() => adapter.toInternalCatalog({ manifest_schema_version: '1' })).toThrow();
+    expect(() => adapter.toInternalCatalog({ id: 'catalog-v2' })).toThrow();
+  });
+
+  it('accepts any manifest_schema_version value as long as id and contracts are present', () => {
+    const adapter = new NewManifestAdapter();
+
+    for (const version of ['1', '16.0.0', '99.0', 'future']) {
+      const internal = adapter.toInternalCatalog({ ...fixtureManifest, manifest_schema_version: version });
+      expect(Object.keys(internal.catalogMap)).toEqual(['catalog-v2']);
+    }
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/newManifestAdapter-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/adapters/newManifestAdapter-test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { NewManifestAdapter } from '../../../../../src/modules/catalog/catalog-adapters';
+
+const fixtureManifest = {
+  id: 'catalog-v2',
+  name: 'Catalog v2',
+  description: 'Fixture for adapter tests',
+  manifest_schema_version: '16.0.0',
+  manifest_version: '7.260701.0',
+  product_version: '7.260701.0',
+  contracts: [
+    {
+      id: null,
+      title: 'Ipinfo',
+      slug: 'ipinfo',
+      description: 'ipinfo contract',
+      short_description: 'ipinfo short',
+      logo: 'logo.png',
+      use_cases: ['Commercial Threat Intel'],
+      verified: true,
+      last_verified_date: null,
+      subscription_link: 'https://example.test/ipinfo',
+      source_code: 'https://example.test/source',
+      manager_supported: true,
+      support_version: '>=7.0.0',
+      version: 'rolling',
+      image_name: 'opencti/connector-ipinfo',
+      image_type: 'EXTERNAL_IMPORT',
+      additional_properties: {
+        max_confidence_level: 75,
+        playbook_supported: false,
+      },
+      config_schema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: 'https://example.test/ipinfo.schema.json',
+        type: 'object',
+        properties: {
+          CONNECTOR_NAME: { type: 'string', default: 'Ipinfo', description: 'name' },
+        },
+        required: [],
+        additionalProperties: true,
+      },
+    },
+    {
+      id: 'contract-2',
+      title: 'Threatmatch',
+      slug: 'threatmatch',
+      description: 'threatmatch contract',
+      short_description: 'threatmatch short',
+      logo: 'logo.png',
+      use_cases: ['Open Source Threat Intel'],
+      verified: false,
+      last_verified_date: null,
+      subscription_link: '',
+      source_code: 'https://example.test/source',
+      manager_supported: false,
+      support_version: '>=7.0.0',
+      version: '1.0.0',
+      image_name: 'opencti/connector-threatmatch',
+      image_type: 'EXTERNAL_IMPORT',
+      additional_properties: {},
+      config_schema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: 'https://example.test/threatmatch.schema.json',
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: true,
+      },
+    },
+  ],
+};
+
+describe('NewManifestAdapter', () => {
+  it('maps TDR-16 manifest contract fields into internal catalog shape keyed by image_name', () => {
+    const adapter = new NewManifestAdapter();
+
+    const internal = adapter.toInternalCatalog(fixtureManifest);
+
+    expect(Object.keys(internal.catalogMap)).toEqual(['catalog-v2']);
+    expect(internal.contractsByImage.has('opencti/connector-ipinfo')).toBeTruthy();
+    expect(internal.contractsByImage.has('opencti/connector-threatmatch')).toBeTruthy();
+
+    const contract = internal.contractsByImage.get('opencti/connector-ipinfo');
+    expect(contract?.container_image).toBe('opencti/connector-ipinfo');
+    expect(contract?.container_type).toBe('EXTERNAL_IMPORT');
+    expect(contract?.max_confidence_level).toBe(75);
+    expect(contract?.manager_supported).toBeTruthy();
+  });
+
+  it('rejects unsupported manifest schema versions', () => {
+    const adapter = new NewManifestAdapter();
+
+    expect(() => adapter.toInternalCatalog({
+      ...fixtureManifest,
+      manifest_schema_version: '2.0.0',
+    })).toThrow();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const lockResourcesMock = vi.fn();
+const updateCatalogManagerInternalCacheMock = vi.fn();
+const getCatalogManagerInternalCacheMock = vi.fn();
+const getCatalogStatusMock = vi.fn();
+const isFeatureEnabledMock = vi.fn();
+const booleanConfMock = vi.fn();
+const confGetMock = vi.fn();
+const fetchMock = vi.fn();
+
+vi.stubGlobal('fetch', fetchMock);
+
+vi.mock('../../../../src/lock/master-lock', () => ({
+  lockResources: lockResourcesMock,
+}));
+
+vi.mock('../../../../src/modules/catalog/catalog-domain', () => ({
+  updateCatalogManagerInternalCache: updateCatalogManagerInternalCacheMock,
+  getCatalogManagerInternalCache: getCatalogManagerInternalCacheMock,
+  getCatalogStatus: getCatalogStatusMock,
+}));
+
+vi.mock('../../../../src/config/conf', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/config/conf')>('../../../../src/config/conf');
+  return {
+    ...actual,
+    default: {
+      get: confGetMock,
+    },
+    booleanConf: booleanConfMock,
+    isFeatureEnabled: isFeatureEnabledMock,
+    logApp: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+  };
+});
+
+describe('catalogManager', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    booleanConfMock.mockReturnValue(true);
+    confGetMock.mockImplementation((key: string) => {
+      if (key === 'app:catalog_manager:lock_key') return 'catalog_manager_lock';
+      if (key === 'app:catalog_manager:interval') return null;
+      if (key === 'app:catalog_manager:custom_catalog_refresh_endpoint_uri') return './connector-catalog.json.local';
+      return undefined;
+    });
+    isFeatureEnabledMock.mockImplementation((flag: string) => flag === 'DECOUPLING_CONNECTOR_VERSIONS');
+    getCatalogStatusMock.mockReturnValue('ready');
+    getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
+    lockResourcesMock.mockResolvedValue({ unlock: vi.fn() });
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'etag-v1' },
+      json: async () => ({
+        id: 'catalog-v2',
+        name: 'Catalog v2',
+        description: 'Fixture for manager tests',
+        manifest_schema_version: '16.0.0',
+        contracts: [],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('acquires the configured lock before refresh', async () => {
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+
+    await manager.start();
+
+    expect(lockResourcesMock).toHaveBeenCalledWith(['catalog_manager_lock'], { retryCount: 0 });
+  });
+
+  it('does not refresh when feature flag is disabled', async () => {
+    isFeatureEnabledMock.mockReturnValue(false);
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+
+    await manager.start();
+
+    expect(lockResourcesMock).not.toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
@@ -165,8 +165,8 @@ describe('catalogManager', () => {
 
     // Wait until a ready call is made (snapshot replaced, keepExistingSnapshot=false)
     await vi.waitFor(() => {
-      const readyCall = updateCatalogManagerInternalCacheMock.mock.calls.find(
-        ([, status]: [unknown, string]) => status === 'ready',
+      const readyCall = (updateCatalogManagerInternalCacheMock.mock.calls as Array<[unknown, string, boolean, string?]>).find(
+        ([, status]) => status === 'ready',
       );
       expect(readyCall).toBeDefined();
       expect(readyCall![2]).toBe(false);
@@ -184,8 +184,8 @@ describe('catalogManager', () => {
     await manager.start();
     // Wait until a full ready call is made (snapshot set = keepExistingSnapshot false)
     await vi.waitFor(() => {
-      const readyCall = updateCatalogManagerInternalCacheMock.mock.calls.find(
-        ([, status, keep]: [unknown, string, boolean]) => status === 'ready' && keep === false,
+      const readyCall = (updateCatalogManagerInternalCacheMock.mock.calls as Array<[unknown, string, boolean, string?]>).find(
+        ([, status, keep]) => status === 'ready' && keep === false,
       );
       expect(readyCall).toBeDefined();
       expect(readyCall![3]).toBe('etag-stable');
@@ -216,8 +216,8 @@ describe('catalogManager', () => {
     await manager.start();
 
     await vi.waitFor(() => {
-      const readyCall = updateCatalogManagerInternalCacheMock.mock.calls.find(
-        ([, status]: [unknown, string]) => status === 'ready',
+      const readyCall = (updateCatalogManagerInternalCacheMock.mock.calls as Array<[unknown, string, boolean, string?]>).find(
+        ([, status]) => status === 'ready',
       );
       expect(readyCall).toBeDefined();
       // 4th argument is revision – should be the ETag value

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
@@ -7,9 +7,15 @@ const getCatalogStatusMock = vi.fn();
 const isFeatureEnabledMock = vi.fn();
 const booleanConfMock = vi.fn();
 const confGetMock = vi.fn();
-const fetchMock = vi.fn();
 
-vi.stubGlobal('fetch', fetchMock);
+// Global fetch is used by the manager directly for HEAD requests (ETag check).
+const headFetchMock = vi.fn();
+// Adapter mocks – per-test behaviour is set via newAdapterFetchMock / legacyAdapterFetchMock
+const newAdapterFetchMock = vi.fn();
+const newAdapterToInternalCatalogMock = vi.fn();
+const legacyAdapterFetchMock = vi.fn();
+const legacyAdapterToInternalCatalogMock = vi.fn();
+const resolveCatalogSourceMock = vi.fn();
 
 vi.mock('../../../../src/lock/master-lock', () => ({
   lockResources: lockResourcesMock,
@@ -34,16 +40,58 @@ vi.mock('../../../../src/config/conf', async () => {
   };
 });
 
+vi.mock('../../../../src/modules/catalog/catalog-adapters', () => ({
+  resolveCatalogSource: resolveCatalogSourceMock,
+  // eslint-disable-next-line object-shorthand
+  LegacyManifestAdapter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.fetch = legacyAdapterFetchMock;
+    this.toInternalCatalog = legacyAdapterToInternalCatalogMock;
+  }),
+  // eslint-disable-next-line object-shorthand
+  NewManifestAdapter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.fetch = newAdapterFetchMock;
+    this.toInternalCatalog = newAdapterToInternalCatalogMock;
+  }),
+}));
+
+/** Wait until a mock receives the expected call, polling every 10 ms. */
+const waitForCall = (mockFn: ReturnType<typeof vi.fn>, ...expectedArgs: unknown[]) =>
+  vi.waitFor(
+    () => expect(mockFn).toHaveBeenCalledWith(...expectedArgs),
+    { timeout: 2000, interval: 10 },
+  );
+
+const REMOTE_SOURCE = { kind: 'remote', uri: 'http://localhost:9090/catalog' };
+
+/** Fake internal catalog returned by toInternalCatalog mocks. */
+const fakeInternalCatalog = () => ({ catalogMap: {}, contractsByImage: new Map() });
+
+/** Default HEAD mock: returns ok with given etag. */
+const setupHeadMock = (etag = 'etag-v1') => {
+  headFetchMock.mockResolvedValue({ ok: true, headers: { get: () => etag } });
+};
+
+/** Make the new adapter return a successful catalog. */
+const makeSuccessfulNewAdapter = (etag = 'etag-v1') => {
+  setupHeadMock(etag);
+  newAdapterFetchMock.mockResolvedValue({ etag, contracts: [] });
+  newAdapterToInternalCatalogMock.mockReturnValue(fakeInternalCatalog());
+};
+
 describe('catalogManager', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
 
+    // Re-stub global fetch each test so the HEAD mock is active after vi.unstubAllGlobals()
+    vi.stubGlobal('fetch', headFetchMock);
+
     booleanConfMock.mockReturnValue(true);
     confGetMock.mockImplementation((key: string) => {
       if (key === 'app:catalog_manager:lock_key') return 'catalog_manager_lock';
       if (key === 'app:catalog_manager:interval') return null;
-      if (key === 'app:catalog_manager:custom_catalog_refresh_endpoint_uri') return './connector-catalog.json.local';
+      if (key === 'app:catalog_manager:custom_catalog_refresh_endpoint_uri') return 'http://localhost:9090/catalog';
+      if (key === 'app:catalog_manager:request_timeout') return null;
       return undefined;
     });
     isFeatureEnabledMock.mockImplementation((flag: string) => flag === 'DECOUPLING_CONNECTOR_VERSIONS');
@@ -51,17 +99,11 @@ describe('catalogManager', () => {
     getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
     lockResourcesMock.mockResolvedValue({ unlock: vi.fn() });
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      headers: { get: () => 'etag-v1' },
-      json: async () => ({
-        id: 'catalog-v2',
-        name: 'Catalog v2',
-        description: 'Fixture for manager tests',
-        manifest_schema_version: '16.0.0',
-        contracts: [],
-      }),
-    });
+    resolveCatalogSourceMock.mockReturnValue({ source: REMOTE_SOURCE, originalUri: REMOTE_SOURCE.uri });
+    makeSuccessfulNewAdapter();
+      // HEAD fetch default (can be overridden per test)
+    legacyAdapterFetchMock.mockResolvedValue([]);
+    legacyAdapterToInternalCatalogMock.mockReturnValue(fakeInternalCatalog());
   });
 
   afterEach(() => {
@@ -73,7 +115,7 @@ describe('catalogManager', () => {
 
     await manager.start();
 
-    expect(lockResourcesMock).toHaveBeenCalledWith(['catalog_manager_lock'], { retryCount: 0 });
+    await waitForCall(lockResourcesMock, ['catalog_manager_lock'], { retryCount: 0 });
   });
 
   it('does not refresh when feature flag is disabled', async () => {
@@ -81,7 +123,120 @@ describe('catalogManager', () => {
     const manager = (await import('../../../../src/manager/catalogManager')).default;
 
     await manager.start();
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
 
     expect(lockResourcesMock).not.toHaveBeenCalled();
+  });
+
+  // ── scenario: load → HTTP 500 error ────────────────────────────────────────
+  it('sets status to error and keeps existing snapshot when remote returns HTTP 500', async () => {
+    getCatalogManagerInternalCacheMock.mockReturnValue({ catalogMap: {}, contractsByImage: new Map() });
+
+    newAdapterFetchMock.mockRejectedValue(Object.assign(new Error('HTTP 500'), { status: 500 }));
+
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+    await manager.start();
+
+    await waitForCall(updateCatalogManagerInternalCacheMock, undefined, 'error', true);
+  });
+
+  // ── scenario: load → bad JSON ───────────────────────────────────────────────
+  it('sets status to error when remote returns malformed JSON', async () => {
+    getCatalogManagerInternalCacheMock.mockReturnValue({ catalogMap: {}, contractsByImage: new Map() });
+
+    newAdapterFetchMock.mockRejectedValue(new SyntaxError('Unexpected token { in JSON'));
+
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+    await manager.start();
+
+    await waitForCall(updateCatalogManagerInternalCacheMock, undefined, 'error', true);
+  });
+
+  // ── scenario: error → recover (new catalog loaded successfully) ─────────────
+  it('sets status to ready with new catalog after recovering from error', async () => {
+    getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
+    getCatalogStatusMock.mockReturnValue('error');
+    makeSuccessfulNewAdapter('etag-recovered');
+
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+    await manager.start();
+
+    // Wait until a ready call is made (snapshot replaced, keepExistingSnapshot=false)
+    await vi.waitFor(() => {
+      const readyCall = updateCatalogManagerInternalCacheMock.mock.calls.find(
+        ([, status]: [unknown, string]) => status === 'ready',
+      );
+      expect(readyCall).toBeDefined();
+      expect(readyCall![2]).toBe(false);
+    }, { timeout: 2000, interval: 10 });
+  });
+
+  // ── scenario: ETag unchanged → skip GET ────────────────────────────────────
+  it('skips GET and sets ready when remote ETag is unchanged', async () => {
+    getCatalogManagerInternalCacheMock.mockReturnValue({ catalogMap: {}, contractsByImage: new Map() });
+    // First start – new adapter returns successfully, manager stores currentEtag
+    makeSuccessfulNewAdapter('etag-stable');
+
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+
+    await manager.start();
+    // Wait until a full ready call is made (snapshot set = keepExistingSnapshot false)
+    await vi.waitFor(() => {
+      const readyCall = updateCatalogManagerInternalCacheMock.mock.calls.find(
+        ([, status, keep]: [unknown, string, boolean]) => status === 'ready' && keep === false,
+      );
+      expect(readyCall).toBeDefined();
+      expect(readyCall![3]).toBe('etag-stable');
+    }, { timeout: 2000, interval: 10 });
+
+    updateCatalogManagerInternalCacheMock.mockClear();
+    newAdapterFetchMock.mockClear();
+
+    // Second start – adapter would reject to simulate what the manager decides on ETag match.
+    // The manager checks currentEtag against the HEAD etag BEFORE calling the adapter's main fetch.
+    // To verify skip: make the adapter fail if called, proving the GET-equivalent was never reached.
+    // The manager handles ETag at HEAD level (via global fetch), so we verify via the cache update.
+
+    await manager.start();
+
+  await waitForCall(updateCatalogManagerInternalCacheMock, undefined, 'ready', true, 'etag-stable');
+
+    // Adapter fetch was NOT called on the second start (ETag skip happened at HEAD level)
+    expect(newAdapterFetchMock).not.toHaveBeenCalled();
+  });
+
+  // ── scenario: revision changes when new catalog is fetched ─────────────────
+  it('writes a new revision when remote catalog changes (new ETag)', async () => {
+    getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
+    makeSuccessfulNewAdapter('etag-new');
+
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+    await manager.start();
+
+    await vi.waitFor(() => {
+      const readyCall = updateCatalogManagerInternalCacheMock.mock.calls.find(
+        ([, status]: [unknown, string]) => status === 'ready',
+      );
+      expect(readyCall).toBeDefined();
+      // 4th argument is revision – should be the ETag value
+      expect(readyCall![3]).toBe('etag-new');
+    }, { timeout: 2000, interval: 10 });
+  });
+
+  // ── scenario: no snapshot → fallback to embedded legacy manifest ────────────
+  it('falls back to embedded legacy manifest when remote fails and no snapshot exists', async () => {
+    getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
+    newAdapterFetchMock.mockRejectedValue(new Error('Network unreachable'));
+
+    const manager = (await import('../../../../src/manager/catalogManager')).default;
+    await manager.start();
+
+    // Wait until the final status is written (either ready via fallback or error)
+    await vi.waitFor(() => {
+      const calls = updateCatalogManagerInternalCacheMock.mock.calls;
+      const lastCall = calls.at(-1);
+      expect(lastCall).toBeDefined();
+      expect(['ready', 'error']).toContain(lastCall![1]);
+    }, { timeout: 2000, interval: 10 });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/catalogManager-test.ts
@@ -42,12 +42,12 @@ vi.mock('../../../../src/config/conf', async () => {
 
 vi.mock('../../../../src/modules/catalog/catalog-adapters', () => ({
   resolveCatalogSource: resolveCatalogSourceMock,
-  // eslint-disable-next-line object-shorthand
+
   LegacyManifestAdapter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
     this.fetch = legacyAdapterFetchMock;
     this.toInternalCatalog = legacyAdapterToInternalCatalogMock;
   }),
-  // eslint-disable-next-line object-shorthand
+
   NewManifestAdapter: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
     this.fetch = newAdapterFetchMock;
     this.toInternalCatalog = newAdapterToInternalCatalogMock;
@@ -101,7 +101,7 @@ describe('catalogManager', () => {
 
     resolveCatalogSourceMock.mockReturnValue({ source: REMOTE_SOURCE, originalUri: REMOTE_SOURCE.uri });
     makeSuccessfulNewAdapter();
-      // HEAD fetch default (can be overridden per test)
+    // HEAD fetch default (can be overridden per test)
     legacyAdapterFetchMock.mockResolvedValue([]);
     legacyAdapterToInternalCatalogMock.mockReturnValue(fakeInternalCatalog());
   });
@@ -123,7 +123,9 @@ describe('catalogManager', () => {
     const manager = (await import('../../../../src/manager/catalogManager')).default;
 
     await manager.start();
-    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
     expect(lockResourcesMock).not.toHaveBeenCalled();
   });
@@ -199,7 +201,7 @@ describe('catalogManager', () => {
 
     await manager.start();
 
-  await waitForCall(updateCatalogManagerInternalCacheMock, undefined, 'ready', true, 'etag-stable');
+    await waitForCall(updateCatalogManagerInternalCacheMock, undefined, 'ready', true, 'etag-stable');
 
     // Adapter fetch was NOT called on the second start (ETag skip happened at HEAD level)
     expect(newAdapterFetchMock).not.toHaveBeenCalled();

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/resolveCatalogSource-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalogManager/resolveCatalogSource-test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../src/config/conf', async () => {
+  const actual = await vi.importActual<typeof import('../../../../src/config/conf')>('../../../../src/config/conf');
+  return {
+    ...actual,
+    default: {
+      get: (key: string) => {
+        if (key === 'xtm:xtmhub_url') return 'https://hub.example.test';
+        return undefined;
+      },
+    },
+    PLATFORM_VERSION: '7.999999.0',
+  };
+});
+
+describe('resolveCatalogSource', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns default hub URL when uri is undefined', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const resolved = resolveCatalogSource(undefined);
+
+    expect(resolved.source.kind).toBe('remote');
+    expect(resolved.source.uri).toBe('https://hub.example.test/opencti/7.999999.0/connectors/manifests/latest');
+  });
+
+  it('returns default hub URL when uri is empty string', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const resolved = resolveCatalogSource('   ');
+
+    expect(resolved.source.kind).toBe('remote');
+    expect(resolved.source.uri).toBe('https://hub.example.test/opencti/7.999999.0/connectors/manifests/latest');
+  });
+
+  it('treats http and https as remote URLs', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    expect(resolveCatalogSource('http://localhost:9999/manifest.json').source)
+      .toEqual({ kind: 'remote', uri: 'http://localhost:9999/manifest.json' });
+    expect(resolveCatalogSource('https://localhost:9999/manifest.json').source)
+      .toEqual({ kind: 'remote', uri: 'https://localhost:9999/manifest.json' });
+  });
+
+  it('treats relative local path as local file resolved from cwd', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const resolved = resolveCatalogSource('./connector-catalog.json.local');
+
+    expect(resolved.source.kind).toBe('local');
+    expect(resolved.source.uri.endsWith('/connector-catalog.json.local')).toBeTruthy();
+  });
+
+  it('strips file:// prefix and resolves as local path', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const resolved = resolveCatalogSource('file:///tmp/catalog.json');
+
+    expect(resolved.source).toEqual({ kind: 'local', uri: '/tmp/catalog.json' });
+  });
+
+  it('rejects unsupported URI schemes', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    expect(() => resolveCatalogSource('ftp://example.test/manifest.json')).toThrow();
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add FeatureFlag **DECOUPLING_CONNECTOR_VERSIONS**
* New config **catalog_manager** settings
* Handle new manifest shape while keeping legacy with embedded manifest shape
* Handle loading manifest from file system or by server
* Catalog Manager added to fetch and populate the catalog
* App catalog fetches and use new manifest, updates if new manifest revision found

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16059 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
