### PR TITLE
fix(backend): iterate not-yet-handled relationships when restoring a cluster (#17347)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/deleteOperation/deleteOperation-domain.ts
@@ -168,7 +168,10 @@ const resolveEntitiesToRestore = async (context: AuthContext, user: AuthUser, de
   while (relationShipHandled.length < relationshipsToRestore.length) {
     const currentSize = relationshipNotHandledYet.length;
     for (let i = 0; i < currentSize; i += 1) {
-      const relationship = relationshipsToRestore[i];
+      // Iterate the not-yet-handled list (which shrinks each round), not the original full list:
+      // currentSize is bounded by relationshipNotHandledYet, so indexing relationshipsToRestore
+      // here would re-process already-handled relationships and skip the remaining ones.
+      const relationship = relationshipNotHandledYet[i];
       const { id: relId, fromId, toId } = relationship;
       // if both sides are in DB (previously or already restored), we can restore this relationship
       if (availableElementsIds.includes(fromId) && availableElementsIds.includes(toId)) {


### PR DESCRIPTION
## Proposed changes

In `deleteOperation-domain.ts`, the relationship-restore worklist loop bounded its index by `relationshipNotHandledYet.length` (`currentSize`, which shrinks each round) but indexed the **original** `relationshipsToRestore[i]`:

```js
const currentSize = relationshipNotHandledYet.length;
for (let i = 0; i < currentSize; i += 1) {
  const relationship = relationshipsToRestore[i]; // wrong array
```

After the first round, the already-handled relationships are removed from `relationshipNotHandledYet`, so `currentSize` shrinks — but the loop keeps reading the first `currentSize` entries of the original array (already handled) and never visits the relationships still pending. The loop then makes no progress and trips the failsafe with a false `Cannot restore the cluster, cycle detected` (or restores incompletely / with duplicates).

Fix: index `relationshipNotHandledYet[i]`.

## Related issues

Closes #17347

## How to test

Restore (from trash) a deleted cluster containing ≥2 interdependent relationships where a still-unhandled relationship is not front-loaded (e.g. a relationship-on-relationship). Before: it fails with a false "cycle detected"; after: the cluster restores correctly.

```bash
cd opencti-platform/opencti-graphql
yarn eslint --config eslint.config.js src/modules/deleteOperation/deleteOperation-domain.ts   # clean
```