### PR TITLE
fix(stream): fix number values in filter (#17275)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -157,7 +157,10 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
           fontFamily: 'Consolas, monaco, monospace',
         };
     const operatorOnClick = isLocalModeSwitchable ? () => handleSwitchLocalMode(currentFilter) : undefined;
-    const value = filtersRepresentativesMap.get(id) ? filtersRepresentativesMap.get(id)?.value : id;
+    let value = filtersRepresentativesMap.get(id) ? filtersRepresentativesMap.get(id)?.value : id;
+    if (typeof value === 'number') {
+      value = value.toString();
+    }
     const isRegardingOfFilter = parentFilter?.key === 'regardingOf' || parentFilter?.key === 'dynamicRegardingOf';
     return (
       <Fragment key={id}>

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -157,10 +157,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
           fontFamily: 'Consolas, monaco, monospace',
         };
     const operatorOnClick = isLocalModeSwitchable ? () => handleSwitchLocalMode(currentFilter) : undefined;
-    let value = filtersRepresentativesMap.get(id) ? filtersRepresentativesMap.get(id)?.value : id;
-    if (typeof value === 'number') {
-      value = value.toString();
-    }
+    const value = filtersRepresentativesMap.get(id) ? filtersRepresentativesMap.get(id)?.value : id;
     const isRegardingOfFilter = parentFilter?.key === 'regardingOf' || parentFilter?.key === 'dynamicRegardingOf';
     return (
       <Fragment key={id}>

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -499,6 +499,11 @@ export const filterValue = (
   if (filterKey === 'relationship_type' || filterKey === 'type') {
     return t_i18n(`relationship_${value}`);
   }
+
+  // Defensive check to prevent errors on string manipulation after this call
+  if (typeof value !== 'string') {
+    return null;
+  }
   return value;
 };
 

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -500,11 +500,12 @@ export const filterValue = (
     return t_i18n(`relationship_${value}`);
   }
 
-  // Defensive check to prevent errors on string manipulation after this call
-  if (typeof value !== 'string') {
-    return null;
+  if (value === undefined || value === null) {
+    return value;
   }
-  return value;
+
+  // Defensive check to prevent errors on string manipulation after this call
+  return typeof value === 'string' ? value : String(value);
 };
 
 export const isFilterEditable = (filtersRestrictions: FiltersRestrictions | undefined, filterKey: string, filterValues: string[]) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request addresses type safety issues when handling filter values in the filter components and utility functions. The main focus is to ensure that filter values are consistently treated as strings, which prevents potential runtime errors when performing string operations.

**Type Handling Improvements:**

* In `FilterValues.tsx`, ensures that the `value` used for filters is always a string by converting numeric values to strings before rendering.
* In `filtersUtils.tsx`, adds a defensive check in the `filterValue` function to return `null` if the value is not a string, preventing errors from string operations on non-string types.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17275

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
