### PR TITLE
fix(fds): wire 5 documented color gaps to real FDS tokens (#17394)

### DIFF
--- a/fds-migration/TOKEN-MAPPING.md
+++ b/fds-migration/TOKEN-MAPPING.md
@@ -262,124 +262,152 @@ section further below.
   **this decision hasn't been explicitly confirmed with Sandy yet**, flagging
   here for Phase 5 sign-off alongside the color deltas.
 
-## Pending design arbitration — no existing FDS token
+## Pending design arbitration — no existing FDS token (all 5 resolved 2026-07-28)
 
-Five confirmed color families where the wiring pass found **no matching FDS
-token at all** (not a naming mismatch, not a "close enough" candidate — an
-actual absence, verified by grepping every `--color-*`/`--gray-*`/`--darkblue-*`
-entry of both `colorsDark`/`colorsLight` blocks in the generated bridge).
-Each was left as a hardcoded literal, exactly as it was before this pilot —
-**no rendering change**. All five are declared out of scope for this PR by
-design: fixing them requires a design decision (does a token get added to
-Figma/`theme.css`, or is the literal accepted as permanent?), not a wiring
-change.
+Five confirmed color families where the original wiring pass found **no
+matching FDS token at all** (not a naming mismatch, not a "close enough"
+candidate — an actual absence, verified by grepping every
+`--color-*`/`--gray-*`/`--darkblue-*` entry of both `colorsDark`/`colorsLight`
+blocks in the generated bridge). **Update 2026-07-28**: the lib's
+`TOKEN-MIGRATION-GUIDE.md` now has a mapping for all five (2 added directly by
+lib PR #52 — border-secondary and `primary.light` root-palette rows — the
+other 3 were already present from an earlier, unattributed lib change, not
+#52 itself). Re-verified each against the current guide/bridge and **wired
+all 5** (see each subsection). 4 of 5 use the guide's proposed token exactly;
+the 5th (`tertiary.blue`, §2) uses the guide's proposed token's **opaque
+sibling** instead of the exact token proposed — flagged for Thibault's review
+in §2, not applied silently. Tracked (now empty of these 5) in
+`migration-state.json`'s `notMigrated` array.
 
 **Cross-product significance**: the same five gaps exist in OpenAEV's theme
-files (same underlying FDS token set, same absence). Rather than have each
-product's pilot propose its own ad hoc fix, these are logged here as a single
-list awaiting **one** design/Figma arbitration that resolves both products at
-once — whatever token (or explicit "no token, stays hardcoded") gets decided
-applies identically to OpenCTI and OpenAEV. Tracked in `migration-state.json`'s
-`notMigrated` array.
+files. The resolutions below are the tokens OpenAEV should use for parity;
+the `tertiary.blue` deviation (§2) should be reviewed once, here, rather than
+re-litigated per product.
 
-### 1. `severity.none` / `severity.default`
+### 1. `severity.none` / `severity.default` — ✅ RESOLVED 2026-07-28
 
 Neutral/unset severity state — no member of the FDS feedback family
 (`error`/`warning`/`alert`/`success`/`info`) represents "no severity", so
-there's nothing to map to.
+there was nothing to map to until now.
 
-| Key | Dark | Light |
+| Key | Dark (before → after) | Light (before → after) |
 |---|---|---|
-| `severity.none` | `#424242` | `#424242` |
-| `severity.default` | `#1C2F49` | `#DDE1FE` |
+| `severity.none` | `#424242` → `--color-feedback-neutral-primary` (`#7a9cd6`) | `#424242` → `--color-feedback-neutral-primary` (`#afb0b6`) |
+| `severity.default` | `#1C2F49` → `--color-feedback-neutral-primary` (`#7a9cd6`) | `#DDE1FE` → `--color-feedback-neutral-primary` (`#afb0b6`) |
 
-Code admission (`ThemeDark.ts`/`ThemeLight.ts`, identical comment in both):
-> "none/default have no FDS equivalent (neutral/unset states) and are left as-is."
+Both keys now resolve to the **same** token (both are semantically "no
+severity set") — `none` and `default` become visually identical for the first
+time (previously two different hardcoded colors, coincidentally). This is the
+mapping the lib guide proposes; flagged here for visibility, not held back,
+since it's a deliberate semantic consolidation rather than an accident.
 
 Usage: `ItemSeverity.tsx`, `ItemPriority.tsx`, `ItemCvssScore.tsx` (×2),
 `ItemMarkings.tsx`.
 
-### 2. `designSystem.tertiary.blue.500` / `.900`
+### 2. `designSystem.tertiary.blue.500` / `.900` — ✅ RESOLVED 2026-07-28 (deviates from guide — flagged to Thibault)
 
 Two rungs of the raw hue-scale table with no FDS scale neighbor — every other
 `tertiary.*` family (`grey`, `darkBlue`, `turquoise`, `green`, `red`, `orange`,
-`yellow`) matched an FDS scalar exactly; `blue` is the sole exception.
+`yellow`) matched an FDS scalar exactly; `blue` was the sole exception.
 
-| Key | Dark | Light |
+| Key | Dark (before → after) | Light (before → after) |
 |---|---|---|
-| `tertiary.blue.500` | `#0099CC` | `#0099CC` |
-| `tertiary.blue.900` | `#003242` | `#003242` |
+| `tertiary.blue.500` | `#0099CC` → `--color-feedback-info-secondary` (`#0079a8`) | `#0099CC` → `--color-feedback-info-secondary` (`#42caff`) |
+| `tertiary.blue.900` | `#003242` → `--color-feedback-info-secondary` (`#0079a8`) | `#003242` → `--color-feedback-info-secondary` (`#42caff`) |
 
-(Identical across modes — consistent with `tertiary.*` being a mode-invariant
-raw scale, same as its FDS-backed siblings.)
+**⚠ Deviation from the guide, for Thibault's review**: `TOKEN-MIGRATION-GUIDE.md`
+(lines 109-110) proposes `--color-feedback-info-secondary-transparency` for
+both rungs, not the plain `--color-feedback-info-secondary` used here. Checked
+both in the bridge: the guide's proposed token resolves to an **8-digit hex
+with ~30% alpha** (dark `#0079a84d`, light `#42caff4d`, a
+`color-mix(..., transparent)` token) — a translucent color — whereas
+`.blue[500]` has a real, opaque consumer (`ScaleBar.tsx`, a configurable
+scale/decay-chart rail-color default) that would visibly wash out/blend with
+the page background if wired to a translucent fill. **`--color-feedback-info-secondary`
+is the exact opaque sibling of the guide's proposed token** (same base color,
+`theme.css` lines 145/550/651, just without the `color-mix` alpha applied) —
+same semantic family the guide already chose, opacity fixed.
 
-Code admission (`ThemeDark.ts`/`ThemeLight.ts`, identical comment in both):
-> "No FDS scale matches these two values, left as-is."
+Two residual trade-offs, both considered and accepted as lower-risk than the
+alpha issue: (a) `.500`/`.900` now resolve to the **same** value — the guide
+itself already flags `.900` as *"⚠ Dormant (0 consommateur produit) —
+candidat à retrait plutôt qu'à mapping"*, independently confirmed here (only
+`.500` has live consumers: `ScaleBar.tsx`, `CustomViewsSettingsDataTable.tsx`
+icon color) — so this collapse has zero visible impact today; (b) unlike the
+rest of the mode-invariant `tertiary.*` family, this token is
+mode-*dependent* (dark `#0079a8` vs. light `#42caff`), a real, larger-than-
+before shift for the one live consumer (`.500`) in both modes — current
+`#0099CC` sits roughly between the two new mode values. This is the one
+point worth a second look from design/Thibault: a mode-invariant scalar
+alternative exists and stays closer to the current value in both modes —
+`FDS.scalars['--blue-600']` = `#009edb` for `.500` (Δ≈imperceptible vs.
+current, both modes) and `FDS.scalars['--blue-900']` = `#003042` for `.900`
+(2/255 delta) — flagged here in case the opaque-but-mode-dependent choice
+made in this pass is reconsidered.
 
