### PR TITLE
feat(fds): add theme-scope hook, plan Navbar migration step (#17388)

### DIFF
--- a/fds-migration/IMPLEMENTATION-ROADMAP.md
+++ b/fds-migration/IMPLEMENTATION-ROADMAP.md
@@ -24,3 +24,20 @@ Not scoped yet. See fds-migration/AGENTS.md rule 5 — do not start component
 migration under this phase without an explicit go-ahead. When it starts,
 order by filigran-design-system `ROADMAP.json` `priority`; readiness for
 this product is COMPONENT-MAPPING.md's "Product status" column.
+
+### Planned: Navbar
+
+- Status: **planned** — not started (no branch, no owner, no go-ahead yet;
+  still bound by rule 5 above). No implementation happens in this pass.
+- Coverage audit already done: `COMPONENT-MAPPING.md` (generated from the
+  lib, do not hand-edit) already carries the row
+  `| Navbar | todo | todo | — | — | — |` — lib status `todo`, this product's
+  status `todo`, no MUI identifiers/occurrences resolved yet (distinct from
+  the separate `Header` row — `AppBar`/`Toolbar`, 4 occurrences / 2 files —
+  in the same audit).
+  Cross-checked against filigran-design-system `ROADMAP.json` `components[]`
+  (`name: "Navbar"`): `status: "todo"`, `figmaDesigned: true`,
+  `figmaNodeId: null`, `priority: 24` (of 25 components — second-lowest).
+  Notes there flag it as "composant structurel, peu de levier de
+  réutilisation cross-produit attendu" — same `todo` status tracked
+  identically for `opencti`, `openaev`, and `opengrc`.

--- a/opencti-platform/opencti-front/src/utils/hooks/useFdsThemeScope.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/hooks/useFdsThemeScope.test.tsx
@@ -1,0 +1,65 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import useFdsThemeScope from './useFdsThemeScope';
+
+describe('Hook: useFdsThemeScope', () => {
+  // Lets the test flip the MUI palette mode after mount without relying on
+  // renderHook's `rerender` (which only re-invokes the hook callback, not
+  // the wrapper) — the wrapper owns the mode as local state and exposes its
+  // setter through this closure variable so `act()` can trigger a real
+  // context update, exactly like a live theme change would.
+  let setMode: (mode: 'light' | 'dark') => void = () => {};
+
+  const ThemeSwitcher = ({ children }: { children: React.ReactNode }) => {
+    const [mode, setLocalMode] = useState<'light' | 'dark'>('dark');
+    setMode = setLocalMode;
+    return (
+      <ThemeProvider theme={createTheme({ palette: { mode } })}>
+        {children}
+      </ThemeProvider>
+    );
+  };
+
+  it('applies the class matching the current theme mode on mount', () => {
+    const container = document.createElement('div');
+    const containerRef = { current: container };
+
+    renderHook(() => useFdsThemeScope(containerRef), { wrapper: ThemeSwitcher });
+
+    expect(container.classList.contains('dark')).toBe(true);
+    expect(container.classList.contains('light')).toBe(false);
+  });
+
+  it('swaps the class reactively when the theme mode changes after mount', () => {
+    const container = document.createElement('div');
+    const containerRef = { current: container };
+
+    renderHook(() => useFdsThemeScope(containerRef), { wrapper: ThemeSwitcher });
+
+    expect(container.classList.contains('dark')).toBe(true);
+
+    act(() => {
+      setMode('light');
+    });
+
+    expect(container.classList.contains('light')).toBe(true);
+    expect(container.classList.contains('dark')).toBe(false);
+
+    act(() => {
+      setMode('dark');
+    });
+
+    expect(container.classList.contains('dark')).toBe(true);
+    expect(container.classList.contains('light')).toBe(false);
+  });
+
+  it('never sets both classes at once, and does nothing when the container is not mounted', () => {
+    const containerRef = { current: null };
+
+    expect(() => {
+      renderHook(() => useFdsThemeScope(containerRef), { wrapper: ThemeSwitcher });
+    }).not.toThrow();
+  });
+});

--- a/opencti-platform/opencti-front/src/utils/hooks/useFdsThemeScope.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useFdsThemeScope.ts
@@ -1,0 +1,41 @@
+import { type MutableRefObject, useEffect } from 'react';
+import { useTheme } from '@mui/styles';
+import type { Theme } from '../../components/Theme';
+
+/**
+ * Bridges the app's MUI `theme.palette.mode` to the `.dark`/`.light`
+ * scoping classes that FDS components (`@filigran/design-system`) rely on
+ * for their CSS custom properties, applied to an arbitrary container
+ * instead of `<html>`/`<body>`.
+ *
+ * This generalizes the ad hoc pattern already in production in
+ * `AskArianePanel.tsx` (`isDarkMode = theme.palette.mode === 'dark'`
+ * toggling a single `'dark'` class on its portal container): it reads the
+ * exact same source, but always sets exactly one of `dark`/`light` (the
+ * original only ever set `dark` or nothing) and stays reactive to theme
+ * changes that happen after mount — e.g. a user flipping dark/light in
+ * Settings.
+ *
+ * Attach `containerRef` to the root of whichever subtree renders FDS
+ * components. Never point it at `document.documentElement`/`document.body`:
+ * FDS scoping is meant to nest per-subtree, not replace the app-wide
+ * `data-theme` attribute already managed by `useDocumentThemeModifier`.
+ *
+ * This hook only wires the classes — it isn't applied to any component
+ * yet, that's a deliberate separate step for each future consumer.
+ */
+const useFdsThemeScope = (containerRef: MutableRefObject<HTMLDivElement | null>) => {
+  const theme = useTheme<Theme>();
+  const isDarkMode = theme.palette.mode === 'dark';
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    container.classList.toggle('dark', isDarkMode);
+    container.classList.toggle('light', !isDarkMode);
+  }, [containerRef, isDarkMode]);
+};
+
+export default useFdsThemeScope;


