### PR TITLE
feat(merge-users): improve user footprint dry-run (#17258)

### DIFF
--- a/opencti-platform/opencti-graphql/builder/dev/dev.js
+++ b/opencti-platform/opencti-graphql/builder/dev/dev.js
@@ -32,6 +32,7 @@ esbuild.build({
         'script/script-clean-relations.js',
         'script/script-insert-dataset.js',
         'script/script-wait-for-api.js',
+        'script/script-user-footprint.js',
         'src/utils/safeEjs.worker.ts'
     ],
     entryNames: '[name]',

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -35,6 +35,7 @@
     "test": "vitest --silent --bail 1 run --config vitest.config.integration.ts --coverage",
     "verify-licenses": "yarn license-checker-rseidelsohn --production --summary --onlyAllow '0BSD;Apache-2.0;BlueOak-1.0.0;BSD-2-Clause;BSD-3-Clause;CC-BY-3.0;CC-BY-4.0;CC0-1.0;Hippocratic-2.1;ISC;LGPL-3.0;MIT;OFL-1.1;Python-2.0;Unlicense;UNLICENSED' --excludePackagesStartingWith 'opencti'",
     "wait-api": "node build/script-wait-for-api.js",
+    "poc:user-footprint": "node build/script-user-footprint.js",
     "get-connectors-manifest": "node script/get-connectors-manifest.js"
   },
   "pkg": {

--- a/opencti-platform/opencti-graphql/script/script-user-footprint.js
+++ b/opencti-platform/opencti-graphql/script/script-user-footprint.js
@@ -1,8 +1,6 @@
-// PoC (merge-users #1): read-only footprint scan for a given user internal_id.
-// For a given --userId, counts how many Elastic documents reference that user, broken
-// down by field, so that a future "merge users" implementation (either approach) can be
-// sized before doing anything. STRICTLY READ ONLY: only elCount/elRawSearch are used,
-// no elUpdate*/delete call is ever made.
+// PoC (merge-users #1, iteration 2): read-only footprint scan for a user internal_id.
+// Counts unique documents per persistent Elasticsearch scope and classifies known
+// references according to the proposed merge disposition matrix.
 //
 // Usage:
 //   yarn build:dev
@@ -11,13 +9,13 @@ import '../src/modules/index';
 import fs from 'node:fs';
 import { executionContext, SYSTEM_USER } from '../src/utils/access';
 import { logApp } from '../src/config/conf';
-import { elCount, searchEngineInit } from '../src/database/engine';
-import { READ_DATA_INDICES, READ_RELATIONSHIPS_INDICES } from '../src/database/utils';
+import { elRawSearch, searchEngineInit } from '../src/database/engine';
+import { READ_DATA_INDICES, READ_INDEX_DELETED_OBJECTS, READ_INDEX_DRAFT_OBJECTS, READ_INDEX_FILES, READ_INDEX_HISTORY } from '../src/database/utils';
 import { schemaAttributesDefinition } from '../src/schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../src/schema/schema-relationsRef';
 import { ENTITY_TYPE_USER } from '../src/schema/internalObject';
 import { INPUT_ASSIGNEE, INPUT_PARTICIPANT } from '../src/schema/general';
-import { RELATION_MEMBER_OF, RELATION_PARTICIPATE_TO, RELATION_HAS_ROLE, RELATION_HAS_CAPABILITY } from '../src/schema/internalRelationship';
+import { buildUserFootprintScopes, buildUserFootprintSearch, parseUserFootprintSearch, summarizeUserFootprint, USER_FOOTPRINT_COVERAGE } from '../src/utils/user-footprint';
 
 const REPORT_FILE = './poc-user-footprint-report.json';
 
@@ -29,54 +27,10 @@ if (!userId) {
   process.exit(1);
 }
 
-// Build a simple "field = userId" equality filter, reused by all the term-based counts.
-const buildEqFilter = (key) => ({
-  mode: 'and',
-  filters: [{ key: [key], values: [userId], operator: 'eq' }],
-  filterGroups: [],
-});
-
-// Count documents in READ_DATA_INDICES having <field> = userId.
-// noFiltersChecking bypasses the "isFilterable" schema check: some User-referencing
-// attributes (e.g. i_attributes.user_id) are not flagged filterable but are still
-// perfectly queryable as plain ES term filters.
-const countByField = async (context, field) => elCount(context, SYSTEM_USER, READ_DATA_INDICES, {
-  filters: buildEqFilter(field),
-  noFiltersChecking: true,
-});
-
-// Count relationship documents (rights: member-of, has-role, has-capability, participate-to)
-// where the user is on the "fromId" or "toId" side of the graph edge.
-const countRelationshipSide = async (context, relationshipType, side) => elCount(context, SYSTEM_USER, READ_RELATIONSHIPS_INDICES, {
-  types: [relationshipType],
-  filters: buildEqFilter(side),
-  noFiltersChecking: true,
-});
-
-// Upper-bound heuristic: full-text search for the userId string across all data indices.
-// This will also match legitimate references embedded in JSON fields (saved filters,
-// stream/trigger/feed filter definitions, etc.) that are not modeled as "id" attributes,
-// but it can also produce false positives (e.g. partial/incidental matches), hence "upper bound".
-const countFullTextHeuristic = async (context) => elCount(context, SYSTEM_USER, READ_DATA_INDICES, {
-  search: `"${userId}"`,
-  noFiltersChecking: true,
-});
-
 const run = async () => {
-  // Minimal dependency check needed for the lightweight bootstrap: connects/selects the
-  // search engine client (read-only, no index/mapping creation happens here).
   await searchEngineInit();
   const context = executionContext('poc-user-footprint');
-  const report = {
-    userId,
-    generatedAt: new Date().toISOString(),
-    fields: {},
-    relationships: {},
-    heuristics: {},
-  };
 
-  // 1. Schema-driven discovery: every "id" attribute whose entityTypes includes User.
-  // Nothing here is hardcoded, it is entirely derived from schemaAttributesDefinition.
   const userIdAttributeNames = [...new Set(
     schemaAttributesDefinition.getIdAttributes()
       .filter((attr) => (attr.entityTypes ?? []).includes(ENTITY_TYPE_USER))
@@ -84,60 +38,60 @@ const run = async () => {
   )];
   logApp.info(`[POC] Discovered ${userIdAttributeNames.length} schema id-attribute(s) referencing User`, { attributes: userIdAttributeNames });
 
-  for (const field of userIdAttributeNames) {
-    const count = await countByField(context, field);
-    report.fields[field] = { count, method: 'elCount term filter (schema-driven id attribute)' };
+  const assigneeDatabaseName = schemaRelationsRefDefinition.getDatabaseName(INPUT_ASSIGNEE);
+  const participantDatabaseName = schemaRelationsRefDefinition.getDatabaseName(INPUT_PARTICIPANT);
+  if (!assigneeDatabaseName || !participantDatabaseName) {
+    throw new Error('Unable to resolve physical assignee/participant relationship fields');
   }
 
-  // 2. STIX ref relationships known to reference users but not exposed as simple id attributes.
-  // Their real ES field name (databaseName, e.g. "object-assignee" -> rel_object-assignee.internal_id)
-  // is looked up dynamically from the schema, not hardcoded.
-  const refsToCheck = [INPUT_ASSIGNEE, INPUT_PARTICIPANT];
-  for (const refName of refsToCheck) {
-    const databaseName = schemaRelationsRefDefinition.getDatabaseName(refName);
-    const count = await countByField(context, refName);
-    report.fields[databaseName ?? refName] = { count, method: `elCount term filter (ref relation "${refName}", resolved databaseName=${databaseName ?? 'unknown'})` };
+  const scopes = buildUserFootprintScopes({
+    userId,
+    schemaFieldNames: userIdAttributeNames,
+    indices: {
+      active: READ_DATA_INDICES,
+      draft: READ_INDEX_DRAFT_OBJECTS,
+      history: READ_INDEX_HISTORY,
+      files: READ_INDEX_FILES,
+      deleted: READ_INDEX_DELETED_OBJECTS,
+    },
+    relationDatabaseNames: {
+      assignee: assigneeDatabaseName,
+      participant: participantDatabaseName,
+    },
+  });
+  const scopeResults = {};
+  for (const scope of scopes) {
+    const response = await elRawSearch(context, SYSTEM_USER, `User footprint (${scope.id})`, buildUserFootprintSearch(scope));
+    scopeResults[scope.id] = parseUserFootprintSearch(scope, response);
   }
 
-  // 3. Graph relationships representing rights: counted separately since transferring
-  // them blindly during a merge would be a rights escalation/loss, not a plain data rewrite.
-  const rightsRelationshipTypes = [RELATION_MEMBER_OF, RELATION_PARTICIPATE_TO, RELATION_HAS_ROLE, RELATION_HAS_CAPABILITY];
-  for (const relationshipType of rightsRelationshipTypes) {
-    const asSource = await countRelationshipSide(context, relationshipType, 'fromId');
-    const asTarget = await countRelationshipSide(context, relationshipType, 'toId');
-    report.relationships[relationshipType] = {
-      asSource,
-      asTarget,
-      method: 'elCount on READ_RELATIONSHIPS_INDICES (fromId/toId)',
-    };
-  }
-
-  // 4. Full-text heuristic (upper bound, may include false positives).
-  const fullTextCount = await countFullTextHeuristic(context);
-  report.heuristics.fullTextSearch = {
-    count: fullTextCount,
-    method: 'elCount full-text search on the userId string (upper bound, may include false positives)',
+  const report = {
+    version: 2,
+    userId,
+    generatedAt: new Date().toISOString(),
+    schemaDiscovery: {
+      rootUserIdAttributes: userIdAttributeNames,
+      limitation: 'Root schema attributes are completed by an explicit registry for nested, serialized, physical, and dedicated-index references.',
+    },
+    scopes: scopeResults,
+    total: summarizeUserFootprint(scopeResults),
+    coverage: USER_FOOTPRINT_COVERAGE,
   };
 
-  // Totals
-  const fieldsTotal = Object.values(report.fields).reduce((acc, v) => acc + v.count, 0);
-  const relationshipsTotal = Object.values(report.relationships)
-    .reduce((acc, v) => acc + v.asSource + v.asTarget, 0);
-  report.total = { fieldsTotal, relationshipsTotal, fullTextHeuristic: fullTextCount };
-
-  // Human-readable console report.
-  console.log('\n=== User footprint report (read-only PoC) ===');
+  console.log('\n=== User footprint report v2 (read-only PoC) ===');
   console.log(`User id: ${userId}\n`);
-  console.log('-- Fields (schema-driven id attributes + ref relations) --');
-  Object.entries(report.fields).forEach(([field, { count }]) => console.log(`  ${field.padEnd(30)} ${count}`));
-  console.log(`  ${'TOTAL'.padEnd(30)} ${fieldsTotal}`);
-  console.log('\n-- Rights relationships (graph edges) --');
-  Object.entries(report.relationships).forEach(([relationshipType, { asSource, asTarget }]) => {
-    console.log(`  ${relationshipType.padEnd(30)} asSource=${asSource} asTarget=${asTarget}`);
+  console.log('-- Unique persistent Elasticsearch documents by scope --');
+  Object.entries(report.scopes).forEach(([scopeId, scope]) => {
+    console.log(`  ${scopeId.padEnd(12)} ${scope.uniqueDocuments}`);
   });
-  console.log(`  ${'TOTAL'.padEnd(30)} ${relationshipsTotal}`);
-  console.log('\n-- Full text heuristic (upper bound) --');
-  console.log(`  ${'match on userId string'.padEnd(30)} ${fullTextCount}`);
+  console.log(`  ${'TOTAL'.padEnd(12)} ${report.total.uniquePersistentDocuments}`);
+  console.log(`  ${'EXACT'.padEnd(12)} ${report.total.exactUniquePersistentDocuments}`);
+  console.log(`  ${'CANDIDATE'.padEnd(12)} ${report.total.candidateUniquePersistentDocuments}`);
+  console.log('\n-- Unique documents by proposed disposition --');
+  Object.entries(report.total.dispositions).forEach(([disposition, count]) => {
+    console.log(`  ${disposition.padEnd(12)} ${count}`);
+  });
+  console.log(`\nUnsupported storage categories: ${report.coverage.unsupported.map(({ storage }) => storage).join(', ')}`);
   console.log(`\nReport written to ${REPORT_FILE}`);
 
   fs.writeFileSync(REPORT_FILE, JSON.stringify(report, null, 2));

--- a/opencti-platform/opencti-graphql/script/script-user-footprint.js
+++ b/opencti-platform/opencti-graphql/script/script-user-footprint.js
@@ -1,0 +1,152 @@
+// PoC (merge-users #1): read-only footprint scan for a given user internal_id.
+// For a given --userId, counts how many Elastic documents reference that user, broken
+// down by field, so that a future "merge users" implementation (either approach) can be
+// sized before doing anything. STRICTLY READ ONLY: only elCount/elRawSearch are used,
+// no elUpdate*/delete call is ever made.
+//
+// Usage:
+//   yarn build:dev
+//   yarn poc:user-footprint --userId=<internal_id>
+import '../src/modules/index';
+import fs from 'node:fs';
+import { executionContext, SYSTEM_USER } from '../src/utils/access';
+import { logApp } from '../src/config/conf';
+import { elCount, searchEngineInit } from '../src/database/engine';
+import { READ_DATA_INDICES, READ_RELATIONSHIPS_INDICES } from '../src/database/utils';
+import { schemaAttributesDefinition } from '../src/schema/schema-attributes';
+import { schemaRelationsRefDefinition } from '../src/schema/schema-relationsRef';
+import { ENTITY_TYPE_USER } from '../src/schema/internalObject';
+import { INPUT_ASSIGNEE, INPUT_PARTICIPANT } from '../src/schema/general';
+import { RELATION_MEMBER_OF, RELATION_PARTICIPATE_TO, RELATION_HAS_ROLE, RELATION_HAS_CAPABILITY } from '../src/schema/internalRelationship';
+
+const REPORT_FILE = './poc-user-footprint-report.json';
+
+const userIdArg = process.argv.find((arg) => arg.startsWith('--userId='));
+const userId = userIdArg?.split('=')[1] || null;
+
+if (!userId) {
+  logApp.error('[POC] Missing required --userId=<internal_id> argument');
+  process.exit(1);
+}
+
+// Build a simple "field = userId" equality filter, reused by all the term-based counts.
+const buildEqFilter = (key) => ({
+  mode: 'and',
+  filters: [{ key: [key], values: [userId], operator: 'eq' }],
+  filterGroups: [],
+});
+
+// Count documents in READ_DATA_INDICES having <field> = userId.
+// noFiltersChecking bypasses the "isFilterable" schema check: some User-referencing
+// attributes (e.g. i_attributes.user_id) are not flagged filterable but are still
+// perfectly queryable as plain ES term filters.
+const countByField = async (context, field) => elCount(context, SYSTEM_USER, READ_DATA_INDICES, {
+  filters: buildEqFilter(field),
+  noFiltersChecking: true,
+});
+
+// Count relationship documents (rights: member-of, has-role, has-capability, participate-to)
+// where the user is on the "fromId" or "toId" side of the graph edge.
+const countRelationshipSide = async (context, relationshipType, side) => elCount(context, SYSTEM_USER, READ_RELATIONSHIPS_INDICES, {
+  types: [relationshipType],
+  filters: buildEqFilter(side),
+  noFiltersChecking: true,
+});
+
+// Upper-bound heuristic: full-text search for the userId string across all data indices.
+// This will also match legitimate references embedded in JSON fields (saved filters,
+// stream/trigger/feed filter definitions, etc.) that are not modeled as "id" attributes,
+// but it can also produce false positives (e.g. partial/incidental matches), hence "upper bound".
+const countFullTextHeuristic = async (context) => elCount(context, SYSTEM_USER, READ_DATA_INDICES, {
+  search: `"${userId}"`,
+  noFiltersChecking: true,
+});
+
+const run = async () => {
+  // Minimal dependency check needed for the lightweight bootstrap: connects/selects the
+  // search engine client (read-only, no index/mapping creation happens here).
+  await searchEngineInit();
+  const context = executionContext('poc-user-footprint');
+  const report = {
+    userId,
+    generatedAt: new Date().toISOString(),
+    fields: {},
+    relationships: {},
+    heuristics: {},
+  };
+
+  // 1. Schema-driven discovery: every "id" attribute whose entityTypes includes User.
+  // Nothing here is hardcoded, it is entirely derived from schemaAttributesDefinition.
+  const userIdAttributeNames = [...new Set(
+    schemaAttributesDefinition.getIdAttributes()
+      .filter((attr) => (attr.entityTypes ?? []).includes(ENTITY_TYPE_USER))
+      .map((attr) => attr.name),
+  )];
+  logApp.info(`[POC] Discovered ${userIdAttributeNames.length} schema id-attribute(s) referencing User`, { attributes: userIdAttributeNames });
+
+  for (const field of userIdAttributeNames) {
+    const count = await countByField(context, field);
+    report.fields[field] = { count, method: 'elCount term filter (schema-driven id attribute)' };
+  }
+
+  // 2. STIX ref relationships known to reference users but not exposed as simple id attributes.
+  // Their real ES field name (databaseName, e.g. "object-assignee" -> rel_object-assignee.internal_id)
+  // is looked up dynamically from the schema, not hardcoded.
+  const refsToCheck = [INPUT_ASSIGNEE, INPUT_PARTICIPANT];
+  for (const refName of refsToCheck) {
+    const databaseName = schemaRelationsRefDefinition.getDatabaseName(refName);
+    const count = await countByField(context, refName);
+    report.fields[databaseName ?? refName] = { count, method: `elCount term filter (ref relation "${refName}", resolved databaseName=${databaseName ?? 'unknown'})` };
+  }
+
+  // 3. Graph relationships representing rights: counted separately since transferring
+  // them blindly during a merge would be a rights escalation/loss, not a plain data rewrite.
+  const rightsRelationshipTypes = [RELATION_MEMBER_OF, RELATION_PARTICIPATE_TO, RELATION_HAS_ROLE, RELATION_HAS_CAPABILITY];
+  for (const relationshipType of rightsRelationshipTypes) {
+    const asSource = await countRelationshipSide(context, relationshipType, 'fromId');
+    const asTarget = await countRelationshipSide(context, relationshipType, 'toId');
+    report.relationships[relationshipType] = {
+      asSource,
+      asTarget,
+      method: 'elCount on READ_RELATIONSHIPS_INDICES (fromId/toId)',
+    };
+  }
+
+  // 4. Full-text heuristic (upper bound, may include false positives).
+  const fullTextCount = await countFullTextHeuristic(context);
+  report.heuristics.fullTextSearch = {
+    count: fullTextCount,
+    method: 'elCount full-text search on the userId string (upper bound, may include false positives)',
+  };
+
+  // Totals
+  const fieldsTotal = Object.values(report.fields).reduce((acc, v) => acc + v.count, 0);
+  const relationshipsTotal = Object.values(report.relationships)
+    .reduce((acc, v) => acc + v.asSource + v.asTarget, 0);
+  report.total = { fieldsTotal, relationshipsTotal, fullTextHeuristic: fullTextCount };
+
+  // Human-readable console report.
+  console.log('\n=== User footprint report (read-only PoC) ===');
+  console.log(`User id: ${userId}\n`);
+  console.log('-- Fields (schema-driven id attributes + ref relations) --');
+  Object.entries(report.fields).forEach(([field, { count }]) => console.log(`  ${field.padEnd(30)} ${count}`));
+  console.log(`  ${'TOTAL'.padEnd(30)} ${fieldsTotal}`);
+  console.log('\n-- Rights relationships (graph edges) --');
+  Object.entries(report.relationships).forEach(([relationshipType, { asSource, asTarget }]) => {
+    console.log(`  ${relationshipType.padEnd(30)} asSource=${asSource} asTarget=${asTarget}`);
+  });
+  console.log(`  ${'TOTAL'.padEnd(30)} ${relationshipsTotal}`);
+  console.log('\n-- Full text heuristic (upper bound) --');
+  console.log(`  ${'match on userId string'.padEnd(30)} ${fullTextCount}`);
+  console.log(`\nReport written to ${REPORT_FILE}`);
+
+  fs.writeFileSync(REPORT_FILE, JSON.stringify(report, null, 2));
+  logApp.info(`[POC] User footprint report written to ${REPORT_FILE}`, { report });
+};
+
+run()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    logApp.error('[POC] User footprint script failed', { error });
+    process.exit(1);
+  });

--- a/opencti-platform/opencti-graphql/src/utils/user-footprint.ts
+++ b/opencti-platform/opencti-graphql/src/utils/user-footprint.ts
@@ -70,14 +70,14 @@ export interface BuildUserFootprintScopesArgs {
 
 const ROOT_FIELD_DISPOSITIONS: Record<string, UserFootprintDisposition> = {
   creator_id: 'transfer',
-  platform_ip_whitelist_exclusion_ids: 'transfer',
+  platform_ip_whitelist_exclusion_ids: 'invalidate',
   xtm_hub_registration_user_id: 'transfer',
   user_id: 'conditional',
   applicant_id: 'conditional',
   recipients: 'transfer',
-  feed_public_user_id: 'transfer',
-  taxii_public_user_id: 'transfer',
-  stream_public_user_id: 'transfer',
+  feed_public_user_id: 'conditional',
+  taxii_public_user_id: 'conditional',
+  stream_public_user_id: 'conditional',
 };
 
 const exact = (field: string, value: string): QueryClause => ({
@@ -137,6 +137,7 @@ const buildCommonObjectReferences = (
 ): UserFootprintReference[] => {
   const operationalDisposition = historical ? 'retain' : 'transfer';
   const lifecycleDisposition = historical ? 'retain' : 'conditional';
+  const securityDisposition = historical ? 'retain' : 'invalidate';
   return [
     createReference(`${prefix}.nested.i_attributes.user_id`, 'i_attributes.user_id', 'attribute_history', 'retain', 'exact', exact('i_attributes.user_id', userId)),
     createReference(`${prefix}.nested.restricted_members.id`, 'restricted_members[].id', 'restricted_members', operationalDisposition, 'exact', nestedExact('restricted_members', 'restricted_members.id', userId)),
@@ -148,8 +149,10 @@ const buildCommonObjectReferences = (
       'exact',
       nestedExact('connections', 'connections.internal_id', userId),
     ),
-    createReference(`${prefix}.field.connector_user_id`, 'connector_user_id', 'operational_reference', operationalDisposition, 'exact', exact('connector_user_id', userId)),
+    createReference(`${prefix}.field.connector_user_id`, 'connector_user_id', 'operational_reference', lifecycleDisposition, 'exact', exact('connector_user_id', userId)),
     createReference(`${prefix}.field.initiator_id`, 'initiator_id', 'lifecycle_reference', lifecycleDisposition, 'exact', exact('initiator_id', userId)),
+    createReference(`${prefix}.field.authorized_authorities`, 'authorized_authorities[]', 'security_right', securityDisposition, 'exact', exact('authorized_authorities', userId)),
+    createReference(`${prefix}.field.activity_listeners_ids`, 'activity_listeners_ids[]', 'security_subscription', securityDisposition, 'exact', exact('activity_listeners_ids', userId)),
     createReference(
       `${prefix}.ref.object-assignee`,
       `rel_${relationDatabaseNames.assignee}.internal_id`,
@@ -306,7 +309,7 @@ export const buildUserFootprintScopes = ({
           'history.restricted_members.id',
           'restricted_members[].id',
           'historical_access',
-          'conditional',
+          'retain',
           'exact',
           nestedExact('restricted_members', 'restricted_members.id', userId),
         ),

--- a/opencti-platform/opencti-graphql/src/utils/user-footprint.ts
+++ b/opencti-platform/opencti-graphql/src/utils/user-footprint.ts
@@ -1,0 +1,493 @@
+import {
+  RELATION_ACCESSES_TO,
+  RELATION_HAS_CAPABILITY,
+  RELATION_HAS_CAPABILITY_IN_DRAFT,
+  RELATION_HAS_ROLE,
+  RELATION_MEMBER_OF,
+  RELATION_PARTICIPATE_TO,
+} from '../schema/internalRelationship';
+import { ENTITY_TYPE_WORKFLOW_DEFINITION, ENTITY_TYPE_WORKFLOW_INSTANCE } from '../modules/workflow/types/workflow-types';
+
+export type UserFootprintDisposition = 'transfer' | 'retain' | 'invalidate' | 'conditional';
+export type UserFootprintCertainty = 'exact' | 'candidate';
+
+type QueryClause = Record<string, unknown>;
+
+export interface UserFootprintReference {
+  id: string;
+  label: string;
+  category: string;
+  disposition: UserFootprintDisposition;
+  certainty: UserFootprintCertainty;
+  query: QueryClause;
+}
+
+export interface UserFootprintScope {
+  id: 'active' | 'draft' | 'history' | 'files' | 'deleted';
+  label: string;
+  indices: string[];
+  references: UserFootprintReference[];
+}
+
+export interface UserFootprintScopeResult {
+  label: string;
+  indices: string[];
+  uniqueDocuments: number;
+  certainties: Partial<Record<UserFootprintCertainty, number>>;
+  references: Record<string, Omit<UserFootprintReference, 'id' | 'query'> & { count: number }>;
+  dispositions: Partial<Record<UserFootprintDisposition, number>>;
+}
+
+export interface UserFootprintSummary {
+  uniquePersistentDocuments: number;
+  exactUniquePersistentDocuments: number;
+  candidateUniquePersistentDocuments: number;
+  referenceMatches: number;
+  dispositions: Partial<Record<UserFootprintDisposition, number>>;
+  countingSemantics: {
+    scopeCounts: string;
+    certaintyCounts: string;
+    dispositionCounts: string;
+    referenceCounts: string;
+  };
+}
+
+export interface BuildUserFootprintScopesArgs {
+  userId: string;
+  schemaFieldNames: string[];
+  indices: {
+    active: string[];
+    draft: string;
+    history: string;
+    files: string;
+    deleted: string;
+  };
+  relationDatabaseNames: {
+    assignee: string;
+    participant: string;
+  };
+}
+
+const ROOT_FIELD_DISPOSITIONS: Record<string, UserFootprintDisposition> = {
+  creator_id: 'transfer',
+  platform_ip_whitelist_exclusion_ids: 'transfer',
+  xtm_hub_registration_user_id: 'transfer',
+  user_id: 'conditional',
+  applicant_id: 'conditional',
+  recipients: 'transfer',
+  feed_public_user_id: 'transfer',
+  taxii_public_user_id: 'transfer',
+  stream_public_user_id: 'transfer',
+};
+
+const exact = (field: string, value: string): QueryClause => ({
+  term: { [`${field}.keyword`]: { value } },
+});
+
+const phrase = (field: string, value: string): QueryClause => ({
+  match_phrase: { [field]: value },
+});
+
+const nested = (path: string, query: QueryClause): QueryClause => ({
+  nested: { path, query, ignore_unmapped: true },
+});
+
+const typed = (entityType: string, query: QueryClause): QueryClause => ({
+  bool: {
+    must: [
+      exact('entity_type', entityType),
+      query,
+    ],
+  },
+});
+
+const nestedExact = (path: string, field: string, value: string): QueryClause => nested(path, exact(field, value));
+const nestedPhrase = (path: string, field: string, value: string): QueryClause => nested(path, phrase(field, value));
+
+const createReference = (
+  id: string,
+  label: string,
+  category: string,
+  disposition: UserFootprintDisposition,
+  certainty: UserFootprintCertainty,
+  query: QueryClause,
+): UserFootprintReference => ({ id, label, category, disposition, certainty, query });
+
+const buildSchemaReferences = (
+  prefix: string,
+  userId: string,
+  schemaFieldNames: string[],
+  historical: boolean,
+): UserFootprintReference[] => {
+  return [...new Set(schemaFieldNames)].sort().map((field) => createReference(
+    `${prefix}.schema.${field}`,
+    field,
+    'schema_root_field',
+    historical ? 'retain' : (ROOT_FIELD_DISPOSITIONS[field] ?? 'conditional'),
+    'exact',
+    exact(field, userId),
+  ));
+};
+
+const buildCommonObjectReferences = (
+  prefix: string,
+  userId: string,
+  historical: boolean,
+  relationDatabaseNames: BuildUserFootprintScopesArgs['relationDatabaseNames'],
+): UserFootprintReference[] => {
+  const operationalDisposition = historical ? 'retain' : 'transfer';
+  const lifecycleDisposition = historical ? 'retain' : 'conditional';
+  return [
+    createReference(`${prefix}.nested.i_attributes.user_id`, 'i_attributes.user_id', 'attribute_history', 'retain', 'exact', exact('i_attributes.user_id', userId)),
+    createReference(`${prefix}.nested.restricted_members.id`, 'restricted_members[].id', 'restricted_members', operationalDisposition, 'exact', nestedExact('restricted_members', 'restricted_members.id', userId)),
+    createReference(
+      `${prefix}.nested.connections.internal_id`,
+      'connections[].internal_id',
+      'generic_graph_reference',
+      historical ? 'retain' : 'conditional',
+      'exact',
+      nestedExact('connections', 'connections.internal_id', userId),
+    ),
+    createReference(`${prefix}.field.connector_user_id`, 'connector_user_id', 'operational_reference', operationalDisposition, 'exact', exact('connector_user_id', userId)),
+    createReference(`${prefix}.field.initiator_id`, 'initiator_id', 'lifecycle_reference', lifecycleDisposition, 'exact', exact('initiator_id', userId)),
+    createReference(
+      `${prefix}.ref.object-assignee`,
+      `rel_${relationDatabaseNames.assignee}.internal_id`,
+      'stix_reference',
+      operationalDisposition,
+      'exact',
+      exact(`rel_${relationDatabaseNames.assignee}.internal_id`, userId),
+    ),
+    createReference(
+      `${prefix}.ref.object-participant`,
+      `rel_${relationDatabaseNames.participant}.internal_id`,
+      'stix_reference',
+      operationalDisposition,
+      'exact',
+      exact(`rel_${relationDatabaseNames.participant}.internal_id`, userId),
+    ),
+    createReference(
+      `${prefix}.workflow.published.createdBy`,
+      'published_version.createdBy',
+      'historical_provenance',
+      'retain',
+      'exact',
+      typed(ENTITY_TYPE_WORKFLOW_DEFINITION, nestedExact('published_version', 'published_version.createdBy', userId)),
+    ),
+    createReference(
+      `${prefix}.workflow.draft.createdBy`,
+      'draft_version.createdBy',
+      'historical_provenance',
+      'retain',
+      'exact',
+      typed(ENTITY_TYPE_WORKFLOW_DEFINITION, nestedExact('draft_version', 'draft_version.createdBy', userId)),
+    ),
+    createReference(
+      `${prefix}.workflow.all.createdBy`,
+      'all_versions[].createdBy',
+      'historical_provenance',
+      'retain',
+      'exact',
+      typed(ENTITY_TYPE_WORKFLOW_DEFINITION, nestedExact('all_versions', 'all_versions.createdBy', userId)),
+    ),
+    createReference(
+      `${prefix}.workflow.history`,
+      'history JSON',
+      'historical_provenance',
+      'retain',
+      'candidate',
+      typed(ENTITY_TYPE_WORKFLOW_INSTANCE, phrase('history', userId)),
+    ),
+    createReference(
+      `${prefix}.workflow.pendingTransition`,
+      'pendingTransition JSON',
+      'lifecycle_reference',
+      lifecycleDisposition,
+      'candidate',
+      typed(ENTITY_TYPE_WORKFLOW_INSTANCE, phrase('pendingTransition', userId)),
+    ),
+    ...['published_version', 'draft_version', 'all_versions'].map((path) => createReference(
+      `${prefix}.workflow.${path}.content`,
+      `${path}.content JSON`,
+      'serialized_configuration',
+      operationalDisposition,
+      'candidate',
+      typed(ENTITY_TYPE_WORKFLOW_DEFINITION, nestedPhrase(path, `${path}.content`, userId)),
+    )),
+    ...[
+      'filters',
+      'origin_filters',
+      'connector_trigger_filters',
+      'task_filters',
+      'pir_filters',
+      'decay_filters',
+      'decay_exclusion_filters',
+      'instance_filters',
+      'list_filters',
+      'metaData.list_filters',
+      'manifest',
+    ].map((field) => createReference(
+      `${prefix}.serialized.${field}`,
+      `${field} serialized content`,
+      'serialized_configuration',
+      operationalDisposition,
+      'candidate',
+      phrase(field, userId),
+    )),
+  ];
+};
+
+const relationshipSideQuery = (relationshipType: string, side: 'from' | 'to', userId: string): QueryClause => typed(
+  relationshipType,
+  nested('connections', {
+    bool: {
+      must: [
+        exact('connections.internal_id', userId),
+        exact('connections.role', `${relationshipType}_${side}`),
+      ],
+    },
+  }),
+);
+
+const buildRightsReferences = (userId: string): UserFootprintReference[] => {
+  const relationshipTypes = [
+    RELATION_MEMBER_OF,
+    RELATION_PARTICIPATE_TO,
+    RELATION_HAS_ROLE,
+    RELATION_HAS_CAPABILITY,
+    RELATION_HAS_CAPABILITY_IN_DRAFT,
+    RELATION_ACCESSES_TO,
+  ];
+  return relationshipTypes.flatMap((relationshipType) => {
+    const expectedDirectMembership = relationshipType === RELATION_MEMBER_OF || relationshipType === RELATION_PARTICIPATE_TO;
+    return (['from', 'to'] as const).map((side) => createReference(
+      `active.rights.${relationshipType}.${side}`,
+      `${relationshipType} (${side} side)`,
+      expectedDirectMembership && side === 'from' ? 'source_membership' : 'unexpected_direct_right',
+      expectedDirectMembership && side === 'from' ? 'invalidate' : 'conditional',
+      'exact',
+      relationshipSideQuery(relationshipType, side, userId),
+    ));
+  });
+};
+
+export const buildUserFootprintScopes = ({
+  userId,
+  schemaFieldNames,
+  indices,
+  relationDatabaseNames,
+}: BuildUserFootprintScopesArgs): UserFootprintScope[] => {
+  const activeReferences = [
+    ...buildSchemaReferences('active', userId, schemaFieldNames, false),
+    ...buildCommonObjectReferences('active', userId, false, relationDatabaseNames),
+    ...buildRightsReferences(userId),
+  ];
+  const draftReferences = [
+    ...buildSchemaReferences('draft', userId, schemaFieldNames, false),
+    ...buildCommonObjectReferences('draft', userId, false, relationDatabaseNames),
+  ];
+  const deletedReferences = [
+    ...buildSchemaReferences('deleted', userId, schemaFieldNames, true),
+    ...buildCommonObjectReferences('deleted', userId, true, relationDatabaseNames),
+  ];
+
+  return [
+    { id: 'active', label: 'Active platform data', indices: indices.active, references: activeReferences },
+    { id: 'draft', label: 'Draft object copies', indices: [indices.draft], references: draftReferences },
+    {
+      id: 'history',
+      label: 'Audit and activity history',
+      indices: [indices.history],
+      references: [
+        createReference('history.user_id', 'user_id', 'historical_provenance', 'retain', 'exact', exact('user_id', userId)),
+        createReference('history.applicant_id', 'applicant_id', 'historical_provenance', 'retain', 'exact', exact('applicant_id', userId)),
+        createReference('history.context.creator_ids', 'context_data.creator_ids', 'historical_provenance', 'retain', 'exact', exact('context_data.creator_ids', userId)),
+        createReference(
+          'history.restricted_members.id',
+          'restricted_members[].id',
+          'historical_access',
+          'conditional',
+          'exact',
+          nestedExact('restricted_members', 'restricted_members.id', userId),
+        ),
+      ],
+    },
+    {
+      id: 'files',
+      label: 'Indexed file metadata',
+      indices: [indices.files],
+      references: [
+        createReference('files.metaData.creator_id', 'metaData.creator_id', 'historical_provenance', 'retain', 'exact', exact('metaData.creator_id', userId)),
+      ],
+    },
+    { id: 'deleted', label: 'Deleted object copies', indices: [indices.deleted], references: deletedReferences },
+  ];
+};
+
+const groupQueries = <T extends string>(references: UserFootprintReference[], selector: (reference: UserFootprintReference) => T): Record<string, QueryClause> => {
+  const grouped = new Map<T, QueryClause[]>();
+  for (const reference of references) {
+    const group = selector(reference);
+    const queries = grouped.get(group) ?? [];
+    queries.push(reference.query);
+    grouped.set(group, queries);
+  }
+  return Object.fromEntries([...grouped.entries()].map(([group, queries]) => [
+    group,
+    { bool: { should: queries, minimum_should_match: 1 } },
+  ]));
+};
+
+export const buildUserFootprintSearch = (scope: UserFootprintScope) => {
+  const referenceFilters = Object.fromEntries(scope.references.map((reference) => [reference.id, reference.query]));
+  const dispositionFilters = groupQueries(scope.references, (reference) => reference.disposition);
+  const certaintyFilters = groupQueries(scope.references, (reference) => reference.certainty);
+  return {
+    index: scope.indices,
+    allow_no_indices: true,
+    ignore_unavailable: true,
+    body: {
+      size: 0,
+      track_total_hits: true,
+      query: {
+        bool: {
+          should: scope.references.map((reference) => reference.query),
+          minimum_should_match: 1,
+        },
+      },
+      aggs: {
+        references: { filters: { filters: referenceFilters } },
+        dispositions: { filters: { filters: dispositionFilters } },
+        certainties: { filters: { filters: certaintyFilters } },
+      },
+    },
+  };
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const readCount = (value: unknown, path: string): number => {
+  if (!isRecord(value) || typeof value.doc_count !== 'number') {
+    throw new Error(`Invalid Elasticsearch footprint response at ${path}`);
+  }
+  return value.doc_count;
+};
+
+const readBuckets = (response: Record<string, unknown>, aggregation: string): Record<string, unknown> => {
+  const aggregations = response.aggregations;
+  if (!isRecord(aggregations) || !isRecord(aggregations[aggregation]) || !isRecord(aggregations[aggregation].buckets)) {
+    throw new Error(`Invalid Elasticsearch footprint response at aggregations.${aggregation}.buckets`);
+  }
+  return aggregations[aggregation].buckets;
+};
+
+const readTotalHits = (response: Record<string, unknown>): number => {
+  const hits = response.hits;
+  if (!isRecord(hits)) {
+    throw new Error('Invalid Elasticsearch footprint response at hits');
+  }
+  if (typeof hits.total === 'number') {
+    return hits.total;
+  }
+  if (isRecord(hits.total) && typeof hits.total.value === 'number') {
+    return hits.total.value;
+  }
+  throw new Error('Invalid Elasticsearch footprint response at hits.total');
+};
+
+export const parseUserFootprintSearch = (scope: UserFootprintScope, rawResponse: unknown): UserFootprintScopeResult => {
+  if (!isRecord(rawResponse)) {
+    throw new Error('Invalid Elasticsearch footprint response');
+  }
+  const referenceBuckets = readBuckets(rawResponse, 'references');
+  const dispositionBuckets = readBuckets(rawResponse, 'dispositions');
+  const certaintyBuckets = readBuckets(rawResponse, 'certainties');
+  const references = Object.fromEntries(scope.references.map(({ id, query: _, ...reference }) => {
+    const bucket = referenceBuckets[id];
+    return [id, { ...reference, count: readCount(bucket, `aggregations.references.buckets.${id}`) }];
+  }));
+  const dispositions = Object.fromEntries(Object.entries(dispositionBuckets).map(([disposition, bucket]) => [
+    disposition,
+    readCount(bucket, `aggregations.dispositions.buckets.${disposition}`),
+  ]));
+  const certainties = Object.fromEntries(Object.entries(certaintyBuckets).map(([certainty, bucket]) => [
+    certainty,
+    readCount(bucket, `aggregations.certainties.buckets.${certainty}`),
+  ]));
+
+  return {
+    label: scope.label,
+    indices: scope.indices,
+    uniqueDocuments: readTotalHits(rawResponse),
+    references,
+    dispositions,
+    certainties,
+  };
+};
+
+export const summarizeUserFootprint = (scopeResults: Record<string, UserFootprintScopeResult>): UserFootprintSummary => {
+  const dispositions: Partial<Record<UserFootprintDisposition, number>> = {};
+  let uniquePersistentDocuments = 0;
+  let exactUniquePersistentDocuments = 0;
+  let candidateUniquePersistentDocuments = 0;
+  let referenceMatches = 0;
+  for (const scope of Object.values(scopeResults)) {
+    uniquePersistentDocuments += scope.uniqueDocuments;
+    exactUniquePersistentDocuments += scope.certainties.exact ?? 0;
+    candidateUniquePersistentDocuments += scope.certainties.candidate ?? 0;
+    referenceMatches += Object.values(scope.references).reduce((total, reference) => total + reference.count, 0);
+    for (const [disposition, count] of Object.entries(scope.dispositions)) {
+      const typedDisposition = disposition as UserFootprintDisposition;
+      dispositions[typedDisposition] = (dispositions[typedDisposition] ?? 0) + count;
+    }
+  }
+  return {
+    uniquePersistentDocuments,
+    exactUniquePersistentDocuments,
+    candidateUniquePersistentDocuments,
+    referenceMatches,
+    dispositions,
+    countingSemantics: {
+      scopeCounts: 'Unique physical Elasticsearch documents matched within each disjoint index scope.',
+      certaintyCounts: 'Unique within each certainty and scope; exact and candidate counts can overlap.',
+      dispositionCounts: 'Unique within each disposition and scope; a document matching different dispositions appears in each relevant disposition.',
+      referenceCounts: 'Per-reference matches are diagnostic and must not be summed as a unique object count.',
+    },
+  };
+};
+
+export const USER_FOOTPRINT_COVERAGE = {
+  status: 'explicit_registry',
+  handled: [
+    'Schema-declared root user ID attributes',
+    'Known nested and non-ID-typed user references',
+    'Physical assignee and participant fields',
+    'Known serialized filter and workflow fields (candidate matches)',
+    'Active, draft, history, file metadata, and deleted-object Elasticsearch indices',
+    'Direct rights and membership relationship anomalies',
+  ],
+  unsupported: [
+    {
+      storage: 'Redis',
+      elements: ['sessions', 'API token cache and usage counters', 'OTP state', 'live stream state', 'locks'],
+      expectedAction: 'Inspect separately; revoke/invalidate credentials and coordinate runtime state.',
+    },
+    {
+      storage: 'RabbitMQ',
+      elements: ['in-flight and persisted messages'],
+      expectedAction: 'Pause or drain processing before merge.',
+    },
+    {
+      storage: 'Object storage',
+      elements: ['user IDs embedded in MinIO/S3 file contents'],
+      expectedAction: 'Not scanned; indexed file metadata is covered separately.',
+    },
+  ],
+  unknowns: [
+    'Serialized user references in fields not registered above cannot be discovered reliably from mappings.',
+    'Candidate JSON/text matches must be parsed structurally before any write.',
+    'New non-schema storage forms require an explicit registry entry and a regression test.',
+  ],
+} as const;

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/user-footprint-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/user-footprint-test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildUserFootprintScopes,
+  buildUserFootprintSearch,
+  parseUserFootprintSearch,
+  summarizeUserFootprint,
+  USER_FOOTPRINT_COVERAGE,
+  type UserFootprintScope,
+} from '../../../src/utils/user-footprint';
+
+const USER_ID = '88ec0c6a-13ce-5e39-b486-354fe4a7084f';
+
+const buildScopes = () => buildUserFootprintScopes({
+  userId: USER_ID,
+  schemaFieldNames: ['user_id', 'creator_id', 'creator_id'],
+  indices: {
+    active: ['opencti_internal_objects*', 'opencti_internal_relationships*'],
+    draft: 'opencti_draft_objects*',
+    history: 'opencti_history*',
+    files: 'opencti_files*',
+    deleted: 'opencti_deleted_objects*',
+  },
+  relationDatabaseNames: {
+    assignee: 'object-assignee',
+    participant: 'object-participant',
+  },
+});
+
+describe('User footprint registry', () => {
+  it('uses physical relationship fields and covers dedicated indices', () => {
+    const scopes = buildScopes();
+    expect(scopes.map(({ id }) => id)).toEqual(['active', 'draft', 'history', 'files', 'deleted']);
+    expect(scopes.find(({ id }) => id === 'active')?.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        label: 'rel_object-assignee.internal_id',
+        query: { term: { 'rel_object-assignee.internal_id.keyword': { value: USER_ID } } },
+      }),
+      expect.objectContaining({
+        label: 'rel_object-participant.internal_id',
+        query: { term: { 'rel_object-participant.internal_id.keyword': { value: USER_ID } } },
+      }),
+    ]));
+    expect(scopes.find(({ id }) => id === 'history')?.indices).toEqual(['opencti_history*']);
+    expect(scopes.find(({ id }) => id === 'files')?.indices).toEqual(['opencti_files*']);
+    expect(scopes.find(({ id }) => id === 'deleted')?.indices).toEqual(['opencti_deleted_objects*']);
+    expect(scopes.find(({ id }) => id === 'draft')?.indices).toEqual(['opencti_draft_objects*']);
+  });
+
+  it('registers exact nested fields and candidate serialized fields separately', () => {
+    const active = buildScopes().find(({ id }) => id === 'active');
+    expect(active?.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        label: 'restricted_members[].id',
+        certainty: 'exact',
+        query: {
+          nested: {
+            path: 'restricted_members',
+            query: { term: { 'restricted_members.id.keyword': { value: USER_ID } } },
+            ignore_unmapped: true,
+          },
+        },
+      }),
+      expect.objectContaining({
+        label: 'pendingTransition JSON',
+        certainty: 'candidate',
+        disposition: 'conditional',
+      }),
+      expect.objectContaining({
+        label: 'i_attributes.user_id',
+        disposition: 'retain',
+      }),
+    ]));
+  });
+
+  it('classifies direct source memberships for invalidation and anomalous rights for review', () => {
+    const active = buildScopes().find(({ id }) => id === 'active');
+    expect(active?.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'active.rights.member-of.from',
+        category: 'source_membership',
+        disposition: 'invalidate',
+      }),
+      expect.objectContaining({
+        id: 'active.rights.has-role.from',
+        category: 'unexpected_direct_right',
+        disposition: 'conditional',
+      }),
+    ]));
+  });
+});
+
+describe('User footprint queries and result parsing', () => {
+  const scope: UserFootprintScope = {
+    id: 'active',
+    label: 'Active data',
+    indices: ['opencti_internal_objects*'],
+    references: [
+      {
+        id: 'active.creator',
+        label: 'creator_id',
+        category: 'schema_root_field',
+        disposition: 'transfer',
+        certainty: 'exact',
+        query: { term: { 'creator_id.keyword': { value: USER_ID } } },
+      },
+      {
+        id: 'active.user',
+        label: 'user_id',
+        category: 'schema_root_field',
+        disposition: 'conditional',
+        certainty: 'exact',
+        query: { term: { 'user_id.keyword': { value: USER_ID } } },
+      },
+    ],
+  };
+
+  it('builds one OR query with unique counts per reference and disposition', () => {
+    const search = buildUserFootprintSearch(scope);
+    expect(search.body.track_total_hits).toBe(true);
+    expect(search.body.query.bool.should).toHaveLength(2);
+    expect(search.body.aggs.references.filters.filters).toHaveProperty('active.creator');
+    expect(search.body.aggs.dispositions.filters.filters).toHaveProperty('transfer');
+    expect(search.body.aggs.dispositions.filters.filters).toHaveProperty('conditional');
+    expect(search.body.aggs.certainties.filters.filters).toHaveProperty('exact');
+  });
+
+  it('keeps the scope total deduplicated while exposing overlapping reference counts', () => {
+    const result = parseUserFootprintSearch(scope, {
+      hits: { total: { value: 3, relation: 'eq' }, hits: [] },
+      aggregations: {
+        references: {
+          buckets: {
+            'active.creator': { doc_count: 3 },
+            'active.user': { doc_count: 2 },
+          },
+        },
+        dispositions: {
+          buckets: {
+            transfer: { doc_count: 3 },
+            conditional: { doc_count: 2 },
+          },
+        },
+        certainties: {
+          buckets: {
+            exact: { doc_count: 3 },
+          },
+        },
+      },
+    });
+    expect(result.uniqueDocuments).toBe(3);
+    expect(result.references['active.creator'].count).toBe(3);
+    expect(result.references['active.user'].count).toBe(2);
+
+    const summary = summarizeUserFootprint({ active: result });
+    expect(summary.uniquePersistentDocuments).toBe(3);
+    expect(summary.exactUniquePersistentDocuments).toBe(3);
+    expect(summary.candidateUniquePersistentDocuments).toBe(0);
+    expect(summary.referenceMatches).toBe(5);
+    expect(summary.dispositions).toEqual({ transfer: 3, conditional: 2 });
+  });
+
+  it('rejects incomplete Elasticsearch responses instead of returning success-shaped defaults', () => {
+    expect(() => parseUserFootprintSearch(scope, { hits: { total: 0 } })).toThrow(
+      'Invalid Elasticsearch footprint response at aggregations.references.buckets',
+    );
+  });
+});
+
+describe('User footprint coverage reporting', () => {
+  it('explicitly reports storage that is not scanned', () => {
+    expect(USER_FOOTPRINT_COVERAGE.unsupported.map(({ storage }) => storage)).toEqual([
+      'Redis',
+      'RabbitMQ',
+      'Object storage',
+    ]);
+    expect(USER_FOOTPRINT_COVERAGE.unknowns).not.toHaveLength(0);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/user-footprint-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/user-footprint-test.ts
@@ -12,7 +12,13 @@ const USER_ID = '88ec0c6a-13ce-5e39-b486-354fe4a7084f';
 
 const buildScopes = () => buildUserFootprintScopes({
   userId: USER_ID,
-  schemaFieldNames: ['user_id', 'creator_id', 'creator_id'],
+  schemaFieldNames: [
+    'user_id',
+    'creator_id',
+    'creator_id',
+    'platform_ip_whitelist_exclusion_ids',
+    'feed_public_user_id',
+  ],
   indices: {
     active: ['opencti_internal_objects*', 'opencti_internal_relationships*'],
     draft: 'opencti_draft_objects*',
@@ -84,6 +90,41 @@ describe('User footprint registry', () => {
         id: 'active.rights.has-role.from',
         category: 'unexpected_direct_right',
         disposition: 'conditional',
+      }),
+    ]));
+  });
+
+  it('never classifies source security rights or operational accounts as automatic transfers', () => {
+    const scopes = buildScopes();
+    const active = scopes.find(({ id }) => id === 'active');
+    const history = scopes.find(({ id }) => id === 'history');
+
+    expect(active?.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        label: 'platform_ip_whitelist_exclusion_ids',
+        disposition: 'invalidate',
+      }),
+      expect.objectContaining({
+        label: 'authorized_authorities[]',
+        disposition: 'invalidate',
+      }),
+      expect.objectContaining({
+        label: 'activity_listeners_ids[]',
+        disposition: 'invalidate',
+      }),
+      expect.objectContaining({
+        label: 'feed_public_user_id',
+        disposition: 'conditional',
+      }),
+      expect.objectContaining({
+        label: 'connector_user_id',
+        disposition: 'conditional',
+      }),
+    ]));
+    expect(history?.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        label: 'restricted_members[].id',
+        disposition: 'retain',
       }),
     ]));
   });


