### PR TITLE
chore(deps): pin node major version follow-up to Node 22 support (#17362)

### DIFF
--- a/opencti-platform/opencti-graphql/package.json
+++ b/opencti-platform/opencti-graphql/package.json
@@ -195,6 +195,7 @@
     "@types/luxon": "3.7.2",
     "@types/mime-types": "3.0.1",
     "@types/nconf": "0.10.7",
+    "@types/node": "22.20.1",
     "@types/node-forge": "1.3.14",
     "@types/ramda": "0.32.0",
     "@types/semver": "7.7.1",

--- a/opencti-platform/opencti-graphql/yarn.lock
+++ b/opencti-platform/opencti-graphql/yarn.lock
@@ -3825,6 +3825,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:22.20.1":
+  version: 22.20.1
+  resolution: "@types/node@npm:22.20.1"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/f2ba54d3d1fb92e1c57c78d32c3a17655b1e87363b707136f55c422b4838d4054901ce5d27f75bb0e5ecb7ebfee3804e0987822d22b473473008091857a09353
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^25.2.0":
   version: 25.9.5
   resolution: "@types/node@npm:25.9.5"
@@ -9869,6 +9878,7 @@ __metadata:
     "@types/luxon": "npm:3.7.2"
     "@types/mime-types": "npm:3.0.1"
     "@types/nconf": "npm:0.10.7"
+    "@types/node": "npm:22.20.1"
     "@types/node-forge": "npm:1.3.14"
     "@types/passport": "npm:1.0.17"
     "@types/passport-local": "npm:1.0.38"
@@ -12127,6 +12137,13 @@ __metadata:
   version: 7.24.6
   resolution: "undici-types@npm:7.24.6"
   checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,24 @@
     'enabled': false,
   },
   packageRules: [
+    // sticks to Node 22.x docker image, matching engines.node (>= 22.0.0)
+    {
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'node',
+      ],
+      allowedVersions: '<23',
+      description: 'Keep node docker image at version 22.x',
+    },
+    {
+      matchDepNames: [
+        '@types/node',
+      ],
+      allowedVersions: '<23',
+      description: 'Keep @types/node at version 22.x, matching engines.node',
+    },
     // sticks to MIT version of apexcharts
     {
       matchDepNames: [


### PR DESCRIPTION
## Summary
- Follow-up to #17362 (drop Node.js 20 support): Renovate wasn't updated to reflect that we're now locked on Node 22.x.
- Add Renovate `packageRules` to cap the `node` docker image and `@types/node` at version 22.x (`allowedVersions: '<23'`), matching `engines.node >= 22.0.0`.
- Pin `@types/node` as an explicit devDependency in `opencti-graphql` (`22.20.1`) — it was previously unpinned and resolving transitively to `26.1.1`, mismatched with the supported Node major version.

## Test plan
- [x] `yarn install` regenerates `yarn.lock` cleanly with `@types/node@22.20.1`
- [x] `tsc --noEmit` passes in `opencti-graphql`
- [x] `renovate.json5` validated as JSON5

Closes #17362

🤖 Generated with [Claude Code](https://claude.com/claude-code)