### PR DESCRIPTION
<!--
Context for reviewers: this PR intentionally targets `design-system/current`,
not `master`. Part of the multi-repo Filigran Design System migration
(tracked in `fds-migration/`); `master` stays untouched.
-->

### Proposed changes

Two independent, separately-committed missions — no Navbar implementation in either.

1. **`useFdsThemeScope` hook** (`src/utils/hooks/useFdsThemeScope.ts` + `.test.tsx`)
   Generalizes the ad hoc dark-mode-class pattern already in production in
   `AskArianePanel.tsx` (`isDarkMode = theme.palette.mode === 'dark'` toggling a
   single `'dark'`/`''` class on its own portal container) into a reusable hook
   for any subtree that renders FDS (`@filigran/design-system`) components:
   - reads the same source (`theme.palette.mode` via `useTheme<Theme>()`, `@mui/styles`);
   - applies **both** `.dark` and `.light` (never just one, never neither) on a
     container scoped by an externally-owned `MutableRefObject` — never
     `document.documentElement`/`document.body`;
   - stays reactive to theme changes after mount (`useEffect` keyed on the
     resolved mode).
   **Zero consumers**: not applied anywhere in this PR. It ships unwired,
   covered only by its own unit test (3 cases: initial mount, reactive swap
   after a theme change post-mount, null-ref no-op guard).

2. **Navbar planning entry** (`fds-migration/IMPLEMENTATION-ROADMAP.md`)
   Adds Navbar under "Phase 2 — Components" with status **planned** (no branch,
   no owner, no go-ahead — still gated by `AGENTS.md` rule 5). References the
   coverage audit already done: `COMPONENT-MAPPING.md`'s existing
   `| Navbar | todo | todo | — | — | — |` row, cross-checked against the lib's
   `ROADMAP.json` (`priority: 24/25`, `figmaDesigned: true`, `figmaNodeId: null`).
   Documentation only.

`fds-migration/reports/` (gitignored/untracked) is untouched by this PR.

### CI coverage on this base branch (`design-system/current`)

Checked which workflows actually evaluate a PR whose **base** is
`design-system/current` rather than `master`, since several are scoped by
`github.base_ref` / `branches:` filters:

- **Covered** — `ci-main.yml` (→ `Frontend quality`, `Backend`, `Frontend e2e`,
  `Client Python`, `License check`) has **no `branches:` filter** on its
  `pull_request` trigger, so it runs regardless of base branch. Empirically
  confirmed on the previous pilot PR (#17115, same base): all of those checks
  ran and passed against `design-system/current`.
- **Not covered / structural gap** — two workflows hard-restrict their
  `pull_request` trigger to `branches: [master, release/current]`
  (`codeql-analysis.yml`) or `branches: [master, lts/*]`
  (`cd-check-images-on-pr.yml`). Neither triggers for this base branch —
  confirmed by their absence from PR #17115's check list. **CodeQL security
  scanning and the CD image check will not run on this PR**; independent
  review is the only safety net for what those two would normally catch,
  same structural hole already identified on the OpenAEV side.
- Side note: `pr-check-linked-issue.yml` is deliberately scoped the same way
  (`if: github.base_ref == 'master' || startsWith(github.base_ref, 'lts/')`),
  so no linked issue is required/enforced here — consistent, not a gap.

### Related issues

* closes — n/a (internal tooling work, no tracking issue)

### How to test this PR

* `yarn test src/utils/hooks/useFdsThemeScope.test.tsx` — 3/3 passing.
* `yarn check-ts`, `yarn lint`, `yarn build` all green (full project).
* Confirm zero UI impact: the hook has no consumers, `IMPLEMENTATION-ROADMAP.md`
  is a doc-only change — nothing to visually check.

### Checklist

- [x] I consider the submitted work as finished
