### PR TITLE
fix(client-python): preserve empty object_refs in report exports (#17175)

### DIFF
--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2316,7 +2316,11 @@ class OpenCTIStix2:
                 ):
                     entity["object_refs"].append(entity_object["standard_id"])
         # OpenCTI permits empty Reports, so retain object_refs for consistency with server-side exports.
-        if entity["type"] == "report" and "object_refs" not in entity and "objects" not in entity:
+        if (
+            entity["type"] == "report"
+            and "object_refs" not in entity
+            and "objects" not in entity
+        ):
             entity["object_refs"] = []
         if "objects" in entity:
             del entity["objects"]

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2316,8 +2316,8 @@ class OpenCTIStix2:
                 ):
                     entity["object_refs"].append(entity_object["standard_id"])
         # OpenCTI permits empty Reports, so retain object_refs for consistency with server-side exports.
-        if not no_custom_attributes and entity["type"] == "report":
-            entity.setdefault("object_refs", [])
+        if entity["type"] == "report" and "object_refs" not in entity and "objects" not in entity:
+            entity["object_refs"] = []
         if "objects" in entity:
             del entity["objects"]
             del entity["objectsIds"]

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -2315,6 +2315,9 @@ class OpenCTIStix2:
                     and "stix-ref-relationship" not in entity_object["parent_types"]
                 ):
                     entity["object_refs"].append(entity_object["standard_id"])
+        # OpenCTI permits empty Reports, so retain object_refs for consistency with server-side exports.
+        if not no_custom_attributes and entity["type"] == "report":
+            entity.setdefault("object_refs", [])
         if "objects" in entity:
             del entity["objects"]
             del entity["objectsIds"]

--- a/client-python/tests/01-unit/utils/test_opencti_stix2.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2.py
@@ -2,12 +2,99 @@ import datetime
 
 import pytest
 
+from pycti import OpenCTIApiClient
 from pycti.utils.opencti_stix2 import OpenCTIStix2
 
 
 @pytest.fixture
 def opencti_stix2(api_client):
     return OpenCTIStix2(api_client)
+
+
+@pytest.fixture
+def offline_opencti_stix2():
+    api_client = OpenCTIApiClient(
+        "http://localhost:4000",
+        "test-token",
+        perform_health_check=False,
+    )
+    yield OpenCTIStix2(api_client)
+    api_client.session.close()
+
+
+def export_entity(opencti_stix2, monkeypatch, entity):
+    monkeypatch.setattr(
+        opencti_stix2,
+        "get_reader",
+        lambda _entity_type: lambda **_kwargs: entity,
+    )
+    monkeypatch.setattr(
+        opencti_stix2.opencti.stix_nested_ref_relationship,
+        "list",
+        lambda **_kwargs: [],
+    )
+
+    return opencti_stix2.get_stix_bundle_or_object_from_entity_id(
+        entity_type=entity["entity_type"],
+        entity_id=entity["id"],
+    )
+
+
+def test_export_empty_report_preserves_object_refs(
+    offline_opencti_stix2: OpenCTIStix2, monkeypatch
+):
+    report = {
+        "id": "internal-report-id",
+        "standard_id": "report--11111111-1111-4111-8111-111111111111",
+        "entity_type": "Report",
+        "parent_types": ["Stix-Domain-Object", "Stix-Core-Object"],
+        "objects": [],
+        "objectsIds": [],
+    }
+
+    bundle = export_entity(offline_opencti_stix2, monkeypatch, report)
+
+    assert bundle["objects"][0]["object_refs"] == []
+
+
+def test_export_populated_report_preserves_object_refs(
+    offline_opencti_stix2: OpenCTIStix2, monkeypatch
+):
+    object_standard_id = "indicator--22222222-2222-4222-8222-222222222222"
+    report = {
+        "id": "internal-report-id",
+        "standard_id": "report--11111111-1111-4111-8111-111111111111",
+        "entity_type": "Report",
+        "parent_types": ["Stix-Domain-Object", "Stix-Core-Object"],
+        "objects": [
+            {
+                "id": "internal-indicator-id",
+                "standard_id": object_standard_id,
+                "entity_type": "Indicator",
+                "parent_types": ["Stix-Domain-Object", "Stix-Core-Object"],
+            }
+        ],
+        "objectsIds": ["internal-indicator-id"],
+    }
+
+    bundle = export_entity(offline_opencti_stix2, monkeypatch, report)
+
+    assert bundle["objects"][0]["object_refs"] == [object_standard_id]
+
+
+def test_export_non_container_does_not_add_object_refs(
+    offline_opencti_stix2: OpenCTIStix2, monkeypatch
+):
+    indicator = {
+        "id": "internal-indicator-id",
+        "standard_id": "indicator--22222222-2222-4222-8222-222222222222",
+        "entity_type": "Indicator",
+        "parent_types": ["Stix-Domain-Object", "Stix-Core-Object"],
+    }
+
+    bundle = export_entity(offline_opencti_stix2, monkeypatch, indicator)
+
+    assert "object_refs" not in bundle["objects"][0]
 
 
 def test_unknown_type(opencti_stix2: OpenCTIStix2, caplog):


### PR DESCRIPTION
### Proposed changes

- Preserve `object_refs: []` when exporting an empty Report through the Python client.
- Add regression coverage for empty Reports, populated Reports and unrelated non-container objects.

### Related issues

- Closes #17175
- Fixes OpenCTI-Platform/connectors#5398
- aligns the Python-client export path with the server-side behaviour introduced for #9831

### How to test this PR

`pytest tests/01-unit/utils/test_opencti_stix2.py -q -k "export_empty_report_preserves_object_refs or export_populated_report_preserves_object_refs or export_non_container_does_not_add_object_refs"`

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)

### Further comments

The connector itself does not construct the bundle. It delegates the operation to `pycti` so preserving the field in `prepare_export()` fixes the shared export path without a connector-specific bandaid-fix.