### PR DESCRIPTION
## Context

Related to #17258. This PoC supports the investigation but does **not** close the complete merge-users feature.

This PoC measures and classifies the user footprint in Elasticsearch before designing the merge executor. It remains **strictly read-only** and is not presented as a complete platform-wide merge dry-run.

This second iteration addresses the main reliability gaps found in the initial volumetry script: missing indices and nested references, incorrect physical relationship fields, overlapping totals, and implicit coverage limitations.

## Goal and non-goals

### Goal

For one `User.internal_id`:

- count the unique persistent Elasticsearch documents that contain a known reference to that user;
- expose diagnostic counts per reference;
- distinguish exact references from candidate serialized matches;
- classify documents using the proposed merge dispositions: `transfer`, `retain`, `invalidate`, or `conditional`;
- explicitly report unsupported storage categories and remaining unknowns.

### Non-goals

This PoC does **not**:

- mutate any object;
- list every impacted document ID;
- structurally parse and rewrite JSON/Base64 payloads;
- inspect Redis, RabbitMQ, or object-storage contents;
- implement the complete executable registry required by the final merge feature.

## What changed in iteration 2

### Shared, testable reference registry

The scan definition was extracted to `src/utils/user-footprint.ts` and combines:

- schema-discovered root ID attributes referencing `User`;
- `i_attributes.user_id`;
- `restricted_members[].id`;
- `connections[].internal_id`;
- `connector_user_id` and `initiator_id`;
- security references such as `authorized_authorities[]`, `activity_listeners_ids[]`, and IP whitelist exclusions;
- dynamically resolved physical fields for `object-assignee` and `object-participant`;
- workflow version authors, workflow history/pending transitions, and known serialized content;
- direct membership and rights relationships.