-Usage: `ScaleBar.tsx` (`.blue[500]`), `CustomViewsSettingsDataTable.tsx`
-(`.blue.500`).
+Usage: `ScaleBar.tsx` (`.blue[500]`, default rail-segment fill),
+`CustomViewsSettingsDataTable.tsx` (`.blue.500`, `Insights` icon color).
+`.900` has no current consumer (per the guide's own note and independently
+confirmed by grep).
 
-### 3. `designSystem.background.bg1`–`bg4` / `.disabled`
+### 3. `designSystem.background.bg1`–`bg4` / `.disabled` — ✅ RESOLVED 2026-07-28
 
 Five elevation-adjacent surfaces beyond `background.main` (the only member of
-this block with an FDS/`THEME_*_DEFAULT_BACKGROUND` match).
+this block with an FDS/`THEME_*_DEFAULT_BACKGROUND` match). The bridge
+resolves per-layer elevation tokens distinctly, so each `bgN` maps to its own
+`-layer-(N-1)` key rather than collapsing to one shared value.
 
-| Key | Dark | Light |
+| Key | Dark (before → after) | Light (before → after) |
 |---|---|---|
-| `background.bg1` | `#0C1524` | `#F7F7F7` |
-| `background.bg2` | `#0D182A` | `#FFFFFF` |
-| `background.bg3` | `#253348` | `#E4E4E4` |
-| `background.bg4` | `#1C2F49` | `#DDE1FE` |
-| `background.disabled` | `#363B46` | `#DFDFDF` |
-
-Code admission (`ThemeDark.ts`/`ThemeLight.ts`, identical comment in both):
-> "bg1-bg4/disabled: no confident 1:1 FDS token found, left as-is."
+| `background.bg1` | `#0C1524` → `--bg-elevation-default-layer-0` (`#070d18`) | `#F7F7F7` → `--bg-elevation-default-layer-0` (`#f2f2f3`) |
+| `background.bg2` | `#0D182A` → `--bg-elevation-default-layer-1` (`#0d172b`) | `#FFFFFF` → `--bg-elevation-default-layer-1` (`#ffffff`, exact match) |
+| `background.bg3` | `#253348` → `--bg-elevation-default-layer-2` (`#13213e`) | `#E4E4E4` → `--bg-elevation-default-layer-2` (`#f4f4f6`) |
+| `background.bg4` | `#1C2F49` → `--bg-elevation-default-layer-3` (`#1f3965`) | `#DDE1FE` → `--bg-elevation-default-layer-3` (`#e4e5e7`) |
+| `background.disabled` | `#363B46` → `--bg-elevation-disabled` (`#18191b`) | `#DFDFDF` → `--bg-elevation-disabled` (`#c8d6ee`) |
 
 Usage: `bg1` → `TopBar.tsx`; `bg4` → `DraftToolbar.tsx`. `bg2`/`bg3`/`disabled`
 are declared on the theme but no direct consumer was found in this sweep —
