### PR TITLE
fix(widget): Audits number error (#17352)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/audits/AuditsNumber.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/audits/AuditsNumber.tsx
@@ -182,7 +182,7 @@ const AuditsNumber: FunctionComponent<AuditsNumberProps> = ({
           queryRef={queryRef!}
           entityType={entityType}
           label={translatedNumberLabel}
-          isUnique={Boolean(selection.unique)}
+          isUnique={Boolean(selection?.unique)}
           onShowWarning={setShowWarning}
         />
       </AuditsWidgetRenderContent>


### PR DESCRIPTION
### Proposed changes
Avoids a Cannot read properties of undefined (reading 'unique') error at display of a widget Number of perspective Activity&History 

### Related issues
closes #17352