Security-related references are deliberately not treated as automatic transfers: source-only rights are invalidated or require explicit review, while historical references are retained.

### Five disjoint Elasticsearch scopes

The script now scans:

1. active platform data;
2. draft objects;
3. activity/history data;
4. indexed file metadata;
5. deleted-object snapshots.

Each scope is queried once with a single OR query and filter aggregations.

### Correct counting semantics

The report now exposes:

- `uniqueDocuments`: unique physical documents within each disjoint scope;
- `exact` / `candidate`: unique documents within each certainty category and scope;
- per-disposition counts: unique within a disposition and scope;
- per-reference counts: diagnostic occurrence counts.

Per-reference and per-disposition counts can overlap and therefore **must not be summed** to obtain the unique footprint total. The report includes these semantics explicitly.

### Strict response validation

Malformed or incomplete Elasticsearch aggregation responses now fail explicitly instead of producing success-shaped zero values.

### Explicit coverage report

The generated JSON report states what is covered and identifies unsupported areas:

- Redis sessions, token usage, OTP state, streams, and locks;
- RabbitMQ in-flight/persisted messages;
- user IDs embedded in S3/MinIO file contents;
- serialized references not registered by this PoC.

Candidate JSON/text matches must be parsed structurally before any future write.

## Latest local result

