### PR TITLE
fix(backend): only drop the deleted marking's type from group max shareable markings (#17339)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/markingDefinition.js
+++ b/opencti-platform/opencti-graphql/src/domain/markingDefinition.js
@@ -131,7 +131,12 @@ export const markingDefinitionDeleteAndUpdateGroups = async (context, user, mark
     const editShareableMarkingsPromises = [];
     groupsWithMarkingInShareableMarkings.forEach((group) => {
       const type = markingDefinition.definition_type;
-      const value = (group.max_shareable_markings ?? []).filter(({ type: t, value: v }) => t !== type && v !== 'none');
+      // Only drop the entry for the deleted marking's type. The query above only matches groups
+      // whose entry value equals the deleted marking id (never the 'none' sentinel), so filtering
+      // by type alone removes it. The previous `&& v !== 'none'` also wiped the 'none' ("not
+      // shareable") entries of every other type, silently making them shareable. This mirrors the
+      // add-path in updateGroupsAfterAddingMarking, which filters by type only.
+      const value = (group.max_shareable_markings ?? []).filter(({ type: t }) => t !== type);
       editShareableMarkingsPromises.push(groupEditField(context, user, group.id, [{ key: 'max_shareable_markings', value }]));
     });
     await Promise.all(editShareableMarkingsPromises);


### PR DESCRIPTION
## Proposed changes

When a marking definition is deleted, `markingDefinitionDeleteAndUpdateGroups` (`src/domain/markingDefinition.js`) rebuilt each affected group's `max_shareable_markings` with:

```js
.filter(({ type: t, value: v }) => t !== type && v !== 'none')
```

The group lookup only selects entries whose `value` equals the **deleted marking id** (never the `'none'` sentinel), so `t !== type` alone already removes the deleted marking. The extra `&& v !== 'none'` additionally stripped **every** `'none'` entry — the `'none'` sentinel means "this marking type is **not** shareable" (see `groupNotShareableMarkingTypes` / `groupMaxShareableMarkings` in `domain/group.js`).

**Impact:** deleting a marking of one type silently removed the "not shareable" restriction of *other* types for that group, turning them shareable — an unintended relaxation of data-sharing restrictions.

The fix filters by `type` only, consistent with the add-path `updateGroupsAfterAddingMarking` (which uses `t !== markingType`).

## Related issues

Closes #17339

## How to test

```bash
cd opencti-platform/opencti-graphql
yarn eslint --config eslint.config.js src/domain/markingDefinition.js   # clean
```

Manual: give a group a `max_shareable_markings` with a specific marking for type A and the `'none'` sentinel for type B; delete the type-A marking; the type-B `'none'` entry is now preserved (previously it was wrongly removed, making type B shareable).