### PR TITLE
chore(merge-users): prototype dedup transfer of rights and stix refs for user merge (poc #4)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/merge-user-rights.ts
+++ b/opencti-platform/opencti-graphql/src/utils/merge-user-rights.ts
@@ -1,0 +1,219 @@
+// PoC merge-users #4 - rights & STIX refs transfer (dedup, no privilege escalation).
+//
+// This module is intentionally isolated: it is NEVER imported by production code. The
+// "apply" function is only exercised by the dedicated integration test
+// (tests/03-integration/01-database/merge-user-rights-poc-test.ts). The "plan" function
+// is pure read (dry-run) and safe to call anywhere.
+//
+// Scope: transferring a User's RIGHTS (member-of a Group, participate-to an
+// Organization) and STIX REFERENCES (created-by, object-assignee, object-participant)
+// from a "source" user to a "target" user, without creating duplicates and without
+// silently combining rights (see MergeUserRightsMode below).
+//
+// Explicitly OUT of scope (must never be touched here):
+// - has-role / has-capability: those are carried by the Group entity, not by the User,
+//   so there is nothing to transfer at the user level (see PoC #1 finding).
+// - creator_id and any other simple `id`-format attribute: already proven feasible by
+//   the schema-driven discovery of PoC #3, handled by a different mechanism.
+// - Runtime state (Redis sessions, tokens, notifications, locks): out of scope, see the
+//   "Résultats du PoC" / product questions in the PR description.
+import { ENTITY_TYPE_GROUP } from '../schema/internalObject';
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
+import { RELATION_MEMBER_OF, RELATION_PARTICIPATE_TO } from '../schema/internalRelationship';
+import { RELATION_CREATED_BY, RELATION_OBJECT_ASSIGNEE, RELATION_OBJECT_PARTICIPANT } from '../schema/stixRefRelationship';
+import { ABSTRACT_STIX_CORE_OBJECT } from '../schema/general';
+import { fullEntitiesThroughRelationsFromList, fullEntitiesThroughRelationsToList } from '../database/middleware-loader';
+import { userAddRelation } from '../domain/user';
+import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipDeleteRefRelation } from '../domain/stixObjectOrStixRelationship';
+import type { AuthContext, AuthUser } from '../types/user';
+import type { BasicStoreEntity } from '../types/store';
+
+/**
+ * Product decision point (NOT decided here, see "Questions produit" in the PR):
+ * - 'union': the target GAINS the memberships the source had and it did not
+ *   (the target's rights become the union of both users' rights).
+ * - 'target-strict': nothing is transferred, the target keeps exactly its own
+ *   memberships ("we do not combine rights", per the spec reminder).
+ * Both modes are implemented so that the impact of each can be observed and compared;
+ * picking the one to keep in production is a product call.
+ */
+export type MergeUserRightsMode = 'union' | 'target-strict';
+
+export type MembershipAction = 'add-to-target' | 'already-present-skip' | 'skip-strict-mode';
+
+export type MembershipRelationType = typeof RELATION_MEMBER_OF | typeof RELATION_PARTICIPATE_TO;
+
+export interface MembershipDiffItem {
+  relationship_type: MembershipRelationType;
+  entity_id: string;
+  entity_type: string;
+  entity_name: string;
+  action: MembershipAction;
+  note: string;
+}
+
+export type RefRelationType = typeof RELATION_CREATED_BY | typeof RELATION_OBJECT_ASSIGNEE | typeof RELATION_OBJECT_PARTICIPANT;
+
+export type RefAction = 'move-to-target' | 'already-present-remove-source-only';
+
+export interface RefTransferItem {
+  relationship_type: RefRelationType;
+  object_id: string;
+  object_type: string;
+  action: RefAction;
+  note: string;
+}
+
+export interface MergeUserRightsPlan {
+  source_id: string;
+  target_id: string;
+  mode: MergeUserRightsMode;
+  memberships: MembershipDiffItem[];
+  refs: RefTransferItem[];
+}
+
+const MEMBERSHIP_RELATIONS: Array<{ relationshipType: MembershipRelationType; entityType: string }> = [
+  { relationshipType: RELATION_MEMBER_OF, entityType: ENTITY_TYPE_GROUP },
+  { relationshipType: RELATION_PARTICIPATE_TO, entityType: ENTITY_TYPE_IDENTITY_ORGANIZATION },
+];
+
+// created-by is included per spec, but PoC #1 already found that, on a User account,
+// this ref conventionally targets an Individual (linked to the user's email), not the
+// User id itself. It is kept here for completeness / genericity: if some data does
+// point created-by to a User id, it will still be picked up and handled like the others.
+const REF_RELATIONS: RefRelationType[] = [RELATION_CREATED_BY, RELATION_OBJECT_ASSIGNEE, RELATION_OBJECT_PARTICIPANT];
+
+const buildMembershipDiff = async (
+  context: AuthContext,
+  user: AuthUser,
+  sourceId: string,
+  targetId: string,
+  mode: MergeUserRightsMode,
+): Promise<MembershipDiffItem[]> => {
+  const diff: MembershipDiffItem[] = [];
+  for (const { relationshipType, entityType } of MEMBERSHIP_RELATIONS) {
+    // eslint-disable-next-line no-await-in-loop
+    const sourceMemberships = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(context, user, sourceId, relationshipType, entityType);
+    // eslint-disable-next-line no-await-in-loop
+    const targetMemberships = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(context, user, targetId, relationshipType, entityType);
+    const targetMembershipIds = new Set(targetMemberships.map((membership) => membership.internal_id));
+    for (const membership of sourceMemberships) {
+      const alreadyOnTarget = targetMembershipIds.has(membership.internal_id);
+      let action: MembershipAction;
+      let note: string;
+      if (alreadyOnTarget) {
+        action = 'already-present-skip';
+        note = 'déjà présent (ignoré) : target has this membership already, no duplicate created';
+      } else if (mode === 'union') {
+        action = 'add-to-target';
+        note = 'union mode: missing on target, added';
+      } else {
+        action = 'skip-strict-mode';
+        note = 'target-strict mode: not transferred, target rights are left untouched';
+      }
+      diff.push({
+        relationship_type: relationshipType,
+        entity_id: membership.internal_id,
+        entity_type: membership.entity_type,
+        entity_name: membership.name,
+        action,
+        note,
+      });
+    }
+  }
+  return diff;
+};
+
+const buildRefDiff = async (
+  context: AuthContext,
+  user: AuthUser,
+  sourceId: string,
+  targetId: string,
+): Promise<RefTransferItem[]> => {
+  const diff: RefTransferItem[] = [];
+  for (const relationshipType of REF_RELATIONS) {
+    // eslint-disable-next-line no-await-in-loop
+    const objectsReferencingSource = await fullEntitiesThroughRelationsFromList<BasicStoreEntity>(context, user, sourceId, relationshipType, ABSTRACT_STIX_CORE_OBJECT);
+    // eslint-disable-next-line no-await-in-loop
+    const objectsReferencingTarget = await fullEntitiesThroughRelationsFromList<BasicStoreEntity>(context, user, targetId, relationshipType, ABSTRACT_STIX_CORE_OBJECT);
+    const targetObjectIds = new Set(objectsReferencingTarget.map((object) => object.internal_id));
+    for (const object of objectsReferencingSource) {
+      const alreadyOnTarget = targetObjectIds.has(object.internal_id);
+      diff.push({
+        relationship_type: relationshipType,
+        object_id: object.internal_id,
+        object_type: object.entity_type,
+        action: alreadyOnTarget ? 'already-present-remove-source-only' : 'move-to-target',
+        note: alreadyOnTarget
+          ? 'déjà présent (ignoré) : object already references target, only the source ref is removed'
+          : 'not referencing target yet: ref moved from source to target',
+      });
+    }
+  }
+  return diff;
+};
+
+/**
+ * Computes the transfer PLAN for a (sourceId, targetId) pair. Pure read/dry-run: it
+ * never writes anything, so it is always safe to call.
+ */
+export const buildMergeUserRightsPlan = async (
+  context: AuthContext,
+  user: AuthUser,
+  sourceId: string,
+  targetId: string,
+  mode: MergeUserRightsMode = 'union',
+): Promise<MergeUserRightsPlan> => {
+  const [memberships, refs] = await Promise.all([
+    buildMembershipDiff(context, user, sourceId, targetId, mode),
+    buildRefDiff(context, user, sourceId, targetId),
+  ]);
+  return {
+    source_id: sourceId, target_id: targetId, mode, memberships, refs,
+  };
+};
+
+/**
+ * Applies a previously computed plan.
+ *
+ * IMPORTANT: this function must NEVER be called from production code. It is exercised
+ * only by the dedicated integration test, which is the only place allowed to import it
+ * for a real apply. Building a fresh plan before applying (as the test does) is what
+ * makes re-running the transfer idempotent: already-transferred items are reported as
+ * "already-present" and skipped, so applying twice never creates a duplicate.
+ */
+export const applyMergeUserRightsPlan = async (context: AuthContext, user: AuthUser, plan: MergeUserRightsPlan): Promise<void> => {
+  for (const item of plan.memberships) {
+    if (item.action === 'add-to-target') {
+      // eslint-disable-next-line no-await-in-loop
+      await userAddRelation(context, user, plan.target_id, { toId: item.entity_id, relationship_type: item.relationship_type });
+    }
+    // 'already-present-skip' and 'skip-strict-mode' are no-ops on purpose: memberships
+    // are never removed from the source by this PoC (the source user is expected to be
+    // deleted as part of the broader merge flow, which cascades relation deletion).
+  }
+  for (const item of plan.refs) {
+    if (item.action === 'move-to-target') {
+      // eslint-disable-next-line no-await-in-loop
+      await stixObjectOrRelationshipAddRefRelation(
+        context,
+        user,
+        item.object_id,
+        { relationship_type: item.relationship_type, toId: plan.target_id },
+        ABSTRACT_STIX_CORE_OBJECT,
+      );
+    }
+    // In both cases the ref towards the source must be removed: either because it was
+    // just replaced by the target ref, or because the target already had it and the
+    // source ref is now a pure duplicate.
+    // eslint-disable-next-line no-await-in-loop
+    await stixObjectOrRelationshipDeleteRefRelation(
+      context,
+      user,
+      item.object_id,
+      plan.source_id,
+      item.relationship_type,
+      ABSTRACT_STIX_CORE_OBJECT,
+    );
+  }
+};

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/merge-user-rights-poc-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/merge-user-rights-poc-test.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ADMIN_USER, getAuthUser, testContext, USER_EDITOR, USER_SECURITY } from '../../utils/testQuery';
+import { assignGroupToUser } from '../../../src/domain/user';
+import { addReport } from '../../../src/domain/report';
+import { stixObjectOrRelationshipAddRefRelation } from '../../../src/domain/stixObjectOrStixRelationship';
+import { deleteElementById, deleteRelationsByFromAndTo } from '../../../src/database/middleware';
+import { fullEntitiesThroughRelationsToList } from '../../../src/database/middleware-loader';
+import { ENTITY_TYPE_CONTAINER_REPORT } from '../../../src/schema/stixDomainObject';
+import { ENTITY_TYPE_GROUP, ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
+import { RELATION_MEMBER_OF } from '../../../src/schema/internalRelationship';
+import { RELATION_CREATED_BY, RELATION_OBJECT_ASSIGNEE } from '../../../src/schema/stixRefRelationship';
+import { ABSTRACT_INTERNAL_RELATIONSHIP, ABSTRACT_STIX_CORE_OBJECT } from '../../../src/schema/general';
+import { controlUserRestrictDeleteAgainstElement } from '../../../src/utils/access';
+import { generateStandardId } from '../../../src/schema/identifier';
+import type { BasicStoreEntity } from '../../../src/types/store';
+import { buildMergeUserRightsPlan, applyMergeUserRightsPlan } from '../../../src/utils/merge-user-rights';
+
+/**
+ * PoC #4 (merge-users investigation) - rights & STIX refs transfer.
+ *
+ * This is the "real hard part" of variant B: transferring memberships (member-of a
+ * Group, participate-to an Organization) and STIX refs (created-by, object-assignee,
+ * object-participant) from a "source" user to a "target" user, without ever creating a
+ * duplicate and without silently combining rights.
+ *
+ * Source user: USER_EDITOR (member of AMBER_GROUP by default)
+ * Target user: USER_SECURITY (member of AMBER_STRICT_GROUP by default)
+ * Both are additionally made members of GREEN_GROUP here, to reproduce the "already
+ * shared" case.
+ */
+describe('Merge-users PoC #4 - rights & STIX refs transfer (dedup, no escalation)', () => {
+  let sourceUser: Awaited<ReturnType<typeof getAuthUser>>;
+  let targetUser: Awaited<ReturnType<typeof getAuthUser>>;
+  let reportBothAssigned: { id: string };
+  let reportSourceOnlyAssigned: { id: string };
+  let reportCreatedBySource: { id: string; entity_type: string; creator_id?: string | string[] };
+
+  beforeAll(async () => {
+    sourceUser = await getAuthUser(USER_EDITOR.id);
+    targetUser = await getAuthUser(USER_SECURITY.id);
+
+    // Defensive cleanup: a previous (interrupted) run of this suite may have already
+    // transferred AMBER_GROUP to the target. Make the suite self-healing so it can be
+    // re-run from a deterministic state without a full platform reset.
+    const amberGroupId = generateStandardId(ENTITY_TYPE_GROUP, { name: 'AMBER GROUP' });
+    await deleteRelationsByFromAndTo(testContext, ADMIN_USER, targetUser.internal_id, amberGroupId, RELATION_MEMBER_OF, ABSTRACT_INTERNAL_RELATIONSHIP).catch(() => {
+      // Relation may not exist: ignore.
+    });
+
+    // Case (a) setup: both source and target already belong to the SAME group.
+    await assignGroupToUser(testContext, ADMIN_USER, sourceUser.internal_id, 'GREEN GROUP');
+    await assignGroupToUser(testContext, ADMIN_USER, targetUser.internal_id, 'GREEN GROUP');
+    // AMBER_GROUP is left as-is: only the source is a member of it by default test data
+    // (case b: a group the source has that the target does not).
+
+    // Case (c) setup: an object assigned to BOTH source and target already.
+    reportBothAssigned = await addReport(testContext, ADMIN_USER, {
+      name: 'PoC#4 - report assigned to both source and target',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+      objectAssignee: [sourceUser.internal_id, targetUser.internal_id],
+    });
+
+    // Case (d) setup: an object assigned to the source ONLY.
+    reportSourceOnlyAssigned = await addReport(testContext, ADMIN_USER, {
+      name: 'PoC#4 - report assigned to source only',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+      objectAssignee: [sourceUser.internal_id],
+    });
+
+    // Case (e) setup: an object CREATED BY the source (creator_id), used to prove that
+    // this rights/refs transfer never touches creator_id (out of scope, see PoC #3).
+    reportCreatedBySource = await addReport(testContext, sourceUser, {
+      name: 'PoC#4 - report created by source (creator_id check)',
+      published: new Date().toISOString(),
+      report_types: ['threat-report'],
+    });
+  });
+
+  afterAll(async () => {
+    for (const reportId of [reportBothAssigned?.id, reportSourceOnlyAssigned?.id, reportCreatedBySource?.id]) {
+      if (reportId) {
+        // eslint-disable-next-line no-await-in-loop
+        await deleteElementById(testContext, ADMIN_USER, reportId, ENTITY_TYPE_CONTAINER_REPORT);
+      }
+    }
+    // Clean up the memberships added by this test (both the beforeAll setup and the
+    // merge apply itself), so re-running the suite starts from a deterministic state.
+    // GREEN_GROUP was added to both users by this test's beforeAll: remove it from both.
+    // AMBER_GROUP is source's default fixture group (not added by us): only remove the
+    // copy the merge added to the target, never touch the source's default membership.
+    const greenGroupId = generateStandardId(ENTITY_TYPE_GROUP, { name: 'GREEN GROUP' });
+    const amberGroupId = generateStandardId(ENTITY_TYPE_GROUP, { name: 'AMBER GROUP' });
+    for (const userId of [sourceUser?.internal_id, targetUser?.internal_id]) {
+      if (userId) {
+        // eslint-disable-next-line no-await-in-loop
+        await deleteRelationsByFromAndTo(testContext, ADMIN_USER, userId, greenGroupId, RELATION_MEMBER_OF, ABSTRACT_INTERNAL_RELATIONSHIP).catch(() => {
+          // Relation may already be gone: ignore.
+        });
+      }
+    }
+    if (targetUser?.internal_id) {
+      await deleteRelationsByFromAndTo(testContext, ADMIN_USER, targetUser.internal_id, amberGroupId, RELATION_MEMBER_OF, ABSTRACT_INTERNAL_RELATIONSHIP).catch(() => {
+        // Relation may not have been added (e.g. if the union-mode test did not run): ignore.
+      });
+    }
+  });
+
+  it('[Plan] should build a plan describing dedup for a shared group and diff for a source-only group', async () => {
+    const plan = await buildMergeUserRightsPlan(testContext, ADMIN_USER, sourceUser.internal_id, targetUser.internal_id, 'union');
+
+    const greenGroupItem = plan.memberships.find((item) => item.entity_name === 'GREEN GROUP');
+    expect(greenGroupItem?.action).toEqual('already-present-skip');
+
+    const amberGroupItem = plan.memberships.find((item) => item.entity_name === 'AMBER GROUP');
+    expect(amberGroupItem?.action).toEqual('add-to-target');
+
+    const reportBothItem = plan.refs.find((item) => item.object_id === reportBothAssigned.id && item.relationship_type === RELATION_OBJECT_ASSIGNEE);
+    expect(reportBothItem?.action).toEqual('already-present-remove-source-only');
+
+    const reportSourceOnlyItem = plan.refs.find((item) => item.object_id === reportSourceOnlyAssigned.id && item.relationship_type === RELATION_OBJECT_ASSIGNEE);
+    expect(reportSourceOnlyItem?.action).toEqual('move-to-target');
+  });
+
+  it('[Plan] "target-strict" mode should never add the source-only group to the target', async () => {
+    const plan = await buildMergeUserRightsPlan(testContext, ADMIN_USER, sourceUser.internal_id, targetUser.internal_id, 'target-strict');
+    const amberGroupItem = plan.memberships.find((item) => item.entity_name === 'AMBER GROUP');
+    expect(amberGroupItem?.action).toEqual('skip-strict-mode');
+  });
+
+  it('(a)+(b) [union] should add the source-only group to the target and never duplicate the shared group', async () => {
+    const plan = await buildMergeUserRightsPlan(testContext, ADMIN_USER, sourceUser.internal_id, targetUser.internal_id, 'union');
+    await applyMergeUserRightsPlan(testContext, ADMIN_USER, plan);
+
+    const targetGroups = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(testContext, ADMIN_USER, targetUser.internal_id, RELATION_MEMBER_OF, ENTITY_TYPE_GROUP);
+    const targetGroupNames = targetGroups.map((group) => group.name);
+
+    // (b) union mode: the target gained the source-only group.
+    expect(targetGroupNames.filter((name) => name === 'AMBER GROUP').length).toEqual(1);
+    // (a) the shared group is present exactly once: no duplicate membership was created.
+    expect(targetGroupNames.filter((name) => name === 'GREEN GROUP').length).toEqual(1);
+  });
+
+  it('[Idempotence] re-building and re-applying the plan should not create a duplicate membership', async () => {
+    const plan = await buildMergeUserRightsPlan(testContext, ADMIN_USER, sourceUser.internal_id, targetUser.internal_id, 'union');
+    // Everything is already transferred: the plan must report every item as already
+    // present, there is nothing left to add.
+    expect(plan.memberships.every((item) => item.action !== 'add-to-target')).toEqual(true);
+
+    await applyMergeUserRightsPlan(testContext, ADMIN_USER, plan);
+
+    const targetGroups = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(testContext, ADMIN_USER, targetUser.internal_id, RELATION_MEMBER_OF, ENTITY_TYPE_GROUP);
+    const targetGroupNames = targetGroups.map((group) => group.name);
+    expect(targetGroupNames.filter((name) => name === 'AMBER GROUP').length).toEqual(1);
+    expect(targetGroupNames.filter((name) => name === 'GREEN GROUP').length).toEqual(1);
+  });
+
+  it('(c)+(d) should transfer object-assignee refs to the target, deduplicating the already-shared assignment', async () => {
+    const plan = await buildMergeUserRightsPlan(testContext, ADMIN_USER, sourceUser.internal_id, targetUser.internal_id, 'union');
+    await applyMergeUserRightsPlan(testContext, ADMIN_USER, plan);
+
+    const assigneesOfReportBoth = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(
+      testContext,
+      ADMIN_USER,
+      reportBothAssigned.id,
+      RELATION_OBJECT_ASSIGNEE,
+      ENTITY_TYPE_USER,
+      { withInferences: false },
+    );
+    // (c) was assigned to both: after the transfer, only the target remains (source
+    // removed, target NOT duplicated).
+    expect(assigneesOfReportBoth.map((u) => u.internal_id)).toEqual([targetUser.internal_id]);
+
+    const assigneesOfReportSourceOnly = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(
+      testContext,
+      ADMIN_USER,
+      reportSourceOnlyAssigned.id,
+      RELATION_OBJECT_ASSIGNEE,
+      ENTITY_TYPE_USER,
+      { withInferences: false },
+    );
+    // (d) was assigned to source only: after the transfer, the target is the sole assignee.
+    expect(assigneesOfReportSourceOnly.map((u) => u.internal_id)).toEqual([targetUser.internal_id]);
+  });
+
+  it('[Idempotence] re-building and re-applying the refs plan should not create a duplicate assignment nor fail', async () => {
+    const plan = await buildMergeUserRightsPlan(testContext, ADMIN_USER, sourceUser.internal_id, targetUser.internal_id, 'union');
+    // Nothing left to move: every ref pointing to the source has already been handled.
+    expect(plan.refs.length).toEqual(0);
+
+    await expect(applyMergeUserRightsPlan(testContext, ADMIN_USER, plan)).resolves.not.toThrow();
+
+    const assigneesOfReportBoth = await fullEntitiesThroughRelationsToList<BasicStoreEntity>(
+      testContext,
+      ADMIN_USER,
+      reportBothAssigned.id,
+      RELATION_OBJECT_ASSIGNEE,
+      ENTITY_TYPE_USER,
+      { withInferences: false },
+    );
+    expect(assigneesOfReportBoth.map((u) => u.internal_id)).toEqual([targetUser.internal_id]);
+  });
+
+  it('[created-by structural finding] created-by cannot target a User id (confirms PoC #1)', async () => {
+    // This documents WHY buildMergeUserRightsPlan.refs never contains a created-by item
+    // pointing to a User in practice: the platform enforces that created-by can only
+    // target an Identity entity (validateCreatedBy), and User is not a STIX Identity.
+    await expect(stixObjectOrRelationshipAddRefRelation(
+      testContext,
+      ADMIN_USER,
+      reportSourceOnlyAssigned.id,
+      { relationship_type: RELATION_CREATED_BY, toId: sourceUser.internal_id },
+      ABSTRACT_STIX_CORE_OBJECT,
+    )).rejects.toThrow();
+  });
+
+  it('(e) the object-assignee/participant transfer must NOT affect controlUserRestrictDeleteAgainstElement (creator_id untouched)', async () => {
+    // This module never touches creator_id: it is handled by a different mechanism
+    // (PoC #3, schema-driven id rewrite). We prove here that granting the target the
+    // source's assignee/participant refs does not accidentally grant it "restrict_delete"
+    // bypass, which is based solely on creator_id.
+    const restrictedTargetUser = { ...targetUser, restrict_delete: true };
+    const restrictedSourceUser = { ...sourceUser, restrict_delete: true };
+
+    // The target never created this report (creator_id === source): restrict_delete
+    // must still forbid it, no matter what refs it has been assigned.
+    expect(() => controlUserRestrictDeleteAgainstElement(restrictedTargetUser, reportCreatedBySource)).toThrow();
+    // The source is still the technical creator: restrict_delete must still allow it.
+    expect(controlUserRestrictDeleteAgainstElement(restrictedSourceUser, reportCreatedBySource)).toEqual(true);
+  });
+});


### PR DESCRIPTION
## Context

PoC #4 of the "merge users" investigation. Goal: prototype and test the hard part of
variant B — properly transferring a source user's **rights** (member-of, participate-to)
and **STIX references** (created-by, object-assignee, object-participant) to a target
user, **without duplicates** and **without privilege escalation**.

The generic `mergeEntities` engine rejects the `User` entity, so the logic is written by
hand in an isolated module that is never wired into production.

## What was delivered

- `src/utils/merge-user-rights.ts`: isolated module (no import outside the test), with:
  - `buildMergeUserRightsPlan(context, user, sourceId, targetId, mode)` — pure, dry-run,
    computes the transfer plan (never writes anything).
  - `applyMergeUserRightsPlan(context, user, plan)` — the only function that writes;
    **called exclusively by the integration test**, never by production code.
  - Two explicit, parameterizable modes for memberships:
    - `union`: the target inherits the groups the source has and it doesn't.
    - `target-strict`: nothing is transferred, the target keeps exactly its own rights.
  - has-role / has-capability: explicitly **excluded** (carried by the Group, not the User).
  - creator_id: explicitly **excluded** (out of scope, see PoC #3).
- `tests/03-integration/01-database/merge-user-rights-poc-test.ts`: vitest integration
  test, 8 cases, run against a real Elastic/Redis/MinIO/RabbitMQ stack (podman).

## PoC Results

### Generated transfer plan (real example, USER_EDITOR -> USER_SECURITY)

Setup: both users are members of `GREEN GROUP` (already shared); only `USER_EDITOR`
(source) is a member of `AMBER GROUP`; one report is assigned to both users, another
to the source only.

Plan excerpt (`mode: 'union'`):

| relation | entity | action | note |
|---|---|---|---|
| member-of | GREEN GROUP | `already-present-skip` | already present (ignored): target already has this membership, no duplicate created |
| member-of | AMBER GROUP | `add-to-target` | union mode: missing on target, added |
| object-assignee | report "assigned to both" | `already-present-remove-source-only` | already present (ignored): object already references target, only the source ref is removed |
| object-assignee | report "assigned to source only" | `move-to-target` | not referencing target yet: ref moved from source to target |

In `target-strict` mode, the same plan reports `skip-strict-mode` for `AMBER GROUP`:
nothing is transferred, the target's rights remain unchanged.

### Test results (cases a→e), real run

```
✓ [Plan] should build a plan describing dedup for a shared group and diff for a source-only group   44ms
✓ [Plan] "target-strict" mode should never add the source-only group to the target                   39ms
✓ (a)+(b) [union] should add the source-only group to the target and never duplicate the shared group 277ms
✓ [Idempotence] re-building and re-applying the plan should not create a duplicate membership          41ms
✓ (c)+(d) should transfer object-assignee refs to the target, deduplicating the already-shared assignment  62ms
✓ [Idempotence] re-building and re-applying the refs plan should not create a duplicate assignment nor fail  43ms
✓ [created-by structural finding] created-by cannot target a User id (confirms PoC #1)                  4ms
✓ (e) the object-assignee/participant transfer must NOT affect controlUserRestrictDeleteAgainstElement (creator_id untouched)  1ms

Test Files  1 passed (1)
     Tests  8 passed (8)
```

Suite re-run twice in a row (the module rebuilds then re-applies the plan on each run):
**zero duplicates, zero errors, identical behavior** — proof of idempotence.

Per-case verification detail:
- **(a)** shared group (`GREEN GROUP`): a single membership after merge (no duplicate).
- **(b)** source-only group (`AMBER GROUP`): transferred in `union` mode, never in
  `target-strict` mode — both behaviors are demonstrated by the test.
- **(c)** object assigned to both: a single assignment remains (the target), the source
  ref removed.
- **(d)** object assigned to the source only: assignment fully transferred to the
  target, no more reference to the source.
- **(e)** `controlUserRestrictDeleteAgainstElement`: the assignee/participant refs
  transfer never changes `creator_id`; the target remains denied for an object it did
  not create, and the source (actual creator) remains allowed. No unintended bypass of
  `restrict_delete`.
- **Structural finding (confirms PoC #1)**: `created-by` structurally CANNOT point to a
  `User` (`validateCreatedBy` rejects the call) — this is not just an observed
  convention, it's an engine-level constraint.

### Business rules table

| Conflict type | Rule applied | Underlying product question |
|---|---|---|
| Group/organization shared by both source and target | Dedup: no action, target keeps a single membership | — (unambiguous) |
| Group/organization only the source has | Depends on mode: `union` = transferred to target / `target-strict` = never transferred | **(Q1)** Should rights be unioned, or should the target's rights be strictly enforced? |
| has-role / has-capability | Never touched (carried by the Group) | None, confirmed structural (PoC #1) |
| STIX ref (assignee/participant) already present on target | Dedup: source ref removed, no extra ref created on target | — (unambiguous) |
| STIX ref present only on the source | Moved to target (add on target + remove on source) | Should a trace of "who was assigned before the merge" be kept? |
| created-by pointing to the source | Never encountered in practice: created-by points to an Individual (email), never to a User | Confirms this PoC has nothing to do here — out of real scope |
| Source's creator_id | Not touched by this module (delegated to PoC #3) | Should creator_id transfer happen BEFORE or AFTER the rights/refs transfer, in the final orchestrator? |

### Product questions to resolve

1. **Union of rights, or the target's rights enforced strictly?** Both modes are
   implemented and tested; the spec mentions "we do not combine rights"
   (`target-strict`), but `union` avoids a silent loss of access for objects already
   assigned to the source. This PoC does not decide — it's a product call to document
   explicitly in the merge procedure.
2. **What happens to the source user's active session after the merge?** Out of scope
   for this module (Redis/tokens are not touched here). To be handled in the global
   orchestrator — see the "runtime state outside Elastic" note in the investigation's
   shared context.
3. **Should the rights transfer be audit-logged?** This PoC logs nothing (no
   history/activity event is emitted by `applyMergeUserRightsPlan`). A real merge
   silently changes a target account's rights — a security decision-maker will likely
   want an explicit trace (who merged whom, when, which rights were added).

### Refined effort estimate

The initial note estimated this part at **4-6 days**. After this PoC:
- The diff/dedup logic itself (rights + refs) is **simple** once the correct query
  direction is identified (`...ToList` vs `...FromList` — a pitfall hit during this PoC,
  see technical section below): ~1-1.5 day for a robust, production-tested version
  (instead of the isolated prototype delivered here).
- The real risk is **not technical but product/orchestration**:
  - Deciding the union/strict mode (a business call, not a dev one).
  - Orchestrating the order of operations with PoC #3 (creator_id) and
    session/token handling (out of scope here) without an inconsistent intermediate state.
  - Adding audit logging if required (event format to be defined).
  - Extending coverage beyond the 3 refs tested here if other refs point to a User in
    the schema (this PoC only covers created-by/assignee/participant, per the spec, but
    an exhaustive review of `getIdAttributes()` à la PoC #3 would still be worthwhile to
    make sure nothing was missed).
- Refined estimate: **3-4 days** for the rights/refs part itself (code + tests +
  review), **+1-2 days** of coordination/orchestration with the other PoCs and the
  product decision on union/strict mode — consistent with the upper end of the initial
  range (4-6 d) once orchestration is counted, but the technical core is faster than
  feared.

### Remaining risk areas

- The `union` mode can create an *indirect* privilege escalation if the source had a
  very permissive group the target was deliberately not supposed to have (the PoC
  naively transfers any missing group, with no notion of permissiveness "level").
- No handling of graph relations other than member-of/participate-to (e.g. rights
  inherited via an organization that is itself a member of a group) — not covered by
  this spec, worth checking whether OpenCTI's rights model has other levels of
  indirection.
- Behavior with a very large number of objects referencing the source (performance of
  `fullEntitiesThroughRelationsFromList` + sequential `await` loop in
  `applyMergeUserRightsPlan`) was not tested at scale — the PoC deliberately uses a
  sequential loop for simplicity/readability; a real implementation would likely want
  batching.

## Checks

- `yarn check-ts`: ✅ (requires `NODE_OPTIONS="--max-old-space-size=8192"` in this
  environment to avoid a compiler OOM — an environment issue, unrelated to the
  introduced code).
- `yarn lint`: ✅ clean on `src/utils/merge-user-rights.ts`.
- `src/utils/merge-user-rights.ts` is not imported anywhere outside the test file
  (verified via grep on `src/`): **no impact on production behavior**.
- Integration test: 8/8 passing, re-run twice (idempotence confirmed).

## Out of scope (reminder)

- Rewriting `creator_id` and other simple `id`-format attributes: PoC #3.
- Redis sessions / tokens / notifications / locks: not handled here.
- Audit logging of the transfer: not implemented (open product question).
