### PR TITLE
fix(ux): inconsistency in the names used for manager vs technical user (#13583)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -426,7 +426,7 @@ export const EXPIRATION_MANAGER_USER: AuthUser = {
   id: EXPIRATION_MANAGER_USER_UUID,
   internal_id: EXPIRATION_MANAGER_USER_UUID,
   individual_id: undefined,
-  name: 'EXPIRATION MANAGER',
+  name: 'EXPIRATION SCHEDULER',
   user_email: 'EXPIRATION MANAGER',
   origin: { user_id: EXPIRATION_MANAGER_USER_UUID, socket: 'internal' },
   roles: [ADMINISTRATOR_ROLE],

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -427,7 +427,7 @@ export const EXPIRATION_MANAGER_USER: AuthUser = {
   internal_id: EXPIRATION_MANAGER_USER_UUID,
   individual_id: undefined,
   name: 'EXPIRATION SCHEDULER',
-  user_email: 'EXPIRATION MANAGER',
+  user_email: 'EXPIRATION SCHEDULER',
   origin: { user_id: EXPIRATION_MANAGER_USER_UUID, socket: 'internal' },
   roles: [ADMINISTRATOR_ROLE],
   groups: [],


### PR DESCRIPTION
### Proposed changes

* Change the name of the expiration manager to expiration scheduler

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/13583

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