-still real gaps (the values are live on `theme.palette.designSystem.background`
-and could be consumed at any point), just not currently rendered anywhere.
+still real, now-tokenized properties that could be consumed at any point.
 
-### 4. `designSystem.border.main` / `.border1` / `.border2`
+### 4. `designSystem.border.main` / `.border1` / `.border2` — ✅ RESOLVED 2026-07-28
 
 Neutral/grey border tones — no "border" concept currently exists in the FDS
 token set (as opposed to `palette.border.*`, the top-level MUI border block,
 which is a separate, already-classified property).
 
-| Key | Dark | Light |
+| Key | Dark (before → after) | Light (before → after) |
 |---|---|---|
-| `border.main` | `#2B3447` | `#D2D2D2` |
-| `border.border1` | `#424751` | `#C2C2C2` |
-| `border.border2` | `#1C253A` | `#999797` |
+| `border.main` | `#2B3447` → `--border-elevation-default` (`#3665b4`) | `#D2D2D2` → `--border-elevation-default` (`#7a7c85`) |
+| `border.border1` | `#424751` → `--border-elevation-subtle` (`#1f3965`) | `#C2C2C2` → `--border-elevation-subtle` (`#cacbce`) |
+| `border.border2` | `#1C253A` → `--border-elevation-subtle` (`#1f3965`) | `#999797` → `--border-elevation-subtle` (`#cacbce`) |
 
-Code admission (`ThemeDark.ts`/`ThemeLight.ts`, identical comment in both):
-> "No confident FDS token found for any of these three, left as-is."
+`border1`/`border2` now resolve to the **same** token (both previously
+different hardcoded grays); per the completeness sweep, neither has a live
+consumer today, so this consolidation has zero current visual impact.
 
 Usage: `main` → `StixCoreObjectQuickSubscription.tsx`. `border1`/`border2` are
-declared but no direct consumer was found in this sweep — same caveat as
-`bg2`/`bg3`/`disabled` above.
+declared but no direct consumer was found in this sweep.
 
