### PR TITLE
feat(telemetry): expose lock acquisition wait and contention metrics (#17341)

### DIFF
--- a/opencti-platform/opencti-graphql/src/config/tracing.ts
+++ b/opencti-platform/opencti-graphql/src/config/tracing.ts
@@ -50,11 +50,11 @@ class MeterManager {
     this.latencyHistogram?.record(val, attributes);
   }
 
-  lockWait(val: number, attributes: any) {
+  lockWait(val: number, attributes?: any) {
     this.lockWaitHistogram?.record(val, attributes);
   }
 
-  lockContention(attributes: any) {
+  lockContention(attributes?: any) {
     this.lockContentions?.add(1, attributes);
   }
 

--- a/opencti-platform/opencti-graphql/src/config/tracing.ts
+++ b/opencti-platform/opencti-graphql/src/config/tracing.ts
@@ -22,6 +22,10 @@ class MeterManager {
 
   private latencyHistogram: Histogram | null = null;
 
+  private lockWaitHistogram: Histogram | null = null;
+
+  private lockContentions: Counter | null = null;
+
   private directBulkGauge: Gauge | null = null;
 
   private sideBulkGauge: Gauge | null = null;
@@ -44,6 +48,14 @@ class MeterManager {
 
   latency(val: number, attributes: any) {
     this.latencyHistogram?.record(val, attributes);
+  }
+
+  lockWait(val: number, attributes: any) {
+    this.lockWaitHistogram?.record(val, attributes);
+  }
+
+  lockContention(attributes: any) {
+    this.lockContentions?.add(1, attributes);
   }
 
   directBulk(val: number, attributes: any) {
@@ -69,11 +81,20 @@ class MeterManager {
       valueType: ValueType.INT,
       description: 'Counts total number of errors',
     });
+    this.lockContentions = meter.createCounter('opencti_lock_contentions', {
+      valueType: ValueType.INT,
+      description: 'Counts lock acquisitions that needed more than one attempt',
+    });
     // - Histograms
     this.latencyHistogram = meter.createHistogram('opencti_api_latency', {
       valueType: ValueType.INT,
       description: 'Latency computing per query',
       advice: { explicitBucketBoundaries: [0, 100, 500, 2000, 5000, 10000, 20000, 30000] },
+    });
+    this.lockWaitHistogram = meter.createHistogram('opencti_lock_acquire_wait', {
+      valueType: ValueType.INT,
+      description: 'Lock acquisition wait time in milliseconds',
+      advice: { explicitBucketBoundaries: [0, 10, 50, 250, 500, 1000, 2500, 5000, 10000, 25000] },
     });
     // - Gauges
     this.directBulkGauge = meter.createGauge('opencti_api_direct_bulk', {

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -6,6 +6,7 @@ import * as R from 'ramda';
 import conf, { booleanConf, configureCA, DEV_MODE, getStoppingState, loadCert, logApp, REDIS_PREFIX, TOPIC_PREFIX } from '../config/conf';
 import { isNotEmptyField } from './utils';
 import { DatabaseError, LockTimeoutError, TYPE_LOCK_ERROR } from '../config/errors';
+import { meterManager } from '../config/tracing';
 import { mergeDeepRightAll, now } from '../utils/format';
 import type { BasicStoreCommon } from '../types/store';
 import type { AuthUser } from '../types/user';
@@ -424,7 +425,15 @@ export const lockResource = async (resources: Array<string>, opts: LockOptions =
   const { signal } = controller;
   const redlock = new Redlock([getClientLock()], { retryCount, retryDelay, retryJitter });
   // Get the lock
+  const acquireStart = Date.now();
   let lock = await redlock.acquire(locks, maxTtl); // Force unlock after maxTtl
+  // A contended acquisition waits in silent retry polls (retry_delay); without these metrics that
+  // wait is invisible: it inflates operation latency but emits no signal until full retry
+  // exhaustion throws a LOCK_ERROR.
+  meterManager.lockWait(Date.now() - acquireStart, {});
+  if (lock.attempts.length > 1) {
+    meterManager.lockContention({});
+  }
   const queue = () => {
     timeout = setTimeout(
       () => {

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -6,7 +6,6 @@ import * as R from 'ramda';
 import conf, { booleanConf, configureCA, DEV_MODE, getStoppingState, loadCert, logApp, REDIS_PREFIX, TOPIC_PREFIX } from '../config/conf';
 import { isNotEmptyField } from './utils';
 import { DatabaseError, LockTimeoutError, TYPE_LOCK_ERROR } from '../config/errors';
-import { meterManager } from '../config/tracing';
 import { mergeDeepRightAll, now } from '../utils/format';
 import type { BasicStoreCommon } from '../types/store';
 import type { AuthUser } from '../types/user';
@@ -427,13 +426,12 @@ export const lockResource = async (resources: Array<string>, opts: LockOptions =
   // Get the lock
   const acquireStart = performance.now(); // monotonic: immune to system clock adjustments
   let lock = await redlock.acquire(locks, maxTtl); // Force unlock after maxTtl
-  // A contended acquisition waits in silent retry polls (retry_delay); without these metrics that
-  // wait is invisible: it inflates operation latency but emits no signal until full retry
-  // exhaustion throws a LOCK_ERROR.
-  meterManager.lockWait(Math.round(performance.now() - acquireStart));
-  if (lock.attempts.length > 1) {
-    meterManager.lockContention();
-  }
+  // A contended acquisition waits in silent retry polls (retry_delay) and emits no signal until full
+  // retry exhaustion throws a LOCK_ERROR. Expose the measured wait and the attempt count on the
+  // returned lock: recording is done by the caller (master-lock) in the MAIN process, because with
+  // app:child_locking_process this code runs in the lock child, where no metric exporter lives.
+  const acquireWaitMs = Math.round(performance.now() - acquireStart);
+  const acquireAttempts = lock.attempts.length;
   const queue = () => {
     timeout = setTimeout(
       () => {
@@ -476,6 +474,8 @@ export const lockResource = async (resources: Array<string>, opts: LockOptions =
   return {
     signal,
     extend,
+    acquireWaitMs,
+    acquireAttempts,
     unlock: async () => {
       // First, wait for an in-flight extension to finish.
       if (extension) {

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -425,14 +425,14 @@ export const lockResource = async (resources: Array<string>, opts: LockOptions =
   const { signal } = controller;
   const redlock = new Redlock([getClientLock()], { retryCount, retryDelay, retryJitter });
   // Get the lock
-  const acquireStart = Date.now();
+  const acquireStart = performance.now(); // monotonic: immune to system clock adjustments
   let lock = await redlock.acquire(locks, maxTtl); // Force unlock after maxTtl
   // A contended acquisition waits in silent retry polls (retry_delay); without these metrics that
   // wait is invisible: it inflates operation latency but emits no signal until full retry
   // exhaustion throws a LOCK_ERROR.
-  meterManager.lockWait(Date.now() - acquireStart, {});
+  meterManager.lockWait(Math.round(performance.now() - acquireStart));
   if (lock.attempts.length > 1) {
-    meterManager.lockContention({});
+    meterManager.lockContention();
   }
   const queue = () => {
     timeout = setTimeout(

--- a/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
+++ b/opencti-platform/opencti-graphql/src/lock/child-lock.manager.ts
@@ -7,6 +7,8 @@ interface InternalLock {
   signal: AbortSignal;
   extend: () => Promise<void>;
   unlock: () => Promise<void>;
+  acquireWaitMs?: number;
+  acquireAttempts?: number;
 }
 
 const activeLocks: Map<string, InternalLock> = new Map<string, InternalLock>();
@@ -28,7 +30,15 @@ initializeOnlyRedisLockClient().then(() => {
         const lock = await lockResource(data.ids, options);
         activeLocks.set(data.operation, lock);
         if (process.send) {
-          process.send({ operation: data.operation, type: data.type, success: true });
+          // Ship the acquisition measures to the parent: metrics are recorded there (master-lock),
+          // this child process has no metric exporter.
+          process.send({
+            operation: data.operation,
+            type: data.type,
+            success: true,
+            acquireWaitMs: lock.acquireWaitMs,
+            acquireAttempts: lock.acquireAttempts,
+          });
         }
       } catch (err) {
         if (process.send) {

--- a/opencti-platform/opencti-graphql/src/lock/master-lock.js
+++ b/opencti-platform/opencti-graphql/src/lock/master-lock.js
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import { TYPE_LOCK_ERROR, UnsupportedError } from '../config/errors';
 import conf, { booleanConf, logApp } from '../config/conf';
 import { lockResource } from '../database/redis';
+import { meterManager } from '../config/tracing';
 
 // Global variable for the child process
 const USE_CHILD_LOCK = booleanConf('app:child_locking_process:enabled', false);
@@ -37,6 +38,19 @@ export const initLockFork = () => {
     logApp.info('[LOCKING] Locking fork process started');
   } else {
     logApp.info('[LOCKING] Locking fork process already started');
+  }
+};
+
+// Record lock acquisition telemetry. Must run in THIS (main) process: it holds the metric exporter.
+// The measurement itself is done next to the redlock acquire (redis.ts lockResource), in whichever
+// process performs it (direct or lock child), and travels back with the lock/IPC message.
+const recordLockAcquire = (acquireWaitMs, acquireAttempts) => {
+  if (acquireWaitMs === undefined) {
+    return;
+  }
+  meterManager.lockWait(acquireWaitMs);
+  if (acquireAttempts > 1) {
+    meterManager.lockContention();
   }
 };
 
@@ -81,6 +95,7 @@ const childLockResources = async (ids, args = {}) => {
     // Set up the lock callback
     lockProcess.callbacks.set(`${operation}-lock`, (msg) => {
       if (msg.success) {
+        recordLockAcquire(msg.acquireWaitMs, msg.acquireAttempts);
         const unlock = () => childUnlockResources(msg.operation);
         resolve({ operation, signal, unlock, result: msg });
       } else {
@@ -96,5 +111,10 @@ const childLockResources = async (ids, args = {}) => {
 
 // Lock resources, direct or child, depending
 export const lockResources = async (ids, args = {}) => {
-  return USE_CHILD_LOCK ? childLockResources(ids, args) : lockResource(ids, args);
+  if (USE_CHILD_LOCK) {
+    return childLockResources(ids, args);
+  }
+  const lock = await lockResource(ids, args);
+  recordLockAcquire(lock.acquireWaitMs, lock.acquireAttempts);
+  return lock;
 };


### PR DESCRIPTION
### Proposed changes

* Add two meters to the meter manager: `opencti_lock_acquire_wait` (histogram, ms, buckets aligned on the lock retry poll period) and `opencti_lock_contentions` (counter of acquisitions that needed more than one attempt). A contended acquisition currently waits in silent retry polls (`app:concurrency:retry_delay`) and emits no signal unless the whole retry budget is exhausted (LOCK_ERROR): the wait inflates operation latency while every existing metric stays flat.
* Measure next to the redlock acquire (`lockResource`): `acquireWaitMs` (monotonic clock) and `acquireAttempts` (from the redlock attempts list) are exposed on the returned lock.
* Record in the main process, in `lockResources` (master-lock): directly from the returned lock, or, with `app:child_locking_process` enabled (the default), from the measures shipped back in the lock-success IPC message. The lock child has no metric exporter, so recording must not happen there.

### Related issues

* closes #17341

### How to test this PR

* Start the platform with the Prometheus exporter enabled (`app:telemetry:metrics:exporter_prometheus`), run any ingestion, and scrape the metrics endpoint: `opencti_lock_acquire_wait_*` and `opencti_lock_contentions_total` are exposed and move. Works with the default child locking process (the measures travel back over IPC).
* Contention case: several workers pushing bundles that embed the same entity (for instance a shared authoring organization on CVE-style feeds). The histogram tail lands in the 250 ms-aligned buckets and the contention counter climbs; an uncontended run stays in the lowest buckets with a flat counter.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Found while investigating ingestion throughput on high-volume feeds embedding shared entities: concurrent upserts of the same organization serialize on the entity lock, and the wait was invisible in telemetry (details and measurements in #17341).

Runtime verification details are in the comments. No labels on the metrics in v1 to keep cardinality flat; a per-entity-type label can be discussed later. No unit test added: the change is two meter registrations and one timing record around an existing call, with no logic branch; I can add an integration test if there is a preferred harness for meter assertions.
