### PR TITLE
fix(integrations): make marketplace layout responsive at small widths (#17246)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/integrations/available/IntegrationsAvailable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/IntegrationsAvailable.tsx
@@ -180,7 +180,9 @@ const IntegrationsAvailable = ({ data }: IntegrationsAvailableProps) => {
 
   return (
     <div data-testid="catalog-page">
-      <Stack direction="row" gap={2} alignItems="flex-start">
+      {/* Below md the sidebar stacks full-width above the cards instead of
+          squeezing them against a fixed 250px column. */}
+      <Stack direction={{ xs: 'column', md: 'row' }} gap={2} alignItems={{ xs: 'stretch', md: 'flex-start' }}>
         <IngestionCatalogFacetSidebar
           filters={filters}
           onFiltersChange={setFilters}
@@ -228,7 +230,7 @@ const IntegrationsAvailable = ({ data }: IntegrationsAvailableProps) => {
                       {section.items.map((item) => (
                         <Grid
                           key={item.key}
-                          size={{ xs: 12, md: 6, lg: 4, xl: 3 }}
+                          size={{ xs: 12, sm: 6, lg: 4, xl: 3 }}
                         >
                           {renderItem(item)}
                         </Grid>

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogFacetSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogFacetSidebar.tsx
@@ -203,12 +203,15 @@ const IngestionCatalogFacetSidebar = ({
   };
 
   return (
+    // Fixed sticky column on md+; below md the page stacks it full-width
+    // above the cards (sticky + max-height are disabled so the filters do
+    // not trap the whole viewport).
     <Box
       component="aside"
       sx={{
-        width: 250,
+        width: { xs: '100%', md: 250 },
         flexShrink: 0,
-        position: 'sticky',
+        position: { xs: 'static', md: 'sticky' },
         top: theme.spacing(2),
       }}
     >
@@ -223,8 +226,8 @@ const IngestionCatalogFacetSidebar = ({
           borderRadius: 1,
           border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
           backgroundColor: theme.palette.background.paper,
-          maxHeight: `calc(100vh - ${theme.spacing(20)})`,
-          overflowY: 'auto',
+          maxHeight: { xs: 'none', md: `calc(100vh - ${theme.spacing(20)})` },
+          overflowY: { xs: 'visible', md: 'auto' },
         }}
       >
         <Stack direction="row" alignItems="center" justifyContent="space-between">

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedFacetSidebar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedFacetSidebar.tsx
@@ -90,12 +90,15 @@ const DeployedFacetSidebar = ({
   };
 
   return (
+    // Fixed sticky column on md+; below md the page stacks it full-width
+    // above the cards (sticky + max-height are disabled so the filters do
+    // not trap the whole viewport).
     <Box
       component="aside"
       sx={{
-        width: 250,
+        width: { xs: '100%', md: 250 },
         flexShrink: 0,
-        position: 'sticky',
+        position: { xs: 'static', md: 'sticky' },
         top: theme.spacing(2),
       }}
     >
@@ -110,8 +113,8 @@ const DeployedFacetSidebar = ({
           borderRadius: 1,
           border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
           backgroundColor: theme.palette.background.paper,
-          maxHeight: `calc(100vh - ${theme.spacing(20)})`,
-          overflowY: 'auto',
+          maxHeight: { xs: 'none', md: `calc(100vh - ${theme.spacing(20)})` },
+          overflowY: { xs: 'visible', md: 'auto' },
         }}
       >
         <Stack direction="row" alignItems="center" justifyContent="space-between">

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsDeployed.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/IntegrationsDeployed.tsx
@@ -134,8 +134,10 @@ const IntegrationsDeployedContent = ({
     return result;
   }, [sections, visibleCount]);
 
+  // Below md the sidebar stacks full-width above the cards instead of
+  // squeezing them against a fixed 250px column.
   return (
-    <Stack direction="row" gap={2} alignItems="flex-start">
+    <Stack direction={{ xs: 'column', md: 'row' }} gap={2} alignItems={{ xs: 'stretch', md: 'flex-start' }}>
       <DeployedFacetSidebar
         filters={filters}
         onFiltersChange={setFilters}
@@ -241,7 +243,7 @@ const IntegrationsDeployedContent = ({
                       {section.items.map((item) => (
                         <Grid
                           key={item.id}
-                          size={{ xs: 12, md: 6, lg: 4, xl: 3 }}
+                          size={{ xs: 12, sm: 6, lg: 4, xl: 3 }}
                         >
                           <DeployedIntegrationCard item={item} onChange={handleItemChange} />
                         </Grid>


### PR DESCRIPTION
## Proposed changes

Closes #17246.

Make the integrations marketplace (Available and Deployed tabs) fully responsive at small screen widths:

- The sidebar + content row now stacks vertically below the `md` breakpoint on both tabs (`Stack direction={{ xs: 'column', md: 'row' }}`), so the filters sit full-width above the cards instead of squeezing them against a fixed 250px column.
- Both facet sidebars (`IngestionCatalogFacetSidebar`, `DeployedFacetSidebar`) become full-width, non-sticky and without max-height below `md`; the fixed 250px sticky column behavior is unchanged from `md` up.
- The card grid steps to 2 columns from the `sm` breakpoint instead of `md` (`size={{ xs: 12, sm: 6, lg: 4, xl: 3 }}`), so 600-900px windows show two cards per row.

No behavior change on md+ viewports except the earlier 2-column step between 600-900px.

## Checks

- `yarn lint` on the changed files: pass
- `yarn check-ts`: pass

## Related

The same responsiveness fix is being applied to the aligned OpenAEV integrations catalog.
