### PR TITLE
fix(backend): address post-merge review on JSON feed export/import and add coverage (#17322)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-json-domain.ts
@@ -223,6 +223,14 @@ export const deleteIngestionJson = async (context: AuthContext, user: AuthUser, 
   return ingestionId;
 };
 
+// Header values commonly carry credentials (Authorization, API keys, cookies):
+// like authentication_value, sensitive ones are blanked in the export and must
+// be set again at import time.
+const SENSITIVE_HEADER_NAME = /authorization|token|key|secret|password|cookie|credential/i;
+export const sanitizeExportedHeaders = (headers: { name: string; value: string }[] | undefined) => {
+  return headers?.map((header) => (SENSITIVE_HEADER_NAME.test(header.name) ? { ...header, value: '' } : header));
+};
+
 // Exports the feed configuration with the JSON mapper embedded (a JSON feed
 // references its mapper, so the export must be self-contained). Credentials,
 // user and markings are platform-specific and are set again at import time.
@@ -258,7 +266,7 @@ export const jsonFeedExport = async (context: AuthContext, user: AuthUser, inges
       pagination_with_sub_page,
       pagination_with_sub_page_attribute_path,
       pagination_with_sub_page_query_verb,
-      headers,
+      headers: sanitizeExportedHeaders(headers),
       query_attributes,
       authentication_type,
       authentication_value: '',

--- a/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/internal/jsonMapper/jsonMapper-domain.ts
@@ -59,9 +59,13 @@ export const createJsonMapperFromConfiguration = async (
   user: AuthUser,
   configuration: { name: string; representations: unknown; variables: unknown },
 ) => {
+  // Exported representations reference entities (default values) by STIX
+  // standard id: convert them back to internal ids so they resolve here.
+  const representations = (configuration.representations ?? []) as JsonMapperRepresentation[];
+  await convertRepresentationsIds(context, user, representations, 'stix');
   const importData = {
     name: configuration.name,
-    representations: JSON.stringify(configuration.representations),
+    representations: JSON.stringify(representations),
     variables: JSON.stringify(configuration.variables),
   };
   const importMapper = await createEntity(context, user, importData, ENTITY_TYPE_JSON_MAPPER);

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-resolver-test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
 import { ADMIN_USER } from '../../../utils/testQuery';
-import { queryAsAdmin, queryAsAdminWithSuccess } from '../../../utils/testQueryHelper';
+import { createUploadFromTestDataFile, queryAsAdmin, queryAsAdminWithSuccess } from '../../../utils/testQueryHelper';
 import { IngestionAuthType } from '../../../../src/generated/graphql';
 
 // Minimal JSON mapper representations - creates a Domain-Name entity from a path
@@ -216,5 +216,184 @@ describe('JSON ingestion resolver — authentication encryption', () => {
     });
     expect(result.data?.ingestionJsonDelete).toBe(jsonIngestionId);
     jsonIngestionId = ''; // mark as deleted so afterAll skips it
+  });
+});
+
+describe('JSON ingestion resolver — configuration export / import', () => {
+  const IMPORT_MUTATION = gql`
+    mutation jsonFeedAddInputFromImport($file: Upload!) {
+      ingestionJsonAddInputFromImport(file: $file) {
+        name
+        description
+        scheduling_period
+        uri
+        verb
+        ssl_verify
+        headers {
+          name
+          value
+        }
+        authentication_type
+        jsonMapper {
+          id
+          name
+        }
+      }
+    }
+  `;
+  const DELETE_MAPPER_MUTATION = gql`mutation deleteJsonMapperFromImport($id: ID!) { jsonMapperDelete(id: $id) }`;
+
+  let exportMapperId: string;
+  let exportIngestionId: string;
+  let importedMapperId: string;
+
+  beforeAll(async () => {
+    const mapperResult = await queryAsAdminWithSuccess({
+      query: gql`
+        mutation createJsonMapperForExportTest($input: JsonMapperAddInput!) {
+          jsonMapperAdd(input: $input) {
+            id
+          }
+        }
+      `,
+      variables: {
+        input: {
+          name: 'JSON mapper for export test',
+          representations: MINIMAL_REPRESENTATIONS,
+        },
+      },
+    });
+    exportMapperId = mapperResult.data?.jsonMapperAdd?.id;
+    expect(exportMapperId).toBeDefined();
+
+    const ingestionResult = await queryAsAdminWithSuccess({
+      query: gql`
+        mutation createJsonIngestionForExportTest($input: IngestionJsonAddInput!) {
+          ingestionJsonAdd(input: $input) {
+            id
+          }
+        }
+      `,
+      variables: {
+        input: {
+          name: 'JSON feed for export test',
+          description: 'JSON feed export description',
+          uri: 'http://jsonserver.invalid/api/export',
+          authentication_type: IngestionAuthType.None,
+          json_mapper_id: exportMapperId,
+          user_id: ADMIN_USER.id,
+          scheduling_period: 'PT1H',
+          verb: 'get',
+        },
+      },
+    });
+    exportIngestionId = ingestionResult.data?.ingestionJsonAdd?.id;
+    expect(exportIngestionId).toBeDefined();
+  });
+
+  afterAll(async () => {
+    if (exportIngestionId) {
+      await queryAsAdmin({
+        query: gql`mutation deleteJsonIngestionExportTest($id: ID!) { ingestionJsonDelete(id: $id) }`,
+        variables: { id: exportIngestionId },
+      });
+    }
+    if (exportMapperId) {
+      await queryAsAdmin({ query: DELETE_MAPPER_MUTATION, variables: { id: exportMapperId } });
+    }
+    if (importedMapperId) {
+      await queryAsAdmin({ query: DELETE_MAPPER_MUTATION, variables: { id: importedMapperId } });
+    }
+  });
+
+  it('should generate a self-contained export configuration with the embedded mapper', async () => {
+    // Covers: jsonFeedExport (ingestion-json-domain.ts)
+    // Covers: IngestionJson.toConfigurationExport field resolver
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        query queryJsonFeedExport($id: String!) {
+          ingestionJson(id: $id) {
+            name
+            toConfigurationExport
+          }
+        }
+      `,
+      variables: { id: exportIngestionId },
+    });
+    const exported = JSON.parse(result.data?.ingestionJson.toConfigurationExport);
+    expect(exported.type).toBe('jsonFeeds');
+    expect(exported.openCTI_version).toBeDefined();
+    expect(exported.configuration).toMatchObject({
+      name: 'JSON feed for export test',
+      description: 'JSON feed export description',
+      uri: 'http://jsonserver.invalid/api/export',
+      verb: 'get',
+      scheduling_period: 'PT1H',
+      // Credentials are platform-specific and never exported.
+      authentication_value: '',
+    });
+    expect(exported.configuration.json_mapper.name).toBe('JSON mapper for export test');
+    expect(exported.configuration.json_mapper.representations).toHaveLength(1);
+    expect(exported.configuration.json_mapper.representations[0].target.entity_type).toBe('Domain-Name');
+  });
+
+  it('should import a configuration and create the embedded mapper when it does not exist', async () => {
+    // Covers: jsonFeedAddInputFromImport mapper creation branch (ingestion-json-domain.ts)
+    // Covers: createJsonMapperFromConfiguration (jsonMapper-domain.ts)
+    const upload = await createUploadFromTestDataFile('jsonFeed/test-json-feed.json', 'test-json-feed.json', 'application/json');
+    const result = await queryAsAdminWithSuccess({
+      query: IMPORT_MUTATION,
+      variables: { file: upload },
+    });
+    const imported = result.data?.ingestionJsonAddInputFromImport;
+    expect(imported).toMatchObject({
+      name: 'jsonFeedAuto',
+      description: 'Imported JSON feed',
+      scheduling_period: 'PT1H',
+      uri: 'http://jsonserver.invalid/api/data',
+      verb: 'get',
+      ssl_verify: true,
+      headers: [{ name: 'Accept', value: 'application/json' }],
+    });
+    expect(imported.jsonMapper.name).toBe('JSON mapper from feed import test');
+    expect(imported.jsonMapper.id).toBeDefined();
+    importedMapperId = imported.jsonMapper.id;
+  });
+
+  it('should reuse the existing mapper when importing the same configuration again', async () => {
+    // Covers: jsonFeedAddInputFromImport mapper reuse branch (ingestion-json-domain.ts)
+    const upload = await createUploadFromTestDataFile('jsonFeed/test-json-feed.json', 'test-json-feed.json', 'application/json');
+    const result = await queryAsAdminWithSuccess({
+      query: IMPORT_MUTATION,
+      variables: { file: upload },
+    });
+    const imported = result.data?.ingestionJsonAddInputFromImport;
+    expect(imported.jsonMapper.id).toBe(importedMapperId);
+  });
+
+  it('should refuse a configuration exported by an incompatible platform version', async () => {
+    // Covers: the version guard of jsonFeedAddInputFromImport
+    const upload = await createUploadFromTestDataFile('jsonFeed/test-json-feed-outdated.json', 'test-json-feed-outdated.json', 'application/json');
+    const result = await queryAsAdmin({
+      query: IMPORT_MUTATION,
+      variables: { file: upload },
+    });
+    expect(result.errors).toBeDefined();
+    if (result.errors) {
+      expect(result.errors[0].message).toContain('Invalid version of the platform');
+    }
+  });
+
+  it('should refuse a configuration without an embedded mapper', async () => {
+    // Covers: the missing mapper guard of jsonFeedAddInputFromImport
+    const upload = await createUploadFromTestDataFile('jsonFeed/test-json-feed-no-mapper.json', 'test-json-feed-no-mapper.json', 'application/json');
+    const result = await queryAsAdmin({
+      query: IMPORT_MUTATION,
+      variables: { file: upload },
+    });
+    expect(result.errors).toBeDefined();
+    if (result.errors) {
+      expect(result.errors[0].message).toContain('missing embedded JSON mapper');
+    }
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-json-resolver-test.ts
@@ -284,6 +284,10 @@ describe('JSON ingestion resolver — configuration export / import', () => {
           user_id: ADMIN_USER.id,
           scheduling_period: 'PT1H',
           verb: 'get',
+          headers: [
+            { name: 'Accept', value: 'application/json' },
+            { name: 'Authorization', value: 'Bearer super-secret-token' },
+          ],
         },
       },
     });
@@ -332,6 +336,12 @@ describe('JSON ingestion resolver — configuration export / import', () => {
       // Credentials are platform-specific and never exported.
       authentication_value: '',
     });
+    // Covers: sanitizeExportedHeaders — sensitive header values are blanked,
+    // non-sensitive ones are exported as-is.
+    expect(exported.configuration.headers).toEqual([
+      { name: 'Accept', value: 'application/json' },
+      { name: 'Authorization', value: '' },
+    ]);
     expect(exported.configuration.json_mapper.name).toBe('JSON mapper for export test');
     expect(exported.configuration.json_mapper.representations).toHaveLength(1);
     expect(exported.configuration.json_mapper.representations[0].target.entity_type).toBe('Domain-Name');

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-taxii-collection-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-taxii-collection-resolver-test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { createUploadFromTestDataFile, queryAsAdmin, queryAsAdminWithSuccess } from '../../../utils/testQueryHelper';
+import { ADMIN_USER } from '../../../utils/testQuery';
+
+describe('TAXII push ingestion resolver — configuration export / import', () => {
+  let createdTaxiiPushId: string = '';
+
+  it('should create a TAXII push ingester', async () => {
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        mutation createTaxiiPushIngester($input: IngestionTaxiiCollectionAddInput!) {
+          ingestionTaxiiCollectionAdd(input: $input) {
+            id
+            name
+            description
+            confidence_to_score
+          }
+        }
+      `,
+      variables: {
+        input: {
+          name: 'Taxii push for export test',
+          description: 'Taxii push export description',
+          confidence_to_score: true,
+          user_id: ADMIN_USER.id,
+          authorized_members: [],
+        },
+      },
+    });
+    const created = result.data?.ingestionTaxiiCollectionAdd;
+    expect(created.id).toBeDefined();
+    createdTaxiiPushId = created.id;
+  });
+
+  it('should generate correct export configuration', async () => {
+    // Covers: taxiiCollectionExport (ingestion-taxii-collection-domain.ts)
+    // Covers: IngestionTaxiiCollection.toConfigurationExport field resolver
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        query queryTaxiiPush($id: String!) {
+          ingestionTaxiiCollection(id: $id) {
+            name
+            toConfigurationExport
+          }
+        }
+      `,
+      variables: { id: createdTaxiiPushId },
+    });
+    const exported = JSON.parse(result.data?.ingestionTaxiiCollection.toConfigurationExport);
+    expect(exported.type).toBe('taxiiPushCollections');
+    expect(exported.openCTI_version).toBeDefined();
+    expect(exported.configuration).toMatchObject({
+      name: 'Taxii push for export test',
+      description: 'Taxii push export description',
+      confidence_to_score: true,
+    });
+    // The portable subset only: user and authorized members stay platform-specific.
+    expect(exported.configuration.user_id).toBeUndefined();
+    expect(exported.configuration.authorized_members).toBeUndefined();
+  });
+
+  it('should parse an imported configuration file', async () => {
+    // Covers: taxiiCollectionAddInputFromImport (ingestion-taxii-collection-domain.ts)
+    const upload = await createUploadFromTestDataFile('taxiiPush/test-taxii-push.json', 'test-taxii-push.json', 'application/json');
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        query taxiiPushAddInputFromImport($file: Upload!) {
+          ingestionTaxiiCollectionAddInputFromImport(file: $file) {
+            name
+            description
+            confidence_to_score
+          }
+        }
+      `,
+      variables: { file: upload },
+    });
+    expect(result.data?.ingestionTaxiiCollectionAddInputFromImport).toMatchObject({
+      name: 'taxiiPushAuto',
+      description: 'Taxii push imported description',
+      confidence_to_score: true,
+    });
+  });
+
+  it('should refuse a configuration exported by an incompatible platform version', async () => {
+    // Covers: the version guard of taxiiCollectionAddInputFromImport
+    const upload = await createUploadFromTestDataFile('taxiiPush/test-taxii-push-outdated.json', 'test-taxii-push-outdated.json', 'application/json');
+    const result = await queryAsAdmin({
+      query: gql`
+        query taxiiPushAddInputFromOutdatedImport($file: Upload!) {
+          ingestionTaxiiCollectionAddInputFromImport(file: $file) {
+            name
+          }
+        }
+      `,
+      variables: { file: upload },
+    });
+    expect(result.errors).toBeDefined();
+    if (result.errors) {
+      expect(result.errors[0].message).toContain('Invalid version of the platform');
+    }
+  });
+
+  it('should delete the TAXII push ingester', async () => {
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        mutation deleteTaxiiPushIngester($id: ID!) {
+          ingestionTaxiiCollectionDelete(id: $id)
+        }
+      `,
+      variables: { id: createdTaxiiPushId },
+    });
+    expect(result.data?.ingestionTaxiiCollectionDelete).toEqual(createdTaxiiPushId);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/data/jsonFeed/test-json-feed-no-mapper.json
+++ b/opencti-platform/opencti-graphql/tests/data/jsonFeed/test-json-feed-no-mapper.json
@@ -1,0 +1,4 @@
+{"openCTI_version":"7.260722.0","type":"jsonFeeds","configuration": {
+  "name": "jsonFeedWithoutMapper",
+  "uri": "http://jsonserver.invalid/api/data"
+}}

--- a/opencti-platform/opencti-graphql/tests/data/jsonFeed/test-json-feed-outdated.json
+++ b/opencti-platform/opencti-graphql/tests/data/jsonFeed/test-json-feed-outdated.json
@@ -1,0 +1,5 @@
+{"openCTI_version":"6.9.4","type":"jsonFeeds","configuration": {
+  "name": "jsonFeedOutdated",
+  "uri": "http://jsonserver.invalid/api/data",
+  "json_mapper": { "name": "Some mapper", "variables": [], "representations": [] }
+}}

--- a/opencti-platform/opencti-graphql/tests/data/jsonFeed/test-json-feed.json
+++ b/opencti-platform/opencti-graphql/tests/data/jsonFeed/test-json-feed.json
@@ -1,0 +1,28 @@
+{"openCTI_version":"7.260722.0","type":"jsonFeeds","configuration": {
+  "name": "jsonFeedAuto",
+  "description": "Imported JSON feed",
+  "scheduling_period": "PT1H",
+  "uri": "http://jsonserver.invalid/api/data",
+  "verb": "get",
+  "body": null,
+  "pagination_with_sub_page": false,
+  "pagination_with_sub_page_attribute_path": null,
+  "pagination_with_sub_page_query_verb": null,
+  "headers": [{"name": "Accept", "value": "application/json"}],
+  "query_attributes": [],
+  "authentication_type": "none",
+  "authentication_value": "",
+  "ssl_verify": true,
+  "json_mapper": {
+    "name": "JSON mapper from feed import test",
+    "variables": [],
+    "representations": [
+      {
+        "id": "b1a2c3d4-0000-0000-0000-000000000010",
+        "type": "entity",
+        "target": { "entity_type": "Domain-Name", "path": "$[*]" },
+        "attributes": [{ "mode": "simple", "key": "value", "attr_path": { "path": "$.domain" } }]
+      }
+    ]
+  }
+}}

--- a/opencti-platform/opencti-graphql/tests/data/taxiiPush/test-taxii-push-outdated.json
+++ b/opencti-platform/opencti-graphql/tests/data/taxiiPush/test-taxii-push-outdated.json
@@ -1,0 +1,5 @@
+{"openCTI_version":"6.9.4","type":"taxiiPushCollections","configuration": {
+  "name": "taxiiPushOutdated",
+  "description": "Exported by a platform older than the minimal compatible version",
+  "confidence_to_score": false
+}}

--- a/opencti-platform/opencti-graphql/tests/data/taxiiPush/test-taxii-push.json
+++ b/opencti-platform/opencti-graphql/tests/data/taxiiPush/test-taxii-push.json
@@ -1,0 +1,5 @@
+{"openCTI_version":"7.260722.0","type":"taxiiPushCollections","configuration": {
+  "name": "taxiiPushAuto",
+  "description": "Taxii push imported description",
+  "confidence_to_score": true
+}}


### PR DESCRIPTION
﻿## Proposed changes

Follow-up of #17323 (merged): closes the remaining post-merge findings on the new backend export/import code.

### Fixes (post-merge Copilot review on #17323)

- `createJsonMapperFromConfiguration` now converts the imported representations ids back to internal ids (`convertRepresentationsIds(..., 'stix')`) before persisting, mirroring the CSV mapper import. Exports convert `default_values` to STIX standard ids, so without the reverse conversion imported mappers (standalone or embedded in a JSON feed) could carry unresolvable default values. This was a pre-existing gap in `jsonMapperImport` that the refactor surfaced.
- `jsonFeedExport` now sanitizes headers through a new `sanitizeExportedHeaders` helper: any header whose name matches authorization/token/key/secret/password/cookie/credential (case-insensitive) has its value blanked in the exported file, matching the "set again at import time" approach already used for `authentication_value`. Non-sensitive headers (e.g. Accept) are exported as-is.

### Test coverage (codecov opencti-graphql-mandatory patch check)

- New ingestion-taxii-collection-resolver-test.ts: creates a TAXII push ingester, verifies the toConfigurationExport payload (portable subset only - no user, no authorized members), parses an imported configuration file, rejects a configuration exported by an incompatible platform version, and deletes the ingester.
- Extended ingestion-json-resolver-test.ts with a configuration export / import block: verifies the self-contained export (embedded JSON mapper with representations, sensitive header values blanked, non-sensitive headers kept), covers both import branches (mapper created from the embedded configuration on first import, existing mapper reused by name on re-import), and both failure guards (incompatible version, missing embedded mapper).
- New test data files under tests/data/jsonFeed and tests/data/taxiiPush (valid, outdated-version and missing-mapper configurations).

## Related issues

- Closes #17322

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality


