### PR TITLE
feat(filters): Saved filters in dashboard FF (#15689)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetFilters.tsx
@@ -181,9 +181,11 @@ const WidgetFilters: FunctionComponent<WidgetFiltersProps> = ({ perspective, typ
                 helpers={helpers}
                 searchContext={type === 'bookmark' ? undefined : searchContext}
               />
-              <Divider orientation="vertical" flexItem />
               {isSavedFiltersAccessible && (
-                <WidgetSavedFiltersIcon onClick={handleSwitchToSavedFilter} />
+                <>
+                  <Divider orientation="vertical" flexItem />
+                  <WidgetSavedFiltersIcon onClick={handleSwitchToSavedFilter} />
+                </>
               )}
             </>
           )}


### PR DESCRIPTION
### Proposed changes
The divider between 'clean filters' and 'add saved filters' buttons should be under FF

### Related issues
partially closes #15689