### PR TITLE
fix(dashboard): Take interval into account in widgets (#17168)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiAreaChart.tsx
@@ -29,7 +29,7 @@ import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
-import { showEstimationWarningForUniqCount, UNIQUE_COUNT_ESTIMATION_WARNING } from '../../../../utils/widget/widgetUtils';
+import { getWidgetInterval, showEstimationWarningForUniqCount, UNIQUE_COUNT_ESTIMATION_WARNING } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetMultiTimeSeries, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 
@@ -169,7 +169,7 @@ const AuditsMultiAreaChart: FunctionComponent<AuditsMultiAreaChartProps> = ({
       operation: 'count' as const,
       startDate: startDate ?? fallbackDates.start,
       endDate: endDate ?? fallbackDates.end,
-      interval: parameters.interval ?? 'day',
+      interval: getWidgetInterval(parameters),
       timeSeriesParameters,
     };
   }, [startDate, endDate, fallbackDates, parameters.interval]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiHeatMap.tsx
@@ -31,6 +31,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
+import { getWidgetInterval } from '../../../../utils/widget/widgetUtils';
 
 const auditsMultiHeatMapTimeSeriesQuery = graphql`
   query AuditsMultiHeatMapTimeSeriesQuery(
@@ -160,7 +161,7 @@ const AuditsMultiHeatMap: FunctionComponent<AuditsMultiHeatMapProps> = ({
       operation: 'count' as const,
       startDate: startDate ?? fallbackDates.start,
       endDate: endDate ?? fallbackDates.end,
-      interval: parameters.interval ?? 'day',
+      interval: getWidgetInterval(parameters),
       timeSeriesParameters,
     };
   }, [startDate, endDate, fallbackDates, parameters.interval]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiLineChart.tsx
@@ -28,7 +28,7 @@ import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines'
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import { UNIQUE_COUNT_ESTIMATION_WARNING, showEstimationWarningForUniqCount } from '../../../../utils/widget/widgetUtils';
+import { UNIQUE_COUNT_ESTIMATION_WARNING, getWidgetInterval, showEstimationWarningForUniqCount } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
@@ -165,7 +165,7 @@ const AuditsMultiLineChart: FunctionComponent<AuditsMultiLineChartProps> = ({
       operation: 'count' as const,
       startDate: startDate ?? fallbackDates.start,
       endDate: endDate ?? fallbackDates.end,
-      interval: parameters.interval ?? 'day',
+      interval: getWidgetInterval(parameters),
       timeSeriesParameters,
     };
   }, [startDate, endDate, fallbackDates, parameters.interval]);

--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsMultiVerticalBars.tsx
@@ -31,6 +31,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetAccessDenied from '../../../../components/dashboard/WidgetAccessDenied';
+import { getWidgetInterval } from '../../../../utils/widget/widgetUtils';
 
 const auditsMultiVerticalBarsTimeSeriesQuery = graphql`
   query AuditsMultiVerticalBarsTimeSeriesQuery(
@@ -153,7 +154,7 @@ const AuditsMultiVerticalBars: FunctionComponent<AuditsMultiVerticalBarsProps> =
       operation: 'count' as const,
       startDate: startDate ?? fallbackDates.start,
       endDate: endDate ?? fallbackDates.end,
-      interval: parameters.interval ?? 'day',
+      interval: getWidgetInterval(parameters),
       timeSeriesParameters,
     };
   }, [startDate, endDate, fallbackDates, parameters.interval]);

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.tsx
@@ -15,6 +15,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DraftsMultiAreaChartTimeSeriesQuery$data } from './__generated__/DraftsMultiAreaChartTimeSeriesQuery.graphql';
+import { getWidgetInterval } from '../../../../utils/widget/widgetUtils';
 
 const draftsMultiAreaChartTimeSeriesQuery = graphql`
   query DraftsMultiAreaChartTimeSeriesQuery(
@@ -96,7 +97,7 @@ const DraftsMultiAreaChart = ({
     operation: 'count',
     startDate,
     endDate,
-    interval: parameters.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     filters,
   }), [startDate, endDate, parameters.interval, selection, filters]);
 

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.tsx
@@ -15,6 +15,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DraftsMultiLineChartTimeSeriesQuery$data } from './__generated__/DraftsMultiLineChartTimeSeriesQuery.graphql';
+import { getWidgetInterval } from '../../../../utils/widget/widgetUtils';
 
 const draftsMultiLineChartTimeSeriesQuery = graphql`
   query DraftsMultiLineChartTimeSeriesQuery(
@@ -96,7 +97,7 @@ const DraftsMultiLineChart = ({
     operation: 'count',
     startDate,
     endDate,
-    interval: parameters.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     filters,
   }), [startDate, endDate, parameters.interval, selection, filters]);
 

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.tsx
@@ -15,6 +15,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DraftsMultiVerticalBarsTimeSeriesQuery$data } from './__generated__/DraftsMultiVerticalBarsTimeSeriesQuery.graphql';
+import { getWidgetInterval } from '../../../../utils/widget/widgetUtils';
 
 const draftsMultiVerticalBarsTimeSeriesQuery = graphql`
   query DraftsMultiVerticalBarsTimeSeriesQuery(
@@ -96,7 +97,7 @@ const DraftsMultiVerticalBars = ({
     operation: 'count',
     startDate,
     endDate,
-    interval: parameters.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     filters,
   }), [startDate, endDate, parameters.interval, selection, filters]);
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
@@ -13,6 +13,7 @@ import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../..
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiAreaChartTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiAreaChartTimeSeriesQuery.graphql';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiAreaChartTimeSeriesQuery = graphql`
   query StixCoreObjectsMultiAreaChartTimeSeriesQuery(
@@ -122,7 +123,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
@@ -9,7 +9,7 @@ import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas'
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
+import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiAreaChartTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiAreaChartTimeSeriesQuery.graphql';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
@@ -99,6 +99,7 @@ const DATA_SELECTION_TYPES = ['Stix-Core-Object'];
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixCoreObjectsMultiAreaChartTimeSeriesQuery['variables'] => {
   const computed = computeStartEndDates(config);
   const startDate = computed.startDate ?? monthsAgo(12);
@@ -121,7 +122,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -144,6 +145,7 @@ const StixCoreObjectsMultiAreaChart = ({
     refreshRate,
     query: stixCoreObjectsMultiAreaChartTimeSeriesQuery,
     config,
+    parameters,
     buildQueryVariables,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
@@ -101,6 +101,7 @@ const DATA_SELECTION_TYPES = ['Stix-Core-Object'];
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixCoreObjectsMultiHeatMapTimeSeriesQuery['variables'] => {
   const { startDate, endDate } = computeStartEndDates(config);
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
@@ -119,7 +120,7 @@ const buildQueryVariables = (
   return {
     startDate: startDate ?? monthsAgo(12),
     endDate: endDate ?? now(),
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -154,6 +155,7 @@ const StixCoreObjectsMultiHeatMap = ({
     refreshRate,
     query: stixCoreObjectsMultiHeatMapTimeSeriesQuery,
     config,
+    parameters,
     buildQueryVariables,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
@@ -14,6 +14,7 @@ import { monthsAgo, now } from '../../../../utils/Time';
 import ApexCharts from 'apexcharts';
 import { StixCoreObjectsMultiHeatMapTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiHeatMapTimeSeriesQuery.graphql';
 import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiHeatMapTimeSeriesQuery = graphql`
   query StixCoreObjectsMultiHeatMapTimeSeriesQuery(
@@ -120,7 +121,7 @@ const buildQueryVariables = (
   return {
     startDate: startDate ?? monthsAgo(12),
     endDate: endDate ?? now(),
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -13,6 +13,7 @@ import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../..
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiLineChartTimeSeriesQuery } from './__generated__/StixCoreObjectsMultiLineChartTimeSeriesQuery.graphql';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiLineChartTimeSeriesQuery = graphql`
   query StixCoreObjectsMultiLineChartTimeSeriesQuery(
@@ -119,7 +120,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -9,7 +9,7 @@ import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines'
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
+import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiLineChartTimeSeriesQuery } from './__generated__/StixCoreObjectsMultiLineChartTimeSeriesQuery.graphql';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
@@ -96,6 +96,7 @@ const DATA_SELECTION_TYPES = ['Stix-Core-Object'];
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixCoreObjectsMultiLineChartTimeSeriesQuery['variables'] => {
   const computed = computeStartEndDates(config);
   const startDate = computed.startDate ?? monthsAgo(12);
@@ -118,7 +119,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -141,6 +142,7 @@ const StixCoreObjectsMultiLineChart = ({
     refreshRate,
     query: stixCoreObjectsMultiLineChartTimeSeriesQuery,
     config,
+    parameters,
     buildQueryVariables,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import testRender from '../../../../utils/tests/test-render';
+import { emptyFilterGroup } from 'src/utils/filters/filtersUtils';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let lastBuildQueryVariables: ((...args: any[]) => any) | undefined;
+
+vi.mock('../../../../components/dashboard/WidgetContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="widget-container">{children}</div>,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoData', () => ({
+  default: () => <div data-testid="widget-no-data" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetVerticalBars', () => ({
+  default: () => <div data-testid="widget-vertical-bars" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoHostEntity', () => ({
+  default: () => <div data-testid="widget-no-host" />,
+}));
+
+vi.mock('../../../../components/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+  LoaderVariant: { inElement: 'inElement' },
+}));
+
+vi.mock('../../../../components/dashboard/useDashboardViz', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (opts: any) => {
+    lastBuildQueryVariables = opts.buildQueryVariables;
+    return {
+      resolvedDataSelection: [{
+        filters: emptyFilterGroup,
+        date_attribute: 'created_at',
+      }],
+      isMissingHostEntity: false,
+      isPreviewMode: false,
+      queryRef: null,
+    };
+  },
+}));
+
+vi.mock('../../../../components/dashboard/dashboard-viz-utils', () => ({
+  computeStartEndDates: () => ({ startDate: null, endDate: null }),
+}));
+
+vi.mock('../../../../utils/hooks/useGranted', () => ({
+  default: () => true,
+  SETTINGS_SETACCESSES: 'SETTINGS_SETACCESSES',
+}));
+
+import StixCoreObjectsMultiVerticalBars from './StixCoreObjectsMultiVerticalBars';
+
+describe('StixCoreObjectsMultiVerticalBars', () => {
+  const minimalProps = {
+    config: { relativeDate: null, startDate: null, endDate: null },
+    dataSelection: [{
+      filters: emptyFilterGroup,
+      date_attribute: 'created_at',
+    }],
+    parameters: {},
+  };
+
+  beforeEach(() => {
+    lastBuildQueryVariables = undefined;
+  });
+
+  it('renders without crashing', () => {
+    const { container } = testRender(<StixCoreObjectsMultiVerticalBars {...minimalProps} />);
+    expect(container).toBeTruthy();
+  });
+
+  it('passes configured interval to query variables', () => {
+    testRender(
+      <StixCoreObjectsMultiVerticalBars
+        {...minimalProps}
+        parameters={{ interval: 'month' }}
+      />,
+    );
+    expect(lastBuildQueryVariables).toBeDefined();
+    const variables = lastBuildQueryVariables!(
+      [{ filters: emptyFilterGroup, date_attribute: 'created_at' }],
+      { relativeDate: null, startDate: null, endDate: null },
+      { interval: 'month' },
+    );
+    expect(variables.interval).toBe('month');
+  });
+
+  it('defaults interval to day when not specified', () => {
+    testRender(<StixCoreObjectsMultiVerticalBars {...minimalProps} />);
+    expect(lastBuildQueryVariables).toBeDefined();
+    const variables = lastBuildQueryVariables!(
+      [{ filters: emptyFilterGroup, date_attribute: 'created_at' }],
+      { relativeDate: null, startDate: null, endDate: null },
+      {},
+    );
+    expect(variables.interval).toBe('day');
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -8,7 +8,7 @@ import WidgetVerticalBars from '../../../../components/dashboard/WidgetVerticalB
 import Loader, { LoaderVariant } from '../../../../components/Loader';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEntity';
-import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
+import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { StixCoreObjectsMultiVerticalBarsTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiVerticalBarsTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
@@ -98,6 +98,7 @@ const DATA_SELECTION_TYPES = ['Stix-Core-Object'];
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixCoreObjectsMultiVerticalBarsTimeSeriesQuery['variables'] => {
   const computed = computeStartEndDates(config);
   const startDate = computed.startDate ?? monthsAgo(12);
@@ -120,7 +121,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -143,6 +144,7 @@ const StixCoreObjectsMultiVerticalBars = ({
     refreshRate,
     query: stixCoreObjectsMultiVerticalBarsTimeSeriesQuery,
     config,
+    parameters,
     buildQueryVariables,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -13,6 +13,7 @@ import { StixCoreObjectsMultiVerticalBarsTimeSeriesQuery } from '@components/com
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
 import { monthsAgo, now } from '../../../../utils/Time';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiVerticalBarsTimeSeriesQuery = graphql`
   query StixCoreObjectsMultiVerticalBarsTimeSeriesQuery(
@@ -121,7 +122,7 @@ const buildQueryVariables = (
   return {
     startDate,
     endDate,
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.tsx
@@ -12,6 +12,7 @@ import WidgetNoHostEntity from '../../../../components/dashboard/WidgetNoHostEnt
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { StixRelationshipsMultiAreaChartTimeSeriesQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsMultiAreaChartTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixRelationshipsMultiAreaChartTimeSeriesQuery = graphql`
   query StixRelationshipsMultiAreaChartTimeSeriesQuery(
@@ -118,7 +119,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate,
     endDate,
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
@@ -13,6 +13,7 @@ import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../u
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboard-viz-utils';
 import { monthsAgo, now } from '../../../../utils/Time';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixRelationshipsMultiHeatMapTimeSeriesQuery = graphql`
   query StixRelationshipsMultiHeatMapTimeSeriesQuery(
@@ -120,7 +121,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate: startDate ?? monthsAgo(12),
     endDate: endDate ?? now(),
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
@@ -88,6 +88,7 @@ const StixRelationshipsMultiLineChartComponent = ({
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixRelationshipsMultiLineChartTimeSeriesQuery['variables'] => {
   const fallbackStart = monthsAgo(12);
   const fallbackEnd = now();
@@ -113,7 +114,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -148,6 +149,7 @@ const StixRelationshipsMultiLineChart = ({
     refreshRate,
     query: stixRelationshipsMultiLineChartTimeSeriesQuery,
     config,
+    parameters,
     buildQueryVariables,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
@@ -13,6 +13,7 @@ import { StixRelationshipsMultiLineChartTimeSeriesQuery } from '@components/comm
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixRelationshipsMultiLineChartTimeSeriesQuery = graphql`
   query StixRelationshipsMultiLineChartTimeSeriesQuery(
@@ -114,7 +115,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate,
     endDate,
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.test.tsx
@@ -98,4 +98,3 @@ describe('StixRelationshipsMultiVerticalBars', () => {
     expect(variables.interval).toBe('day');
   });
 });
-

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import testRender from '../../../../utils/tests/test-render';
+import { emptyFilterGroup } from 'src/utils/filters/filtersUtils';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let lastBuildQueryVariables: ((...args: any[]) => any) | undefined;
+
+vi.mock('../../../../components/dashboard/WidgetContainer', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="widget-container">{children}</div>,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoData', () => ({
+  default: () => <div data-testid="widget-no-data" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetVerticalBars', () => ({
+  default: () => <div data-testid="widget-vertical-bars" />,
+}));
+
+vi.mock('../../../../components/dashboard/WidgetNoHostEntity', () => ({
+  default: () => <div data-testid="widget-no-host" />,
+}));
+
+vi.mock('../../../../components/Loader', () => ({
+  default: () => <div data-testid="loader" />,
+  LoaderVariant: { inElement: 'inElement' },
+}));
+
+vi.mock('../../../../components/dashboard/useDashboardViz', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: (opts: any) => {
+    lastBuildQueryVariables = opts.buildQueryVariables;
+    return {
+      resolvedDataSelection: [{
+        filters: emptyFilterGroup,
+        date_attribute: 'created_at',
+      }],
+      isMissingHostEntity: false,
+      isPreviewMode: false,
+      queryRef: null,
+    };
+  },
+}));
+
+vi.mock('../../../../components/dashboard/dashboard-types', () => ({}));
+
+vi.mock('../../../../utils/hooks/useGranted', () => ({
+  default: () => true,
+  SETTINGS_SETACCESSES: 'SETTINGS_SETACCESSES',
+}));
+
+import StixRelationshipsMultiVerticalBars from './StixRelationshipsMultiVerticalBars';
+
+describe('StixRelationshipsMultiVerticalBars', () => {
+  const minimalProps = {
+    config: { relativeDate: null, startDate: null, endDate: null },
+    dataSelection: [{
+      filters: emptyFilterGroup,
+      date_attribute: 'created_at',
+    }],
+    parameters: {},
+  };
+
+  beforeEach(() => {
+    lastBuildQueryVariables = undefined;
+  });
+
+  it('renders without crashing', () => {
+    const { container } = testRender(<StixRelationshipsMultiVerticalBars {...minimalProps} />);
+    expect(container).toBeTruthy();
+  });
+
+  it('passes configured interval to query variables', () => {
+    testRender(
+      <StixRelationshipsMultiVerticalBars
+        {...minimalProps}
+        parameters={{ interval: 'month' }}
+      />,
+    );
+    expect(lastBuildQueryVariables).toBeDefined();
+    const variables = lastBuildQueryVariables!(
+      [{ filters: emptyFilterGroup, date_attribute: 'created_at' }],
+      { relativeDate: null, startDate: null, endDate: null },
+      { interval: 'month' },
+    );
+    expect(variables.interval).toBe('month');
+  });
+
+  it('defaults interval to day when not specified', () => {
+    testRender(<StixRelationshipsMultiVerticalBars {...minimalProps} />);
+    expect(lastBuildQueryVariables).toBeDefined();
+    const variables = lastBuildQueryVariables!(
+      [{ filters: emptyFilterGroup, date_attribute: 'created_at' }],
+      { relativeDate: null, startDate: null, endDate: null },
+      {},
+    );
+    expect(variables.interval).toBe('day');
+  });
+});
+

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
@@ -87,6 +87,7 @@ const StixRelationshipsMultiVerticalBarsComponent = ({
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  parameters?: WidgetParameters,
 ): StixRelationshipsMultiVerticalBarsTimeSeriesQuery['variables'] => {
   const fallbackStart = monthsAgo(12);
   const fallbackEnd = now();
@@ -112,7 +113,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate,
     endDate,
-    interval: 'day',
+    interval: parameters?.interval ?? 'day',
     timeSeriesParameters,
   };
 };
@@ -149,6 +150,7 @@ const StixRelationshipsMultiVerticalBars = ({
     refreshRate,
     query: stixRelationshipsMultiVerticalBarsTimeSeriesQuery,
     config,
+    parameters,
     buildQueryVariables,
   });
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
@@ -13,6 +13,7 @@ import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../u
 import { StixRelationshipsMultiVerticalBarsTimeSeriesQuery } from './__generated__/StixRelationshipsMultiVerticalBarsTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixRelationshipsMultiVerticalBarsTimeSeriesQuery = graphql`
   query StixRelationshipsMultiVerticalBarsTimeSeriesQuery(
@@ -113,7 +114,7 @@ const buildQueryVariables = (
     operation: 'count',
     startDate,
     endDate,
-    interval: parameters?.interval ?? 'day',
+    interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationParameters.tsx
@@ -28,7 +28,14 @@ import { useFormatter } from 'src/components/i18n';
 import { findFiltersFromKeys, getEntityTypeThreeFirstLevelsFilterValues, isDraftWorkspaceFilterGroup, SELF_ID, SELF_ID_VALUE } from 'src/utils/filters/filtersUtils';
 import useAttributes from '../../../utils/hooks/useAttributes';
 import type { WidgetColumn, WidgetParameters, WidgetPerspective } from 'src/utils/widget/widget';
-import { getCurrentAvailableParameters, getCurrentCategory, getCurrentIsRelationships, isWidgetListOrTimeline, getMaxResultCount } from 'src/utils/widget/widgetUtils';
+import {
+  getCurrentAvailableParameters,
+  getCurrentCategory,
+  getCurrentIsRelationships,
+  isWidgetListOrTimeline,
+  getMaxResultCount,
+  getWidgetInterval,
+} from 'src/utils/widget/widgetUtils';
 import EntitySelectWithTypes from '../../../components/fields/EntitySelectWithTypes';
 import { FilterGroup } from 'src/utils/filters/filtersHelpers-types';
 import useAuth from '../../../utils/hooks/useAuth';
@@ -406,7 +413,7 @@ const WidgetCreationParameters = () => {
           <Select
             labelId="relative"
             fullWidth={true}
-            value={parameters.interval ?? 'day'}
+            value={getWidgetInterval(parameters)}
             onChange={(event) => handleChangeParameter('interval', event.target.value)
             }
           >

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.test.tsx
@@ -383,9 +383,10 @@ describe('widgetUtils', () => {
   });
 
   describe('getWidgetInterval', () => {
-    it('should return "day" when parameters have no interval set', () => {
+    it('should return "day" when parameters have no interval set or is undefined', () => {
       const params = {} as WidgetParameters;
       expect(getWidgetInterval(params)).toBe('day');
+      expect(getWidgetInterval(undefined)).toBe('day');
     });
 
     it('should return "day" when interval is undefined', () => {

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.test.tsx
@@ -12,8 +12,9 @@ import {
   WidgetVisualizationTypes,
   workspacesWidgetVisualizationTypes,
   fintelTemplatesWidgetVisualizationTypes,
+  getWidgetInterval,
 } from './widgetUtils';
-import type { WidgetDataSelection, WidgetMultiTimeSeries } from './widget';
+import type { WidgetDataSelection, WidgetMultiTimeSeries, WidgetParameters } from './widget';
 
 describe('widgetUtils', () => {
   describe('getCurrentCategory', () => {
@@ -378,6 +379,26 @@ describe('widgetUtils', () => {
 
     it('should return false for empty data selection', () => {
       expect(showEstimationWarningForUniqCount([], [])).toBe(false);
+    });
+  });
+
+  describe('getWidgetInterval', () => {
+    it('should return "day" when parameters have no interval set', () => {
+      const params = {} as WidgetParameters;
+      expect(getWidgetInterval(params)).toBe('day');
+    });
+
+    it('should return "day" when interval is undefined', () => {
+      const params = { interval: undefined } as WidgetParameters;
+      expect(getWidgetInterval(params)).toBe('day');
+    });
+
+    it('should return the configured interval when set', () => {
+      expect(getWidgetInterval({ interval: 'week' } as WidgetParameters)).toBe('week');
+      expect(getWidgetInterval({ interval: 'month' } as WidgetParameters)).toBe('month');
+      expect(getWidgetInterval({ interval: 'quarter' } as WidgetParameters)).toBe('quarter');
+      expect(getWidgetInterval({ interval: 'year' } as WidgetParameters)).toBe('year');
+      expect(getWidgetInterval({ interval: 'day' } as WidgetParameters)).toBe('day');
     });
   });
 

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
@@ -261,7 +261,7 @@ export const isWidgetListOrTimeline = (type: string) => {
 /**
  * Returns the time interval to use in a widget.
  */
-export const getWidgetInterval = (params: WidgetParameters) => params?.interval ?? 'day';
+export const getWidgetInterval = (params?: WidgetParameters) => params?.interval ?? 'day';
 
 export const renderWidgetIcon = (key: string, fontSize: 'large' | 'small' | 'medium') => {
   switch (key) {

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
@@ -18,7 +18,7 @@ import {
 } from 'mdi-material-ui';
 import React from 'react';
 
-import type { WidgetDataSelection, WidgetMultiTimeSeries } from './widget';
+import type { WidgetDataSelection, WidgetMultiTimeSeries, WidgetParameters } from './widget';
 
 const widgetVisualizationTypes = [
   {
@@ -257,6 +257,11 @@ export const getCurrentIsRelationships = (type: string) => {
 export const isWidgetListOrTimeline = (type: string) => {
   return indexedVisualizationTypes[type as WidgetVisualizationTypes]?.key === 'list' || indexedVisualizationTypes[type as WidgetVisualizationTypes]?.key === 'timeline';
 };
+
+/**
+ * Returns the time interval to use in a widget.
+ */
+export const getWidgetInterval = (params: WidgetParameters) => params?.interval ?? 'day';
 
 export const renderWidgetIcon = (key: string, fontSize: 'large' | 'small' | 'medium') => {
   switch (key) {


### PR DESCRIPTION
### Proposed changes
- Take into account the interval selected by the user in the 'parameters' tab instead of always displaying the widget with the 'day' interval for the widgets : vertical bar (entities and relationship perspectives), heat map (entities perspective), line (entities and relationship perspectives), area (entities perspective).

- Add frontend tests for Entities and Relationships vertical bar widgets

<img width="1199" height="498" alt="image" src="https://github.com/user-attachments/assets/5b3771be-8957-4e1e-b552-0963c52cf0ae" />



### Related issues
fixes #17168
fixes #17032
fixes #16857