### PR TITLE
fix(widget): Take start and end dates into account in relationship widgets (#17243)

### DIFF
--- a/opencti-platform/opencti-front/src/components/dashboard/DashboardAuditsViz.tsx
+++ b/opencti-platform/opencti-front/src/components/dashboard/DashboardAuditsViz.tsx
@@ -12,10 +12,10 @@ import AuditsRadar from '@components/common/audits/AuditsRadar';
 import AuditsMultiHeatMap from '@components/common/audits/AuditsMultiHeatMap';
 import AuditsTreeMap from '@components/common/audits/AuditsTreeMap';
 import AuditsWordCloud from '@components/common/audits/AuditsWordCloud';
-import { computeRelativeDate, dayStartDate, formatDate } from '../../utils/Time';
 import type { Widget, WidgetHost } from '../../utils/widget/widget';
 import type { DashboardConfig } from './dashboard-types';
 import WidgetNotImplemented from './WidgetNotImplemented';
+import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
 
 interface DashboardAuditsVizProps {
   widget: Widget;
@@ -32,13 +32,7 @@ const DashboardAuditsViz = ({
   host,
   refreshRate,
 }: DashboardAuditsVizProps) => {
-  const startDate = config.relativeDate
-    ? computeRelativeDate(config.relativeDate)
-    : config.startDate;
-
-  const endDate = config.relativeDate
-    ? formatDate(dayStartDate(null, false))
-    : config.endDate;
+  const { startDate, endDate } = computeStartEndDates(config);
 
   switch (widget.type) {
     case 'number':

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
@@ -3,7 +3,7 @@ import type { WidgetDataSelection } from '../../utils/widget/widget';
 import { removeIdAndIncorrectKeysFromFilterGroupObject, getAvailableFilterKeysForEntityTypes, buildFiltersForCustomView } from '../../utils/filters/filtersUtils';
 import type { SchemaType } from '../../utils/hooks/useAuth';
 import type { FilterGroup } from '../../utils/filters/filtersHelpers-types';
-import { resolveDataSelection } from './dashboardVizUtils';
+import { resolveDataSelection, computeStartEndDates } from './dashboardVizUtils';
 
 vi.mock('src/relay/environment', () => ({
   fetchQuery: vi.fn(),
@@ -519,5 +519,53 @@ describe('resolvedDataSelection', () => {
       });
       expect(isMissingSavedFilters).toBe(false);
     });
+  });
+});
+
+describe('computeStartEndDates', () => {
+  it('returns undefined dates when no config is provided', () => {
+    const { startDate, endDate } = computeStartEndDates();
+    expect(startDate).toBeUndefined();
+    expect(endDate).toBeUndefined();
+  });
+
+  it('returns undefined dates when config has no date fields', () => {
+    const { startDate, endDate } = computeStartEndDates({});
+    expect(startDate).toBeUndefined();
+    expect(endDate).toBeUndefined();
+  });
+
+  it('returns absolute dates from config', () => {
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+    const { startDate, endDate } = computeStartEndDates(config);
+    expect(startDate).toBe('2025-01-01T00:00:00Z');
+    expect(endDate).toBe('2025-06-01T00:00:00Z');
+  });
+
+  it('computes relative dates when relativeDate is set, ignoring absolute dates', () => {
+    const config = {
+      relativeDate: 'days-7',
+      startDate: '2025-01-01T00:00:00Z',
+      endDate: '2025-06-01T00:00:00Z',
+    };
+    const { startDate, endDate } = computeStartEndDates(config);
+    // relativeDate should override absolute dates
+    expect(startDate).not.toBe('2025-01-01T00:00:00Z');
+    expect(endDate).not.toBe('2025-06-01T00:00:00Z');
+    expect(startDate).toBeDefined();
+    expect(endDate).toBeDefined();
+  });
+
+  it('falls back to default date range when fallbackToDefaultDates is true and no dates configured', () => {
+    const { startDate, endDate } = computeStartEndDates({}, true);
+    expect(startDate).toBeDefined();
+    expect(endDate).toBeDefined();
+  });
+
+  it('uses config dates over fallback defaults when both are available', () => {
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+    const { startDate, endDate } = computeStartEndDates(config, true);
+    expect(startDate).toBe('2025-01-01T00:00:00Z');
+    expect(endDate).toBe('2025-06-01T00:00:00Z');
   });
 });

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
@@ -3,7 +3,14 @@ import type { WidgetDataSelection } from '../../utils/widget/widget';
 import { removeIdAndIncorrectKeysFromFilterGroupObject, getAvailableFilterKeysForEntityTypes, buildFiltersForCustomView } from '../../utils/filters/filtersUtils';
 import type { SchemaType } from '../../utils/hooks/useAuth';
 import type { FilterGroup } from '../../utils/filters/filtersHelpers-types';
-import { resolveDataSelection, computeStartEndDates } from './dashboardVizUtils';
+import {
+  resolveDataSelection,
+  computeStartEndDates,
+  computeWidgetFiltersForSelection,
+  computeWidgetFiltersForMultiSelection,
+  buildRelationshipMultiWidgetBaseQueryVariables,
+  buildRelationshipSingleWidgetBaseQueryVariables,
+} from './dashboardVizUtils';
 
 vi.mock('src/relay/environment', () => ({
   fetchQuery: vi.fn(),
@@ -128,7 +135,7 @@ describe('resolvedDataSelection', () => {
       dataSelection,
       perspective: 'entities',
     });
-    const main = ['Stix-Core-Object'];
+    const main = ['Stix-Core-Object', 'DraftWorkspace'];
     expect(resolvedDataSelection[0].filters).toStrictEqual(
       removeIdAndIncorrectKeysFromFilterGroupObject(
         dataSelection[0].filters,
@@ -141,7 +148,7 @@ describe('resolvedDataSelection', () => {
         getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
       ),
     );
-    expect(resolvedDataSelection[0].dynamicFrom).toStrictEqual(
+    expect(resolvedDataSelection[0].dynamicTo).toStrictEqual(
       removeIdAndIncorrectKeysFromFilterGroupObject(
         dataSelection[0].dynamicTo,
         getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
@@ -173,7 +180,7 @@ describe('resolvedDataSelection', () => {
         getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
       ),
     );
-    expect(resolvedDataSelection[0].dynamicFrom).toStrictEqual(
+    expect(resolvedDataSelection[0].dynamicTo).toStrictEqual(
       removeIdAndIncorrectKeysFromFilterGroupObject(
         dataSelection[0].dynamicTo,
         getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
@@ -205,7 +212,7 @@ describe('resolvedDataSelection', () => {
         getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
       ),
     );
-    expect(resolvedDataSelection[0].dynamicFrom).toStrictEqual(
+    expect(resolvedDataSelection[0].dynamicTo).toStrictEqual(
       removeIdAndIncorrectKeysFromFilterGroupObject(
         dataSelection[0].dynamicTo,
         getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
@@ -246,7 +253,7 @@ describe('resolvedDataSelection', () => {
           customViewTargetEntityId,
         },
       });
-      const main = ['Stix-Core-Object'];
+      const main = ['Stix-Core-Object', 'DraftWorkspace'];
       expect(resolvedDataSelection[0].filters).toStrictEqual(
         removeIdAndIncorrectKeysFromFilterGroupObject(
           buildFiltersForCustomView(dataSelection[0].filters, customViewTargetEntityId),
@@ -256,13 +263,13 @@ describe('resolvedDataSelection', () => {
       expect(resolvedDataSelection[0].dynamicFrom).toStrictEqual(
         removeIdAndIncorrectKeysFromFilterGroupObject(
           buildFiltersForCustomView(dataSelection[0].dynamicFrom, customViewTargetEntityId),
-          getAvailableFilterKeysForEntityTypes(filterKeysSchema, main, true),
+          getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
         ),
       );
       expect(resolvedDataSelection[0].dynamicTo).toStrictEqual(
         removeIdAndIncorrectKeysFromFilterGroupObject(
           buildFiltersForCustomView(dataSelection[0].dynamicTo, customViewTargetEntityId),
-          getAvailableFilterKeysForEntityTypes(filterKeysSchema, main, true),
+          getAvailableFilterKeysForEntityTypes(filterKeysSchema, secondary, true),
         ),
       );
       expect(isMissingHostEntity).toBe(false);
@@ -543,17 +550,21 @@ describe('computeStartEndDates', () => {
   });
 
   it('computes relative dates when relativeDate is set, ignoring absolute dates', () => {
-    const config = {
-      relativeDate: 'days-7',
-      startDate: '2025-01-01T00:00:00Z',
-      endDate: '2025-06-01T00:00:00Z',
-    };
-    const { startDate, endDate } = computeStartEndDates(config);
-    // relativeDate should override absolute dates
-    expect(startDate).not.toBe('2025-01-01T00:00:00Z');
-    expect(endDate).not.toBe('2025-06-01T00:00:00Z');
-    expect(startDate).toBeDefined();
-    expect(endDate).toBeDefined();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-03-15T10:30:00.000Z'));
+    try {
+      const config = {
+        relativeDate: 'days-7',
+        startDate: '2025-01-01T00:00:00Z',
+        endDate: '2025-06-01T00:00:00Z',
+      };
+      const { startDate, endDate } = computeStartEndDates(config);
+      // relativeDate should override absolute dates
+      expect(startDate).toBe('2025-03-08T10:30:00.000Z');
+      expect(endDate).toBe('2025-03-15T10:30:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('falls back to default date range when fallbackToDefaultDates is true and no dates configured', () => {
@@ -567,5 +578,401 @@ describe('computeStartEndDates', () => {
     const { startDate, endDate } = computeStartEndDates(config, true);
     expect(startDate).toBe('2025-01-01T00:00:00Z');
     expect(endDate).toBe('2025-06-01T00:00:00Z');
+  });
+});
+
+describe('computeWidgetFiltersForSelection', () => {
+  it('returns default dateAttribute "created_at" when selection has no date_attribute', () => {
+    const result = computeWidgetFiltersForSelection({}, {});
+    expect(result.dateAttribute).toBe('created_at');
+  });
+
+  it('uses selection date_attribute when provided', () => {
+    const selection: WidgetDataSelection = { date_attribute: 'updated_at' };
+    const result = computeWidgetFiltersForSelection(selection, {});
+    expect(result.dateAttribute).toBe('updated_at');
+  });
+
+  it('falls back to "created_at" when date_attribute is empty string', () => {
+    const selection: WidgetDataSelection = { date_attribute: '' };
+    const result = computeWidgetFiltersForSelection(selection, {});
+    expect(result.dateAttribute).toBe('created_at');
+  });
+
+  it('passes config dates through to startDate/endDate', () => {
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+    const result = computeWidgetFiltersForSelection({}, config);
+    expect(result.startDate).toBe(config.startDate);
+    expect(result.endDate).toBe(config.endDate);
+  });
+
+  it('returns undefined dates when no config is provided', () => {
+    const result = computeWidgetFiltersForSelection({});
+    expect(result.startDate).toBeUndefined();
+    expect(result.endDate).toBeUndefined();
+  });
+
+  it('includes date filters in the result when config has dates', () => {
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+    const result = computeWidgetFiltersForSelection({}, config);
+    const allFilterKeys = result.filters?.filters.map((f) => f.key).flat();
+    expect(allFilterKeys).toContain('created_at');
+  });
+
+  it('uses custom date_attribute in date filters', () => {
+    const selectionFilters: FilterGroup = {
+      mode: 'and',
+      filters: [{
+        key: 'entity_type',
+        values: ['Malware'],
+        operator: 'eq',
+        mode: 'or',
+      }],
+      filterGroups: [],
+    };
+    const selection: WidgetDataSelection = { date_attribute: 'start_time', filters: selectionFilters };
+    const config = { startDate: '2025-03-01T00:00:00Z' };
+    const result = computeWidgetFiltersForSelection(selection, config);
+    expect(result.filters).toStrictEqual({
+      mode: 'and',
+      filters: [
+        {
+          key: ['start_time'],
+          values: ['2025-03-01T00:00:00Z'],
+          operator: 'gt',
+          mode: 'or',
+        },
+      ],
+      filterGroups: [{
+        key: ['entity_type'],
+        values: ['Malware'],
+        operator: 'eq',
+        mode: 'or',
+      }],
+    });
+  });
+
+  it('passes selection filters through to the result', () => {
+    const selectionFilters: FilterGroup = {
+      mode: 'and',
+      filters: [{
+        key: 'entity_type',
+        values: ['Malware'],
+        operator: 'eq',
+        mode: 'or',
+      }],
+      filterGroups: [],
+    };
+    const result = computeWidgetFiltersForSelection({ filters: selectionFilters }, {});
+    expect(result.filters).toStrictEqual({
+      mode: 'and',
+      filters: [{ key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' }],
+      filterGroups: [],
+    });
+  });
+
+  it('does not apply fallback dates by default', () => {
+    const result = computeWidgetFiltersForSelection({}, {});
+    expect(result.startDate).toBeUndefined();
+    expect(result.endDate).toBeUndefined();
+  });
+});
+
+describe('computeWidgetFiltersForMultiSelection', () => {
+  it('returns timeSeriesParameters for each selection with correct filters and dates', () => {
+    const selectionA: WidgetDataSelection = {
+      date_attribute: 'created_at',
+      filters: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Malware'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+    };
+    const selectionB: WidgetDataSelection = {
+      date_attribute: 'updated_at',
+      filters: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Report'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+    };
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+
+    const result = computeWidgetFiltersForMultiSelection([selectionA, selectionB], config, ['Stix-Core-Object']);
+
+    expect(result.startDate).toBe(config.startDate);
+    expect(result.endDate).toBe(config.endDate);
+    expect(result.timeSeriesParameters).toHaveLength(2);
+
+    // First selection: created_at + Malware filter + date filters
+    expect(result.timeSeriesParameters[0].field).toBe('created_at');
+    expect(result.timeSeriesParameters[0].types).toStrictEqual(['Stix-Core-Object']);
+    let firstLevelFilterKeys = result.timeSeriesParameters[0].filters?.filters.map((f) => f.key).flat();
+    expect(firstLevelFilterKeys).toContain('created_at');
+    let secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups[0].filters;
+    expect(secondLevelFilters).toEqual({
+      mode: 'and',
+      filters: [{
+        key: ['entity_type'],
+        values: ['Malware'],
+        operator: 'eq',
+        mode: 'or',
+      }],
+      filterGroups: [],
+    });
+
+    // Second selection: updated_at + Report filter + date filters
+    expect(result.timeSeriesParameters[1].field).toBe('updated_at');
+    expect(result.timeSeriesParameters[1].types).toStrictEqual(['Stix-Core-Object']);
+    firstLevelFilterKeys = result.timeSeriesParameters[1].filters?.filters.map((f) => f.key).flat();
+    expect(firstLevelFilterKeys).toContain('updated_at');
+    secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups[0].filters;
+    expect(secondLevelFilters).toEqual({
+      mode: 'and',
+      filters: [{
+        key: ['entity_type'],
+        values: ['Report'],
+        operator: 'eq',
+        mode: 'or',
+      }],
+      filterGroups: [],
+    });
+  });
+});
+
+describe('buildRelationshipMultiWidgetBaseQueryVariables', () => {
+  it('returns correct structure with operation, dates, interval, and timeSeriesParameters', () => {
+    const selectionA: WidgetDataSelection = {
+      date_attribute: 'created_at',
+      filters: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Malware'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+      dynamicFrom: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Indicator'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+    };
+    const selectionB: WidgetDataSelection = {
+      date_attribute: 'updated_at',
+      filters: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Report'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+      dynamicTo: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Campaign'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+    };
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+
+    const result = buildRelationshipMultiWidgetBaseQueryVariables([selectionA, selectionB], config);
+
+    expect(result.operation).toBe('count');
+    expect(result.startDate).toBe(config.startDate);
+    expect(result.endDate).toBe(config.endDate);
+    expect(result.interval).toBe('day');
+    expect(result.timeSeriesParameters).toHaveLength(2);
+
+    // First selection
+    expect(result.timeSeriesParameters[0]).toStrictEqual({
+      field: 'created_at',
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'entity_type',
+            mode: 'or',
+            operator: 'eq',
+            values: ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'],
+          },
+        ],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: ['created_at'], values: ['2025-01-01T00:00:00Z'], operator: 'gt', mode: 'or' },
+              { key: ['created_at'], values: ['2025-06-01T00:00:00Z'], operator: 'lt', mode: 'or' },
+            ],
+            filterGroups: [{
+              mode: 'and',
+              filters: [{ key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' }],
+              filterGroups: [],
+            }],
+          },
+        ],
+      },
+      dynamicFrom: {
+        mode: 'and',
+        filters: [{ key: ['entity_type'], values: ['Indicator'], operator: 'eq', mode: 'or' }],
+        filterGroups: [],
+      },
+      dynamicTo: undefined,
+    });
+
+    // Second selection
+    expect(result.timeSeriesParameters[1]).toStrictEqual({
+      field: 'updated_at',
+      filters: {
+        mode: 'and',
+        filters: [
+          { key: ['entity_type'], values: ['Report'], operator: 'eq', mode: 'or' },
+          { key: ['updated_at'], values: ['2025-01-01T00:00:00Z'], operator: 'gt', mode: 'or' },
+          { key: ['updated_at'], values: ['2025-06-01T00:00:00Z'], operator: 'lt', mode: 'or' },
+        ],
+        filterGroups: [],
+      },
+      dynamicFrom: undefined,
+      dynamicTo: {
+        mode: 'and',
+        filters: [{ key: ['entity_type'], values: ['Campaign'], operator: 'eq', mode: 'or' }],
+        filterGroups: [],
+      },
+    });
+  });
+
+  it('uses custom interval from parameters', () => {
+    const selection: WidgetDataSelection = { date_attribute: 'created_at' };
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+    const parameters = { interval: 'month' };
+
+    const result = buildRelationshipMultiWidgetBaseQueryVariables([selection], config, parameters);
+
+    expect(result.interval).toBe('month');
+  });
+});
+
+describe('buildRelationshipSingleWidgetBaseQueryVariables', () => {
+  it('returns correct structure with dates, filters, dynamicFrom and dynamicTo', () => {
+    const selection: WidgetDataSelection = {
+      date_attribute: 'created_at',
+      filters: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Malware'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+      dynamicFrom: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Indicator'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+      dynamicTo: {
+        mode: 'and',
+        filters: [{
+          key: 'entity_type',
+          values: ['Campaign'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
+      },
+    };
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+
+    const result = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
+
+    expect(result).toStrictEqual({
+      startDate: '2025-01-01T00:00:00Z',
+      endDate: '2025-06-01T00:00:00Z',
+      dateAttribute: 'created_at',
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'entity_type',
+            mode: 'or',
+            operator: 'eq',
+            values: ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'],
+          },
+        ],
+        filterGroups: [
+          {
+            mode: 'and',
+            filters: [
+              { key: ['created_at'], values: ['2025-01-01T00:00:00Z'], operator: 'gt', mode: 'or' },
+              { key: ['created_at'], values: ['2025-06-01T00:00:00Z'], operator: 'lt', mode: 'or' },
+            ],
+            filterGroups: [{
+              mode: 'and',
+              filters: [{ key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' }],
+              filterGroups: [],
+            }],
+          },
+        ],
+      },
+      dynamicFrom: {
+        mode: 'and',
+        filters: [{ key: ['entity_type'], values: ['Indicator'], operator: 'eq', mode: 'or' }],
+        filterGroups: [],
+      },
+      dynamicTo: {
+        mode: 'and',
+        filters: [{ key: ['entity_type'], values: ['Campaign'], operator: 'eq', mode: 'or' }],
+        filterGroups: [],
+      },
+    });
+  });
+
+  it('returns undefined dynamicFrom and dynamicTo when not provided', () => {
+    const selection: WidgetDataSelection = { date_attribute: 'created_at' };
+    const config = { startDate: '2025-01-01T00:00:00Z', endDate: '2025-06-01T00:00:00Z' };
+
+    const result = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
+
+    expect(result.dynamicFrom).toBeUndefined();
+    expect(result.dynamicTo).toBeUndefined();
+  });
+
+  it('defaults dateAttribute to created_at when not specified', () => {
+    const selection: WidgetDataSelection = {};
+    const config = {};
+
+    const result = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
+
+    expect(result.dateAttribute).toBe('created_at');
   });
 });

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
@@ -740,7 +740,7 @@ describe('computeWidgetFiltersForMultiSelection', () => {
     expect(result.timeSeriesParameters[1].types).toStrictEqual(['Stix-Core-Object']);
     firstLevelFilterKeys = result.timeSeriesParameters[1].filters?.filters.map((f) => f.key).flat();
     expect(firstLevelFilterKeys).toContain('updated_at');
-    secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups;
+    secondLevelFilters = result.timeSeriesParameters[1].filters?.filterGroups;
     expect(secondLevelFilters).toEqual([{
       mode: 'and',
       filters: [{

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
@@ -728,7 +728,7 @@ describe('computeWidgetFiltersForMultiSelection', () => {
       mode: 'and',
       filters: [{
         key: ['entity_type'],
-        values: ['Report'],
+        values: ['Malware'],
         operator: 'eq',
         mode: 'or',
       }],

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
@@ -560,8 +560,8 @@ describe('computeStartEndDates', () => {
       };
       const { startDate, endDate } = computeStartEndDates(config);
       // relativeDate should override absolute dates
-      expect(startDate).toBe('2025-03-08T10:30:00.000Z');
-      expect(endDate).toBe('2025-03-15T10:30:00.000Z');
+      expect(startDate).toBe('2025-03-08T10:30:00+00:00');
+      expect(endDate).toBe('2025-03-15T10:30:00+00:00');
     } finally {
       vi.useRealTimers();
     }
@@ -644,10 +644,14 @@ describe('computeWidgetFiltersForSelection', () => {
         },
       ],
       filterGroups: [{
-        key: ['entity_type'],
-        values: ['Malware'],
-        operator: 'eq',
-        mode: 'or',
+        mode: 'and',
+        filters: [{
+          key: ['entity_type'],
+          values: ['Malware'],
+          operator: 'eq',
+          mode: 'or',
+        }],
+        filterGroups: [],
       }],
     });
   });
@@ -719,25 +723,8 @@ describe('computeWidgetFiltersForMultiSelection', () => {
     expect(result.timeSeriesParameters[0].types).toStrictEqual(['Stix-Core-Object']);
     let firstLevelFilterKeys = result.timeSeriesParameters[0].filters?.filters.map((f) => f.key).flat();
     expect(firstLevelFilterKeys).toContain('created_at');
-    let secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups[0].filters;
-    expect(secondLevelFilters).toEqual({
-      mode: 'and',
-      filters: [{
-        key: ['entity_type'],
-        values: ['Malware'],
-        operator: 'eq',
-        mode: 'or',
-      }],
-      filterGroups: [],
-    });
-
-    // Second selection: updated_at + Report filter + date filters
-    expect(result.timeSeriesParameters[1].field).toBe('updated_at');
-    expect(result.timeSeriesParameters[1].types).toStrictEqual(['Stix-Core-Object']);
-    firstLevelFilterKeys = result.timeSeriesParameters[1].filters?.filters.map((f) => f.key).flat();
-    expect(firstLevelFilterKeys).toContain('updated_at');
-    secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups[0].filters;
-    expect(secondLevelFilters).toEqual({
+    let secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups;
+    expect(secondLevelFilters).toEqual([{
       mode: 'and',
       filters: [{
         key: ['entity_type'],
@@ -746,7 +733,24 @@ describe('computeWidgetFiltersForMultiSelection', () => {
         mode: 'or',
       }],
       filterGroups: [],
-    });
+    }]);
+
+    // Second selection: updated_at + Report filter + date filters
+    expect(result.timeSeriesParameters[1].field).toBe('updated_at');
+    expect(result.timeSeriesParameters[1].types).toStrictEqual(['Stix-Core-Object']);
+    firstLevelFilterKeys = result.timeSeriesParameters[1].filters?.filters.map((f) => f.key).flat();
+    expect(firstLevelFilterKeys).toContain('updated_at');
+    secondLevelFilters = result.timeSeriesParameters[0].filters?.filterGroups;
+    expect(secondLevelFilters).toEqual([{
+      mode: 'and',
+      filters: [{
+        key: ['entity_type'],
+        values: ['Report'],
+        operator: 'eq',
+        mode: 'or',
+      }],
+      filterGroups: [],
+    }]);
   });
 });
 
@@ -815,7 +819,7 @@ describe('buildRelationshipMultiWidgetBaseQueryVariables', () => {
         mode: 'and',
         filters: [
           {
-            key: 'entity_type',
+            key: ['entity_type'],
             mode: 'or',
             operator: 'eq',
             values: ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'],
@@ -850,11 +854,25 @@ describe('buildRelationshipMultiWidgetBaseQueryVariables', () => {
       filters: {
         mode: 'and',
         filters: [
-          { key: ['entity_type'], values: ['Report'], operator: 'eq', mode: 'or' },
-          { key: ['updated_at'], values: ['2025-01-01T00:00:00Z'], operator: 'gt', mode: 'or' },
-          { key: ['updated_at'], values: ['2025-06-01T00:00:00Z'], operator: 'lt', mode: 'or' },
+          {
+            key: ['entity_type'],
+            mode: 'or',
+            operator: 'eq',
+            values: ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'],
+          },
         ],
-        filterGroups: [],
+        filterGroups: [{
+          mode: 'and',
+          filters: [
+            { key: ['updated_at'], values: ['2025-01-01T00:00:00Z'], operator: 'gt', mode: 'or' },
+            { key: ['updated_at'], values: ['2025-06-01T00:00:00Z'], operator: 'lt', mode: 'or' },
+          ],
+          filterGroups: [{
+            mode: 'and',
+            filters: [{ key: ['entity_type'], values: ['Report'], operator: 'eq', mode: 'or' }],
+            filterGroups: [],
+          }],
+        }],
       },
       dynamicFrom: undefined,
       dynamicTo: {
@@ -923,7 +941,7 @@ describe('buildRelationshipSingleWidgetBaseQueryVariables', () => {
         mode: 'and',
         filters: [
           {
-            key: 'entity_type',
+            key: ['entity_type'],
             mode: 'or',
             operator: 'eq',
             values: ['stix-core-relationship', 'stix-sighting-relationship', 'object', 'object-label'],

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.test.ts
@@ -560,8 +560,9 @@ describe('computeStartEndDates', () => {
       };
       const { startDate, endDate } = computeStartEndDates(config);
       // relativeDate should override absolute dates
-      expect(startDate).toBe('2025-03-08T10:30:00+00:00');
-      expect(endDate).toBe('2025-03-15T10:30:00+00:00');
+      expect(new Date(startDate as string).toISOString()) // convert to ISO so this assertion does not depend on the local timezone
+        .toBe('2025-03-08T10:30:00.000Z');
+      expect(new Date(endDate as string).toISOString()).toBe('2025-03-15T10:30:00.000Z');
     } finally {
       vi.useRealTimers();
     }

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
@@ -119,6 +119,35 @@ export const computeStartEndDates = (config?: DashboardConfig) => {
 };
 
 /**
+ * Resolves the dateAttribute, computes start/end dates from the dashboard config,
+ * and builds the widget filters for a single data selection.
+ *
+ * This is the low-level building block used by higher-level helpers and by widgets
+ * that need to customise the returned query variables beyond the common pattern.
+ */
+export const computeWidgetFiltersForSelection = (
+  selection?: WidgetDataSelection,
+  config?: DashboardConfig,
+  opts: { isKnowledgeRelationshipWidget?: boolean } = {},
+) => {
+  const dateAttribute = selection?.date_attribute?.length
+    ? selection.date_attribute
+    : 'created_at';
+  const { startDate, endDate } = computeStartEndDates(config);
+  const { filters } = buildFiltersAndOptionsForWidgets(
+    selection?.filters,
+    {
+      startDate,
+      endDate,
+      dateAttribute,
+      isKnowledgeRelationshipWidget: opts.isKnowledgeRelationshipWidget ?? false,
+    },
+  );
+
+  return { dateAttribute, startDate, endDate, filters: normalizeFilterGroupForBackend(filters) };
+};
+
+/**
  * Builds the common base query variables for relationship widgets supporting multiple data selection.
  * Computes start/end dates from config, resolves dateAttribute,
  * builds and normalizes filters (including dynamicFrom/dynamicTo).
@@ -132,25 +161,16 @@ export const buildRelationshipMultiWidgetBaseQueryVariables = (
 ) => {
   const fallbackStart = monthsAgo(12);
   const fallbackEnd = now();
-  const computed = computeStartEndDates(config);
-  const startDate = computed.startDate ?? fallbackStart;
-  const endDate = computed.endDate ?? fallbackEnd;
+  const { startDate: computedStart, endDate: computedEnd } = computeStartEndDates(config);
+  const startDate = computedStart ?? fallbackStart;
+  const endDate = computedEnd ?? fallbackEnd;
 
   const timeSeriesParameters = dataSelection.map((selection) => {
-    const dateAttribute = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(selection.filters,
-      {
-        startDate,
-        endDate,
-        dateAttribute,
-        isKnowledgeRelationshipWidget: true,
-      });
+    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config, { isKnowledgeRelationshipWidget: true });
 
     return {
       field: dateAttribute,
-      filters: normalizeFilterGroupForBackend(filters),
+      filters,
       dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
       dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
@@ -177,25 +197,13 @@ export const buildRelationshipSingleWidgetBaseQueryVariables = (
   selection: WidgetDataSelection,
   config: DashboardConfig,
 ) => {
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    {
-      startDate,
-      endDate,
-      dateAttribute,
-      isKnowledgeRelationshipWidget: true,
-    },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config, { isKnowledgeRelationshipWidget: true });
 
   return {
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
     dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
@@ -112,8 +112,6 @@ export const resolveDataSelection = async ({
  * If no dates are configured and `fallbackToDefaultDates` is true, falls back to the last 12 months.
  */
 export const computeStartEndDates = (config?: DashboardConfig, fallbackToDefaultDates = false) => {
-  const fallbackStartDate = fallbackToDefaultDates ? monthsAgo(12) : undefined;
-  const fallbackEndDate = fallbackToDefaultDates ? now() : undefined;
   const startDate = config?.relativeDate
     ? computeRelativeDate(config.relativeDate)
     : config?.startDate;
@@ -122,10 +120,12 @@ export const computeStartEndDates = (config?: DashboardConfig, fallbackToDefault
     ? formatDate(dayStartDate(null, false))
     : config?.endDate;
 
-  return {
-    startDate: startDate ?? fallbackStartDate,
-    endDate: endDate ?? fallbackEndDate,
-  };
+  return fallbackToDefaultDates
+    ? {
+        startDate: startDate ?? monthsAgo(12),
+        endDate: endDate ?? now(),
+      }
+    : { startDate, endDate };
 };
 
 /**

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
@@ -1,11 +1,18 @@
-import type { WidgetHost, WidgetDataSelection, WidgetPerspective } from 'src/utils/widget/widget';
+import { WidgetDataSelection, WidgetHost, WidgetParameters, WidgetPerspective } from 'src/utils/widget/widget';
 import { graphql } from 'react-relay';
-import { buildFiltersForCustomView, removeIdAndIncorrectKeysFromFilterGroupObject, getAvailableFilterKeysForEntityTypes } from 'src/utils/filters/filtersUtils';
+import {
+  buildFiltersAndOptionsForWidgets,
+  buildFiltersForCustomView,
+  getAvailableFilterKeysForEntityTypes,
+  normalizeFilterGroupForBackend,
+  removeIdAndIncorrectKeysFromFilterGroupObject,
+} from 'src/utils/filters/filtersUtils';
 import { type FilterDefinition } from 'src/utils/hooks/useAuth';
-import { computeRelativeDate, dayStartDate, formatDate } from 'src/utils/Time';
+import { computeRelativeDate, dayStartDate, formatDate, monthsAgo, now } from 'src/utils/Time';
 import { fetchQuery } from 'src/relay/environment';
 import { DashboardConfig } from './dashboard-types';
 import { dashboardVizUtilsSavedFilterQuery$data } from './__generated__/dashboardVizUtilsSavedFilterQuery.graphql';
+import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 export const savedFilterQuery = graphql`
   query dashboardVizUtilsSavedFilterQuery($id: ID!) {
@@ -109,4 +116,87 @@ export const computeStartEndDates = (config?: DashboardConfig) => {
     : config?.endDate;
 
   return { startDate, endDate };
+};
+
+/**
+ * Builds the common base query variables for relationship widgets supporting multiple data selection.
+ * Computes start/end dates from config, resolves dateAttribute,
+ * builds and normalizes filters (including dynamicFrom/dynamicTo).
+ *
+ * Each widget can destructure the result and add its own specific fields.
+ */
+export const buildRelationshipMultiWidgetBaseQueryVariables = (
+  dataSelection: WidgetDataSelection[],
+  config: DashboardConfig,
+  parameters?: WidgetParameters,
+) => {
+  const fallbackStart = monthsAgo(12);
+  const fallbackEnd = now();
+  const computed = computeStartEndDates(config);
+  const startDate = computed.startDate ?? fallbackStart;
+  const endDate = computed.endDate ?? fallbackEnd;
+
+  const timeSeriesParameters = dataSelection.map((selection) => {
+    const dateAttribute = selection.date_attribute?.length
+      ? selection.date_attribute
+      : 'created_at';
+    const { filters } = buildFiltersAndOptionsForWidgets(selection.filters,
+      {
+        startDate,
+        endDate,
+        dateAttribute,
+        isKnowledgeRelationshipWidget: true,
+      });
+
+    return {
+      field: dateAttribute,
+      filters: normalizeFilterGroupForBackend(filters),
+      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    };
+  });
+
+  return {
+    operation: 'count',
+    startDate,
+    endDate,
+    interval: getWidgetInterval(parameters),
+    timeSeriesParameters,
+  };
+};
+
+/**
+ * Builds the common base query variables for relationship widgets using a single data selection.
+ * Computes start/end dates from config, resolves dateAttribute,
+ * builds and normalizes filters (including dynamicFrom/dynamicTo),
+ * and provides default ordering and pagination.
+ *
+ * Used by widgets like Timeline, Number, etc. that operate on a single selection.
+ */
+export const buildRelationshipSingleWidgetBaseQueryVariables = (
+  selection: WidgetDataSelection,
+  config: DashboardConfig,
+) => {
+  const dateAttribute = selection.date_attribute?.length
+    ? selection.date_attribute
+    : 'created_at';
+  const { startDate, endDate } = computeStartEndDates(config);
+  const { filters } = buildFiltersAndOptionsForWidgets(
+    selection.filters,
+    {
+      startDate,
+      endDate,
+      dateAttribute,
+      isKnowledgeRelationshipWidget: true,
+    },
+  );
+
+  return {
+    startDate,
+    endDate,
+    dateAttribute,
+    filters: normalizeFilterGroupForBackend(filters),
+    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
+    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+  };
 };

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
@@ -157,7 +157,12 @@ export const computeWidgetFiltersForSelection = (
     },
   );
 
-  return { dateAttribute, startDate, endDate, filters: normalizeFilterGroupForBackend(filters) };
+  return {
+    dateAttribute,
+    startDate,
+    endDate,
+    filters: normalizeFilterGroupForBackend(filters),
+  };
 };
 
 /**

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
@@ -167,18 +167,18 @@ export const computeWidgetFiltersForSelection = (
 export const computeWidgetFiltersForMultiSelection = (
   dataSelection: WidgetDataSelection[],
   config: DashboardConfig,
+  types: string[],
   opts: {
-    types?: string[];
     isKnowledgeRelationshipWidget?: boolean;
     fallbackToDefaultDates?: boolean;
   } = {},
 ) => {
   const { startDate, endDate } = computeStartEndDates(config, opts.fallbackToDefaultDates);
   const timeSeriesParameters = dataSelection.map((selection) => {
-    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
+    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config, opts);
     return {
       field: dateAttribute,
-      types: opts?.types,
+      types,
       filters,
     };
   });
@@ -201,6 +201,7 @@ export const buildRelationshipMultiWidgetBaseQueryVariables = (
     isKnowledgeRelationshipWidget: true,
     fallbackToDefaultDates: true,
   };
+  const { startDate, endDate } = computeStartEndDates(config, opts.fallbackToDefaultDates);
 
   const timeSeriesParameters = dataSelection.map((selection) => {
     const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config, opts);
@@ -212,8 +213,6 @@ export const buildRelationshipMultiWidgetBaseQueryVariables = (
       dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
   });
-
-  const { startDate, endDate } = computeWidgetFiltersForSelection(dataSelection[0], config, opts);
 
   return {
     operation: 'count',

--- a/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
+++ b/opencti-platform/opencti-front/src/components/dashboard/dashboardVizUtils.ts
@@ -106,7 +106,14 @@ export const resolveDataSelection = async ({
   };
 };
 
-export const computeStartEndDates = (config?: DashboardConfig) => {
+/**
+ * Computes the start and end dates from the dashboard config.
+ * Handles relative dates (e.g. "last 7 days") and absolute dates.
+ * If no dates are configured and `fallbackToDefaultDates` is true, falls back to the last 12 months.
+ */
+export const computeStartEndDates = (config?: DashboardConfig, fallbackToDefaultDates = false) => {
+  const fallbackStartDate = fallbackToDefaultDates ? monthsAgo(12) : undefined;
+  const fallbackEndDate = fallbackToDefaultDates ? now() : undefined;
   const startDate = config?.relativeDate
     ? computeRelativeDate(config.relativeDate)
     : config?.startDate;
@@ -115,7 +122,10 @@ export const computeStartEndDates = (config?: DashboardConfig) => {
     ? formatDate(dayStartDate(null, false))
     : config?.endDate;
 
-  return { startDate, endDate };
+  return {
+    startDate: startDate ?? fallbackStartDate,
+    endDate: endDate ?? fallbackEndDate,
+  };
 };
 
 /**
@@ -123,28 +133,56 @@ export const computeStartEndDates = (config?: DashboardConfig) => {
  * and builds the widget filters for a single data selection.
  *
  * This is the low-level building block used by higher-level helpers and by widgets
- * that need to customise the returned query variables beyond the common pattern.
+ * that need to customize the returned query variables beyond the common pattern.
  */
 export const computeWidgetFiltersForSelection = (
   selection?: WidgetDataSelection,
   config?: DashboardConfig,
-  opts: { isKnowledgeRelationshipWidget?: boolean } = {},
+  opts: {
+    isKnowledgeRelationshipWidget?: boolean;
+    fallbackToDefaultDates?: boolean;
+  } = {},
 ) => {
   const dateAttribute = selection?.date_attribute?.length
     ? selection.date_attribute
     : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
+  const { startDate, endDate } = computeStartEndDates(config, opts.fallbackToDefaultDates);
   const { filters } = buildFiltersAndOptionsForWidgets(
     selection?.filters,
     {
       startDate,
       endDate,
       dateAttribute,
-      isKnowledgeRelationshipWidget: opts.isKnowledgeRelationshipWidget ?? false,
+      isKnowledgeRelationshipWidget: opts.isKnowledgeRelationshipWidget ?? undefined,
     },
   );
 
   return { dateAttribute, startDate, endDate, filters: normalizeFilterGroupForBackend(filters) };
+};
+
+/**
+ * Resolves the dateAttribute, computes start/end dates from the dashboard config,
+ * and builds the widget filters for a multiple data selection.
+ */
+export const computeWidgetFiltersForMultiSelection = (
+  dataSelection: WidgetDataSelection[],
+  config: DashboardConfig,
+  opts: {
+    types?: string[];
+    isKnowledgeRelationshipWidget?: boolean;
+    fallbackToDefaultDates?: boolean;
+  } = {},
+) => {
+  const { startDate, endDate } = computeStartEndDates(config, opts.fallbackToDefaultDates);
+  const timeSeriesParameters = dataSelection.map((selection) => {
+    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
+    return {
+      field: dateAttribute,
+      types: opts?.types,
+      filters,
+    };
+  });
+  return { startDate, endDate, timeSeriesParameters };
 };
 
 /**
@@ -159,14 +197,13 @@ export const buildRelationshipMultiWidgetBaseQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ) => {
-  const fallbackStart = monthsAgo(12);
-  const fallbackEnd = now();
-  const { startDate: computedStart, endDate: computedEnd } = computeStartEndDates(config);
-  const startDate = computedStart ?? fallbackStart;
-  const endDate = computedEnd ?? fallbackEnd;
+  const opts = {
+    isKnowledgeRelationshipWidget: true,
+    fallbackToDefaultDates: true,
+  };
 
   const timeSeriesParameters = dataSelection.map((selection) => {
-    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config, { isKnowledgeRelationshipWidget: true });
+    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config, opts);
 
     return {
       field: dateAttribute,
@@ -175,6 +212,8 @@ export const buildRelationshipMultiWidgetBaseQueryVariables = (
       dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
     };
   });
+
+  const { startDate, endDate } = computeWidgetFiltersForSelection(dataSelection[0], config, opts);
 
   return {
     operation: 'count',

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDistributionList.tsx
@@ -6,8 +6,7 @@ import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDistributionList from '../../../../components/dashboard/WidgetDistributionList';
 import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/defaultRepresentatives';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
@@ -118,21 +117,14 @@ interface DraftsDistributionListProps {
 
 const buildQueryVariables = (resolvedDataSelection: WidgetDataSelection[], config: DashboardConfig): DraftsDistributionListQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count' as DraftsDistributionListQuery['variables']['operation'],
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsDonut.tsx
@@ -5,11 +5,10 @@ import { useFormatter } from '../../../../components/i18n';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDonut from '../../../../components/dashboard/WidgetDonut';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import type { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DraftsDonutDistributionQuery } from './__generated__/DraftsDonutDistributionQuery.graphql';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from 'src/utils/filters/filtersUtils';
 import useDashboardViz from 'src/components/dashboard/useDashboardViz';
 import WidgetRenderContent from 'src/components/dashboard/WidgetRenderContent';
 
@@ -104,22 +103,14 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): DraftsDonutDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute && selection.date_attribute.length > 0
-      ? selection.date_attribute
-      : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsHorizontalBars.tsx
@@ -5,8 +5,7 @@ import { useFormatter } from '../../../../components/i18n';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetHorizontalBars from '../../../../components/dashboard/WidgetHorizontalBars';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import useDistributionGraphData from '../../../../utils/hooks/useDistributionGraphData';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
@@ -121,21 +120,14 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): DraftsHorizontalBarsDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsList.tsx
@@ -1,8 +1,7 @@
 import React, { CSSProperties, ReactNode, useRef } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
@@ -88,22 +87,15 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): DraftsListQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = computeStartEndDates(config);
   const orderBy = (selection.sort_by && selection.sort_by.length > 0
     ? selection.sort_by
     : 'created_at') as DraftsListQuery['variables']['orderBy'];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     first: selection.number ?? 10,
     orderBy,
     orderMode: (selection.sort_mode ?? 'desc') as DraftsListQuery['variables']['orderMode'],
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../../../components/dashboard/WidgetRenderContent', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeStartEndDates: () => ({ startDate: null, endDate: null }),
+  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
 }));
 
 vi.mock('../../../../utils/hooks/useGranted', () => ({

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.test.tsx
@@ -42,7 +42,15 @@ vi.mock('../../../../components/dashboard/WidgetRenderContent', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
+  computeWidgetFiltersForSelection: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _selection: any, _config: any,
+    opts: { fallbackToDefaultDates?: boolean } = {},
+  ) => ({
+    startDate: opts.fallbackToDefaultDates ? '2024-01-01T00:00:00.000Z' : null,
+    endDate: opts.fallbackToDefaultDates ? '2025-01-01T00:00:00.000Z' : null,
+    timeSeriesParameters: [],
+  }),
 }));
 
 vi.mock('../../../../utils/hooks/useGranted', () => ({

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.tsx
@@ -1,8 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { monthsAgo, now } from '../../../../utils/Time';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
@@ -94,20 +93,17 @@ const buildQueryVariables = (
   parameters?: WidgetParameters,
 ): DraftsMultiAreaChartTimeSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
   const { startDate: rawStartDate, endDate: rawEndDate } = computeStartEndDates(config);
   const startDate = rawStartDate ?? monthsAgo(12);
   const endDate = rawEndDate ?? now();
-  const { filters } = buildFiltersAndOptionsForWidgets(selection.filters);
+  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     field: dateAttribute,
     operation: 'count',
     startDate,
     endDate,
     interval: getWidgetInterval(parameters),
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiAreaChart.tsx
@@ -1,8 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
-import { monthsAgo, now } from '../../../../utils/Time';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
@@ -93,10 +92,11 @@ const buildQueryVariables = (
   parameters?: WidgetParameters,
 ): DraftsMultiAreaChartTimeSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate: rawStartDate, endDate: rawEndDate } = computeStartEndDates(config);
-  const startDate = rawStartDate ?? monthsAgo(12);
-  const endDate = rawEndDate ?? now();
-  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(
+    selection,
+    config,
+    { fallbackToDefaultDates: true },
+  );
   return {
     field: dateAttribute,
     operation: 'count',

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../../../components/dashboard/WidgetRenderContent', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeStartEndDates: () => ({ startDate: null, endDate: null }),
+  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
 }));
 
 vi.mock('../../../../utils/hooks/useGranted', () => ({

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.test.tsx
@@ -42,7 +42,15 @@ vi.mock('../../../../components/dashboard/WidgetRenderContent', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
+  computeWidgetFiltersForSelection: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _selection: any, _config: any,
+    opts: { fallbackToDefaultDates?: boolean } = {},
+  ) => ({
+    startDate: opts.fallbackToDefaultDates ? '2024-01-01T00:00:00.000Z' : null,
+    endDate: opts.fallbackToDefaultDates ? '2025-01-01T00:00:00.000Z' : null,
+    timeSeriesParameters: [],
+  }),
 }));
 
 vi.mock('../../../../utils/hooks/useGranted', () => ({

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.tsx
@@ -1,8 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
-import { monthsAgo, now } from '../../../../utils/Time';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
@@ -92,10 +91,11 @@ const buildQueryVariables = (
   parameters?: WidgetParameters,
 ): DraftsMultiLineChartTimeSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate: rawStartDate, endDate: rawEndDate } = computeStartEndDates(config);
-  const startDate = rawStartDate ?? monthsAgo(12);
-  const endDate = rawEndDate ?? now();
-  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(
+    selection,
+    config,
+    { fallbackToDefaultDates: true },
+  );
   return {
     field: dateAttribute,
     operation: 'count',

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiLineChart.tsx
@@ -1,8 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { monthsAgo, now } from '../../../../utils/Time';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
@@ -93,20 +92,17 @@ const buildQueryVariables = (
   parameters?: WidgetParameters,
 ): DraftsMultiLineChartTimeSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
   const { startDate: rawStartDate, endDate: rawEndDate } = computeStartEndDates(config);
   const startDate = rawStartDate ?? monthsAgo(12);
   const endDate = rawEndDate ?? now();
-  const { filters } = buildFiltersAndOptionsForWidgets(selection.filters);
+  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     field: dateAttribute,
     operation: 'count',
     startDate,
     endDate,
     interval: getWidgetInterval(parameters),
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.test.tsx
@@ -42,7 +42,7 @@ vi.mock('../../../../components/dashboard/WidgetRenderContent', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeStartEndDates: () => ({ startDate: null, endDate: null }),
+  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
 }));
 
 vi.mock('../../../../utils/hooks/useGranted', () => ({

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.test.tsx
@@ -42,7 +42,15 @@ vi.mock('../../../../components/dashboard/WidgetRenderContent', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
+  computeWidgetFiltersForSelection: (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _selection: any, _config: any,
+    opts: { fallbackToDefaultDates?: boolean } = {},
+  ) => ({
+    startDate: opts.fallbackToDefaultDates ? '2024-01-01T00:00:00.000Z' : null,
+    endDate: opts.fallbackToDefaultDates ? '2025-01-01T00:00:00.000Z' : null,
+    timeSeriesParameters: [],
+  }),
 }));
 
 vi.mock('../../../../utils/hooks/useGranted', () => ({

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.tsx
@@ -1,9 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
-import { monthsAgo, now } from '../../../../utils/Time';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
@@ -94,10 +92,11 @@ const buildQueryVariables = (
   parameters?: WidgetParameters,
 ): DraftsMultiVerticalBarsTimeSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate: rawStartDate, endDate: rawEndDate } = computeStartEndDates(config);
-  const startDate = rawStartDate ?? monthsAgo(12);
-  const endDate = rawEndDate ?? now();
-  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(
+    selection,
+    config,
+    { fallbackToDefaultDates: true },
+  );
   return {
     field: dateAttribute,
     operation: 'count',

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsMultiVerticalBars.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { monthsAgo, now } from '../../../../utils/Time';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
@@ -94,20 +94,17 @@ const buildQueryVariables = (
   parameters?: WidgetParameters,
 ): DraftsMultiVerticalBarsTimeSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
   const { startDate: rawStartDate, endDate: rawEndDate } = computeStartEndDates(config);
   const startDate = rawStartDate ?? monthsAgo(12);
   const endDate = rawEndDate ?? now();
-  const { filters } = buildFiltersAndOptionsForWidgets(selection.filters);
+  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     field: dateAttribute,
     operation: 'count',
     startDate,
     endDate,
     interval: getWidgetInterval(parameters),
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
@@ -2,8 +2,8 @@ import { CSSProperties, ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
@@ -40,17 +40,10 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): DraftsNumberQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate } = computeStartEndDates(config);
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     startDate,
     endDate: dayAgo(),
   };

--- a/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drafts/DraftsNumber.tsx
@@ -2,7 +2,6 @@ import { CSSProperties, ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
-import { normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDistributionList.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDistributionList from '../../../../components/dashboard/WidgetDistributionList';
@@ -12,7 +11,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import type { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { StixCoreObjectsDistributionListDistributionQuery } from './__generated__/StixCoreObjectsDistributionListDistributionQuery.graphql';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsDistributionListDistributionQuery = graphql`
   query StixCoreObjectsDistributionListDistributionQuery(
@@ -147,22 +146,15 @@ const DATA_SELECTION_TYPES = ['Stix-Core-Object'];
 
 const buildQueryVariables = (resolvedDataSelection: WidgetDataSelection[], config: DashboardConfig) => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     types: DATA_SELECTION_TYPES,
     field: selection.attribute ?? 'entity_type',
     operation: 'count' as StixCoreObjectsDistributionListDistributionQuery['variables']['operation'],
-    startDate: config?.startDate,
-    endDate: config?.endDate,
+    startDate,
+    endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsDonut.tsx
@@ -9,8 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixCoreObjectsDonutDistributionQuery } from './__generated__/StixCoreObjectsDonutDistributionQuery.graphql';
 import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsDonutDistributionQuery = graphql`
   query StixCoreObjectsDonutDistributionQuery(
@@ -136,14 +135,9 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixCoreObjectsDonutDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute && selection.date_attribute.length > 0
-      ? selection.date_attribute
-      : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
+  const { startDate, endDate, dateAttribute, filters } = computeWidgetFiltersForSelection(
+    selection,
+    config,
   );
   return {
     types: DATA_SELECTION_TYPES,
@@ -152,7 +146,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsHorizontalBars.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetHorizontalBars from '../../../../components/dashboard/WidgetHorizontalBars';
@@ -11,7 +10,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixCoreObjectsHorizontalBarsDistributionQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsHorizontalBarsDistributionQuery.graphql';
 import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsHorizontalBarsDistributionQuery = graphql`
     query StixCoreObjectsHorizontalBarsDistributionQuery(
@@ -154,17 +153,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixCoreObjectsHorizontalBarsDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-
-  const { startDate, endDate } = computeStartEndDates(config);
-
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
 
   return {
     types: DATA_SELECTION_TYPES,
@@ -173,7 +162,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsList.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useRef } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { getDefaultWidgetColumns } from '../../widgets/WidgetListsDefaultColumns';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetListCoreObjects from '../../../../components/dashboard/WidgetListCoreObjects';
@@ -11,7 +10,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import type { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { OrderingMode, StixCoreObjectsListQuery, StixCoreObjectsOrdering } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsListQuery.graphql';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 export const stixCoreObjectsListQuery = graphql`
   query StixCoreObjectsListQuery(
@@ -468,22 +467,15 @@ const buildQueryVariables = (resolvedDataSelection: WidgetDataSelection[], confi
   const orderBy = (selection.sort_by && selection.sort_by.length > 0
     ? selection.sort_by
     : 'created_at') as StixCoreObjectsOrdering | null | undefined;
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
   const first = selection.number ?? 10;
   const orderMode = (selection.sort_mode ?? 'asc') as OrderingMode;
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     types: DATA_SELECTION_TYPES,
     first,
     orderBy,
     orderMode,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
@@ -102,7 +102,8 @@ const buildQueryVariables = (
   const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(
     resolvedDataSelection,
     config,
-    { types: DATA_SELECTION_TYPES, fallbackToDefaultDates: true },
+    DATA_SELECTION_TYPES,
+    { fallbackToDefaultDates: true },
   );
   return {
     startDate,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiAreaChart.tsx
@@ -1,8 +1,6 @@
 import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas';
@@ -11,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiAreaChartTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiAreaChartTimeSeriesQuery.graphql';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForMultiSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiAreaChartTimeSeriesQuery = graphql`
@@ -101,24 +99,11 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixCoreObjectsMultiAreaChartTimeSeriesQuery['variables'] => {
-  const computed = computeStartEndDates(config);
-  const startDate = computed.startDate ?? monthsAgo(12);
-  const endDate = computed.endDate ?? now();
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute && selection.date_attribute.length > 0
-        ? selection.date_attribute
-        : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(
-      selection.filters,
-      { startDate, endDate, dateAttribute },
-    );
-    return {
-      field: dateAttribute,
-      types: DATA_SELECTION_TYPES,
-      filters: normalizeFilterGroupForBackend(filters),
-    };
-  });
+  const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(
+    resolvedDataSelection,
+    config,
+    { types: DATA_SELECTION_TYPES, fallbackToDefaultDates: true },
+  );
   return {
     startDate,
     endDate,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHeatMap.tsx
@@ -8,11 +8,9 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
-import { monthsAgo, now } from '../../../../utils/Time';
+import { computeWidgetFiltersForMultiSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import ApexCharts from 'apexcharts';
 import { StixCoreObjectsMultiHeatMapTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiHeatMapTimeSeriesQuery.graphql';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiHeatMapTimeSeriesQuery = graphql`
@@ -103,23 +101,10 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixCoreObjectsMultiHeatMapTimeSeriesQuery['variables'] => {
-  const { startDate, endDate } = computeStartEndDates(config);
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute?.length
-        ? selection.date_attribute
-        : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(selection.filters);
-    return {
-      field: dateAttribute,
-      types: DATA_SELECTION_TYPES,
-      filters: normalizeFilterGroupForBackend(filters),
-    };
-  });
-
+  const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(resolvedDataSelection, config, DATA_SELECTION_TYPES, { fallbackToDefaultDates: true });
   return {
-    startDate: startDate ?? monthsAgo(12),
-    endDate: endDate ?? now(),
+    startDate,
+    endDate,
     interval: getWidgetInterval(parameters),
     timeSeriesParameters,
   };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiHorizontalBars.tsx
@@ -7,7 +7,6 @@ import { horizontalBarsChartOptions } from '../../../../utils/Charts';
 import { simpleNumberFormat } from '../../../../utils/Number';
 import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/defaultRepresentatives';
 import { itemColor } from '../../../../utils/Colors';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
@@ -18,7 +17,7 @@ import {
 import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { ReactNode } from 'react';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { ApexOptions } from 'apexcharts';
 
 const stixCoreObjectsMultiHorizontalBarsDistributionQuery = graphql`
@@ -492,29 +491,11 @@ const buildQueryVariables = (
   const selection = resolvedDataSelection[0];
   const subSelection = resolvedDataSelection[1];
 
-  const { startDate, endDate } = computeStartEndDates(config);
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
 
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-
-  const subDateAttribute = subSelection?.date_attribute?.length
-    ? subSelection.date_attribute
-    : 'created_at';
-
-  const { filters } = buildFiltersAndOptionsForWidgets(selection.filters, {
-    startDate,
-    endDate,
-    dateAttribute,
-  });
-
-  const { filters: subFilters } = buildFiltersAndOptionsForWidgets(
-    subSelection?.filters,
-    {
-      startDate,
-      endDate,
-      dateAttribute: subDateAttribute,
-    },
+  const { dateAttribute: subDateAttribute, filters: subFilters } = computeWidgetFiltersForSelection(
+    subSelection,
+    config,
   );
 
   return {
@@ -524,7 +505,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
     subDistributionField: subSelection?.attribute ?? 'entity_type',
     subDistributionOperation: 'count',
@@ -532,7 +513,7 @@ const buildQueryVariables = (
     subDistributionEndDate: endDate,
     subDistributionDateAttribute: subDateAttribute,
     subDistributionTypes: DATA_SELECTION_TYPES,
-    subDistributionFilters: normalizeFilterGroupForBackend(subFilters),
+    subDistributionFilters: subFilters,
     subDistributionLimit: subSelection?.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -99,7 +99,8 @@ const buildQueryVariables = (
   const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(
     resolvedDataSelection,
     config,
-    { types: DATA_SELECTION_TYPES, fallbackToDefaultDates: true },
+    DATA_SELECTION_TYPES,
+    { fallbackToDefaultDates: true },
   );
   return {
     startDate,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { monthsAgo, now } from '../../../../utils/Time';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiLineChartTimeSeriesQuery } from './__generated__/StixCoreObjectsMultiLineChartTimeSeriesQuery.graphql';
-import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForMultiSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiLineChartTimeSeriesQuery = graphql`
@@ -97,17 +96,11 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixCoreObjectsMultiLineChartTimeSeriesQuery['variables'] => {
-  const computed = computeStartEndDates(config);
-  const startDate = computed.startDate ?? monthsAgo(12);
-  const endDate = computed.endDate ?? now();
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
-    return {
-      field: dateAttribute,
-      types: DATA_SELECTION_TYPES,
-      filters,
-    };
-  });
+  const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(
+    resolvedDataSelection,
+    config,
+    { types: DATA_SELECTION_TYPES, fallbackToDefaultDates: true },
+  );
   return {
     startDate,
     endDate,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiLineChart.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines';
@@ -11,7 +10,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { StixCoreObjectsMultiLineChartTimeSeriesQuery } from './__generated__/StixCoreObjectsMultiLineChartTimeSeriesQuery.graphql';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiLineChartTimeSeriesQuery = graphql`
@@ -102,18 +101,11 @@ const buildQueryVariables = (
   const startDate = computed.startDate ?? monthsAgo(12);
   const endDate = computed.endDate ?? now();
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute && selection.date_attribute.length > 0
-        ? selection.date_attribute
-        : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(
-      selection.filters,
-      { startDate, endDate, dateAttribute },
-    );
+    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
     return {
       field: dateAttribute,
       types: DATA_SELECTION_TYPES,
-      filters: normalizeFilterGroupForBackend(filters),
+      filters,
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../../../../components/dashboard/useDashboardViz', () => ({
 }));
 
 vi.mock('../../../../components/dashboard/dashboardVizUtils', () => ({
-  computeStartEndDates: () => ({ startDate: null, endDate: null }),
+  computeWidgetFiltersForMultiSelection: () => ({ startDate: null, endDate: null, timeSeriesParameters: [] }),
 }));
 
 import StixCoreObjectsMultiVerticalBars from './StixCoreObjectsMultiVerticalBars';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -9,8 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { StixCoreObjectsMultiVerticalBarsTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiVerticalBarsTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
-import { monthsAgo, now } from '../../../../utils/Time';
+import { computeWidgetFiltersForMultiSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
 const stixCoreObjectsMultiVerticalBarsTimeSeriesQuery = graphql`
@@ -99,17 +98,11 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixCoreObjectsMultiVerticalBarsTimeSeriesQuery['variables'] => {
-  const computed = computeStartEndDates(config);
-  const startDate = computed.startDate ?? monthsAgo(12);
-  const endDate = computed.endDate ?? now();
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
-    return {
-      field: dateAttribute,
-      types: DATA_SELECTION_TYPES,
-      filters,
-    };
-  });
+  const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(
+    resolvedDataSelection,
+    config,
+    { types: DATA_SELECTION_TYPES, fallbackToDefaultDates: true },
+  );
   return {
     startDate,
     endDate,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetVerticalBars from '../../../../components/dashboard/WidgetVerticalBars';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { Widget, WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { StixCoreObjectsMultiVerticalBarsTimeSeriesQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsMultiVerticalBarsTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeStartEndDates, computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { monthsAgo, now } from '../../../../utils/Time';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
 
@@ -104,17 +103,11 @@ const buildQueryVariables = (
   const startDate = computed.startDate ?? monthsAgo(12);
   const endDate = computed.endDate ?? now();
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-      ? selection.date_attribute
-      : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(
-      selection.filters,
-      { startDate, endDate, dateAttribute },
-    );
+    const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
     return {
       field: dateAttribute,
       types: DATA_SELECTION_TYPES,
-      filters: normalizeFilterGroupForBackend(filters),
+      filters,
     };
   });
   return {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -104,10 +104,9 @@ const buildQueryVariables = (
   const startDate = computed.startDate ?? monthsAgo(12);
   const endDate = computed.endDate ?? now();
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute && selection.date_attribute.length > 0
-        ? selection.date_attribute
-        : 'created_at';
+    const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
+      ? selection.date_attribute
+      : 'created_at';
     const { filters } = buildFiltersAndOptionsForWidgets(
       selection.filters,
       { startDate, endDate, dateAttribute },

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsMultiVerticalBars.tsx
@@ -101,7 +101,8 @@ const buildQueryVariables = (
   const { startDate, endDate, timeSeriesParameters } = computeWidgetFiltersForMultiSelection(
     resolvedDataSelection,
     config,
-    { types: DATA_SELECTION_TYPES, fallbackToDefaultDates: true },
+    DATA_SELECTION_TYPES,
+    { fallbackToDefaultDates: true },
   );
   return {
     startDate,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsNumber.tsx
@@ -1,7 +1,6 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNumber from '../../../../components/dashboard/WidgetNumber';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import type { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { StixCoreObjectsNumberNumberSeriesQuery } from './__generated__/StixCoreObjectsNumberNumberSeriesQuery.graphql';
 import type { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { ReactNode } from 'react';
 import { useGetNumberWidgetTitle } from 'src/utils/widget/widgetUtils';
 
@@ -86,18 +85,11 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ) => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute && selection.date_attribute.length > 0
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { startDate, dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     types: DATA_SELECTION_TYPES,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     startDate,
     endDate: dayAgo(),
   };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsPolarArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsPolarArea.tsx
@@ -11,8 +11,7 @@ import { OpenCTIChartProps } from '../charts/Chart';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsPolarAreaDistributionQuery = graphql`
   query StixCoreObjectsPolarAreaDistributionQuery(
@@ -128,16 +127,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixCoreObjectsPolarAreaDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = computeStartEndDates(config);
-  const dateAttribute
-    = selection.date_attribute
-      && selection.date_attribute.length > 0
-      ? selection.date_attribute
-      : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
 
   return {
     types: DATA_SELECTION_TYPES,
@@ -146,7 +136,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsRadar.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetRadar from '../../../../components/dashboard/WidgetRadar';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { Widget, WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { StixCoreObjectsRadarDistributionQuery } from './__generated__/StixCoreObjectsRadarDistributionQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsRadarDistributionQuery = graphql`
   query StixCoreObjectsRadarDistributionQuery(
@@ -138,15 +137,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixCoreObjectsRadarDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(selection.filters, {
-    startDate,
-    endDate,
-    dateAttribute,
-  });
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
 
   return {
     types: DATA_SELECTION_TYPES,
@@ -155,7 +146,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTimeline.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { OrderingMode, StixCoreObjectsOrdering, StixCoreObjectsTimelineQuery } from './__generated__/StixCoreObjectsTimelineQuery.graphql';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetTimeline from '../../../../components/dashboard/WidgetTimeline';
@@ -11,7 +10,7 @@ import type { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../..
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsTimelineQuery = graphql`
   query StixCoreObjectsTimelineQuery(
@@ -119,21 +118,13 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ) => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute && selection.date_attribute.length > 0
-      ? selection.date_attribute
-      : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config);
   return {
     types: DATA_SELECTION_TYPES,
     first: selection.number ?? 10,
     orderBy: dateAttribute as StixCoreObjectsOrdering,
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
@@ -119,9 +119,7 @@ const buildQueryVariables = (
     = selection.date_attribute?.length
       ? selection.date_attribute
       : 'created_at';
-  const {
-    filters,
-  } = buildFiltersAndOptionsForWidgets(
+  const { filters } = buildFiltersAndOptionsForWidgets(
     selection.filters,
     { startDate, endDate, dateAttribute },
   );

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsTreeMap.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties, ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetTree from '../../../../components/dashboard/WidgetTree';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixCoreObjectsTreeMapDistributionQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsTreeMapDistributionQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 import { OpenCTIChartProps } from '@components/common/charts/Chart';
 
 const stixCoreObjectsTreeMapDistributionQuery = graphql`
@@ -114,15 +113,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixCoreObjectsTreeMapDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = computeStartEndDates(config);
-  const dateAttribute
-    = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
 
   return {
     types: DATA_SELECTION_TYPES,
@@ -131,7 +122,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectsWordCloud.tsx
@@ -9,8 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixCoreObjectsWordCloudDistributionQuery } from '@components/common/stix_core_objects/__generated__/StixCoreObjectsWordCloudDistributionQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
+import { computeWidgetFiltersForSelection } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixCoreObjectsWordCloudDistributionQuery = graphql`
   query StixCoreObjectsWordCloudDistributionQuery(
@@ -125,15 +124,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixCoreObjectsWordCloudDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = computeStartEndDates(config);
-  const dateAttribute
-    = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute },
-  );
+  const { dateAttribute, startDate, endDate, filters } = computeWidgetFiltersForSelection(selection, config);
 
   return {
     types: DATA_SELECTION_TYPES,
@@ -142,7 +133,7 @@ const buildQueryVariables = (
     startDate,
     endDate,
     dateAttribute,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     limit: selection.number ?? 10,
   };
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDistributionList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDistributionList.tsx
@@ -3,7 +3,6 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { getMainRepresentative, isFieldForIdentifier } from '../../../../utils/defaultRepresentatives';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../utils/hooks/useGranted';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetDistributionList from '../../../../components/dashboard/WidgetDistributionList';
@@ -12,7 +11,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { WidgetDataSelection, WidgetHost } from '../../../../utils/widget/widget';
 import { StixRelationshipsDistributionListDistributionQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsDistributionListDistributionQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsDistributionListDistributionQuery = graphql`
   query StixRelationshipsDistributionListDistributionQuery(
@@ -148,19 +147,8 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsDistributionListDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    {
-      startDate,
-      endDate,
-      dateAttribute,
-      isKnowledgeRelationshipWidget: true,
-    },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
+
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
@@ -169,9 +157,9 @@ const buildQueryVariables = (
     dateAttribute,
     limit: selection.number ?? 10,
     isTo: selection.isTo ?? undefined,
-    filters: normalizeFilterGroupForBackend(filters),
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    filters,
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDonut.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsDonut.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import ApexCharts from 'apexcharts';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetDonut from '../../../../components/dashboard/WidgetDonut';
@@ -11,7 +10,7 @@ import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
 import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderContent';
 import { StixRelationshipsDonutDistributionQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsDonutDistributionQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 export const stixRelationshipsDonutsDistributionQuery = graphql`
   query StixRelationshipsDonutDistributionQuery(
@@ -140,22 +139,16 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsDonutDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { startDate, endDate, dateAttribute, isKnowledgeRelationshipWidget: true },
-  );
+  const { filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
     operation: 'count',
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsHorizontalBars.tsx
@@ -1,6 +1,5 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetHorizontalBars from '../../../../components/dashboard/WidgetHorizontalBars';
@@ -12,7 +11,7 @@ import { StixRelationshipsHorizontalBarsDistributionQuery } from './__generated_
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 export const stixRelationshipsHorizontalBarsDistributionQuery = graphql`
   query StixRelationshipsHorizontalBarsDistributionQuery(
@@ -152,13 +151,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsHorizontalBarsDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { isKnowledgeRelationshipWidget: true },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
@@ -167,10 +160,10 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsList.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useRef } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { getDefaultWidgetColumns } from '../../widgets/WidgetListsDefaultColumns';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetListRelationships from '../../../../components/dashboard/WidgetListRelationships';
@@ -12,6 +11,7 @@ import type { StixRelationshipsListQuery, StixRelationshipsOrdering } from '@com
 import { OrderingMode } from '@components/common/stix_relationships/__generated__/StixRelationshipsListQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from 'src/components/dashboard/dashboardVizUtils';
 
 export const stixRelationshipsListQuery = graphql`
   query StixRelationshipsListQuery(
@@ -4509,26 +4509,18 @@ const StixRelationshipsListComponent = ({
 
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
+  config: DashboardConfig,
 ): StixRelationshipsListQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    {
-      dateAttribute,
-      isKnowledgeRelationshipWidget: true,
-    },
-  );
+  const { dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     first: selection.number ?? 50,
     orderBy: (dateAttribute as StixRelationshipsOrdering),
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-    filters: normalizeFilterGroupForBackend(filters),
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    filters,
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMap.tsx
@@ -3,7 +3,6 @@ import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import LocationMiniMapTargets from '../location/LocationMiniMapTargets';
 import { computeLevel } from '../../../../utils/Number';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import useDashboardViz from '../../../../components/dashboard/useDashboardViz';
@@ -13,7 +12,7 @@ import {
 } from '@components/common/stix_relationships/__generated__/StixRelationshipsMapStixRelationshipsDistributionQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 export const stixRelationshipsMapStixRelationshipsDistributionQuery = graphql`
   query StixRelationshipsMapStixRelationshipsDistributionQuery(
@@ -152,15 +151,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsMapStixRelationshipsDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = computeStartEndDates(config);
-  const dateAttribute
-    = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { isKnowledgeRelationshipWidget: true },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
@@ -169,10 +160,10 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiAreaChart.tsx
@@ -1,7 +1,5 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiAreas from '../../../../components/dashboard/WidgetMultiAreas';
@@ -11,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { StixRelationshipsMultiAreaChartTimeSeriesQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsMultiAreaChartTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
+import { buildRelationshipMultiWidgetBaseQueryVariables } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsMultiAreaChartTimeSeriesQuery = graphql`
   query StixRelationshipsMultiAreaChartTimeSeriesQuery(
@@ -92,35 +90,8 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixRelationshipsMultiAreaChartTimeSeriesQuery['variables'] => {
-  const fallbackStart = monthsAgo(12);
-  const fallbackEnd = now();
-  const startDate = config.startDate ?? fallbackStart;
-  const endDate = config.endDate ?? fallbackEnd;
-
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(
-      selection.filters,
-      { startDate, endDate, isKnowledgeRelationshipWidget: true },
-    );
-
-    return {
-      field: dateAttribute,
-      filters: normalizeFilterGroupForBackend(filters),
-      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
-    };
-  });
-
-  return {
-    operation: 'count',
-    startDate,
-    endDate,
-    interval: getWidgetInterval(parameters),
-    timeSeriesParameters,
-  };
+  return buildRelationshipMultiWidgetBaseQueryVariables(
+    resolvedDataSelection, config, parameters) as StixRelationshipsMultiAreaChartTimeSeriesQuery['variables'];
 };
 
 interface StixRelationshipsMultiAreaChartProps {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHeatMap.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiHeatMap from '../../../../components/dashboard/WidgetMultiHeatMap';
@@ -10,9 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixRelationshipsMultiHeatMapTimeSeriesQuery } from './__generated__/StixRelationshipsMultiHeatMapTimeSeriesQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
-import { monthsAgo, now } from '../../../../utils/Time';
-import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
+import { buildRelationshipMultiWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsMultiHeatMapTimeSeriesQuery = graphql`
   query StixRelationshipsMultiHeatMapTimeSeriesQuery(
@@ -100,29 +97,8 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixRelationshipsMultiHeatMapTimeSeriesQuery['variables'] => {
-  const { startDate, endDate } = computeStartEndDates(config);
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(
-      selection.filters,
-      { isKnowledgeRelationshipWidget: true },
-    );
-
-    return {
-      field: dateAttribute,
-      filters: normalizeFilterGroupForBackend(filters),
-      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
-    };
-  });
-  return {
-    operation: 'count',
-    startDate: startDate ?? monthsAgo(12),
-    endDate: endDate ?? now(),
-    interval: getWidgetInterval(parameters),
-    timeSeriesParameters,
-  };
+  return buildRelationshipMultiWidgetBaseQueryVariables(
+    resolvedDataSelection, config, parameters) as StixRelationshipsMultiHeatMapTimeSeriesQuery['variables'];
 };
 
 interface StixRelationshipsMultiHeatMapProps {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiHorizontalBars/StixRelationshipsMultiHorizontalBars.tsx
@@ -11,7 +11,7 @@ import WidgetNoData from '../../../../../components/dashboard/WidgetNoData';
 import WidgetHorizontalBars from '../../../../../components/dashboard/WidgetHorizontalBars';
 import Loader, { LoaderVariant } from '../../../../../components/Loader';
 import useDashboardViz from '../../../../../components/dashboard/useDashboardViz';
-import { computeStartEndDates } from '../../../../../components/dashboard/dashboardVizUtils';
+import { computeWidgetFiltersForSelection } from '../../../../../components/dashboard/dashboardVizUtils';
 import WidgetNoHostEntity from '../../../../../components/dashboard/WidgetNoHostEntity';
 import WidgetNoSavedFilters from '../../../../../components/dashboard/WidgetNoSavedFilters';
 import { useStixRelationshipsMultiHorizontalBars } from './useStixRelationshipsMultiHorizontalBars';
@@ -375,12 +375,10 @@ const buildQueryVariables = (
   const selection = resolvedDataSelection[0];
   const subSelection = resolvedDataSelection.length > 1 ? resolvedDataSelection[1] : undefined;
 
-  const { startDate, endDate } = computeStartEndDates(config);
-
   const finalField = selection.attribute || 'entity_type';
   const finalSubDistributionField = subSelection?.attribute || 'entity_type';
 
-  const filtersAndOptions = buildFiltersAndOptionsForWidgets(selection.filters, { isKnowledgeRelationshipWidget: true });
+  const { startDate, endDate, dateAttribute, filters } = computeWidgetFiltersForSelection(selection, config, { isKnowledgeRelationshipWidget: true });
   const subDistributionFiltersAndOptions = subSelection
     ? buildFiltersAndOptionsForWidgets(subSelection.filters)
     : undefined;
@@ -390,9 +388,9 @@ const buildQueryVariables = (
     operation: 'count' as const,
     startDate,
     endDate,
-    dateAttribute: selection.date_attribute ?? 'created_at',
+    dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filtersAndOptions?.filters),
+    filters,
     isTo: selection.isTo,
     dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
     dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
@@ -1,8 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetMultiLines from '../../../../components/dashboard/WidgetMultiLines';
@@ -12,8 +10,7 @@ import { StixRelationshipsMultiLineChartTimeSeriesQuery } from '@components/comm
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
-import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
-import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
+import { buildRelationshipMultiWidgetBaseQueryVariables } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsMultiLineChartTimeSeriesQuery = graphql`
   query StixRelationshipsMultiLineChartTimeSeriesQuery(
@@ -91,34 +88,8 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixRelationshipsMultiLineChartTimeSeriesQuery['variables'] => {
-  const fallbackStart = monthsAgo(12);
-  const fallbackEnd = now();
-  const computed = computeStartEndDates(config);
-  const startDate = computed.startDate ?? fallbackStart;
-  const endDate = computed.endDate ?? fallbackEnd;
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute
-      = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(selection.filters, {
-      startDate,
-      endDate,
-      isKnowledgeRelationshipWidget: true,
-    });
-
-    return {
-      field: dateAttribute,
-      filters: normalizeFilterGroupForBackend(filters),
-      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
-    };
-  });
-  return {
-    operation: 'count',
-    startDate,
-    endDate,
-    interval: getWidgetInterval(parameters),
-    timeSeriesParameters,
-  };
+  return buildRelationshipMultiWidgetBaseQueryVariables(
+    resolvedDataSelection, config, parameters) as StixRelationshipsMultiLineChartTimeSeriesQuery['variables'];
 };
 
 interface StixRelationshipsMultiLineChartProps {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiLineChart.tsx
@@ -13,6 +13,7 @@ import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../u
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
+import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsMultiLineChartTimeSeriesQuery = graphql`
   query StixRelationshipsMultiLineChartTimeSeriesQuery(
@@ -92,8 +93,9 @@ const buildQueryVariables = (
 ): StixRelationshipsMultiLineChartTimeSeriesQuery['variables'] => {
   const fallbackStart = monthsAgo(12);
   const fallbackEnd = now();
-  const startDate = config.startDate ?? fallbackStart;
-  const endDate = config.endDate ?? fallbackEnd;
+  const computed = computeStartEndDates(config);
+  const startDate = computed.startDate ?? fallbackStart;
+  const endDate = computed.endDate ?? fallbackEnd;
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
     const dateAttribute
       = selection.date_attribute?.length ? selection.date_attribute : 'created_at';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
@@ -13,6 +13,7 @@ import { StixRelationshipsMultiVerticalBarsTimeSeriesQuery } from './__generated
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
 import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
+import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsMultiVerticalBarsTimeSeriesQuery = graphql`
   query StixRelationshipsMultiVerticalBarsTimeSeriesQuery(
@@ -91,8 +92,9 @@ const buildQueryVariables = (
 ): StixRelationshipsMultiVerticalBarsTimeSeriesQuery['variables'] => {
   const fallbackStart = monthsAgo(12);
   const fallbackEnd = now();
-  const startDate = config.startDate ?? fallbackStart;
-  const endDate = config.endDate ?? fallbackEnd;
+  const computed = computeStartEndDates(config);
+  const startDate = computed.startDate ?? fallbackStart;
+  const endDate = computed.endDate ?? fallbackEnd;
   const timeSeriesParameters = resolvedDataSelection.map((selection) => {
     const dateAttribute = selection.date_attribute?.length
       ? selection.date_attribute

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsMultiVerticalBars.tsx
@@ -1,8 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { monthsAgo, now } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetVerticalBars from '../../../../components/dashboard/WidgetVerticalBars';
@@ -12,8 +10,7 @@ import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../u
 import { StixRelationshipsMultiVerticalBarsTimeSeriesQuery } from './__generated__/StixRelationshipsMultiVerticalBarsTimeSeriesQuery.graphql';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import ApexCharts from 'apexcharts';
-import { getWidgetInterval } from 'src/utils/widget/widgetUtils';
-import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
+import { buildRelationshipMultiWidgetBaseQueryVariables } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsMultiVerticalBarsTimeSeriesQuery = graphql`
   query StixRelationshipsMultiVerticalBarsTimeSeriesQuery(
@@ -90,34 +87,8 @@ const buildQueryVariables = (
   config: DashboardConfig,
   parameters?: WidgetParameters,
 ): StixRelationshipsMultiVerticalBarsTimeSeriesQuery['variables'] => {
-  const fallbackStart = monthsAgo(12);
-  const fallbackEnd = now();
-  const computed = computeStartEndDates(config);
-  const startDate = computed.startDate ?? fallbackStart;
-  const endDate = computed.endDate ?? fallbackEnd;
-  const timeSeriesParameters = resolvedDataSelection.map((selection) => {
-    const dateAttribute = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-    const { filters } = buildFiltersAndOptionsForWidgets(
-      selection.filters,
-      { startDate, endDate, isKnowledgeRelationshipWidget: true },
-    );
-
-    return {
-      field: dateAttribute,
-      filters: normalizeFilterGroupForBackend(filters),
-      dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-      dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
-    };
-  });
-  return {
-    operation: 'count',
-    startDate,
-    endDate,
-    interval: getWidgetInterval(parameters),
-    timeSeriesParameters,
-  };
+  return buildRelationshipMultiWidgetBaseQueryVariables(
+    resolvedDataSelection, config, parameters) as StixRelationshipsMultiVerticalBarsTimeSeriesQuery['variables'];
 };
 
 interface StixRelationshipsMultiVerticalBarsProps {

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
@@ -12,6 +12,7 @@ import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../u
 import { ReactNode } from 'react';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { useGetNumberWidgetTitle } from 'src/utils/widget/widgetUtils';
+import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsNumberNumberQuery = graphql`
     query StixRelationshipsNumberNumberSeriesQuery(
@@ -96,15 +97,18 @@ const StixRelationshipsNumberComponent = ({
 
 const buildQueryVariables = (
   resolvedDataSelection: WidgetDataSelection[],
+  config: DashboardConfig,
 ): StixRelationshipsNumberNumberSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
+  const dateAttribute = selection.date_attribute?.length
+    ? selection.date_attribute
+    : 'created_at';
+  const { startDate, endDate } = computeStartEndDates(config);
   const { filters } = buildFiltersAndOptionsForWidgets(
     selection.filters,
     {
+      startDate,
+      endDate,
       dateAttribute,
       isKnowledgeRelationshipWidget: true,
     },

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsNumber.tsx
@@ -1,7 +1,6 @@
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import { dayAgo } from '../../../../utils/Time';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetNumber from '../../../../components/dashboard/WidgetNumber';
@@ -12,7 +11,7 @@ import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../u
 import { ReactNode } from 'react';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
 import { useGetNumberWidgetTitle } from 'src/utils/widget/widgetUtils';
-import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsNumberNumberQuery = graphql`
     query StixRelationshipsNumberNumberSeriesQuery(
@@ -100,26 +99,14 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsNumberNumberSeriesQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    {
-      startDate,
-      endDate,
-      dateAttribute,
-      isKnowledgeRelationshipWidget: true,
-    },
-  );
+  const { dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     dateAttribute,
     endDate: dayAgo(),
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsPolarArea.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsPolarArea.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetPolarArea from '../../../../components/dashboard/WidgetPolarArea';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixRelationshipsPolarAreaDistributionQuery } from './__generated__/StixRelationshipsPolarAreaDistributionQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsPolarAreasDistributionQuery = graphql`
   query StixRelationshipsPolarAreaDistributionQuery(
@@ -141,13 +140,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsPolarAreaDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { isKnowledgeRelationshipWidget: true },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
@@ -156,10 +149,10 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsRadar.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetRadar from '../../../../components/dashboard/WidgetRadar';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixRelationshipsRadarDistributionQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsRadarDistributionQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsRadarsDistributionQuery = graphql`
   query StixRelationshipsRadarDistributionQuery(
@@ -145,13 +144,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsRadarDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { isKnowledgeRelationshipWidget: true },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
@@ -160,10 +153,10 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -1057,8 +1057,9 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsTimelineStixRelationshipQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute
-    = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
+  const dateAttribute = selection.date_attribute?.length
+    ? selection.date_attribute
+    : 'created_at';
   const { startDate, endDate } = computeStartEndDates(config);
   const { filters } = buildFiltersAndOptionsForWidgets(
     selection.filters,

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { resolveLink } from '../../../../utils/Entity';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetTimeline from '../../../../components/dashboard/WidgetTimeline';
@@ -15,7 +14,7 @@ import {
   StixRelationshipsOrdering,
   StixRelationshipsTimelineStixRelationshipQuery,
 } from '@components/common/stix_relationships/__generated__/StixRelationshipsTimelineStixRelationshipQuery.graphql';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsTimelineStixRelationshipQuery = graphql`
   query StixRelationshipsTimelineStixRelationshipQuery(
@@ -1057,27 +1056,14 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsTimelineStixRelationshipQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const dateAttribute = selection.date_attribute?.length
-    ? selection.date_attribute
-    : 'created_at';
-  const { startDate, endDate } = computeStartEndDates(config);
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    {
-      startDate,
-      endDate,
-      dateAttribute,
-      isKnowledgeRelationshipWidget: true,
-    },
-  );
-
+  const { dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
   return {
+    filters,
+    dynamicFrom,
+    dynamicTo,
     first: selection.number ?? 10,
     orderBy: dateAttribute as StixRelationshipsOrdering,
     orderMode: (selection.sort_mode ?? 'desc') as OrderingMode,
-    filters: normalizeFilterGroupForBackend(filters),
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
@@ -11,6 +11,7 @@ import { StixRelationshipsTreeMapDistributionQuery } from './__generated__/StixR
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { OpenCTIChartProps } from '@components/common/charts/Chart';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
+import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsTreeMapsDistributionQuery = graphql`
   query StixRelationshipsTreeMapDistributionQuery(
@@ -129,7 +130,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsTreeMapDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = config;
+  const { startDate, endDate } = computeStartEndDates(config);
   const dateAttribute
     = selection.date_attribute?.length
       ? selection.date_attribute

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTreeMap.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties, ReactNode, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetTree from '../../../../components/dashboard/WidgetTree';
@@ -11,7 +10,7 @@ import { StixRelationshipsTreeMapDistributionQuery } from './__generated__/StixR
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { OpenCTIChartProps } from '@components/common/charts/Chart';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from 'src/components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from 'src/components/dashboard/dashboardVizUtils';
 
 const stixRelationshipsTreeMapsDistributionQuery = graphql`
   query StixRelationshipsTreeMapDistributionQuery(
@@ -130,15 +129,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsTreeMapDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-  const { startDate, endDate } = computeStartEndDates(config);
-  const dateAttribute
-    = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { isKnowledgeRelationshipWidget: true },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
@@ -147,10 +138,10 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsWordCloud.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsWordCloud.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
-import { buildFiltersAndOptionsForWidgets, normalizeFilterGroupForBackend } from '../../../../utils/filters/filtersUtils';
 import WidgetContainer from '../../../../components/dashboard/WidgetContainer';
 import WidgetNoData from '../../../../components/dashboard/WidgetNoData';
 import WidgetWordCloud from '../../../../components/dashboard/WidgetWordCloud';
@@ -10,7 +9,7 @@ import WidgetRenderContent from '../../../../components/dashboard/WidgetRenderCo
 import { StixRelationshipsWordCloudDistributionQuery } from '@components/common/stix_relationships/__generated__/StixRelationshipsWordCloudDistributionQuery.graphql';
 import { WidgetDataSelection, WidgetHost, WidgetParameters } from '../../../../utils/widget/widget';
 import { DashboardConfig } from '../../../../components/dashboard/dashboard-types';
-import { computeStartEndDates } from '../../../../components/dashboard/dashboardVizUtils';
+import { buildRelationshipSingleWidgetBaseQueryVariables } from '../../../../components/dashboard/dashboardVizUtils';
 
 export const stixRelationshipsWordCloudsDistributionQuery = graphql`
   query StixRelationshipsWordCloudDistributionQuery(
@@ -139,18 +138,7 @@ const buildQueryVariables = (
   config: DashboardConfig,
 ): StixRelationshipsWordCloudDistributionQuery['variables'] => {
   const selection = resolvedDataSelection[0];
-
-  const { startDate, endDate } = computeStartEndDates(config);
-
-  const dateAttribute
-    = selection.date_attribute?.length
-      ? selection.date_attribute
-      : 'created_at';
-
-  const { filters } = buildFiltersAndOptionsForWidgets(
-    selection.filters,
-    { isKnowledgeRelationshipWidget: true },
-  );
+  const { startDate, endDate, dateAttribute, filters, dynamicFrom, dynamicTo } = buildRelationshipSingleWidgetBaseQueryVariables(selection, config);
 
   return {
     field: selection.attribute ?? 'entity_type',
@@ -159,10 +147,10 @@ const buildQueryVariables = (
     endDate,
     dateAttribute,
     limit: selection.number ?? 10,
-    filters: normalizeFilterGroupForBackend(filters),
+    filters,
     isTo: selection.isTo,
-    dynamicFrom: normalizeFilterGroupForBackend(selection.dynamicFrom),
-    dynamicTo: normalizeFilterGroupForBackend(selection.dynamicTo),
+    dynamicFrom,
+    dynamicTo,
   };
 };
 


### PR DESCRIPTION
### Proposed changes
- Take start date, end date and relative time of dashboard into account in relationships widgets
- Create utils function to build generic variables for widgets
- Add frontend tests

### Related issues
closes #17243