### PR TITLE
fix(client-python): create and link inline registry values on windows-registry-key import (#2574)

### DIFF
--- a/client-python/pycti/entities/opencti_stix_cyber_observable.py
+++ b/client-python/pycti/entities/opencti_stix_cyber_observable.py
@@ -1513,6 +1513,38 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     data=base64.b64decode(observable_data["payload_bin"]),
                     mime_type=observable_data["mime_type"],
                 )
+            if type == "Windows-Registry-Key" and observable_data.get("values"):
+                key_id = result["data"]["stixCyberObservableAdd"]["id"]
+                for registry_value in observable_data["values"]:
+                    value_result = self.create(
+                        observableData={
+                            "type": "windows-registry-value-type",
+                            **registry_value,
+                        },
+                        createdBy=created_by,
+                        objectMarking=object_marking,
+                        objectLabel=object_label,
+                        update=update,
+                    )
+                    if value_result is not None:
+                        self.opencti.query(
+                            """
+                                mutation StixCyberObservableAddRelation($id: ID!, $input: StixRefRelationshipAddInput!) {
+                                    stixCyberObservableEdit(id: $id) {
+                                        relationAdd(input: $input) {
+                                            id
+                                        }
+                                    }
+                                }
+                            """,
+                            {
+                                "id": key_id,
+                                "input": {
+                                    "toId": value_result["id"],
+                                    "relationship_type": "values",
+                                },
+                            },
+                        )
             return self.opencti.process_multiple_fields(
                 result["data"]["stixCyberObservableAdd"]
             )

--- a/client-python/tests/02-integration/entities/test_observables.py
+++ b/client-python/tests/02-integration/entities/test_observables.py
@@ -15,9 +15,7 @@ def test_windows_registry_key_values_creation(api_client):
 
     key_without_values, key_with_values = bundle["objects"]
 
-    registry_key_1 = api_client.stix_cyber_observable.read(
-        id=key_without_values["id"]
-    )
+    registry_key_1 = api_client.stix_cyber_observable.read(id=key_without_values["id"])
     assert registry_key_1["attribute_key"] == key_without_values["key"]
 
     registry_key_2 = api_client.stix_cyber_observable.read(id=key_with_values["id"])

--- a/client-python/tests/02-integration/entities/test_observables.py
+++ b/client-python/tests/02-integration/entities/test_observables.py
@@ -3,6 +3,57 @@ import datetime
 import json
 
 
+def test_windows_registry_key_values_creation(api_client):
+    # https://github.com/OpenCTI-Platform/opencti/issues/2574
+    with open("tests/data/windows_registry_key_bundle.json", "r") as content_file:
+        content = content_file.read()
+    bundle = json.loads(content)
+
+    imported_objects, _ = api_client.stix2.import_bundle_from_json(json_data=content)
+    assert imported_objects is not None
+    assert len(imported_objects) == 2
+
+    key_without_values, key_with_values = bundle["objects"]
+
+    registry_key_1 = api_client.stix_cyber_observable.read(
+        id=key_without_values["id"]
+    )
+    assert registry_key_1["attribute_key"] == key_without_values["key"]
+
+    registry_key_2 = api_client.stix_cyber_observable.read(id=key_with_values["id"])
+    assert registry_key_2["attribute_key"] == key_with_values["key"]
+
+    nested = api_client.query(
+        """
+            query WindowsRegistryKeyValues($fromOrToId: String) {
+                stixNestedRefRelationships(fromOrToId: $fromOrToId, relationship_type: ["values"]) {
+                    edges {
+                        node {
+                            to {
+                                ... on WindowsRegistryValueType {
+                                    name
+                                    data
+                                    data_type
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """,
+        {"fromOrToId": registry_key_2["id"]},
+    )
+    edges = nested["data"]["stixNestedRefRelationships"]["edges"]
+    values = {
+        (e["node"]["to"]["name"], e["node"]["to"]["data"], e["node"]["to"]["data_type"])
+        for e in edges
+    }
+    expected = {
+        (v["name"], v["data"], v["data_type"]) for v in key_with_values["values"]
+    }
+    assert values == expected
+
+
 def test_promote_observable_to_indicator_deprecated(api_client):
     # deprecated [>=6.2 & <6.8]
     obs1 = api_client.stix_cyber_observable.create(

--- a/client-python/tests/data/windows_registry_key_bundle.json
+++ b/client-python/tests/data/windows_registry_key_bundle.json
@@ -1,0 +1,30 @@
+{
+    "type": "bundle",
+    "id": "bundle--3ca62449-744e-4cad-96a2-5ff302b289bd",
+    "objects": [
+        {
+            "type": "windows-registry-key",
+            "spec_version": "2.1",
+            "id": "windows-registry-key--9d60798d-4e3e-5fe4-af8a-0e4986f0f90a",
+            "key": "HKEY_LOCAL_MACHINE\\System\\FooOnly\\BarOnly"
+        },
+        {
+            "type": "windows-registry-key",
+            "spec_version": "2.1",
+            "id": "windows-registry-key--2ba37ae7-2745-5082-9dfd-9486dad41016",
+            "key": "hkey_local_machine\\system\\bar\\foo",
+            "values": [
+                {
+                    "name": "first",
+                    "data": "qwerty",
+                    "data_type": "REG_SZ"
+                },
+                {
+                    "name": "second",
+                    "data": "azerty",
+                    "data_type": "REG_DWORD"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Proposed changes

* `pycti` silently dropped the inline `values` array on STIX 2.1 `windows-registry-key` observables during import — registry values were never created or linked to the key.
* `create()` in `opencti_stix_cyber_observable.py` now creates a `Windows-Registry-Value-Type` observable for each entry in `observable_data["values"]` and links it back to the key via `stixCyberObservableEdit(id).relationAdd` (the `values` ref relationship), mirroring the existing marking-definition linking pattern.

### Related issues
* closes #2574

### How to test this PR
1. Import the bundle from `tests/data/windows_registry_key_bundle.json` (taken directly from the issue) via `api_client.stix2.import_bundle_from_json`.
2. Verify both `windows-registry-key` objects are created (one with no values, one with two).
3. Query `stixNestedRefRelationships(fromOrToId, relationship_type: ["values"])` on the key that has values and confirm both `Windows-Registry-Value-Type` observables (`name`/`data`/`data_type`) are present and linked.
4. Run `tests/02-integration/entities/test_observables.py::test_windows_registry_key_values_creation`.
5. Re-import the same bundle and confirm no duplicate values/relations are created (idempotency).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

STIX 2.1 export (`stix-2-1-converter.ts`) and registry-value `standard_id` stability (#13501) were already fixed on `main`, so this PR only addresses the remaining import-side gap. Values are linked via the existing generic ref-relationship mechanism rather than a new dedicated GraphQL field, consistent with how other embedded types (e.g. `body-multipart`) are handled and visible today via the frontend's "Nested objects" panel.