### PR TITLE
fix(backend): use both range ends in computeRangeIntersection fallback (#17342)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/format.js
+++ b/opencti-platform/opencti-graphql/src/utils/format.js
@@ -127,7 +127,7 @@ export const computeRangeIntersection = (a, b) => {
   }
   // No range intersection, get min/max to build the range
   const minStart = moment.min([a.start, b.start]);
-  const maxStop = moment.max([b.end, b.end]);
+  const maxStop = moment.max([a.end, b.end]);
   return { start: minStart.toISOString(), end: maxStop.toISOString() };
 };
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/format-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/format-utils-test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { checkScore } from '../../../src/utils/format';
+import { buildPeriodFromDates, checkScore, computeRangeIntersection } from '../../../src/utils/format';
+
+describe('computeRangeIntersection tests', () => {
+  it('should return the overlapping window when the two ranges intersect', () => {
+    const a = buildPeriodFromDates('2020-01-01T00:00:00.000Z', '2020-06-01T00:00:00.000Z');
+    const b = buildPeriodFromDates('2020-03-01T00:00:00.000Z', '2020-09-01T00:00:00.000Z');
+    const result = computeRangeIntersection(a, b);
+    expect(result.start).toEqual('2020-03-01T00:00:00.000Z');
+    expect(result.end).toEqual('2020-06-01T00:00:00.000Z');
+  });
+
+  it('should span both ranges (min start, max end) when they do not intersect', () => {
+    // a ends AFTER b: the max end must be a.end, not b.end.
+    const a = buildPeriodFromDates('2020-01-01T00:00:00.000Z', '2020-06-01T00:00:00.000Z');
+    const b = buildPeriodFromDates('2019-01-01T00:00:00.000Z', '2019-03-01T00:00:00.000Z');
+    const result = computeRangeIntersection(a, b);
+    expect(result.start).toEqual('2019-01-01T00:00:00.000Z');
+    expect(result.end).toEqual('2020-06-01T00:00:00.000Z');
+  });
+});
 
 describe('checkScoreValue tests', () => {
   it('should throw validationError for score > 100', () => {

--- a/opencti-platform/opencti-graphql/tests/20-rules/relationToRelationBuilder-test.ts
+++ b/opencti-platform/opencti-graphql/tests/20-rules/relationToRelationBuilder-test.ts
@@ -88,8 +88,9 @@ describe('relationToRelationBuilder applyUpsert function', () => {
       [existingRelationId, createdRelationId],
       {
         confidence: 40, // mid value between created relationship (30) and existing relationship (50)
+        // The two periods do not overlap, so the inferred relation covers both of them
         start_time: existingRelationStartTime.toISOString(),
-        stop_time: existingRelationStopTime.toISOString(),
+        stop_time: createdRelationStopTime,
         objectMarking: [], // no markings for both the created and the existing relation
       });
     expect(middleware.createInferredRelation).toHaveBeenCalledWith(
@@ -136,8 +137,9 @@ describe('relationToRelationBuilder applyUpsert function', () => {
       [createdRelationId, existingRelationId],
       {
         confidence: 25, // mid value between created relationship (0 by default) and existing relationship (50)
+        // The two periods do not overlap, so the inferred relation covers both of them
         start_time: existingRelationStartTime.toISOString(),
-        stop_time: existingRelationStopTime.toISOString(),
+        stop_time: createdRelationStopTime,
         objectMarking: ['markingA', 'markingB', 'markingC'], // combination of markings from created and existing relations
       });
     expect(middleware.createInferredRelation).toHaveBeenCalledWith(
@@ -191,8 +193,9 @@ describe('relationToRelationBuilder applyUpsert function', () => {
       [createdRelationId, existingRelationId],
       {
         confidence: 0, // mid value between created relationship (0 by default) and existing relationship (0 by default)
+        // The two periods do not overlap, so the inferred relation covers both of them
         start_time: existingRelationStartTime.toISOString(),
-        stop_time: existingRelationStopTime.toISOString(),
+        stop_time: createdRelationStopTime,
         objectMarking: [],
       });
     expect(middleware.createInferredRelation).toHaveBeenCalledWith(


### PR DESCRIPTION
## Proposed changes

`computeRangeIntersection` (`src/utils/format.js`) computed the fallback span for two non-intersecting ranges with `moment.max([b.end, b.end])`, which ignores `a.end` (copy-paste — the `minStart` line just above correctly uses `[a.start, b.start]`).

When the ranges do not intersect and `a` ends after `b`, the computed `end` was wrongly truncated to `b.end`. This function feeds the sighting inference rules (`SightingObservableRule`/`SightingIndicatorRule`) that set `first_seen`/`last_seen` (`start_time`/`stop_time`) on inferred relationships, so inferred edges got an incorrect validity window.

Fix: `moment.max([a.end, b.end])`.

## Related issues

Closes #17342

## How to test

```bash
cd opencti-platform/opencti-graphql
yarn vitest run --config vitest.config.ci-unit.ts tests/01-unit/utils/format-utils-test.ts
```

Adds `computeRangeIntersection` tests for the intersecting case and the non-intersecting case where `a` ends after `b` (the latter fails without the fix). 10/10 tests pass.