-### 5. `primary.light` fallback, **dark mode only** (`#B2ECFF`)
+### 5. `primary.light` fallback (`#B2ECFF` dark, `#7587FF` light) — ✅ RESOLVED 2026-07-28 (both modes)
 
 Top-level `palette.primary.light` (not `designSystem.primary.light`, which
 **is** wired to `brand-secondary` — see section 5 above) falls back to a
-hardcoded literal when no DB-override `primary` is supplied:
-`primary ? alpha(primary, 0.08) : '#B2ECFF'`. Grepped the full generated
-bridge (`fds-tokens.generated.ts`): `#B2ECFF`/`b2ecff` has **zero** matches
-anywhere in either `colorsDark` or `colorsLight`.
+hardcoded literal when no DB-override `primary` is supplied. Both modes now
+reference `--color-filigran-brand-secondary`:
 
-Light mode's equivalent fallback (`#7587FF`) is deliberately **not** included
-here: it does have exact matches in the bridge (`--color-filigran-brand-secondary`
-and `--darkblue-300`, both `#7587ff`) — a token exists, this code path just
-doesn't reference it yet. That's a wiring opportunity, not a gap, so it's out
-of this list.
-
-| Key | Dark (no FDS match) | Light (for reference — matches exist, not a gap) |
+| Key | Dark (before → after) | Light (before → after) |
 |---|---|---|
-| `primary.light` (fallback) | `#B2ECFF` | `#7587FF` |
+| `primary.light` (fallback) | `#B2ECFF` → `--color-filigran-brand-secondary` (`#a8e7ff`) | `#7587FF` → `--color-filigran-brand-secondary` (`#7587ff`, exact match) |
 
