### PR TITLE
fix(smtp): OAuth refresh token rotation (#15924)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/smtp.js
+++ b/opencti-platform/opencti-graphql/src/database/smtp.js
@@ -6,7 +6,7 @@ import { getEntityFromCache } from './cache';
 import { ENTITY_TYPE_SETTINGS } from '../schema/internalObject';
 import { executionContext, SYSTEM_USER } from '../utils/access';
 import { isEmptyField } from './utils';
-import { getSmtpConfiguration } from '../modules/smtpConfiguration/smtpConfiguration-domain';
+import { getSmtpConfiguration, smtpConfigurationRefreshTokenUpdate } from '../modules/smtpConfiguration/smtpConfiguration-domain';
 import { decryptSmtpSecret } from '../modules/smtpConfiguration/smtpConfiguration-crypto';
 
 const SMTP_FORCED_EMAIL = conf.get('smtp:forced_sender_email');
@@ -52,7 +52,7 @@ let inFlightRefresh; // concurrent refresh attempts are coalesced via an in-flig
 
 const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000; // Refresh the token a bit before it actually expires
 
-const refreshSmtpAccessToken = async ({ oauthClientId, oauthClientSecret, oauthIssuer, oauthRefreshToken }) => {
+const refreshSmtpAccessToken = async ({ oauthClientId, oauthClientSecret, oauthIssuer, oauthRefreshToken, onRefreshToken }) => {
   if (cachedAccessToken && Date.now() < cachedAccessTokenExpiresAt - ACCESS_TOKEN_REFRESH_MARGIN_MS) {
     return cachedAccessToken;
   }
@@ -72,6 +72,9 @@ const refreshSmtpAccessToken = async ({ oauthClientId, oauthClientSecret, oauthI
     }
     if (!tokens?.access_token) {
       throw new Error('Unable to refresh SMTP OAuth2 access token: refresh token grant did not return an access_token');
+    }
+    if (tokens.refresh_token && tokens.refresh_token !== oauthRefreshToken && onRefreshToken) {
+      await onRefreshToken(tokens.refresh_token, oauthRefreshToken);
     }
     cachedAccessToken = tokens.access_token;
     const expiresInSeconds = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600;
@@ -93,6 +96,7 @@ export const buildSmtpAuth = async (authType, {
   oauthClientSecret,
   oauthIssuer,
   oauthRefreshToken,
+  onRefreshToken,
 } = {}) => {
   if (authType === 'oauth2') {
     if (!oauthUser || !oauthClientId || !oauthClientSecret || !oauthIssuer || !oauthRefreshToken) {
@@ -103,6 +107,7 @@ export const buildSmtpAuth = async (authType, {
       oauthClientSecret,
       oauthIssuer,
       oauthRefreshToken,
+      onRefreshToken,
     });
     return {
       type: 'OAuth2',
@@ -163,6 +168,10 @@ const getDbAuthParams = async (dbConfig) => ({
   oauthClientSecret: await decryptSmtpSecret(dbConfig.oauth_client_secret_encrypted),
   oauthIssuer: dbConfig.oauth_issuer,
   oauthRefreshToken: await decryptSmtpSecret(dbConfig.oauth_refresh_token_encrypted),
+  onRefreshToken: async (newRefreshToken, previousRefreshToken) => {
+    const context = executionContext('smtp-refresh-token');
+    await smtpConfigurationRefreshTokenUpdate(context, SYSTEM_USER, previousRefreshToken, newRefreshToken);
+  },
 });
 
 // Build a nodemailer transporter from the effective SMTP configuration.

--- a/opencti-platform/opencti-graphql/src/modules/smtpConfiguration/smtpConfiguration-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/smtpConfiguration/smtpConfiguration-domain.ts
@@ -6,7 +6,7 @@ import { publishUserAction } from '../../listener/UserActionListener';
 import { notify } from '../../database/redis';
 import { BUS_TOPICS, isFeatureEnabled } from '../../config/conf';
 import { ALLOW_EMAIL_REWRITE, SMTP_JSON_CONFIG, smtpTest } from '../../database/smtp';
-import { encryptSmtpSecret } from './smtpConfiguration-crypto';
+import { decryptSmtpSecret, encryptSmtpSecret } from './smtpConfiguration-crypto';
 import type { BasicStoreSettings, SmtpConfiguration } from '../../types/settings';
 import { getEntityFromCache } from '../../database/cache';
 import { ENTITY_TYPE_SETTINGS } from '../../schema/internalObject';
@@ -103,6 +103,29 @@ export const smtpConfigurationEdit = async (
   await notify(BUS_TOPICS[ENTITY_TYPE_SETTINGS].EDIT_TOPIC, element, user);
   const stored = (element as unknown as BasicStoreSettings).smtp_configuration!;
   return { ...stored, forced_sender_email: !ALLOW_EMAIL_REWRITE };
+};
+
+export const smtpConfigurationRefreshTokenUpdate = async (
+  context: AuthContext,
+  user: AuthUser,
+  previousRefreshToken: string,
+  newRefreshToken: string,
+): Promise<void> => {
+  if (newRefreshToken === previousRefreshToken) return;
+  const settings = await getEntityFromCache<BasicStoreSettings>(context, user, ENTITY_TYPE_SETTINGS);
+  const existing = settings.smtp_configuration;
+  if (!existing?.use_db_config || existing.auth_type !== SmtpAuthType.Oauth2) return;
+  const storedRefreshToken = await decryptSmtpSecret(existing.oauth_refresh_token_encrypted);
+  if (storedRefreshToken !== previousRefreshToken) return;
+  const oauthRefreshTokenEncrypted = await encryptSmtpSecret(newRefreshToken);
+  const patch = {
+    smtp_configuration: {
+      ...existing,
+      oauth_refresh_token_encrypted: oauthRefreshTokenEncrypted,
+    },
+  };
+  const { element } = await patchAttribute(context, user, settings.id, ENTITY_TYPE_SETTINGS, patch);
+  await notify(BUS_TOPICS[ENTITY_TYPE_SETTINGS].EDIT_TOPIC, element, user);
 };
 
 export const smtpConfigurationDelete = async (

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/smtp-test.ts
@@ -76,6 +76,7 @@ vi.mock('../../../src/config/tracing', async (importOriginal) => {
 // Default: no DB config (use_db_config: false / no row) → fall back to JSON config.
 const smtpConfigurationDomainMocks = vi.hoisted(() => ({
   getSmtpConfiguration: vi.fn(async () => null),
+  smtpConfigurationRefreshTokenUpdate: vi.fn(async () => undefined),
 }));
 vi.mock('../../../src/modules/smtpConfiguration/smtpConfiguration-domain', () => smtpConfigurationDomainMocks);
 
@@ -104,6 +105,7 @@ type SmtpCredentials = {
   oauthClientSecret?: string;
   oauthIssuer?: string;
   oauthRefreshToken?: string;
+  onRefreshToken?: (newRefreshToken: string, previousRefreshToken: string) => Promise<void>;
 };
 
 // The JS source infers all destructured params as required; cast to the intended optional API.
@@ -141,6 +143,20 @@ describe('buildSmtpAuth — OAuth2', () => {
       clientSecret: 'my-client-secret',
       accessToken: 'refreshed-access-token',
     });
+  });
+
+  it('should report a rotated refresh token returned by the identity provider', async () => {
+    const { refreshTokenGrant } = await import('openid-client');
+    (refreshTokenGrant as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      access_token: 'new-access-token',
+      refresh_token: 'new-refresh-token',
+      expires_in: 3600,
+    });
+    const onRefreshToken = vi.fn(async () => undefined);
+
+    await buildSmtpAuth('oauth2', { ...oauth2Config, onRefreshToken });
+
+    expect(onRefreshToken).toHaveBeenCalledWith('new-refresh-token', 'my-refresh-token');
   });
 
   it('should use oauthUser and not username even when both are provided', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/smtpConfiguration/smtpConfiguration-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/smtpConfiguration/smtpConfiguration-domain-test.ts
@@ -7,6 +7,7 @@ import {
   getSmtpConfigurationForAdmin,
   smtpConfigurationDelete,
   smtpConfigurationEdit,
+  smtpConfigurationRefreshTokenUpdate,
   smtpConfigurationTest,
 } from '../../../../src/modules/smtpConfiguration/smtpConfiguration-domain';
 import { SYSTEM_USER } from '../../../../src/utils/access';
@@ -17,6 +18,7 @@ vi.mock('../../../../src/database/smtp', () => ({
 }));
 
 vi.mock('../../../../src/modules/smtpConfiguration/smtpConfiguration-crypto', () => ({
+  decryptSmtpSecret: vi.fn(async (v: string | null | undefined) => v),
   encryptSmtpSecret: vi.fn(async (v: string | null | undefined) => (v ? `encrypted:${v}` : v)),
 }));
 
@@ -103,7 +105,6 @@ describe('feature flag disabled', () => {
     expect(Cache.getEntityFromCache).not.toHaveBeenCalled();
   });
 });
-
 // ---------- getSmtpConfiguration ----------
 
 describe('getSmtpConfiguration', () => {
@@ -240,6 +241,43 @@ describe('smtpConfigurationEdit', () => {
     expect(contextData.input).not.toHaveProperty('password_encrypted');
     expect(contextData.input).not.toHaveProperty('oauth_client_secret');
     expect(contextData.input).not.toHaveProperty('oauth_client_secret_encrypted');
+  });
+});
+
+describe('smtpConfigurationRefreshTokenUpdate', () => {
+  it('should replace and encrypt the stored OAuth2 refresh token', async () => {
+    vi.mocked(Cache.getEntityFromCache).mockResolvedValue({
+      ...MOCK_SETTINGS,
+      smtp_configuration: {
+        ...MOCK_SMTP_CONFIG_STORED,
+        use_db_config: true,
+        auth_type: 'oauth2',
+        oauth_refresh_token_encrypted: 'old-refresh-token',
+      },
+    });
+    vi.mocked(Middleware.patchAttribute).mockResolvedValue({ element: MOCK_SETTINGS } as any);
+
+    await smtpConfigurationRefreshTokenUpdate(mockContext, mockUser, 'old-refresh-token', 'new-refresh-token');
+
+    const patch = (vi.mocked(Middleware.patchAttribute).mock.calls[0] as any[])[4];
+    expect(patch.smtp_configuration.oauth_refresh_token_encrypted).toBe('encrypted:new-refresh-token');
+    expect(patch.smtp_configuration).not.toHaveProperty('oauth_refresh_token');
+  });
+
+  it('should not overwrite a refresh token that was already rotated', async () => {
+    vi.mocked(Cache.getEntityFromCache).mockResolvedValue({
+      ...MOCK_SETTINGS,
+      smtp_configuration: {
+        ...MOCK_SMTP_CONFIG_STORED,
+        use_db_config: true,
+        auth_type: 'oauth2',
+        oauth_refresh_token_encrypted: 'already-rotated-token',
+      },
+    });
+
+    await smtpConfigurationRefreshTokenUpdate(mockContext, mockUser, 'old-refresh-token', 'new-refresh-token');
+
+    expect(Middleware.patchAttribute).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
### Proposed changes

* Persist a rotated SMTP OAuth refresh token when the identity provider returns a new one.
* Keep the existing refresh token when the provider returns none or returns the same value.
* Encrypt rotated tokens before storage and avoid overwriting a token that was already rotated concurrently.
* Add unit coverage for token rotation, encrypted persistence, and concurrent update protection.

### Related issues

* Part of #15924

### How to test this PR

* Run `yarn vitest run tests/01-unit/database/smtp-test.ts tests/01-unit/modules/smtpConfiguration/smtpConfiguration-domain-test.ts` from `opencti-platform/opencti-graphql`.
* Run `NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/tsc --noEmit` from `opencti-platform/opencti-graphql`.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The access token remains an in-memory value. The database is updated only when the OAuth provider returns a non-empty refresh token that differs from the one used for the grant.