### PR TITLE
poc(merge-users): demonstrate distributed user alias policies

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/data-builder.js
+++ b/opencti-platform/opencti-graphql/src/database/data-builder.js
@@ -6,7 +6,7 @@ import { FROM_START, now, UNTIL_END } from '../utils/format';
 import { inferIndexFromConceptType, isEmptyField, isNotEmptyField } from './utils';
 import { isStixRelationshipExceptRef } from '../schema/stixRelationship';
 import { isStixCoreRelationship } from '../schema/stixCoreRelationship';
-import { DatabaseError } from '../config/errors';
+import { ConfigurationError, DatabaseError } from '../config/errors';
 import {
   isStixRefRelationship,
   RELATION_CREATED_BY,
@@ -18,20 +18,34 @@ import {
 } from '../schema/stixRefRelationship';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { isStixSightingRelationship } from '../schema/stixSightingRelationship';
-import { ENTITY_TYPE_STATUS, isDatedInternalObject } from '../schema/internalObject';
+import { ENTITY_TYPE_STATUS, ENTITY_TYPE_USER, isDatedInternalObject } from '../schema/internalObject';
 import { isStixObject } from '../schema/stixCoreObject';
 import { isStixMetaObject } from '../schema/stixMetaObject';
 import { isStixDomainObject, isStixObjectAliased, resolveAliasesField, STIX_ORGANIZATIONS_RESTRICTED, STIX_ORGANIZATIONS_UNRESTRICTED } from '../schema/stixDomainObject';
-import { getEntitiesListFromCache } from './cache';
-import { isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT } from '../utils/access';
+import { getEntitiesListFromCache, getEntitiesMapFromCache } from './cache';
+import { isUserHasCapability, KNOWLEDGE_ORGANIZATION_RESTRICT, SYSTEM_USER } from '../utils/access';
 import { cleanMarkings } from '../utils/markingDefinition-utils';
 import { RELATION_IN_PIR } from '../schema/internalRelationship';
 import { pushAll } from '../utils/arrayUtil';
+import { resolveMergeUsersPocAliasId } from '../utils/merge-users-poc-alias';
+
+const resolveOperationalCreatorId = async (context, userId) => {
+  const targetId = resolveMergeUsersPocAliasId(userId);
+  if (targetId === userId) {
+    return userId;
+  }
+  const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  if (!platformUsers.get(targetId)) {
+    throw ConfigurationError('MERGE_POC_ALIAS_MAP target user cannot be resolved', { id: targetId });
+  }
+  return targetId;
+};
 
 export const buildEntityData = async (context, user, input, type, opts = {}) => {
   const { fromRule, restore } = opts;
   const internalId = input.internal_id || generateInternalId();
   const standardId = input.standard_id || generateStandardId(type, input);
+  const creatorId = await resolveOperationalCreatorId(context, user.internal_id);
   // Complete with identifiers
   const today = now();
   const inferred = isNotEmptyField(fromRule);
@@ -41,7 +55,7 @@ export const buildEntityData = async (context, user, input, type, opts = {}) => 
     R.assoc(ID_INTERNAL, internalId),
     R.assoc(ID_STANDARD, standardId),
     R.assoc('entity_type', type),
-    R.assoc('creator_id', [user.internal_id]),
+    R.assoc('creator_id', [creatorId]),
     R.dissoc('update'),
     R.dissoc('upsertOperations'),
     R.dissoc('file'),
@@ -191,7 +205,7 @@ export const buildRelationData = async (context, user, input, opts = {}) => {
   data.standard_id = standardId;
   data.entity_type = relationshipType;
   data.relationship_type = relationshipType;
-  data.creator_id = [user.internal_id];
+  data.creator_id = [await resolveOperationalCreatorId(context, user.internal_id)];
   data.created_at = today;
   data.updated_at = today;
   data.refreshed_at = today;

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -127,12 +127,15 @@ import {
 import { extractEntityRepresentativeName, extractRepresentative } from './entity-representative';
 import { checkAndConvertFilters, extractFiltersFromGroup, isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
 import {
+  ASSIGNEE_FILTER,
+  CREATOR_FILTER,
   ID_SUBFILTER,
   IDS_FILTER,
   INSTANCE_DYNAMIC_REGARDING_OF,
   INSTANCE_REGARDING_OF,
   INSTANCE_REGARDING_OF_DIRECTION_FORCED,
   INSTANCE_REGARDING_OF_DIRECTION_REVERSE,
+  PARTICIPANT_FILTER,
   RELATION_INFERRED_SUBFILTER,
   RELATION_TYPE_SUBFILTER,
   TYPE_FILTER,
@@ -168,6 +171,7 @@ import { getDraftContext } from '../utils/draftContext';
 import { enrichWithRemoteCredentials } from '../config/credentials';
 import { ENTITY_TYPE_DRAFT_WORKSPACE } from '../modules/draftWorkspace/draftWorkspace-types';
 import { ENTITY_IPV4_ADDR, ENTITY_IPV6_ADDR, isStixCyberObservable } from '../schema/stixCyberObservable';
+import { coalesceMergeUsersPocAliasAggregationBuckets, getMergeUsersPocCanonicalAliasMap, isMergeUsersPocAliasEnabled } from '../utils/merge-users-poc-alias';
 import { lockResources } from '../lock/master-lock';
 import { DRAFT_OPERATION_CREATE, DRAFT_OPERATION_DELETE, DRAFT_OPERATION_DELETE_LINKED, DRAFT_OPERATION_UPDATE_LINKED } from '../modules/draftWorkspace/draftOperations';
 import { RELATION_SAMPLE } from '../modules/malwareAnalysis/malwareAnalysis-types';
@@ -2390,6 +2394,30 @@ const buildFieldForQuery = (field: string) => {
     ? field
     : `${field}.keyword`;
 };
+const buildUserAliasAggregationSource = (field: string, aliasAware: boolean) => {
+  const queryField = field.endsWith('.keyword') ? field : buildFieldForQuery(field);
+  if (!aliasAware || !isMergeUsersPocAliasEnabled()) {
+    return { field: queryField };
+  }
+  return {
+    script: {
+      lang: 'painless',
+      source: `
+        if (doc[params.field].size() == 0) return [];
+        def ids = [];
+        for (def id : doc[params.field]) {
+          def canonicalId = params.aliases.containsKey(id) ? params.aliases[id] : id;
+          if (!ids.contains(canonicalId)) ids.add(canonicalId);
+        }
+        return ids;
+      `,
+      params: {
+        field: queryField,
+        aliases: getMergeUsersPocCanonicalAliasMap(),
+      },
+    },
+  };
+};
 const buildFieldForScriptQuery = (field: string) => {
   return buildFieldForQuery(field).replaceAll('*', 'internal_id');
 };
@@ -3577,21 +3605,35 @@ type AggregationCountOpts = QueryBodyBuilderOpts & {
   weightField?: string | null;
   normalizeLabel?: boolean | null;
   convertEntityTypeLabel?: boolean | null;
+  userAliasPolicy?: 'operational';
 };
+const USER_ALIAS_AGGREGATION_FIELDS = new Set([
+  'creator_id',
+  'rel_object-assignee.internal_id',
+  'rel_object-participant.internal_id',
+]);
 export const elAggregationCount = async (
   context: AuthContext,
   user: AuthUser,
   indexName: string[] | string | undefined,
   options: AggregationCountOpts = { field: '' },
 ): Promise<{ label: string; value: any; count: number }[]> => {
-  const { field, types = null, weightField = 'i_inference_weight', normalizeLabel = true, convertEntityTypeLabel = false } = options;
+  const {
+    field,
+    types = null,
+    weightField = 'i_inference_weight',
+    normalizeLabel = true,
+    convertEntityTypeLabel = false,
+    userAliasPolicy,
+  } = options;
   const isIdFields = field?.endsWith('internal_id') || field?.endsWith('.id');
+  const aliasAware = userAliasPolicy === 'operational' && USER_ALIAS_AGGREGATION_FIELDS.has(field);
   const body = await elQueryBodyBuilder(context, user, { ...options, noSize: true, noSort: true });
   body.size = 0;
   body.aggs = {
     genres: {
       terms: {
-        field: buildFieldForQuery(field),
+        ...buildUserAliasAggregationSource(field, aliasAware),
         size: MAX_AGGREGATION_SIZE,
       },
       aggs: {
@@ -3843,10 +3885,11 @@ export const elAggregationsList = async (
 ): Promise<{ name: string; values: any }[]> => {
   const { types = [], resolveToRepresentative = true, postResolveFilter } = opts;
   const queryAggs: any = {};
+  const aliasAwareAggregations = new Set([CREATOR_FILTER, ASSIGNEE_FILTER, PARTICIPANT_FILTER]);
   aggregations.forEach((agg) => {
     queryAggs[agg.name] = {
       terms: {
-        field: agg.field,
+        ...buildUserAliasAggregationSource(agg.field, aliasAwareAggregations.has(agg.name)),
         size: 500, // Aggregate on top 500 should get all needed results
       },
     };
@@ -3873,7 +3916,17 @@ export const elAggregationsList = async (
     throw DatabaseError('Aggregations computing list fail', { cause: err, query });
   });
   const aggsMap = Object.keys(data.aggregations);
-  const aggsValues = R.uniq(R.flatten(aggsMap.map((agg) => data.aggregations[agg].buckets?.map((b: { key: string }) => b.key))));
+  const aggregationBuckets = new Map<string, any[]>();
+  aggsMap.forEach((agg) => {
+    const buckets = data.aggregations[agg].buckets ?? [];
+    const resolvedBuckets = aliasAwareAggregations.has(agg)
+      ? coalesceMergeUsersPocAliasAggregationBuckets(buckets)
+      : buckets;
+    aggregationBuckets.set(agg, resolvedBuckets);
+  });
+  const aggsValues = [...new Set(aggsMap.flatMap((agg) => {
+    return (aggregationBuckets.get(agg) ?? []).map((bucket: { key: string }) => bucket.key);
+  }))];
   if (resolveToRepresentative) {
     const baseFields = ['internal_id', 'name', 'entity_type']; // Needs to take elements required to fill extractEntityRepresentative function
     // If post filter is required, we need to retrieve all fields
@@ -3883,12 +3936,12 @@ export const elAggregationsList = async (
     }
     const aggsElementsCache = R.mergeAll(aggsElements.map((element) => ({ [element.internal_id]: extractEntityRepresentativeName(element) })));
     return aggsMap.map((agg) => {
-      const values = data.aggregations[agg].buckets?.map((b: { key: string }) => ({ label: aggsElementsCache[b.key], value: b.key }))?.filter((v: { label: any }) => !!v.label);
+      const values = aggregationBuckets.get(agg)?.map((b: { key: string }) => ({ label: aggsElementsCache[b.key], value: b.key }))?.filter((v: { label: any }) => !!v.label);
       return { name: agg, values };
     });
   }
   return aggsMap.map((agg) => {
-    const values = data.aggregations[agg].buckets?.map((b: any) => ({ label: b.key, value: b.key }));
+    const values = aggregationBuckets.get(agg)?.map((b: any) => ({ label: b.key, value: b.key }));
     return { name: agg, values };
   });
 };

--- a/opencti-platform/opencti-graphql/src/database/members.ts
+++ b/opencti-platform/opencti-graphql/src/database/members.ts
@@ -4,6 +4,32 @@ import type { BasicStoreEntity } from '../types/store';
 import { loadThroughDenormalized } from '../resolvers/stix';
 import { INPUT_ASSIGNEE, INPUT_PARTICIPANT } from '../schema/general';
 import type { Creator } from '../generated/graphql';
+import { resolveMergeUsersPocAliasId } from '../utils/merge-users-poc-alias';
+import { getEntitiesMapFromCache } from './cache';
+import { ENTITY_TYPE_USER } from '../schema/internalObject';
+import { ConfigurationError } from '../config/errors';
+
+const canonicalizeDisplayedMembers = async (
+  context: AuthContext,
+  members: BasicStoreEntity[],
+): Promise<BasicStoreEntity[]> => {
+  const canonicalIds = members.map((member) => resolveMergeUsersPocAliasId(member.internal_id));
+  if (canonicalIds.every((id, index) => id === members[index].internal_id)) {
+    return members;
+  }
+  const platformUsers = await getEntitiesMapFromCache<BasicStoreEntity>(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  const displayedMembers = canonicalIds.map((id, index) => {
+    if (id === members[index].internal_id) {
+      return members[index];
+    }
+    const target = platformUsers.get(id);
+    if (!target) {
+      throw ConfigurationError('MERGE_POC_ALIAS_MAP target user cannot be resolved', { id });
+    }
+    return target;
+  });
+  return [...new Map(displayedMembers.map((member) => [member.internal_id, member])).values()];
+};
 
 export const loadCreators = async (
   context: AuthContext,
@@ -42,7 +68,8 @@ export const loadParticipants = async (
   if (!participants) {
     return [];
   }
-  return filterMembersUsersWithUsersOrgs(context, user, participants);
+  const canonicalParticipants = await canonicalizeDisplayedMembers(context, participants);
+  return filterMembersUsersWithUsersOrgs(context, user, canonicalParticipants);
 };
 
 export const loadAssignees = async (
@@ -54,5 +81,6 @@ export const loadAssignees = async (
   if (!assignees) {
     return [];
   }
-  return filterMembersUsersWithUsersOrgs(context, user, assignees);
+  const canonicalAssignees = await canonicalizeDisplayedMembers(context, assignees);
+  return filterMembersUsersWithUsersOrgs(context, user, canonicalAssignees);
 };

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -42,6 +42,8 @@ import { completeContextDataForEntity, publishUserAction } from '../listener/Use
 import { extractEntityRepresentativeName } from './entity-representative';
 import { asyncMap } from '../utils/data-processing';
 import { isFilterGroupNotEmpty } from '../utils/filtering/filtering-utils';
+import { expandMergeUsersPocAliasFilterGroup } from '../utils/merge-users-poc-alias';
+import { ENTITY_TYPE_ACTIVITY, ENTITY_TYPE_HISTORY, ENTITY_TYPE_PIR_HISTORY } from '../schema/internalObject';
 
 export interface FiltersWithNested extends Filter {
   nested?: Array<{
@@ -275,13 +277,20 @@ export const buildRelationsFilter = <T extends BasicStoreCommon>(relationTypes: 
     R.dissoc('confidences'),
   )(args);
 
-  let computedFilters = filters;
+  const queriedTypes = Array.isArray(types) ? types : [types];
+  const preservesHistoricalUserIds = queriedTypes.some((type) => {
+    return type === ENTITY_TYPE_ACTIVITY || type === ENTITY_TYPE_HISTORY || type === ENTITY_TYPE_PIR_HISTORY;
+  });
+  const aliasExpandedFilters = filters && !preservesHistoricalUserIds
+    ? expandMergeUsersPocAliasFilterGroup(filters)
+    : filters;
+  let computedFilters = aliasExpandedFilters;
   // Args filters must be wrapper on top of api filters
   if (filtersFromOptionsContent.length > 0) {
     computedFilters = {
       mode: FilterMode.And,
       filters: filtersFromOptionsContent,
-      filterGroups: filters && isFilterGroupNotEmpty(filters) ? [filters] : [],
+      filterGroups: aliasExpandedFilters && isFilterGroupNotEmpty(aliasExpandedFilters) ? [aliasExpandedFilters] : [],
     };
   }
   return {

--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -12,6 +12,7 @@ import {
   AccessRequiredError,
   ALREADY_DELETED_ERROR,
   AlreadyDeletedError,
+  ConfigurationError,
   DatabaseError,
   ForbiddenAccess,
   FunctionalError,
@@ -126,7 +127,9 @@ import {
   RELATION_EXTERNAL_REFERENCE,
   RELATION_GRANTED_TO,
   RELATION_OBJECT,
+  RELATION_OBJECT_ASSIGNEE,
   RELATION_OBJECT_MARKING,
+  RELATION_OBJECT_PARTICIPANT,
   STIX_REF_RELATIONSHIP_TYPES,
 } from '../schema/stixRefRelationship';
 import { ENTITY_TYPE_HISTORY, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_STATUS, ENTITY_TYPE_USER } from '../schema/internalObject';
@@ -200,7 +203,7 @@ import {
   topRelationsList,
 } from './middleware-loader';
 import { checkRelationConsistency, isRelationConsistent } from '../utils/modelConsistency';
-import { getEntitiesListFromCache, getEntityFromCache } from './cache';
+import { getEntitiesListFromCache, getEntitiesMapFromCache, getEntityFromCache } from './cache';
 import { ACTION_TYPE_SHARE, ACTION_TYPE_UNSHARE, createListTask } from '../domain/backgroundTask-common';
 import { type BasicStoreEntityVocabulary, ENTITY_TYPE_VOCABULARY, vocabularyDefinitions } from '../modules/vocabulary/vocabulary-types';
 import { getVocabulariesCategories, getVocabularyCategoryForField, isEntityFieldAnOpenVocabulary, updateElasticVocabularyValue } from '../modules/vocabulary/vocabulary-utils';
@@ -211,6 +214,7 @@ import { validateInputCreation, validateInputUpdate } from '../schema/schema-val
 import { telemetry } from '../config/tracing';
 import { cleanMarkings, handleMarkingOperations } from '../utils/markingDefinition-utils';
 import { buildUpdatePatchForUpsert, generateInputsForUpsert } from '../utils/upsert-utils';
+import { canonicalizeMergeUsersPocAliasUpdateInputs, getMergeUsersPocCanonicalAliasMap, resolveMergeUsersPocAliasId } from '../utils/merge-users-poc-alias';
 import { buildChanges, generateCreateMessage, generateRestoreMessage } from './data-changes';
 import { authorizedMembers, authorizedMembersActivationDate, confidence, iAliasedIds, iAttributes, modified, type RefAttribute, updatedAt } from '../schema/attribute-definition';
 import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
@@ -882,6 +886,7 @@ export const distributionEntities = async (
   const distributionData = await elAggregationCount(context, user, args.onlyInferred ? READ_DATA_INDICES_INFERRED : READ_DATA_INDICES, {
     ...distributionArgs,
     field: finalField,
+    userAliasPolicy: 'operational',
   });
   // Take a maximum amount of distribution depending on the ordering.
   const orderingFunction = order === 'asc' ? R.ascend : R.descend;
@@ -2361,6 +2366,36 @@ const updateAttributeRaw = async (
   };
 };
 
+const MERGE_USERS_POC_OPERATIONAL_WRITE_KEYS = new Set([
+  'creator_id',
+  'objectAssignee',
+  'objectParticipant',
+  RELATION_OBJECT_ASSIGNEE,
+  RELATION_OBJECT_PARTICIPANT,
+]);
+
+const validateMergeUsersPocAliasTargets = async (
+  context: AuthContext,
+  inputs: Array<{ key: string; value?: unknown[] | null }>,
+) => {
+  const configuredTargetIds = new Set(Object.values(getMergeUsersPocCanonicalAliasMap()));
+  const targetIds = inputs
+    .filter((input) => MERGE_USERS_POC_OPERATIONAL_WRITE_KEYS.has(input.key))
+    .flatMap((input) => input.value ?? [])
+    .filter((value): value is string => typeof value === 'string')
+    .map((id) => ({ id, targetId: resolveMergeUsersPocAliasId(id) }))
+    .filter(({ id, targetId }) => id !== targetId || configuredTargetIds.has(id))
+    .map(({ targetId }) => targetId);
+  if (targetIds.length === 0) {
+    return;
+  }
+  const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  const missingTargetIds = [...new Set(targetIds)].filter((id) => !platformUsers.get(id));
+  if (missingTargetIds.length > 0) {
+    throw ConfigurationError('MERGE_POC_ALIAS_MAP target users cannot be resolved', { ids: missingTargetIds });
+  }
+};
+
 const resolveRefsForInputs = async (
   context: AuthContext,
   user: AuthUser,
@@ -2857,7 +2892,9 @@ export const updateAttributeFromLoadedWithRefs = async <T extends StoreObject>(
     controlUserConfidenceAgainstElement(user, initial);
   }
   const newInputs = adaptUpdateInputsConfidence(user, inputs, initial) as EditInput[];
-  const revolvedInputs = await resolveRefsForInputs(context, user, initial.entity_type, newInputs);
+  await validateMergeUsersPocAliasTargets(context, newInputs);
+  const aliasAwareInputs = canonicalizeMergeUsersPocAliasUpdateInputs(newInputs);
+  const revolvedInputs = await resolveRefsForInputs(context, user, initial.entity_type, aliasAwareInputs);
 
   return updateAttributeMetaResolved<T>(context, user, initial, revolvedInputs as EditInput[], opts);
 };
@@ -3204,13 +3241,18 @@ const upsertElement = async (
 
   // upsertOperations : resolve refs
   if (updatePatch.upsertOperations?.length > 0) {
-    updatePatch.upsertOperations = await resolveRefsForInputs(context, user, type, updatePatch.upsertOperations);
+    const upsertOperations = updatePatch.upsertOperations as EditInput[];
+    await validateMergeUsersPocAliasTargets(context, upsertOperations);
+    const aliasAwareOperations = canonicalizeMergeUsersPocAliasUpdateInputs(upsertOperations);
+    updatePatch.upsertOperations = await resolveRefsForInputs(context, user, type, aliasAwareOperations);
   }
 
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   const validEnterpriseEdition = isEnterpriseEditionFromSettings(settings);
   // All inputs impacted by modifications (+inner)
-  const inputs = await generateInputsForUpsert(context, user, resolvedElement, type, updatePatch, confidenceForUpsert, validEnterpriseEdition) as EditInput[];
+  const rawInputs = await generateInputsForUpsert(context, user, resolvedElement, type, updatePatch, confidenceForUpsert, validEnterpriseEdition) as EditInput[];
+  await validateMergeUsersPocAliasTargets(context, rawInputs);
+  const inputs = canonicalizeMergeUsersPocAliasUpdateInputs(rawInputs);
 
   // -- If modifications need to be done, add updated_at and modified
   if (inputs.length > 0) {
@@ -3295,10 +3337,15 @@ export const createRelationRaw = async (
 ) => {
   let lock;
   const { fromRule, locks = [] } = opts;
-  const { fromId, toId, relationship_type: relationshipType } = rawInput;
 
   // region confidence control
   const input = structuredClone(rawInput);
+  const { relationship_type: relationshipType } = input;
+  if (relationshipType === RELATION_OBJECT_ASSIGNEE || relationshipType === RELATION_OBJECT_PARTICIPANT) {
+    await validateMergeUsersPocAliasTargets(context, [{ key: relationshipType, value: [input.toId] }]);
+    input.toId = resolveMergeUsersPocAliasId(input.toId);
+  }
+  const { fromId, toId } = input;
   const { confidenceLevelToApply } = controlCreateInputWithUserConfidence(user, input as ObjectWithConfidence, relationshipType);
   input.confidence = confidenceLevelToApply; // confidence of the new relation will be capped to user's confidence
   // endregion
@@ -3610,6 +3657,17 @@ const internalCreateEntityRaw = async (
 ) => {
   // region confidence control
   const input = { ...rawInput };
+  const operationalUserInputs = ['objectAssignee', 'objectParticipant']
+    .filter((field) => input[field] !== undefined)
+    .map((field) => ({ key: field, value: Array.isArray(input[field]) ? input[field] : [input[field]] }));
+  await validateMergeUsersPocAliasTargets(context, operationalUserInputs);
+  for (const field of ['objectAssignee', 'objectParticipant']) {
+    if (Array.isArray(input[field])) {
+      input[field] = input[field].map((id: unknown) => typeof id === 'string' ? resolveMergeUsersPocAliasId(id) : id);
+    } else if (typeof input[field] === 'string') {
+      input[field] = resolveMergeUsersPocAliasId(input[field]);
+    }
+  }
   const { confidenceLevelToApply } = controlCreateInputWithUserConfidence(user, input as ObjectWithConfidence, type);
   input.confidence = confidenceLevelToApply; // confidence of new entity will be capped to user's confidence
   // authorized_members renaming

--- a/opencti-platform/opencti-graphql/src/domain/stixObjectOrStixRelationship.ts
+++ b/opencti-platform/opencti-graphql/src/domain/stixObjectOrStixRelationship.ts
@@ -3,7 +3,7 @@ import { READ_PLATFORM_INDICES, UPDATE_OPERATION_ADD, UPDATE_OPERATION_REMOVE } 
 import { type EntityOptions, storeLoadById } from '../database/middleware-loader';
 import { ABSTRACT_STIX_OBJECT, ABSTRACT_STIX_REF_RELATIONSHIP, ABSTRACT_STIX_RELATIONSHIP } from '../schema/general';
 import { FunctionalError, UnsupportedError } from '../config/errors';
-import { isStixRefRelationship, RELATION_CREATED_BY, RELATION_OBJECT_MARKING } from '../schema/stixRefRelationship';
+import { isStixRefRelationship, RELATION_CREATED_BY, RELATION_OBJECT_ASSIGNEE, RELATION_OBJECT_MARKING, RELATION_OBJECT_PARTICIPANT } from '../schema/stixRefRelationship';
 import { pageEntitiesOrRelationsConnection, storeLoadByIdWithRefs, transformPatchToInput, updateAttributeFromLoadedWithRefs, validateCreatedBy } from '../database/middleware';
 import { notify } from '../database/redis';
 import { BUS_TOPICS } from '../config/conf';
@@ -13,8 +13,13 @@ import type { BasicStoreCommon, BasicStoreObject, BasicConnection } from '../typ
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { buildRelationData } from '../database/data-builder';
 import { validateMarking } from '../utils/access';
+import { canonicalizeMergeUsersPocAliasIds, expandMergeUsersPocAliasIds, resolveMergeUsersPocAliasId } from '../utils/merge-users-poc-alias';
 
 type BusTopicsKeyType = keyof typeof BUS_TOPICS;
+
+const isOperationalUserRelationship = (relationshipType: string) => {
+  return relationshipType === RELATION_OBJECT_ASSIGNEE || relationshipType === RELATION_OBJECT_PARTICIPANT;
+};
 
 export const findById = async <T extends BasicStoreObject> (context: AuthContext, user: AuthUser, id: string): Promise<T> => {
   return await elLoadById(context, user, id, { indices: READ_PLATFORM_INDICES }) as unknown as T;
@@ -43,7 +48,13 @@ const patchElementWithRefRelationships = async (
   if (!fieldName) {
     throw UnsupportedError('This relationship type is not supported', { relationship_type });
   }
-  const inputs = transformPatchToInput({ [fieldName]: targets }, { [fieldName]: operation });
+  let aliasAwareTargets = targets;
+  if (isOperationalUserRelationship(relationship_type)) {
+    aliasAwareTargets = operation === UPDATE_OPERATION_ADD
+      ? canonicalizeMergeUsersPocAliasIds(targets)
+      : expandMergeUsersPocAliasIds(targets);
+  }
+  const inputs = transformPatchToInput({ [fieldName]: aliasAwareTargets }, { [fieldName]: operation });
   const { element: patchedFrom } = await updateAttributeFromLoadedWithRefs(context, user, initial, inputs, opts);
   return patchedFrom;
 };
@@ -56,16 +67,19 @@ export const stixObjectOrRelationshipAddRefRelation = async (
   type: string,
   opts = {},
 ): Promise<any> => { // TODO remove any when all resolvers in ts
+  const targetId = isOperationalUserRelationship(input.relationship_type)
+    ? resolveMergeUsersPocAliasId(input.toId)
+    : input.toId;
   // Validate specific relations, created by and markings
   if (input.relationship_type === RELATION_OBJECT_MARKING) {
-    await validateMarking(context, user, input.toId);
+    await validateMarking(context, user, targetId);
   }
   if (input.relationship_type === RELATION_CREATED_BY) {
-    await validateCreatedBy(context, user, input.toId);
+    await validateCreatedBy(context, user, targetId);
   }
   // Add the relationship with patching
-  const to = await findById(context, user, input.toId);
-  const patchedFrom = await patchElementWithRefRelationships(context, user, stixObjectOrRelationshipId, type, input.relationship_type, [input.toId], UPDATE_OPERATION_ADD, opts);
+  const to = await findById(context, user, targetId);
+  const patchedFrom = await patchElementWithRefRelationships(context, user, stixObjectOrRelationshipId, type, input.relationship_type, [targetId], UPDATE_OPERATION_ADD, opts);
   const { element: refRelation } = await buildRelationData(context, user, { from: patchedFrom, to, relationship_type: input.relationship_type });
   await notify(BUS_TOPICS[type as BusTopicsKeyType].EDIT_TOPIC, refRelation, user);
   return refRelation as any;

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -307,15 +307,26 @@ const buildCreatorUser = (user) => {
     [RELATION_PARTICIPATE_TO]: user[RELATION_PARTICIPATE_TO],
   };
 };
+const buildDisplayedCreator = (platformUsers, id) => {
+  const canonicalId = resolveMergeUsersPocAliasId(id);
+  const creator = INTERNAL_USERS[canonicalId] || buildCreatorUser(platformUsers.get(canonicalId));
+  if (!creator && canonicalId !== id) {
+    throw ConfigurationError('MERGE_POC_ALIAS_MAP target user cannot be resolved', { id: canonicalId });
+  }
+  return creator || SYSTEM_USER;
+};
 export const batchCreator = async (context, user, userIds) => {
   const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-  return userIds.map((id) => INTERNAL_USERS[id] || buildCreatorUser(platformUsers.get(id)) || SYSTEM_USER);
+  return userIds.map((id) => buildDisplayedCreator(platformUsers, id));
 };
 
 export const batchCreators = async (context, user, userListIds) => {
   const userIds = userListIds.map((u) => (Array.isArray(u) ? u : [u]));
   const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-  return userIds.map((ids) => ids.map((id) => INTERNAL_USERS[id] || buildCreatorUser(platformUsers.get(id)) || SYSTEM_USER));
+  return userIds.map((ids) => R.uniqBy(
+    (creator) => creator.id,
+    ids.map((id) => buildDisplayedCreator(platformUsers, id)),
+  ));
 };
 
 export const userOrganizationsPaginatedWithoutInferences = async (context, user, userId, opts) => {
@@ -1989,18 +2000,14 @@ export const buildCompleteUser = async (context, client) => {
 };
 
 export const resolveUserByIdFromCache = async (context, id) => {
-  // PoC merge-users #2: alias redirection, no-op unless MERGE_POC_ALIAS_MAP is set.
-  const resolvedId = resolveMergeUsersPocAliasId(id);
-  if (INTERNAL_USERS[resolvedId]) return INTERNAL_USERS[resolvedId];
+  if (INTERNAL_USERS[id]) return INTERNAL_USERS[id];
   const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-  return platformUsers.get(resolvedId);
+  return platformUsers.get(id);
 };
 
 export const resolveUserById = async (context, id) => {
-  // PoC merge-users #2: alias redirection, no-op unless MERGE_POC_ALIAS_MAP is set.
-  const resolvedId = resolveMergeUsersPocAliasId(id);
-  if (INTERNAL_USERS[resolvedId]) return INTERNAL_USERS[resolvedId];
-  const client = await storeLoadById(context, SYSTEM_USER, resolvedId, ENTITY_TYPE_USER);
+  if (INTERNAL_USERS[id]) return INTERNAL_USERS[id];
+  const client = await storeLoadById(context, SYSTEM_USER, id, ENTITY_TYPE_USER);
   return buildCompleteUser(context, client);
 };
 

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -57,6 +57,7 @@ import { ABSTRACT_INTERNAL_RELATIONSHIP, ABSTRACT_STIX_DOMAIN_OBJECT, OPENCTI_AD
 import { generateStandardId } from '../schema/identifier';
 import { ENTITY_TYPE_CAPABILITY, ENTITY_TYPE_GROUP, ENTITY_TYPE_ROLE, ENTITY_TYPE_SETTINGS, ENTITY_TYPE_USER } from '../schema/internalObject';
 import { getTokensUsage, updateTokenUsage } from '../database/redis/token_usage';
+import { resolveMergeUsersPocAliasId } from '../utils/merge-users-poc-alias';
 import {
   isInternalRelationship,
   RELATION_ACCESSES_TO,
@@ -1988,14 +1989,18 @@ export const buildCompleteUser = async (context, client) => {
 };
 
 export const resolveUserByIdFromCache = async (context, id) => {
-  if (INTERNAL_USERS[id]) return INTERNAL_USERS[id];
+  // PoC merge-users #2: alias redirection, no-op unless MERGE_POC_ALIAS_MAP is set.
+  const resolvedId = resolveMergeUsersPocAliasId(id);
+  if (INTERNAL_USERS[resolvedId]) return INTERNAL_USERS[resolvedId];
   const platformUsers = await getEntitiesMapFromCache(context, SYSTEM_USER, ENTITY_TYPE_USER);
-  return platformUsers.get(id);
+  return platformUsers.get(resolvedId);
 };
 
 export const resolveUserById = async (context, id) => {
-  if (INTERNAL_USERS[id]) return INTERNAL_USERS[id];
-  const client = await storeLoadById(context, SYSTEM_USER, id, ENTITY_TYPE_USER);
+  // PoC merge-users #2: alias redirection, no-op unless MERGE_POC_ALIAS_MAP is set.
+  const resolvedId = resolveMergeUsersPocAliasId(id);
+  if (INTERNAL_USERS[resolvedId]) return INTERNAL_USERS[resolvedId];
+  const client = await storeLoadById(context, SYSTEM_USER, resolvedId, ENTITY_TYPE_USER);
   return buildCompleteUser(context, client);
 };
 

--- a/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
+++ b/opencti-platform/opencti-graphql/src/utils/filtering/filtering-stix/stix-testers.ts
@@ -59,6 +59,7 @@ import type { AuthUser } from '../../../types/user';
 import { UnsupportedError } from '../../../config/errors';
 import type { PirInformation } from '../../../modules/pir/pir-types';
 import { pushAll } from '../../arrayUtil';
+import { canonicalizeMergeUsersPocAliasIds, resolveMergeUsersPocAliasId } from '../../merge-users-poc-alias';
 
 // -----------------------------------------------------------------------------------
 // Testers for each possible filter.
@@ -186,7 +187,8 @@ export const testCreatedBy = (stix: any, filter: Filter, changeContext?: { filte
  */
 export const testCreator = (stix: any, filter: Filter, changeContext?: { filterKey: string; eventContext: FilterEventContext }) => {
   const stixValues: string[] = stix.extensions?.[STIX_EXT_OCTI]?.creator_ids ?? [];
-  return testStringFilter(filter, stixValues, changeContext);
+  const aliasFilter = { ...filter, values: filter.values.map((value) => typeof value === 'string' ? resolveMergeUsersPocAliasId(value) : value) };
+  return testStringFilter(aliasFilter, canonicalizeMergeUsersPocAliasIds(stixValues), changeContext);
 };
 
 /**
@@ -195,7 +197,8 @@ export const testCreator = (stix: any, filter: Filter, changeContext?: { filterK
  */
 export const testAssignee = (stix: any, filter: Filter, changeContext?: { filterKey: string; eventContext: FilterEventContext }) => {
   const stixValues: string[] = stix.extensions?.[STIX_EXT_OCTI]?.assignee_ids ?? [];
-  return testStringFilter(filter, stixValues, changeContext);
+  const aliasFilter = { ...filter, values: filter.values.map((value) => typeof value === 'string' ? resolveMergeUsersPocAliasId(value) : value) };
+  return testStringFilter(aliasFilter, canonicalizeMergeUsersPocAliasIds(stixValues), changeContext);
 };
 
 /**
@@ -204,7 +207,8 @@ export const testAssignee = (stix: any, filter: Filter, changeContext?: { filter
  */
 export const testParticipant = (stix: any, filter: Filter, changeContext?: { filterKey: string; eventContext: FilterEventContext }) => {
   const stixValues: string[] = stix.extensions?.[STIX_EXT_OCTI]?.participant_ids ?? [];
-  return testStringFilter(filter, stixValues, changeContext);
+  const aliasFilter = { ...filter, values: filter.values.map((value) => typeof value === 'string' ? resolveMergeUsersPocAliasId(value) : value) };
+  return testStringFilter(aliasFilter, canonicalizeMergeUsersPocAliasIds(stixValues), changeContext);
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/utils/merge-users-poc-alias.ts
+++ b/opencti-platform/opencti-graphql/src/utils/merge-users-poc-alias.ts
@@ -1,17 +1,21 @@
+import { type Filter, type FilterGroup, FilterOperator } from '../generated/graphql';
+import { ASSIGNEE_FILTER, CREATOR_FILTER, PARTICIPANT_FILTER } from './filtering/filtering-constants';
+import { isInternalId } from '../schema/schemaUtils';
+
 /**
- * PoC #2 (merge users investigation) - "alias" prototype.
+ * PoC #2 (merge users investigation) - distributed alias prototype.
  *
- * This module is a throwaway prototype used to measure the impact of redirecting
- * reads of a "source" user id to a "target" user id, WITHOUT rewriting any stored data.
+ * The iteration deliberately exposes separate operations because one global
+ * source-to-target replacement is not correct in every context:
+ * - display and new operational writes canonicalize to the target;
+ * - searches expand the target to all physical aliases;
+ * - aggregations coalesce physical buckets under the target;
+ * - authorization and historical attribution are not passed through this module.
  *
- * It is opt-in only: with the env var unset, `getMergeUsersPocAliasMap()` returns an
- * empty map and `resolveMergeUsersPocAliasId()` is a no-op, so default production
- * behavior is strictly unchanged.
+ * It is opt-in only. With the env var unset, every operation is a no-op.
  *
  * Enable with:
  *   MERGE_POC_ALIAS_MAP='{"<sourceUserId>":"<targetUserId>"}'
- *
- * See PR description ("Résultats du PoC") for what this does and does not cover.
  */
 
 let cachedRawValue: string | undefined;
@@ -21,32 +25,179 @@ const parseAliasMap = (raw: string | undefined): Map<string, string> => {
   if (!raw) {
     return new Map();
   }
+
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw);
-    return new Map(Object.entries(parsed));
-  } catch {
-    // Fail closed: an invalid value must not accidentally enable the redirection.
-    return new Map();
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error('MERGE_POC_ALIAS_MAP must be a JSON object mapping source user ids to target user ids', { cause: error });
   }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('MERGE_POC_ALIAS_MAP must be a JSON object mapping source user ids to target user ids');
+  }
+
+  const aliasMap = new Map<string, string>();
+  for (const [sourceId, targetId] of Object.entries(parsed)) {
+    if (!sourceId || typeof targetId !== 'string' || !targetId) {
+      throw new Error('MERGE_POC_ALIAS_MAP entries must contain non-empty string user ids');
+    }
+    if (!isInternalId(sourceId) || !isInternalId(targetId)) {
+      throw new Error('MERGE_POC_ALIAS_MAP entries must contain internal user ids');
+    }
+    aliasMap.set(sourceId, targetId);
+  }
+
+  for (const sourceId of aliasMap.keys()) {
+    const visited = new Set<string>();
+    let currentId = sourceId;
+    while (aliasMap.has(currentId)) {
+      if (visited.has(currentId)) {
+        throw new Error(`MERGE_POC_ALIAS_MAP contains a cycle involving user ${currentId}`);
+      }
+      visited.add(currentId);
+      currentId = aliasMap.get(currentId) as string;
+    }
+  }
+
+  return aliasMap;
 };
 
 // Lazily parsed (and re-parsed if the env var changes, e.g. between test cases).
 const getMergeUsersPocAliasMap = (): Map<string, string> => {
   const raw = process.env.MERGE_POC_ALIAS_MAP;
   if (raw !== cachedRawValue) {
+    const aliasMap = parseAliasMap(raw);
     cachedRawValue = raw;
-    cachedAliasMap = parseAliasMap(raw);
+    cachedAliasMap = aliasMap;
   }
   return cachedAliasMap;
 };
 
 /**
- * Returns the "target" id to use instead of the given id if it is registered
- * as a PoC alias "source", otherwise returns the id unchanged.
+ * Canonicalizes an id for display or a new operational write.
  */
 export const resolveMergeUsersPocAliasId = (id: string): string => {
   const aliasMap = getMergeUsersPocAliasMap();
-  return aliasMap.get(id) ?? id;
+  let resolvedId = id;
+  while (aliasMap.has(resolvedId)) {
+    resolvedId = aliasMap.get(resolvedId) as string;
+  }
+  return resolvedId;
+};
+
+export const canonicalizeMergeUsersPocAliasIds = (ids: string[]): string[] => {
+  return [...new Set(ids.map((id) => resolveMergeUsersPocAliasId(id)))];
+};
+
+/**
+ * Expands a logical user id to every id under which operational data may still
+ * be physically stored.
+ */
+export const expandMergeUsersPocAliasIds = (ids: string[]): string[] => {
+  const aliasMap = getMergeUsersPocAliasMap();
+  const expandedIds = ids.flatMap((id) => {
+    const targetId = resolveMergeUsersPocAliasId(id);
+    const sourceIds = [...aliasMap.keys()].filter((sourceId) => resolveMergeUsersPocAliasId(sourceId) === targetId);
+    return [targetId, ...sourceIds];
+  });
+  return [...new Set(expandedIds)];
+};
+
+export const getMergeUsersPocCanonicalAliasMap = (): Record<string, string> => {
+  const canonicalAliases = [...getMergeUsersPocAliasMap().keys()].map((sourceId) => {
+    return [sourceId, resolveMergeUsersPocAliasId(sourceId)];
+  });
+  return Object.fromEntries(canonicalAliases);
+};
+
+const USER_OPERATIONAL_FILTER_KEYS = new Set([
+  CREATOR_FILTER,
+  ASSIGNEE_FILTER,
+  PARTICIPANT_FILTER,
+  'creator_id',
+  'rel_object-assignee.internal_id',
+  'rel_object-participant.internal_id',
+]);
+
+const expandOperationalFilter = (filter: Filter): Filter => {
+  const rawKey = filter.key as unknown as string | string[];
+  const keys = Array.isArray(rawKey) ? rawKey : [rawKey];
+  const isOperationalUserFilter = keys.length === 1 && USER_OPERATIONAL_FILTER_KEYS.has(keys[0]);
+  const isEqualityFilter = filter.operator === undefined
+    || filter.operator === null
+    || filter.operator === FilterOperator.Eq
+    || filter.operator === FilterOperator.NotEq;
+  if (!isOperationalUserFilter || !isEqualityFilter) {
+    return filter;
+  }
+
+  const expandedValues = filter.values.flatMap((value) => {
+    return typeof value === 'string' ? expandMergeUsersPocAliasIds([value]) : [value];
+  });
+  return { ...filter, values: [...new Set(expandedValues)] };
+};
+
+interface MergeUsersPocAliasUpdateInput {
+  key: string;
+  value?: unknown[] | null;
+  operation?: string | null;
+}
+
+const USER_OPERATIONAL_WRITE_KEYS = new Set([
+  'creator_id',
+  ASSIGNEE_FILTER,
+  PARTICIPANT_FILTER,
+]);
+
+export const canonicalizeMergeUsersPocAliasUpdateInputs = <T extends MergeUsersPocAliasUpdateInput>(inputs: T[]): T[] => {
+  return inputs.map((input) => {
+    if (!USER_OPERATIONAL_WRITE_KEYS.has(input.key) || input.value === null || input.value === undefined) {
+      return input;
+    }
+    const aliasAwareValues = input.value.flatMap((value) => {
+      if (typeof value !== 'string') {
+        return [value];
+      }
+      return input.operation === 'remove'
+        ? expandMergeUsersPocAliasIds([value])
+        : [resolveMergeUsersPocAliasId(value)];
+    });
+    return { ...input, value: [...new Set(aliasAwareValues)] };
+  });
+};
+
+/**
+ * Expands only operational user filters. Security filters such as
+ * restricted_members and historical references such as createdBy remain exact.
+ */
+export const expandMergeUsersPocAliasFilterGroup = (filterGroup: FilterGroup): FilterGroup => {
+  return {
+    ...filterGroup,
+    filters: filterGroup.filters.map(expandOperationalFilter),
+    filterGroups: filterGroup.filterGroups.map(expandMergeUsersPocAliasFilterGroup),
+  };
+};
+
+export interface MergeUsersPocAliasAggregationBucket {
+  key: string;
+  doc_count: number;
+  [key: string]: unknown;
+}
+
+export const coalesceMergeUsersPocAliasAggregationBuckets = (
+  buckets: MergeUsersPocAliasAggregationBucket[],
+): MergeUsersPocAliasAggregationBucket[] => {
+  const bucketsByTarget = new Map<string, MergeUsersPocAliasAggregationBucket>();
+  for (const bucket of buckets) {
+    const targetId = resolveMergeUsersPocAliasId(bucket.key);
+    const existingBucket = bucketsByTarget.get(targetId);
+    bucketsByTarget.set(targetId, {
+      ...(existingBucket ?? bucket),
+      key: targetId,
+      doc_count: (existingBucket?.doc_count ?? 0) + bucket.doc_count,
+    });
+  }
+  return [...bucketsByTarget.values()];
 };
 
 export const isMergeUsersPocAliasEnabled = (): boolean => getMergeUsersPocAliasMap().size > 0;

--- a/opencti-platform/opencti-graphql/src/utils/merge-users-poc-alias.ts
+++ b/opencti-platform/opencti-graphql/src/utils/merge-users-poc-alias.ts
@@ -1,0 +1,52 @@
+/**
+ * PoC #2 (merge users investigation) - "alias" prototype.
+ *
+ * This module is a throwaway prototype used to measure the impact of redirecting
+ * reads of a "source" user id to a "target" user id, WITHOUT rewriting any stored data.
+ *
+ * It is opt-in only: with the env var unset, `getMergeUsersPocAliasMap()` returns an
+ * empty map and `resolveMergeUsersPocAliasId()` is a no-op, so default production
+ * behavior is strictly unchanged.
+ *
+ * Enable with:
+ *   MERGE_POC_ALIAS_MAP='{"<sourceUserId>":"<targetUserId>"}'
+ *
+ * See PR description ("Résultats du PoC") for what this does and does not cover.
+ */
+
+let cachedRawValue: string | undefined;
+let cachedAliasMap: Map<string, string> = new Map();
+
+const parseAliasMap = (raw: string | undefined): Map<string, string> => {
+  if (!raw) {
+    return new Map();
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return new Map(Object.entries(parsed));
+  } catch {
+    // Fail closed: an invalid value must not accidentally enable the redirection.
+    return new Map();
+  }
+};
+
+// Lazily parsed (and re-parsed if the env var changes, e.g. between test cases).
+const getMergeUsersPocAliasMap = (): Map<string, string> => {
+  const raw = process.env.MERGE_POC_ALIAS_MAP;
+  if (raw !== cachedRawValue) {
+    cachedRawValue = raw;
+    cachedAliasMap = parseAliasMap(raw);
+  }
+  return cachedAliasMap;
+};
+
+/**
+ * Returns the "target" id to use instead of the given id if it is registered
+ * as a PoC alias "source", otherwise returns the id unchanged.
+ */
+export const resolveMergeUsersPocAliasId = (id: string): string => {
+  const aliasMap = getMergeUsersPocAliasMap();
+  return aliasMap.get(id) ?? id;
+};
+
+export const isMergeUsersPocAliasEnabled = (): boolean => getMergeUsersPocAliasMap().size > 0;

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/merge-users-poc-alias-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/merge-users-poc-alias-test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  canonicalizeMergeUsersPocAliasIds,
+  canonicalizeMergeUsersPocAliasUpdateInputs,
+  coalesceMergeUsersPocAliasAggregationBuckets,
+  expandMergeUsersPocAliasFilterGroup,
+  expandMergeUsersPocAliasIds,
+  getMergeUsersPocCanonicalAliasMap,
+  resolveMergeUsersPocAliasId,
+} from '../../../src/utils/merge-users-poc-alias';
+import { type Filter, type FilterGroup, FilterMode, FilterOperator } from '../../../src/generated/graphql';
+import { testAssignee, testCreatedBy, testCreator, testParticipant } from '../../../src/utils/filtering/filtering-stix/stix-testers';
+import { STIX_EXT_OCTI } from '../../../src/types/stix-2-1-extensions';
+import { getExplicitUserAccessRight, MEMBER_ACCESS_RIGHT_VIEW, SYSTEM_USER } from '../../../src/utils/access';
+
+const SOURCE_ID = '11111111-1111-4111-8111-111111111111';
+const INTERMEDIATE_ID = '22222222-2222-4222-8222-222222222222';
+const TARGET_ID = '33333333-3333-4333-8333-333333333333';
+
+const enableAlias = (aliases: Record<string, string> = { [SOURCE_ID]: TARGET_ID }) => {
+  process.env.MERGE_POC_ALIAS_MAP = JSON.stringify(aliases);
+};
+
+afterEach(() => {
+  delete process.env.MERGE_POC_ALIAS_MAP;
+});
+
+describe('Merge users PoC alias policies', () => {
+  it('is a no-op unless explicitly enabled', () => {
+    expect(resolveMergeUsersPocAliasId(SOURCE_ID)).toEqual(SOURCE_ID);
+    expect(expandMergeUsersPocAliasIds([TARGET_ID])).toEqual([TARGET_ID]);
+  });
+
+  it('rejects malformed maps and alias cycles instead of silently changing behavior', () => {
+    process.env.MERGE_POC_ALIAS_MAP = 'not-json';
+    expect(() => resolveMergeUsersPocAliasId(SOURCE_ID)).toThrow('MERGE_POC_ALIAS_MAP must be a JSON object');
+
+    enableAlias({ [SOURCE_ID]: 'User--33333333-3333-4333-8333-333333333333' });
+    expect(() => resolveMergeUsersPocAliasId(SOURCE_ID)).toThrow('MERGE_POC_ALIAS_MAP entries must contain internal user ids');
+
+    enableAlias({ [SOURCE_ID]: INTERMEDIATE_ID, [INTERMEDIATE_ID]: SOURCE_ID });
+    expect(() => resolveMergeUsersPocAliasId(SOURCE_ID)).toThrow('MERGE_POC_ALIAS_MAP contains a cycle');
+  });
+
+  it('canonicalizes writes and expands reads across transitive aliases', () => {
+    enableAlias({ [SOURCE_ID]: INTERMEDIATE_ID, [INTERMEDIATE_ID]: TARGET_ID });
+
+    expect(resolveMergeUsersPocAliasId(SOURCE_ID)).toEqual(TARGET_ID);
+    expect(canonicalizeMergeUsersPocAliasIds([SOURCE_ID, INTERMEDIATE_ID, TARGET_ID])).toEqual([TARGET_ID]);
+    expect(expandMergeUsersPocAliasIds([TARGET_ID])).toEqual([TARGET_ID, SOURCE_ID, INTERMEDIATE_ID]);
+    expect(getMergeUsersPocCanonicalAliasMap()).toEqual({
+      [SOURCE_ID]: TARGET_ID,
+      [INTERMEDIATE_ID]: TARGET_ID,
+    });
+  });
+
+  it('expands only operational user filters, including nested groups', () => {
+    enableAlias();
+    const filters: FilterGroup = {
+      mode: FilterMode.And,
+      filters: [
+        { key: ['creator_id'], values: [TARGET_ID], operator: FilterOperator.Eq },
+        { key: ['restricted_members'], values: [TARGET_ID], operator: FilterOperator.Eq },
+        { key: ['createdBy'], values: [TARGET_ID], operator: FilterOperator.Eq },
+      ],
+      filterGroups: [{
+        mode: FilterMode.Or,
+        filters: [{ key: ['objectAssignee'], values: [TARGET_ID], operator: FilterOperator.Eq }],
+        filterGroups: [],
+      }],
+    };
+
+    const expanded = expandMergeUsersPocAliasFilterGroup(filters);
+
+    expect(expanded.filters[0].values).toEqual([TARGET_ID, SOURCE_ID]);
+    expect(expanded.filters[1].values).toEqual([TARGET_ID]);
+    expect(expanded.filters[2].values).toEqual([TARGET_ID]);
+    expect(expanded.filterGroups[0].filters[0].values).toEqual([TARGET_ID, SOURCE_ID]);
+    expect(filters.filters[0].values).toEqual([TARGET_ID]);
+  });
+
+  it('supports legacy string filter keys', () => {
+    enableAlias();
+    const filters: FilterGroup = {
+      mode: FilterMode.And,
+      filters: [{
+        key: 'creator_id',
+        values: [TARGET_ID],
+      } as unknown as Filter],
+      filterGroups: [],
+    };
+
+    expect(expandMergeUsersPocAliasFilterGroup(filters).filters[0].values).toEqual([TARGET_ID, SOURCE_ID]);
+  });
+
+  it('canonicalizes generic operational updates and expands removals', () => {
+    enableAlias();
+
+    expect(canonicalizeMergeUsersPocAliasUpdateInputs([
+      { key: 'creator_id', value: [SOURCE_ID], operation: 'replace' },
+      { key: 'objectAssignee', value: [SOURCE_ID], operation: 'add' },
+      { key: 'objectParticipant', value: [TARGET_ID], operation: 'remove' },
+      { key: 'restricted_members', value: [SOURCE_ID], operation: 'replace' },
+    ])).toEqual([
+      { key: 'creator_id', value: [TARGET_ID], operation: 'replace' },
+      { key: 'objectAssignee', value: [TARGET_ID], operation: 'add' },
+      { key: 'objectParticipant', value: [TARGET_ID, SOURCE_ID], operation: 'remove' },
+      { key: 'restricted_members', value: [SOURCE_ID], operation: 'replace' },
+    ]);
+  });
+
+  it('coalesces source and target aggregation buckets without double listing the user', () => {
+    enableAlias();
+
+    expect(coalesceMergeUsersPocAliasAggregationBuckets([
+      { key: SOURCE_ID, doc_count: 2 },
+      { key: TARGET_ID, doc_count: 3 },
+      { key: 'other-user', doc_count: 1 },
+    ])).toEqual([
+      { key: TARGET_ID, doc_count: 5 },
+      { key: 'other-user', doc_count: 1 },
+    ]);
+  });
+
+  it('matches operational stream filters by alias while preserving historical attribution', () => {
+    enableAlias();
+    const stix = {
+      created_by_ref: SOURCE_ID,
+      extensions: {
+        [STIX_EXT_OCTI]: {
+          creator_ids: [SOURCE_ID],
+          assignee_ids: [SOURCE_ID],
+          participant_ids: [SOURCE_ID],
+        },
+      },
+    };
+    const filter: Filter = {
+      key: ['creator'],
+      mode: FilterMode.Or,
+      operator: FilterOperator.Eq,
+      values: [TARGET_ID],
+    };
+
+    expect(testCreator(stix, filter)).toBe(true);
+    expect(testAssignee(stix, { ...filter, key: ['objectAssignee'] })).toBe(true);
+    expect(testParticipant(stix, { ...filter, key: ['objectParticipant'] })).toBe(true);
+    expect(testCreatedBy(stix, { ...filter, key: ['createdBy'] })).toBe(false);
+  });
+
+  it('does not inherit restricted-member access from the source user', () => {
+    enableAlias();
+    const user = (id: string) => ({
+      ...SYSTEM_USER,
+      id,
+      internal_id: id,
+      capabilities: [],
+      organizations: [],
+      roles: [],
+      groups: [],
+    });
+    const element = {
+      restricted_members: [{
+        id: SOURCE_ID,
+        access_right: MEMBER_ACCESS_RIGHT_VIEW,
+        groups_restriction_ids: [],
+      }],
+      authorized_authorities: [],
+    };
+
+    expect(getExplicitUserAccessRight(user(SOURCE_ID), element)).toEqual(MEMBER_ACCESS_RIGHT_VIEW);
+    expect(getExplicitUserAccessRight(user(TARGET_ID), element)).toBeNull();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/merge-users-poc-alias-fetching-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/merge-users-poc-alias-fetching-test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ADMIN_USER, getAuthUser, testContext, USER_EDITOR, USER_SECURITY } from '../../utils/testQuery';
+import { addReport } from '../../../src/domain/report';
+import { resolveUserByIdFromCache } from '../../../src/domain/user';
+import { deleteElementById } from '../../../src/database/middleware';
+import { fullEntitiesList } from '../../../src/database/middleware-loader';
+import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
+import type { BasicStoreEntity } from '../../../src/types/store';
+import { FilterMode } from '../../../src/generated/graphql';
+
+/**
+ * PoC #2 (merge-users investigation) - "alias" prototype.
+ *
+ * This test demonstrates, with real data, the central finding of the investigation:
+ * redirecting a user id to another user id at the cache-resolution level (Family A)
+ * is enough to change what is *displayed* (e.g. a representative/creator name), but it
+ * has NO effect on *raw Elasticsearch queries* that filter directly on the stored id
+ * (Family B, e.g. a "creator_id" filter). The alias is therefore not neutral: data
+ * created by the "source" user remains invisible to any filter targeting the "target"
+ * user, even though the source user itself now resolves as the target everywhere the
+ * cache is used.
+ *
+ * Source user: USER_EDITOR (creates a report -> report.creator_id = USER_EDITOR.id)
+ * Target user: USER_SECURITY (the alias destination)
+ */
+describe('Merge-users PoC #2 - alias redirection impact on fetching', () => {
+  // `USER_EDITOR.id` / `USER_SECURITY.id` (from testQuery.ts) are STIX standard ids,
+  // used only to look up the real internal ids below. `creator_id` on stored entities
+  // (and the cache map) is keyed by the internal id, so the alias and the filters
+  // below must use `internal_id`, not the standard id.
+  let sourceUser: Awaited<ReturnType<typeof getAuthUser>>;
+  let targetUser: Awaited<ReturnType<typeof getAuthUser>>;
+  let reportId: string;
+
+  beforeAll(async () => {
+    sourceUser = await getAuthUser(USER_EDITOR.id);
+    targetUser = await getAuthUser(USER_SECURITY.id);
+    const report = await addReport(testContext, sourceUser, {
+      name: 'Merge-users PoC alias - report created by source user',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+    });
+    reportId = report.id;
+  });
+
+  afterAll(async () => {
+    delete process.env.MERGE_POC_ALIAS_MAP;
+    if (reportId) {
+      await deleteElementById(testContext, ADMIN_USER, reportId, ENTITY_TYPE_CONTAINER_REPORT);
+    }
+  });
+
+  it('should NOT redirect anything when the alias flag is unset (default production behavior)', async () => {
+    delete process.env.MERGE_POC_ALIAS_MAP;
+    const resolved = await resolveUserByIdFromCache(testContext, sourceUser.internal_id) as { internal_id: string } | undefined;
+    expect(resolved?.internal_id).toEqual(sourceUser.internal_id);
+  });
+
+  it('[Family A] should resolve the source user as the target user through the cache once the alias is enabled', async () => {
+    process.env.MERGE_POC_ALIAS_MAP = JSON.stringify({ [sourceUser.internal_id]: targetUser.internal_id });
+    const resolved = await resolveUserByIdFromCache(testContext, sourceUser.internal_id) as { internal_id: string } | undefined;
+    // Family A works: any code path resolving a user id through the cache (e.g. a
+    // "creator" representative shown in the UI) now sees the target user instead
+    // of the source user, with no data rewrite involved.
+    expect(resolved?.internal_id).toEqual(targetUser.internal_id);
+  });
+
+  it('[Family B] should NOT surface the report through a raw "creator_id = target" filter once the alias is enabled', async () => {
+    process.env.MERGE_POC_ALIAS_MAP = JSON.stringify({ [sourceUser.internal_id]: targetUser.internal_id });
+    // This filter is the standard filtering mechanism (buildEntityFilters) hitting
+    // Elasticsearch directly on the stored `creator_id` field: it never goes through
+    // resolveUserByIdFromCache, so the alias has zero effect here.
+    const reportsForTargetUser = await fullEntitiesList<BasicStoreEntity>(testContext, ADMIN_USER, [ENTITY_TYPE_CONTAINER_REPORT], {
+      filters: {
+        mode: FilterMode.And,
+        filters: [{ key: ['creator_id'], values: [targetUser.internal_id] }],
+        filterGroups: [],
+      },
+    });
+    expect(reportsForTargetUser.map((r) => r.id)).not.toContain(reportId);
+
+    // Proof that the data is untouched: the report is still found when filtering on
+    // the source id, exactly as if the alias did not exist.
+    const reportsForSourceUser = await fullEntitiesList<BasicStoreEntity>(testContext, ADMIN_USER, [ENTITY_TYPE_CONTAINER_REPORT], {
+      filters: {
+        mode: FilterMode.And,
+        filters: [{ key: ['creator_id'], values: [sourceUser.internal_id] }],
+        filterGroups: [],
+      },
+    });
+    expect(reportsForSourceUser.map((r) => r.id)).toContain(reportId);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/merge-users-poc-alias-fetching-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/merge-users-poc-alias-fetching-test.ts
@@ -1,93 +1,231 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { ADMIN_USER, getAuthUser, testContext, USER_EDITOR, USER_SECURITY } from '../../utils/testQuery';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
 import { addReport } from '../../../src/domain/report';
-import { resolveUserByIdFromCache } from '../../../src/domain/user';
-import { deleteElementById } from '../../../src/database/middleware';
+import { findCreators, resolveUserByIdFromCache } from '../../../src/domain/user';
+import { deleteElementById, distributionEntities, updateAttribute } from '../../../src/database/middleware';
 import { fullEntitiesList } from '../../../src/database/middleware-loader';
+import { EditOperation, FilterMode } from '../../../src/generated/graphql';
 import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
 import type { BasicStoreEntity } from '../../../src/types/store';
-import { FilterMode } from '../../../src/generated/graphql';
+import { getExplicitUserAccessRight, MEMBER_ACCESS_RIGHT_VIEW } from '../../../src/utils/access';
+import { ADMIN_USER, getAuthUser, testContext, USER_EDITOR, USER_SECURITY } from '../../utils/testQuery';
+import { queryAsAdmin } from '../../utils/testQueryHelper';
+import { stixObjectOrRelationshipAddRefRelations } from '../../../src/domain/stixObjectOrStixRelationship';
+import { RELATION_OBJECT_ASSIGNEE } from '../../../src/schema/stixRefRelationship';
 
-/**
- * PoC #2 (merge-users investigation) - "alias" prototype.
- *
- * This test demonstrates, with real data, the central finding of the investigation:
- * redirecting a user id to another user id at the cache-resolution level (Family A)
- * is enough to change what is *displayed* (e.g. a representative/creator name), but it
- * has NO effect on *raw Elasticsearch queries* that filter directly on the stored id
- * (Family B, e.g. a "creator_id" filter). The alias is therefore not neutral: data
- * created by the "source" user remains invisible to any filter targeting the "target"
- * user, even though the source user itself now resolves as the target everywhere the
- * cache is used.
- *
- * Source user: USER_EDITOR (creates a report -> report.creator_id = USER_EDITOR.id)
- * Target user: USER_SECURITY (the alias destination)
- */
-describe('Merge-users PoC #2 - alias redirection impact on fetching', () => {
-  // `USER_EDITOR.id` / `USER_SECURITY.id` (from testQuery.ts) are STIX standard ids,
-  // used only to look up the real internal ids below. `creator_id` on stored entities
-  // (and the cache map) is keyed by the internal id, so the alias and the filters
-  // below must use `internal_id`, not the standard id.
+const READ_REPORT_USERS_QUERY = gql`
+  query report($id: String) {
+    report(id: $id) {
+      creators {
+        id
+      }
+      objectAssignee {
+        id
+      }
+      objectParticipant {
+        id
+      }
+    }
+  }
+`;
+
+describe('Merge-users PoC #2 - distributed alias policies', () => {
   let sourceUser: Awaited<ReturnType<typeof getAuthUser>>;
   let targetUser: Awaited<ReturnType<typeof getAuthUser>>;
-  let reportId: string;
+  const reportIds: string[] = [];
+
+  const enableAlias = () => {
+    process.env.MERGE_POC_ALIAS_MAP = JSON.stringify({ [sourceUser.internal_id]: targetUser.internal_id });
+  };
+
+  const findReportIds = async (key: string, userId: string) => {
+    const reports = await fullEntitiesList<BasicStoreEntity>(testContext, ADMIN_USER, [ENTITY_TYPE_CONTAINER_REPORT], {
+      filters: {
+        mode: FilterMode.And,
+        filters: [{ key: [key], values: [userId] }],
+        filterGroups: [],
+      },
+    });
+    return reports.map((report) => report.id);
+  };
 
   beforeAll(async () => {
+    delete process.env.MERGE_POC_ALIAS_MAP;
     sourceUser = await getAuthUser(USER_EDITOR.id);
     targetUser = await getAuthUser(USER_SECURITY.id);
     const report = await addReport(testContext, sourceUser, {
-      name: 'Merge-users PoC alias - report created by source user',
+      name: 'Merge-users PoC alias - legacy source references',
       published: new Date().toISOString(),
       report_types: ['threat-report'],
+      objectAssignee: [sourceUser.internal_id],
+      objectParticipant: [sourceUser.internal_id],
     });
-    reportId = report.id;
+    reportIds.push(report.id);
+  });
+
+  afterEach(() => {
+    delete process.env.MERGE_POC_ALIAS_MAP;
   });
 
   afterAll(async () => {
     delete process.env.MERGE_POC_ALIAS_MAP;
-    if (reportId) {
-      await deleteElementById(testContext, ADMIN_USER, reportId, ENTITY_TYPE_CONTAINER_REPORT);
-    }
+    await Promise.all(reportIds.map((id) => deleteElementById(
+      testContext,
+      ADMIN_USER,
+      id,
+      ENTITY_TYPE_CONTAINER_REPORT,
+    )));
   });
 
-  it('should NOT redirect anything when the alias flag is unset (default production behavior)', async () => {
+  it('canonicalizes dedicated display loaders while keeping security principals exact', async () => {
+    const readDisplayedUserIds = async () => {
+      const result = await queryAsAdmin({ query: READ_REPORT_USERS_QUERY, variables: { id: reportIds[0] } });
+      expect(result.errors).toBeUndefined();
+      const report = result.data?.report as {
+        creators: Array<{ id: string }>;
+        objectAssignee: Array<{ id: string }>;
+        objectParticipant: Array<{ id: string }>;
+      };
+      return {
+        creators: report.creators.map(({ id }) => id),
+        assignees: report.objectAssignee.map(({ id }) => id),
+        participants: report.objectParticipant.map(({ id }) => id),
+      };
+    };
+
+    expect(await readDisplayedUserIds()).toEqual({
+      creators: [sourceUser.internal_id],
+      assignees: [sourceUser.internal_id],
+      participants: [sourceUser.internal_id],
+    });
+    enableAlias();
+    expect(await readDisplayedUserIds()).toEqual({
+      creators: [targetUser.internal_id],
+      assignees: [targetUser.internal_id],
+      participants: [targetUser.internal_id],
+    });
+    const principal = await resolveUserByIdFromCache(testContext, sourceUser.internal_id) as { internal_id: string } | undefined;
+    expect(principal?.internal_id).toEqual(sourceUser.internal_id);
+  });
+
+  it('expands operational filters over physically unchanged legacy data', async () => {
+    const legacyReportId = reportIds[0];
+    enableAlias();
+    expect(await findReportIds('creator_id', targetUser.internal_id)).toContain(legacyReportId);
+    expect(await findReportIds('objectAssignee', targetUser.internal_id)).toContain(legacyReportId);
+    expect(await findReportIds('objectParticipant', targetUser.internal_id)).toContain(legacyReportId);
+
     delete process.env.MERGE_POC_ALIAS_MAP;
-    const resolved = await resolveUserByIdFromCache(testContext, sourceUser.internal_id) as { internal_id: string } | undefined;
-    expect(resolved?.internal_id).toEqual(sourceUser.internal_id);
+    expect(await findReportIds('creator_id', targetUser.internal_id)).not.toContain(legacyReportId);
+    expect(await findReportIds('creator_id', sourceUser.internal_id)).toContain(legacyReportId);
   });
 
-  it('[Family A] should resolve the source user as the target user through the cache once the alias is enabled', async () => {
-    process.env.MERGE_POC_ALIAS_MAP = JSON.stringify({ [sourceUser.internal_id]: targetUser.internal_id });
-    const resolved = await resolveUserByIdFromCache(testContext, sourceUser.internal_id) as { internal_id: string } | undefined;
-    // Family A works: any code path resolving a user id through the cache (e.g. a
-    // "creator" representative shown in the UI) now sees the target user instead
-    // of the source user, with no data rewrite involved.
-    expect(resolved?.internal_id).toEqual(targetUser.internal_id);
-  });
+  it('coalesces real distribution counts before limiting aggregation buckets', async () => {
+    const targetReport = await addReport(testContext, targetUser, {
+      name: 'Merge-users PoC alias - target aggregation bucket',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+    });
+    reportIds.push(targetReport.id);
 
-  it('[Family B] should NOT surface the report through a raw "creator_id = target" filter once the alias is enabled', async () => {
-    process.env.MERGE_POC_ALIAS_MAP = JSON.stringify({ [sourceUser.internal_id]: targetUser.internal_id });
-    // This filter is the standard filtering mechanism (buildEntityFilters) hitting
-    // Elasticsearch directly on the stored `creator_id` field: it never goes through
-    // resolveUserByIdFromCache, so the alias has zero effect here.
-    const reportsForTargetUser = await fullEntitiesList<BasicStoreEntity>(testContext, ADMIN_USER, [ENTITY_TYPE_CONTAINER_REPORT], {
+    enableAlias();
+    const creators = await findCreators(testContext, ADMIN_USER, {
+      entityTypes: [ENTITY_TYPE_CONTAINER_REPORT],
+    }) as { edges: Array<{ node: { id: string } }> };
+    const creatorIds = creators.edges.map((edge) => edge.node.id);
+    expect(creatorIds).toContain(targetUser.internal_id);
+    expect(creatorIds).not.toContain(sourceUser.internal_id);
+
+    const distribution = await distributionEntities(testContext, ADMIN_USER, [ENTITY_TYPE_CONTAINER_REPORT], {
+      field: 'creator_id',
+      limit: 10,
       filters: {
         mode: FilterMode.And,
-        filters: [{ key: ['creator_id'], values: [targetUser.internal_id] }],
+        filters: [{ key: ['internal_id'], values: [reportIds[0], targetReport.id] }],
         filterGroups: [],
       },
     });
-    expect(reportsForTargetUser.map((r) => r.id)).not.toContain(reportId);
+    expect(distribution).toHaveLength(1);
+    expect(distribution[0].entity.internal_id).toEqual(targetUser.internal_id);
+    expect(distribution[0].value).toEqual(2);
+  });
 
-    // Proof that the data is untouched: the report is still found when filtering on
-    // the source id, exactly as if the alias did not exist.
-    const reportsForSourceUser = await fullEntitiesList<BasicStoreEntity>(testContext, ADMIN_USER, [ENTITY_TYPE_CONTAINER_REPORT], {
-      filters: {
-        mode: FilterMode.And,
-        filters: [{ key: ['creator_id'], values: [sourceUser.internal_id] }],
-        filterGroups: [],
-      },
+  it('canonicalizes new creator, assignee, and participant references', async () => {
+    enableAlias();
+    const report = await addReport(testContext, sourceUser, {
+      name: 'Merge-users PoC alias - canonical target references',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+      objectAssignee: [sourceUser.internal_id],
+      objectParticipant: [sourceUser.internal_id],
     });
-    expect(reportsForSourceUser.map((r) => r.id)).toContain(reportId);
+    reportIds.push(report.id);
+
+    delete process.env.MERGE_POC_ALIAS_MAP;
+    expect(await findReportIds('creator_id', targetUser.internal_id)).toContain(report.id);
+    expect(await findReportIds('objectAssignee', targetUser.internal_id)).toContain(report.id);
+    expect(await findReportIds('objectParticipant', targetUser.internal_id)).toContain(report.id);
+    expect(await findReportIds('creator_id', sourceUser.internal_id)).not.toContain(report.id);
+  });
+
+  it('canonicalizes generic updates and removes every equivalent physical reference', async () => {
+    const report = await addReport(testContext, sourceUser, {
+      name: 'Merge-users PoC alias - generic update paths',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+      objectAssignee: [sourceUser.internal_id],
+      objectParticipant: [sourceUser.internal_id],
+    });
+    reportIds.push(report.id);
+
+    enableAlias();
+    await updateAttribute(testContext, ADMIN_USER, report.id, ENTITY_TYPE_CONTAINER_REPORT, [
+      { key: 'creator_id', value: [sourceUser.internal_id], operation: EditOperation.Replace },
+      { key: 'objectParticipant', value: [sourceUser.internal_id], operation: EditOperation.Replace },
+      { key: 'objectAssignee', value: [targetUser.internal_id], operation: EditOperation.Remove },
+    ]);
+
+    delete process.env.MERGE_POC_ALIAS_MAP;
+    expect(await findReportIds('creator_id', targetUser.internal_id)).toContain(report.id);
+    expect(await findReportIds('creator_id', sourceUser.internal_id)).not.toContain(report.id);
+    expect(await findReportIds('objectParticipant', targetUser.internal_id)).toContain(report.id);
+    expect(await findReportIds('objectParticipant', sourceUser.internal_id)).not.toContain(report.id);
+    expect(await findReportIds('objectAssignee', targetUser.internal_id)).not.toContain(report.id);
+    expect(await findReportIds('objectAssignee', sourceUser.internal_id)).not.toContain(report.id);
+  });
+
+  it('fails writes explicitly when an alias target user does not exist', async () => {
+    const missingTargetId = '99999999-9999-4999-8999-999999999999';
+    process.env.MERGE_POC_ALIAS_MAP = JSON.stringify({
+      [sourceUser.internal_id]: missingTargetId,
+    });
+
+    await expect(addReport(testContext, sourceUser, {
+      name: 'Merge-users PoC alias - invalid target must fail',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+    })).rejects.toThrow('MERGE_POC_ALIAS_MAP target user cannot be resolved');
+
+    await expect(stixObjectOrRelationshipAddRefRelations(
+      testContext,
+      ADMIN_USER,
+      reportIds[0],
+      { relationship_type: RELATION_OBJECT_ASSIGNEE, toIds: [sourceUser.internal_id] },
+      ENTITY_TYPE_CONTAINER_REPORT,
+    )).rejects.toThrow('MERGE_POC_ALIAS_MAP target users cannot be resolved');
+  });
+
+  it('keeps restricted-member access target-strict', () => {
+    enableAlias();
+    const element = {
+      restricted_members: [{
+        id: sourceUser.internal_id,
+        access_right: MEMBER_ACCESS_RIGHT_VIEW,
+        groups_restriction_ids: [],
+      }],
+      authorized_authorities: [],
+    };
+    expect(getExplicitUserAccessRight({ ...sourceUser, id: sourceUser.internal_id }, element)).toEqual(MEMBER_ACCESS_RIGHT_VIEW);
+    expect(getExplicitUserAccessRight({ ...targetUser, id: targetUser.internal_id }, element)).toBeNull();
   });
 });


### PR DESCRIPTION
## Context

Throwaway PoC for the merge-users investigation. It now tries to make a user alias work across representative operational paths rather than stopping at the first unsupported query.

The result is intentionally **not a production proposal**: it demonstrates that aliasing requires several context-specific policies and remains a distributed, permanent maintenance cost.

**Strict scope:** opt-in through `MERGE_POC_ALIAS_MAP`; no data rewrite; no default behavior change when unset.

## Policy matrix demonstrated

| Context | Policy |
|---|---|
| Creator/assignee/participant display | Canonicalize source to target in dedicated display loaders |
| Elasticsearch operational filters | Expand target to target + physical source aliases |
| Aggregations/distributions | Coalesce source and target buckets before Elasticsearch bucket limits |
| New operational writes, generic updates and upserts | Canonicalize to the target |
| Operational removals | Expand to every equivalent physical ID |
| Live stream/trigger filters | Compare creator, assignee and participant through alias equivalence |
| Security principals and `restricted_members` | Preserve exact identity |
| `createdBy`, History, Activity and PirHistory | Preserve exact provenance |

## Covered paths

- Strict JSON/internal-ID validation, transitive aliases and cycle detection.
- Explicit failure when a configured target user cannot be resolved.
- Creator, assignee and participant GraphQL display loaders.
- Nested and legacy string-key operational filters.
- Creator/assignee/participant aggregation lists and real distribution counts.
- Entity/relation creation, generic field updates, upserts and single/bulk operational ref mutations.
- Alias-aware removals of legacy physical references.
- Real-time STIX filter testers.
- Target-strict access checks and exact security-principal reconstruction.

## Evidence

- **55 unit tests passed**: 9 alias-policy tests + 46 existing STIX filtering tests.
- **7 real Elasticsearch integration scenarios passed**: display, filters, counts, writes, generic updates/removals, invalid targets and security boundaries.
- **14 existing user-visibility integration tests passed**.
- TypeScript: passed.
- ESLint: passed.
- Backend production build: passed.
- Final independent code review: no remaining significant issue.

## What this PoC shows

The alias can be made to cover these representative families, but only by introducing distinct semantics in many layers:

- canonicalization is correct for display and new operational writes;
- expansion is required for queries and removals;
- aggregation needs bucket coalescing before limiting;
- streams need equivalence comparisons;
- security and historical attribution must remain exact.

A global source-to-target resolver is unsafe: it can turn a historical task initiator, connector applicant or another reconstructed principal into the target user and implicitly change privileges. Therefore the alias must stay contextual and every new user-reference path must choose and maintain the correct policy.

This iteration strengthens the original conclusion: **an alias is technically feasible for selected paths, but correctness requires distributed policy hooks and creates permanent architectural debt.**

## Deliberate remaining limits

This PoC does not cover the exhaustive registry from PoC #1, Redis, RabbitMQ, sessions/tokens/credentials, object-storage metadata/content, or every serialized reference. Those remain additional mechanisms that an alias strategy would need to address.