### PR TITLE
chore(deps): drop Node.js 20 support (#17362)

### DIFF
--- a/docs/docs/deployment/installation.md
+++ b/docs/docs/deployment/installation.md
@@ -303,9 +303,9 @@ cd ../..
 
 The application is just a NodeJS process, the creation of the database schema and the migration will be done at starting.
 
-> Please verify NodeJS version is greater or equals to v22 and corepack is installed.
-> Please note that some Node.js version are outdated in linux package manager, you can download a recent one in https://nodejs.org/en/download or alternatively nvm can help to chose a recent version of Node.js https://github.com/nvm-sh/nvm
-> To install corepack, execute the following command after the installation of nodejs: `npm install -g corepack`
+> Please verify that the NodeJS version is greater than or equal to v22 and that corepack is installed.
+> Please note that some Node.js versions are outdated in the Linux package manager; you can download a recent one from https://nodejs.org/en/download, or alternatively nvm can help you choose a recent version of Node.js: https://github.com/nvm-sh/nvm
+> To install corepack, execute the following command after installing Node.js: `npm install -g corepack`
 
 ```bash
 node --version

--- a/docs/docs/deployment/installation.md
+++ b/docs/docs/deployment/installation.md
@@ -303,13 +303,13 @@ cd ../..
 
 The application is just a NodeJS process, the creation of the database schema and the migration will be done at starting.
 
-> Please verify NodeJS version is greater or equals to v20 and corepack is installed.
+> Please verify NodeJS version is greater or equals to v22 and corepack is installed.
 > Please note that some Node.js version are outdated in linux package manager, you can download a recent one in https://nodejs.org/en/download or alternatively nvm can help to chose a recent version of Node.js https://github.com/nvm-sh/nvm
 > To install corepack, execute the following command after the installation of nodejs: `npm install -g corepack`
 
 ```bash
 node --version
-#v20.11.1
+#v22.14.0
 corepack --version
 #0.34.0
 ```

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -174,7 +174,7 @@
   },
   "packageManager": "yarn@4.17.1+sha512.ccbfabf7d7b6b32075088be9386fb9a2e00bb6887ef07fa56effabc890a56d53da1ccc4128d62db245fcbd3961b236d75335bdf7d5320ed6eafb7588b7ad4697",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "resolutions": {
     "@filigran/chatbot/lodash": "4.18.1",

--- a/opencti-platform/opencti-graphql/builder/builder.js
+++ b/opencti-platform/opencti-graphql/builder/builder.js
@@ -55,7 +55,7 @@ await esbuild.build({
   entryNames: '[name]',
   bundle: true,
   platform: 'node',
-  target: ['node20'],
+  target: ['node22'],
   minifyWhitespace: !isDev,
   minifyIdentifiers: false,
   minifySyntax: !isDev,

--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -46,7 +46,7 @@
   },
   "packageManager": "yarn@4.17.1",
   "engines": {
-    "node": ">= 20.0.0"
+    "node": ">= 22.0.0"
   },
   "dependencies": {
     "@apollo/server": "5.5.1",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=20.0.0` to `>=22.0.0` in `opencti-front` and `opencti-graphql` `package.json`
- Update install docs to state Node 22 as the minimum version, matching the Dockerfile (`node:22-alpine3.23`) and CI (`node:22-alpine3.23`) which already build/test on Node 22

## Why
Node 20 no longer works with the platform, but `engines` still advertised it as supported, which is misleading for integrators/packagers.

Closes #17362