### PR TITLE
feat(scr): added telemetry to security coverage and security coverage results #17171

### DIFF
--- a/docs/docs/reference/usage-telemetry.md
+++ b/docs/docs/reference/usage-telemetry.md
@@ -104,6 +104,9 @@ All AI usage counters are backend-agnostic: the same counter is incremented whet
 - The number of data sharing surfaces, broken down by type (`live_stream`, `feed`, `taxii_collection`, `public_dashboard`) and public (anonymous access) state
 - The number of playbooks, broken down by running state
 - The number of playbook executions started
+- The number of security coverages 
+- The number of security coverages results
+- The number of 'has covered' relationships
 - The number of activated inference rules
 - The number of notification triggers, broken down by type (`live`, `digest`)
 - The number of notifiers, broken down by connector (`email`, `webhook`, `ui`, `other`)
@@ -117,6 +120,7 @@ All AI usage counters are backend-agnostic: the same counter is incremented whet
 - Whether the file indexing manager is running
 - The number of indexed files
 - Whether the platform is registered on XTM Hub
+- The number of OpenAEV connectors linked to OpenCTI
 
 ### Email and notifications
 

--- a/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/telemetryManager.ts
@@ -69,6 +69,8 @@ import { EnvStrategyType, isStrategyActivated } from '../modules/authenticationP
 import { listRules } from '../modules/retentionRules/retentionRules-domain';
 import { fullEntitiesList } from '../database/middleware-loader';
 import { isSavedFilterShared } from '../modules/savedFilter/savedFilter-domain';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT } from '../modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
+import { RELATION_HAS_COVERED } from '../schema/stixCoreRelationship';
 
 const TELEMETRY_MANAGER_KEY = conf.get('telemetry_manager:lock_key');
 
@@ -485,7 +487,9 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // region Connectors information
     const connectors = await getEntitiesListFromCache<BasicStoreEntityConnector>(context, TELEMETRY_MANAGER_USER, ENTITY_TYPE_CONNECTOR);
     const activeConnectors = connectors.filter((c) => c.active);
+    const oaevConnectors = connectors.filter((c) => c.name.toLowerCase().startsWith('openaev coverage'));
     manager.setActiveConnectorsCount(activeConnectors.length);
+    manager.setOaevConnectorsCount(oaevConnectors.length);
     // Breakdown by catalog identity (see computeActiveConnectorsByIdentity):
     // composer-managed connectors resolve to the catalog contract slug
     // through their stored container image; manually registered connectors
@@ -546,10 +550,18 @@ export const fetchTelemetryData = async (manager: TelemetryMeterManager) => {
     // endregion SSO providers
 
     // region Security Coverages
-    const securityCoveragesCount = await elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, {
-      types: [ENTITY_TYPE_SECURITY_COVERAGE],
-    });
+    const [
+      securityCoveragesCount,
+      securityCoverageResultsCount,
+      relationshipsHasCoveredCount,
+    ] = await Promise.all([
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, { types: [ENTITY_TYPE_SECURITY_COVERAGE] }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_DOMAIN_OBJECTS, { types: [ENTITY_TYPE_SECURITY_COVERAGE_RESULT] }),
+      elCount(context, TELEMETRY_MANAGER_USER, READ_INDEX_STIX_CORE_RELATIONSHIPS, { types: [RELATION_HAS_COVERED] }),
+    ]);
     manager.setSecurityCoveragesCount(securityCoveragesCount);
