### PR TITLE
fix(frontend): make integrations cards and lines real links for ctrl+click (#17333)

### DIFF
--- a/opencti-platform/opencti-front/src/components/ItemCreators.tsx
+++ b/opencti-platform/opencti-front/src/components/ItemCreators.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import Security from '../utils/Security';
+import { shouldOpenInNewTabMouseEvent } from '../utils/domEvent';
 import { SETTINGS_SETACCESSES } from '../utils/hooks/useGranted';
 import { Stack } from '@mui/material';
 import Tag from '@common/tag/Tag';
@@ -23,6 +24,17 @@ interface ItemCreatorsProps {
 const ItemCreators = ({ creators }: ItemCreatorsProps) => {
   const navigate = useNavigate();
 
+  // Chips cannot be real anchors without losing the Tag styling: honor
+  // ctrl/cmd click manually so the user page can open in a new tab.
+  const goToUser = (event: React.MouseEvent, creatorId: string) => {
+    const link = `/dashboard/settings/accesses/users/${creatorId}`;
+    if (shouldOpenInNewTabMouseEvent(event)) {
+      window.open(link, '_blank');
+    } else {
+      navigate(link);
+    }
+  };
+
   return (
     <Stack direction="row" gap={1} flexWrap="wrap">
       {creators.map((creator) => {
@@ -40,7 +52,7 @@ const ItemCreators = ({ creators }: ItemCreatorsProps) => {
               <Tag
                 key={creator.id}
                 label={creator.name}
-                onClick={() => navigate(`/dashboard/settings/accesses/users/${creator.id}`)}
+                onClick={(event) => goToUser(event, creator.id)}
               />
             )}
           </Security>

--- a/opencti-platform/opencti-front/src/private/components/integrations/available/AvailableIntegrationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/available/AvailableIntegrationLine.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Stack, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
@@ -16,6 +16,7 @@ import { useFormatter } from '../../../../components/i18n';
 import useGranted, { INGESTION_SETINGESTIONS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import stopEvent from '../../../../utils/domEvent';
 
 // Shared column geometry between the header row and the lines, mirroring the
 // deployed tab lines view: the name column absorbs the remaining space and
@@ -91,7 +92,6 @@ export interface AvailableIntegrationLineProps {
 const AvailableIntegrationLine = ({ item, isEnterpriseEdition, onClickDeploy, onClickCreate }: AvailableIntegrationLineProps) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme();
-  const navigate = useNavigate();
   const canCreate = useGranted([INGESTION_SETINGESTIONS]);
 
   const connector = item.connector?.connector;
@@ -104,20 +104,18 @@ const AvailableIntegrationLine = ({ item, isEnterpriseEdition, onClickDeploy, on
     ? connector.short_description
     : t_i18n(item.builtIn?.description ?? '');
 
-  // Opening a connector line navigates to its catalog detail; a built-in line
+  // Opening a connector line navigates to its catalog detail (rendered as a
+  // real link so ctrl/cmd/middle click opens a new tab); a built-in line
   // opens its creation drawer (like the matching cards).
-  const handleLineClick = () => {
-    if (connector) {
-      navigate(`/dashboard/integrations/catalog/${connector.slug}`);
-    } else if (canCreate) {
-      onClickCreate();
-    }
-  };
+  const linkProps = connector
+    ? { component: Link, to: `/dashboard/integrations/catalog/${connector.slug}` }
+    : {};
 
   return (
     <Box
       data-testid="available-integration-line"
-      onClick={handleLineClick}
+      {...linkProps}
+      onClick={!connector && canCreate ? onClickCreate : undefined}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -125,6 +123,8 @@ const AvailableIntegrationLine = ({ item, isEnterpriseEdition, onClickDeploy, on
         paddingInline: 1.5,
         paddingBlock: 0.75,
         cursor: connector || canCreate ? 'pointer' : undefined,
+        textDecoration: 'none',
+        color: 'inherit',
         transition: 'background-color 0.2s ease-in-out',
         '&:hover': {
           backgroundColor: theme.palette.action.hover,
@@ -242,8 +242,8 @@ const AvailableIntegrationLine = ({ item, isEnterpriseEdition, onClickDeploy, on
           </Typography>
         )}
       </Box>
-      {/* Actions column. */}
-      <Box onClick={(event) => event.stopPropagation()} sx={cellSx('actions')}>
+      {/* Actions column: lives inside the row link, block navigation. */}
+      <Box onClick={stopEvent} sx={cellSx('actions')}>
         <Security needs={[INGESTION_SETINGESTIONS]}>
           {item.builtIn ? (
             <Stack direction="row" alignItems="center">

--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/IngestionCatalogCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { CardActions, Stack, Typography } from '@mui/material';
 import { GroupsOutlined } from '@mui/icons-material';
-import { useNavigate } from 'react-router-dom';
 import { alpha, useTheme } from '@mui/material/styles';
 import { IngestionConnector } from '@components/integrations/catalog/types';
 import EnterpriseEditionButton from '@components/common/entreprise_edition/EnterpriseEditionButton';
@@ -14,6 +13,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { INGESTION_SETINGESTIONS } from '../../../../utils/hooks/useGranted';
 import Security from '../../../../utils/Security';
 import Card from '../../../../components/common/card/Card';
+import stopEvent from '../../../../utils/domEvent';
 import FiligranIcon from '@components/common/FiligranIcon';
 import { LogoFiligranIcon } from 'filigran-icon';
 
@@ -113,7 +113,9 @@ const ConnectorActions = ({
         sx={{ marginLeft: '0!important' }}
         direction="row"
         gap={1}
-        onClick={(e) => e.stopPropagation()}
+        // The actions live inside the card link: block both the click
+        // bubbling and the native anchor navigation.
+        onClick={stopEvent}
       >
         <Security needs={[INGESTION_SETINGESTIONS]}>
           {isEnterpriseEdition ? (
@@ -143,18 +145,12 @@ const IngestionCatalogCard = ({
   const { t_i18n } = useFormatter();
   const theme = useTheme();
 
-  const navigate = useNavigate();
-
   const link = `/dashboard/integrations/catalog/${connector.slug}`;
 
   const connectorMetadata = getConnectorMetadata(
     connector.container_type,
     t_i18n,
   );
-
-  const handleCardClick = () => {
-    navigate(link);
-  };
 
   return (
     <Box
@@ -173,7 +169,8 @@ const IngestionCatalogCard = ({
       }}
     >
       <Card
-        onClick={handleCardClick}
+        // A real link so ctrl/cmd/middle click opens the connector in a new tab.
+        to={link}
         sx={{
           height: 280,
           borderRadius: 1,

--- a/opencti-platform/opencti-front/src/private/components/integrations/components/MarketplaceUi.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/components/MarketplaceUi.tsx
@@ -9,6 +9,7 @@ import { useFormatter } from '../../../../components/i18n';
 import GradientCard from '../../../../components/GradientCard';
 import { UserContext } from '../../../../utils/hooks/useAuth';
 import { isNotEmptyField } from '../../../../utils/utils';
+import stopEvent, { shouldOpenInNewTabMouseEvent } from '../../../../utils/domEvent';
 
 export const BrowseMoreButton = () => {
   const { t_i18n } = useFormatter();
@@ -52,9 +53,15 @@ export const DeployedCountChip = ({ count, to }: { count: number; to?: string })
         variant="outlined"
         onClick={to
           ? (event) => {
-            // The chip may live inside a clickable card: do not trigger it.
-              event.stopPropagation();
-              navigate(to);
+            // The chip lives inside a card or line rendered as a link: block
+            // both the bubbling and the anchor navigation, then honor
+            // ctrl/cmd/middle click by opening the deployed tab in a new tab.
+              stopEvent(event);
+              if (shouldOpenInNewTabMouseEvent(event)) {
+                window.open(to, '_blank');
+              } else {
+                navigate(to);
+              }
             }
           : undefined}
         sx={{

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationCard.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationCard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Stack, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
@@ -10,6 +9,7 @@ import { DeployedIntegrationItem } from '@components/integrations/deployed/useDe
 import { useFormatter } from '../../../../components/i18n';
 import Card from '../../../../components/common/card/Card';
 import ItemBoolean from '../../../../components/ItemBoolean';
+import stopEvent from '../../../../utils/domEvent';
 
 interface StatusDotProps {
   item: DeployedIntegrationItem;
@@ -80,7 +80,6 @@ export interface DeployedIntegrationCardProps {
 const DeployedIntegrationCard = ({ item, onChange }: DeployedIntegrationCardProps) => {
   const { t_i18n, n, nsdt } = useFormatter();
   const theme = useTheme();
-  const navigate = useNavigate();
   const typeMetadata = useDeployedTypeMetadata();
   const { label: typeLabel, icon: TypeIcon } = typeMetadata(item.sectionKey);
 
@@ -112,7 +111,8 @@ const DeployedIntegrationCard = ({ item, onChange }: DeployedIntegrationCardProp
       }}
     >
       <Card
-        onClick={() => navigate(item.detailUrl)}
+        // A real link so ctrl/cmd/middle click opens the detail in a new tab.
+        to={item.detailUrl}
         sx={{
           height: 220,
           borderRadius: 1,
@@ -247,7 +247,7 @@ const DeployedIntegrationCard = ({ item, onChange }: DeployedIntegrationCardProp
               <Metric label={t_i18n('User')} value={item.userName} />
             )}
           </Stack>
-          <Box onClick={(event) => event.stopPropagation()}>
+          <Box onClick={stopEvent}>
             {statusChip}
           </Box>
         </Stack>

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationLine.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Stack, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import { alpha, useTheme } from '@mui/material/styles';
@@ -10,6 +10,7 @@ import { DeployedIntegrationItem } from '@components/integrations/deployed/useDe
 import { useFormatter } from '../../../../components/i18n';
 import ItemBoolean from '../../../../components/ItemBoolean';
 import { EMPTY_VALUE } from '../../../../utils/String';
+import stopEvent from '../../../../utils/domEvent';
 
 // Shared column geometry between the header row and the lines, so every
 // section renders as a proper aligned table. Widths are percentages of the
@@ -92,7 +93,6 @@ export interface DeployedIntegrationLineProps {
 const DeployedIntegrationLine = ({ item, onChange }: DeployedIntegrationLineProps) => {
   const { t_i18n, n, nsdt, rd } = useFormatter();
   const theme = useTheme();
-  const navigate = useNavigate();
   const typeMetadata = useDeployedTypeMetadata();
   const { label: typeLabel, icon: TypeIcon } = typeMetadata(item.sectionKey);
 
@@ -114,7 +114,9 @@ const DeployedIntegrationLine = ({ item, onChange }: DeployedIntegrationLineProp
   return (
     <Box
       data-testid="integration-line"
-      onClick={() => navigate(item.detailUrl)}
+      // A real link so ctrl/cmd/middle click opens the detail in a new tab.
+      component={Link}
+      to={item.detailUrl}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -122,6 +124,8 @@ const DeployedIntegrationLine = ({ item, onChange }: DeployedIntegrationLineProp
         paddingInline: 1.5,
         paddingBlock: 0.75,
         cursor: 'pointer',
+        textDecoration: 'none',
+        color: 'inherit',
         transition: 'background-color 0.2s ease-in-out',
         '&:hover': {
           backgroundColor: theme.palette.action.hover,
@@ -283,8 +287,8 @@ const DeployedIntegrationLine = ({ item, onChange }: DeployedIntegrationLineProp
           </Typography>
         )}
       </Box>
-      {/* Status column. */}
-      <Box onClick={(event) => event.stopPropagation()} sx={cellSx('status')}>
+      {/* Status column: lives inside the row link, block navigation. */}
+      <Box onClick={stopEvent} sx={cellSx('status')}>
         {item.status === 'processing'
           ? <ItemBoolean status={undefined} label={statusText} />
           : <ItemBoolean status={item.status === 'active'} label={statusText} />}


### PR DESCRIPTION
## Proposed changes

Closes #17333.

In the new integrations experience, cards and lines navigated with a JavaScript onClick handler (useNavigate), so ctrl+click, cmd+click and middle-click could not open the target in a new tab, unlike everywhere else in the platform (the generic data table already renders a real anchor with new-tab support).

- IngestionCatalogCard: the card now uses the shared Card 'to' prop, which renders a CardActionArea as a real react-router Link. The actions area (deploy button, deployed chip) blocks both the click bubbling and the native anchor navigation via the shared stopEvent helper.
- DeployedIntegrationCard: same conversion to the Card 'to' prop; the status chip container uses stopEvent.
- DeployedIntegrationLine: the row is now rendered as a Link (Box component={Link}); the status cell uses stopEvent.
- AvailableIntegrationLine: connector rows are rendered as a Link to the catalog detail; built-in rows keep the onClick behavior since they open the creation drawer (an action, not a navigation). The actions cell uses stopEvent.
- DeployedCountChip (MarketplaceUi): the chip stays a click handler because it is nested inside cards/rows that are now real anchors (nested anchors are invalid HTML), but it now honors ctrl/cmd click by opening the deployed tab in a new tab, and uses stopEvent so it never triggers the parent link.
- ItemCreators: the creator chips now honor ctrl/cmd click to open the user page in a new tab (chips cannot become real anchors without losing the Tag styling).

## Assessment of the rest of the frontend

A full sweep for onClick-based navigation found no other card/line gap:

- DataTableLine (all standard list views) already renders a real anchor with explicit ctrl/cmd/middle click support.
- PublicDashboardLineActions 'View dashboard' is a popover menu item (action semantics, not a row link).
- RegisterPlatformBanner / SmtpRefreshTokenBanner CTAs are banner buttons, not list items.
- FileWork draft navigation is an action IconButton that switches draft context before navigating.
- Alerts and SSOSingletonStrategies line clicks open drawers, not navigations.

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality (lint + type-check pass)
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (no doc update needed)
- [ ] Where necessary I refactored code to improve the overall quality