### PR TITLE
fix(rbac): allow participate-to relation creation only for administrated organization (#17375)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1428,8 +1428,12 @@ export const userAddRelation = async (context, user, userId, input) => {
   }
   // Check in case organization admins adds non-grantable group a user
   const myGrantableGroups = R.uniq(user.administrated_organizations.map((orga) => orga.grantable_groups).flat());
+  const myAdministratedOrganizationsIds = user.administrated_organizations.map((orga) => orga.id);
   if (isOnlyOrgaAdmin(user)) {
-    if (input.relationship_type === 'member-of' && !myGrantableGroups.includes(input.toId)) {
+    if (input.relationship_type === RELATION_MEMBER_OF && !myGrantableGroups.includes(input.toId)) {
+      throw ForbiddenAccess();
+    }
+    if (input.relationship_type === RELATION_PARTICIPATE_TO && !myAdministratedOrganizationsIds.includes(input.toId)) {
       throw ForbiddenAccess();
     }
   }
@@ -1466,12 +1470,14 @@ export const userDeleteRelation = async (context, user, targetUser, toId, relati
 };
 
 export const userIdDeleteRelation = async (context, user, userId, toId, relationshipType) => {
-  // check the user is accessible
-  const userData = await loadUserToUpdateWithAccessCheck(context, user, userId);
-
   if (!isInternalRelationship(relationshipType)) {
     throw FunctionalError(`Only ${ABSTRACT_INTERNAL_RELATIONSHIP} can be deleted through this method, got ${relationshipType}.`);
   }
+  if (relationshipType === RELATION_PARTICIPATE_TO) {
+    return userDeleteOrganizationRelation(context, user, userId, toId);
+  }
+  // check the user is accessible
+  const userData = await loadUserToUpdateWithAccessCheck(context, user, userId);
   return userDeleteRelation(context, user, userData, toId, relationshipType);
 };
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/user-test.ts
@@ -870,6 +870,25 @@ describe('User has no settings capability and is organization admin query behavi
             }
         }
     `;
+  const USER_RELATION_ADD_PARTICIPATE_TO_QUERY = gql`
+    mutation UserRelationAddParticipateTo($id: ID!, $toId: ID!) {
+      userEdit(id: $id) {
+        relationAdd(input: { toId: $toId, relationship_type: "participate-to" }) {
+          id
+          entity_type
+        }
+      }
+    }
+  `;
+  const USER_RELATION_DELETE_PARTICIPATE_TO_QUERY = gql`
+    mutation UserRelationDeleteParticipateTo($id: ID!, $toId: StixRef!) {
+      userEdit(id: $id) {
+        relationDelete(toId: $toId, relationship_type: "participate-to") {
+          id
+        }
+      }
+    }
+  `;
 
   afterAll(async () => {
     // remove the capability to administrate the Organization
@@ -1001,6 +1020,24 @@ describe('User has no settings capability and is organization admin query behavi
       },
     });
   });
+  it('should not add participate-to relation if target organization is not administrated', async () => {
+    await queryAsUserIsExpectedForbidden(USER_EDITOR, {
+      query: USER_RELATION_ADD_PARTICIPATE_TO_QUERY,
+      variables: {
+        id: userInternalId,
+        toId: platformOrganizationId,
+      },
+    });
+  });
+  it('should not delete participate-to relation if target organization is not administrated', async () => {
+    await queryAsUserIsExpectedForbidden(USER_EDITOR, {
+      query: USER_RELATION_DELETE_PARTICIPATE_TO_QUERY,
+      variables: {
+        id: userInternalId,
+        toId: platformOrganizationId,
+      },
+    });
+  });
   it('should administrate more than 1 organization', async () => {
     // Need to add granted_groups to PLATFORM_ORGANIZATION because of line 533 in domain/user.js
     const grantableGroupQueryResult = await queryAsAdmin({
@@ -1051,6 +1088,26 @@ describe('User has no settings capability and is organization admin query behavi
       },
     });
     expect(queryResult.data.userEdit.organizationDelete.id).toEqual(userInternalId);
+  });
+  it('should add participate-to relation if target organization is administrated', async () => {
+    const queryResult = await queryAsUserWithSuccess(USER_EDITOR, {
+      query: USER_RELATION_ADD_PARTICIPATE_TO_QUERY,
+      variables: {
+        id: userInternalId,
+        toId: platformOrganizationId,
+      },
+    });
+    expect(queryResult.data.userEdit.relationAdd.entity_type).toEqual('participate-to');
+  });
+  it('should delete participate-to relation if target organization is administrated', async () => {
+    const queryResult = await queryAsUserWithSuccess(USER_EDITOR, {
+      query: USER_RELATION_DELETE_PARTICIPATE_TO_QUERY,
+      variables: {
+        id: userInternalId,
+        toId: platformOrganizationId,
+      },
+    });
+    expect(queryResult.data.userEdit.relationDelete.id).toEqual(userInternalId);
   });
   it('should remove Editor from PLATFORM_ORGANIZATION', async () => {
     const queryResult = await queryAsAdminWithSuccess({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* check if organization is administrated by user when he/she is only orga admin (NO capa SET ACCESS) before adding relation particpate-to 


### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17375

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
* you need a user who does not have capa set access and is organization admin (this mean that this user will be allowed to access Settings > Security > User without SET ACCESS capa
* open graphQL playground and try the query 

```
mutation UserAddRelationTest($userId: ID!, $targetOrganizationId: ID!) {
  userEdit(id: $userId) {
    relationAdd(
      input: {
        toId: $targetOrganizationId
        relationship_type: "participate-to"
      }
    ) {
      id
      entity_type
    }
  }
}

#variables
{
  "userId": "SER_ID",
  "targetOrganizationId": "ID_ORGA_TARGET"
}
```
* you should have an error: "You are not allowed to do this."

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
