### PR TITLE
fix(backend): isolate JSON feed failures in the ingestion manager (#17337)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -656,33 +656,43 @@ export const jsonExecutor = async (context: AuthContext) => {
   const ingestions = await findAllJsonIngestion(context, SYSTEM_USER, opts);
   for (let i = 0; i < ingestions.length; i += 1) {
     const ingestion = ingestions[i];
-    if (isMustExecuteIteration(ingestion.last_execution_date, ingestion.scheduling_period)) {
-      const { messages_number, messages_size } = await queueDetails(connectorIdFromIngestId(ingestion.id));
-      if (messages_number === 0) { // If no more ingestion to do
-        logApp.info(`[OPENCTI-MODULE] Executing Json ingestion for ${ingestion.name}`);
-        const { objects, variables, nextExecutionState } = await executeJsonQuery(context, ingestion, {
-          timeout: FEED_REQUEST_TIMEOUT,
-        });
-        logApp.info(`[OPENCTI-MODULE] Json ingestion execution for ${objects.length} items`);
-        // Push the bundle to absorption queue if required
-        if (objects.length > 0) {
-          const bundle: StixBundle = {
-            id: `bundle--${uuidv4()}`,
-            spec_version: '2.1',
-            type: 'bundle',
-            objects,
-          };
-          await pushBundleToConnectorQueue(context, ingestion, bundle);
+    // Isolate each feed: a single failing JSON ingestion (e.g. remote server down, timeout or
+    // invalid response) must not prevent the other JSON feeds from running in this cycle. On
+    // error we also update last_execution_date so the failing feed respects its scheduling
+    // period before retrying, consistent with the csv/rss/taxii executors.
+    try {
+      if (isMustExecuteIteration(ingestion.last_execution_date, ingestion.scheduling_period)) {
+        const { messages_number, messages_size } = await queueDetails(connectorIdFromIngestId(ingestion.id));
+        if (messages_number === 0) { // If no more ingestion to do
+          logApp.info(`[OPENCTI-MODULE] Executing Json ingestion for ${ingestion.name}`);
+          const { objects, variables, nextExecutionState } = await executeJsonQuery(context, ingestion, {
+            timeout: FEED_REQUEST_TIMEOUT,
+          });
+          logApp.info(`[OPENCTI-MODULE] Json ingestion execution for ${objects.length} items`);
+          // Push the bundle to absorption queue if required
+          if (objects.length > 0) {
+            const bundle: StixBundle = {
+              id: `bundle--${uuidv4()}`,
+              spec_version: '2.1',
+              type: 'bundle',
+              objects,
+            };
+            await pushBundleToConnectorQueue(context, ingestion, bundle);
+          }
+          // Save new state for next execution
+          const ingestionState = mergeQueryState(ingestion.query_attributes, variables, nextExecutionState);
+          const state = { ingestion_json_state: ingestionState, last_execution_date: now() };
+          await patchJsonIngestion(context, SYSTEM_USER, ingestion.internal_id, state);
+          await updateBuiltInConnectorInfo(context, ingestion.user_id, ingestion.id, { state: ingestionState });
+        } else {
+          // Update the state
+          await updateBuiltInConnectorInfo(context, ingestion.user_id, ingestion.id, { buffering: true, messages_size });
         }
-        // Save new state for next execution
-        const ingestionState = mergeQueryState(ingestion.query_attributes, variables, nextExecutionState);
-        const state = { ingestion_json_state: ingestionState, last_execution_date: now() };
-        await patchJsonIngestion(context, SYSTEM_USER, ingestion.internal_id, state);
-        await updateBuiltInConnectorInfo(context, ingestion.user_id, ingestion.id, { state: ingestionState });
-      } else {
-        // Update the state
-        await updateBuiltInConnectorInfo(context, ingestion.user_id, ingestion.id, { buffering: true, messages_size });
       }
+    } catch (e: any) {
+      logApp.warn('[OPENCTI-MODULE] INGESTION - Json ingestion execution', { cause: e.message, name: ingestion.name });
+      await patchJsonIngestion(context, SYSTEM_USER, ingestion.internal_id, { last_execution_date: now() })
+        .catch((reason) => logApp.error('ERROR', { cause: reason }));
     }
   }
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestionManager-feed-timeout-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/ingestion/ingestionManager-feed-timeout-test.ts
@@ -267,4 +267,53 @@ describe('Ingestion manager feed timeout behavior', () => {
       expect.objectContaining({ timeout: 50 }),
     );
   });
+
+  it('should continue JSON iteration when one feed fails and another is healthy', async () => {
+    const baseIngestion = {
+      user_id: 'user--1',
+      scheduling_period: 'auto',
+      last_execution_date: undefined,
+      query_attributes: [],
+    };
+    const failingIngestion = {
+      ...baseIngestion,
+      id: 'json--fail',
+      internal_id: 'json-internal--fail',
+      name: 'Failing JSON',
+    };
+    const healthyIngestion = {
+      ...baseIngestion,
+      id: 'json--ok',
+      internal_id: 'json-internal--ok',
+      name: 'Working JSON',
+    };
+    // The failing feed is processed first: before the fix, its throw aborted the loop and the
+    // healthy feed was never reached.
+    findAllJsonIngestionMock.mockResolvedValue([failingIngestion, healthyIngestion]);
+    executeJsonQueryMock.mockImplementation((_ctx: unknown, ingestion: { internal_id: string }) => {
+      if (ingestion.internal_id === 'json-internal--fail') {
+        return Promise.reject(new Error('remote feed is down'));
+      }
+      return Promise.resolve({ objects: [], variables: {}, nextExecutionState: {} });
+    });
+
+    const { jsonExecutor } = await import('../../../../src/manager/ingestionManager');
+
+    // A single failing feed must not stop the whole JSON iteration.
+    await expect(jsonExecutor({} as any)).resolves.toBeUndefined();
+
+    // The healthy feed after the failing one is still processed.
+    expect(executeJsonQueryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      healthyIngestion,
+      expect.objectContaining({ timeout: 50 }),
+    );
+    // The failing feed's last_execution_date is updated so it respects its scheduling period.
+    expect(patchJsonIngestionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'json-internal--fail',
+      expect.objectContaining({ last_execution_date: expect.any(String) }),
+    );
+  });
 });


### PR DESCRIPTION
## Proposed changes

`jsonExecutor` (`src/manager/ingestionManager.ts`) processed JSON ingestion feeds in a sequential loop and awaited `executeJsonQuery`/`pushBundleToConnectorQueue`/`patchJsonIngestion` **without a per-feed guard**. A single feed whose remote server is down, times out, or returns an invalid response threw out of the loop, so **every JSON feed after it was skipped for that cycle** — and the failing feed's `last_execution_date` was never updated, causing aggressive retries.

The sibling executors (`csvExecutor`, `rssExecutor`, `taxiiExecutor`) already isolate each feed with a `.catch()` that logs and updates `last_execution_date`. This change brings `jsonExecutor` in line: each feed iteration is wrapped in try/catch, logging a warning and updating `last_execution_date` on failure.

## Related issues

Closes #17337

## How to test

```bash
cd opencti-platform/opencti-graphql
yarn vitest run --config vitest.config.ci-unit.ts tests/01-unit/modules/ingestion/ingestionManager-feed-timeout-test.ts
```

Adds a test ("should continue JSON iteration when one feed fails and another is healthy") — a failing feed is processed first, and the test asserts the healthy feed after it is still executed and the failing feed's `last_execution_date` is updated. 5/5 tests pass; the new test fails without the fix.