-No inline code comment admits this one (unlike gaps 1-4 above) — it surfaced
-during the completeness sweep (`fds-migration/reports/constants-completeness-sweep/RAPPORT.md`,
+⚠ **Dark-mode note**: the lib guide itself flags this as an *approximate*
+match ("`#B2ECFF`≈`blue-200`"), not exact — `#a8e7ff` is a real, if minor,
+color shift from the current `#B2ECFF` (R -10, G -5, B 0). Light mode is an
+**exact** match (`#7587FF` = `#7587ff`), confirming the pre-existing note
+below that it was "a wiring opportunity, not a gap" — now wired for
+consistency with the dark-mode fix.
+
+No inline code comment admitted this one (unlike gaps 1, 3, 4 above) — it
+surfaced during the completeness sweep (`fds-migration/reports/constants-completeness-sweep/RAPPORT.md`,
 section 9.1: *"`primary.light` (fallback without override) — 🔴 HARDCODED
 (the `main` is 🟢/🟡, this `.light` fallback is not)"*), not from a
 pre-existing code annotation.

--- a/fds-migration/migration-state.json
+++ b/fds-migration/migration-state.json
@@ -35,6 +35,46 @@
       "file": "opencti-platform/opencti-front/src/components/ThemeLight.ts",
       "pattern": "00719E",
       "reason": "Old hand-copied designSystem.alert.info.primary value (pre-FDS). Its presence means the designSystem block wiring was reverted."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeDark.ts",
+      "pattern": "B2ECFF",
+      "reason": "Old hand-copied palette.primary.light dark-mode fallback (pre-FDS gap, resolved 2026-07-28 to --color-filigran-brand-secondary)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeDark.ts",
+      "pattern": "1C253A",
+      "reason": "Old hand-copied designSystem.border.border2 value (pre-FDS gap, resolved 2026-07-28 to --border-elevation-subtle)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeLight.ts",
+      "pattern": "7587FF",
+      "reason": "Old hand-copied palette.primary.light fallback (pre-FDS gap, resolved 2026-07-28 to --color-filigran-brand-secondary — was already an exact bridge match, just not yet expressed as a token reference)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeLight.ts",
+      "pattern": "999797",
+      "reason": "Old hand-copied designSystem.border.border2 value (pre-FDS gap, resolved 2026-07-28 to --border-elevation-subtle)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeDark.ts",
+      "pattern": "0099CC",
+      "reason": "Old hand-copied designSystem.tertiary.blue.500 value (pre-FDS gap, resolved 2026-07-28 to --color-feedback-info-secondary)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeDark.ts",
+      "pattern": "003242",
+      "reason": "Old hand-copied designSystem.tertiary.blue.900 value (pre-FDS gap, resolved 2026-07-28 to --color-feedback-info-secondary)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeLight.ts",
+      "pattern": "0099CC",
+      "reason": "Old hand-copied designSystem.tertiary.blue.500 value (pre-FDS gap, resolved 2026-07-28 to --color-feedback-info-secondary)."
+    },
+    {
+      "file": "opencti-platform/opencti-front/src/components/ThemeLight.ts",
+      "pattern": "003242",
+      "reason": "Old hand-copied designSystem.tertiary.blue.900 value (pre-FDS gap, resolved 2026-07-28 to --color-feedback-info-secondary)."
     }
   ],
   "migratedZones": [
@@ -51,12 +91,11 @@
   "notMigrated": [
     "typography (h1-h6, subtitle1/2, body1/2, caption, button, overline) — see fds-migration/TYPO-MAPPING-TODO.md, arbitration pending with Thibault",
     "spacing/borderRadius — still hardcoded MUI defaults (borderRadius: 4, theme.spacing(N)), no FDS spacing tokens consumed anywhere in ThemeDark.ts/ThemeLight.ts",
-    "palette.ee / palette.xtmhub — both still hand-copied hex (EE_COLOR pre-existing; xtmhub ('#00f1bd', both modes) arrived via the 2026-07-27 master sync merge, commit b1f6459 / PR #17308-#17309). Deferred as a pair until palette.ee is picked up in a future migration pass — see fds-migration/TOKEN-MAPPING.md section 9.",
-    "palette.severity.{none,default}, designSystem.tertiary.blue.{500,900}, designSystem.background.{bg1,bg2,bg3,bg4,disabled}, designSystem.border.{main,border1,border2}, and the top-level palette.primary.light dark-mode fallback (#B2ECFF) — 5 confirmed color families with no matching FDS token anywhere in the generated bridge (verified 2026-07-27). Same gaps also present in OpenAEV; pending a single cross-product design/Figma arbitration rather than two separate ad hoc fixes. See fds-migration/TOKEN-MAPPING.md, 'Pending design arbitration — no existing FDS token' section."
+    "palette.ee / palette.xtmhub — both still hand-copied hex (EE_COLOR pre-existing; xtmhub ('#00f1bd', both modes) arrived via the 2026-07-27 master sync merge, commit b1f6459 / PR #17308-#17309). Deferred as a pair until palette.ee is picked up in a future migration pass — see fds-migration/TOKEN-MAPPING.md section 9."
   ],
   "knownCaveats": [
     "background/paper/nav/primary/secondary/accent/text_color are passed into ThemeDark()/ThemeLight() as function params sourced from the DB's Theme.theme_* fields (AppThemeProvider.tsx), falling back to the FDS-backed constants only when the DB field is null. The built-in Dark/Light Theme rows in every real deployment have these fields explicitly populated with the pre-FDS hex values, so the new FDS values for these 7 properties are invisible until those DB rows are updated separately (proven via GraphQL query + pixel-exact screenshot comparison, see fds-migration/reports/targeted-captures/README.md). error/warn/success/dangerZone/severity are plain FDS constants with no DB override and ARE visually live today.",
     "check-fds-conformity.mjs's bridge-freshness check will report STALE in this specific multi-repo collection workspace even though the bridge IS fresh. Root cause: the check reads theme.css from a hardcoded sibling path (../filigran-design-system relative to the product) which resolves to a local main checkout of the lib repo that is behind origin/main (missing merged PRs) in this environment — not this workspace's actual, up-to-date session worktree. Verified by hashing theme.css at every relevant lib commit and by byte-for-byte diffing a fresh regeneration from the correct worktree against the committed bridge: identical. Do NOT 'fix' this by regenerating from the stale sibling checkout — that silently reintroduces older token values (this happened once during this pilot and was reverted, commit 89dad4c). Only regenerate if you've confirmed the sibling lib checkout is actually up to date with origin/main."
   ],
-  "lastReconciled": "2025 pilot — colors wired + visually checkpointed (Phase 5) + targeted-capture deep dive; typography intentionally deferred (TYPO-MAPPING-TODO.md); DB theme-row update deferred, coordinated separately by product owner."
+  "lastReconciled": "2025 pilot — colors wired + visually checkpointed (Phase 5) + targeted-capture deep dive; typography intentionally deferred (TYPO-MAPPING-TODO.md); DB theme-row update deferred, coordinated separately by product owner. 2026-07-28 — all 5 documented color gaps rewired: severity.none/default, designSystem.background.bg1-4/disabled, designSystem.border.main/border1/border2, palette.primary.light dark+light fallback (all --> direct guide-proposed tokens), and designSystem.tertiary.blue.{500,900} (--> --color-feedback-info-secondary, the guide's proposed token's opaque sibling — the guide's own -transparency proposal was rejected as a rendering regression for ScaleBar.tsx; deviation flagged to Thibault for review, see TOKEN-MAPPING.md)."
 }

