### PR TITLE
fix(dashboard): Fix number widget undefined title (#16456)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsNumber.tsx
@@ -20,10 +20,9 @@ import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
-import useEntityTranslation from '../../../../utils/hooks/useEntityTranslation';
 import WidgetNumber from '../../../../components/dashboard/WidgetNumber';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
-import { UNIQUE_COUNT_ESTIMATION_THRESHOLD, UNIQUE_COUNT_ESTIMATION_WARNING } from '../../../../utils/widget/widgetUtils';
+import { UNIQUE_COUNT_ESTIMATION_THRESHOLD, UNIQUE_COUNT_ESTIMATION_WARNING, useGetNumberWidgetTitle } from '../../../../utils/widget/widgetUtils';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
@@ -126,7 +125,6 @@ const AuditsNumber: FunctionComponent<AuditsNumberProps> = ({
 }) => {
   const [showWarning, setShowWarning] = useState(false);
   const { t_i18n } = useFormatter();
-  const { translateEntityType } = useEntityTranslation();
 
   const buildQueryVariables = useCallback((resolvedDataSelection: WidgetDataSelection[]): AuditsNumberNumberSeriesQuery['variables'] => {
     const selection = resolvedDataSelection[0];
@@ -158,9 +156,8 @@ const AuditsNumber: FunctionComponent<AuditsNumberProps> = ({
     parameters,
     buildQueryVariables,
   });
-
-  const title = parameters.title ?? t_i18n('Audits number');
-  const translatedTitle = translateEntityType(title);
+  const DEFAULT_TITLE = t_i18n('Audits number');
+  const translatedNumberLabel = useGetNumberWidgetTitle(parameters, DEFAULT_TITLE);
 
   const selection = resolvedDataSelection[0];
   const warning = showWarning ? t_i18n(UNIQUE_COUNT_ESTIMATION_WARNING) : undefined;
@@ -169,7 +166,7 @@ const AuditsNumber: FunctionComponent<AuditsNumberProps> = ({
     <WidgetContainer
       padding="medium"
       height={height}
-      title={t_i18n('Entities number')}
+      title={DEFAULT_TITLE}
       variant={variant}
       action={popover}
       showPreviewTag={isPreviewMode}
@@ -184,7 +181,7 @@ const AuditsNumber: FunctionComponent<AuditsNumberProps> = ({
         <AuditsNumberComponent
           queryRef={queryRef!}
           entityType={entityType}
-          label={translatedTitle}
+          label={translatedNumberLabel}
           isUnique={Boolean(selection.unique)}
           onShowWarning={setShowWarning}
         />

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, ReactNode, useEffect, useRef, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
@@ -7,12 +7,12 @@ import { computeStartEndDates } from '../../../../components/dashboard/dashboard
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
-import useEntityTranslation from '../../../../utils/hooks/useEntityTranslation';
 import WidgetNumber from '../../../../components/dashboard/WidgetNumber';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
 import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DraftsNumberQuery } from './__generated__/DraftsNumberQuery.graphql';
+import { useGetNumberWidgetTitle } from 'src/utils/widget/widgetUtils';
 
 const draftsNumberQuery = graphql`
   query DraftsNumberQuery(
@@ -58,17 +58,16 @@ const buildQueryVariables = (
 
 interface DraftsNumberComponentProps {
   queryRef: PreloadedQuery<DraftsNumberQuery>;
-  parameters?: WidgetParameters;
   entityType?: string;
+  label: string;
 }
 
 const DraftsNumberComponent = ({
   queryRef,
-  parameters,
   entityType,
+  label,
 }: DraftsNumberComponentProps) => {
   const { t_i18n } = useFormatter();
-  const { translateEntityType } = useEntityTranslation();
   const data = usePreloadedQuery(draftsNumberQuery, queryRef);
 
   if (!data?.draftWorkspacesNumber) {
@@ -76,13 +75,11 @@ const DraftsNumberComponent = ({
   }
 
   const { total, count } = data.draftWorkspacesNumber;
-  const title = parameters?.title ?? t_i18n('Draft workspaces number');
-  const translatedTitle = translateEntityType(title);
 
   return (
     <WidgetNumber
       entityType={entityType}
-      label={translatedTitle}
+      label={label}
       value={total}
       diffLabel={t_i18n('24 hours')}
       diffValue={total - count}
@@ -115,6 +112,9 @@ const DraftsNumber = ({
 }: DraftsNumberProps) => {
   const { t_i18n } = useFormatter();
 
+  const DEFAULT_TITLE = t_i18n('Draft workspaces number');
+  const translatedNumberLabel = useGetNumberWidgetTitle(parameters, DEFAULT_TITLE);
+
   const { isMissingHostEntity, isMissingSavedFilters, isPreviewMode, queryRef } = useDashboardViz<DraftsNumberQuery>({
     perspective: 'entities',
     dataSelection,
@@ -129,7 +129,7 @@ const DraftsNumber = ({
     <WidgetContainer
       padding="medium"
       height={height}
-      title={t_i18n('Draft workspaces number')}
+      title={DEFAULT_TITLE}
       variant={variant}
       action={popover}
       showPreviewTag={isPreviewMode}
@@ -142,8 +142,8 @@ const DraftsNumber = ({
       >
         <DraftsNumberComponent
           queryRef={queryRef!}
-          parameters={parameters}
           entityType={entityType}
+          label={translatedNumberLabel}
         />
       </WidgetRenderContent>
     </WidgetContainer>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsNumber.tsx
@@ -4,7 +4,6 @@ import { dayAgo } from '../../../../utils/Time';
 import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
-import useEntityTranslation from '../../../../utils/hooks/useEntityTranslation';
 import WidgetNumber from '../../../../components/dashboard/WidgetNumber';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
@@ -13,6 +12,7 @@ import { StixCoreObjectsNumberNumberSeriesQuery } from './__generated__/StixCore
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
 import { ReactNode } from 'react';
+import { useGetNumberWidgetTitle } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsNumberNumberQuery = graphql`
     query StixCoreObjectsNumberNumberSeriesQuery(
@@ -115,10 +115,9 @@ const StixCoreObjectsNumber = ({
   host,
 }: StixCoreObjectsNumberProps) => {
   const { t_i18n } = useFormatter();
-  const { translateEntityType } = useEntityTranslation();
+  const DEFAULT_TITLE = t_i18n('Entities number');
 
-  const title = parameters.title ?? t_i18n('Entities number');
-  const translatedTitle = translateEntityType(title);
+  const translatedNumberLabel = useGetNumberWidgetTitle(parameters, DEFAULT_TITLE);
 
   const { isMissingHostEntity, isMissingSavedFilters, isPreviewMode, queryRef } = useDashboardViz<StixCoreObjectsNumberNumberSeriesQuery>({
     perspective: 'entities',
@@ -134,7 +133,7 @@ const StixCoreObjectsNumber = ({
     <WidgetContainer
       padding="medium"
       height={height}
-      title={t_i18n('Entities number')}
+      title={DEFAULT_TITLE}
       variant={variant}
       action={popover}
       showPreviewTag={isPreviewMode}
@@ -149,7 +148,7 @@ const StixCoreObjectsNumber = ({
           <StixCoreObjectsNumberComponent
             queryRef={queryRef!}
             entityType={entityType}
-            label={translatedTitle}
+            label={translatedNumberLabel}
           />
         </WidgetRenderContent>
       </div>

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
@@ -4,7 +4,6 @@ import { dayAgo } from '../../../../utils/Time';
 import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
-import useEntityTranslation from '../../../../utils/hooks/useEntityTranslation';
 import WidgetNumber from '../../../../components/dashboard/WidgetNumber';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
@@ -12,6 +11,7 @@ import { StixRelationshipsNumberNumberSeriesQuery } from '@components/common/sti
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { ReactNode } from 'react';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { useGetNumberWidgetTitle } from 'src/utils/widget/widgetUtils';
 
 const stixRelationshipsNumberNumberQuery = graphql`
     query StixRelationshipsNumberNumberSeriesQuery(
@@ -63,17 +63,16 @@ const stixRelationshipsNumberNumberQuery = graphql`
 interface StixRelationshipsNumberComponentProps {
   queryRef: PreloadedQuery<StixRelationshipsNumberNumberSeriesQuery>;
   dataSelection: WidgetDataSelection[];
-  parameters?: WidgetParameters;
   entityType?: string;
+  label: string;
 }
 
 const StixRelationshipsNumberComponent = ({
   queryRef,
-  parameters,
   entityType,
+  label,
 }: StixRelationshipsNumberComponentProps) => {
   const { t_i18n } = useFormatter();
-  const { translateEntityType } = useEntityTranslation();
   const data = usePreloadedQuery(
     stixRelationshipsNumberNumberQuery,
     queryRef,
@@ -83,13 +82,11 @@ const StixRelationshipsNumberComponent = ({
     return <WidgetNoData />;
   }
   const { total, count } = data.stixRelationshipsNumber;
-  const title = parameters?.title ?? t_i18n('Entities number');
-  const translatedTitle = translateEntityType(title);
 
   return (
     <WidgetNumber
       entityType={entityType}
-      label={translatedTitle}
+      label={label}
       value={total}
       diffLabel={t_i18n('24 hours')}
       diffValue={total - count}
@@ -147,6 +144,9 @@ const StixRelationshipsNumber = ({
 }: StixRelationshipsNumberProps) => {
   const { t_i18n } = useFormatter();
 
+  const DEFAULT_TITLE = t_i18n('Relationships number');
+  const translatedNumberLabel = useGetNumberWidgetTitle(parameters, DEFAULT_TITLE);
+
   const { resolvedDataSelection, isMissingHostEntity, isMissingSavedFilters, isPreviewMode, queryRef } = useDashboardViz<StixRelationshipsNumberNumberSeriesQuery>({
     perspective: 'relationships',
     dataSelection,
@@ -161,7 +161,7 @@ const StixRelationshipsNumber = ({
     <WidgetContainer
       padding="medium"
       height={height}
-      title={t_i18n('Relationships number')}
+      title={DEFAULT_TITLE}
       variant={variant}
       action={popover}
       showPreviewTag={isPreviewMode}
@@ -175,8 +175,8 @@ const StixRelationshipsNumber = ({
         <StixRelationshipsNumberComponent
           queryRef={queryRef!}
           dataSelection={resolvedDataSelection}
-          parameters={parameters}
           entityType={entityType}
+          label={translatedNumberLabel}
         />
       </WidgetRenderContent>
     </WidgetContainer>

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntityTranslation.test.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntityTranslation.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import useEntityTranslation from './useEntityTranslation';
+
+// Mock translations: only some keys have a translation.
+const translations: Record<string, string> = {
+  entity_Malware: 'Logiciel malveillant',
+  entity_Report: 'Rapport',
+  relationship_targets: 'cible',
+};
+
+vi.mock('../../components/i18n', () => ({
+  useFormatter: () => ({
+    t_i18n: (key: string) => translations[key] ?? key,
+  }),
+}));
+
+describe('useEntityTranslation', () => {
+  const setup = () => renderHook(() => useEntityTranslation());
+
+  describe('translateEntityType', () => {
+    it('should return entity translation when entity_ prefix matches', () => {
+      const { result } = setup();
+      expect(result.current.translateEntityType('Malware')).toBe('Logiciel malveillant');
+      expect(result.current.translateEntityType('Report')).toBe('Rapport');
+    });
+
+    it('should return relationship translation when relationship_ prefix matches', () => {
+      const { result } = setup();
+      expect(result.current.translateEntityType('targets')).toBe('cible');
+    });
+
+    it('should fall back to t_i18n(type) when neither entity_ nor relationship_ prefix matches', () => {
+      const { result } = setup();
+      // 'unknown-type' has no entity_ or relationship_ translation,
+      // so it falls through to t_i18n('unknown-type') which returns the key itself.
+      expect(result.current.translateEntityType('unknown-type')).toBe('unknown-type');
+    });
+
+    it('should return the input as-is for an empty string', () => {
+      const { result } = setup();
+      expect(result.current.translateEntityType('')).toBe('');
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/hooks/useEntityTranslation.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useEntityTranslation.ts
@@ -4,6 +4,9 @@ const useEntityTranslation = () => {
   const { t_i18n } = useFormatter();
 
   const translateEntityType = (type: string) => {
+    if (type === '') {
+      return type;
+    }
     if (t_i18n(`entity_${type}`) !== `entity_${type}`) {
       return t_i18n(`entity_${type}`);
     }

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import {
   getCurrentCategory,
   getCurrentAvailableParameters,
@@ -13,8 +14,15 @@ import {
   workspacesWidgetVisualizationTypes,
   fintelTemplatesWidgetVisualizationTypes,
   getWidgetInterval,
+  useGetNumberWidgetTitle,
 } from './widgetUtils';
 import type { WidgetDataSelection, WidgetMultiTimeSeries, WidgetParameters } from './widget';
+
+vi.mock('src/utils/hooks/useEntityTranslation', () => ({
+  default: () => ({
+    translateEntityType: (label: string) => `translated_${label}`,
+  }),
+}));
 
 describe('widgetUtils', () => {
   describe('getCurrentCategory', () => {
@@ -427,6 +435,28 @@ describe('widgetUtils', () => {
       ];
 
       expect(validTypes.length).toBe(18);
+    });
+  });
+
+  describe('useGetNumberWidgetTitle', () => {
+    it('should return translated custom title when parameters.title is set', () => {
+      const { result } = renderHook(() => useGetNumberWidgetTitle({ title: 'My Custom Title' } as WidgetParameters, 'Default'));
+      expect(result.current).toBe('translated_My Custom Title');
+    });
+
+    it('should return translated default title when parameters.title is empty', () => {
+      const { result } = renderHook(() => useGetNumberWidgetTitle({ title: '' } as WidgetParameters, 'Fallback Title'));
+      expect(result.current).toBe('translated_Fallback Title');
+    });
+
+    it('should return translated default title when parameters.title is null', () => {
+      const { result } = renderHook(() => useGetNumberWidgetTitle({ title: null } as WidgetParameters, 'Default Title'));
+      expect(result.current).toBe('translated_Default Title');
+    });
+
+    it('should return translated default title when parameters.title is undefined', () => {
+      const { result } = renderHook(() => useGetNumberWidgetTitle({} as WidgetParameters, 'Number of entities'));
+      expect(result.current).toBe('translated_Number of entities');
     });
   });
 });

--- a/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/widget/widgetUtils.tsx
@@ -19,6 +19,8 @@ import {
 import React from 'react';
 
 import type { WidgetDataSelection, WidgetMultiTimeSeries, WidgetParameters } from './widget';
+import { isNotEmptyField } from '../utils';
+import useEntityTranslation from 'src/utils/hooks/useEntityTranslation';
 
 const widgetVisualizationTypes = [
   {
@@ -262,6 +264,15 @@ export const isWidgetListOrTimeline = (type: string) => {
  * Returns the time interval to use in a widget.
  */
 export const getWidgetInterval = (params?: WidgetParameters) => params?.interval ?? 'day';
+
+/**
+ * Construct the label title for a number widget.
+ */
+export const useGetNumberWidgetTitle = (parameters: WidgetParameters, defaultTitle: string) => {
+  const { translateEntityType } = useEntityTranslation();
+  const numberLabel = isNotEmptyField(parameters.title) ? parameters.title : defaultTitle;
+  return translateEntityType(numberLabel);
+};
 
 export const renderWidgetIcon = (key: string, fontSize: 'large' | 'small' | 'medium') => {
   switch (key) {


### PR DESCRIPTION
### Proposed changes
When a user remove the title of a widget of type Number, we should not have an error, and a default title (depending on the perspective) should be displayed instead

Add tests for useEntityTranslation

<img width="668" height="263" alt="image" src="https://github.com/user-attachments/assets/56dfe044-b6ff-4e7d-a3ce-cd4ae0aac4cb" />


### Related issues
closes #16456