### PR TITLE
fix(front): remove fileUri method which was producing broken links and fix favicon & manifest links (#16683)

### DIFF
--- a/opencti-platform/opencti-front/index.html
+++ b/opencti-platform/opencti-front/index.html
@@ -11,7 +11,7 @@
         <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
         <meta name="dеѕсrірtіоn" content="%APP_DESCRIPTION%">
         <link id="favicon" rel="shortcut icon" href="%APP_FAVICON%">
-        <link id="manifest" rel="manifest" href="%APP_MANIFEST%">
+        <link id="manifest" rel="manifest" href="./assets/static/manifest.json">
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -1,6 +1,5 @@
 import { buttonClasses } from '@mui/material/Button';
 import type { ExtendedThemeOptions } from './Theme';
-import { fileUri } from '../relay/environment';
 import LogoText from '../static/images/logo_text_dark.svg';
 import LogoCollapsed from '../static/images/logo_dark.svg';
 import { hexToRGB } from '../utils/Colors';
@@ -36,8 +35,8 @@ const ThemeDark = (
   accent: string | null = null,
   text_color = THEME_DARK_DEFAULT_TEXT,
 ): ExtendedThemeOptions => ({
-  logo: logo || fileUri(LogoText),
-  logo_collapsed: logo_collapsed || fileUri(LogoCollapsed),
+  logo: logo || LogoText,
+  logo_collapsed: logo_collapsed || LogoCollapsed,
   borderRadius: 4,
   palette: {
     mode: 'dark',

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -1,6 +1,5 @@
 import { buttonClasses } from '@mui/material/Button';
 import type { ExtendedThemeOptions } from './Theme';
-import { fileUri } from '../relay/environment';
 import LogoText from '../static/images/logo_text_light.svg';
 import LogoCollapsed from '../static/images/logo_light.svg';
 import { hexToRGB } from '../utils/Colors';
@@ -36,8 +35,8 @@ const ThemeLight = (
   accent: string | null = null,
   text_color = THEME_LIGHT_DEFAULT_TEXT,
 ): ExtendedThemeOptions => ({
-  logo: logo || fileUri(LogoText),
-  logo_collapsed: logo_collapsed || fileUri(LogoCollapsed),
+  logo: logo || LogoText,
+  logo_collapsed: logo_collapsed || LogoCollapsed,
   borderRadius: 4,
   palette: {
     mode: 'light',

--- a/opencti-platform/opencti-front/src/components/graph/utils/graphImages.ts
+++ b/opencti-platform/opencti-front/src/components/graph/utils/graphImages.ts
@@ -43,7 +43,6 @@ import Task from '../../../static/images/entities/task.svg';
 import Unknown from '../../../static/images/entities/unknown.svg';
 import StixCyberObservable from '../../../static/images/entities/stix-cyber-observable.svg';
 import Relationship from '../../../static/images/entities/relationship.svg';
-import { fileUri } from '../../../relay/environment';
 import SecurityPlatform from '../../../static/images/entities/security-platform.svg';
 import SecurityCoverage from '../../../static/images/entities/security-coverage.svg';
 
@@ -58,7 +57,7 @@ type GraphImages = {
 
 const generateHtmlImageElement = (src: string) => {
   const img = new Image();
-  img.src = fileUri(src);
+  img.src = src;
   return img;
 };
 

--- a/opencti-platform/opencti-front/src/private/components/chatbox/ChatbotManager.ts
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/ChatbotManager.ts
@@ -1,5 +1,5 @@
 import type { Theme } from '../../../components/Theme';
-import { APP_BASE_PATH, fileUri } from '../../../relay/environment';
+import { APP_BASE_PATH } from '../../../relay/environment';
 import embleme from '../../../static/images/embleme_filigran_white.png';
 import { DARK_BLUE } from '../../../utils/htmlToPdf/utils/constants';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -120,7 +120,7 @@ class ChatbotManager {
         showTitle: true,
         showAgentMessages: false,
         title: this.t_i18n('Ask Ariane'),
-        titleAvatarSrc: fileUri(embleme),
+        titleAvatarSrc: embleme,
         titleBackgroundColor: 'linear-gradient(90deg, #3C108C 0%, #5E1AD5 100%)',
         welcomeMessage: this.t_i18n('Hi there 👋 You\'re speaking with an AI Agent. I\'m here to answer your questions, so what brings you here today?'),
         errorMessage: this.t_i18n('Sorry, an error has occurred, please try again later.'),

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsList.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsList.test.tsx
@@ -4,7 +4,6 @@ import testRender from '../../../../utils/tests/test-render';
 
 vi.mock('../../../../relay/environment', () => ({
   APP_BASE_PATH: '',
-  fileUri: (f: string) => f,
   MESSAGING$: { messages$: { subscribe: () => ({}) } },
   environment: {},
   fetchQuery: vi.fn(),

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.test.tsx
@@ -4,7 +4,6 @@ import testRender from '../../../../utils/tests/test-render';
 
 vi.mock('../../../../relay/environment', () => ({
   APP_BASE_PATH: '',
-  fileUri: (f: string) => f,
   MESSAGING$: { messages$: { subscribe: () => ({}) } },
   environment: {},
   fetchQuery: vi.fn(),

--- a/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/ListFilters.test.tsx
@@ -4,7 +4,6 @@ import testRender, { createMockUserContext } from '../../../../utils/tests/test-
 
 vi.mock('../../../../relay/environment', () => ({
   APP_BASE_PATH: '',
-  fileUri: (f: string) => f,
   MESSAGING$: { messages$: { subscribe: () => ({}) } },
   environment: {},
   QueryRenderer: ({ render }: { render: (args: { props: null }) => React.ReactNode }) => render({ props: null }),

--- a/opencti-platform/opencti-front/src/private/components/common/location/LocationMiniMap.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/location/LocationMiniMap.jsx
@@ -7,7 +7,6 @@ import L from 'leaflet';
 import countries from '../../../../static/geo/countries.json';
 import inject18n from '../../../../components/i18n';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { fileUri } from '../../../../relay/environment';
 import CityDark from '../../../../static/images/leaflet/city_dark.png';
 import MarkerDark from '../../../../static/images/leaflet/marker_dark.png';
 import CityLight from '../../../../static/images/leaflet/city_light.png';
@@ -16,16 +15,16 @@ import { isValidLatitude, isValidLongitude, validateCoordinates } from '../../..
 import Card from '@common/card/Card';
 
 const cityIcon = (dark = true) => new L.Icon({
-  iconUrl: dark ? fileUri(CityDark) : fileUri(CityLight),
-  iconRetinaUrl: dark ? fileUri(CityDark) : fileUri(CityLight),
+  iconUrl: dark ? CityDark : CityLight,
+  iconRetinaUrl: dark ? CityDark : CityLight,
   iconAnchor: [12, 12],
   popupAnchor: [0, -12],
   iconSize: [25, 25],
 });
 
 const positionIcon = (dark = true) => new L.Icon({
-  iconUrl: dark ? fileUri(MarkerDark) : fileUri(MarkerLight),
-  iconRetinaUrl: dark ? fileUri(MarkerDark) : fileUri(MarkerLight),
+  iconUrl: dark ? MarkerDark : MarkerLight,
+  iconRetinaUrl: dark ? MarkerDark : MarkerLight,
   iconAnchor: [12, 12],
   popupAnchor: [0, -12],
   iconSize: [25, 25],

--- a/opencti-platform/opencti-front/src/private/components/common/location/LocationMiniMapTargets.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/location/LocationMiniMapTargets.jsx
@@ -3,7 +3,6 @@ import { GeoJSON, MapContainer, Marker, TileLayer } from 'react-leaflet';
 import L from 'leaflet';
 import { useTheme } from '@mui/material/styles';
 import { UserContext } from '../../../../utils/hooks/useAuth';
-import { fileUri } from '../../../../relay/environment';
 import CityOrange from '../../../../static/images/leaflet/city_orange.png';
 import { usePublicSettings } from '../../../../public/PublicSettingsProvider';
 import allCountries from '../../../../static/geo/countries.json';
@@ -23,8 +22,8 @@ const colors = [
 ];
 
 const pointerIcon = new L.Icon({
-  iconUrl: fileUri(CityOrange),
-  iconRetinaUrl: fileUri(CityOrange),
+  iconUrl: CityOrange,
+  iconRetinaUrl: CityOrange,
   iconAnchor: [5, 55],
   popupAnchor: [10, -44],
   iconSize: [25, 25],

--- a/opencti-platform/opencti-front/src/public/components/PublicDataSharing.tsx
+++ b/opencti-platform/opencti-front/src/public/components/PublicDataSharing.tsx
@@ -6,7 +6,7 @@ import PublicFeedLines from '@components/data/feeds/PublicFeedLines';
 import React from 'react';
 import { loadQuery, usePreloadedQuery } from 'react-relay';
 import type { Theme } from '../../components/Theme';
-import { environment, fileUri } from '../../relay/environment';
+import { environment } from '../../relay/environment';
 import { LoginRootPublicQuery } from '../__generated__/LoginRootPublicQuery.graphql';
 import { rootPublicQuery } from '../LoginRoot';
 import logoLight from '../../static/images/logo_light.png';
@@ -48,7 +48,7 @@ const PublicDataSharing = () => {
     <>
       <div className={classes.container}>
         <img
-          src={loginLogo && loginLogo.length > 0 ? loginLogo : fileUri(theme.palette.mode === 'dark' ? logoDark : logoLight)}
+          src={loginLogo && loginLogo.length > 0 ? loginLogo : theme.palette.mode === 'dark' ? logoDark : logoLight}
           alt="logo"
           className={classes.logo}
         />

--- a/opencti-platform/opencti-front/src/public/components/login/LoginLogo.tsx
+++ b/opencti-platform/opencti-front/src/public/components/login/LoginLogo.tsx
@@ -4,8 +4,6 @@ import { useTheme } from '@mui/styles';
 import { LoginLogoFragment$key } from './__generated__/LoginLogoFragment.graphql';
 import logoDark from '../../../static/images/logo_text_dark.png';
 import logoLight from '../../../static/images/logo_text_light.png';
-import { isEmptyField } from '../../../utils/utils';
-import { fileUri } from '../../../relay/environment';
 import type { Theme } from '../../../components/Theme';
 
 const fragment = graphql`
@@ -23,10 +21,7 @@ interface LoginLogoProps {
 const LoginLogo = ({ data }: LoginLogoProps) => {
   const theme = useTheme<Theme>();
   const { platform_theme } = useFragment(fragment, data);
-  let logo = platform_theme?.theme_logo_login;
-  if (isEmptyField(logo)) {
-    logo = fileUri(theme.palette.mode === 'dark' ? logoDark : logoLight);
-  }
+  const logo = platform_theme?.theme_logo_login || (theme.palette.mode === 'dark' ? logoDark : logoLight);
 
   return (
     <img

--- a/opencti-platform/opencti-front/src/relay/environment.jsx
+++ b/opencti-platform/opencti-front/src/relay/environment.jsx
@@ -49,8 +49,6 @@ const isEmptyPath = R.isNil(window.BASE_PATH) || R.isEmpty(window.BASE_PATH);
 const contextPath = isEmptyPath || window.BASE_PATH === '/' ? '' : window.BASE_PATH;
 export const APP_BASE_PATH = isEmptyPath || contextPath.startsWith('/') ? contextPath : `/${contextPath}`;
 
-export const fileUri = (fileImport) => `${APP_BASE_PATH}${fileImport}`; // No slash here, will be replace by the builder
-
 // Create Network
 let subscriptionClient;
 const loc = window.location;

--- a/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
+++ b/opencti-platform/opencti-front/src/utils/htmlToPdf/htmlToPdf.ts
@@ -4,7 +4,7 @@ import htmlToPdfmake from 'html-to-pdfmake';
 import pdfMake from 'pdfmake/build/pdfmake';
 import { Content, ImageDefinition, TDocumentDefinitions } from 'pdfmake/interfaces';
 import { FintelDesign } from '@components/common/form/FintelDesignField';
-import { APP_BASE_PATH, fileUri } from '../../relay/environment';
+import { APP_BASE_PATH } from '../../relay/environment';
 import { capitalizeWords } from '../String';
 import logoWhite from '../../static/images/logo_text_white.png';
 import { getBase64ImageFromURL, isImageFromUrlSvg } from '../Image';
@@ -181,7 +181,7 @@ export const htmlToPdfReport = async (
   }
 
   if (!logo) {
-    logo = await getBase64ImageFromURL(fileUri(logoWhite));
+    logo = await getBase64ImageFromURL(logoWhite);
   }
 
   let htmlData = removeUnnecessaryHtml(content);

--- a/opencti-platform/opencti-front/vite.config.ts
+++ b/opencti-platform/opencti-front/vite.config.ts
@@ -55,8 +55,7 @@ export default defineConfig(({ mode }) => {
             .replace(/%APP_SCRIPT_SNIPPET%/g,  '')
             .replace(/%APP_TITLE%/g, 'OpenCTI Dev')
             .replace(/%APP_DESCRIPTION%/g, 'OpenCTI Development platform')
-            .replace(/%APP_FAVICON%/g, `${basePath}/assets/static/favicon.png`)
-            .replace(/%APP_MANIFEST%/g, `${basePath}/assets/static/manifest.json`),
+            .replace(/%APP_FAVICON%/g, `./assets/static/favicon.png`),
       },
       react(),
       relay,

--- a/opencti-platform/opencti-graphql/src/http/httpPlatform.js
+++ b/opencti-platform/opencti-graphql/src/http/httpPlatform.js
@@ -585,8 +585,7 @@ const createApp = async (app, schema) => {
           : 'OpenCTI - Cyber Threat Intelligence Platform')
         .replace(/%APP_DESCRIPTION%/g, validator.escape(description))
         .replace(/%APP_FAVICON%/g, isNotEmptyField(settingFavicon) ? validator.escape(settingFavicon)
-          : `${basePath}/static/ext/favicon.png`)
-        .replace(/%APP_MANIFEST%/g, `${basePath}/static/ext/manifest.json`);
+          : './assets/static/favicon.png');
       res.set('Cache-Control', 'private, no-cache, no-store, must-revalidate');
       res.set('Expires', '-1');
       res.set('Pragma', 'no-cache');


### PR DESCRIPTION
### Proposed changes

* since we are using base: ./ in vite, the method fileUri receive only absolute URL that must not be modified since they already contains the app path. This method can be removed
* fix favicon and manifest.json links

### Related issues
* Fix #16683 

### How to test this PR
* Build the frontend and start the backend with APP__BASE_PATH=/foo
* Check that application load
  * ensure embedded images are correctly loaded
  * ensure favicon is correctly loaded
  * ensure manifest.json is correctly loaded

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality
