### PR TITLE
fix(widget): relationship timeline widget not rendering date correctly (#16374)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { WidgetDataSelection } from '../../../../utils/widget/widget';
+import { buildStixRelationshipsTimelineData } from './StixRelationshipsTimeline';
+
+describe('buildStixRelationshipsTimelineData', () => {
+  it('uses relationship date attribute on relDate without overriding remote node created field', () => {
+    const selection = {
+      filters: {
+        mode: 'and',
+        filters: [
+          {
+            key: 'fromId',
+            values: ['from-1'],
+            operator: 'eq',
+            mode: 'or',
+          },
+        ],
+        filterGroups: [],
+      },
+      isTo: true,
+    } as unknown as WidgetDataSelection;
+
+    const timelineData = buildStixRelationshipsTimelineData(
+      [
+        {
+          node: {
+            id: 'rel-1',
+            created: '2024-01-01T00:00:00.000Z',
+            created_at: '2024-02-01T00:00:00.000Z',
+            from: {
+              id: 'from-1',
+              entity_type: 'Threat-Actor',
+              created: '2023-01-01T00:00:00.000Z',
+            },
+            to: {
+              id: 'to-1',
+              entity_type: 'Malware',
+              created: '2020-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      ] as Parameters<typeof buildStixRelationshipsTimelineData>[0],
+      selection,
+      'created_at',
+    );
+
+    expect(timelineData).toHaveLength(1);
+    expect(timelineData[0]?.value.id).toBe('to-1');
+    expect(timelineData[0]?.value.created).toBe('2020-01-01T00:00:00.000Z');
+    expect(timelineData[0]?.value.relDate).toBe('2024-02-01T00:00:00.000Z');
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { WidgetDataSelection } from '../../../../utils/widget/widget';
-import { buildStixRelationshipsTimelineData } from './StixRelationshipsTimeline';
+import { buildStixRelationshipsTimelineData, RELATIONSHIP_TIMELINE_DATE_KEY } from './StixRelationshipsTimeline';
 
 describe('buildStixRelationshipsTimelineData', () => {
   it('uses relationship date attribute on relDate without overriding remote node created field', () => {
@@ -39,7 +39,7 @@ describe('buildStixRelationshipsTimelineData', () => {
             },
           },
         },
-      ] as Parameters<typeof buildStixRelationshipsTimelineData>[0],
+      ] as unknown as Parameters<typeof buildStixRelationshipsTimelineData>[0],
       selection,
       'created_at',
     );
@@ -47,6 +47,6 @@ describe('buildStixRelationshipsTimelineData', () => {
     expect(timelineData).toHaveLength(1);
     expect(timelineData[0]?.value.id).toBe('to-1');
     expect(timelineData[0]?.value.created).toBe('2020-01-01T00:00:00.000Z');
-    expect(timelineData[0]?.value.relDate).toBe('2024-02-01T00:00:00.000Z');
+    expect(timelineData[0]?.value[RELATIONSHIP_TIMELINE_DATE_KEY]).toBe('2024-02-01T00:00:00.000Z');
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.test.ts
@@ -49,4 +49,31 @@ describe('buildStixRelationshipsTimelineData', () => {
     expect(timelineData[0]?.value.created).toBe('2020-01-01T00:00:00.000Z');
     expect(timelineData[0]?.value[RELATIONSHIP_TIMELINE_DATE_KEY]).toBe('2024-02-01T00:00:00.000Z');
   });
+
+  it('supports non-created relationship date attributes (e.g. start_time)', () => {
+    const selection = {
+      filters: { filters: [{ key: 'fromId', values: ['from-1'] }] },
+      isTo: true,
+    } as unknown as WidgetDataSelection;
+
+    const timelineData = buildStixRelationshipsTimelineData(
+      [
+        {
+          node: {
+            id: 'rel-1',
+            created: '2024-01-01T00:00:00.000Z',
+            created_at: '2024-02-01T00:00:00.000Z',
+            start_time: '2024-03-01T00:00:00.000Z',
+            from: { id: 'from-1', entity_type: 'Threat-Actor' },
+            to: { id: 'to-1', entity_type: 'Malware' },
+          },
+        },
+      ] as unknown as Parameters<typeof buildStixRelationshipsTimelineData>[0],
+      selection,
+      'start_time',
+    );
+
+    expect(timelineData).toHaveLength(1);
+    expect(timelineData[0]?.value[RELATIONSHIP_TIMELINE_DATE_KEY]).toBe('2024-03-01T00:00:00.000Z');
+  });
 });

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -994,6 +994,7 @@ const StixRelationshipsTimelineComponent = ({
     return <WidgetNoData />;
   }
 
+  const dateKey = 'relDate';
   const selection = dataSelection[0];
   const dateAttribute
     = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
@@ -1017,8 +1018,7 @@ const StixRelationshipsTimelineComponent = ({
     return {
       value: {
         ...remoteNode,
-        created:
-            rel[dateAttribute as keyof typeof rel] ?? rel.created,
+        [dateKey]: rel[dateAttribute as keyof typeof rel],
       },
       link,
     };
@@ -1027,7 +1027,7 @@ const StixRelationshipsTimelineComponent = ({
   return (
     <WidgetTimeline
       data={timelineData}
-      dateAttribute={dateAttribute}
+      dateAttribute={dateKey}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -981,6 +981,47 @@ interface StixRelationshipsTimelineComponentProps {
   dataSelection: WidgetDataSelection[];
 }
 
+const RELATIONSHIP_TIMELINE_DATE_KEY = 'relDate';
+
+type TimelineEdges = NonNullable<
+  NonNullable<StixRelationshipsTimelineStixRelationshipQuery['response']['stixRelationships']>['edges']
+>;
+
+type TimelineRelationshipNode = TimelineEdges[number]['node'];
+type TimelineRemoteNode = NonNullable<TimelineRelationshipNode['from']> | NonNullable<TimelineRelationshipNode['to']>;
+
+export const buildStixRelationshipsTimelineData = (
+  edges: TimelineEdges,
+  selection: WidgetDataSelection,
+  dateAttribute: string,
+  dateKey: string = RELATIONSHIP_TIMELINE_DATE_KEY,
+) => {
+  const fromId
+    = selection.filters?.filters?.find((o) => o.key === 'fromId')?.values ?? null;
+  return edges.flatMap((edge) => {
+    const rel = edge.node;
+    const remoteNode: TimelineRemoteNode | null
+      = rel.from
+        && fromId
+        && fromId.includes(rel.from.id)
+        && selection.isTo !== false
+        ? rel.to
+        : rel.from;
+    if (!remoteNode) return [];
+    const restricted = rel.from === null || rel.to === null;
+    const link = restricted
+      ? undefined
+      : `${resolveLink(remoteNode.entity_type)}/${remoteNode.id}/knowledge/relations/${rel.id}`;
+    return [{
+      value: {
+        ...remoteNode,
+        [dateKey]: rel[dateAttribute as keyof TimelineRelationshipNode],
+      },
+      link,
+    }];
+  });
+};
+
 const StixRelationshipsTimelineComponent = ({
   queryRef,
   dataSelection,
@@ -994,40 +1035,19 @@ const StixRelationshipsTimelineComponent = ({
     return <WidgetNoData />;
   }
 
-  const dateKey = 'relDate';
   const selection = dataSelection[0];
   const dateAttribute
     = selection.date_attribute?.length ? selection.date_attribute : 'created_at';
-  const fromId
-    = selection.filters?.filters?.find((o) => o.key === 'fromId')?.values ?? null;
-  const edges = data.stixRelationships.edges;
-  const timelineData = edges.flatMap((edge) => {
-    const rel = edge.node;
-    const remoteNode
-      = rel.from
-        && fromId
-        && fromId.includes(rel.from.id)
-        && selection.isTo !== false
-        ? rel.to
-        : rel.from;
-    if (!remoteNode) return [];
-    const restricted = rel.from === null || rel.to === null;
-    const link = restricted
-      ? undefined
-      : `${resolveLink(remoteNode.entity_type)}/${remoteNode.id}/knowledge/relations/${rel.id}`;
-    return {
-      value: {
-        ...remoteNode,
-        [dateKey]: rel[dateAttribute as keyof typeof rel],
-      },
-      link,
-    };
-  });
+  const timelineData = buildStixRelationshipsTimelineData(
+    data.stixRelationships.edges,
+    selection,
+    dateAttribute,
+  );
 
   return (
     <WidgetTimeline
       data={timelineData}
-      dateAttribute={dateKey}
+      dateAttribute={RELATIONSHIP_TIMELINE_DATE_KEY}
     />
   );
 };

--- a/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_relationships/StixRelationshipsTimeline.tsx
@@ -981,7 +981,7 @@ interface StixRelationshipsTimelineComponentProps {
   dataSelection: WidgetDataSelection[];
 }
 
-const RELATIONSHIP_TIMELINE_DATE_KEY = 'relDate';
+export const RELATIONSHIP_TIMELINE_DATE_KEY = 'relTimelineDate';
 
 type TimelineEdges = NonNullable<
   NonNullable<StixRelationshipsTimelineStixRelationshipQuery['response']['stixRelationships']>['edges']
@@ -1000,7 +1000,7 @@ export const buildStixRelationshipsTimelineData = (
     = selection.filters?.filters?.find((o) => o.key === 'fromId')?.values ?? null;
   return edges.flatMap((edge) => {
     const rel = edge.node;
-    const remoteNode: TimelineRemoteNode | null
+    const remoteNode: TimelineRemoteNode | null | undefined
       = rel.from
         && fromId
         && fromId.includes(rel.from.id)


### PR DESCRIPTION
### Proposed changes

* Set fixed name for the date key used by the timeline widget
* Refactored logic to a function
* Unit tested new logic

### Related issues

* closes https://github.com/OpenCTI-Platform/opencti/issues/16374

### How to test this PR

See issue for repro steps.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Review commit by commit recommended due to refactor
