### PR TITLE
[PoC merge-users #3] Merge script skeleton (schema-driven, dry-run)

### DIFF
--- a/opencti-platform/opencti-graphql/builder/dev/dev.js
+++ b/opencti-platform/opencti-graphql/builder/dev/dev.js
@@ -32,6 +32,7 @@ esbuild.build({
         'script/script-clean-relations.js',
         'script/script-insert-dataset.js',
         'script/script-wait-for-api.js',
+        'script/script-merge-user-plan.js',
         'src/utils/safeEjs.worker.ts'
     ],
     entryNames: '[name]',

--- a/opencti-platform/opencti-graphql/builder/prod/prod.js
+++ b/opencti-platform/opencti-graphql/builder/prod/prod.js
@@ -30,6 +30,7 @@ esbuild.build({
         'src/back.js',
         'src/lock/child-lock.manager.ts',
         'script/script-clean-relations.js',
+        'script/script-merge-user-plan.js',
         'src/utils/safeEjs.worker.ts'
     ],
     entryNames: '[name]',

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -12,6 +12,7 @@
     "build:antlr": "java -jar ./builder/antlr/antlr-4.13.0-complete.jar -Dlanguage=JavaScript ./src/stixpattern/STIXPattern.g4 -o ./src/stixpattern/",
     "migrate:add": "migrate create --template-file src/templates/migration-template.ts --migrations-dir=./src/migrations",
     "clean:relations": "yarn build:prod && node build/script-clean-relations.js",
+    "poc:merge-plan": "node build/script-merge-user-plan.js",
     "backend:stack:analysis": "node builder/dev/stack.js && node --env-file=.env build/script-stack-analysis back",
     "frontend:stack:analysis": "node builder/dev/stack.js && node --env-file=.env build/script-stack-analysis front",
     "lint": "DEBUG=eslint:cli-engine TIMING=1 eslint --quiet --cache --config eslint.config.mjs src",

--- a/opencti-platform/opencti-graphql/script/script-merge-user-plan.js
+++ b/opencti-platform/opencti-graphql/script/script-merge-user-plan.js
@@ -1,0 +1,31 @@
+// PoC merge-users #3 - schema-driven, dry-run merge plan.
+// Usage:
+//   node build/script-merge-user-plan.js --sourceId=<id> --targetId=<id>
+//   node build/script-merge-user-plan.js --csv=<path-to-csv>   (columns: source_id,target_id)
+// This script NEVER writes to Elasticsearch: it only prints the plan of operations that a
+// future merge engine would need to execute.
+import '../src/modules/index';
+import { logApp } from '../src/config/conf';
+import { buildMergeUserPlan, parseMergeUserCsv } from '../src/utils/merge-user-plan';
+
+const getArg = (name) => {
+  const arg = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return arg ? arg.split('=').slice(1).join('=') : undefined;
+};
+
+const sourceId = getArg('sourceId');
+const targetId = getArg('targetId');
+const csvPath = getArg('csv');
+
+const pairs = csvPath
+  ? parseMergeUserCsv(csvPath)
+  : (sourceId && targetId ? [{ sourceId, targetId }] : []);
+
+if (pairs.length === 0) {
+  logApp.error('[SCRIPT] Missing arguments. Usage: --sourceId=<id> --targetId=<id> or --csv=<path>');
+  process.exit(1);
+}
+
+const plans = pairs.map((pair) => buildMergeUserPlan(pair));
+// eslint-disable-next-line no-console
+console.log(JSON.stringify(csvPath ? plans : plans[0], null, 2));

--- a/opencti-platform/opencti-graphql/src/utils/merge-user-plan.ts
+++ b/opencti-platform/opencti-graphql/src/utils/merge-user-plan.ts
@@ -1,0 +1,144 @@
+// PoC merge-users #3 - schema-driven dry-run plan builder.
+// This module is intentionally read-only: it only DESCRIBES the operations that a
+// future merge engine would need to perform, it never writes to Elasticsearch.
+import * as fs from 'node:fs';
+import { schemaAttributesDefinition } from '../schema/schema-attributes';
+import type { AttributeDefinition, IdAttribute } from '../schema/attribute-definition';
+import { ENTITY_TYPE_USER } from '../schema/internalObject';
+import { READ_DATA_INDICES } from '../database/utils';
+
+export type MergeUserPair = { sourceId: string; targetId: string };
+
+export type MergeOperationComplexity = 'simple' | 'json' | 'graph_rights' | 'runtime';
+
+export type MergeOperation = {
+  champ: string;
+  type_operation: string;
+  index_cible: string;
+  complexite: MergeOperationComplexity;
+  executable_par_script: boolean;
+  commentaire?: string;
+};
+
+export type MergeUserPlan = {
+  source_id: string;
+  target_id: string;
+  operations_schema_driven: MergeOperation[];
+  operations_hors_schema: MergeOperation[];
+};
+
+const isIdAttribute = (attribute: AttributeDefinition): attribute is IdAttribute => attribute.type === 'string' && attribute.format === 'id';
+
+/**
+ * Pure filter, extracted so it can be unit tested against an arbitrary list of attributes
+ * without touching the live (singleton, write-once) `schemaAttributesDefinition` registry.
+ * This is what makes the discovery "schema-driven": no attribute name is hardcoded here,
+ * only the generic rule "id-format attribute pointing to a User".
+ */
+export const filterUserIdAttributes = (attributes: AttributeDefinition[]): IdAttribute[] => {
+  return attributes.filter(isIdAttribute).filter((attribute) => attribute.entityTypes?.includes(ENTITY_TYPE_USER));
+};
+
+/**
+ * Schema-driven discovery of every attribute that can hold a reference to a User.
+ * This is the core of the PoC: it relies solely on `schemaAttributesDefinition`, so any
+ * new `id` attribute registered with `entityTypes` including ENTITY_TYPE_USER will be
+ * picked up automatically, without touching this function.
+ */
+export const discoverUserIdAttributes = (): IdAttribute[] => {
+  return filterUserIdAttributes(schemaAttributesDefinition.getIdAttributes());
+};
+
+const buildSchemaDrivenOperations = (): MergeOperation[] => {
+  return discoverUserIdAttributes().map((attribute) => {
+    // attrRawIds means the id(s) can be buried inside a JSON blob (e.g. object attributes,
+    // or string/json attributes storing structured data): a straight string replace is not
+    // enough, the value must be parsed first.
+    const isComplexJson = attribute.attrRawIds !== undefined;
+    return {
+      champ: attribute.name,
+      type_operation: isComplexJson ? 'rewrite_id_in_json' : 'rewrite_id_attribute',
+      index_cible: READ_DATA_INDICES.join(','),
+      complexite: isComplexJson ? 'json' : 'simple',
+      executable_par_script: true,
+      commentaire: isComplexJson
+        ? 'Id(s) potentially embedded in a JSON/object value, requires attrRawIds parsing before rewrite'
+        : undefined,
+    };
+  });
+};
+
+/**
+ * Categories that are NOT discoverable from `schemaAttributesDefinition.getIdAttributes()`
+ * because they are not modeled as simple `id`-format attributes (STIX refs, graph
+ * relationships materializing rights, or runtime state living outside Elasticsearch).
+ * They are enumerated explicitly here and kept in a clearly separated section of the plan.
+ */
+const buildOutOfSchemaOperations = (): MergeOperation[] => [
+  {
+    champ: 'created-by',
+    type_operation: 'rewrite_stix_ref_relationship',
+    index_cible: READ_DATA_INDICES.join(','),
+    complexite: 'simple',
+    executable_par_script: true,
+    commentaire: 'STIX ref relationship, not an id-format attribute',
+  },
+  {
+    champ: 'object-assignee',
+    type_operation: 'rewrite_stix_ref_relationship',
+    index_cible: READ_DATA_INDICES.join(','),
+    complexite: 'simple',
+    executable_par_script: true,
+    commentaire: 'STIX ref relationship, not an id-format attribute',
+  },
+  {
+    champ: 'object-participant',
+    type_operation: 'rewrite_stix_ref_relationship',
+    index_cible: READ_DATA_INDICES.join(','),
+    complexite: 'simple',
+    executable_par_script: true,
+    commentaire: 'STIX ref relationship, not an id-format attribute',
+  },
+  {
+    champ: 'member_of / has_role / has_capability / participate_to',
+    type_operation: 'merge_or_deduplicate_rights',
+    index_cible: READ_DATA_INDICES.join(','),
+    complexite: 'graph_rights',
+    executable_par_script: false,
+    commentaire: 'Graph relationships materialize rights: must be merged/de-duplicated, never blindly rewritten (e.g. avoid duplicate role assignment)',
+  },
+  {
+    champ: 'sessions_tokens_notifications_locks',
+    type_operation: 'invalidate_or_migrate_runtime_state',
+    index_cible: 'redis',
+    complexite: 'runtime',
+    executable_par_script: false,
+    commentaire: 'Runtime state (Redis sessions, tokens + cache, notifications, locks) lives outside Elasticsearch and is out of this script scope',
+  },
+];
+
+export const buildMergeUserPlan = (pair: MergeUserPair): MergeUserPlan => ({
+  source_id: pair.sourceId,
+  target_id: pair.targetId,
+  operations_schema_driven: buildSchemaDrivenOperations(),
+  operations_hors_schema: buildOutOfSchemaOperations(),
+});
+
+/**
+ * Minimal CSV parser for the "source_id,target_id" format expected by the batch mode.
+ * Kept dependency-free on purpose since the file format is trivial.
+ */
+export const parseMergeUserCsv = (csvPath: string): MergeUserPair[] => {
+  const content = fs.readFileSync(csvPath, 'utf8');
+  const lines = content.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return [];
+  }
+  const [header, ...rows] = lines;
+  const hasHeader = header.toLowerCase().replace(/\s/g, '') === 'source_id,target_id';
+  const dataLines = hasHeader ? rows : lines;
+  return dataLines.map((line) => {
+    const [sourceId, targetId] = line.split(',').map((value) => value.trim());
+    return { sourceId, targetId };
+  });
+};

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/merge-user-plan-adaptivity-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/merge-user-plan-adaptivity-test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { filterUserIdAttributes } from '../../../src/utils/merge-user-plan';
+import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
+import type { AttributeDefinition } from '../../../src/schema/attribute-definition';
+
+// This test is the "auto-adaptivity proof" required by the PoC: it demonstrates that
+// `filterUserIdAttributes` (the core of the schema-driven discovery used by
+// `script-merge-user-plan.js`) picks up ANY new id-format attribute pointing to a User
+// without a single line of code being changed in the merge-plan module. Only the fixture
+// list below is extended, exactly like a new attribute would be added to the real schema
+// (e.g. in src/schema/attribute-definition.ts) by an unrelated feature.
+describe('Merge user plan - schema-driven auto-adaptivity', () => {
+  it('does not know any attribute name upfront, only the generic "id pointing to User" rule', () => {
+    const existingAttributes: AttributeDefinition[] = [
+      { name: 'creator_id', label: 'Creators', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_USER], update: true, mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
+      { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+      { name: 'object-marking', label: 'Marking', type: 'string', format: 'id', entityTypes: ['Marking-Definition'], mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: false },
+    ];
+    const before = filterUserIdAttributes(existingAttributes);
+    expect(before.map((a) => a.name)).toEqual(['creator_id']);
+
+    // Simulate a brand new attribute being registered by an unrelated future feature
+    // (e.g. a "reviewer_id" field on some entity type), without touching merge-user-plan.ts.
+    const brandNewAttribute: AttributeDefinition = {
+      name: 'reviewer_id', label: 'Reviewer', type: 'string', format: 'id', entityTypes: [ENTITY_TYPE_USER], mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true,
+    };
+    const after = filterUserIdAttributes([...existingAttributes, brandNewAttribute]);
+
+    // The new field appears alone, no other change was required.
+    expect(after.map((a) => a.name)).toEqual(['creator_id', 'reviewer_id']);
+  });
+});


### PR DESCRIPTION
## Context

PoC #3 of the "merge users" investigation (merging a source user into a target user).
This PoC tests the **(A) standalone script/tool** approach: it proves that we can start
in the backend context and **automatically discover, via the schema**, the list of
fields to rewrite in order to merge a source user into a target user. It stops at
**dry-run** (planning) — the actual rewrite is out of scope (PoC #4).

## What was done

- `script/script-merge-user-plan.js`: lightweight bootstrap script (same pattern as
  `script-clean-relations.js`), args `--sourceId=<id> --targetId=<id>` or
  `--csv=<path>` (columns `source_id,target_id`) for batch processing.
- `src/utils/merge-user-plan.ts`: core logic, schema-driven.
  - `discoverUserIdAttributes()` relies solely on
    `schemaAttributesDefinition.getIdAttributes()` filtered on `entityTypes` including
    `ENTITY_TYPE_USER` — **no field name is hardcoded**.
  - The presence of `attrRawIds` on the attribute is used to distinguish a simple
    rewrite (`rewrite_id_attribute`) from a complex rewrite buried inside JSON
    (`rewrite_id_in_json`).
  - Out-of-schema categories (STIX refs `created-by`/`object-assignee`/
    `object-participant`, graph relationships = rights, runtime state) are explicitly
    enumerated and kept separate in `operations_hors_schema`.
- Added both scripts to `builder/dev/dev.js` and `builder/prod/prod.js` (esbuild
  entryPoints) + `package.json` entry: `yarn poc:merge-plan -- --sourceId=... --targetId=...`.
- Unit test `tests/01-unit/database/merge-user-plan-adaptivity-test.ts`: proof of
  auto-adaptivity (see below).

**No Elasticsearch write. Production behavior is not modified** (new, isolated file,
not called anywhere else).

## PoC Results

### JSON plan generated for a (source, target) pair

```json
{
  "source_id": "88ec0c6a-13ce-5e39-b486-354fe4a7084f",
  "target_id": "11111111-1111-1111-1111-111111111111",
  "operations_schema_driven": [
    { "champ": "creator_id", "type_operation": "rewrite_id_attribute", "index_cible": "<READ_DATA_INDICES>", "complexite": "simple", "executable_par_script": true },
    { "champ": "platform_ip_whitelist_exclusion_ids", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "xtm_hub_registration_user_id", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "user_id", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "applicant_id", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "recipients", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "feed_public_user_id", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "taxii_public_user_id", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true },
    { "champ": "stream_public_user_id", "type_operation": "rewrite_id_attribute", "complexite": "simple", "executable_par_script": true }
  ],
  "operations_hors_schema": [
    { "champ": "created-by", "type_operation": "rewrite_stix_ref_relationship", "complexite": "simple", "executable_par_script": true, "commentaire": "STIX ref relationship, not an id-format attribute" },
    { "champ": "object-assignee", "type_operation": "rewrite_stix_ref_relationship", "complexite": "simple", "executable_par_script": true, "commentaire": "STIX ref relationship, not an id-format attribute" },
    { "champ": "object-participant", "type_operation": "rewrite_stix_ref_relationship", "complexite": "simple", "executable_par_script": true, "commentaire": "STIX ref relationship, not an id-format attribute" },
    { "champ": "member_of / has_role / has_capability / participate_to", "type_operation": "merge_or_deduplicate_rights", "complexite": "graph_rights", "executable_par_script": false, "commentaire": "Graph relationships materialize rights: must be merged/de-duplicated, never blindly rewritten" },
    { "champ": "sessions_tokens_notifications_locks", "type_operation": "invalidate_or_migrate_runtime_state", "index_cible": "redis", "complexite": "runtime", "executable_par_script": false, "commentaire": "Runtime state lives outside Elasticsearch and is out of this script scope" }
  ]
}
```
(field names in the raw output are kept as-is — `champ`, `type_operation`, `index_cible`,
`complexite`, `executable_par_script`, `commentaire` — the actual `index_cible` value is
the full `READ_DATA_INDICES` list, truncated above for readability. The `--csv` mode
produces an array of these plans, one per pair.)

Notable finding: no `id` attribute in the schema has `attrRawIds` defined on the User
`entityTypes` in the tested instance → 0 "complex JSON" operations detected in this
dataset (the code branch exists and was manually validated by simulating an attribute
with `attrRawIds`).

### Automatic vs manual share

| Category | Nb operations | Auto-executable by a script |
|---|---|---|
| Schema-driven id attributes (`operations_schema_driven`) | 9 | ✅ Yes (direct id→id rewrite) |
| STIX refs (`created-by`, `object-assignee`, `object-participant`) | 3 | ✅ Yes, but with dedicated logic (relationships, not attributes) — not discovered by the attribute schema |
| Graph relationships = rights (member_of, has_role, has_capability, participate_to) | 1 (grouped) | ❌ No — requires merge/de-duplication, not a rewrite |
| Runtime state (sessions, tokens, notifications, locks) | 1 (grouped) | ❌ No — outside Elasticsearch, outside script scope |

That's **9/14 operations (~64%) discovered and qualified entirely by the schema**,
with no hardcoded name. The remaining 5 require hand-written, dedicated logic (but
they are, in turn, enumerable once and for all — they don't shift with every schema
change).

### Proof of auto-adaptivity

See `tests/01-unit/database/merge-user-plan-adaptivity-test.ts`: the test calls
`filterUserIdAttributes` (the discovery function used by the script) on a list of
attribute definitions, then adds a fictitious `reviewer_id` attribute
(`format: 'id'`, `entityTypes: [ENTITY_TYPE_USER]`) that doesn't exist anywhere in
`merge-user-plan.ts`. Result: `reviewer_id` appears alone in the plan, with no change
to the discovery code — only by adding the attribute to the schema (here simulated via
the fixture, in real conditions via `schemaAttributesDefinition.registerAttributes(...)`).

```
✓ tests/01-unit/database/merge-user-plan-adaptivity-test.ts (1 test)
```

### Effort estimate to turn this skeleton into a real merge engine

Going from this skeleton (discovery + planning) to a merge engine that actually
executes the rewrite represents, by my estimate:
- **Rewriting simple id attributes** (the 9 identified) via `elUpdateByQueryForMigration`:
  low effort, ~1-2 days (bulk queries per attribute, handling `multiple` fields).
- **Rewriting STIX refs** (`created-by`, `object-assignee`, `object-participant`):
  ~2-3 days (these are relationships, not attributes: relationships need to be
  recreated/reattached rather than patching a field, handling duplicates if the
  target already has the same ref).
- **Merging/de-duplicating rights** (member_of, has_role, has_capability,
  participate_to): the trickiest part, ~4-6 days (business rules: union of
  roles/capabilities, conflict handling between source and target rights, security
  regression tests).
- **Coordinating with runtime state** (invalidating Redis sessions/tokens,
  notifications): ~1-2 days, but requires a real product discussion (what happens to
  an active session of the merged user?).
- **Rollback / safety / traceability of the merge** (operation log, "dry-run before
  commit" mode, handling CSV batches with partial failures): ~2-3 days.

**Total estimate: ~2 to 3 person-weeks** for a complete, robust engine, building on
this skeleton (the schema-driven part, which appeared to be the main technical risk,
is already solved and requires no further notable work).

## Acceptance criteria

- [x] `yarn check-ts` passes.
- [x] `yarn lint` passes (no errors on the added files).
- [x] `node build/script-merge-user-plan.js --sourceId=... --targetId=...` produces a JSON plan.
- [x] `node build/script-merge-user-plan.js --csv=...` produces an array of JSON plans.
- [x] Zero database writes (dry-run only, verified by code review: no call to
      `elUpdateByQueryForMigration`/`elIndex`/... is made).