Run against the existing local test dataset for the same admin user used by iteration 1:

| Scope | Unique documents |
|---|---:|
| Active | 829 |
| Draft | 377 |
| History | 38,678 |
| File metadata | 0 |
| Deleted objects | 9 |
| **Total** | **39,893** |
| Exact | 39,893 |
| Candidate | 0 |

Proposed disposition counts on this dataset:

| Disposition | Unique documents within category |
|---|---:|
| `transfer` | 1,197 |
| `retain` | 39,141 |
| `invalidate` | 1 |
| `conditional` | 56 |

A document may match multiple dispositions; these values intentionally overlap.

## Important findings

- `object-assignee` and `object-participant` must use their resolved physical Elasticsearch fields (`rel_object-assignee.internal_id` and `rel_object-participant.internal_id`).
- Relationship endpoints are stored through nested `connections` entries, not flat `fromId` / `toId` fields.
- Effective rights are mostly transitive through `User -> member-of -> Group`; direct `has-role` / `has-capability` references to a user are anomalies, not a complete rights model.
- A root field name such as `user_id` is not enough to define a merge action: its semantics must ultimately be classified per `entity_type` and lifecycle status.
- Historical and deleted snapshots must not be treated like active ownership references.

## Usage

```bash
yarn build:dev
yarn poc:user-footprint --userId={internal_id}
```

The command writes `./poc-user-footprint-report.json` locally; the report is not committed.

## Verification

- 8 focused unit tests: **OK**;
- targeted ESLint: **OK**;
- TypeScript check: **OK**;
- GraphQL code generation, schema build, and development bundle: **OK**;
- real local Elasticsearch execution: **OK**;
- zero database writes: the scanner only performs `size: 0` raw searches and aggregations.

## Conclusion and follow-up

This PR is now a substantially more reliable **Elasticsearch footprint/volumetry PoC** and a useful baseline for estimating the merge workload.

It is still not the complete merge dry-run. That next step requires an executable, versioned registry that classifies references per entity type and status, structurally parses serialized fields, inspects non-Elasticsearch storage, simulates conflicts/deduplication, and fails whenever a discovered reference remains unclassified.