### PR TITLE
fix(ci): use event payload instead of external action for PR title checks (#17234)

### DIFF
--- a/.github/workflows/pr-check-conventions.yml
+++ b/.github/workflows/pr-check-conventions.yml
@@ -16,11 +16,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Slashgear/action-check-pr-title@76166c63ec0b25cdbe693e5e972e83ca186313fb
-        with:
-          regexp: '^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z0-9._/-]+\))?!?: .+ \(#[0-9]+(, ?#[0-9]+)*\)$'
-          flags: "gm"
-          helpMessage: "Format: 'type(scope?): description (#issue)' for example 'docs: updating a doc page (#1234)'. see https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md#how-can-you-contribute"
+      - name: Check PR title matches convention
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          PATTERN='^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z0-9._/-]+\))?!?: .+ \(#[0-9]+(, ?#[0-9]+)*\)$'
+          if ! echo "$PR_TITLE" | grep -Pq "$PATTERN"; then
+            echo "::error::PR title does not match convention: '$PR_TITLE'"
+            echo "Format: 'type(scope?): description (#issue)' for example 'docs: updating a doc page (#1234)'. see https://github.com/OpenCTI-Platform/opencti/blob/master/CONTRIBUTING.md#how-can-you-contribute"
+            exit 1
+          fi
+          echo "PR title is valid: '$PR_TITLE'"
 
   check-signed-commits:
     name: Check signed commits in PR


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* remove market place action that is not usable for forks
* use data from the event payload instead

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17234 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

We need to merge it first.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
