### PR TITLE
feat(sc): Redirection of SCR to SC Results Tab (#14716)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/GraphToolbarExpandTools.tsx
@@ -135,6 +135,12 @@ const expandRelationshipsQuery = graphql`
               name
               description
             }
+            ... on SecurityCoverage {
+              name
+            }
+            ... on SecurityCoverageResult {
+              name
+            }
             ... on Individual {
               name
             }
@@ -374,6 +380,12 @@ const expandRelationshipsQuery = graphql`
             ... on Grouping {
               name
               description
+            }
+            ... on SecurityCoverage {
+              name
+            }
+            ... on SecurityCoverageResult {
+              name
             }
             ... on Individual {
               name

--- a/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
@@ -1,22 +1,10 @@
-import React, { Component } from 'react';
-import * as PropTypes from 'prop-types';
-import { Navigate } from 'react-router-dom';
-import { compose } from 'ramda';
-import withStyles from '@mui/styles/withStyles';
+import { Navigate, useParams } from 'react-router-dom';
 import { graphql } from 'react-relay';
-import inject18n from '../../components/i18n';
 import { QueryRenderer } from '../../relay/environment';
 import { resolveLink } from '../../utils/Entity';
 import Loader from '../../components/Loader';
 import ErrorNotFound from '../../components/ErrorNotFound';
-import withRouter from '../../utils/compat_router/withRouter';
-
-const styles = () => ({
-  container: {
-    margin: 0,
-    padding: 0,
-  },
-});
+import makeStyles from '@mui/styles/makeStyles';
 
 export const stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery = graphql`
   query StixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery(
@@ -96,93 +84,88 @@ export const stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery = gra
   }
 `;
 
-class StixObjectOrStixRelationship extends Component {
-  render() {
-    const {
-      classes,
-      params: { id },
-    } = this.props;
-    return (
-      <div className={classes.container}>
-        <QueryRenderer
-          query={stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery}
-          variables={{ id }}
-          render={({ props }) => {
-            if (props) {
-              if (props.stixObjectOrStixRelationship) {
-                let redirectLink;
-                const { stixObjectOrStixRelationship } = props;
-                const fromRestricted = stixObjectOrStixRelationship.from === null;
-                const toRestricted = stixObjectOrStixRelationship.to === null;
-                if (
-                  stixObjectOrStixRelationship.relationship_type
-                  === 'stix-sighting-relationship'
-                ) {
-                  if (!toRestricted) {
-                    redirectLink = `${resolveLink(
-                      stixObjectOrStixRelationship.to.entity_type,
-                    )}/${
-                      stixObjectOrStixRelationship.to.id
-                    }/knowledge/sightings/${stixObjectOrStixRelationship.id}`;
-                  } else {
-                    redirectLink = !fromRestricted
-                      ? `${resolveLink(
-                        stixObjectOrStixRelationship.from.entity_type,
-                      )}/${
-                        stixObjectOrStixRelationship.from.id
-                      }/knowledge/sightings/${stixObjectOrStixRelationship.id}`
-                      : undefined;
-                  }
-                } else if (stixObjectOrStixRelationship.relationship_type) {
-                  if (stixObjectOrStixRelationship.from?.relationship_type) {
-                    redirectLink = !toRestricted
-                      ? `${resolveLink(
-                        stixObjectOrStixRelationship.to.entity_type,
-                      )}/${
-                        stixObjectOrStixRelationship.to.id
-                      }/knowledge/relations/${stixObjectOrStixRelationship.id}`
-                      : undefined;
-                  } else if (!fromRestricted) {
-                    redirectLink = `${resolveLink(
+const useStyles = makeStyles({
+  container: {
+    margin: 0,
+    padding: 0,
+  },
+});
+
+const StixObjectOrStixRelationship = () => {
+  const classes = useStyles();
+  const { id } = useParams();
+
+  return (
+    <div className={classes.container}>
+      <QueryRenderer
+        query={stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery}
+        variables={{ id }}
+        render={({ props }) => {
+          if (props) {
+            if (props.stixObjectOrStixRelationship) {
+              let redirectLink;
+              const { stixObjectOrStixRelationship } = props;
+              const fromRestricted = stixObjectOrStixRelationship.from === null;
+              const toRestricted = stixObjectOrStixRelationship.to === null;
+              if (
+                stixObjectOrStixRelationship.relationship_type
+                === 'stix-sighting-relationship'
+              ) {
+                if (!toRestricted) {
+                  redirectLink = `${resolveLink(
+                    stixObjectOrStixRelationship.to.entity_type,
+                  )}/${
+                    stixObjectOrStixRelationship.to.id
+                  }/knowledge/sightings/${stixObjectOrStixRelationship.id}`;
+                } else {
+                  redirectLink = !fromRestricted
+                    ? `${resolveLink(
                       stixObjectOrStixRelationship.from.entity_type,
                     )}/${
                       stixObjectOrStixRelationship.from.id
-                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`;
-                  } else {
-                    redirectLink = !toRestricted
-                      ? `${resolveLink(
-                        stixObjectOrStixRelationship.to.entity_type,
-                      )}/${
-                        stixObjectOrStixRelationship.to.id
-                      }/knowledge/relations/${stixObjectOrStixRelationship.id}`
-                      : undefined;
-                  }
-                } else {
+                    }/knowledge/sightings/${stixObjectOrStixRelationship.id}`
+                    : undefined;
+                }
+              } else if (stixObjectOrStixRelationship.relationship_type) {
+                if (stixObjectOrStixRelationship.from?.relationship_type) {
+                  redirectLink = !toRestricted
+                    ? `${resolveLink(
+                      stixObjectOrStixRelationship.to.entity_type,
+                    )}/${
+                      stixObjectOrStixRelationship.to.id
+                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`
+                    : undefined;
+                } else if (!fromRestricted) {
                   redirectLink = `${resolveLink(
-                    stixObjectOrStixRelationship.entity_type,
-                  )}/${stixObjectOrStixRelationship.id}`;
+                    stixObjectOrStixRelationship.from.entity_type,
+                  )}/${
+                    stixObjectOrStixRelationship.from.id
+                  }/knowledge/relations/${stixObjectOrStixRelationship.id}`;
+                } else {
+                  redirectLink = !toRestricted
+                    ? `${resolveLink(
+                      stixObjectOrStixRelationship.to.entity_type,
+                    )}/${
+                      stixObjectOrStixRelationship.to.id
+                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`
+                    : undefined;
                 }
-                if (redirectLink) {
-                  return <Navigate exact from={`/id/${id}`} to={redirectLink} replace={true} />;
-                }
+              } else {
+                redirectLink = `${resolveLink(
+                  stixObjectOrStixRelationship.entity_type,
+                )}/${stixObjectOrStixRelationship.id}`;
               }
-              return <ErrorNotFound />;
+              if (redirectLink) {
+                return <Navigate exact from={`/id/${id}`} to={redirectLink} replace={true} />;
+              }
             }
-            return <Loader />;
-          }}
-        />
-      </div>
-    );
-  }
-}
-
-StixObjectOrStixRelationship.propTypes = {
-  params: PropTypes.object,
-  navigate: PropTypes.func,
+            return <ErrorNotFound />;
+          }
+          return <Loader />;
+        }}
+      />
+    </div>
+  );
 };
 
-export default compose(
-  inject18n,
-  withRouter,
-  withStyles(styles),
-)(StixObjectOrStixRelationship);
+export default StixObjectOrStixRelationship;

--- a/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/StixObjectOrStixRelationship.jsx
@@ -1,10 +1,10 @@
 import { Navigate, useParams } from 'react-router-dom';
 import { graphql } from 'react-relay';
 import { QueryRenderer } from '../../relay/environment';
-import { resolveLink } from '../../utils/Entity';
 import Loader from '../../components/Loader';
 import ErrorNotFound from '../../components/ErrorNotFound';
 import makeStyles from '@mui/styles/makeStyles';
+import { useComputeLink } from '../../utils/hooks/useAppData';
 
 export const stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery = graphql`
   query StixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery(
@@ -15,6 +15,11 @@ export const stixObjectOrStixRelationshipStixObjectOrStixRelationshipQuery = gra
         id
         parent_types
         entity_type
+      }
+      ... on SecurityCoverageResult {
+        resultOf {
+          id
+        }
       }
       ... on StixCoreRelationship {
         id
@@ -94,6 +99,7 @@ const useStyles = makeStyles({
 const StixObjectOrStixRelationship = () => {
   const classes = useStyles();
   const { id } = useParams();
+  const computeLink = useComputeLink();
 
   return (
     <div className={classes.container}>
@@ -103,58 +109,8 @@ const StixObjectOrStixRelationship = () => {
         render={({ props }) => {
           if (props) {
             if (props.stixObjectOrStixRelationship) {
-              let redirectLink;
-              const { stixObjectOrStixRelationship } = props;
-              const fromRestricted = stixObjectOrStixRelationship.from === null;
-              const toRestricted = stixObjectOrStixRelationship.to === null;
-              if (
-                stixObjectOrStixRelationship.relationship_type
-                === 'stix-sighting-relationship'
-              ) {
-                if (!toRestricted) {
-                  redirectLink = `${resolveLink(
-                    stixObjectOrStixRelationship.to.entity_type,
-                  )}/${
-                    stixObjectOrStixRelationship.to.id
-                  }/knowledge/sightings/${stixObjectOrStixRelationship.id}`;
-                } else {
-                  redirectLink = !fromRestricted
-                    ? `${resolveLink(
-                      stixObjectOrStixRelationship.from.entity_type,
-                    )}/${
-                      stixObjectOrStixRelationship.from.id
-                    }/knowledge/sightings/${stixObjectOrStixRelationship.id}`
-                    : undefined;
-                }
-              } else if (stixObjectOrStixRelationship.relationship_type) {
-                if (stixObjectOrStixRelationship.from?.relationship_type) {
-                  redirectLink = !toRestricted
-                    ? `${resolveLink(
-                      stixObjectOrStixRelationship.to.entity_type,
-                    )}/${
-                      stixObjectOrStixRelationship.to.id
-                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`
-                    : undefined;
-                } else if (!fromRestricted) {
-                  redirectLink = `${resolveLink(
-                    stixObjectOrStixRelationship.from.entity_type,
-                  )}/${
-                    stixObjectOrStixRelationship.from.id
-                  }/knowledge/relations/${stixObjectOrStixRelationship.id}`;
-                } else {
-                  redirectLink = !toRestricted
-                    ? `${resolveLink(
-                      stixObjectOrStixRelationship.to.entity_type,
-                    )}/${
-                      stixObjectOrStixRelationship.to.id
-                    }/knowledge/relations/${stixObjectOrStixRelationship.id}`
-                    : undefined;
-                }
-              } else {
-                redirectLink = `${resolveLink(
-                  stixObjectOrStixRelationship.entity_type,
-                )}/${stixObjectOrStixRelationship.id}`;
-              }
+              const { stixObjectOrStixRelationship: node } = props;
+              const redirectLink = computeLink(node);
               if (redirectLink) {
                 return <Navigate exact from={`/id/${id}`} to={redirectLink} replace={true} />;
               }

--- a/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/groupings/GroupingKnowledge.jsx
@@ -134,9 +134,7 @@ class GroupingKnowledgeComponent extends Component {
           <Route
             path="/relations/:relationId"
             element={(
-              <StixCoreRelationship
-                entityId={grouping.id}
-              />
+              <StixCoreRelationship />
             )}
           />
           <Route index element={<Navigate replace={true} to="graph" />} />

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisKnowledge.tsx
@@ -35,9 +35,7 @@ const MalwareAnalysisKnowledge = ({ malwareAnalysis, entityLink }: MalwareAnalys
     <Route
       path="/relations/:relationId"
       element={(
-        <StixCoreRelationship
-          entityId={malwareAnalysis.id}
-        />
+        <StixCoreRelationship />
       )}
     />
   </Routes>

--- a/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/notes/Root.jsx
@@ -145,7 +145,7 @@ const RootNote = () => {
                     extraRoutes={(
                       <Route
                         path="/knowledge/relations/:relationId"
-                        element={<StixCoreRelationship entityId={note.id} />}
+                        element={<StixCoreRelationship />}
                       />
                     )}
                   />

--- a/opencti-platform/opencti-front/src/private/components/analyses/opinions/Root.jsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/opinions/Root.jsx
@@ -89,9 +89,7 @@ class RootOpinion extends Component {
                     <Route
                       path="/knowledge/relations/:relationId"
                       element={(
-                        <StixCoreRelationship
-                          entityId={props.opinion.id}
-                        />
+                        <StixCoreRelationship />
                       )}
                     />
                   </Routes>

--- a/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/reports/ReportKnowledge.tsx
@@ -384,9 +384,7 @@ const ReportKnowledgeComponent = (props: ReportKnowledgeComponentProps) => {
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={report.id}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route index element={<Navigate replace={true} to="graph" />} />

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -156,9 +156,7 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
                   path="/knowledge/*"
                   element={(
                     <div>
-                      <SecurityCoverageKnowledge
-                        securityCoverageData={securityCoverage}
-                      />
+                      <SecurityCoverageKnowledge />
                     </div>
                   )}
                 />
@@ -166,9 +164,7 @@ const RootSecurityCoverage = ({ queryRef, securityCoverageId }: RootSecurityCove
                 <Route
                   path="/relations/:relationId"
                   element={(
-                    <StixCoreRelationship
-                      entityId={securityCoverageId}
-                    />
+                    <StixCoreRelationship />
                   )}
                 />
               </>

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -49,7 +49,6 @@ const securityCoverageQuery = graphql`
       }
       currentUserAccessRight
       ...SecurityCoverage_securityCoverage
-      ...SecurityCoverageKnowledge_securityCoverage
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageKnowledge.tsx
@@ -1,38 +1,14 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { graphql, useFragment } from 'react-relay';
-import { SecurityCoverageKnowledge_securityCoverage$key } from './__generated__/SecurityCoverageKnowledge_securityCoverage.graphql';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
 
-const securityCoverageKnowledgeFragment = graphql`
-  fragment SecurityCoverageKnowledge_securityCoverage on SecurityCoverage {
-    id
-    name
-    description
-    entity_type
-    security_platform_type
-  }
-`;
-
-const SecurityCoverageKnowledgeComponent = ({
-  securityCoverageData,
-}: {
-  securityCoverageData: SecurityCoverageKnowledge_securityCoverage$key;
-}) => {
-  const securityCoverage = useFragment(
-    securityCoverageKnowledgeFragment,
-    securityCoverageData,
-  );
+const SecurityCoverageKnowledgeComponent = () => {
   return (
     <div data-testid="security-coverage-knowledge">
       <Routes>
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={securityCoverage.id}
-              paddingRight={false}
-            />
+            <StixCoreRelationship />
           )}
         />
       </Routes>

--- a/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/channels/ChannelKnowledge.jsx
@@ -37,10 +37,7 @@ const ChannelKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={channel.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/malwares/MalwareKnowledge.jsx
@@ -41,10 +41,7 @@ const MalwareKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={malware.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/tools/ToolKnowledge.jsx
@@ -37,10 +37,7 @@ const ToolKnowledgeComponent = ({
         <Route
           path="/relations/:relationId/*"
           element={(
-            <StixCoreRelationship
-              entityId={tool.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityKnowledge.jsx
@@ -36,10 +36,7 @@ const VulnerabilityKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={vulnerability.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_incidents/IncidentKnowledge.jsx
@@ -290,9 +290,7 @@ class IncidentKnowledgeComponent extends Component {
           <Route
             path="/relations/:relationId"
             element={(
-              <StixCoreRelationship
-                entityId={caseData.id}
-              />
+              <StixCoreRelationship />
             )}
           />
           <Route index element={<Navigate replace={true} to="graph" />} />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfis/CaseRfiKnowledge.jsx
@@ -287,9 +287,7 @@ class CaseRfiKnowledgeComponent extends Component {
           <Route
             path="/relations/:relationId"
             element={(
-              <StixCoreRelationship
-                entityId={caseData.id}
-              />
+              <StixCoreRelationship />
             )}
           />
           <Route index element={<Navigate replace={true} to="graph" />} />

--- a/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/case_rfts/CaseRftKnowledge.jsx
@@ -288,9 +288,7 @@ class CaseRftKnowledgeComponent extends Component {
           <Route
             path="/relations/:relationId"
             element={(
-              <StixCoreRelationship
-                entityId={caseData.id}
-              />
+              <StixCoreRelationship />
             )}
           />
           <Route index element={<Navigate replace={true} to="graph" />} />

--- a/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/feedbacks/Root.tsx
@@ -169,9 +169,7 @@ const RootFeedbackComponent = ({ queryRef, caseId }: RootFeedbackComponentProps)
           <Route
             path="/knowledge/relations/:relationId"
             element={(
-              <StixCoreRelationship
-                entityId={feedbackData.id}
-              />
+              <StixCoreRelationship />
             )}
           />
         )}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixDomainObjectLine.jsx
@@ -16,7 +16,6 @@ import { ListItemButton } from '@mui/material';
 import { useFormatter } from '../../../../components/i18n';
 import ItemIcon from '../../../../components/ItemIcon';
 import ContainerStixCoreObjectPopover from './ContainerStixCoreObjectPopover';
-import { resolveLink } from '../../../../utils/Entity';
 import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import ItemMarkings from '../../../../components/ItemMarkings';
@@ -25,6 +24,7 @@ import Security from '../../../../utils/Security';
 import ItemEntityType from '../../../../components/ItemEntityType';
 import { DraftChip } from '../draft/DraftChip';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import { useComputeLink } from '../../../../utils/hooks/useAppData';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -85,10 +85,11 @@ const ContainerStixDomainObjectLineComponent = (props) => {
   } = props;
   const classes = useStyles();
   const { t_i18n, fd, n } = useFormatter();
+  const computeLink = useComputeLink();
   const refTypes = types ?? ['manual'];
   const isThroughInference = refTypes.includes('inferred');
   const isOnlyThroughInference = isThroughInference && !refTypes.includes('manual');
-  const link = `${resolveLink(node.entity_type)}/${node.id}`;
+  const link = computeLink(node);
   const linkAnalyses = `${link}/analyses`;
   return (
     <ListItem
@@ -336,6 +337,15 @@ export const ContainerStixDomainObjectLine = createFragmentContainer(
         }
         ... on Case {
           name
+        }
+        ... on SecurityCoverage {
+          name
+        }
+        ... on SecurityCoverageResult {
+          name
+          resultOf {
+            id
+          }
         }
         ... on Task {
           name

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKillChainPhasesView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectKillChainPhasesView.tsx
@@ -22,13 +22,13 @@ const useStyles = makeStyles(() => ({
 }));
 
 interface StixCoreObjectKillChainPhasesViewProps {
-  killChainPhases: ReadonlyArray<{
+  killChainPhases?: ReadonlyArray<{
     entity_type: string;
     id: string;
     kill_chain_name: string;
     phase_name: string;
     x_opencti_order?: number | null;
-  }>;
+  }> | null;
   firstLine?: boolean;
   displayIcon?: boolean;
 }
@@ -48,7 +48,7 @@ const StixCoreObjectKillChainPhasesView = ({
       </Label>
       <FieldOrEmpty source={killChainPhases}>
         <List sx={{ py: 0 }}>
-          {killChainPhases.map((killChainPhase) => {
+          {(killChainPhases ?? []).map((killChainPhase) => {
             return (
               <ListItem
                 key={killChainPhase.phase_name}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationship.jsx
@@ -23,14 +23,10 @@ const stixCoreRelationshipQuery = graphql`
   }
 `;
 
-// TODO : transform into modern React Component + TS
-
 class StixCoreRelationship extends Component {
   render() {
     const {
       classes,
-      entityId,
-      paddingRight,
       params: { relationId },
     } = this.props;
     return (
@@ -42,9 +38,7 @@ class StixCoreRelationship extends Component {
             if (props && props.stixCoreRelationship) {
               return (
                 <StixCoreRelationshipOverview
-                  entityId={entityId}
-                  stixCoreRelationship={props.stixCoreRelationship}
-                  paddingRight={paddingRight}
+                  data={props.stixCoreRelationship}
                 />
               );
             }

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationship.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationship.jsx
@@ -23,6 +23,8 @@ const stixCoreRelationshipQuery = graphql`
   }
 `;
 
+// TODO : transform into modern React Component + TS
+
 class StixCoreRelationship extends Component {
   render() {
     const {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.jsx
@@ -157,6 +157,7 @@ const styles = (theme) => ({
 
 const TRUNCATE_CHARS_COUNT = 40;
 
+// TODO : transform into modern React Component + TS
 class StixCoreRelationshipContainer extends Component {
   constructor(props) {
     super(props);

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.tsx
@@ -4470,7 +4470,7 @@ const StixCoreRelationshipOverview = ({
               <Security needs={[KNOWLEDGE_KNUPDATE]}>
                 <>
                   <IconButton
-                    aria-label={t_i18n('edit')}
+                    aria-label={t_i18n('Edit')}
                     color="primary"
                     onClick={() => setOpenEdit(true)}
                     size="small"

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipOverview.tsx
@@ -7,28 +7,23 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
-import withStyles from '@mui/styles/withStyles';
-import withTheme from '@mui/styles/withTheme';
-import * as PropTypes from 'prop-types';
+import makeStyles from '@mui/styles/makeStyles';
 import * as R from 'ramda';
-import { Component } from 'react';
-import { createFragmentContainer, graphql } from 'react-relay';
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
+import { graphql, useFragment } from 'react-relay';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import Card from '../../../../components/common/card/Card';
 import CardTitle from '../../../../components/common/card/CardTitle';
 import Label from '../../../../components/common/label/Label';
-import inject18n from '../../../../components/i18n';
+import { useFormatter } from '../../../../components/i18n';
 import ItemAuthor from '../../../../components/ItemAuthor';
 import ItemConfidence from '../../../../components/ItemConfidence';
 import ItemCreators from '../../../../components/ItemCreators';
 import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import ItemStatus from '../../../../components/ItemStatus';
-import { commitMutation } from '../../../../relay/environment';
 import { itemColor } from '../../../../utils/Colors';
-import withRouter from '../../../../utils/compat_router/withRouter';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
-import { resolveLink } from '../../../../utils/Entity';
 import { KNOWLEDGE_KNUPDATE } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { capitalizeFirstLetter, truncate } from '../../../../utils/String';
@@ -46,576 +41,12 @@ import StixCoreRelationshipSharing from './StixCoreRelationshipSharing';
 import StixCoreRelationshipStixCoreRelationships from './StixCoreRelationshipStixCoreRelationships';
 import ExpandableMarkdown from '../../../../components/ExpandableMarkdown';
 import SecurityCoverageInformation from '../../analyses/security_coverages/SecurityCoverageInformation';
+import useApiMutation from 'src/utils/hooks/useApiMutation';
+import { StixCoreRelationshipOverview_stixCoreRelationship$key } from './__generated__/StixCoreRelationshipOverview_stixCoreRelationship.graphql';
+import { useComputeLink } from 'src/utils/hooks/useAppData';
+import { Theme } from 'src/components/Theme';
 
-const styles = (theme) => ({
-  container: {
-    margin: 0,
-    position: 'relative',
-  },
-  gridContainer: {
-    marginBottom: 20,
-  },
-  editButton: {
-    position: 'fixed',
-    bottom: 30,
-    right: 30,
-  },
-  editButtonWithPadding: {
-    position: 'fixed',
-    bottom: 30,
-    right: 220,
-  },
-  item: {
-    position: 'absolute',
-    width: 180,
-    height: 80,
-    borderRadius: 8,
-  },
-  itemHeader: {
-    padding: '10px 0 10px 0',
-  },
-  icon: {
-    position: 'absolute',
-    top: 8,
-    left: 5,
-    fontSize: 8,
-  },
-  type: {
-    width: '100%',
-    textAlign: 'center',
-    color: theme.palette.text.primary,
-    fontSize: 11,
-  },
-  content: {
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '0 10px 0 10px',
-    height: 40,
-    maxHeight: 40,
-    color: theme.palette.text.primary,
-    textAlign: 'center',
-    wordBreak: 'break-word',
-  },
-  name: {
-    display: 'inline-block',
-    lineHeight: 1,
-    fontSize: 12,
-    verticalAlign: 'middle',
-  },
-  middle: {
-    margin: '0 auto',
-    paddingTop: 20,
-    width: 200,
-    textAlign: 'center',
-    color: theme.palette.text.primary,
-  },
-  paper: {
-    marginTop: theme.spacing(1),
-    padding: '15px',
-    borderRadius: 4,
-  },
-  paperWithoutPadding: {
-    marginTop: theme.spacing(1),
-    padding: 0,
-    borderRadius: 4,
-  },
-  paperRelationships: {
-    marginTop: theme.spacing(3),
-    position: 'relative',
-    padding: 0,
-    borderRadius: 4,
-  },
-  paperReports: {
-    minHeight: '100%',
-    marginTop: theme.spacing(1),
-    padding: '25px 15px 15px 15px',
-    borderRadius: 4,
-  },
-  buttonExpand: {
-    position: 'absolute',
-    left: 0,
-    bottom: 0,
-    width: '100%',
-    height: 25,
-    color: theme.palette.primary.main,
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? 'rgba(255, 255, 255, .1)'
-        : 'rgba(0, 0, 0, .1)',
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? 'rgba(255, 255, 255, .2)'
-          : 'rgba(0, 0, 0, .2)',
-    },
-  },
-});
-
-const TRUNCATE_CHARS_COUNT = 40;
-
-// TODO : transform into modern React Component + TS
-class StixCoreRelationshipContainer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { openEdit: false, openDelete: false, expanded: false };
-  }
-
-  handleToggleExpand() {
-    this.setState({ expanded: !this.state.expanded });
-  }
-
-  handleOpenEdition() {
-    this.setState({ openEdit: true });
-  }
-
-  handleCloseEdition() {
-    const { stixCoreRelationship } = this.props;
-    commitMutation({
-      mutation: stixCoreRelationshipEditionFocus,
-      variables: {
-        id: stixCoreRelationship.id,
-        input: { focusOn: '' },
-      },
-    });
-    this.setState({ openEdit: false });
-  }
-
-  handleOpenDelete() {
-    this.setState({ displayDelete: true });
-  }
-
-  handleCloseDelete() {
-    this.setState({ displayDelete: false });
-  }
-
-  submitDelete() {
-    this.setState({ deleting: true });
-    const {
-      location,
-      stixCoreRelationship,
-    } = this.props;
-    commitMutation({
-      mutation: stixCoreRelationshipEditionDeleteMutation,
-      variables: {
-        id: stixCoreRelationship.id,
-      },
-      onCompleted: () => {
-        this.handleCloseEdition();
-        this.props.navigate(
-          location.pathname.replace(`/relations/${stixCoreRelationship.id}`, ''),
-        );
-      },
-    });
-  }
-
-  render() {
-    const { t, fldt, nsdt, classes, stixCoreRelationship } = this.props;
-    const { expanded } = this.state;
-    const { from, to, relationship_type, coverage_information } = stixCoreRelationship;
-    const fromRestricted = from === null;
-
-    const linkFrom = from
-      ? from.relationship_type
-        ? `${resolveLink(from.from.entity_type)}/${
-          from.from.id
-        }/knowledge/relations`
-        : resolveLink(from.entity_type)
-      : '';
-    const toRestricted = to === null;
-
-    const linkTo = to
-      ? to.relationship_type
-        ? `${resolveLink(to.from.entity_type)}/${
-          to.from.id
-        }/knowledge/relations`
-        : resolveLink(to.entity_type)
-      : '';
-    const expandable = stixCoreRelationship.x_opencti_inferences
-      && stixCoreRelationship.x_opencti_inferences.length > 1;
-
-    const fromText = getMainRepresentative(from) !== 'Unknown'
-      ? getMainRepresentative(from)
-      : t(`relationship_${from.entity_type}`);
-
-    const toText = getMainRepresentative(to) !== 'Unknown'
-      ? getMainRepresentative(to)
-      : t(`relationship_${to.entity_type}`);
-
-    return (
-      <div className={classes.container}>
-        <Grid
-          container={true}
-          spacing={3}
-          classes={{ container: classes.gridContainer }}
-        >
-          <Grid item xs={6}>
-            <Card
-              title={<>{t('Relationship')}{stixCoreRelationship.draftVersion && (<DraftChip />)}</>}
-              action={!stixCoreRelationship.is_inferred && (
-                <Security needs={[KNOWLEDGE_KNUPDATE]}>
-                  <IconButton
-                    aria-label={t('edit')}
-                    color="primary"
-                    onClick={this.handleOpenEdition.bind(this)}
-                    size="small"
-                  >
-                    <EditOutlined fontSize="small" />
-                  </IconButton>
-                  <StixCoreRelationshipEdition
-                    open={this.state.openEdit}
-                    stixCoreRelationshipId={stixCoreRelationship.id}
-                    handleClose={this.handleCloseEdition.bind(this)}
-                    handleDelete={this.handleOpenDelete.bind(this)}
-                  />
-                </Security>
-              )}
-            >
-              <Link to={!fromRestricted ? `${linkFrom}/${from.id}` : '#'}>
-                <div
-                  className={classes.item}
-                  style={{
-                    border: `1px solid ${itemColor(
-                      !fromRestricted ? from.entity_type : 'Restricted',
-                    )}`,
-                    top: 20,
-                    left: 20,
-                  }}
-                >
-                  <div
-                    className={classes.itemHeader}
-                    style={{
-                      borderBottom: `1px solid ${itemColor(
-                        !fromRestricted ? from.entity_type : 'Restricted',
-                      )}`,
-                    }}
-                  >
-                    <div className={classes.icon}>
-                      <ItemIcon
-                        type={!fromRestricted ? from.entity_type : 'Restricted'}
-                        color={itemColor(
-                          !fromRestricted ? from.entity_type : 'Restricted',
-                        )}
-                        size="small"
-                      />
-                    </div>
-                    <div className={classes.type}>
-                      { }
-                      {!fromRestricted
-                        ? from.relationship_type
-                          ? t('Relationship')
-                          : t(`entity_${from.entity_type}`)
-                        : t('Restricted')}
-                    </div>
-                  </div>
-                  <div className={classes.content}>
-                    <span className={classes.name}>
-                      <Tooltip title={fromText}>
-                        {!fromRestricted
-                          ? truncate(fromText, TRUNCATE_CHARS_COUNT)
-                          : t('Restricted')}
-                      </Tooltip>
-                      {!fromRestricted && stixCoreRelationship.from.draftVersion && (<DraftChip />)}
-                    </span>
-                  </div>
-                </div>
-              </Link>
-              <div className={classes.middle}>
-                <ArrowRightAlt fontSize="large" />
-                <Typography sx={{ fontSize: '14px', fontWeight: 400 }}>
-                  {capitalizeFirstLetter(t(`relationship_${stixCoreRelationship.relationship_type}`))}
-                </Typography>
-              </div>
-              <Link to={!toRestricted ? `${linkTo}/${to.id}` : '#'}>
-                <div
-                  className={classes.item}
-                  style={{
-                    border: `1px solid ${itemColor(
-                      !toRestricted ? to.entity_type : 'Restricted',
-                    )}`,
-                    top: 20,
-                    right: 20,
-                  }}
-                >
-                  <div
-                    className={classes.itemHeader}
-                    style={{
-                      borderBottom: `1px solid ${itemColor(
-                        !toRestricted ? to.entity_type : 'Restricted',
-                      )}`,
-                    }}
-                  >
-                    <div className={classes.icon}>
-                      <ItemIcon
-                        type={!toRestricted ? to.entity_type : 'Unknown'}
-                        color={itemColor(
-                          !toRestricted ? to.entity_type : 'Restricted',
-                        )}
-                        size="small"
-                      />
-                    </div>
-                    <div className={classes.type}>
-                      {
-                        !toRestricted
-                          ? to.relationship_type
-                            ? t('Relationship')
-                            : t(`entity_${to.entity_type}`)
-                          : t('Restricted')
-                      }
-                    </div>
-                  </div>
-                  <div className={classes.content}>
-                    <span className={classes.name}>
-                      <Tooltip title={toText}>
-                        {!toRestricted
-                          ? truncate(toText, TRUNCATE_CHARS_COUNT)
-                          : t('Restricted')}
-                      </Tooltip>
-                      {!toRestricted && stixCoreRelationship.to.draftVersion && (<DraftChip />)}
-                    </span>
-                  </div>
-                </div>
-              </Link>
-              <Divider style={{ marginTop: 30, marginBottom: 15 }} />
-              <Stack gap={2}>
-                <div>
-                  <Label>
-                    {t('Description')}
-                  </Label>
-                  <ExpandableMarkdown
-                    source={stixCoreRelationship.x_opencti_inferences !== null
-                      ? t('Inferred knowledge')
-                      : stixCoreRelationship.description
-                    }
-                    limit={400}
-                  />
-                </div>
-                <Divider />
-
-                <Grid container={true} spacing={2}>
-                  <Grid item xs={6}>
-                    <Label>
-                      {t('Marking')}
-                    </Label>
-                    <ItemMarkings markingDefinitions={stixCoreRelationship.objectMarking ?? []} />
-                    <Label
-                      sx={{ marginTop: 2 }}
-                    >
-                      {t('Start time')}
-                    </Label>
-                    {nsdt(stixCoreRelationship.start_time)}
-                    <Label sx={{ marginTop: 2 }}>
-                      {t('Stop time')}
-                    </Label>
-                    {nsdt(stixCoreRelationship.stop_time)}
-                  </Grid>
-                  <Grid item xs={6}>
-                    {relationship_type === 'has-covered'
-                      && (
-                        <Box sx={{ marginBottom: 2 }}>
-                          <SecurityCoverageInformation coverage_information={coverage_information} />
-                        </Box>
-                      )
-                    }
-                    <StixCoreRelationshipSharing
-                      elementId={stixCoreRelationship.id}
-                    />
-                    <StixCoreObjectKillChainPhasesView
-                      killChainPhases={stixCoreRelationship.killChainPhases}
-                      displayIcon
-                    />
-                  </Grid>
-                </Grid>
-              </Stack>
-            </Card>
-          </Grid>
-          <Grid item xs={6}>
-            <Card title={t('Details')}>
-              <Grid container={true} spacing={2}>
-                <Grid item xs={6}>
-                  <Label>
-                    {t('Confidence level')}
-                  </Label>
-                  <ItemConfidence
-                    confidence={stixCoreRelationship.confidence}
-                    entityType="stix-core-relationship"
-                  />
-                  {stixCoreRelationship.x_opencti_inferences === null && (
-                    <div>
-                      <Label
-                        sx={{ marginTop: 2 }}
-                      >
-                        {t('Author')}
-                      </Label>
-                      <ItemAuthor
-                        createdBy={R.propOr(
-                          null,
-                          'createdBy',
-                          stixCoreRelationship,
-                        )}
-                      />
-                    </div>
-                  )}
-                  <Label
-                    sx={{ marginTop: 2 }}
-                  >
-                    {t('Original creation date')}
-                  </Label>
-                  {nsdt(stixCoreRelationship.created)}
-                  <Label
-                    sx={{ marginTop: 2 }}
-                  >
-                    {t('Modification date')}
-                  </Label>
-                  {nsdt(stixCoreRelationship.updated_at)}
-                </Grid>
-                <Grid item xs={6}>
-                  <Label>
-                    {t('Processing status')}
-                  </Label>
-                  <ItemStatus
-                    status={stixCoreRelationship.status}
-                    disabled={!stixCoreRelationship.workflowEnabled}
-                  />
-                  <StixCoreRelationshipObjectLabelsView
-                    labels={stixCoreRelationship.objectLabel}
-                    id={stixCoreRelationship.id}
-                    sx={{ marginTop: 2 }}
-                  />
-                  <Label
-                    sx={{ marginTop: 2 }}
-                  >
-                    {t('Platform creation date')}
-                  </Label>
-                  {fldt(stixCoreRelationship.created_at)}
-                  <Label
-                    sx={{ marginTop: 2 }}
-                  >
-                    {t('Creators')}
-                  </Label>
-                  <ItemCreators
-                    creators={stixCoreRelationship.creators ?? []}
-                  />
-                </Grid>
-              </Grid>
-            </Card>
-          </Grid>
-          {stixCoreRelationship.x_opencti_inferences == null && (
-            <>
-              <Grid item xs={6}>
-                <StixCoreRelationshipStixCoreRelationships
-                  entityId={stixCoreRelationship.id}
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <StixCoreObjectOrStixRelationshipLastContainers
-                  stixCoreObjectOrStixRelationshipId={stixCoreRelationship.id}
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <StixCoreRelationshipExternalReferences
-                  stixCoreRelationshipId={stixCoreRelationship.id}
-                />
-              </Grid>
-              <Grid item xs={6}>
-                <StixCoreRelationshipLatestHistory
-                  stixCoreRelationshipId={stixCoreRelationship.id}
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <StixCoreObjectOrStixCoreRelationshipNotes
-                  stixCoreObjectOrStixCoreRelationshipId={stixCoreRelationship.id}
-                  isRelationship={true}
-                  defaultMarkings={stixCoreRelationship.objectMarking ?? []}
-                />
-              </Grid>
-            </>
-          )}
-        </Grid>
-        <div>
-          {stixCoreRelationship.x_opencti_inferences !== null && (
-            <div style={{ margin: '50px 0 0 0' }}>
-              <CardTitle>
-                {t('Inference explanation')} (
-                {stixCoreRelationship.x_opencti_inferences.length})
-              </CardTitle>
-              {R.take(
-                expanded ? 200 : 1,
-                stixCoreRelationship.x_opencti_inferences,
-              ).map((inference) => (
-                <StixCoreRelationshipInference
-                  key={inference.rule.id}
-                  inference={inference}
-                  stixRelationship={stixCoreRelationship}
-                />
-              ))}
-              {expandable && (
-                <IconButton
-                  aria-label={expanded ? t('Collapse') : t('Expand')}
-                  variant="tertiary"
-                  size="small"
-                  onClick={this.handleToggleExpand.bind(this)}
-                  classes={{ root: classes.buttonExpand }}
-                >
-                  {expanded ? (
-                    <ExpandLessOutlined />
-                  ) : (
-                    <ExpandMoreOutlined />
-                  )}
-                </IconButton>
-              )}
-            </div>
-          )}
-        </div>
-        <Dialog
-          open={this.state.displayDelete}
-          onClose={this.handleCloseDelete.bind(this)}
-          title={t('Are you sure?')}
-          size="small"
-        >
-          <DialogContentText>
-            {t('Do you want to delete this relationship?')}
-          </DialogContentText>
-          <DialogActions>
-            <Button
-              onClick={this.handleCloseDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Cancel')}
-            </Button>
-            <Button
-              color="secondary"
-              onClick={this.submitDelete.bind(this)}
-              disabled={this.state.deleting}
-            >
-              {t('Confirm')}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </div>
-    );
-  }
-}
-
-StixCoreRelationshipContainer.propTypes = {
-  entityId: PropTypes.string,
-  stixCoreRelationship: PropTypes.object,
-  paddingRight: PropTypes.bool,
-  classes: PropTypes.object,
-  t: PropTypes.func,
-  nsdt: PropTypes.func,
-  match: PropTypes.object,
-  navigate: PropTypes.func,
-  location: PropTypes.object,
-};
-
-const StixCoreRelationshipOverview = createFragmentContainer(
-  StixCoreRelationshipContainer,
-  {
-    stixCoreRelationship: graphql`
+const fragment = graphql`
       fragment StixCoreRelationshipOverview_stixCoreRelationship on StixCoreRelationship {
         id
         draftVersion {
@@ -1571,6 +1002,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                           objectMarking {
                             id
                             definition
+                            definition_type
                             x_opencti_order
                             x_opencti_color
                           }
@@ -1858,6 +1290,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                               objectMarking {
                                 id
                                 definition
+                                definition_type
                                 x_opencti_order
                                 x_opencti_color
                               }
@@ -2139,6 +1572,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                               objectMarking {
                                 id
                                 definition
+                                definition_type
                                 x_opencti_order
                                 x_opencti_color
                               }
@@ -2428,6 +1862,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                           objectMarking {
                             id
                             definition
+                            definition_type
                             x_opencti_order
                             x_opencti_color
                           }
@@ -2813,6 +2248,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                               objectMarking {
                                 id
                                 definition
+                                definition_type
                                 x_opencti_order
                                 x_opencti_color
                               }
@@ -3099,6 +2535,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                           objectMarking {
                             id
                             definition
+                            definition_type
                             x_opencti_order
                             x_opencti_color
                           }
@@ -3386,6 +2823,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                               objectMarking {
                                 id
                                 definition
+                                definition_type
                                 x_opencti_order
                                 x_opencti_color
                               }
@@ -3667,6 +3105,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                               objectMarking {
                                 id
                                 definition
+                                definition_type
                                 x_opencti_order
                                 x_opencti_color
                               }
@@ -3838,6 +3277,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
         objectMarking {
           id
           definition
+          definition_type
           x_opencti_order
           x_opencti_color
         }
@@ -3878,6 +3318,11 @@ const StixCoreRelationshipOverview = createFragmentContainer(
             observable_value
             representative {
               main
+            }
+          }
+          ... on SecurityCoverageResult {
+            resultOf {
+              id
             }
           }
           ... on AttackPattern {
@@ -3989,6 +3434,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                     objectMarking {
                       id
                       definition
+                      definition_type
                       x_opencti_order
                       x_opencti_color
                     }
@@ -4505,6 +3951,7 @@ const StixCoreRelationshipOverview = createFragmentContainer(
                     objectMarking {
                       id
                       definition
+                      definition_type
                       x_opencti_order
                       x_opencti_color
                     }
@@ -4865,13 +4312,509 @@ const StixCoreRelationshipOverview = createFragmentContainer(
         toId
         toType
       }
-    `,
-  },
-);
+    `;
 
-export default R.compose(
-  inject18n,
-  withRouter,
-  withTheme,
-  withStyles(styles),
-)(StixCoreRelationshipOverview);
+const useStyles = makeStyles((theme: Theme) => ({
+  container: {
+    margin: 0,
+    position: 'relative',
+  },
+  gridContainer: {
+    marginBottom: 20,
+  },
+  item: {
+    position: 'absolute',
+    width: 180,
+    height: 80,
+    borderRadius: 8,
+  },
+  itemHeader: {
+    padding: '10px 0 10px 0',
+  },
+  icon: {
+    position: 'absolute',
+    top: 8,
+    left: 5,
+    fontSize: 8,
+  },
+  type: {
+    width: '100%',
+    textAlign: 'center',
+    color: theme.palette.text.primary,
+    fontSize: 11,
+  },
+  content: {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '0 10px 0 10px',
+    height: 40,
+    maxHeight: 40,
+    color: theme.palette.text.primary,
+    textAlign: 'center',
+    wordBreak: 'break-word',
+  },
+  name: {
+    display: 'inline-block',
+    lineHeight: 1,
+    fontSize: 12,
+    verticalAlign: 'middle',
+  },
+  middle: {
+    margin: '0 auto',
+    paddingTop: 20,
+    width: 200,
+    textAlign: 'center',
+    color: theme.palette.text.primary,
+  },
+  buttonExpand: {
+    position: 'absolute',
+    left: 0,
+    bottom: 0,
+    width: '100%',
+    height: 25,
+    color: theme.palette.primary.main,
+    backgroundColor:
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, .1)'
+        : 'rgba(0, 0, 0, .1)',
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
+    '&:hover': {
+      backgroundColor:
+        theme.palette.mode === 'dark'
+          ? 'rgba(255, 255, 255, .2)'
+          : 'rgba(0, 0, 0, .2)',
+    },
+  },
+}));
+
+const TRUNCATE_CHARS_COUNT = 40;
+
+interface StixCoreRelationshipOverviewProps {
+  data: StixCoreRelationshipOverview_stixCoreRelationship$key;
+}
+
+const StixCoreRelationshipOverview = ({
+  data,
+}: StixCoreRelationshipOverviewProps) => {
+  const [openEdit, setOpenEdit] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [openDelete, setOpenDelete] = useState(false);
+  const [commitFocusMutation] = useApiMutation(stixCoreRelationshipEditionFocus);
+  const [commitDeleteMutation] = useApiMutation(stixCoreRelationshipEditionDeleteMutation);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { t_i18n, nsdt, fldt } = useFormatter();
+  const classes = useStyles();
+  const stixCoreRelationship = useFragment(fragment, data);
+  const computeLink = useComputeLink();
+
+  const handleCloseEdition = () => {
+    commitFocusMutation({
+      variables: {
+        id: stixCoreRelationship.id,
+        input: { focusOn: '' },
+      },
+    });
+    setOpenEdit(false);
+  };
+
+  const submitDelete = () => {
+    setDeleting(true);
+    commitDeleteMutation({
+      variables: {
+        id: stixCoreRelationship.id,
+      },
+      onCompleted: () => {
+        handleCloseEdition();
+        navigate(
+          location.pathname.replace(`/relations/${stixCoreRelationship.id}`, ''),
+        );
+      },
+    });
+  };
+
+  const { from, to, relationship_type, coverage_information } = stixCoreRelationship;
+  const fromRestricted = from === null;
+
+  const linkFrom = from ? computeLink(from) : '';
+  const toRestricted = to === null;
+
+  const linkTo = to ? computeLink(to) : '';
+
+  const expandable = stixCoreRelationship.x_opencti_inferences
+    && stixCoreRelationship.x_opencti_inferences.length > 1;
+
+  const fromText = getMainRepresentative(from) !== 'Unknown'
+    ? getMainRepresentative(from)
+    : t_i18n(`relationship_${from?.entity_type}`);
+
+  const toText = getMainRepresentative(to) !== 'Unknown'
+    ? getMainRepresentative(to)
+    : t_i18n(`relationship_${to?.entity_type}`);
+
+  return (
+    <div className={classes.container}>
+      <Grid
+        container={true}
+        spacing={3}
+        classes={{ container: classes.gridContainer }}
+      >
+        <Grid item xs={6}>
+          <Card
+            title={<>{t_i18n('Relationship')}{stixCoreRelationship.draftVersion && (<DraftChip />)}</>}
+            action={!stixCoreRelationship.is_inferred && (
+              <Security needs={[KNOWLEDGE_KNUPDATE]}>
+                <>
+                  <IconButton
+                    aria-label={t_i18n('edit')}
+                    color="primary"
+                    onClick={() => setOpenEdit(true)}
+                    size="small"
+                  >
+                    <EditOutlined fontSize="small" />
+                  </IconButton>
+                  <StixCoreRelationshipEdition
+                    open={openEdit}
+                    stixCoreRelationshipId={stixCoreRelationship.id}
+                    handleClose={handleCloseEdition}
+                    handleDelete={() => setOpenDelete(true)}
+                    noStoreUpdate={false}
+                  />
+                </>
+              </Security>
+            )}
+          >
+            <Link to={linkFrom ?? ''}>
+              <div
+                className={classes.item}
+                style={{
+                  border: `1px solid ${itemColor(
+                    !fromRestricted ? from?.entity_type : 'Restricted',
+                  )}`,
+                  top: 20,
+                  left: 20,
+                }}
+              >
+                <div
+                  className={classes.itemHeader}
+                  style={{
+                    borderBottom: `1px solid ${itemColor(
+                      !fromRestricted ? from?.entity_type : 'Restricted',
+                    )}`,
+                  }}
+                >
+                  <div className={classes.icon}>
+                    <ItemIcon
+                      type={!fromRestricted ? from?.entity_type : 'Restricted'}
+                      color={itemColor(
+                        !fromRestricted ? from?.entity_type : 'Restricted',
+                      )}
+                      size="small"
+                    />
+                  </div>
+                  <div className={classes.type}>
+                    { }
+                    {!fromRestricted
+                      ? from?.relationship_type
+                        ? t_i18n('Relationship')
+                        : t_i18n(`entity_${from?.entity_type}`)
+                      : t_i18n('Restricted')}
+                  </div>
+                </div>
+                <div className={classes.content}>
+                  <span className={classes.name}>
+                    <Tooltip title={fromText}>
+                      <>
+                        {!fromRestricted
+                          ? truncate(fromText, TRUNCATE_CHARS_COUNT)
+                          : t_i18n('Restricted')}
+                      </>
+                    </Tooltip>
+                    {!fromRestricted && from?.draftVersion && (<DraftChip />)}
+                  </span>
+                </div>
+              </div>
+            </Link>
+            <div className={classes.middle}>
+              <ArrowRightAlt fontSize="large" />
+              <Typography sx={{ fontSize: '14px', fontWeight: 400 }}>
+                {capitalizeFirstLetter(t_i18n(`relationship_${stixCoreRelationship.relationship_type}`))}
+              </Typography>
+            </div>
+            <Link to={linkTo ?? ''}>
+              <div
+                className={classes.item}
+                style={{
+                  border: `1px solid ${itemColor(
+                    !toRestricted ? to?.entity_type : 'Restricted',
+                  )}`,
+                  top: 20,
+                  right: 20,
+                }}
+              >
+                <div
+                  className={classes.itemHeader}
+                  style={{
+                    borderBottom: `1px solid ${itemColor(
+                      !toRestricted ? to?.entity_type : 'Restricted',
+                    )}`,
+                  }}
+                >
+                  <div className={classes.icon}>
+                    <ItemIcon
+                      type={!toRestricted ? to?.entity_type : 'Unknown'}
+                      color={itemColor(
+                        !toRestricted ? to?.entity_type : 'Restricted',
+                      )}
+                      size="small"
+                    />
+                  </div>
+                  <div className={classes.type}>
+                    {
+                      !toRestricted
+                        ? to?.relationship_type
+                          ? t_i18n('Relationship')
+                          : t_i18n(`entity_${to?.entity_type}`)
+                        : t_i18n('Restricted')
+                    }
+                  </div>
+                </div>
+                <div className={classes.content}>
+                  <span className={classes.name}>
+                    <Tooltip title={toText}>
+                      <>
+                        {!toRestricted
+                          ? truncate(toText, TRUNCATE_CHARS_COUNT)
+                          : t_i18n('Restricted')}
+                      </>
+                    </Tooltip>
+                    {!toRestricted && to?.draftVersion && (<DraftChip />)}
+                  </span>
+                </div>
+              </div>
+            </Link>
+            <Divider style={{ marginTop: 30, marginBottom: 15 }} />
+            <Stack gap={2}>
+              <div>
+                <Label>
+                  {t_i18n('Description')}
+                </Label>
+                <ExpandableMarkdown
+                  source={stixCoreRelationship.x_opencti_inferences !== null
+                    ? t_i18n('Inferred knowledge')
+                    : stixCoreRelationship.description
+                  }
+                  limit={400}
+                />
+              </div>
+              <Divider />
+
+              <Grid container={true} spacing={2}>
+                <Grid item xs={6}>
+                  <Label>
+                    {t_i18n('Marking')}
+                  </Label>
+                  <ItemMarkings markingDefinitions={stixCoreRelationship.objectMarking ?? []} />
+                  <Label
+                    sx={{ marginTop: 2 }}
+                  >
+                    {t_i18n('Start time')}
+                  </Label>
+                  {nsdt(stixCoreRelationship.start_time)}
+                  <Label sx={{ marginTop: 2 }}>
+                    {t_i18n('Stop time')}
+                  </Label>
+                  {nsdt(stixCoreRelationship.stop_time)}
+                </Grid>
+                <Grid item xs={6}>
+                  {relationship_type === 'has-covered'
+                    && (
+                      <Box sx={{ marginBottom: 2 }}>
+                        <SecurityCoverageInformation coverage_information={coverage_information} />
+                      </Box>
+                    )
+                  }
+                  <StixCoreRelationshipSharing
+                    elementId={stixCoreRelationship.id}
+                  />
+                  <StixCoreObjectKillChainPhasesView
+                    killChainPhases={stixCoreRelationship.killChainPhases}
+                    displayIcon
+                  />
+                </Grid>
+              </Grid>
+            </Stack>
+          </Card>
+        </Grid>
+        <Grid item xs={6}>
+          <Card title={t_i18n('Details')}>
+            <Grid container={true} spacing={2}>
+              <Grid item xs={6}>
+                <Label>
+                  {t_i18n('Confidence level')}
+                </Label>
+                <ItemConfidence
+                  confidence={stixCoreRelationship.confidence}
+                  entityType="stix-core-relationship"
+                />
+                {stixCoreRelationship.x_opencti_inferences === null && (
+                  <div>
+                    <Label
+                      sx={{ marginTop: 2 }}
+                    >
+                      {t_i18n('Author')}
+                    </Label>
+                    <ItemAuthor
+                      createdBy={R.propOr(
+                        null,
+                        'createdBy',
+                        stixCoreRelationship,
+                      )}
+                    />
+                  </div>
+                )}
+                <Label
+                  sx={{ marginTop: 2 }}
+                >
+                  {t_i18n('Original creation date')}
+                </Label>
+                {nsdt(stixCoreRelationship.created)}
+                <Label
+                  sx={{ marginTop: 2 }}
+                >
+                  {t_i18n('Modification date')}
+                </Label>
+                {nsdt(stixCoreRelationship.updated_at)}
+              </Grid>
+              <Grid item xs={6}>
+                <Label>
+                  {t_i18n('Processing status')}
+                </Label>
+                <ItemStatus
+                  status={stixCoreRelationship.status}
+                  disabled={!stixCoreRelationship.workflowEnabled}
+                />
+                <StixCoreRelationshipObjectLabelsView
+                  labels={stixCoreRelationship.objectLabel}
+                  id={stixCoreRelationship.id}
+                  sx={{ marginTop: 2 }}
+                />
+                <Label
+                  sx={{ marginTop: 2 }}
+                >
+                  {t_i18n('Platform creation date')}
+                </Label>
+                {fldt(stixCoreRelationship.created_at)}
+                <Label
+                  sx={{ marginTop: 2 }}
+                >
+                  {t_i18n('Creators')}
+                </Label>
+                <ItemCreators
+                  creators={stixCoreRelationship.creators ?? []}
+                />
+              </Grid>
+            </Grid>
+          </Card>
+        </Grid>
+        {stixCoreRelationship.x_opencti_inferences == null && (
+          <>
+            <Grid item xs={6}>
+              <StixCoreRelationshipStixCoreRelationships
+                entityId={stixCoreRelationship.id}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <StixCoreObjectOrStixRelationshipLastContainers
+                stixCoreObjectOrStixRelationshipId={stixCoreRelationship.id}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <StixCoreRelationshipExternalReferences
+                stixCoreRelationshipId={stixCoreRelationship.id}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <StixCoreRelationshipLatestHistory
+                stixCoreRelationshipId={stixCoreRelationship.id}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <StixCoreObjectOrStixCoreRelationshipNotes
+                stixCoreObjectOrStixCoreRelationshipId={stixCoreRelationship.id}
+                isRelationship={true}
+                defaultMarkings={stixCoreRelationship.objectMarking ?? []}
+              />
+            </Grid>
+          </>
+        )}
+      </Grid>
+      <div>
+        {stixCoreRelationship.x_opencti_inferences !== null && (
+          <div style={{ margin: '50px 0 0 0' }}>
+            <CardTitle>
+              {t_i18n('Inference explanation')} (
+              {stixCoreRelationship.x_opencti_inferences?.length})
+            </CardTitle>
+            {R.take(
+              expanded ? 200 : 1,
+              stixCoreRelationship.x_opencti_inferences ?? [],
+            ).map((inference) => (
+              <StixCoreRelationshipInference
+                key={inference?.rule.id}
+                inference={inference}
+                stixRelationship={stixCoreRelationship}
+              />
+            ))}
+            {expandable && (
+              <IconButton
+                aria-label={expanded ? t_i18n('Collapse') : t_i18n('Expand')}
+                variant="tertiary"
+                size="small"
+                onClick={() => setExpanded(true)}
+                classes={{ root: classes.buttonExpand }}
+              >
+                {expanded ? (
+                  <ExpandLessOutlined />
+                ) : (
+                  <ExpandMoreOutlined />
+                )}
+              </IconButton>
+            )}
+          </div>
+        )}
+      </div>
+      <Dialog
+        open={openDelete}
+        onClose={() => setOpenDelete(false)}
+        title={t_i18n('Are you sure?')}
+        size="small"
+      >
+        <DialogContentText>
+          {t_i18n('Do you want to delete this relationship?')}
+        </DialogContentText>
+        <DialogActions>
+          <Button
+            onClick={() => setOpenDelete(false)}
+            disabled={deleting}
+          >
+            {t_i18n('Cancel')}
+          </Button>
+          <Button
+            color="secondary"
+            onClick={submitDelete}
+            disabled={deleting}
+          >
+            {t_i18n('Confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default StixCoreRelationshipOverview;

--- a/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Relationships.tsx
@@ -110,6 +110,11 @@ const relationshipsStixCoreRelationshipsLineFragment = graphql`
           main
         }
       }
+      ... on SecurityCoverageResult {
+        resultOf {
+          id
+        }
+      }
     }
     to {
       ... on BasicObject {

--- a/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/entities/EntitiesStixDomainObjectLine.jsx
@@ -197,6 +197,9 @@ export const entitiesFragment = graphql`
     ... on SecurityCoverageResult {
       name
       description
+      resultOf {
+        id
+      }
     }
     ... on CourseOfAction {
       name

--- a/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/events/EventKnowledge.jsx
@@ -35,10 +35,7 @@ const EventKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={event.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualKnowledge.jsx
@@ -36,10 +36,7 @@ const IndividualKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={individual.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
@@ -36,10 +36,7 @@ const OrganizationKnowledgeComponent = ({
         <Route
           path="/relations/:relationId/*"
           element={(
-            <StixCoreRelationship
-              entityId={organization.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/sectors/SectorKnowledge.jsx
@@ -34,10 +34,7 @@ const SectorKnowledgeComponent = ({
         <Route
           path="/relations/:relationId/*"
           element={(
-            <StixCoreRelationship
-              entityId={sector.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/securityPlatforms/SecurityPlatformKnowledge.tsx
@@ -39,10 +39,7 @@ const SecurityPlatformKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={securityPlatform.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemKnowledge.jsx
@@ -37,10 +37,7 @@ const SystemKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={system.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentKnowledge.tsx
@@ -41,10 +41,7 @@ const IncidentKnowledge = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={incident.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/observed_data/Root.tsx
@@ -140,9 +140,7 @@ const RootObservedData = ({ queryRef, observedDataId }: RootObservedDataProps) =
             <Route
               path="/knowledge/relations/:relationId/"
               element={(
-                <StixCoreRelationship
-                  entityId={observedData.id}
-                />
+                <StixCoreRelationship />
               )}
             />
           )}

--- a/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/administrative_areas/AdministrativeAreaKnowledge.tsx
@@ -36,10 +36,7 @@ const AdministrativeAreaKnowledge = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={administrativeArea.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/locations/cities/CityKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/cities/CityKnowledge.tsx
@@ -33,10 +33,7 @@ const CityKnowledge = ({ cityData }: { cityData: CityKnowledge_city$key }) => {
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={city.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/locations/countries/CountryKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/countries/CountryKnowledge.tsx
@@ -37,10 +37,7 @@ const CountryKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={country.id}
-              paddingRight={20}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/locations/positions/PositionKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/positions/PositionKnowledge.jsx
@@ -35,10 +35,7 @@ const PositionKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={position.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/locations/regions/RegionKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/locations/regions/RegionKnowledge.tsx
@@ -36,10 +36,7 @@ const RegionKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={region.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/artifacts/ArtifactKnowledge.tsx
@@ -23,9 +23,7 @@ const ArtifactKnowledge = ({ artifact, connectorsForImport }: ArtifactKnowledgeP
     <Route
       path="/relations/:relationId"
       element={(
-        <StixCoreRelationship
-          entityId={artifact.id}
-        />
+        <StixCoreRelationship />
       )}
     />
     <Route

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorKnowledge.tsx
@@ -23,9 +23,7 @@ const IndicatorKnowledge = ({ indicatorId }: IndicatorKnowledgeProps) => (
     <Route
       path="/relations/:relationId"
       element={(
-        <StixCoreRelationship
-          entityId={indicatorId}
-        />
+        <StixCoreRelationship />
       )}
     />
     <Route

--- a/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/infrastructures/InfrastructureKnowledge.tsx
@@ -59,10 +59,7 @@ const InfrastructureKnowledge = ({ infrastructure }: { infrastructure: Infrastru
         <Route
           path="/relations/:relationId/"
           element={(
-            <StixCoreRelationship
-              entityId={infrastructureData.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableKnowledge.jsx
@@ -31,9 +31,7 @@ const StixCyberObservableKnowledgeComponent = (props) => {
       <Route
         path="/relations/:relationId"
         element={(
-          <StixCoreRelationship
-            entityId={stixCyberObservable.id}
-          />
+          <StixCoreRelationship />
         )}
       />
       <Route

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternKnowledge.jsx
@@ -38,7 +38,7 @@ const AttackPatternKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={
-            <StixCoreRelationship entityId={attackPattern.id} paddingRight />
+            <StixCoreRelationship />
           }
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionKnowledge.jsx
@@ -7,14 +7,13 @@ import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreR
 
 class CourseOfActionKnowledgeComponent extends Component {
   render() {
-    const { courseOfAction } = this.props;
     return (
       <>
         <Routes>
           <Route
             path="/relations/:relationId"
             element={
-              <StixCoreRelationship entityId={courseOfAction.id} />
+              <StixCoreRelationship />
             }
           />
         </Routes>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/DataComponentKnowledge.tsx
@@ -1,32 +1,14 @@
-import { FunctionComponent } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { graphql, useFragment } from 'react-relay';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { DataComponentKnowledge_dataComponent$key } from './__generated__/DataComponentKnowledge_dataComponent.graphql';
 
-const DataComponentKnowledgeFragment = graphql`
-  fragment DataComponentKnowledge_dataComponent on DataComponent {
-    id
-    name
-    aliases
-  }
-`;
-
-interface DataComponentKnowledgeProps {
-  data: DataComponentKnowledge_dataComponent$key;
-}
-
-const DataComponentKnowledge: FunctionComponent<
-  DataComponentKnowledgeProps
-> = ({ data }) => {
-  const dataComponent = useFragment(DataComponentKnowledgeFragment, data);
+const DataComponentKnowledge = () => {
   return (
     <>
       <Routes>
         <Route
           path="/relations/:relationId"
           element={
-            <StixCoreRelationship entityId={dataComponent.id} />
+            <StixCoreRelationship />
           }
         />
       </Routes>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_components/Root.tsx
@@ -52,7 +52,6 @@ const dataComponentQuery = graphql`
       x_opencti_graph_data
       currentUserAccessRight
       ...DataComponent_dataComponent
-      ...DataComponentKnowledge_dataComponent
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
@@ -145,7 +144,7 @@ const RootDataComponent = () => {
                       <Route
                         path="/knowledge/*"
                         element={
-                          <DataComponentKnowledge data={dataComponent} />
+                          <DataComponentKnowledge />
                         }
                       />
                     )}

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/DataSourceKnowledge.tsx
@@ -1,33 +1,14 @@
-import { FunctionComponent } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import { graphql, useFragment } from 'react-relay';
 import StixCoreRelationship from '../../common/stix_core_relationships/StixCoreRelationship';
-import { DataSourceKnowledge_dataSource$key } from './__generated__/DataSourceKnowledge_dataSource.graphql';
 
-const DataSourceKnowledgeFragment = graphql`
-  fragment DataSourceKnowledge_dataSource on DataSource {
-    id
-    name
-    aliases
-  }
-`;
-
-interface DataSourceKnowledgeComponentProps {
-  data: DataSourceKnowledge_dataSource$key;
-  enableReferences: boolean;
-}
-
-const DataSourceKnowledgeComponent: FunctionComponent<
-  DataSourceKnowledgeComponentProps
-> = ({ data }) => {
-  const dataSource = useFragment(DataSourceKnowledgeFragment, data);
+const DataSourceKnowledgeComponent = () => {
   return (
     <>
       <Routes>
         <Route
           path="/relations/:relationId"
           element={
-            <StixCoreRelationship entityId={dataSource.id} />
+            <StixCoreRelationship />
           }
         />
       </Routes>

--- a/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/data_sources/Root.tsx
@@ -51,7 +51,6 @@ const dataSourceQuery = graphql`
       x_opencti_graph_data
       currentUserAccessRight
       ...DataSource_dataSource
-      ...DataSourceKnowledge_dataSource
       ...FileImportViewer_entity
       ...FileExportViewer_entity
       ...FileExternalReferencesViewer_entity
@@ -144,10 +143,7 @@ const RootDataSourceComponent = ({ queryRef, dataSourceId }: RootDataSourceCompo
                 <Route
                   path="/knowledge/*"
                   element={(
-                    <DataSourceKnowledgeComponent
-                      data={dataSource}
-                      enableReferences={false}
-                    />
+                    <DataSourceKnowledgeComponent />
                   )}
                 />,
               </>

--- a/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/narratives/NarrativeKnowledge.jsx
@@ -36,10 +36,7 @@ const NarrativeKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={narrative.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignKnowledge.jsx
@@ -41,10 +41,7 @@ const CampaignKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={campaign.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetKnowledge.jsx
@@ -42,10 +42,7 @@ const IntrusionSetKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={intrusionSet.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupKnowledge.jsx
@@ -42,10 +42,7 @@ const ThreatActorGroupKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={threatActorGroup.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualKnowledge.tsx
@@ -45,10 +45,7 @@ const ThreatActorIndividualKnowledgeComponent = ({
         <Route
           path="/relations/:relationId"
           element={(
-            <StixCoreRelationship
-              entityId={threatActorIndividual.id}
-              paddingRight={true}
-            />
+            <StixCoreRelationship />
           )}
         />
         <Route

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -16102,6 +16102,7 @@ type SecurityCoverageResult implements BasicObject & StixObject & StixCoreObject
   coverage_valid_to: DateTime
   coverage_information: [CoverageResult!]
   external_uri: String
+  resultOf: SecurityCoverage
 }
 
 enum SecurityCoverageResultOrdering {

--- a/opencti-platform/opencti-front/src/utils/Entity.test.ts
+++ b/opencti-platform/opencti-front/src/utils/Entity.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLink } from './Entity';
+
+describe('Function: resolveLink', () => {
+  it('should return URL to SecurityCoverage when type is a SecurityCoverageResult', () => {
+    expect(resolveLink('Security-Coverage-Result')).toEqual('/dashboard/analyses/security_coverages');
+  });
+
+  it('should return URL to SecurityCoverage when type is Security-Coverage', () => {
+    expect(resolveLink('Security-Coverage')).toEqual('/dashboard/analyses/security_coverages');
+  });
+
+  // Workspaces
+  it('should return URL to dashboards for Dashboard type', () => {
+    expect(resolveLink('Dashboard')).toEqual('/dashboard/workspaces/dashboards');
+  });
+
+  it('should return URL to dashboards for lowercase dashboard (workspace context)', () => {
+    expect(resolveLink('dashboard')).toEqual('/dashboard/workspaces/dashboards');
+  });
+
+  it('should return URL to investigations for Investigation type', () => {
+    expect(resolveLink('Investigation')).toEqual('/dashboard/workspaces/investigations');
+  });
+
+  it('should return URL to investigations for lowercase investigation (workspace context)', () => {
+    expect(resolveLink('investigation')).toEqual('/dashboard/workspaces/investigations');
+  });
+
+  // Threats
+  it('should return URL to campaigns for Campaign type', () => {
+    expect(resolveLink('Campaign')).toEqual('/dashboard/threats/campaigns');
+  });
+
+  it('should return URL to intrusion sets for Intrusion-Set type', () => {
+    expect(resolveLink('Intrusion-Set')).toEqual('/dashboard/threats/intrusion_sets');
+  });
+
+  it('should return URL to threat actors group for Threat-Actor-Group type', () => {
+    expect(resolveLink('Threat-Actor-Group')).toEqual('/dashboard/threats/threat_actors_group');
+  });
+
+  it('should return URL to threat actors individual for Threat-Actor-Individual type', () => {
+    expect(resolveLink('Threat-Actor-Individual')).toEqual('/dashboard/threats/threat_actors_individual');
+  });
+
+  // Techniques
+  it('should return URL to attack patterns for Attack-Pattern type', () => {
+    expect(resolveLink('Attack-Pattern')).toEqual('/dashboard/techniques/attack_patterns');
+  });
+
+  it('should return URL to courses of action for Course-Of-Action type', () => {
+    expect(resolveLink('Course-Of-Action')).toEqual('/dashboard/techniques/courses_of_action');
+  });
+
+  it('should return URL to narratives for Narrative type', () => {
+    expect(resolveLink('Narrative')).toEqual('/dashboard/techniques/narratives');
+  });
+
+  it('should return URL to data components for Data-Component type', () => {
+    expect(resolveLink('Data-Component')).toEqual('/dashboard/techniques/data_components');
+  });
+
+  it('should return URL to data sources for Data-Source type', () => {
+    expect(resolveLink('Data-Source')).toEqual('/dashboard/techniques/data_sources');
+  });
+
+  // Analyses
+  it('should return URL to reports for Report type', () => {
+    expect(resolveLink('Report')).toEqual('/dashboard/analyses/reports');
+  });
+
+  it('should return URL to notes for Note type', () => {
+    expect(resolveLink('Note')).toEqual('/dashboard/analyses/notes');
+  });
+
+  it('should return URL to opinions for Opinion type', () => {
+    expect(resolveLink('Opinion')).toEqual('/dashboard/analyses/opinions');
+  });
+
+  it('should return URL to groupings for Grouping type', () => {
+    expect(resolveLink('Grouping')).toEqual('/dashboard/analyses/groupings');
+  });
+
+  it('should return URL to external references for External-Reference type', () => {
+    expect(resolveLink('External-Reference')).toEqual('/dashboard/analyses/external_references');
+  });
+
+  it('should return URL to malware analyses for Malware-Analysis type', () => {
+    expect(resolveLink('Malware-Analysis')).toEqual('/dashboard/analyses/malware_analyses');
+  });
+
+  // Arsenal
+  it('should return URL to malwares for Malware type', () => {
+    expect(resolveLink('Malware')).toEqual('/dashboard/arsenal/malwares');
+  });
+
+  it('should return URL to tools for Tool type', () => {
+    expect(resolveLink('Tool')).toEqual('/dashboard/arsenal/tools');
+  });
+
+  it('should return URL to vulnerabilities for Vulnerability type', () => {
+    expect(resolveLink('Vulnerability')).toEqual('/dashboard/arsenal/vulnerabilities');
+  });
+
+  it('should return URL to channels for Channel type', () => {
+    expect(resolveLink('Channel')).toEqual('/dashboard/arsenal/channels');
+  });
+
+  // Events
+  it('should return URL to incidents for Incident type', () => {
+    expect(resolveLink('Incident')).toEqual('/dashboard/events/incidents');
+  });
+
+  it('should return URL to observed data for Observed-Data type', () => {
+    expect(resolveLink('Observed-Data')).toEqual('/dashboard/events/observed_data');
+  });
+
+  it('should return URL to sightings for stix-sighting-relationship type', () => {
+    expect(resolveLink('stix-sighting-relationship')).toEqual('/dashboard/events/sightings');
+  });
+
+  // Entities
+  it('should return URL to individuals for Individual type', () => {
+    expect(resolveLink('Individual')).toEqual('/dashboard/entities/individuals');
+  });
+
+  it('should return URL to organizations for Organization type', () => {
+    expect(resolveLink('Organization')).toEqual('/dashboard/entities/organizations');
+  });
+
+  it('should return URL to sectors for Sector type', () => {
+    expect(resolveLink('Sector')).toEqual('/dashboard/entities/sectors');
+  });
+
+  it('should return URL to systems for System type', () => {
+    expect(resolveLink('System')).toEqual('/dashboard/entities/systems');
+  });
+
+  it('should return URL to events for Event type', () => {
+    expect(resolveLink('Event')).toEqual('/dashboard/entities/events');
+  });
+
+  it('should return URL to security platforms for SecurityPlatform type', () => {
+    expect(resolveLink('SecurityPlatform')).toEqual('/dashboard/entities/security_platforms');
+  });
+
+  // Locations
+  it('should return URL to cities for City type', () => {
+    expect(resolveLink('City')).toEqual('/dashboard/locations/cities');
+  });
+
+  it('should return URL to countries for Country type', () => {
+    expect(resolveLink('Country')).toEqual('/dashboard/locations/countries');
+  });
+
+  it('should return URL to regions for Region type', () => {
+    expect(resolveLink('Region')).toEqual('/dashboard/locations/regions');
+  });
+
+  it('should return URL to positions for Position type', () => {
+    expect(resolveLink('Position')).toEqual('/dashboard/locations/positions');
+  });
+
+  it('should return URL to administrative areas for Administrative-Area type', () => {
+    expect(resolveLink('Administrative-Area')).toEqual('/dashboard/locations/administrative_areas');
+  });
+
+  // Observations
+  it('should return URL to indicators for Indicator type', () => {
+    expect(resolveLink('Indicator')).toEqual('/dashboard/observations/indicators');
+  });
+
+  it('should return URL to infrastructures for Infrastructure type', () => {
+    expect(resolveLink('Infrastructure')).toEqual('/dashboard/observations/infrastructures');
+  });
+
+  it('should return URL to artifacts for Artifact type', () => {
+    expect(resolveLink('Artifact')).toEqual('/dashboard/observations/artifacts');
+  });
+
+  it('should return URL to observables for IPv4-Addr type', () => {
+    expect(resolveLink('IPv4-Addr')).toEqual('/dashboard/observations/observables');
+  });
+
+  it('should return URL to observables for Domain-Name type', () => {
+    expect(resolveLink('Domain-Name')).toEqual('/dashboard/observations/observables');
+  });
+
+  it('should return URL to observables for Url type', () => {
+    expect(resolveLink('Url')).toEqual('/dashboard/observations/observables');
+  });
+
+  it('should return URL to observables for StixFile type', () => {
+    expect(resolveLink('StixFile')).toEqual('/dashboard/observations/observables');
+  });
+
+  it('should return URL to observables for generic Stix-Cyber-Observable type', () => {
+    expect(resolveLink('Stix-Cyber-Observable')).toEqual('/dashboard/observations/observables');
+  });
+
+  // Cases
+  it('should return URL to case incidents for Case-Incident type', () => {
+    expect(resolveLink('Case-Incident')).toEqual('/dashboard/cases/incidents');
+  });
+
+  it('should return URL to feedbacks for Feedback type', () => {
+    expect(resolveLink('Feedback')).toEqual('/dashboard/cases/feedbacks');
+  });
+
+  it('should return URL to RFIs for Case-Rfi type', () => {
+    expect(resolveLink('Case-Rfi')).toEqual('/dashboard/cases/rfis');
+  });
+
+  it('should return URL to RFTs for Case-Rft type', () => {
+    expect(resolveLink('Case-Rft')).toEqual('/dashboard/cases/rfts');
+  });
+
+  it('should return URL to tasks for Task type', () => {
+    expect(resolveLink('Task')).toEqual('/dashboard/cases/tasks');
+  });
+
+  // Settings
+  it('should return URL to users for User type', () => {
+    expect(resolveLink('User')).toEqual('/dashboard/settings/accesses/users');
+  });
+
+  it('should return URL to users for Creator type', () => {
+    expect(resolveLink('Creator')).toEqual('/dashboard/settings/accesses/users');
+  });
+
+  it('should return URL to users for Assignee type', () => {
+    expect(resolveLink('Assignee')).toEqual('/dashboard/settings/accesses/users');
+  });
+
+  it('should return URL to groups for Group type', () => {
+    expect(resolveLink('Group')).toEqual('/dashboard/settings/accesses/groups');
+  });
+
+  it('should return URL to email templates for EmailTemplate type', () => {
+    expect(resolveLink('EmailTemplate')).toEqual('/dashboard/settings/accesses/email_templates');
+  });
+
+  it('should return URL to authentications for AuthenticationProvider type', () => {
+    expect(resolveLink('AuthenticationProvider')).toEqual('/dashboard/settings/accesses/authentications');
+  });
+
+  it('should return URL to entity types customization for FintelTemplate type', () => {
+    expect(resolveLink('FintelTemplate')).toEqual('/dashboard/settings/customization/entity_types');
+  });
+
+  it('should return URL to fintel designs for FintelDesign type', () => {
+    expect(resolveLink('FintelDesign')).toEqual('/dashboard/settings/customization/fintel_designs');
+  });
+
+  it('should return URL to decay rules for DecayRule type', () => {
+    expect(resolveLink('DecayRule')).toEqual('/dashboard/settings/customization/decay');
+  });
+
+  // Other
+  it('should return URL to connectors for Connectors type', () => {
+    expect(resolveLink('Connectors')).toEqual('/dashboard/data/ingestion/connectors');
+  });
+
+  it('should return URL to automation for Playbook type', () => {
+    expect(resolveLink('Playbook')).toEqual('/dashboard/data/processing/automation');
+  });
+
+  it('should return URL to draft import for DraftWorkspace type', () => {
+    expect(resolveLink('DraftWorkspace')).toEqual('/dashboard/data/import/draft');
+  });
+
+  it('should return URL to PIRs for Pir type', () => {
+    expect(resolveLink('Pir')).toEqual('/dashboard/pirs');
+  });
+
+  // Default / unknown
+  it('should return null for an unknown type', () => {
+    expect(resolveLink('Unknown-Type')).toBeNull();
+  });
+
+  it('should return null when called with no argument', () => {
+    expect(resolveLink()).toBeNull();
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/Entity.ts
+++ b/opencti-platform/opencti-front/src/utils/Entity.ts
@@ -21,6 +21,7 @@ export const resolveLink = (type = 'unknown'): string | null => {
     case 'Note':
       return '/dashboard/analyses/notes';
     case 'Security-Coverage':
+    case 'Security-Coverage-Result':
       return '/dashboard/analyses/security_coverages';
     case 'Observed-Data':
       return '/dashboard/events/observed_data';

--- a/opencti-platform/opencti-front/src/utils/hooks/useAppData.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAppData.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createMockUserContext, testRenderHook } from '../tests/test-render';
+import { useComputeLinkFn } from './useAppData';
+import { SchemaType } from './useAuth';
+
+describe('Hook: useComputeLinkFn', () => {
+  describe('Function: computeLink()', () => {
+    it('should compute SecurityCoverageResult URL correctly', () => {
+      const { hook } = testRenderHook(
+        () => useComputeLinkFn(),
+        {
+          userContext: createMockUserContext({
+            schema: {
+              scrs: [],
+              sdos: [],
+              smos: [],
+              scos: [],
+            } as unknown as SchemaType,
+          }),
+        },
+      );
+      const computeLink = hook.result.current;
+      const url = computeLink({
+        entity_type: 'Security-Coverage-Result',
+        id: 'scr-id',
+        resultOf: {
+          id: 'sc-id',
+        },
+      });
+      expect(url).toEqual('/dashboard/analyses/security_coverages/sc-id/result');
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/hooks/useAppData.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAppData.tsx
@@ -21,11 +21,16 @@ export type AppDataProps = {
 export const useComputeLinkFn = () => {
   const { isRelationship } = useSchema();
   const computeLink = (node: ComputeLinkNode): string | undefined => {
-    let redirectLink;
-    if (node.relationship_type === 'stix-sighting-relationship' && node.from) {
-      redirectLink = `${resolveLink(node.from.entity_type)}/${
-        node.from.id
-      }/knowledge/sightings/${node.id}`;
+    let redirectLink: string | undefined;
+    // Special case of Sightings.
+    if (node.relationship_type === 'stix-sighting-relationship') {
+      if (node.to) {
+        redirectLink = `${resolveLink(node.to.entity_type)}/${node.to.id}/knowledge/sightings/${node.id}`;
+      } else if (node.from) {
+        redirectLink = `${resolveLink(node.from.entity_type)}/${node.from.id}/knowledge/sightings/${node.id}`;
+      } else {
+        redirectLink = undefined;
+      }
     } else if (node.relationship_type) {
       if (
         node.from
@@ -34,25 +39,24 @@ export const useComputeLinkFn = () => {
         && node.from.entity_type !== 'Security-Coverage-Result'
       ) {
         // 'from' not restricted and not a relationship and not SCR
-        redirectLink = `${resolveLink(node.from.entity_type)}/${
-          node.from.id
-        }/knowledge/relations/${node.id}`;
+        redirectLink = `${resolveLink(node.from.entity_type)}/${node.from.id}/knowledge/relations/${node.id}`;
       } else if (
         node.to
         && node.to.entity_type
         && !isRelationship(node.to.entity_type)
       ) {
         // if 'from' is restricted or a relationship, redirect to the knowledge relationship tab of 'to'
-        redirectLink = `${resolveLink(node.to.entity_type)}/${
-          node.to.id
-        }/knowledge/relations/${node.id}`;
+        redirectLink = `${resolveLink(node.to.entity_type)}/${node.to.id}/knowledge/relations/${node.id}`;
       } else {
         redirectLink = undefined; // no redirection if from and to are restricted
       }
+    // Special case of Workspaces (investigations and dashboards).
     } else if (node.entity_type === 'Workspace') {
       redirectLink = `${resolveLink(node.type)}/${node.id}`;
+    // Special case of Security coverage results.
     } else if (node.entity_type === 'Security-Coverage-Result') {
       redirectLink = `${resolveLink(node.entity_type)}/${node.resultOf?.id}/result`;
+    // Default link of entities.
     } else {
       redirectLink = `${resolveLink(node.entity_type)}/${node.id}`;
     }

--- a/opencti-platform/opencti-front/src/utils/hooks/useAppData.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAppData.tsx
@@ -10,6 +10,7 @@ export type ComputeLinkNode = {
   from?: { entity_type: string; id: string };
   to?: { entity_type: string; id: string };
   type?: string;
+  resultOf?: { id: string };
 };
 
 export type AppDataProps = {
@@ -17,7 +18,7 @@ export type AppDataProps = {
   metricsDefinition: MetricsDefinition[];
 };
 
-const useComputeLinkFn = () => {
+export const useComputeLinkFn = () => {
   const { isRelationship } = useSchema();
   const computeLink = (node: ComputeLinkNode): string | undefined => {
     let redirectLink;
@@ -26,7 +27,7 @@ const useComputeLinkFn = () => {
         node.from.id
       }/knowledge/sightings/${node.id}`;
     } else if (node.relationship_type) {
-      if (node.from && !isRelationship(node.from.entity_type)) { // 'from' not restricted and not a relationship
+      if (node.from && !isRelationship(node.from.entity_type) && node.from.entity_type !== 'Security-Coverage-Result') { // 'from' not restricted and not a relationship and not SCR
         redirectLink = `${resolveLink(node.from.entity_type)}/${
           node.from.id
         }/knowledge/relations/${node.id}`;
@@ -39,6 +40,8 @@ const useComputeLinkFn = () => {
       }
     } else if (node.entity_type === 'Workspace') {
       redirectLink = `${resolveLink(node.type)}/${node.id}`;
+    } else if (node.entity_type === 'Security-Coverage-Result') {
+      redirectLink = `${resolveLink(node.entity_type)}/${node.resultOf?.id}/result`;
     } else {
       redirectLink = `${resolveLink(node.entity_type)}/${node.id}`;
     }

--- a/opencti-platform/opencti-front/src/utils/hooks/useAppData.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useAppData.tsx
@@ -4,13 +4,13 @@ import { resolveLink } from '../Entity';
 import useSchema from './useSchema';
 
 export type ComputeLinkNode = {
-  id: string;
-  entity_type: string;
+  id?: string;
+  entity_type?: string;
   relationship_type?: string;
-  from?: { entity_type: string; id: string };
-  to?: { entity_type: string; id: string };
+  from?: { entity_type?: string; id?: string } | null;
+  to?: { entity_type?: string; id?: string } | null;
   type?: string;
-  resultOf?: { id: string };
+  resultOf?: { id: string } | null;
 };
 
 export type AppDataProps = {
@@ -27,11 +27,22 @@ export const useComputeLinkFn = () => {
         node.from.id
       }/knowledge/sightings/${node.id}`;
     } else if (node.relationship_type) {
-      if (node.from && !isRelationship(node.from.entity_type) && node.from.entity_type !== 'Security-Coverage-Result') { // 'from' not restricted and not a relationship and not SCR
+      if (
+        node.from
+        && node.from.entity_type
+        && !isRelationship(node.from.entity_type)
+        && node.from.entity_type !== 'Security-Coverage-Result'
+      ) {
+        // 'from' not restricted and not a relationship and not SCR
         redirectLink = `${resolveLink(node.from.entity_type)}/${
           node.from.id
         }/knowledge/relations/${node.id}`;
-      } else if (node.to && !isRelationship(node.to.entity_type)) { // if 'from' is restricted or a relationship, redirect to the knowledge relationship tab of 'to'
+      } else if (
+        node.to
+        && node.to.entity_type
+        && !isRelationship(node.to.entity_type)
+      ) {
+        // if 'from' is restricted or a relationship, redirect to the knowledge relationship tab of 'to'
         redirectLink = `${resolveLink(node.to.entity_type)}/${
           node.to.id
         }/knowledge/relations/${node.id}`;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -30174,6 +30174,7 @@ export type SecurityCoverageResult = BasicObject & StixCoreObject & StixDomainOb
   refreshed_at?: Maybe<Scalars['DateTime']['output']>;
   reports?: Maybe<ReportConnection>;
   representative: Representative;
+  resultOf?: Maybe<SecurityCoverage>;
   revoked: Scalars['Boolean']['output'];
   roles?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   spec_version: Scalars['String']['output'];
@@ -50954,6 +50955,7 @@ export type SecurityCoverageResultResolvers<ContextType = any, ParentType extend
   refreshed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   reports?: Resolver<Maybe<ResolversTypes['ReportConnection']>, ParentType, ContextType, Partial<SecurityCoverageResultReportsArgs>>;
   representative?: Resolver<ResolversTypes['Representative'], ParentType, ContextType>;
+  resultOf?: Resolver<Maybe<ResolversTypes['SecurityCoverage']>, ParentType, ContextType>;
   revoked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   roles?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   spec_version?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-resolver.ts
@@ -1,11 +1,16 @@
 import { stixDomainObjectAddRelation, stixDomainObjectDeleteRelation } from '../../../domain/stixDomainObject';
 import type { Resolvers } from '../../../generated/graphql';
+import { loadThroughDenormalized } from '../../../resolvers/stix';
 import { addSecurityCoverageResult, deleteSecurityCoverageResult, findById, findSecurityCoverageResultPaginated } from './securityCoverageResult-domain';
+import { INPUT_RESULT_OF } from './securityCoverageResult-types';
 
 const SecurityCoverageResultResolvers: Resolvers = {
   Query: {
     securityCoverageResult: (_, { id }, context) => findById(context, context.user, id),
     securityCoverageResults: (_, args, context) => findSecurityCoverageResultPaginated(context, context.user, args),
+  },
+  SecurityCoverageResult: {
+    resultOf: (scr, _, context) => loadThroughDenormalized(context, context.user, scr, INPUT_RESULT_OF),
   },
   Mutation: {
     securityCoverageResultAdd: (_, { input }, context) => addSecurityCoverageResult(context, context.user, input),

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.graphql
@@ -156,6 +156,7 @@ type SecurityCoverageResult implements BasicObject & StixObject & StixCoreObject
   coverage_valid_to: DateTime
   coverage_information: [CoverageResult!]
   external_uri: String
+  resultOf: SecurityCoverage
 }
 
 # Ordering


### PR DESCRIPTION
### Proposed changes

* refactor `StixCoreRelationshipOverview` to function and TypeScript
* refactor calls to component `StixCoreRelationship` providing non used props

### Related issues

* #14716
* closes #17042

### How to test this PR

Go to Data > Relationships and click on a has-covered relationship (you should go to the relationship view based on the target of the relationship). On this page, clic on the source SecurityCoverageResult, you should be redirected to the Result tab of the associated SecurityCoverage.

Go to Data > Entities, click on a SCR, you are redirected to the Result tab of the associated SC.

### Checklist

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality