### PR TITLE
fix(ux): cannot load entities/observables anymore when there is a large number of them (#13437)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjects.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import IconButton from '@common/button/IconButton';
 import Fab from '@mui/material/Fab';
 import { Add } from '@mui/icons-material';
@@ -141,7 +141,6 @@ const ContainerAddStixCoreObjects = (props) => {
   } = viewStorage;
   const contextFilters = useBuildEntityTypeBasedFilterContext(targetStixCoreObjectTypes, filters);
 
-  const containerRef = useRef(null);
   const [mappingSearch, setMappingSearch] = useState(null);
   const [currentSelectedText, setCurrentSelectedText] = useState(selectedText);
   if (currentSelectedText !== selectedText) {
@@ -350,7 +349,7 @@ const ContainerAddStixCoreObjects = (props) => {
       >
         <QueryRenderer
           query={containerAddStixCoreObjectsLinesQuery}
-          variables={{ count: 100, ...searchPaginationOptions }}
+          variables={{ count: 25, ...searchPaginationOptions }}
           render={({ props: renderProps }) => (
             <ContainerAddStixCoreObjectsLines
               data={renderProps}
@@ -364,7 +363,6 @@ const ContainerAddStixCoreObjects = (props) => {
               onDelete={onDelete}
               setNumberOfElements={helpers.handleSetNumberOfElements}
               mapping={mapping}
-              containerRef={containerRef}
               enableReferences={enableReferences}
               onLabelClick={helpers.handleAddFilter}
             />
@@ -430,7 +428,6 @@ const ContainerAddStixCoreObjects = (props) => {
           }
         }}
         title={t_i18n('Add entities')}
-        containerRef={containerRef}
       >
         <>
           {renderSearchResults(searchPaginationOptions)}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
@@ -274,7 +274,7 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
     <ListItem
       classes={{ root: classes.item }}
       divider={true}
-      style={{ minWidth: 40 }}
+      style={{ minWidth: 40, paddingLeft: 20 }}
     >
       <ListItemIcon
         classes={{ root: classes.itemIconDisabled }}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLines.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLines.jsx
@@ -292,7 +292,7 @@ class ContainerAddStixCoreObjectsLinesComponent extends Component {
   }
 
   render() {
-    const { initialLoading, dataColumns, relay, containerRef, enableReferences, containerId } = this.props;
+    const { initialLoading, dataColumns, relay, enableReferences, containerId } = this.props;
     const { addedStixCoreObjects, referenceDialogOpened } = this.state;
     const dataList = R.pathOr([], ['stixCoreObjects', 'edges'], this.props.data);
     const computedAddedStixCoreObjects = {};
@@ -325,7 +325,6 @@ class ContainerAddStixCoreObjectsLinesComponent extends Component {
           addedElements={computedAddedStixCoreObjects}
           onToggleEntity={this.stixCoreObjectToggled.bind(this)}
           disableExport={true}
-          containerRef={containerRef}
         />
         {enableReferences && (
           <Formik
@@ -371,7 +370,6 @@ ContainerAddStixCoreObjectsLinesComponent.propTypes = {
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,
   mapping: PropTypes.bool,
-  containerRef: PropTypes.object,
   enableReferences: PropTypes.bool,
   onLabelClick: PropTypes.func,
 };


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* handle infinite scroll pagination on add entity/observable
* fix dummy placeholder line padding

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #13437

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
