### PR TITLE
feat(rabbitmq): split bundles directly in backend (#17259)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/rabbitmq-utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq-utils.ts
@@ -374,13 +374,12 @@ export class OpenCTIStix2Splitter {
     eventVersion?: string,
     cleanupInconsistentBundle: boolean = false,
   ): SplitBundleResult {
-    let bundleData: StixBundle;
-    if (useJson) {
-      bundleData = typeof bundle === 'string' ? JSON.parse(bundle) : bundle;
-    } else {
-      bundleData = bundle as StixBundle;
-    }
-
+    // Reset internal state to allow reusing the same splitter instance safely
+    this.cacheIndex = {};
+    this.cacheRefs = {};
+    this.elements = [];
+    this.incompatibleItems = [];
+    const bundleData: StixBundle = typeof bundle === 'string' ? JSON.parse(bundle) : bundle;
     if (!('objects' in bundleData)) {
       throw new Error('File data is not a valid bundle');
     }

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq-utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq-utils.ts
@@ -1,0 +1,454 @@
+import { v4 as uuidv4, v5 as uuidv5 } from 'uuid';
+import jsonCanonicalize from 'canonicalize';
+
+// Namespace used by OpenCTI to generate deterministic STIX ids (mirrors OASIS_NAMESPACE).
+const OASIS_NAMESPACE = '00abedb4-aa42-466c-9c01-fed23315a9b7';
+
+const OPENCTI_EXTENSION = 'extension-definition--ea279b3e-5c71-4632-ac08-831c66a786ba';
+
+// region supported types (mirror of pycti opencti_stix2_utils)
+const SUPPORTED_INTERNAL_OBJECTS = [
+  'user',
+  'group',
+  'capability',
+  'role',
+  'settings',
+  'notification',
+  'work',
+  'trash',
+  'draftworkspace',
+  'playbook',
+  'deleteoperation',
+  'workspace',
+  'publicdashboard',
+];
+
+const STIX_META_OBJECTS = [
+  'label',
+  'vocabulary',
+  'kill-chain-phase',
+];
+
+const STIX_CORE_OBJECTS = [
+  'attack-pattern',
+  'campaign',
+  'case-incident',
+  'x-opencti-case-incident',
+  'case-rfi',
+  'x-opencti-case-rfi',
+  'case-rft',
+  'x-opencti-case-rft',
+  'channel',
+  'course-of-action',
+  'data-component',
+  'x-mitre-data-component',
+  'data-source',
+  'x-mitre-data-source',
+  'event',
+  'external-reference',
+  'feedback',
+  'x-opencti-feedback',
+  'grouping',
+  'identity',
+  'incident',
+  'indicator',
+  'infrastructure',
+  'intrusion-set',
+  'language',
+  'location',
+  'malware',
+  'malware-analysis',
+  'marking-definition',
+  'narrative',
+  'note',
+  'observed-data',
+  'opinion',
+  'report',
+  'task',
+  'x-opencti-task',
+  'threat-actor',
+  'tool',
+  'vulnerability',
+  'security-coverage',
+];
+
+const SUPPORTED_STIX_ENTITY_OBJECTS = [...STIX_META_OBJECTS, ...STIX_CORE_OBJECTS];
+
+const STIX_CYBER_OBSERVABLE_TYPES = [
+  'autonomous-system',
+  'directory',
+  'domain-name',
+  'email-addr',
+  'email-message',
+  'email-mime-part-type',
+  'artifact',
+  'file',
+  'x509-certificate',
+  'ipv4-addr',
+  'ipv6-addr',
+  'mac-addr',
+  'mutex',
+  'network-traffic',
+  'process',
+  'software',
+  'url',
+  'user-account',
+  'windows-registry-key',
+  'windows-registry-value-type',
+  'hostname',
+  'cryptographic-key',
+  'cryptocurrency-wallet',
+  'text',
+  'user-agent',
+  'bank-account',
+  'phone-number',
+  'credential',
+  'tracking-number',
+  'payment-card',
+  'media-content',
+  'simple-observable',
+  'persona',
+  'ssh-key',
+  'ai-prompt',
+  'imei',
+  'iccid',
+  'imsi',
+];
+
+const SUPPORTED_TYPES = [
+  ...SUPPORTED_STIX_ENTITY_OBJECTS, // entities
+  ...SUPPORTED_INTERNAL_OBJECTS, // internals
+  ...STIX_CYBER_OBSERVABLE_TYPES, // observables
+  'relationship',
+  'sighting', // relationships
+  'pir',
+];
+// endregion
+
+/**
+ * Check if a STIX ID type is supported for processing.
+ */
+export const isIdSupported = (key: string): boolean => {
+  if (key.includes('--')) {
+    const idType = key.split('--')[0];
+    return SUPPORTED_TYPES.includes(idType);
+  }
+  // If not a stix id, don't try to filter
+  return true;
+};
+
+/**
+ * Generate a STIX ID for an external reference.
+ */
+export const externalReferenceGenerateId = (
+  { url, sourceName, externalId }: { url?: string; sourceName?: string; externalId?: string },
+): string | null => {
+  let data: Record<string, string>;
+  if (url !== undefined && url !== null) {
+    data = { url };
+  } else if (sourceName !== undefined && sourceName !== null && externalId !== undefined && externalId !== null) {
+    data = { source_name: sourceName, external_id: externalId };
+  } else {
+    return null;
+  }
+  const canonical = jsonCanonicalize(data) as string;
+  return `external-reference--${uuidv5(canonical, OASIS_NAMESPACE)}`;
+};
+
+/**
+ * Generate a STIX ID for a kill chain phase.
+ */
+export const killChainPhaseGenerateId = (
+  { phaseName, killChainName }: { phaseName?: string; killChainName?: string },
+): string => {
+  const data = { phase_name: phaseName, kill_chain_name: killChainName };
+  const canonical = jsonCanonicalize(data) as string;
+  return `kill-chain-phase--${uuidv5(canonical, OASIS_NAMESPACE)}`;
+};
+
+type StixItem = Record<string, any>;
+
+export interface StixBundle {
+  type: string;
+  id: string;
+  spec_version?: string;
+  x_opencti_seq?: number;
+  x_opencti_event_version?: string;
+  objects: StixItem[];
+}
+
+export type SplitBundleResult = {
+  expectations: number;
+  incompatibleItems: StixItem[];
+  bundles: (string | StixBundle)[];
+};
+
+/**
+ * STIX2 bundle splitter for OpenCTI.
+ *
+ * Splits large STIX2 bundles into smaller chunks for processing,
+ * handling dependencies between objects and deduplicating references.
+ *
+ * TypeScript translation of pycti.utils.opencti_stix2_splitter.OpenCTIStix2Splitter.
+ */
+export class OpenCTIStix2Splitter {
+  private cacheIndex: Record<string, StixItem> = {};
+
+  private cacheRefs: Record<string, string[]> = {};
+
+  private elements: StixItem[] = [];
+
+  private incompatibleItems: StixItem[] = [];
+
+  /**
+   * Get internal IDs from OpenCTI extensions in a STIX object.
+   */
+  private getInternalIdsInExtension(item: StixItem): string[] {
+    const ids: string[] = [];
+    if (item.x_opencti_id) {
+      ids.push(item.x_opencti_id);
+    }
+    const extension = item.extensions?.[OPENCTI_EXTENSION];
+    if (extension?.id) {
+      ids.push(extension.id);
+    }
+    return ids;
+  }
+
+  /**
+   * Enlist an element and its dependencies for processing.
+   */
+  private enlistElement(
+    itemId: string,
+    rawData: Record<string, StixItem>,
+    cleanupInconsistentBundle: boolean,
+    parentAcc: string[],
+  ): number {
+    let nbDeps = 1;
+    if (!(itemId in rawData)) {
+      return 0;
+    }
+
+    const existingItem = this.cacheIndex[itemId];
+    if (existingItem !== undefined) {
+      return existingItem.nb_deps;
+    }
+
+    const item = rawData[itemId];
+    if (this.cacheRefs[itemId] === undefined) {
+      this.cacheRefs[itemId] = [];
+    }
+    for (const key of Object.keys(item)) {
+      const value = item[key];
+      // Recursive enlist for every refs
+      if (key.endsWith('_refs') && item[key] !== null && item[key] !== undefined) {
+        const toKeep: string[] = [];
+        for (const elementRef of item[key]) {
+          // We need to check if this ref is not already a reference
+          const isMissingRef = rawData[elementRef] === undefined;
+          const mustBeCleaned = isMissingRef && cleanupInconsistentBundle;
+          const notDependencyRef = this.cacheRefs[elementRef] === undefined
+            || !this.cacheRefs[elementRef].includes(itemId);
+          // Prevent any self reference
+          if (
+            isIdSupported(elementRef)
+            && !mustBeCleaned
+            && !parentAcc.includes(elementRef)
+            && elementRef !== itemId
+            && notDependencyRef
+          ) {
+            this.cacheRefs[itemId].push(elementRef);
+            nbDeps += this.enlistElement(
+              elementRef,
+              rawData,
+              cleanupInconsistentBundle,
+              [...parentAcc, elementRef],
+            );
+            if (!toKeep.includes(elementRef)) {
+              toKeep.push(elementRef);
+            }
+          }
+          item[key] = toKeep;
+        }
+      } else if (key.endsWith('_ref')) {
+        const isMissingRef = rawData[value] === undefined;
+        const mustBeCleaned = isMissingRef && cleanupInconsistentBundle;
+        const notDependencyRef = this.cacheRefs[value] === undefined
+          || !this.cacheRefs[value].includes(itemId);
+        // Prevent any self reference
+        if (
+          value !== null
+          && value !== undefined
+          && !mustBeCleaned
+          && !parentAcc.includes(value)
+          && isIdSupported(value)
+          && value !== itemId
+          && notDependencyRef
+        ) {
+          this.cacheRefs[itemId].push(value);
+          nbDeps += this.enlistElement(
+            value,
+            rawData,
+            cleanupInconsistentBundle,
+            [...parentAcc, value],
+          );
+        } else {
+          item[key] = null;
+        }
+      } else if (key === 'external_references' && item[key] !== null && item[key] !== undefined) {
+        // specific case of splitting external references (deduplicating and cleanup)
+        const deduplicatedReferences: StixItem[] = [];
+        const deduplicatedReferencesCache: Record<string, string> = {};
+        for (const reference of item[key]) {
+          const referenceId = externalReferenceGenerateId({
+            url: reference.url,
+            sourceName: reference.source_name,
+            externalId: reference.external_id,
+          });
+          if (referenceId !== null && deduplicatedReferencesCache[referenceId] === undefined) {
+            deduplicatedReferencesCache[referenceId] = referenceId;
+            deduplicatedReferences.push(reference);
+          }
+        }
+        item[key] = deduplicatedReferences;
+      } else if (key === 'kill_chain_phases' && item[key] !== null && item[key] !== undefined) {
+        // specific case of splitting kill_chain phases (deduplicating and cleanup)
+        const deduplicatedKillChain: StixItem[] = [];
+        const deduplicatedKillChainCache: Record<string, string> = {};
+        for (const killChain of item[key]) {
+          const killChainId = killChainPhaseGenerateId({
+            killChainName: killChain.kill_chain_name,
+            phaseName: killChain.phase_name,
+          });
+          if (deduplicatedKillChainCache[killChainId] === undefined) {
+            deduplicatedKillChainCache[killChainId] = killChainId;
+            deduplicatedKillChain.push(killChain);
+          }
+        }
+        item[key] = deduplicatedKillChain;
+      }
+    }
+
+    // Get the final dep counting and add in cache
+    item.nb_deps = nbDeps;
+    // Put in cache
+    if (this.cacheIndex[itemId] === undefined) {
+      let isCompatible: boolean;
+      // enlist only if compatible
+      if (item.type === 'relationship') {
+        isCompatible = item.source_ref !== null && item.source_ref !== undefined
+          && item.target_ref !== null && item.target_ref !== undefined;
+      } else if (item.type === 'sighting') {
+        isCompatible = item.sighting_of_ref !== null && item.sighting_of_ref !== undefined
+          && (item.where_sighted_refs ?? []).length > 0;
+      } else {
+        isCompatible = isIdSupported(itemId);
+      }
+
+      if (isCompatible) {
+        this.elements.push(item);
+      } else {
+        this.incompatibleItems.push(item);
+      }
+      this.cacheIndex[itemId] = item;
+      for (const internalId of this.getInternalIdsInExtension(item)) {
+        this.cacheIndex[internalId] = item;
+      }
+    }
+
+    return nbDeps;
+  }
+
+  /**
+   * Split a valid STIX2 bundle into a list of bundles.
+   *
+   * @param bundle the STIX2 bundle to split (JSON string or object)
+   * @param useJson whether to return bundles as JSON string (true) or object (false)
+   * @param eventVersion optional event version to include in bundles
+   * @param cleanupInconsistentBundle whether to cleanup inconsistent references
+   * @returns the number of expectations, the incompatible items and the list of bundles
+   */
+  public splitBundleWithExpectations(
+    bundle: string | StixBundle,
+    useJson: boolean = true,
+    eventVersion?: string,
+    cleanupInconsistentBundle: boolean = false,
+  ): SplitBundleResult {
+    let bundleData: StixBundle;
+    if (useJson) {
+      bundleData = typeof bundle === 'string' ? JSON.parse(bundle) : bundle;
+    } else {
+      bundleData = bundle as StixBundle;
+    }
+
+    if (!('objects' in bundleData)) {
+      throw new Error('File data is not a valid bundle');
+    }
+    if (!('id' in bundleData) || bundleData.id === undefined) {
+      bundleData.id = `bundle--${uuidv4()}`;
+    }
+
+    const rawData: Record<string, StixItem> = {};
+
+    // Build flat list of elements
+    for (const item of bundleData.objects) {
+      rawData[item.id] = item;
+      for (const internalId of this.getInternalIdsInExtension(item)) {
+        rawData[internalId] = item;
+      }
+    }
+    for (const item of bundleData.objects) {
+      this.enlistElement(item.id, rawData, cleanupInconsistentBundle, []);
+    }
+
+    // Build the bundles
+    const bundles: (string | StixBundle)[] = [];
+
+    this.elements.sort((a, b) => a.nb_deps - b.nb_deps);
+
+    const elementsWithDeps = this.elements.map((e) => ({ nb_deps: e.nb_deps, elements: [e] }));
+
+    let numberExpectations = 0;
+    for (const entity of elementsWithDeps) {
+      numberExpectations += entity.elements.length;
+      bundles.push(
+        OpenCTIStix2Splitter.stix2CreateBundle(
+          bundleData.id,
+          entity.nb_deps,
+          entity.elements,
+          useJson,
+          eventVersion,
+        ),
+      );
+    }
+
+    return {
+      expectations: numberExpectations,
+      incompatibleItems: this.incompatibleItems,
+      bundles,
+    };
+  }
+
+  /**
+   * Create a STIX2 bundle with items.
+   */
+  public static stix2CreateBundle(
+    bundleId: string,
+    bundleSeq: number,
+    items: StixItem[],
+    useJson: boolean,
+    eventVersion?: string,
+  ): string | StixBundle {
+    const bundle: StixBundle = {
+      type: 'bundle',
+      id: bundleId,
+      spec_version: '2.1',
+      x_opencti_seq: bundleSeq,
+      objects: items,
+    };
+    if (eventVersion !== undefined && eventVersion !== null) {
+      bundle.x_opencti_event_version = eventVersion;
+    }
+    return useJson ? JSON.stringify(bundle) : bundle;
+  }
+}

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -718,13 +718,12 @@ export const pushToWorkerForConnector = async (connectorId, message) => {
   const rawBundle = Buffer.from(message.content, 'base64').toString('utf-8');
   let bundles;
   let expectationsNumber;
-  if (message.no_split) {
+  const bundleContent = JSON.parse(rawBundle);
+  if (message.no_split || !Array.isArray(bundleContent.objects) || bundleContent.objects.length <= 1) {
     // Split is explicitly disabled, keep the bundle intact but keep expectations aligned with the number of objects
-    const bundleContent = JSON.parse(rawBundle);
     bundles = [rawBundle];
     expectationsNumber = Array.isArray(bundleContent.objects) ? bundleContent.objects.length : 1;
   } else {
-    const bundleContent = JSON.parse(rawBundle);
     const eventVersion = bundleContent.x_opencti_event_version;
     const stix2Splitter = new OpenCTIStix2Splitter();
     const { expectations, bundles: splitBundles } = stix2Splitter.splitBundleWithExpectations(rawBundle, true, eventVersion);

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -3,7 +3,7 @@ import util from 'util';
 import { ATTR_DB_NAMESPACE, ATTR_DB_OPERATION_NAME, SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION } from '@opentelemetry/semantic-conventions';
 import { LRUCache } from 'lru-cache';
 import conf, { booleanConf, configureCA, loadCert, logApp } from '../config/conf';
-import { DatabaseError, UnsupportedError } from '../config/errors';
+import { DatabaseError } from '../config/errors';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { telemetry } from '../config/tracing';
 import { isEmptyField, isNotEmptyField, RABBIT_QUEUE_PREFIX, wait } from './utils';
@@ -732,7 +732,10 @@ export const pushToWorkerForConnector = async (connectorId, message) => {
     expectationsNumber = expectations;
   }
   if (bundles.length === 0) {
-    throw UnsupportedError('Nothing to import', { connectorId, work_id: message.work_id });
+    // Nothing to split/send (e.g. an empty bundle such as an empty draft validation).
+    // Keep the previous lenient behavior and simply skip instead of failing the caller.
+    logApp.debug('[RABBITMQ] Skipping push, bundle has nothing to import', { connectorId, work_id: message.work_id });
+    return true;
   }
   // Write the expectations to the work (like send_stix2_bundle)
   if (isNotEmptyField(message.work_id)) {

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -719,9 +719,10 @@ export const pushToWorkerForConnector = async (connectorId, message) => {
   let bundles;
   let expectationsNumber;
   if (message.no_split) {
-    // Split is explicitly disabled, keep the bundle intact and count it as a single expectation
+    // Split is explicitly disabled, keep the bundle intact but keep expectations aligned with the number of objects
+    const bundleContent = JSON.parse(rawBundle);
     bundles = [rawBundle];
-    expectationsNumber = 1;
+    expectationsNumber = Array.isArray(bundleContent.objects) ? bundleContent.objects.length : 1;
   } else {
     const bundleContent = JSON.parse(rawBundle);
     const eventVersion = bundleContent.x_opencti_event_version;

--- a/opencti-platform/opencti-graphql/src/database/rabbitmq.js
+++ b/opencti-platform/opencti-graphql/src/database/rabbitmq.js
@@ -3,10 +3,11 @@ import util from 'util';
 import { ATTR_DB_NAMESPACE, ATTR_DB_OPERATION_NAME, SEMATTRS_DB_NAME, SEMATTRS_DB_OPERATION } from '@opentelemetry/semantic-conventions';
 import { LRUCache } from 'lru-cache';
 import conf, { booleanConf, configureCA, loadCert, logApp } from '../config/conf';
-import { DatabaseError } from '../config/errors';
-import { SYSTEM_USER } from '../utils/access';
+import { DatabaseError, UnsupportedError } from '../config/errors';
+import { executionContext, SYSTEM_USER } from '../utils/access';
 import { telemetry } from '../config/tracing';
-import { isEmptyField, RABBIT_QUEUE_PREFIX, wait } from './utils';
+import { isEmptyField, isNotEmptyField, RABBIT_QUEUE_PREFIX, wait } from './utils';
+import { OpenCTIStix2Splitter } from './rabbitmq-utils';
 import { getHttpClient } from '../utils/http-client';
 import { fullEntitiesList } from './middleware-loader';
 import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_SYNC } from '../schema/internalObject';
@@ -695,9 +696,57 @@ export const rabbitMQIsAlive = async () => {
   return assertExchangeResult;
 };
 
-export const pushToWorkerForConnector = (connectorId, message) => {
+/**
+ * Push a message to the worker queue of a connector.
+ *
+ * For bundle messages (type === 'bundle'), this mirrors the python helper
+ * `send_stix2_bundle` behavior: the bundle carried in `message.content` is split
+ * into per-element bundles (ordered by dependencies), the resulting expectations
+ * number is written to the associated work, and each split bundle is sent to the
+ * worker as a separate message.
+ * Non-bundle messages (e.g. `type === 'event'`) and messages flagged `no_split`
+ * are forwarded as-is.
+ */
+export const pushToWorkerForConnector = async (connectorId, message) => {
   const routingKey = pushRouting(connectorId);
-  return send(WORKER_EXCHANGE, routingKey, JSON.stringify(message));
+  // Only STIX bundle messages carry a splittable content, everything else is sent as-is
+  const isBundleMessage = message?.type === 'bundle' && isNotEmptyField(message?.content);
+  if (!isBundleMessage) {
+    return send(WORKER_EXCHANGE, routingKey, JSON.stringify(message));
+  }
+  // Decode the base64 STIX bundle content
+  const rawBundle = Buffer.from(message.content, 'base64').toString('utf-8');
+  let bundles;
+  let expectationsNumber;
+  if (message.no_split) {
+    // Split is explicitly disabled, keep the bundle intact and count it as a single expectation
+    bundles = [rawBundle];
+    expectationsNumber = 1;
+  } else {
+    const bundleContent = JSON.parse(rawBundle);
+    const eventVersion = bundleContent.x_opencti_event_version;
+    const stix2Splitter = new OpenCTIStix2Splitter();
+    const { expectations, bundles: splitBundles } = stix2Splitter.splitBundleWithExpectations(rawBundle, true, eventVersion);
+    bundles = splitBundles;
+    expectationsNumber = expectations;
+  }
+  if (bundles.length === 0) {
+    throw UnsupportedError('Nothing to import', { connectorId, work_id: message.work_id });
+  }
+  // Write the expectations to the work (like send_stix2_bundle)
+  if (isNotEmptyField(message.work_id)) {
+    // Lazy import to avoid a circular dependency between rabbitmq and the work domain
+    const { updateExpectationsNumber } = await import('../domain/work');
+    const context = executionContext('rabbitmq_push');
+    await updateExpectationsNumber(context, SYSTEM_USER, message.work_id, expectationsNumber);
+  }
+  // Send each split bundle separately to the worker
+  for (let index = 0; index < bundles.length; index += 1) {
+    const content = Buffer.from(bundles[index], 'utf-8').toString('base64');
+    const bundleMessage = { ...message, content };
+    await send(WORKER_EXCHANGE, routingKey, JSON.stringify(bundleMessage));
+  }
+  return true;
 };
 
 export const pushToConnector = (connectorId, message) => {

--- a/opencti-platform/opencti-graphql/src/domain/stix.js
+++ b/opencti-platform/opencti-graphql/src/domain/stix.js
@@ -7,7 +7,7 @@ import { FunctionalError, UnsupportedError } from '../config/errors';
 import { connectorsForExport } from './connector';
 import { findById as findMarkingDefinitionById, markingDefinitionDeleteAndUpdateGroups } from './markingDefinition';
 import { now, observableValue } from '../utils/format';
-import { createWork, updateExpectationsNumber } from './work';
+import { createWork } from './work';
 import { pushToConnector, pushToWorkerForConnector } from '../database/rabbitmq';
 import { isStixDomainObjectShareableContainer } from '../schema/stixDomainObject';
 import { ABSTRACT_STIX_CORE_OBJECT, ABSTRACT_STIX_OBJECT, buildRefRelationKey, CONNECTOR_INTERNAL_EXPORT_FILE, INPUT_GRANTED_REFS } from '../schema/general';
@@ -71,10 +71,6 @@ export const sendStixBundle = async (context, user, connectorId, bundle, work_id
       const workName = `${connector.name} run @ ${now()}`;
       const work = await createWork(context, user, connector, workName, connector.internal_id, { receivedTime: now() });
       target_work_id = work.id;
-      if (jsonBundle.objects.length === 1) {
-        // Only add explicit expectation if the worker will not split anything
-        await updateExpectationsNumber(context, context.user, target_work_id, jsonBundle.objects.length);
-      }
     }
     const content = Buffer.from(bundle, 'utf-8').toString('base64');
     await pushToWorkerForConnector(connectorId, {

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager/ingestionManagerPushToQueue.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager/ingestionManagerPushToQueue.ts
@@ -9,7 +9,7 @@ import type {
 import { connectorIdFromIngestId } from '../../domain/connector';
 import { ConnectorType } from '../../generated/graphql';
 import { now, utcDate } from '../../utils/format';
-import { createWork, updateExpectationsNumber } from '../../domain/work';
+import { createWork } from '../../domain/work';
 import { SYSTEM_USER } from '../../utils/access';
 import { patchAttribute } from '../../database/middleware';
 import { ENTITY_TYPE_CONNECTOR } from '../../schema/internalObject';
@@ -66,10 +66,6 @@ export const pushBundleToConnectorQueue = async (context: AuthContext, ingestion
   const work: any = await createWorkForIngestion(context, ingestion);
   const stixBundle = JSON.stringify(bundle);
   const content = Buffer.from(stixBundle, 'utf-8').toString('base64');
-  if (bundle.objects.length === 1) {
-    // Only add explicit expectation if the worker will not split anything
-    await updateExpectationsNumber(context, SYSTEM_USER, work.id, bundle.objects.length);
-  }
   await pushToWorkerForConnector(connectorId, {
     type: 'bundle',
     applicant_id: ingestion.user_id ?? OPENCTI_SYSTEM_UUID,

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -51,7 +51,7 @@ import {
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
 import { getDraftContext } from '../utils/draftContext';
 import { getBestBackgroundConnectorId, pushToWorkerForConnector } from '../database/rabbitmq';
-import { updateExpectationsNumber, updateProcessedTime } from '../domain/work';
+import { updateProcessedTime } from '../domain/work';
 import { convertStoreToStix_2_1, convertTypeToStixType } from '../database/stix-2-1-converter';
 import { STIX_EXT_OCTI } from '../types/stix-2-1-extensions';
 import { RELATION_BASED_ON } from '../schema/stixCoreRelationship';
@@ -256,10 +256,6 @@ const buildAndSendBundle = async (context, user, task, objects, opts) => {
   // Send actions to queue
   const stixBundle = JSON.stringify({ id: uuidv4(), type: 'bundle', objects });
   const content = Buffer.from(stixBundle, 'utf-8').toString('base64');
-  // Only add explicit expectation if the worker will not split anything
-  if (objects.length === 1 || opts.forceNoSplit) {
-    await updateExpectationsNumber(context, user, task.work_id, objects.length);
-  }
   await pushToWorkerForConnector(task.connector_id, {
     type: 'bundle',
     applicant_id: user.id,

--- a/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts
@@ -18,7 +18,7 @@ import { pushToWorkerForConnector } from '../../database/rabbitmq';
 import { notify, setEditContext } from '../../database/redis';
 import { buildStixBundle } from '../../database/stix-2-1-converter';
 import { buildPagination, computeSumOfList, cursorToOffset, isDraftIndex, READ_INDEX_DRAFT_OBJECTS, READ_INDEX_HISTORY, READ_INDEX_INTERNAL_OBJECTS } from '../../database/utils';
-import { createWork, updateExpectationsNumber } from '../../domain/work';
+import { createWork } from '../../domain/work';
 import {
   DraftChangeType,
   type DraftWorkspaceAddInput,
@@ -789,10 +789,6 @@ export const validateDraftWorkspace = async (context: AuthContext, user: AuthUse
 
   const contextOutOfDraft = { ...context, draft_context: '' };
   const work: any = await createWork(contextOutOfDraft, SYSTEM_USER, DRAFT_VALIDATION_CONNECTOR, `Draft validation ${draftWorkspace.name} (${draft_id})`, DRAFT_VALIDATION_CONNECTOR.internal_id, { receivedTime: now() });
-  if (stixBundle.objects.length === 1) {
-    // Only add explicit expectation if the worker will not split anything
-    await updateExpectationsNumber(contextOutOfDraft, context.user, work.id, stixBundle.objects.length);
-  }
   await pushToWorkerForConnector(DRAFT_VALIDATION_CONNECTOR.id, { type: 'bundle', applicant_id: user.internal_id, content, update: true, work_id: work.id, draft_id: '' });
   const draftValidationInput = [{ key: 'draft_status', value: [DRAFT_STATUS_VALIDATED] }, { key: 'validation_work_id', value: [work.id] }];
   const { element } = await updateAttribute(context, user, draft_id, ENTITY_TYPE_DRAFT_WORKSPACE, draftValidationInput);

--- a/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/form/form-domain.ts
@@ -11,7 +11,7 @@ import { connectorIdFromIngestId, registerConnectorForIngestion, unregisterConne
 import { publishUserAction } from '../../listener/UserActionListener';
 import { isFeatureEnabled, logApp } from '../../config/conf';
 import { pushToWorkerForConnector } from '../../database/rabbitmq';
-import { createWork, updateExpectationsNumber } from '../../domain/work';
+import { createWork } from '../../domain/work';
 import { ConnectorPriorityGroup, ConnectorType, FilterMode, type DraftWorkspaceAddInput, type FormSubmissionInput, type MemberAccessInput } from '../../generated/graphql';
 import { now, nowTime } from '../../utils/format';
 import { BYPASS, isUserHasCapability, SYSTEM_USER } from '../../utils/access';
@@ -466,10 +466,6 @@ export const formSubmit = async (
 
     const stixBundle = JSON.stringify(bundle);
     const content = Buffer.from(stixBundle, 'utf-8').toString('base64');
-
-    if (bundle.objects.length > 0) {
-      await updateExpectationsNumber(context, SYSTEM_USER, work.id, bundle.objects.length);
-    }
 
     let draftId = null;
     if (finalIsDraft) {

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/taskManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/taskManager-test.ts
@@ -140,8 +140,8 @@ describe('TaskManager sendResultToQueue tests', () => {
       expect(bundle.objects[0].id).toBe(objects[i].id);
     }
 
-    // updateExpectationsNumber should be called for each single-object bundle
-    expect(updateExpectationsNumber).toHaveBeenCalledTimes(3);
+    // Expectations are now written inside pushToWorkerForConnector (mocked here), so taskManager must not call it directly
+    expect(updateExpectationsNumber).not.toHaveBeenCalled();
   });
 
   it('should send all objects in a single bundle when forceNoSplit is true', async () => {
@@ -169,9 +169,8 @@ describe('TaskManager sendResultToQueue tests', () => {
     expect(bundle.objects).toHaveLength(3);
     expect(bundle.objects.map((o: { id: string }) => o.id)).toEqual(['object-1', 'object-2', 'object-3']);
 
-    // updateExpectationsNumber should be called once with the total count
-    expect(updateExpectationsNumber).toHaveBeenCalledTimes(1);
-    expect(updateExpectationsNumber).toHaveBeenCalledWith(context, user, 'work-123', 3);
+    // Expectations are now written inside pushToWorkerForConnector (mocked here), so taskManager must not call it directly
+    expect(updateExpectationsNumber).not.toHaveBeenCalled();
   });
 
   it('should not call pushToWorkerForConnector when objects array is empty', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
This pull request refactors how STIX bundle expectations are tracked and sent to connector worker queues. The main change is to centralize the logic for splitting STIX bundles and updating work expectations inside the `pushToWorkerForConnector` function, rather than requiring callers to handle this themselves. As a result, redundant calls to `updateExpectationsNumber` have been removed from various places in the codebase, and the worker queue push logic is now more robust and consistent.

The most important changes are:

**Centralized bundle splitting and expectation tracking:**
* [`opencti-platform/opencti-graphql/src/database/rabbitmq.js`](diffhunk://#diff-fe445e8f2feb8b98b44af49659e37e81993ef3537c2dd1a24a8fb570cbcb42fcL698-R749): Refactored `pushToWorkerForConnector` to handle STIX bundle splitting, update work expectations, and send each split bundle as a separate message. This mirrors the Python helper's behavior and removes the need for callers to manually update expectations.

**Removal of redundant expectation updates:**
* [`opencti-platform/opencti-graphql/src/domain/stix.js`](diffhunk://#diff-9f9e60c6ee3f2b91ac3f558b033ae662f625844bddd08b124b6404404379d604L74-L77): Removed explicit calls to `updateExpectationsNumber` in `sendStixBundle`, since this is now handled by `pushToWorkerForConnector`.
* [`opencti-platform/opencti-graphql/src/manager/ingestionManager/ingestionManagerPushToQueue.ts`](diffhunk://#diff-6c71d0959c5ec3728b713f3ef80314d8757f05893304431de6eebf199d30b2e0L69-L72): Removed redundant expectation update logic before queueing bundles.
* [`opencti-platform/opencti-graphql/src/manager/taskManager.js`](diffhunk://#diff-aee000261724b7522467c27742e1411eaa0820f44bc2d8b92783b848581999a6L259-L262): Removed manual expectation updates in `buildAndSendBundle`.
* [`opencti-platform/opencti-graphql/src/modules/draftWorkspace/draftWorkspace-domain.ts`](diffhunk://#diff-8c7925b8530dd506a447faefb6be3ae305a642cfe8e5f8912988b8bbd044f6a7L792-L795): Removed unnecessary expectation updates during draft workspace validation.
* [`opencti-platform/opencti-graphql/src/modules/form/form-domain.ts`](diffhunk://#diff-4651cf8678f549cc65668e1261992a347859de7a6a3b60b06e794a5d907c5e29L470-L473): Removed manual expectation updates in form submission logic.

**Code cleanup and import adjustments:**
* Updated imports across multiple files to remove unused `updateExpectationsNumber` where it's no longer needed. [[1]](diffhunk://#diff-9f9e60c6ee3f2b91ac3f558b033ae662f625844bddd08b124b6404404379d604L10-R10) [[2]](diffhunk://#diff-6c71d0959c5ec3728b713f3ef80314d8757f05893304431de6eebf199d30b2e0L12-R12) [[3]](diffhunk://#diff-aee000261724b7522467c27742e1411eaa0820f44bc2d8b92783b848581999a6L54-R54) [[4]](diffhunk://#diff-8c7925b8530dd506a447faefb6be3ae305a642cfe8e5f8912988b8bbd044f6a7L21-R21) [[5]](diffhunk://#diff-4651cf8678f549cc65668e1261992a347859de7a6a3b60b06e794a5d907c5e29L14-R14)

This refactor ensures that bundle processing and expectation tracking are consistent and reduces the risk of errors from duplicated logic.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17259

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
