### PR TITLE
fix(backend): sort decay_points numerically in descending order (#17345)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/decayRule/decayRule-domain.ts
@@ -97,7 +97,10 @@ export const addDecayRule = async (context: AuthContext, user: AuthUser, input: 
   };
 
   if (input.decay_points) {
-    input.decay_points.sort().reverse();
+    // Sort numerically in descending order. Array.prototype.sort() defaults to lexicographic
+    // ordering (e.g. [5, 40, 80] => [80, 5, 40]), which breaks computeNextScoreReactionDate's
+    // assumption that decay_points are in descending numeric order.
+    input.decay_points.sort((a, b) => b - a);
 
     // cannot use array.filter on a read-only array.
     for (let i = input.decay_points.length - 1; i >= 0; i -= 1) {
@@ -127,7 +130,9 @@ export const fieldPatchDecayRule = async (context: AuthContext, user: AuthUser, 
 
   const decayPointsInput = finalInput.find((editInput) => editInput.key === 'decay_points');
   if (decayPointsInput) {
-    decayPointsInput.value.sort().reverse();
+    // Sort numerically in descending order (see createDecayRule): the default sort is
+    // lexicographic and would misorder multi-digit scores.
+    decayPointsInput.value.sort((a, b) => b - a);
 
     // cannot use array.filter on a read-only array.
     for (let i = decayPointsInput.value.length - 1; i >= 0; i -= 1) {


### PR DESCRIPTION
## Proposed changes

`createDecayRule` and `fieldPatchDecayRule` (`src/modules/decayRule/decayRule-domain.ts`) ordered `decay_points` with `.sort().reverse()`. `Array.prototype.sort()` with no comparator sorts **lexicographically**, so numeric decay points were misordered — e.g. `[5, 40, 80]` became `[80, 5, 40]` instead of `[80, 40, 5]`.

`computeNextScoreReactionDate` assumes `decay_points` are in descending numeric order (`decay_points.find((p) => p < stableScore)`), so a misordered list selects the wrong reaction point → wrong indicator score-decay reaction date and revoke timing.

Fix: use `.sort((a, b) => b - a)` in both functions.

## Related issues

Closes #17345

## How to test

Create or edit a decay rule with `decay_points` such as `[5, 40, 80]`; the stored order is now `[80, 40, 5]` (previously `[80, 5, 40]`), so decay reaction dates are computed against the correct thresholds.

```bash
cd opencti-platform/opencti-graphql
yarn eslint --config eslint.config.js src/modules/decayRule/decayRule-domain.ts   # clean
```