### PR TITLE
fix(frontend): align Filigran Experience card footer button sizes (#17314)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionButton.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionButton.tsx
@@ -1,4 +1,5 @@
 import Button from '@common/button/Button';
+import type { ButtonSize } from '@common/button/Button.types';
 import React, { useState } from 'react';
 import makeStyles from '@mui/styles/makeStyles';
 import EnterpriseEditionAgreement from '@components/common/entreprise_edition/EnterpriseEditionAgreement';
@@ -26,12 +27,14 @@ const EnterpriseEditionButton = ({
   disabled = false,
   withEEChip = false,
   title = 'Manage your Enterprise Edition license',
+  size = 'small',
 }: {
   feature?: string;
   inLine?: boolean;
   disabled?: boolean;
   withEEChip?: boolean;
   title?: string;
+  size?: ButtonSize;
 }) => {
   const { t_i18n } = useFormatter();
   const classes = useStyles();
@@ -57,7 +60,7 @@ const EnterpriseEditionButton = ({
       />
       {isAdmin ? (
         <Button
-          size="small"
+          size={size}
           variant="secondary"
           // color="ee"
           onClick={() => setOpenEnterpriseEditionConsent(true)}
@@ -75,7 +78,7 @@ const EnterpriseEditionButton = ({
       ) : (
         <Button
           variant="secondary"
-          size="small"
+          size={size}
           disabled={disabled}
           onClick={() => setFeedbackCreation(true)}
           classes={{ root: classes.button }}

--- a/opencti-platform/opencti-front/src/private/components/settings/Experience.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Experience.tsx
@@ -172,17 +172,18 @@ const ExperienceComponent: FunctionComponent<ExperienceComponentProps> = ({ quer
         <>
           <DangerZoneButton
             sensitiveType="ce_ee_toggle"
+            size="default"
             onClick={() => setOpenEEChanges(true)}
           >
             {t_i18n('Disable Enterprise Edition')}
           </DangerZoneButton>
-          <EnterpriseEditionButton inLine title="Update license" />
+          <EnterpriseEditionButton inLine size="default" title="Update license" />
         </>
       )
     : undefined;
 
   const eeCommunityFooter = isGrantedToParameters
-    ? <EnterpriseEditionButton inLine title="Try OpenCTI Enterprise Edition" />
+    ? <EnterpriseEditionButton inLine size="default" title="Try OpenCTI Enterprise Edition" />
     : (
         <Button
           variant="secondary"


### PR DESCRIPTION
## Proposed changes

- Expose an optional `size` prop on `EnterpriseEditionButton` (defaulting to `small` so all existing call sites - Settings, EE dialogs, integration catalog - are unchanged) and forward it to both underlying buttons (admin and feedback variants).
- Pass `size="default"` from the Filigran Experience screen for the "Update license" and "Try OpenCTI Enterprise Edition" buttons so they match the other card footer actions.
- Pass `size="default"` to the "Disable Enterprise Edition" `DangerZoneButton` in the same footer (its hardcoded `size="small"` is overridable via props spread) so all four footer actions share the same height.

## Related issues

- Fixes #17314

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (lint + type check pass; visual check on the Experience screen)
- [ ] I added/update the relevant documentation (no doc impacted)
- [ ] Where necessary I refactored code to improve the overall quality (not applicable)