--- a/opencti-platform/opencti-front/src/components/ThemeDark.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeDark.ts
@@ -56,7 +56,7 @@ const ThemeDark = (
       contrastText: '#000000',
       text: { primary: FDS.colors.dark['--color-feedback-error-tertiary'] } },
     success: { main: FDS.colors.dark['--color-feedback-success-primary'], dark: FDS.colors.dark['--color-feedback-success-secondary'] },
-    primary: { main: primary || THEME_DARK_DEFAULT_PRIMARY, light: primary ? alpha(primary, 0.08) : '#B2ECFF' },
+    primary: { main: primary || THEME_DARK_DEFAULT_PRIMARY, light: primary ? alpha(primary, 0.08) : FDS.colors.dark['--color-filigran-brand-secondary'] },
     secondary: { main: secondary || THEME_DARK_DEFAULT_SECONDARY },
     gradient: { main: '#00f18d' },
     border: {
@@ -122,15 +122,16 @@ const ThemeDark = (
     },
     severity: {
       // critical/high/medium/low/info mapped to the closest FDS feedback
-      // token (not 1:1 — see TOKEN-MAPPING.md). none/default have no FDS
-      // equivalent (neutral/unset states) and are left as-is.
+      // token (not 1:1 — see TOKEN-MAPPING.md). none/default now share the
+      // neutral feedback token (both are semantically "no severity set");
+      // this makes the two visually identical for the first time.
       critical: FDS.colors.dark['--color-feedback-error-primary'],
       high: FDS.colors.dark['--color-feedback-warning-primary'],
       medium: FDS.colors.dark['--color-feedback-alert-primary'],
       low: FDS.colors.dark['--color-feedback-success-primary'],
       info: FDS.colors.dark['--color-feedback-info-primary'],
-      none: '#424242',
-      default: '#1C2F49',
+      none: FDS.colors.dark['--color-feedback-neutral-primary'],
+      default: FDS.colors.dark['--color-feedback-neutral-primary'],
     },
     // This block used to be hand-copied from Figma exports — every value
     // below is now sourced from the generated FDS bridge (fds-tokens.generated.ts).
@@ -164,18 +165,20 @@ const ThemeDark = (
       },
       background: {
         main: THEME_DARK_DEFAULT_BACKGROUND,
-        // bg1-bg4/disabled: no confident 1:1 FDS token found, left as-is.
-        bg1: '#0C1524',
-        bg2: '#0D182A',
-        bg3: '#253348',
-        bg4: '#1C2F49',
-        disabled: '#363B46',
+        // bg1-bg4 map to the elevation-layer scale (layer-0..3, darkest to
+        // lightest); disabled uses the dedicated disabled-elevation token.
+        bg1: FDS.colors.dark['--bg-elevation-default-layer-0'],
+        bg2: FDS.colors.dark['--bg-elevation-default-layer-1'],
+        bg3: FDS.colors.dark['--bg-elevation-default-layer-2'],
+        bg4: FDS.colors.dark['--bg-elevation-default-layer-3'],
+        disabled: FDS.colors.dark['--bg-elevation-disabled'],
       },
-      // No confident FDS token found for any of these three, left as-is.
+      // main uses the default elevation border; border1/border2 share the
+      // subtle elevation border (see TOKEN-MAPPING.md).
       border: {
-        main: '#2B3447',
-        border1: '#424751',
-        border2: '#1C253A',
+        main: FDS.colors.dark['--border-elevation-default'],
+        border1: FDS.colors.dark['--border-elevation-subtle'],
+        border2: FDS.colors.dark['--border-elevation-subtle'],
       },
       gradient: {
         background: FDS.gradients.dark['--gradient-default'],
@@ -211,10 +214,13 @@ const ThemeDark = (
           700: FDS.scalars['--gray-700'],
           800: FDS.scalars['--gray-800'],
         },
-        // No FDS scale matches these two values, left as-is.
+        // Mapped to the opaque feedback-info-secondary token (not its
+        // -transparency sibling proposed by the guide — see TOKEN-MAPPING.md,
+        // ScaleBar.tsx needs a solid fill). .500/.900 now share one value;
+        // .900 has zero live consumers today (same note in the guide itself).
         blue: {
-          500: '#0099CC',
-          900: '#003242',
+          500: FDS.colors.dark['--color-feedback-info-secondary'],
+          900: FDS.colors.dark['--color-feedback-info-secondary'],
         },
         darkBlue: {
           300: FDS.scalars['--darkblue-300'],

--- a/opencti-platform/opencti-front/src/components/ThemeLight.ts
+++ b/opencti-platform/opencti-front/src/components/ThemeLight.ts
@@ -57,7 +57,7 @@ const ThemeLight = (
       text: { primary: FDS.colors.light['--color-feedback-error-tertiary'] },
     },
     success: { main: FDS.colors.light['--color-feedback-success-primary'], dark: FDS.colors.light['--color-feedback-success-tertiary'] },
-    primary: { main: primary || THEME_LIGHT_DEFAULT_PRIMARY, light: primary ? alpha(primary, 0.08) : '#7587FF' },
+    primary: { main: primary || THEME_LIGHT_DEFAULT_PRIMARY, light: primary ? alpha(primary, 0.08) : FDS.colors.light['--color-filigran-brand-secondary'] },
     secondary: { main: secondary || THEME_LIGHT_DEFAULT_SECONDARY },
     gradient: { main: '#00BD94' },
     border: {
@@ -122,13 +122,17 @@ const ThemeLight = (
       text: '#18191B',
     },
     severity: {
+      // critical/high/medium/low/info mapped to the closest FDS feedback
+      // token (not 1:1 — see TOKEN-MAPPING.md). none/default now share the
+      // neutral feedback token (both are semantically "no severity set");
+      // this makes the two visually identical for the first time.
       critical: FDS.colors.light['--color-feedback-error-primary'],
       high: FDS.colors.light['--color-feedback-warning-primary'],
       medium: FDS.colors.light['--color-feedback-alert-primary'],
       low: FDS.colors.light['--color-feedback-success-primary'],
       info: FDS.colors.light['--color-feedback-info-primary'],
-      none: '#424242',
-      default: '#DDE1FE',
+      none: FDS.colors.light['--color-feedback-neutral-primary'],
+      default: FDS.colors.light['--color-feedback-neutral-primary'],
     },
     // This block used to be hand-copied from Figma exports — every value
     // below is now sourced from the generated FDS bridge (fds-tokens.generated.ts).
@@ -160,18 +164,20 @@ const ThemeLight = (
       },
       background: {
         main: THEME_LIGHT_DEFAULT_BACKGROUND,
-        // bg1-bg4/disabled: no confident 1:1 FDS token found, left as-is.
-        bg1: '#F7F7F7',
-        bg2: '#FFFFFF',
-        bg3: '#E4E4E4',
-        bg4: '#DDE1FE',
-        disabled: '#DFDFDF',
+        // bg1-bg4 map to the elevation-layer scale (layer-0..3, darkest to
+        // lightest); disabled uses the dedicated disabled-elevation token.
+        bg1: FDS.colors.light['--bg-elevation-default-layer-0'],
+        bg2: FDS.colors.light['--bg-elevation-default-layer-1'],
+        bg3: FDS.colors.light['--bg-elevation-default-layer-2'],
+        bg4: FDS.colors.light['--bg-elevation-default-layer-3'],
+        disabled: FDS.colors.light['--bg-elevation-disabled'],
       },
-      // No confident FDS token found for any of these three, left as-is.
+      // main uses the default elevation border; border1/border2 share the
+      // subtle elevation border (see TOKEN-MAPPING.md).
       border: {
-        main: '#D2D2D2',
-        border1: '#C2C2C2',
-        border2: '#999797',
+        main: FDS.colors.light['--border-elevation-default'],
+        border1: FDS.colors.light['--border-elevation-subtle'],
+        border2: FDS.colors.light['--border-elevation-subtle'],
       },
       gradient: {
         background: FDS.gradients.light['--gradient-default'],
@@ -207,10 +213,13 @@ const ThemeLight = (
           700: FDS.scalars['--gray-700'],
           800: FDS.scalars['--gray-800'],
         },
-        // No FDS scale matches these two values, left as-is.
+        // Mapped to the opaque feedback-info-secondary token (not its
+        // -transparency sibling proposed by the guide — see TOKEN-MAPPING.md,
+        // ScaleBar.tsx needs a solid fill). .500/.900 now share one value;
+        // .900 has zero live consumers today (same note in the guide itself).
         blue: {
-          500: '#0099CC',
-          900: '#003242',
+          500: FDS.colors.light['--color-feedback-info-secondary'],
+          900: FDS.colors.light['--color-feedback-info-secondary'],
         },
         darkBlue: {
           300: FDS.scalars['--darkblue-300'],


### PR DESCRIPTION
## What

Wires all 5 color families previously documented in `fds-migration/TOKEN-MAPPING.md` (§ "Pending design arbitration — no existing FDS token") as having **no matching FDS token**. The lib's `TOKEN-MIGRATION-GUIDE.md` now maps all 5 (2 added directly by lib PR #52 — border-secondary and `primary.light` root-palette rows; the other 3 were already present from an earlier, unattributed lib change).

| Family | Dark (before → after) | Light (before → after) |
|---|---|---|
| `primary.light` fallback | `#B2ECFF` → `--color-filigran-brand-secondary` (`#a8e7ff`) | `#7587FF` → `--color-filigran-brand-secondary` (`#7587ff`, exact) |
| `severity.none`/`default` | `#424242`/`#1C2F49` → `--color-feedback-neutral-primary` (both → `#7a9cd6`) | `#424242`/`#DDE1FE` → `--color-feedback-neutral-primary` (both → `#afb0b6`) |
| `background.bg1-4/disabled` | 5 hardcoded → 5 elevation-layer tokens | idem |
| `border.main/border1/border2` | 3 hardcoded → default + subtle (border1/border2 share one token) | idem |
| `tertiary.blue.500/900` | `#0099CC`/`#003242` → `--color-feedback-info-secondary` (both → `#0079a8`) | `#0099CC`/`#003242` → `--color-feedback-info-secondary` (both → `#42caff`) |

Full before/after tables and rationale for each family: `fds-migration/TOKEN-MAPPING.md`.

## ⚠ Deviation from the guide — for @tcazin's review

For `tertiary.blue.500/900`, the guide (`TOKEN-MIGRATION-GUIDE.md` lines 109-110) proposes **`--color-feedback-info-secondary-transparency`** for both rungs. That token resolves to an 8-digit hex with ~30% alpha (dark `#0079a84d`, light `#42caff4d` — a `color-mix(..., transparent)` token) — **translucent**.

`designSystem.tertiary.blue[500]` has a real, **opaque** consumer: `ScaleBar.tsx` uses it as the default fill for a configurable scale-bar rail segment. Wiring it to a 30%-alpha token would visibly wash it out against the page background instead of rendering a solid fill.

Used **`--color-feedback-info-secondary`** instead — the exact opaque sibling of the guide's proposed token (same base color in `theme.css`, just without the `color-mix` alpha applied). Same semantic family the guide already chose, opacity fixed.

Two residual, lower-severity trade-offs kept as-is (both considered and accepted, detailed in TOKEN-MAPPING.md §2):
- `.500`/`.900` now resolve to the same value — the guide itself already flags `.900` as dormant (0 product consumers), independently confirmed here.
- Unlike the rest of the mode-invariant `tertiary.*` family, this token is mode-dependent. A mode-invariant scalar alternative (`--blue-600`/`--blue-900`) exists and stays closer to the current value in both modes — flagged in `TOKEN-MAPPING.md` in case the choice made here should be revisited.

## Proof / verification

- `yarn check-ts`: clean
- `eslint` on both changed theme files: clean
- `check-fds-conformity.mjs`: 15/16 (the 1 failure is the pre-existing, documented `bridge-freshness: STALE` false positive — see `migration-state.json` `knownCaveats`, this workspace's sibling lib checkout is behind `origin/main`, not the actual bridge)
- `yarn build`: succeeds (only pre-existing chunk-size warnings)
- No bridge regeneration performed: all needed tokens (including the opaque `--color-feedback-info-secondary` sibling) were already present in the committed bridge, confirmed via a full structured key-by-key diff against a scratch regeneration. Regenerating for real would have also pulled in an unrelated, out-of-scope light-mode contrast fix from lib PR #37.

## Scope

Theme files + migration docs only (`ThemeDark.ts`, `ThemeLight.ts`, `TOKEN-MAPPING.md`, `migration-state.json`). No `fds-migration/reports/` changes (untracked, stays that way). No bridge regeneration/commit.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
