### PR TITLE
fix(dashboard): Not implemented widgets display (#16472)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardAuditsViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardAuditsViz.tsx
@@ -15,6 +15,7 @@ import AuditsWordCloud from '@components/common/audits/AuditsWordCloud';
 import { computeRelativeDate, dayStartDate, formatDate } from '../../utils/Time';
 import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
+import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
 
 interface DashboardAuditsVizProps {
   widget: Widget;
@@ -237,7 +238,9 @@ const DashboardAuditsViz = ({
         />
       );
     default:
-      return 'Not implemented yet';
+      return (
+        <WidgetNotImplemented popover={popover} />
+      );
   }
 };
 

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardAuditsViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardAuditsViz.tsx
@@ -15,7 +15,7 @@ import AuditsWordCloud from '@components/common/audits/AuditsWordCloud';
 import { computeRelativeDate, dayStartDate, formatDate } from '../../utils/Time';
 import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
-import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
+import WidgetNotImplemented from './WidgetNotImplemented';
 
 interface DashboardAuditsVizProps {
   widget: Widget;

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardEntitiesViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardEntitiesViz.tsx
@@ -27,7 +27,7 @@ import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
 import { isDraftWorkspaceFilterGroup } from '../../utils/filters/filtersUtils';
 import useHelper from '../../utils/hooks/useHelper';
-import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
+import WidgetNotImplemented from './WidgetNotImplemented';
 
 interface DashboardEntitiesVizProps {
   widget: Widget;

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardEntitiesViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardEntitiesViz.tsx
@@ -27,6 +27,7 @@ import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
 import { isDraftWorkspaceFilterGroup } from '../../utils/filters/filtersUtils';
 import useHelper from '../../utils/hooks/useHelper';
+import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
 
 interface DashboardEntitiesVizProps {
   widget: Widget;
@@ -383,7 +384,9 @@ const DashboardEntitiesViz = ({
         />
       );
     default:
-      return 'Not implemented yet';
+      return (
+        <WidgetNotImplemented popover={popover} />
+      );
   }
 };
 

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardRawViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardRawViz.tsx
@@ -4,6 +4,7 @@ import type { Widget, WidgetHost } from 'src/utils/widget/widget';
 import StixCoreObjectsCustomAttributes from '@components/common/stix_core_objects/StixCoreObjectsCustomAttributes';
 import type { DashboardConfig } from './dashboard-types';
 import { computeStartEndDates } from 'src/components/dashboard/dashboard-viz-utils';
+import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
 
 interface DashboardRawVizProps {
   widget: Widget;
@@ -44,7 +45,9 @@ const DashboardRawViz = ({
         />
       );
     default:
-      return 'Not implemented yet';
+      return (
+        <WidgetNotImplemented popover={popover} />
+      );
   }
 };
 

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardRawViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardRawViz.tsx
@@ -4,7 +4,7 @@ import type { Widget, WidgetHost } from 'src/utils/widget/widget';
 import StixCoreObjectsCustomAttributes from '@components/common/stix_core_objects/StixCoreObjectsCustomAttributes';
 import type { DashboardConfig } from './dashboard-types';
 import { computeStartEndDates } from 'src/components/dashboard/dashboard-viz-utils';
-import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
+import WidgetNotImplemented from './WidgetNotImplemented';
 
 interface DashboardRawVizProps {
   widget: Widget;

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardRelationshipsViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardRelationshipsViz.tsx
@@ -17,7 +17,7 @@ import StixRelationshipsMap from '../../private/components/common/stix_relations
 import StixRelationshipsWordCloud from '../../private/components/common/stix_relationships/StixRelationshipsWordCloud';
 import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
-import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
+import WidgetNotImplemented from './WidgetNotImplemented';
 
 interface DashboardRelationshipsVizProps {
   widget: Widget;

--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardRelationshipsViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardRelationshipsViz.tsx
@@ -17,6 +17,7 @@ import StixRelationshipsMap from '../../private/components/common/stix_relations
 import StixRelationshipsWordCloud from '../../private/components/common/stix_relationships/StixRelationshipsWordCloud';
 import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
+import WidgetNotImplemented from 'src/components/dashboard/WidgetNotImplemented';
 
 interface DashboardRelationshipsVizProps {
   widget: Widget;
@@ -251,7 +252,9 @@ const DashboardRelationshipsViz = ({
         />
       );
     default:
-      return 'Not implemented yet';
+      return (
+        <WidgetNotImplemented popover={popover} />
+      );
   }
 };
 

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetNotImplemented.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetNotImplemented.tsx
@@ -1,0 +1,19 @@
+import WidgetContainer from 'src/components/dashboard/WidgetContainer';
+import { useFormatter } from 'src/components/i18n';
+import { ReactNode } from 'react';
+import WidgetNoData from 'src/components/dashboard/WidgetNoData';
+
+interface WidgetNotImplementedProps {
+  popover: ReactNode;
+}
+
+const WidgetNotImplemented = ({ popover }: WidgetNotImplementedProps) => {
+  const { t_i18n } = useFormatter();
+  return (
+    <WidgetContainer action={popover}>
+      <WidgetNoData message={t_i18n('Not implemented yet')} />
+    </WidgetContainer>
+  );
+};
+
+export default WidgetNotImplemented;

--- a/opencti-platform/opencti-front/src/components/dashboard/WidgetNotImplemented.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/WidgetNotImplemented.tsx
@@ -1,7 +1,7 @@
-import WidgetContainer from 'src/components/dashboard/WidgetContainer';
-import { useFormatter } from 'src/components/i18n';
 import { ReactNode } from 'react';
-import WidgetNoData from 'src/components/dashboard/WidgetNoData';
+import WidgetContainer from './WidgetContainer';
+import WidgetNoData from './WidgetNoData';
+import { useFormatter } from '../i18n';
 
 interface WidgetNotImplementedProps {
   popover: ReactNode;


### PR DESCRIPTION
### Proposed changes
- Not implemented widgets should have the same actions possible as other widgets: be updatable, deletable, exportable
- Not implemented widgets should be displayed in the same wrapper as other widgets (design)

### Related issues
closes #16472

### Screenshots
- Before
<img width="713" height="298" alt="image" src="https://github.com/user-attachments/assets/5baa5082-db03-4c8e-b72d-222806987fa7" />


- After
<img width="930" height="503" alt="image" src="https://github.com/user-attachments/assets/53c586af-976b-404b-8f67-921416c0847b" />