+    manager.setSecurityCoverageResultsCount(securityCoverageResultsCount);
+    manager.setRelationshipsHasCoveredCount(relationshipsHasCoveredCount);
     // endregion
 
     // region Shared saved filters

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -118,6 +118,9 @@ export class TelemetryMeterManager {
   // Number of active connectors
   activeConnectorsCount = 0;
 
+  // Number of OpenAEV connectors
+  oaevConnectorsCount = 0;
+
   // Active connectors broken down by catalog identity (slug, managed, type).
   // Composer-managed connectors carry the exact catalog contract slug; manual
   // connectors fall back to their registered name (managed=false).
@@ -192,6 +195,12 @@ export class TelemetryMeterManager {
 
   // Number security coverages
   securityCoveragesCount = 0;
+
+  // Number security coverages
+  securityCoverageResultsCount = 0;
+
+  // Number of relationships has-covered
+  relationshipsHasCoveredCount = 0;
 
   // Number of decay rules created
   decayRuleCreationCount = 0;
@@ -389,6 +398,10 @@ export class TelemetryMeterManager {
     this.activeConnectorsCount = n;
   }
 
+  setOaevConnectorsCount(n: number) {
+    this.oaevConnectorsCount = n;
+  }
+
   setActiveConnectorsByIdentity(items: DimensionalGaugeItem[]) {
     this.activeConnectorsByIdentity = items;
   }
@@ -495,6 +508,14 @@ export class TelemetryMeterManager {
 
   setSecurityCoveragesCount(n: number) {
     this.securityCoveragesCount = n;
+  }
+
+  setSecurityCoverageResultsCount(n: number) {
+    this.securityCoverageResultsCount = n;
+  }
+
+  setRelationshipsHasCoveredCount(n: number) {
+    this.relationshipsHasCoveredCount = n;
   }
 
   setDecayRuleCreationCount(n: number) {
@@ -684,6 +705,7 @@ export class TelemetryMeterManager {
     this.registerGauge('total_service_account_count', 'number of service account', 'serviceAccountCount');
     this.registerGauge('total_instances_count', 'cluster number of instances', 'instancesCount');
     this.registerGauge('active_connectors_count', 'number of active connectors', 'activeConnectorsCount');
+    this.registerGauge('oaev_connectors_count', 'number of OpenAEV connectors', 'oaevConnectorsCount');
     this.registerDimensionalGauge('active_connectors_by_identity', 'active connectors broken down by catalog identity (slug, managed, type)', 'activeConnectorsByIdentity');
     this.registerGauge('is_enterprise_edition', 'enterprise Edition is activated', 'isEEActivated', { unit: 'boolean' });
     this.registerGauge('call_dissemination', 'dissemination feature usage', 'disseminationCount');
@@ -712,6 +734,8 @@ export class TelemetryMeterManager {
     this.registerGauge('form_intake_deleted_count', 'Number of form intakes deleted', 'formIntakeDeletedCount');
     this.registerGauge('form_intake_submitted_count', 'Number of form intakes submitted', 'formIntakeSubmittedCount');
     this.registerGauge('security_coverages_count', 'Number of security coverages', 'securityCoveragesCount');
+    this.registerGauge('security_coverage_results_count', 'Number of security coverage results', 'securityCoverageResultsCount');
+    this.registerGauge('relationships_has_covered_count', 'Number of relationships has-covered', 'relationshipsHasCoveredCount');
     this.registerGauge('decay_rule_creation_count', 'Number of decay rules created', 'decayRuleCreationCount');
     this.registerGauge('is_history_retention_rule_active', 'Whether the history retention rule is active on the platform', 'isHistoryRetentionRuleActive', { unit: 'boolean' });
     this.registerGauge('is_activity_retention_rule_active', 'Whether the activity retention rule is active on the platform', 'isActivityRetentionRuleActive', { unit: 'boolean' });

--- a/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
+++ b/opencti-platform/opencti-graphql/src/telemetry/TelemetryMeterManager.ts
@@ -193,13 +193,13 @@ export class TelemetryMeterManager {
   // Number of form intakes submitted
   formIntakeSubmittedCount = 0;
 
-  // Number security coverages
+  // Number of security coverages
   securityCoveragesCount = 0;
 
-  // Number security coverages
+  // Number of security coverage results
   securityCoverageResultsCount = 0;
 
-  // Number of relationships has-covered
+  // Number of has-covered relationships
   relationshipsHasCoveredCount = 0;
 
   // Number of decay rules created


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Added following telemetry : 
* Number of has_covered relationships
* Number of Security Coverages
* Number of Security Coverages Results
* Number of OAEV instances linked to OCTI
* Updated documentation

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17171 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
1) In telemetryManager, temporarly replace THREE_HOUR with ONE_MINUTE (line 126) : 
<img width="657" height="103" alt="Capture d’écran 2026-07-23 à 15 15 13" src="https://github.com/user-attachments/assets/10b637ce-931e-4001-88c4-bb8782f3f6df" />

2) In your opencti-graphql/telemetry folder, delete all files

3) Launch backend and connect to your octi account

4) after one minute, you should see you telemetry data in a telemetry file in opencti-graphql/telemetry folder

5) search for : 
- opencti_security_coverages_count : "asInt" should correspond to the number of SC you have in db
<img width="974" height="66" alt="Capture d’écran 2026-07-23 à 15 18 03" src="https://github.com/user-attachments/assets/2e24d433-b835-49d8-a28a-b18061c11314" />
And do the same for : 

- opencti_security_coverage_results_count : nber of Security Coverages Results
- opencti_relationships_has_covered_count : nber of has covered relationships
- opencti_oaev_connectors_count : nber of OpenAEV instances connected

6) revert telemetryManager changes


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
