### PR TITLE
feat(catalog): decoupling fetch catalog manifest (#16059)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/connectors/ConnectorManagerStatusContext.tsx
@@ -11,6 +11,11 @@ export const connectorManagerStatusQuery = graphql`
       active
       last_sync_execution
     }
+    catalogVersionInfo {
+      status
+      revision
+      updated_at
+    }
   }
 `;
 
@@ -18,16 +23,23 @@ interface ConnectorManagerStatusContextValue {
   connectorManagers: readonly { id: string; active: boolean }[] | null;
   hasRegisteredManagers: boolean;
   hasActiveManagers: boolean;
+  catalogVersionInfo: {
+    status: string;
+    revision: string | null;
+    updated_at: string | null;
+  } | null;
 }
 
 const ConnectorManagerStatusContext = createContext<ConnectorManagerStatusContextValue | null>(null);
 
 interface ConnectorManagerStatusProviderProps {
   children: ReactNode;
+  onCatalogVersionChange?: (revision: string | null) => void;
 }
 
 export const ConnectorManagerStatusProvider: React.FC<ConnectorManagerStatusProviderProps> = ({
   children,
+  onCatalogVersionChange,
 }) => {
   const [fetchKey, setFetchKey] = React.useState(0);
 
@@ -49,13 +61,47 @@ export const ConnectorManagerStatusProvider: React.FC<ConnectorManagerStatusProv
   );
 
   const connectorManagers = data?.connectorManagers || null;
+  const rawVersionInfo = data?.catalogVersionInfo ?? null;
+  const catalogVersionInfo = rawVersionInfo
+    ? { ...rawVersionInfo, revision: rawVersionInfo.revision ?? null, updated_at: rawVersionInfo.updated_at ?? null }
+    : null;
   const hasRegisteredManagers = connectorManagers ? connectorManagers.length > 0 : false;
   const hasActiveManagers = connectorManagers ? connectorManagers.some((cm) => cm.active) : false;
+
+  useEffect(() => {
+    if (catalogVersionInfo?.status === 'ready') {
+      return undefined;
+    }
+
+    // When catalog is still loading (or in error), poll faster to detect the
+    // first ready revision and trigger catalog refetch promptly.
+    const subscription = interval(FIVE_SECONDS).subscribe(() => {
+      setFetchKey((prev) => prev + 1);
+    });
+
+    return () => subscription.unsubscribe();
+  }, [catalogVersionInfo?.status]);
+
+  useEffect(() => {
+    if (!onCatalogVersionChange) {
+      return;
+    }
+
+    // While catalog is loading or in error, we pass null so consumers can keep
+    // waiting for the next ready revision.
+    if (!catalogVersionInfo || catalogVersionInfo.status !== 'ready') {
+      onCatalogVersionChange(null);
+      return;
+    }
+
+    onCatalogVersionChange(catalogVersionInfo.revision ?? null);
+  }, [catalogVersionInfo?.status, catalogVersionInfo?.revision, onCatalogVersionChange]);
 
   const contextValue: ConnectorManagerStatusContextValue = {
     connectorManagers,
     hasRegisteredManagers,
     hasActiveManagers,
+    catalogVersionInfo,
   };
 
   return (

--- a/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
@@ -280,17 +280,12 @@ const Integrations = () => {
   const { setTitle } = useConnectedDocumentModifier();
   setTitle(t_i18n('Integrations'));
 
-  const lastSeenCatalogRevision = useRef<string | null | undefined>(undefined);
+  const lastSeenCatalogRevision = useRef<string | null>(null);
   const [catalogFetchKey, setCatalogFetchKey] = useState(0);
 
   const handleCatalogVersionChange = useCallback((revision: string | null) => {
-    const prev = lastSeenCatalogRevision.current;
     if (!revision) return;
-    if (prev === undefined) {
-      lastSeenCatalogRevision.current = revision;
-      return;
-    }
-    if (prev !== revision) {
+    if (lastSeenCatalogRevision.current !== revision) {
       lastSeenCatalogRevision.current = revision;
       setCatalogFetchKey((k) => k + 1);
     }

--- a/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/Integrations.tsx
@@ -1,14 +1,14 @@
-import React, { Suspense, useEffect, useMemo } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { Box, Stack, Tab, Tabs, Typography } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { useQueryLoader } from 'react-relay';
 import { ConnectorManagerStatusProvider, useConnectorManagerStatus } from '@components/data/connectors/ConnectorManagerStatusContext';
 import ConnectorDeploymentBanner from '@components/data/connectors/ConnectorDeploymentBanner';
-import IngestionConnectorsCatalogs, { ingestionConnectorsCatalogsQuery } from '@components/integrations/catalog/IngestionConnectorsCatalog';
+import IngestionConnectorsCatalogs from '@components/integrations/catalog/IngestionConnectorsCatalog';
 import IngestionConnectors, { ingestionConnectorsQuery } from '@components/integrations/catalog/IngestionConnectors';
-import { IngestionConnectorsCatalogsQuery } from '@components/integrations/catalog/__generated__/IngestionConnectorsCatalogsQuery.graphql';
 import { IngestionConnectorsQuery } from '@components/integrations/catalog/__generated__/IngestionConnectorsQuery.graphql';
+import { IngestionConnectorsCatalogsQuery } from '@components/integrations/catalog/__generated__/IngestionConnectorsCatalogsQuery.graphql';
 import {
   IngestionFeeds,
   IngestionFeedsData,
@@ -50,20 +50,21 @@ interface IntegrationsDataProviderProps {
 
 // Loads every data source the current user is granted to see, and passes them
 // down to the hero and both tabs. Ungranted sources stay null.
-const IntegrationsDataProvider = ({ children }: IntegrationsDataProviderProps) => {
+interface IntegrationsDataProviderExtraProps extends IntegrationsDataProviderProps {
+  catalogFetchKey: number;
+}
+
+const IntegrationsDataProvider = ({ children, catalogFetchKey }: IntegrationsDataProviderExtraProps) => {
   const isConnectorReader = useGranted([MODULES]);
   const isIngestionReader = useGranted([INGESTION]);
   const isFormReader = useGranted([KNOWLEDGE_KNUPDATE, KNOWLEDGE_KNASKIMPORT]);
 
-  const [catalogsRef, loadCatalogs] = useQueryLoader<IngestionConnectorsCatalogsQuery>(ingestionConnectorsCatalogsQuery);
   const [deploymentRef, loadDeployment] = useQueryLoader<IngestionConnectorsQuery>(ingestionConnectorsQuery);
   const [feedsRef, loadFeeds] = useQueryLoader<IngestionFeedsQuery>(ingestionFeedsQuery);
   const [formsRef, loadForms] = useQueryLoader<IngestionFeedsFormsQuery>(ingestionFeedsFormsQuery);
 
   useEffect(() => {
     if (isConnectorReader) {
-      // fetch once the catalogs and use the cache during runtime
-      loadCatalogs({}, { fetchPolicy: 'store-or-network' });
       loadDeployment({}, { fetchPolicy: 'store-and-network' });
     }
     if (isIngestionReader) {
@@ -117,9 +118,9 @@ const IntegrationsDataProvider = ({ children }: IntegrationsDataProviderProps) =
   };
 
   const renderWithCatalogs = () => {
-    if (catalogsRef && deploymentRef) {
+    if (isConnectorReader && deploymentRef) {
       return (
-        <IngestionConnectorsCatalogs queryRef={catalogsRef}>
+        <IngestionConnectorsCatalogs fetchKey={catalogFetchKey}>
           {({ data: catalogsData }) => (
             <IngestionConnectors queryRef={deploymentRef}>
               {({ data: deploymentData }) => renderWithFeeds(catalogsData, deploymentData)}
@@ -131,7 +132,7 @@ const IntegrationsDataProvider = ({ children }: IntegrationsDataProviderProps) =
     return renderWithFeeds(null, null);
   };
 
-  const isLoading = (isConnectorReader && (!catalogsRef || !deploymentRef))
+  const isLoading = (isConnectorReader && !deploymentRef)
     || (isIngestionReader && !feedsRef)
     || (isFormReader && !formsRef);
   if (isLoading) {
@@ -279,16 +280,37 @@ const Integrations = () => {
   const { setTitle } = useConnectedDocumentModifier();
   setTitle(t_i18n('Integrations'));
 
+  const lastSeenCatalogRevision = useRef<string | null | undefined>(undefined);
+  const [catalogFetchKey, setCatalogFetchKey] = useState(0);
+
+  const handleCatalogVersionChange = useCallback((revision: string | null) => {
+    const prev = lastSeenCatalogRevision.current;
+    if (!revision) return;
+    if (prev === undefined) {
+      lastSeenCatalogRevision.current = revision;
+      return;
+    }
+    if (prev !== revision) {
+      lastSeenCatalogRevision.current = revision;
+      setCatalogFetchKey((k) => k + 1);
+    }
+  }, []);
+
   if (tab !== 'deployed' && tab !== 'available') {
     return <Navigate to="/dashboard/integrations/deployed" replace={true} />;
   }
 
   return (
+    // Outer Suspense catches the provider's own initial suspension.
+    // The provider must stay OUTSIDE the inner Suspense so that catalog
+    // data suspensions never unmount it (which would reset polling state).
     <Suspense fallback={<Loader variant={LoaderVariant.container} />}>
-      <ConnectorManagerStatusProvider>
-        <IntegrationsDataProvider>
-          {(data) => <IntegrationsComponent tab={tab} data={data} />}
-        </IntegrationsDataProvider>
+      <ConnectorManagerStatusProvider onCatalogVersionChange={handleCatalogVersionChange}>
+        <Suspense fallback={<Loader variant={LoaderVariant.container} />}>
+          <IntegrationsDataProvider catalogFetchKey={catalogFetchKey}>
+            {(data) => <IntegrationsComponent tab={tab} data={data} />}
+          </IntegrationsDataProvider>
+        </Suspense>
       </ConnectorManagerStatusProvider>
     </Suspense>
   );

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionConnectorsCatalog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionConnectorsCatalog.tsx
@@ -1,5 +1,4 @@
-import { graphql, usePreloadedQuery } from 'react-relay';
-import type { PreloadedQuery } from 'react-relay';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import React from 'react';
 import { IngestionConnectorsCatalogsQuery } from '@components/integrations/catalog/__generated__/IngestionConnectorsCatalogsQuery.graphql';
 
@@ -15,12 +14,22 @@ export const ingestionConnectorsCatalogsQuery = graphql`
 `;
 
 interface IngestionConnectorsCatalogsProps {
-  queryRef: PreloadedQuery<IngestionConnectorsCatalogsQuery>;
+  // Incrementing fetchKey tells Relay to discard its cached response and issue
+  // a real network request. Relay deduplicates by (query, variables), so a
+  // React key remount alone is not sufficient.
+  fetchKey?: number;
   children: ({ data }: { data: IngestionConnectorsCatalogsQuery['response'] }) => React.ReactNode;
 }
 
-const IngestionConnectorsCatalogs: React.FC<IngestionConnectorsCatalogsProps> = ({ queryRef, children }) => {
-  const data = usePreloadedQuery(ingestionConnectorsCatalogsQuery, queryRef);
+const IngestionConnectorsCatalogs: React.FC<IngestionConnectorsCatalogsProps> = ({ fetchKey = 0, children }) => {
+  const data = useLazyLoadQuery<IngestionConnectorsCatalogsQuery>(
+    ingestionConnectorsCatalogsQuery,
+    {},
+    {
+      fetchPolicy: 'network-only',
+      fetchKey,
+    },
+  );
 
   return children({ data });
 };

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/hooks/useIngestionCatalogFilters.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/hooks/useIngestionCatalogFilters.ts
@@ -351,6 +351,39 @@ const useIngestionCatalogFilters = ({
     return [...new Set(items.flatMap((item) => (item.licenseType ? [item.licenseType] : [])))].sort();
   }, [items]);
 
+  useEffect(() => {
+    const validTypeSet = new Set(availableTypes);
+    const validUseCaseSet = new Set(availableUseCases);
+    const validSolutionCategorySet = new Set(availableSolutionCategories);
+    const validLicenseTypeSet = new Set(availableLicenseTypes);
+    setFilters((prev) => {
+      const nextTypes = prev.types.filter((type) => validTypeSet.has(type as IngestionConnectorType));
+      const nextUseCases = prev.useCases.filter((useCase) => validUseCaseSet.has(useCase));
+      const nextSolutionCategories = prev.solutionCategories.filter((category) => validSolutionCategorySet.has(category));
+      const nextLicenseTypes = prev.licenseTypes.filter((licenseType) => validLicenseTypeSet.has(licenseType));
+
+      if (
+        nextTypes.length === prev.types.length
+        && nextUseCases.length === prev.useCases.length
+        && nextSolutionCategories.length === prev.solutionCategories.length
+        && nextLicenseTypes.length === prev.licenseTypes.length
+      ) {
+        return prev;
+      }
+
+      // Catalog payload can change at runtime (fallback -> remote or manifest switch).
+      // Drop URL-carried facets that no longer exist in the current catalog to prevent
+      // the UI from getting stuck in an empty filtered state.
+      return {
+        ...prev,
+        types: nextTypes,
+        useCases: nextUseCases,
+        solutionCategories: nextSolutionCategories,
+        licenseTypes: nextLicenseTypes,
+      };
+    });
+  }, [availableTypes, availableUseCases]);
+
   const filteredItems = useMemo(
     () => items.filter((item) => matchesFilters(item, filters)),
     [items, filters],

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9632,6 +9632,7 @@ type Query {
   channels(first: Int, after: ID, orderBy: ChannelsOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): ChannelConnection
   catalog(id: String!): Catalog
   catalogs: [Catalog!]!
+  catalogVersionInfo: CatalogVersionInfo!
   contract(slug: String!): ExtendedContract
   language(id: String!): Language
   languages(first: Int, after: ID, orderBy: LanguagesOrdering, orderMode: OrderingMode, filters: FilterGroup, search: String): LanguageConnection
@@ -10486,6 +10487,7 @@ type Mutation {
   channelContextClean(id: ID!): Channel
   channelRelationAdd(id: ID!, input: StixRefRelationshipAddInput!): StixRefRelationship
   channelRelationDelete(id: ID!, toId: StixRef!, relationship_type: String!): Channel
+  refreshCatalog: Boolean!
   languageAdd(input: LanguageAddInput!): Language
   languageDelete(id: ID!): ID
   languageFieldPatch(id: ID!, input: [EditInput]!, commitMessage: String, references: [String]): Language
@@ -11108,6 +11110,12 @@ type Catalog implements InternalObject & BasicObject {
 type ExtendedContract {
   catalog_id: String!
   contract: String!
+}
+
+type CatalogVersionInfo {
+  status: String!
+  revision: String
+  updated_at: String
 }
 
 enum CatalogsOrdering {

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -154,7 +154,7 @@
       "lock_key": "catalog_manager_lock",
       "interval": null,
       "request_timeout": 15000,
-      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.local.json"
+      "custom_catalog_refresh_endpoint_uri": null
     }
   },
   "demo_mode": false,

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -148,6 +148,13 @@
     },
     "forgot_password": {
       "otp_ttl_second": 600
+    },
+    "catalog_manager": {
+      "enabled": true,
+      "lock_key": "catalog_manager_lock",
+      "interval": null,
+      "request_timeout": 15000,
+      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.local.json"
     }
   },
   "demo_mode": false,

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -43,6 +43,13 @@
       "password": "admin",
       "token": "d434ce02-e58e-4cac-8b4c-42bf16748e84"
     },
+    "catalog_manager": {
+      "enabled": true,
+      "lock_key": "catalog_manager_lock",
+      "interval": null,
+      "request_timeout": 15000,
+      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.local.json"
+    },
     "encryption_key": "wbQnxC2ZIoohYzkXW19LiYU2V3lfoCVFkBadFd/dFAY="
   },
   "platform_id": "7992a4b1-128c-4656-bf97-2018b6f1f395",

--- a/opencti-platform/opencti-graphql/config/test.json
+++ b/opencti-platform/opencti-graphql/config/test.json
@@ -47,8 +47,7 @@
       "enabled": true,
       "lock_key": "catalog_manager_lock",
       "interval": null,
-      "request_timeout": 15000,
-      "custom_catalog_refresh_endpoint_uri": "./connector-catalog.local.json"
+      "request_timeout": 15000
     },
     "encryption_key": "wbQnxC2ZIoohYzkXW19LiYU2V3lfoCVFkBadFd/dFAY="
   },

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -3855,6 +3855,13 @@ export type CatalogEdge = {
   node: Catalog;
 };
 
+export type CatalogVersionInfo = {
+  __typename?: 'CatalogVersionInfo';
+  revision?: Maybe<Scalars['String']['output']>;
+  status: Scalars['String']['output'];
+  updated_at?: Maybe<Scalars['String']['output']>;
+};
+
 export enum CatalogsOrdering {
   Score = '_score',
   Name = 'name'
@@ -17386,6 +17393,7 @@ export type Mutation = {
   publicDashboardDelete?: Maybe<Scalars['ID']['output']>;
   publicDashboardFieldPatch?: Maybe<PublicDashboard>;
   queryTaskAdd: BackgroundTask;
+  refreshCatalog: Scalars['Boolean']['output'];
   regionAdd?: Maybe<Region>;
   regionEdit?: Maybe<RegionEditMutations>;
   registerConnector?: Maybe<Connector>;
@@ -24492,6 +24500,7 @@ export type Query = {
   caseTemplates?: Maybe<CaseTemplateConnection>;
   cases?: Maybe<CaseConnection>;
   catalog?: Maybe<Catalog>;
+  catalogVersionInfo: CatalogVersionInfo;
   catalogs: Array<Catalog>;
   channel?: Maybe<Channel>;
   channels?: Maybe<ChannelConnection>;
@@ -39716,6 +39725,7 @@ export type ResolversTypes = ResolversObject<{
   Catalog: ResolverTypeWrapper<GraphqlCatalog>;
   CatalogConnection: ResolverTypeWrapper<Omit<CatalogConnection, 'edges'> & { edges: Array<ResolversTypes['CatalogEdge']> }>;
   CatalogEdge: ResolverTypeWrapper<Omit<CatalogEdge, 'node'> & { node: ResolversTypes['Catalog'] }>;
+  CatalogVersionInfo: ResolverTypeWrapper<CatalogVersionInfo>;
   CatalogsOrdering: CatalogsOrdering;
   CertAuthConfig: ResolverTypeWrapper<CertAuthConfig>;
   CertAuthConfigInput: CertAuthConfigInput;
@@ -40853,6 +40863,7 @@ export type ResolversParentTypes = ResolversObject<{
   Catalog: GraphqlCatalog;
   CatalogConnection: Omit<CatalogConnection, 'edges'> & { edges: Array<ResolversParentTypes['CatalogEdge']> };
   CatalogEdge: Omit<CatalogEdge, 'node'> & { node: ResolversParentTypes['Catalog'] };
+  CatalogVersionInfo: CatalogVersionInfo;
   CertAuthConfig: CertAuthConfig;
   CertAuthConfigInput: CertAuthConfigInput;
   ChangePasswordInput: ChangePasswordInput;
@@ -42974,6 +42985,12 @@ export type CatalogConnectionResolvers<ContextType = any, ParentType extends Res
 export type CatalogEdgeResolvers<ContextType = any, ParentType extends ResolversParentTypes['CatalogEdge'] = ResolversParentTypes['CatalogEdge']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   node?: Resolver<ResolversTypes['Catalog'], ParentType, ContextType>;
+}>;
+
+export type CatalogVersionInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['CatalogVersionInfo'] = ResolversParentTypes['CatalogVersionInfo']> = ResolversObject<{
+  revision?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  updated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type CertAuthConfigResolvers<ContextType = any, ParentType extends ResolversParentTypes['CertAuthConfig'] = ResolversParentTypes['CertAuthConfig']> = ResolversObject<{
@@ -47895,6 +47912,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   publicDashboardDelete?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationPublicDashboardDeleteArgs, 'id'>>;
   publicDashboardFieldPatch?: Resolver<Maybe<ResolversTypes['PublicDashboard']>, ParentType, ContextType, RequireFields<MutationPublicDashboardFieldPatchArgs, 'id' | 'input'>>;
   queryTaskAdd?: Resolver<ResolversTypes['BackgroundTask'], ParentType, ContextType, RequireFields<MutationQueryTaskAddArgs, 'input'>>;
+  refreshCatalog?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   regionAdd?: Resolver<Maybe<ResolversTypes['Region']>, ParentType, ContextType, RequireFields<MutationRegionAddArgs, 'input'>>;
   regionEdit?: Resolver<Maybe<ResolversTypes['RegionEditMutations']>, ParentType, ContextType, RequireFields<MutationRegionEditArgs, 'id'>>;
   registerConnector?: Resolver<Maybe<ResolversTypes['Connector']>, ParentType, ContextType, Partial<MutationRegisterConnectorArgs>>;
@@ -49511,6 +49529,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   caseTemplates?: Resolver<Maybe<ResolversTypes['CaseTemplateConnection']>, ParentType, ContextType, Partial<QueryCaseTemplatesArgs>>;
   cases?: Resolver<Maybe<ResolversTypes['CaseConnection']>, ParentType, ContextType, Partial<QueryCasesArgs>>;
   catalog?: Resolver<Maybe<ResolversTypes['Catalog']>, ParentType, ContextType, RequireFields<QueryCatalogArgs, 'id'>>;
+  catalogVersionInfo?: Resolver<ResolversTypes['CatalogVersionInfo'], ParentType, ContextType>;
   catalogs?: Resolver<Array<ResolversTypes['Catalog']>, ParentType, ContextType>;
   channel?: Resolver<Maybe<ResolversTypes['Channel']>, ParentType, ContextType, RequireFields<QueryChannelArgs, 'id'>>;
   channels?: Resolver<Maybe<ResolversTypes['ChannelConnection']>, ParentType, ContextType, Partial<QueryChannelsArgs>>;
@@ -53572,6 +53591,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   Catalog?: CatalogResolvers<ContextType>;
   CatalogConnection?: CatalogConnectionResolvers<ContextType>;
   CatalogEdge?: CatalogEdgeResolvers<ContextType>;
+  CatalogVersionInfo?: CatalogVersionInfoResolvers<ContextType>;
   CertAuthConfig?: CertAuthConfigResolvers<ContextType>;
   Channel?: ChannelResolvers<ContextType>;
   ChannelConnection?: ChannelConnectionResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -114,7 +114,6 @@ const refreshCatalogInternal = async () => {
     }
 
     try {
-      logApp.info('[OPENCTI-MODULE] Catalog manager will fallback to embedded legacy manifest');
       logApp.info('[OPENCTI-MODULE] Catalog manager falling back to embedded legacy manifest');
       const legacyRaw = await legacyAdapter.fetch({ kind: 'local', uri: 'embedded' });
       const legacyInternal = legacyAdapter.toInternalCatalog(legacyRaw);
@@ -148,14 +147,36 @@ const refreshCatalog = async () => {
 const isDecouplingEnabled = () => CATALOG_MANAGER_ENABLED && isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS);
 
 const triggerRefreshInBackground = () => {
+  if (!isDecouplingEnabled()) return;
   void refreshCatalog().catch((error) => {
     logApp.warn('[OPENCTI-MODULE] Catalog manager background refresh failed', { cause: error });
   });
 };
 
+const loadEmbeddedFallback = async () => {
+  try {
+    logApp.info('[OPENCTI-MODULE] Catalog manager loading embedded legacy manifest as static baseline');
+    const legacyRaw = await legacyAdapter.fetch({ kind: 'local', uri: 'embedded' });
+    const legacyInternal = legacyAdapter.toInternalCatalog(legacyRaw);
+    const legacyRevision = computeCatalogRevision(legacyRaw);
+    updateCatalogManagerInternalCache(legacyInternal, 'ready', false, legacyRevision);
+  } catch (error) {
+    logApp.warn('[OPENCTI-MODULE] Catalog manager failed to load embedded legacy manifest', { cause: error });
+    updateCatalogManagerInternalCache(undefined, 'error');
+  }
+};
+
 const start = async () => {
-  if (!isDecouplingEnabled()) {
-    logApp.info('[OPENCTI-MODULE] Catalog manager not started (disabled by configuration or feature flag)');
+  if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    logApp.info('[OPENCTI-MODULE] Catalog manager not started (feature flag disabled)');
+    return;
+  }
+
+  if (!CATALOG_MANAGER_ENABLED) {
+    // Manager is explicitly disabled: serve the embedded fallback so the catalog
+    // domain reaches 'ready' and the UI stops polling indefinitely.
+    logApp.info('[OPENCTI-MODULE] Catalog manager disabled by configuration; loading embedded fallback');
+    await loadEmbeddedFallback();
     return;
   }
 

--- a/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/catalogManager.ts
@@ -1,0 +1,185 @@
+import { clearIntervalAsync, setIntervalAsync, type SetIntervalAsyncTimer } from 'set-interval-async/fixed';
+import { createHash } from 'node:crypto';
+import conf, { booleanConf, isFeatureEnabled, logApp } from '../config/conf';
+import { lockResources } from '../lock/master-lock';
+import { TYPE_LOCK_ERROR } from '../config/errors';
+import { LegacyManifestAdapter, NewManifestAdapter, resolveCatalogSource } from '../modules/catalog/catalog-adapters';
+import { getCatalogManagerInternalCache, getCatalogStatus, type CatalogStatus, updateCatalogManagerInternalCache } from '../modules/catalog/catalog-domain';
+
+const DECOUPLING_CONNECTOR_VERSIONS = 'DECOUPLING_CONNECTOR_VERSIONS';
+
+const CATALOG_MANAGER_ENABLED = booleanConf('app:catalog_manager:enabled', true);
+const CATALOG_MANAGER_LOCK_KEY = conf.get('app:catalog_manager:lock_key') || 'catalog_manager_lock';
+const CATALOG_MANAGER_INTERVAL = conf.get('app:catalog_manager:interval');
+const CUSTOM_CATALOG_SOURCE_URI = conf.get('app:catalog_manager:custom_catalog_refresh_endpoint_uri');
+const CATALOG_MANAGER_REQUEST_TIMEOUT = conf.get('app:catalog_manager:request_timeout');
+
+let scheduler: SetIntervalAsyncTimer<[]> | undefined;
+let currentEtag: string | undefined;
+
+const legacyAdapter = new LegacyManifestAdapter();
+const newManifestAdapter = new NewManifestAdapter();
+
+const DEFAULT_CATALOG_MANAGER_REQUEST_TIMEOUT = 15000;
+
+const getCatalogManagerRequestTimeoutMs = (): number => {
+  const timeoutMs = Number(CATALOG_MANAGER_REQUEST_TIMEOUT);
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    return timeoutMs;
+  }
+  return DEFAULT_CATALOG_MANAGER_REQUEST_TIMEOUT;
+};
+
+const createRequestTimeoutSignal = (): AbortSignal => AbortSignal.timeout(getCatalogManagerRequestTimeoutMs());
+
+const computeCatalogRevision = (rawManifest: unknown, etag?: string): string => {
+  if (etag) {
+    return etag;
+  }
+  return createHash('sha256').update(JSON.stringify(rawManifest)).digest('hex');
+};
+
+const isCatalogRequestTimeout = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as { name?: string; message?: string; code?: string };
+  const name = err.name ?? '';
+  const message = (err.message ?? '').toLowerCase();
+  const code = err.code ?? '';
+
+  return name === 'TimeoutError'
+    || (name === 'AbortError' && message.includes('timeout'))
+    || message.includes('timed out')
+    || code === 'ABORT_ERR';
+};
+
+const setCatalogStatusWithoutReplacingSnapshot = (status: CatalogStatus) => {
+  updateCatalogManagerInternalCache(undefined, status, true);
+};
+
+const refreshCatalogInternal = async () => {
+  const existingStatus = getCatalogStatus();
+  if (existingStatus !== 'loading') {
+    setCatalogStatusWithoutReplacingSnapshot('loading');
+  }
+
+  const sourceConfig = resolveCatalogSource(CUSTOM_CATALOG_SOURCE_URI).source;
+  const shouldCheckEtag = sourceConfig.kind === 'remote';
+  let nextEtag: string | undefined;
+
+  try {
+    if (shouldCheckEtag) {
+      logApp.info('[OPENCTI-MODULE] Catalog manager checking remote manifest via HEAD', { uri: sourceConfig.uri });
+      const headResponse = await fetch(sourceConfig.uri, { method: 'HEAD', signal: createRequestTimeoutSignal() });
+      if (headResponse.ok) {
+        nextEtag = headResponse.headers.get('etag') ?? undefined;
+        if (nextEtag && currentEtag && nextEtag === currentEtag) {
+          logApp.info('[OPENCTI-MODULE] Catalog manager skipping fetch, remote manifest unchanged (ETag match)', { etag: currentEtag });
+          updateCatalogManagerInternalCache(undefined, 'ready', true, currentEtag);
+          return;
+        }
+      }
+    }
+
+    logApp.info(`[OPENCTI-MODULE] Catalog manager fetching manifest from ${sourceConfig.kind} source`, { uri: sourceConfig.uri });
+    const rawManifest = await newManifestAdapter.fetch(sourceConfig, { signal: createRequestTimeoutSignal() });
+
+    if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+      return;
+    }
+
+    const internalCatalog = newManifestAdapter.toInternalCatalog(rawManifest);
+    const revision = computeCatalogRevision(rawManifest, nextEtag);
+    updateCatalogManagerInternalCache(internalCatalog, 'ready', false, revision);
+
+    if (shouldCheckEtag && nextEtag) {
+      currentEtag = nextEtag;
+    }
+  } catch (error) {
+    if (isCatalogRequestTimeout(error)) {
+      logApp.warn('[OPENCTI-MODULE] Catalog manager request timed out', {
+        timeoutMs: getCatalogManagerRequestTimeoutMs(),
+        source: sourceConfig,
+      });
+    }
+
+    logApp.warn('[OPENCTI-MODULE] Catalog manager failed to refresh the catalog from configured source', { cause: error });
+
+    if (getCatalogManagerInternalCache()) {
+      logApp.info('[OPENCTI-MODULE] Catalog manager keeps existing snapshot; no embedded fallback needed');
+      updateCatalogManagerInternalCache(undefined, 'error', true);
+      return;
+    }
+
+    try {
+      logApp.info('[OPENCTI-MODULE] Catalog manager will fallback to embedded legacy manifest');
+      logApp.info('[OPENCTI-MODULE] Catalog manager falling back to embedded legacy manifest');
+      const legacyRaw = await legacyAdapter.fetch({ kind: 'local', uri: 'embedded' });
+      const legacyInternal = legacyAdapter.toInternalCatalog(legacyRaw);
+      const legacyRevision = computeCatalogRevision(legacyRaw);
+      updateCatalogManagerInternalCache(legacyInternal, 'ready', false, legacyRevision);
+    } catch (legacyError) {
+      logApp.warn('[OPENCTI-MODULE] Catalog manager failed to load embedded legacy manifest fallback', { cause: legacyError });
+      updateCatalogManagerInternalCache(undefined, 'error');
+    }
+  }
+};
+
+const refreshCatalog = async () => {
+  let lock;
+  try {
+    lock = await lockResources([CATALOG_MANAGER_LOCK_KEY], { retryCount: 0 });
+    await refreshCatalogInternal();
+  } catch (error: any) {
+    if (error?.name === TYPE_LOCK_ERROR) {
+      logApp.debug('[OPENCTI-MODULE] Catalog manager refresh already running on another API');
+      return;
+    }
+    throw error;
+  } finally {
+    if (lock) {
+      await lock.unlock();
+    }
+  }
+};
+
+const isDecouplingEnabled = () => CATALOG_MANAGER_ENABLED && isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS);
+
+const triggerRefreshInBackground = () => {
+  void refreshCatalog().catch((error) => {
+    logApp.warn('[OPENCTI-MODULE] Catalog manager background refresh failed', { cause: error });
+  });
+};
+
+const start = async () => {
+  if (!isDecouplingEnabled()) {
+    logApp.info('[OPENCTI-MODULE] Catalog manager not started (disabled by configuration or feature flag)');
+    return;
+  }
+
+  triggerRefreshInBackground();
+
+  if (CATALOG_MANAGER_INTERVAL && Number(CATALOG_MANAGER_INTERVAL) > 0) {
+    scheduler = setIntervalAsync(async () => {
+      triggerRefreshInBackground();
+    }, Number(CATALOG_MANAGER_INTERVAL));
+    logApp.info(`[OPENCTI-MODULE] Catalog manager scheduled every ${Number(CATALOG_MANAGER_INTERVAL)}ms`);
+  } else {
+    logApp.info('[OPENCTI-MODULE] Catalog manager configured for startup-only refresh');
+  }
+};
+
+const shutdown = async () => {
+  if (scheduler) {
+    await clearIntervalAsync(scheduler);
+    scheduler = undefined;
+  }
+};
+
+export default {
+  start,
+  shutdown,
+  triggerRefreshInBackground,
+};

--- a/opencti-platform/opencti-graphql/src/managers.ts
+++ b/opencti-platform/opencti-graphql/src/managers.ts
@@ -32,6 +32,7 @@ import { shutdownAllManagers, startAllManagers } from './manager/managerModule';
 import clusterManager from './manager/clusterManager';
 import activityListener from './manager/activityListener';
 import activityManager from './manager/activityManager';
+import catalogManager from './manager/catalogManager';
 import draftValidationConnector from './modules/draftWorkspace/draftWorkspace-connector';
 import authenticationProviderListener from './modules/authenticationProvider/authenticationProvider-listener';
 import supportPackageListener from './modules/support/supportPackage-listener';
@@ -143,6 +144,7 @@ export const startModules = async () => {
   // region Audit
   startingPromises.push(activityListener.start());
   startingPromises.push(activityManager.start());
+  startingPromises.push(catalogManager.start());
   // endregion
 
   startingPromises.push(supportPackageListener.start());
@@ -232,6 +234,7 @@ export const shutdownModules = async () => {
   // region Audit listener
   stoppingPromises.push(activityListener.shutdown());
   stoppingPromises.push(activityManager.shutdown());
+  stoppingPromises.push(catalogManager.shutdown());
   // endregion
   stoppingPromises.push(supportPackageListener.shutdown());
   stoppingPromises.push(authenticationProviderListener.shutdown());

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
@@ -1,0 +1,200 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import conf, { PLATFORM_VERSION } from '../../config/conf';
+import filigranCatalog from '../../__generated__/opencti-manifest.json';
+import type { CatalogContract, CatalogDefinition, IngestionConnectorType } from './catalog-types';
+import { buildInternalCatalog, type InternalCatalog } from './catalog-cache';
+import { UnsupportedError } from '../../config/errors';
+
+export type CatalogSourceConfig = {
+  kind: 'remote' | 'local';
+  uri: string;
+};
+
+export type CatalogResolutionConfig = {
+  source: CatalogSourceConfig;
+  originalUri: string;
+};
+
+export type RawManifest = unknown;
+
+export interface CatalogSourceAdapter {
+  fetch(source: CatalogSourceConfig, options?: { signal?: AbortSignal }): Promise<RawManifest>;
+  toInternalCatalog(raw: RawManifest): InternalCatalog;
+}
+
+const CATALOG_PRODUCT = 'opencti';
+const CATALOG_INTEGRATION_TYPE = 'connectors';
+
+const isHttpUri = (value: string) => value.startsWith('http://') || value.startsWith('https://');
+
+export const resolveCatalogSource = (uri?: string | null): CatalogResolutionConfig => {
+  const configuredUri = uri?.trim();
+
+  if (!configuredUri) {
+    const xtmHubUrl = conf.get('xtm:xtmhub_url');
+    const remoteUri = `${xtmHubUrl}/${CATALOG_PRODUCT}/${PLATFORM_VERSION}/${CATALOG_INTEGRATION_TYPE}/manifests/latest`;
+    return {
+      source: { kind: 'remote', uri: remoteUri },
+      originalUri: remoteUri,
+    };
+  }
+
+  if (isHttpUri(configuredUri)) {
+    return {
+      source: { kind: 'remote', uri: configuredUri },
+      originalUri: configuredUri,
+    };
+  }
+
+  if (configuredUri.includes('://') && !configuredUri.startsWith('file://')) {
+    throw UnsupportedError(`Unsupported catalog source URI scheme: ${configuredUri}`);
+  }
+
+  const withoutFilePrefix = configuredUri.startsWith('file://')
+    ? configuredUri.slice('file://'.length)
+    : configuredUri;
+  const localPath = path.isAbsolute(withoutFilePrefix)
+    ? withoutFilePrefix
+    : path.resolve(process.cwd(), withoutFilePrefix);
+
+  return {
+    source: { kind: 'local', uri: localPath },
+    originalUri: configuredUri,
+  };
+};
+
+const toBoolean = (value: unknown, defaultValue = false) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value === 'true';
+  return defaultValue;
+};
+
+const toNumber = (value: unknown, defaultValue: number) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return defaultValue;
+};
+
+const toStringArray = (value: unknown) => (Array.isArray(value) ? value.filter((entry) => typeof entry === 'string') : []);
+
+const defaultConfigSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://filigran.io/opencti/catalog/default_config.schema.json',
+  type: 'object',
+  properties: {},
+  required: [],
+  additionalProperties: true,
+} as CatalogContract['config_schema'];
+
+const normalizeContractFromNewManifest = (contract: Record<string, any>): CatalogContract => {
+  const additional = (contract.additional_properties ?? {}) as Record<string, any>;
+  const schema = contract.config_schema ?? defaultConfigSchema;
+
+  return {
+    id: contract.id ?? null,
+    integration_name: contract.integration_name ?? undefined,
+    title: contract.title ?? '',
+    slug: contract.slug ?? '',
+    description: contract.description ?? '',
+    short_description: contract.short_description ?? '',
+    logo: contract.logo ?? '',
+    use_cases: toStringArray(contract.use_cases),
+    verified: toBoolean(contract.verified, false),
+    last_verified_date: contract.last_verified_date ?? '',
+    playbook_supported: toBoolean(additional.playbook_supported, false),
+    max_confidence_level: toNumber(additional.max_confidence_level, 100),
+    support_version: contract.support_version ?? '',
+    subscription_link: contract.subscription_link ?? '',
+    source_code: contract.source_code ?? '',
+    manager_supported: toBoolean(contract.manager_supported, false),
+    container_version: contract.version ?? '',
+    container_image: contract.image_name ?? contract.container_image ?? '',
+    container_type: (contract.image_type ?? contract.container_type ?? 'EXTERNAL_IMPORT') as IngestionConnectorType,
+    config_schema: {
+      ...defaultConfigSchema,
+      ...schema,
+      properties: schema?.properties ?? {},
+      required: schema?.required ?? [],
+      additionalProperties: schema?.additionalProperties ?? true,
+    },
+  };
+};
+
+const toCatalogDefinitionsFromNewManifest = (raw: Record<string, any>): CatalogDefinition[] => {
+  if (!raw.id || !Array.isArray(raw.contracts)) {
+    throw UnsupportedError('Catalog manifest is missing required fields: id and contracts');
+  }
+
+  const contracts = raw.contracts.map((contract: Record<string, any>) => normalizeContractFromNewManifest(contract));
+
+  return [{
+    id: String(raw.id),
+    name: String(raw.name ?? 'Connector Catalog'),
+    description: String(raw.description ?? ''),
+    contracts,
+  }];
+};
+
+const pickLatestContractsBySlug = (contracts: CatalogContract[]): CatalogContract[] => {
+  // Manifest order defines recency for now: last contract entry for a slug wins.
+  const latestBySlug = new Map<string, CatalogContract>();
+  contracts.forEach((contract) => {
+    latestBySlug.set(contract.slug, contract);
+  });
+  return Array.from(latestBySlug.values());
+};
+
+export class LegacyManifestAdapter implements CatalogSourceAdapter {
+  async fetch(_source: CatalogSourceConfig): Promise<RawManifest> {
+    const customCatalogs: string[] = conf.get('app:custom_catalogs') ?? [];
+    const definitions: CatalogDefinition[] = [filigranCatalog as unknown as CatalogDefinition];
+
+    for (let index = 0; index < customCatalogs.length; index += 1) {
+      const customCatalogPath = customCatalogs[index];
+      const content = await readFile(customCatalogPath, { encoding: 'utf8', flag: 'r' });
+      definitions.push(JSON.parse(content) as CatalogDefinition);
+    }
+
+    return definitions;
+  }
+
+  toInternalCatalog(raw: RawManifest): InternalCatalog {
+    const catalogDefinitions = raw as CatalogDefinition[];
+    return buildInternalCatalog(catalogDefinitions);
+  }
+}
+
+export class NewManifestAdapter implements CatalogSourceAdapter {
+  async fetch(source: CatalogSourceConfig, options?: { signal?: AbortSignal }): Promise<RawManifest> {
+    if (source.kind === 'local') {
+      const content = await readFile(source.uri, { encoding: 'utf8', flag: 'r' });
+      return JSON.parse(content);
+    }
+
+    const res = await fetch(source.uri, { signal: options?.signal });
+    if (!res.ok) {
+      throw UnsupportedError(`Failed to fetch remote catalog (${res.status}) from ${source.uri}`);
+    }
+    return res.json();
+  }
+
+  toInternalCatalog(raw: RawManifest): InternalCatalog {
+    const manifest = raw as Record<string, any>;
+    const normalized = toCatalogDefinitionsFromNewManifest(manifest);
+
+    // Keep all versions for future workflows, but expose latest contract per slug
+    // through current catalog query behavior.
+    const allContracts = normalized[0].contracts;
+    const latestContracts = pickLatestContractsBySlug(allContracts);
+    const latestDefinitions: CatalogDefinition[] = [{
+      ...normalized[0],
+      contracts: latestContracts,
+    }];
+
+    return buildInternalCatalog(latestDefinitions, allContracts);
+  }
+}

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-adapters.ts
@@ -24,7 +24,12 @@ export interface CatalogSourceAdapter {
 }
 
 const CATALOG_PRODUCT = 'opencti';
-const CATALOG_INTEGRATION_TYPE = 'connectors';
+const CATALOG_INTEGRATION_TYPE = 'connector';
+
+const buildDefaultRemoteCatalogUri = (xtmHubUrl: string) => {
+  const normalizedBaseUrl = xtmHubUrl.replace(/\/+$/, '');
+  return `${normalizedBaseUrl}/${CATALOG_PRODUCT}/${PLATFORM_VERSION}/${CATALOG_INTEGRATION_TYPE}/manifests/latest`;
+};
 
 const isHttpUri = (value: string) => value.startsWith('http://') || value.startsWith('https://');
 
@@ -33,7 +38,7 @@ export const resolveCatalogSource = (uri?: string | null): CatalogResolutionConf
 
   if (!configuredUri) {
     const xtmHubUrl = conf.get('xtm:xtmhub_url');
-    const remoteUri = `${xtmHubUrl}/${CATALOG_PRODUCT}/${PLATFORM_VERSION}/${CATALOG_INTEGRATION_TYPE}/manifests/latest`;
+    const remoteUri = buildDefaultRemoteCatalogUri(xtmHubUrl);
     return {
       source: { kind: 'remote', uri: remoteUri },
       originalUri: remoteUri,

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
@@ -1,0 +1,162 @@
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { UnsupportedError } from '../../config/errors';
+import { logApp } from '../../config/conf';
+import type { CatalogContract, CatalogDefinition, CatalogType } from './catalog-types';
+
+type InternalCatalog = {
+  catalogMap: Record<string, CatalogType>;
+  contractsByImage: Map<string, CatalogContract>;
+  /** Flat contracts as they appear in the manifest (all versions retained). */
+  allContracts?: CatalogContract[];
+  /** Grouped contracts by connector slug (all versions retained). */
+  contractsBySlug?: Map<string, CatalogContract[]>;
+  /** Latest contract per connector slug (currently selected as last manifest occurrence). */
+  latestContractsBySlug?: Map<string, CatalogContract>;
+};
+
+const ajv = new Ajv({ coerceTypes: true });
+addFormats(ajv, ['password', 'uri', 'duration', 'email', 'date-time', 'date']);
+const schemaValidatorCache = new Map<string, ReturnType<typeof ajv.compile>>();
+
+const isEmptyValue = (value: unknown) => value === null || value === undefined || value === '';
+
+const getOrCompileCatalogSchemaValidator = (cacheKey: string, jsonValidation: object) => {
+  let validate = schemaValidatorCache.get(cacheKey);
+  if (!validate) {
+    validate = ajv.compile(jsonValidation);
+    schemaValidatorCache.set(cacheKey, validate);
+  }
+  return validate;
+};
+
+const sanitizeManagerConfigurationSchema = (contract: CatalogContract) => {
+  if (!contract.manager_supported || !contract.config_schema) {
+    return contract;
+  }
+
+  const finalContract = {
+    ...contract,
+    config_schema: {
+      ...contract.config_schema,
+      properties: { ...contract.config_schema.properties },
+      required: [...contract.config_schema.required],
+    },
+  };
+
+  const excludedConfigVars = ['OPENCTI_TOKEN', 'OPENCTI_URL', 'CONNECTOR_TYPE', 'CONNECTOR_RUN_AND_TERMINATE'];
+  for (let i = 0; i < excludedConfigVars.length; i += 1) {
+    delete finalContract.config_schema.properties[excludedConfigVars[i]];
+  }
+  finalContract.config_schema.required = finalContract.config_schema.required
+    .filter((item) => !excludedConfigVars.includes(item));
+
+  return finalContract;
+};
+
+const validateManagerSupportedContract = (catalogId: string, contract: CatalogContract) => {
+  if (!contract.manager_supported) return;
+
+  if (!contract.config_schema) {
+    logApp.warn('A contract has manager_supported=true but is missing config_schema', { contractTitle: contract.title });
+    return;
+  }
+
+  if (isEmptyValue(contract.container_image)) {
+    throw UnsupportedError('Contract must define container_image field', { contractTitle: contract.title });
+  }
+  if (isEmptyValue(contract.container_type)) {
+    throw UnsupportedError('Contract must define container_type field', { contractTitle: contract.title });
+  }
+
+  const jsonValidation = {
+    type: contract.config_schema.type,
+    properties: contract.config_schema.properties,
+    required: contract.config_schema.required,
+    additionalProperties: contract.config_schema.additionalProperties,
+  };
+
+  try {
+    getOrCompileCatalogSchemaValidator(`catalog-contract:${catalogId}:${contract.slug}`, jsonValidation);
+  } catch (err) {
+    throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
+  }
+};
+
+export const clearCatalogCacheValidators = () => {
+  schemaValidatorCache.clear();
+};
+
+export const buildCatalogMapFromDefinitions = (catalogDefinitions: CatalogDefinition[]): Record<string, CatalogType> => {
+  const catalogMap: Record<string, CatalogType> = {};
+
+  for (let index = 0; index < catalogDefinitions.length; index += 1) {
+    const catalog = catalogDefinitions[index];
+
+    for (let contractIndex = 0; contractIndex < catalog.contracts.length; contractIndex += 1) {
+      validateManagerSupportedContract(catalog.id, catalog.contracts[contractIndex]);
+    }
+
+    catalogMap[catalog.id] = {
+      definition: catalog,
+      graphql: {
+        id: catalog.id,
+        entity_type: 'Catalog',
+        parent_types: ['Internal'],
+        standard_id: `catalog--${catalog.id}`,
+        name: catalog.name,
+        description: catalog.description,
+        contracts: catalog.contracts.map((contract) => JSON.stringify(sanitizeManagerConfigurationSchema(contract))),
+      },
+    };
+  }
+
+  return catalogMap;
+};
+
+export const buildContractsByImageCache = (catalogMap: Record<string, CatalogType>): Map<string, CatalogContract> => {
+  const contracts = Object.values(catalogMap)
+    .map((catalog) => catalog.definition.contracts.map((contract) => sanitizeManagerConfigurationSchema(contract)))
+    .flat();
+  return new Map(contracts.map((contract) => [contract.container_image, contract]));
+};
+
+export const buildContractsBySlugCache = (allContracts: CatalogContract[]): Map<string, CatalogContract[]> => {
+  const grouped = new Map<string, CatalogContract[]>();
+  allContracts.forEach((contract) => {
+    const current = grouped.get(contract.slug) ?? [];
+    current.push(contract);
+    grouped.set(contract.slug, current);
+  });
+  return grouped;
+};
+
+export const buildLatestContractsBySlugCache = (allContracts: CatalogContract[]): Map<string, CatalogContract> => {
+  // Last contract occurrence for a given slug wins (manifest order driven).
+  const latest = new Map<string, CatalogContract>();
+  allContracts.forEach((contract) => {
+    latest.set(contract.slug, contract);
+  });
+  return latest;
+};
+
+export const buildInternalCatalog = (
+  catalogDefinitions: CatalogDefinition[],
+  allContracts?: CatalogContract[],
+): InternalCatalog => {
+  const catalogMap = buildCatalogMapFromDefinitions(catalogDefinitions);
+  const contractsByImage = buildContractsByImageCache(catalogMap);
+  const resolvedAllContracts = allContracts ?? Object.values(catalogMap)
+    .flatMap((catalog) => catalog.definition.contracts.map((contract) => sanitizeManagerConfigurationSchema(contract)));
+  const contractsBySlug = buildContractsBySlugCache(resolvedAllContracts);
+  const latestContractsBySlug = buildLatestContractsBySlugCache(resolvedAllContracts);
+  return {
+    catalogMap,
+    contractsByImage,
+    allContracts: resolvedAllContracts,
+    contractsBySlug,
+    latestContractsBySlug,
+  };
+};
+
+export type { InternalCatalog };

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-cache.ts
@@ -2,6 +2,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { UnsupportedError } from '../../config/errors';
 import { logApp } from '../../config/conf';
+import { idGenFromData } from '../../schema/identifier';
 import type { CatalogContract, CatalogDefinition, CatalogType } from './catalog-types';
 
 type InternalCatalog = {
@@ -103,7 +104,7 @@ export const buildCatalogMapFromDefinitions = (catalogDefinitions: CatalogDefini
         id: catalog.id,
         entity_type: 'Catalog',
         parent_types: ['Internal'],
-        standard_id: `catalog--${catalog.id}`,
+        standard_id: idGenFromData('Catalog', { id: catalog.id }),
         name: catalog.name,
         description: catalog.description,
         contracts: catalog.contracts.map((contract) => JSON.stringify(sanitizeManagerConfigurationSchema(contract))),

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-domain.ts
@@ -5,14 +5,24 @@ import type { AuthContext, AuthUser } from '../../types/user';
 import { type CatalogContract, type CatalogDefinition, type CatalogType } from './catalog-types';
 import { isEmptyField } from '../../database/utils';
 import { UnsupportedError } from '../../config/errors';
-import { idGenFromData } from '../../schema/identifier';
 import filigranCatalog from '../../__generated__/opencti-manifest.json';
-import conf, { logApp } from '../../config/conf';
+import conf, { isFeatureEnabled, logApp } from '../../config/conf';
 import type { ConnectorContractConfiguration, ContractConfigInput } from '../../generated/graphql';
 import { readFile } from 'node:fs/promises';
 import type { ValidateFunction } from 'ajv';
+import { buildCatalogMapFromDefinitions, buildContractsByImageCache, clearCatalogCacheValidators, type InternalCatalog } from './catalog-cache';
 
 const validatorCache = new Map<string, ValidateFunction>();
+const MAX_VALIDATOR_CACHE_SIZE = 500;
+const DECOUPLING_CONNECTOR_VERSIONS = 'DECOUPLING_CONNECTOR_VERSIONS';
+
+export type CatalogStatus = 'loading' | 'ready' | 'error';
+
+export type CatalogVersionInfo = {
+  status: CatalogStatus;
+  revision: string | null;
+  updated_at: string | null;
+};
 
 /**
  * Compiles (or retrieves from cache) an AJV validator for a given schema.
@@ -22,6 +32,10 @@ const validatorCache = new Map<string, ValidateFunction>();
 const getOrCompileValidator = (cacheKey: string, jsonValidation: object): ValidateFunction => {
   let validate = validatorCache.get(cacheKey);
   if (!validate) {
+    if (validatorCache.size >= MAX_VALIDATOR_CACHE_SIZE) {
+      logApp.warn('Validator cache size limit reached, compiling without caching', { size: validatorCache.size });
+      return ajv.compile(jsonValidation);
+    }
     validate = ajv.compile(jsonValidation);
     validatorCache.set(cacheKey, validate);
   }
@@ -36,90 +50,90 @@ addFormats(ajv, ['password', 'uri', 'duration', 'email', 'date-time', 'date']);
 let catalogMap: Promise<Record<string, CatalogType>> | undefined;
 // cache for contracts by image map
 let contractsByImageCache: Promise<Map<string, CatalogContract>> | undefined;
+let managerInternalCatalog: InternalCatalog | undefined;
+let managerCatalogStatus: CatalogStatus = 'loading';
+let managerCatalogRevision: string | null = null;
+let managerCatalogUpdatedAt: string | null = null;
 
 // Build catalog map from files
 const buildCatalogMap = async (): Promise<Record<string, CatalogType>> => {
-  const newCatalogMap: Record<string, CatalogType> = {};
-  const catalogs = [];
-  catalogs.push(JSON.stringify(filigranCatalog));
+  const catalogDefinitions: CatalogDefinition[] = [filigranCatalog as unknown as CatalogDefinition];
   // Add custom catalogs
   for (let index = 0; index < CUSTOM_CATALOGS.length; index += 1) {
     const customCatalog = CUSTOM_CATALOGS[index];
     const catalog = await readFile(customCatalog, { encoding: 'utf8', flag: 'r' });
-    catalogs.push(catalog);
+    catalogDefinitions.push(JSON.parse(catalog) as CatalogDefinition);
   }
-  // Prepare catalogs map
-  for (let index = 0; index < catalogs.length; index += 1) {
-    const catalogRaw = catalogs[index];
-    const catalog = JSON.parse(catalogRaw) as CatalogDefinition;
-    // Validate each contract
-    for (let contractIndex = 0; contractIndex < catalog.contracts.length; contractIndex += 1) {
-      const contract = catalog.contracts[contractIndex];
-      if (contract.manager_supported) {
-        if (!contract.config_schema) {
-          logApp.warn('A contract has manager_supported=true but is missing config_schema', { contractTitle: contract.title });
-        } else {
-          if (isEmptyField(contract.container_image)) {
-            throw UnsupportedError('Contract must define container_image field', { contractTitle: contract.title });
-          }
-          if (isEmptyField(contract.container_type)) {
-            throw UnsupportedError('Contract must define container_type field', { contractTitle: contract.title });
-          }
 
-          if (contract.config_schema) {
-            const jsonValidation = {
-              type: contract.config_schema.type,
-              properties: contract.config_schema.properties,
-              required: contract.config_schema.required,
-              additionalProperties: contract.config_schema.additionalProperties,
-            };
-            try {
-              getOrCompileValidator(`catalog-contract:${catalog.id}:${contract.slug}`, jsonValidation);
-            } catch (err) {
-              throw UnsupportedError('Contract must be a valid json schema definition', { cause: err });
-            }
-          }
-        }
-      }
-    }
-    newCatalogMap[catalog.id] = {
-      definition: catalog,
-      graphql: {
-        id: catalog.id,
-        entity_type: 'Catalog',
-        parent_types: ['Internal'],
-        standard_id: idGenFromData('catalog', { id: catalog.id }),
-        name: catalog.name,
-        description: catalog.description,
-        contracts: catalog.contracts.map((c) => {
-          const finalContract = c;
-          if (finalContract.manager_supported) {
-            if (!finalContract.config_schema) {
-              logApp.warn('A contract has manager_supported=true but is missing config_schema', { contractTitle: finalContract.title });
-            } else {
-              const EXCLUDED_CONFIG_VARS = ['OPENCTI_TOKEN', 'OPENCTI_URL', 'CONNECTOR_TYPE', 'CONNECTOR_RUN_AND_TERMINATE'];
-              EXCLUDED_CONFIG_VARS.forEach((property) => {
-                delete finalContract.config_schema.properties[property];
-              });
-              finalContract.config_schema.required = c.config_schema.required.filter((item) => !EXCLUDED_CONFIG_VARS.includes(item));
-            }
-          }
-          return JSON.stringify(finalContract);
-        }),
-      },
-    };
-  }
-  return newCatalogMap;
+  return buildCatalogMapFromDefinitions(catalogDefinitions);
 };
 
 // Enable custom catalogs - clears cache and enables live catalog loading
 export const resetCatalogs = () => {
   catalogMap = undefined;
   contractsByImageCache = undefined;
+  managerInternalCatalog = undefined;
+  managerCatalogStatus = 'loading';
+  managerCatalogRevision = null;
+  managerCatalogUpdatedAt = null;
   validatorCache.clear();
+  clearCatalogCacheValidators();
+};
+
+export const updateCatalogManagerInternalCache = (
+  internalCatalog: InternalCatalog | undefined,
+  status: CatalogStatus,
+  keepExistingSnapshot = false,
+  revision?: string | null,
+) => {
+  if (!keepExistingSnapshot) {
+    managerInternalCatalog = internalCatalog;
+  }
+  if (revision !== undefined) {
+    managerCatalogRevision = revision;
+  }
+  managerCatalogUpdatedAt = new Date().toISOString();
+  logApp.info('[OPENCTI-MODULE] Updating catalog manager internal cache status', {
+    status,
+    hasSnapshot: Boolean(managerInternalCatalog),
+    keepExistingSnapshot,
+    revision: managerCatalogRevision,
+  });
+  managerCatalogStatus = status;
+};
+
+export const getCatalogManagerInternalCache = () => managerInternalCatalog;
+
+export const getCatalogStatus = (): CatalogStatus => {
+  if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    return 'ready';
+  }
+  return managerCatalogStatus;
+};
+
+export const getCatalogVersionInfo = (): CatalogVersionInfo => {
+  if (!isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    return {
+      status: 'ready',
+      revision: null,
+      updated_at: null,
+    };
+  }
+  return {
+    status: managerCatalogStatus,
+    revision: managerCatalogRevision,
+    updated_at: managerCatalogUpdatedAt,
+  };
 };
 
 const getCatalogs = async (): Promise<Record<string, CatalogType>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    if (managerInternalCatalog) {
+      return managerInternalCatalog.catalogMap;
+    }
+    // No remote snapshot yet (loading or error): fall through to embedded catalog as baseline.
+  }
+
   if (!catalogMap) {
     // We memoize the Promise immediately (not after it resolves) so that
     // all concurrent calls share the same in-flight execution.
@@ -443,11 +457,17 @@ export const computeConnectorTargetContract = (
 };
 
 export const getSupportedContractsByImage = async (): Promise<Map<string, CatalogContract>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS)) {
+    if (managerInternalCatalog) {
+      return managerInternalCatalog.contractsByImage;
+    }
+    // No remote snapshot yet (loading or error): fall through to embedded catalog as baseline.
+  }
+
   if (!contractsByImageCache) {
     contractsByImageCache = (async () => {
       const catalogDefinitions = await getCatalogs();
-      const contracts = Object.values(catalogDefinitions).map((catalog) => catalog.definition.contracts).flat();
-      return new Map(contracts.map((contract) => [contract.container_image, contract]));
+      return buildContractsByImageCache(catalogDefinitions);
     })().catch((err) => {
       contractsByImageCache = undefined;
       throw err;
@@ -493,3 +513,61 @@ export const findContractBySlug = (context: AuthContext, user: AuthUser, contrac
 export const findContractByContainerImage = (context: AuthContext, user: AuthUser, containerImage: string) => {
   return findContract(context, user, (contract) => contract.container_image === containerImage);
 };
+
+// region New multi-version helpers (additive, non-breaking)
+
+/**
+ * Returns all connector contracts from the active catalog snapshot.
+ * For manifest_schema_version 1 with stacked contracts, this includes all versions.
+ */
+export const getAllConnectorContracts = async (): Promise<CatalogContract[]> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog?.allContracts) {
+    return managerInternalCatalog.allContracts;
+  }
+  const catalogs = await getCatalogs();
+  return Object.values(catalogs).flatMap((catalog) => catalog.definition.contracts);
+};
+
+/**
+ * Returns all contracts grouped by connector slug.
+ */
+export const getContractsBySlug = async (): Promise<Map<string, CatalogContract[]>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog?.contractsBySlug) {
+    return managerInternalCatalog.contractsBySlug;
+  }
+  const allContracts = await getAllConnectorContracts();
+  const grouped = new Map<string, CatalogContract[]>();
+  allContracts.forEach((contract) => {
+    const current = grouped.get(contract.slug) ?? [];
+    current.push(contract);
+    grouped.set(contract.slug, current);
+  });
+  return grouped;
+};
+
+/**
+ * Returns the latest contract per connector slug.
+ * Current strategy: last contract occurrence for a slug wins.
+ */
+export const getLatestContractsBySlug = async (): Promise<Map<string, CatalogContract>> => {
+  if (isFeatureEnabled(DECOUPLING_CONNECTOR_VERSIONS) && managerInternalCatalog?.latestContractsBySlug) {
+    return managerInternalCatalog.latestContractsBySlug;
+  }
+  const grouped = await getContractsBySlug();
+  const latest = new Map<string, CatalogContract>();
+  grouped.forEach((contracts, slug) => {
+    const last = contracts[contracts.length - 1];
+    if (last) latest.set(slug, last);
+  });
+  return latest;
+};
+
+/**
+ * Finds the latest contract for a connector slug.
+ */
+export const findLatestContractBySlug = async (slug: string): Promise<CatalogContract | undefined> => {
+  const latestBySlug = await getLatestContractsBySlug();
+  return latestBySlug.get(slug);
+};
+
+// endregion

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-resolver.ts
@@ -1,4 +1,5 @@
-import { findCatalog, findById, findContractBySlug } from './catalog-domain';
+import { findCatalog, findById, findContractBySlug, getCatalogVersionInfo } from './catalog-domain';
+import catalogManager from '../../manager/catalogManager';
 import type { Resolvers } from '../../generated/graphql';
 
 const catalogResolver: Resolvers = {
@@ -9,8 +10,17 @@ const catalogResolver: Resolvers = {
     catalogs: (_, args, context) => {
       return findCatalog(context, context.user);
     },
+    catalogVersionInfo: () => {
+      return getCatalogVersionInfo();
+    },
     contract: (_, { slug }, context) => {
       return findContractBySlug(context, context.user, slug);
+    },
+  },
+  Mutation: {
+    refreshCatalog: () => {
+      catalogManager.triggerRefreshInBackground();
+      return true;
     },
   },
 };

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog-types.ts
@@ -16,6 +16,8 @@ type TypedProperty<K extends keyof TypeMap = keyof TypeMap> = {
 };
 
 export interface CatalogContract {
+  id?: string | null;
+  integration_name?: string;
   title: string;
   slug: string;
   description: string;

--- a/opencti-platform/opencti-graphql/src/modules/catalog/catalog.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/catalog/catalog.graphql
@@ -16,6 +16,12 @@ type ExtendedContract {
   contract: String!
 }
 
+type CatalogVersionInfo {
+  status: String!
+  revision: String
+  updated_at: String
+}
+
 # Ordering
 enum CatalogsOrdering {
   name
@@ -36,5 +42,11 @@ type CatalogEdge {
 type Query {
   catalog(id: String!): Catalog @auth(for: [INGESTION])
   catalogs: [Catalog!]! @auth(for: [INGESTION])
+  catalogVersionInfo: CatalogVersionInfo! @auth(for: [INGESTION])
   contract(slug: String!): ExtendedContract @auth(for: [INGESTION])
+}
+
+# Mutations
+type Mutation {
+  refreshCatalog: Boolean! @auth(for: [INGESTION])
 }

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/decoupling-status-and-contract-groups-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog-domain/decoupling-status-and-contract-groups-test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isFeatureEnabledMock = vi.fn();
+
+vi.mock('../../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../src/config/conf')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: vi.fn(() => []),
+    },
+    isFeatureEnabled: (...args: unknown[]) => isFeatureEnabledMock(...args),
+    logApp: {
+      ...actual.logApp,
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+});
+
+describe('catalog-domain decoupling helpers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isFeatureEnabledMock.mockReset();
+  });
+
+  it('returns ready/null version info when feature flag is disabled', async () => {
+    isFeatureEnabledMock.mockReturnValue(false);
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+
+    expect(catalogDomain.getCatalogStatus()).toBe('ready');
+    expect(catalogDomain.getCatalogVersionInfo()).toEqual({
+      status: 'ready',
+      revision: null,
+      updated_at: null,
+    });
+  });
+
+  it('stores status and revision when manager cache is updated', async () => {
+    isFeatureEnabledMock.mockReturnValue(true);
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+
+    const internalCatalog = {
+      catalogMap: {},
+      contractsByImage: new Map(),
+      allContracts: [],
+      contractsBySlug: new Map(),
+      latestContractsBySlug: new Map(),
+    } as any;
+
+    catalogDomain.updateCatalogManagerInternalCache(internalCatalog, 'ready', false, 'rev-123');
+
+    expect(catalogDomain.getCatalogStatus()).toBe('ready');
+    expect(catalogDomain.getCatalogVersionInfo().revision).toBe('rev-123');
+    expect(catalogDomain.getCatalogVersionInfo().updated_at).toBeTypeOf('string');
+  });
+
+  it('keeps existing snapshot when keepExistingSnapshot=true', async () => {
+    isFeatureEnabledMock.mockReturnValue(true);
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+
+    const firstSnapshot = {
+      catalogMap: {},
+      contractsByImage: new Map(),
+      allContracts: [],
+      contractsBySlug: new Map(),
+      latestContractsBySlug: new Map(),
+    } as any;
+
+    catalogDomain.updateCatalogManagerInternalCache(firstSnapshot, 'ready', false, 'rev-a');
+    catalogDomain.updateCatalogManagerInternalCache(undefined, 'error', true, 'rev-b');
+
+    expect(catalogDomain.getCatalogManagerInternalCache()).toBe(firstSnapshot);
+    expect(catalogDomain.getCatalogVersionInfo().status).toBe('error');
+    expect(catalogDomain.getCatalogVersionInfo().revision).toBe('rev-b');
+  });
+
+  it('returns grouped/latest contracts from manager cache when decoupling is enabled', async () => {
+    isFeatureEnabledMock.mockReturnValue(true);
+    const catalogDomain = await import('../../../../src/modules/catalog/catalog-domain');
+
+    const ipinfoV1 = { slug: 'ipinfo', container_version: '1.0.0' };
+    const ipinfoV2 = { slug: 'ipinfo', container_version: '1.1.0' };
+    const shodanV1 = { slug: 'shodan', container_version: '2.0.0' };
+
+    const grouped = new Map([
+      ['ipinfo', [ipinfoV1, ipinfoV2]],
+      ['shodan', [shodanV1]],
+    ]);
+    const latest = new Map([
+      ['ipinfo', ipinfoV2],
+      ['shodan', shodanV1],
+    ]);
+
+    const internalCatalog = {
+      catalogMap: {},
+      contractsByImage: new Map(),
+      allContracts: [ipinfoV1, ipinfoV2, shodanV1],
+      contractsBySlug: grouped,
+      latestContractsBySlug: latest,
+    } as any;
+
+    catalogDomain.updateCatalogManagerInternalCache(internalCatalog, 'ready', false, 'rev-contracts');
+
+    const allContracts = await catalogDomain.getAllConnectorContracts();
+    const contractsBySlug = await catalogDomain.getContractsBySlug();
+    const latestBySlug = await catalogDomain.getLatestContractsBySlug();
+    const latestIpinfo = await catalogDomain.findLatestContractBySlug('ipinfo');
+
+    expect(allContracts).toHaveLength(3);
+    expect(contractsBySlug.get('ipinfo')).toHaveLength(2);
+    expect(latestBySlug.get('ipinfo')).toBe(ipinfoV2);
+    expect(latestIpinfo).toBe(ipinfoV2);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog/catalog-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/catalog/catalog-resolver-test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const findByIdMock = vi.fn();
+const findCatalogMock = vi.fn();
+const findContractBySlugMock = vi.fn();
+const getCatalogVersionInfoMock = vi.fn();
+const triggerRefreshInBackgroundMock = vi.fn();
+
+vi.mock('../../../../src/modules/catalog/catalog-domain', () => ({
+  findById: (...args: unknown[]) => findByIdMock(...args),
+  findCatalog: (...args: unknown[]) => findCatalogMock(...args),
+  findContractBySlug: (...args: unknown[]) => findContractBySlugMock(...args),
+  getCatalogVersionInfo: (...args: unknown[]) => getCatalogVersionInfoMock(...args),
+}));
+
+vi.mock('../../../../src/manager/catalogManager', () => ({
+  default: {
+    triggerRefreshInBackground: (...args: unknown[]) => triggerRefreshInBackgroundMock(...args),
+  },
+}));
+
+const invokeResolver = async (
+  resolverEntry: unknown,
+  parent: unknown,
+  args: unknown,
+  context: unknown,
+  info: unknown,
+) => {
+  if (typeof resolverEntry === 'function') {
+    return resolverEntry(parent, args, context, info);
+  }
+  if (
+    resolverEntry
+    && typeof resolverEntry === 'object'
+    && 'resolve' in resolverEntry
+    && typeof (resolverEntry as { resolve: unknown }).resolve === 'function'
+  ) {
+    return (resolverEntry as { resolve: (p: unknown, a: unknown, c: unknown, i: unknown) => unknown })
+      .resolve(parent, args, context, info);
+  }
+  throw new Error('Resolver is not callable');
+};
+
+describe('catalog-resolver', () => {
+  beforeEach(() => {
+    findByIdMock.mockReset();
+    findCatalogMock.mockReset();
+    findContractBySlugMock.mockReset();
+    getCatalogVersionInfoMock.mockReset();
+    triggerRefreshInBackgroundMock.mockReset();
+  });
+
+  it('maps Query.catalog to findById', async () => {
+    const { default: resolver } = await import('../../../../src/modules/catalog/catalog-resolver');
+    const context = { user: { id: 'u1' } } as any;
+
+    findByIdMock.mockResolvedValue({ id: 'catalog-1' });
+
+    const result = await invokeResolver(resolver.Query?.catalog, {}, { id: 'catalog-1' }, context, {});
+
+    expect(findByIdMock).toHaveBeenCalledWith(context, context.user, 'catalog-1');
+    expect(result).toEqual({ id: 'catalog-1' });
+  });
+
+  it('maps Query.catalogs to findCatalog', async () => {
+    const { default: resolver } = await import('../../../../src/modules/catalog/catalog-resolver');
+    const context = { user: { id: 'u1' } } as any;
+
+    findCatalogMock.mockResolvedValue([{ id: 'catalog-1' }]);
+
+    const result = await invokeResolver(resolver.Query?.catalogs, {}, {}, context, {});
+
+    expect(findCatalogMock).toHaveBeenCalledWith(context, context.user);
+    expect(result).toEqual([{ id: 'catalog-1' }]);
+  });
+
+  it('maps Query.catalogVersionInfo to getCatalogVersionInfo', async () => {
+    const { default: resolver } = await import('../../../../src/modules/catalog/catalog-resolver');
+
+    getCatalogVersionInfoMock.mockReturnValue({ status: 'ready', revision: 'r1', updated_at: 'now' });
+
+    const result = await invokeResolver(resolver.Query?.catalogVersionInfo, {}, {}, {}, {});
+
+    expect(getCatalogVersionInfoMock).toHaveBeenCalled();
+    expect(result).toEqual({ status: 'ready', revision: 'r1', updated_at: 'now' });
+  });
+
+  it('maps Query.contract to findContractBySlug', async () => {
+    const { default: resolver } = await import('../../../../src/modules/catalog/catalog-resolver');
+    const context = { user: { id: 'u1' } } as any;
+
+    findContractBySlugMock.mockResolvedValue({ catalog_id: 'catalog-1', contract: '{}' });
+
+    const result = await invokeResolver(resolver.Query?.contract, {}, { slug: 'ipinfo' }, context, {});
+
+    expect(findContractBySlugMock).toHaveBeenCalledWith(context, context.user, 'ipinfo');
+    expect(result).toEqual({ catalog_id: 'catalog-1', contract: '{}' });
+  });
+
+  it('maps Mutation.refreshCatalog to triggerRefreshInBackground and returns true', async () => {
+    const { default: resolver } = await import('../../../../src/modules/catalog/catalog-resolver');
+
+    const result = await invokeResolver(resolver.Mutation?.refreshCatalog, {}, {}, {}, {});
+
+    expect(triggerRefreshInBackgroundMock).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/catalogManager-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/catalogManager-test.ts
@@ -1,0 +1,347 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TYPE_LOCK_ERROR_VALUE = 'LOCK_ERROR';
+
+const setIntervalAsyncMock = vi.fn();
+const clearIntervalAsyncMock = vi.fn();
+const confGetMock = vi.fn();
+const booleanConfMock = vi.fn();
+const isFeatureEnabledMock = vi.fn();
+const logInfoMock = vi.fn();
+const logWarnMock = vi.fn();
+const logDebugMock = vi.fn();
+const lockResourcesMock = vi.fn();
+const resolveCatalogSourceMock = vi.fn();
+const legacyFetchMock = vi.fn();
+const legacyToInternalCatalogMock = vi.fn();
+const newFetchMock = vi.fn();
+const newToInternalCatalogMock = vi.fn();
+const getCatalogManagerInternalCacheMock = vi.fn();
+const getCatalogStatusMock = vi.fn();
+const updateCatalogManagerInternalCacheMock = vi.fn();
+
+vi.mock('set-interval-async/fixed', () => ({
+  setIntervalAsync: (...args: unknown[]) => setIntervalAsyncMock(...args),
+  clearIntervalAsync: (...args: unknown[]) => clearIntervalAsyncMock(...args),
+}));
+
+vi.mock('../../../src/config/conf', () => ({
+  default: {
+    get: (...args: unknown[]) => confGetMock(...args),
+  },
+  booleanConf: (...args: unknown[]) => booleanConfMock(...args),
+  isFeatureEnabled: (...args: unknown[]) => isFeatureEnabledMock(...args),
+  logApp: {
+    info: (...args: unknown[]) => logInfoMock(...args),
+    warn: (...args: unknown[]) => logWarnMock(...args),
+    debug: (...args: unknown[]) => logDebugMock(...args),
+  },
+}));
+
+vi.mock('../../../src/lock/master-lock', () => ({
+  lockResources: (...args: unknown[]) => lockResourcesMock(...args),
+}));
+
+vi.mock('../../../src/config/errors', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/errors')>();
+  return {
+    ...actual,
+    TYPE_LOCK_ERROR: TYPE_LOCK_ERROR_VALUE,
+  };
+});
+
+vi.mock('../../../src/modules/catalog/catalog-adapters', () => {
+  class LegacyManifestAdapter {
+    fetch(...args: unknown[]) {
+      return legacyFetchMock(...args);
+    }
+
+    toInternalCatalog(...args: unknown[]) {
+      return legacyToInternalCatalogMock(...args);
+    }
+  }
+
+  class NewManifestAdapter {
+    fetch(...args: unknown[]) {
+      return newFetchMock(...args);
+    }
+
+    toInternalCatalog(...args: unknown[]) {
+      return newToInternalCatalogMock(...args);
+    }
+  }
+
+  return {
+    LegacyManifestAdapter,
+    NewManifestAdapter,
+    resolveCatalogSource: (...args: unknown[]) => resolveCatalogSourceMock(...args),
+  };
+});
+
+vi.mock('../../../src/modules/catalog/catalog-domain', () => ({
+  getCatalogManagerInternalCache: (...args: unknown[]) => getCatalogManagerInternalCacheMock(...args),
+  getCatalogStatus: (...args: unknown[]) => getCatalogStatusMock(...args),
+  updateCatalogManagerInternalCache: (...args: unknown[]) => updateCatalogManagerInternalCacheMock(...args),
+}));
+
+const waitAsync = () => new Promise<void>((resolve) => {
+  setImmediate(() => resolve());
+});
+
+const loadManagerModule = async () => {
+  vi.resetModules();
+  const { default: manager } = await import('../../../src/manager/catalogManager');
+  return manager;
+};
+
+describe('catalogManager', () => {
+  const lockUnlockMock = vi.fn();
+  const timerRef = { id: 'timer' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    booleanConfMock.mockReturnValue(true);
+    isFeatureEnabledMock.mockReturnValue(true);
+    confGetMock.mockImplementation((key: string) => {
+      if (key === 'app:catalog_manager:lock_key') return 'catalog_manager_lock';
+      if (key === 'app:catalog_manager:interval') return 0;
+      if (key === 'app:catalog_manager:custom_catalog_refresh_endpoint_uri') return undefined;
+      if (key === 'app:catalog_manager:request_timeout') return 15000;
+      return undefined;
+    });
+
+    resolveCatalogSourceMock.mockReturnValue({
+      source: { kind: 'remote', uri: 'https://hub.example/octi/6.8.13/connector/manifests' },
+      originalUri: 'https://hub.example/octi/6.8.13/connector/manifests',
+    });
+
+    lockResourcesMock.mockResolvedValue({ unlock: lockUnlockMock });
+
+    getCatalogStatusMock.mockReturnValue('ready');
+    getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
+
+    newFetchMock.mockResolvedValue({ id: 'catalog' });
+    newToInternalCatalogMock.mockReturnValue({ definitions: [] });
+    legacyFetchMock.mockResolvedValue([{ id: 'legacy' }]);
+    legacyToInternalCatalogMock.mockReturnValue({ definitions: [{ id: 'legacy' }] });
+
+    setIntervalAsyncMock.mockReturnValue(timerRef);
+    clearIntervalAsyncMock.mockResolvedValue(undefined);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      headers: { get: () => null },
+    }));
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not start when decoupling feature flag is disabled', async () => {
+    isFeatureEnabledMock.mockReturnValue(false);
+    const manager = await loadManagerModule();
+
+    await manager.start();
+    await waitAsync();
+
+    expect(lockResourcesMock).not.toHaveBeenCalled();
+    expect(setIntervalAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('loads embedded fallback when catalog manager is disabled by config', async () => {
+    booleanConfMock.mockReturnValue(false);
+    const manager = await loadManagerModule();
+
+    await manager.start();
+
+    expect(legacyFetchMock).toHaveBeenCalledWith({ kind: 'local', uri: 'embedded' });
+    expect(updateCatalogManagerInternalCacheMock).toHaveBeenCalledWith(
+      { definitions: [{ id: 'legacy' }] },
+      'ready',
+      false,
+      expect.any(String),
+    );
+    expect(setIntervalAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('schedules periodic refresh when interval is positive', async () => {
+    confGetMock.mockImplementation((key: string) => {
+      if (key === 'app:catalog_manager:lock_key') return 'catalog_manager_lock';
+      if (key === 'app:catalog_manager:interval') return 30000;
+      if (key === 'app:catalog_manager:custom_catalog_refresh_endpoint_uri') return undefined;
+      if (key === 'app:catalog_manager:request_timeout') return 15000;
+      return undefined;
+    });
+    const manager = await loadManagerModule();
+
+    await manager.start();
+
+    expect(setIntervalAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does startup-only refresh when interval is not set', async () => {
+    const manager = await loadManagerModule();
+
+    await manager.start();
+    await waitAsync();
+
+    expect(setIntervalAsyncMock).not.toHaveBeenCalled();
+    expect(lockResourcesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips fetch when remote ETag is unchanged', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'etag-1' },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(newFetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates internal cache on successful remote refresh', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'etag-42' },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(newFetchMock).toHaveBeenCalledWith(
+      { kind: 'remote', uri: 'https://hub.example/octi/6.8.13/connector/manifests' },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(updateCatalogManagerInternalCacheMock).toHaveBeenCalledWith(
+      { definitions: [] },
+      'ready',
+      false,
+      'etag-42',
+    );
+  });
+
+  it('returns early after fetch when feature is disabled during refresh', async () => {
+    isFeatureEnabledMock.mockImplementationOnce(() => true).mockImplementationOnce(() => false);
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(newFetchMock).toHaveBeenCalledTimes(1);
+    expect(updateCatalogManagerInternalCacheMock).toHaveBeenCalledWith(undefined, 'loading', true);
+    expect(updateCatalogManagerInternalCacheMock).not.toHaveBeenCalledWith(
+      { definitions: [] },
+      'ready',
+      false,
+      expect.anything(),
+    );
+  });
+
+  it('keeps existing snapshot and sets error when refresh fails', async () => {
+    newFetchMock.mockRejectedValue(new Error('network failed'));
+    getCatalogManagerInternalCacheMock.mockReturnValue({ definitions: [{ id: 'existing' }] });
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(updateCatalogManagerInternalCacheMock).toHaveBeenCalledWith(undefined, 'error', true);
+    expect(legacyFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to embedded legacy manifest when refresh fails and cache is empty', async () => {
+    newFetchMock.mockRejectedValue(new Error('network failed'));
+    getCatalogManagerInternalCacheMock.mockReturnValue(undefined);
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(legacyFetchMock).toHaveBeenCalledWith({ kind: 'local', uri: 'embedded' });
+    expect(updateCatalogManagerInternalCacheMock).toHaveBeenCalledWith(
+      { definitions: [{ id: 'legacy' }] },
+      'ready',
+      false,
+      expect.any(String),
+    );
+  });
+
+  it('sets error when both refresh and fallback fail', async () => {
+    newFetchMock.mockRejectedValue(new Error('network failed'));
+    legacyFetchMock.mockRejectedValue(new Error('embedded failed'));
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(updateCatalogManagerInternalCacheMock).toHaveBeenLastCalledWith(undefined, 'error');
+  });
+
+  it('swallows lock conflict errors', async () => {
+    lockResourcesMock.mockRejectedValue({ name: TYPE_LOCK_ERROR_VALUE });
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(logDebugMock).toHaveBeenCalledWith('[OPENCTI-MODULE] Catalog manager refresh already running on another API');
+    expect(newFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('logs timeout warning when refresh request times out', async () => {
+    newFetchMock.mockRejectedValue({ name: 'TimeoutError' });
+
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(logWarnMock).toHaveBeenCalledWith(
+      '[OPENCTI-MODULE] Catalog manager request timed out',
+      expect.objectContaining({ timeoutMs: 15000 }),
+    );
+  });
+
+  it('always unlocks resource after refresh attempt', async () => {
+    const manager = await loadManagerModule();
+
+    manager.triggerRefreshInBackground();
+    await waitAsync();
+
+    expect(lockUnlockMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears scheduled task on shutdown', async () => {
+    confGetMock.mockImplementation((key: string) => {
+      if (key === 'app:catalog_manager:lock_key') return 'catalog_manager_lock';
+      if (key === 'app:catalog_manager:interval') return 30000;
+      if (key === 'app:catalog_manager:custom_catalog_refresh_endpoint_uri') return undefined;
+      if (key === 'app:catalog_manager:request_timeout') return 15000;
+      return undefined;
+    });
+
+    const manager = await loadManagerModule();
+
+    await manager.start();
+    await manager.shutdown();
+
+    expect(clearIntervalAsyncMock).toHaveBeenCalledWith(timerRef);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/catalog/catalog-adapters-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/catalog/catalog-adapters-test.ts
@@ -1,0 +1,259 @@
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const confGetMock = vi.fn();
+const readFileMock = vi.fn();
+const buildInternalCatalogMock = vi.fn();
+
+vi.mock('../../../../src/config/conf', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => confGetMock(...args),
+  },
+  PLATFORM_VERSION: '7.260722.0',
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => readFileMock(...args),
+}));
+
+vi.mock('../../../../src/modules/catalog/catalog-cache', () => ({
+  buildInternalCatalog: (...args: unknown[]) => buildInternalCatalogMock(...args),
+}));
+
+vi.mock('../../../../src/__generated__/opencti-manifest.json', () => ({
+  default: {
+    id: 'embedded-catalog',
+    name: 'Embedded Catalog',
+    description: 'Embedded test catalog',
+    contracts: [],
+  },
+}));
+
+describe('catalog-adapters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confGetMock.mockImplementation((key: string) => {
+      if (key === 'xtm:xtmhub_url') return 'https://hub.filigran.io/';
+      if (key === 'app:custom_catalogs') return [];
+      return undefined;
+    });
+    buildInternalCatalogMock.mockReturnValue({ built: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolveCatalogSource builds default remote URL from hub config', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    const result = resolveCatalogSource(undefined);
+
+    expect(result).toEqual({
+      source: {
+        kind: 'remote',
+        uri: 'https://hub.filigran.io/opencti/7.260722.0/connector/manifests/latest',
+      },
+      originalUri: 'https://hub.filigran.io/opencti/7.260722.0/connector/manifests/latest',
+    });
+  });
+
+  it('resolveCatalogSource returns provided http URI as remote source', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    const result = resolveCatalogSource('https://custom.example/catalog');
+
+    expect(result).toEqual({
+      source: { kind: 'remote', uri: 'https://custom.example/catalog' },
+      originalUri: 'https://custom.example/catalog',
+    });
+  });
+
+  it('resolveCatalogSource resolves relative file paths to absolute local paths', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    const result = resolveCatalogSource('fixtures/catalog.json');
+
+    expect(result.source.kind).toBe('local');
+    expect(result.source.uri).toBe(path.resolve(process.cwd(), 'fixtures/catalog.json'));
+    expect(result.originalUri).toBe('fixtures/catalog.json');
+  });
+
+  it('resolveCatalogSource strips file:// prefix', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    const result = resolveCatalogSource('file:///tmp/test-catalog.json');
+
+    expect(result).toEqual({
+      source: { kind: 'local', uri: '/tmp/test-catalog.json' },
+      originalUri: 'file:///tmp/test-catalog.json',
+    });
+  });
+
+  it('resolveCatalogSource throws on unsupported URI schemes', async () => {
+    const { resolveCatalogSource } = await import('../../../../src/modules/catalog/catalog-adapters');
+
+    expect(() => resolveCatalogSource('ftp://catalog.json')).toThrow('Unsupported catalog source URI scheme: ftp://catalog.json');
+  });
+
+  it('LegacyManifestAdapter.fetch returns embedded + custom catalogs', async () => {
+    confGetMock.mockImplementation((key: string) => {
+      if (key === 'app:custom_catalogs') return ['/tmp/custom1.json', '/tmp/custom2.json'];
+      if (key === 'xtm:xtmhub_url') return 'https://hub.filigran.io/';
+      return undefined;
+    });
+    readFileMock.mockImplementation((filePath: string) => {
+      if (filePath === '/tmp/custom1.json') {
+        return JSON.stringify({ id: 'custom-1', contracts: [] });
+      }
+      if (filePath === '/tmp/custom2.json') {
+        return JSON.stringify({ id: 'custom-2', contracts: [] });
+      }
+      throw new Error(`Unexpected file: ${filePath}`);
+    });
+
+    const { LegacyManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new LegacyManifestAdapter();
+
+    const result = await adapter.fetch({ kind: 'local', uri: 'ignored' });
+
+    expect(result).toEqual([
+      expect.objectContaining({ id: 'embedded-catalog' }),
+      { id: 'custom-1', contracts: [] },
+      { id: 'custom-2', contracts: [] },
+    ]);
+    expect(readFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('LegacyManifestAdapter.toInternalCatalog forwards definitions to buildInternalCatalog', async () => {
+    const { LegacyManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new LegacyManifestAdapter();
+    const definitions = [{ id: 'legacy', contracts: [] }];
+
+    const result = adapter.toInternalCatalog(definitions);
+
+    expect(buildInternalCatalogMock).toHaveBeenCalledWith(definitions);
+    expect(result).toEqual({ built: true });
+  });
+
+  it('NewManifestAdapter.fetch reads and parses local JSON manifest', async () => {
+    readFileMock.mockResolvedValue('{"id":"manifest-1","contracts":[]}');
+    const { NewManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new NewManifestAdapter();
+
+    const result = await adapter.fetch({ kind: 'local', uri: '/tmp/manifest.json' });
+
+    expect(readFileMock).toHaveBeenCalledWith('/tmp/manifest.json', { encoding: 'utf8', flag: 'r' });
+    expect(result).toEqual({ id: 'manifest-1', contracts: [] });
+  });
+
+  it('NewManifestAdapter.fetch returns remote JSON when response is ok', async () => {
+    const remoteManifest = { id: 'remote-1', contracts: [] };
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => remoteManifest });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { NewManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new NewManifestAdapter();
+
+    const result = await adapter.fetch({ kind: 'remote', uri: 'https://hub/catalog' }, { signal: undefined });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://hub/catalog', { signal: undefined });
+    expect(result).toEqual(remoteManifest);
+  });
+
+  it('NewManifestAdapter.fetch throws on non-ok remote response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { NewManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new NewManifestAdapter();
+
+    await expect(adapter.fetch({ kind: 'remote', uri: 'https://hub/catalog' })).rejects.toThrow(
+      'Failed to fetch remote catalog (503) from https://hub/catalog',
+    );
+  });
+
+  it('NewManifestAdapter.toInternalCatalog validates required manifest fields', async () => {
+    const { NewManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new NewManifestAdapter();
+
+    expect(() => adapter.toInternalCatalog({ contracts: [] })).toThrow('Catalog manifest is missing required fields: id and contracts');
+    expect(() => adapter.toInternalCatalog({ id: 'catalog-1', contracts: 'not-array' })).toThrow('Catalog manifest is missing required fields: id and contracts');
+  });
+
+  it('NewManifestAdapter.toInternalCatalog keeps latest contract per slug and passes all contracts as second arg', async () => {
+    const { NewManifestAdapter } = await import('../../../../src/modules/catalog/catalog-adapters');
+    const adapter = new NewManifestAdapter();
+
+    const rawManifest = {
+      id: 'catalog-1',
+      name: 'Catalog One',
+      description: 'Desc',
+      contracts: [
+        {
+          id: 'c1',
+          title: 'IPInfo v1',
+          slug: 'ipinfo',
+          version: '1.0.0',
+          image_name: 'opencti/ipinfo:1.0.0',
+          verified: 'true',
+          use_cases: ['enrichment', 12],
+          additional_properties: {
+            playbook_supported: 'true',
+            max_confidence_level: '80',
+          },
+          config_schema: {
+            properties: { key: { type: 'string' } },
+            required: ['key'],
+            additionalProperties: false,
+          },
+        },
+        {
+          id: 'c2',
+          title: 'IPInfo v2',
+          slug: 'ipinfo',
+          version: '2.0.0',
+          container_image: 'opencti/ipinfo:2.0.0',
+        },
+      ],
+    };
+
+    adapter.toInternalCatalog(rawManifest);
+
+    expect(buildInternalCatalogMock).toHaveBeenCalledTimes(1);
+    const [latestDefinitions, allContracts] = buildInternalCatalogMock.mock.calls[0];
+
+    expect(Array.isArray(latestDefinitions)).toBe(true);
+    expect(latestDefinitions).toHaveLength(1);
+    expect(latestDefinitions[0].contracts).toHaveLength(1);
+    expect(latestDefinitions[0].contracts[0]).toEqual(expect.objectContaining({
+      id: 'c2',
+      slug: 'ipinfo',
+      container_version: '2.0.0',
+      container_image: 'opencti/ipinfo:2.0.0',
+      container_type: 'EXTERNAL_IMPORT',
+      playbook_supported: false,
+      max_confidence_level: 100,
+      verified: false,
+      use_cases: [],
+    }));
+
+    expect(allContracts).toHaveLength(2);
+    expect(allContracts[0]).toEqual(expect.objectContaining({
+      id: 'c1',
+      slug: 'ipinfo',
+      container_version: '1.0.0',
+      container_image: 'opencti/ipinfo:1.0.0',
+      playbook_supported: true,
+      max_confidence_level: 80,
+      verified: true,
+      use_cases: ['enrichment'],
+      config_schema: expect.objectContaining({
+        properties: { key: { type: 'string' } },
+        required: ['key'],
+        additionalProperties: false,
+      }),
+    }));
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add FeatureFlag DECOUPLING_CONNECTOR_VERSIONS
* New config catalog_manager settings
* Handle new manifest shape while keeping legacy with embedded manifest shape
* Handle loading manifest from file system or by server
* Catalog Manager added to fetch and populate the catalog
* App catalog fetches and use new manifest, updates if new manifest revision found


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16059 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
