### PR TITLE
fix: refs should stay restricted after entity update (#17233)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -17,6 +17,7 @@ import { INPUT_OBJECTS } from '../schema/general';
 import { enrichWithRemoteCredentials } from '../config/credentials';
 import type { ExclusionListCacheItem } from './exclusionListCache';
 import { refreshLocalCacheForEntity } from './cache';
+import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 
 const USE_SSL = booleanConf('redis:use_ssl', false);
 const REDIS_CA = conf.get('redis:ca').map((path: string) => loadCert(path));
@@ -340,9 +341,9 @@ export const notify = async (topic: string, instance: any, user: AuthUser) => {
     // Resolved object_refs must be dissoc from original objects as not directly used for live update
     // and can imply very large event message
     if (Array.isArray(instance)) {
-      data = (instance as any[]).map((i) => R.dissoc(INPUT_OBJECTS, i));
+      data = (instance as any[]).map(removeResolvedRefs);
     } else {
-      data = R.dissoc(INPUT_OBJECTS, instance);
+      data = removeResolvedRefs(instance);
     }
     // Direct refresh the current instance cache
     await refreshLocalCacheForEntity(topic, data as unknown as BasicStoreCommon);
@@ -350,6 +351,11 @@ export const notify = async (topic: string, instance: any, user: AuthUser) => {
     await getClientPubSub().publish(topic, { instance: data, user });
   }
   return instance;
+};
+
+export const removeResolvedRefs = (instance: any) => {
+  const refInputNames = new Set([INPUT_OBJECTS, ...schemaRelationsRefDefinition.getAllInputNames()]);
+  return Object.fromEntries(Object.entries(instance).filter(([k]) => !refInputNames.has(k)));
 };
 
 // region user context (clientContext)

--- a/opencti-platform/opencti-graphql/src/resolvers/stix.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stix.js
@@ -20,7 +20,7 @@ const internalLoadThroughDenormalized = (context, user, element, inputName) => {
       return []; // Granted_refs are not part of all core entities
     }
   }
-  if (element[inputName] && inputName !== INPUT_CREATED_BY) {
+  if (element[inputName]) {
     // if element is already loaded, just send the data
     return element[inputName];
   }

--- a/opencti-platform/opencti-graphql/src/resolvers/stix.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stix.js
@@ -3,7 +3,7 @@ import { sendStixBundle, stixDelete, stixObjectMerge } from '../domain/stix';
 import { stixLoadByIdStringify } from '../database/middleware';
 import { connectorsForEnrichment } from '../database/repository';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
-import { INPUT_CREATED_BY, INPUT_GRANTED_REFS } from '../schema/general';
+import { INPUT_GRANTED_REFS } from '../schema/general';
 import { isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT, REDACTED_USER } from '../utils/access';
 import { ENABLED_DEMO_MODE } from '../config/conf';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';

--- a/opencti-platform/opencti-graphql/src/resolvers/stix.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/stix.js
@@ -3,7 +3,7 @@ import { sendStixBundle, stixDelete, stixObjectMerge } from '../domain/stix';
 import { stixLoadByIdStringify } from '../database/middleware';
 import { connectorsForEnrichment } from '../database/repository';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
-import { INPUT_GRANTED_REFS } from '../schema/general';
+import { INPUT_CREATED_BY, INPUT_GRANTED_REFS } from '../schema/general';
 import { isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT, REDACTED_USER } from '../utils/access';
 import { ENABLED_DEMO_MODE } from '../config/conf';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
@@ -20,7 +20,7 @@ const internalLoadThroughDenormalized = (context, user, element, inputName) => {
       return []; // Granted_refs are not part of all core entities
     }
   }
-  if (element[inputName]) {
+  if (element[inputName] && inputName !== INPUT_CREATED_BY) {
     // if element is already loaded, just send the data
     return element[inputName];
   }

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
@@ -1,4 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/schema/schema-relationsRef', () => ({
+  schemaRelationsRefDefinition: {
+    getAllInputNames: vi.fn(() => ['createdBy', 'objectMarking', 'objectLabel']),
+  },
+}));
+
+import { removeResolvedRefs } from '../../../src/database/redis';
 import { generateClusterNodes, generateNatMap } from '../../../src/database/redis';
 
 describe('redis', () => {
@@ -23,5 +31,32 @@ describe('redis', () => {
     expect(second.at(0)).toBe('10.0.1.231:30001');
     expect(second.at(1).host).toBe('203.0.113.73');
     expect(second.at(1).port).toBe(30002);
+  });
+});
+
+describe('removeResolvedRefs', () => {
+  it('should strip resolved ref fields and INPUT_OBJECTS', () => {
+    const instance = {
+      id: 'malware-1',
+      name: 'MalwareA',
+      'created-by': 'identity-1',
+      createdBy: { id: 'identity-1' },
+      'object-marking': ['marking-1'],
+      objectMarking: [{ definition: 'TLP:RED' }],
+      objectLabel: [{ value: 'malware' }],
+      objects: [{ id: 'obj-1' }],
+    };
+
+    expect(removeResolvedRefs(instance)).toEqual({
+      id: 'malware-1',
+      name: 'MalwareA',
+      'created-by': 'identity-1',
+      'object-marking': ['marking-1'],
+    });
+  });
+
+  it('should keep all fields when there are no resolved refs', () => {
+    const instance = { id: 'a', name: 'B', description: 'C' };
+    expect(removeResolvedRefs(instance)).toEqual(instance);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removes refs from instance when notify
*

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17233 

### How to test this PR
* Connect OpenCTI on 2 browsers with 2 different users (UserA and UserB)
* On each one go to the same malware (malware need to have markings and creators)
* UserA is admin and UserB can see the malware but not its Author, Restricted is displayed
* With UserA, update the description
* With UserB, you have received the new description, and can now see the Author

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
