### PR TITLE
feat(client-python): opt-in exponential retry schedule for worker missing-reference waits (#17395)

### DIFF
--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import json
+import math
 import mimetypes
 import os
 import random
@@ -66,14 +67,70 @@ STIX_EXT_OCTI_SCO: str = "extension-definition--f93e2c80-4231-4f9a-af8b-95c9bd56
 STIX_EXT_MITRE: str = "extension-definition--322b8f77-262a-4cb8-a915-1e441e00329b"
 PROCESSING_COUNT: int = 4
 MAX_PROCESSING_COUNT: int = 100
-# Missing-reference retry schedule: fast-first exponential with +-50% jitter. Most missing
-# references are a short race (the referenced entity lands well under a second later), so the
-# first retry comes quickly; later steps grow so the total wait budget stays ~7.5s and slow
-# dependencies keep their chances. Delays (mean): 0.5s, 1s, 2s, 4s.
-MISSING_REF_RETRY_INITIAL_DELAY: float = float(
-    os.getenv("OPENCTI_MISSING_REF_RETRY_INITIAL_DELAY", "0.5")
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean flag from the environment; unknown values fall back to the default."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off"):
+        return False
+    return default
+
+
+def _env_float(name: str, default: float, minimum: float) -> float:
+    """Read a float tuning knob from the environment, tolerant to misconfiguration.
+
+    A malformed value falls back to the default (no crash at import time), and the result is
+    clamped to `minimum` so a bad value cannot produce negative sleeps.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if not math.isfinite(value):
+        return default
+    return max(value, minimum)
+
+
+# Missing-reference retry schedule.
+# Default (flag off): legacy flat wait, random.uniform(1, 3) s before each retry.
+# Opt-in (OPENCTI_MISSING_REF_RETRY_EXPONENTIAL=true): fast-first exponential with +-50%
+# jitter. Most missing references are a short race (the referenced entity lands well under a
+# second later), so the first retry comes quickly; later steps grow so the total wait budget
+# stays ~7.5s and slow dependencies keep their chances. Delays (mean): 0.5s, 1s, 2s, 4s.
+# Initial delay >= 0 (0 disables the wait); factor >= 1 (1 = constant delay).
+MISSING_REF_RETRY_EXPONENTIAL: bool = _env_bool(
+    "OPENCTI_MISSING_REF_RETRY_EXPONENTIAL", default=False
 )
-MISSING_REF_RETRY_FACTOR: float = float(os.getenv("OPENCTI_MISSING_REF_RETRY_FACTOR", "2"))
+MISSING_REF_RETRY_INITIAL_DELAY: float = _env_float(
+    "OPENCTI_MISSING_REF_RETRY_INITIAL_DELAY", default=0.5, minimum=0.0
+)
+MISSING_REF_RETRY_FACTOR: float = _env_float(
+    "OPENCTI_MISSING_REF_RETRY_FACTOR", default=2.0, minimum=1.0
+)
+
+
+def missing_ref_retry_delay(attempt_index: int) -> float:
+    """Seconds to wait before missing-reference retry number `attempt_index` (0-based).
+
+    Legacy schedule unless MISSING_REF_RETRY_EXPONENTIAL is on, see the module constants.
+    """
+    if not MISSING_REF_RETRY_EXPONENTIAL:
+        return round(random.uniform(1, 3), 2)
+    base_delay = MISSING_REF_RETRY_INITIAL_DELAY * (
+        MISSING_REF_RETRY_FACTOR**attempt_index
+    )
+    return round(random.uniform(base_delay * 0.5, base_delay * 1.5), 2)
+
+
 MARKDOWN_EXPORT_FIELDS: Tuple[str, ...] = (
     "description",
     "x_opencti_description",
@@ -3585,16 +3642,11 @@ class OpenCTIStix2:
                     processing_count += 1
                 # Platform detects a missing reference and have to retry
                 elif ERROR_TYPE_MISSING_REFERENCE in error_msg and in_retry:
+                    # attempt is 1-based: 1 = first retry, PROCESSING_COUNT = last one
                     bundles_missing_reference_error_counter.add(
-                        1, {"attempt": processing_count}
+                        1, {"attempt": processing_count + 1}
                     )
-                    base_delay = MISSING_REF_RETRY_INITIAL_DELAY * (
-                        MISSING_REF_RETRY_FACTOR**processing_count
-                    )
-                    sleep_jitter = round(
-                        random.uniform(base_delay * 0.5, base_delay * 1.5), 2
-                    )
-                    time.sleep(sleep_jitter)
+                    time.sleep(missing_ref_retry_delay(processing_count))
                     processing_count += 1
                 # A bad gateway error occurs
                 elif ERROR_TYPE_BAD_GATEWAY in error_msg:

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -150,6 +150,10 @@ bundles_missing_reference_error_counter = meter.create_counter(
     name="opencti_bundles_missing_reference_error_counter",
     description="number of bundles in missing reference error",
 )
+bundles_missing_reference_retry_attempt_counter = meter.create_counter(
+    name="opencti_bundles_missing_reference_retry_attempt_counter",
+    description="number of missing reference retries, by 1-based attempt number",
+)
 bundles_bad_gateway_error_counter = meter.create_counter(
     name="opencti_bundles_bad_gateway_error_counter",
     description="number of bundles in bad gateway error",
@@ -3642,8 +3646,9 @@ class OpenCTIStix2:
                     processing_count += 1
                 # Platform detects a missing reference and have to retry
                 elif ERROR_TYPE_MISSING_REFERENCE in error_msg and in_retry:
+                    bundles_missing_reference_error_counter.add(1)
                     # attempt is 1-based: 1 = first retry, PROCESSING_COUNT = last one
-                    bundles_missing_reference_error_counter.add(
+                    bundles_missing_reference_retry_attempt_counter.add(
                         1, {"attempt": processing_count + 1}
                     )
                     time.sleep(missing_ref_retry_delay(processing_count))

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -66,6 +66,14 @@ STIX_EXT_OCTI_SCO: str = "extension-definition--f93e2c80-4231-4f9a-af8b-95c9bd56
 STIX_EXT_MITRE: str = "extension-definition--322b8f77-262a-4cb8-a915-1e441e00329b"
 PROCESSING_COUNT: int = 4
 MAX_PROCESSING_COUNT: int = 100
+# Missing-reference retry schedule: fast-first exponential with +-50% jitter. Most missing
+# references are a short race (the referenced entity lands well under a second later), so the
+# first retry comes quickly; later steps grow so the total wait budget stays ~7.5s and slow
+# dependencies keep their chances. Delays (mean): 0.5s, 1s, 2s, 4s.
+MISSING_REF_RETRY_INITIAL_DELAY: float = float(
+    os.getenv("OPENCTI_MISSING_REF_RETRY_INITIAL_DELAY", "0.5")
+)
+MISSING_REF_RETRY_FACTOR: float = float(os.getenv("OPENCTI_MISSING_REF_RETRY_FACTOR", "2"))
 MARKDOWN_EXPORT_FIELDS: Tuple[str, ...] = (
     "description",
     "x_opencti_description",
@@ -3577,8 +3585,15 @@ class OpenCTIStix2:
                     processing_count += 1
                 # Platform detects a missing reference and have to retry
                 elif ERROR_TYPE_MISSING_REFERENCE in error_msg and in_retry:
-                    bundles_missing_reference_error_counter.add(1)
-                    sleep_jitter = round(random.uniform(1, 3), 2)
+                    bundles_missing_reference_error_counter.add(
+                        1, {"attempt": processing_count}
+                    )
+                    base_delay = MISSING_REF_RETRY_INITIAL_DELAY * (
+                        MISSING_REF_RETRY_FACTOR**processing_count
+                    )
+                    sleep_jitter = round(
+                        random.uniform(base_delay * 0.5, base_delay * 1.5), 2
+                    )
                     time.sleep(sleep_jitter)
                     processing_count += 1
                 # A bad gateway error occurs

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_import_retries.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_import_retries.py
@@ -50,19 +50,25 @@ class _MissingRefThenSuccess:
 
 
 def _run_import_with_retries(monkeypatch, opencti_stix2, failures):
-    """Run import_item_with_retries against a failing import_item; capture sleeps and attempts."""
+    """Run import_item_with_retries against a failing import_item; capture sleeps and counters."""
     sleeps = []
     attempts = []
+    error_adds = []
     monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
     monkeypatch.setattr(
         stix2_module.bundles_missing_reference_error_counter,
+        "add",
+        lambda amount, attributes=None: error_adds.append((amount, attributes)),
+    )
+    monkeypatch.setattr(
+        stix2_module.bundles_missing_reference_retry_attempt_counter,
         "add",
         lambda amount, attributes=None: attempts.append(attributes["attempt"]),
     )
     monkeypatch.setattr(opencti_stix2, "import_item", _MissingRefThenSuccess(failures))
     # No work_id: nothing is reported to the platform on the terminal path.
     result = opencti_stix2.import_item_with_retries({"id": "x", "type": "report"})
-    return result, sleeps, attempts
+    return result, sleeps, attempts, error_adds
 
 
 # --- schedule function -------------------------------------------------------------------------
@@ -103,13 +109,15 @@ def test_exponential_schedule_honors_knobs(monkeypatch, uniform_bounds):
 def test_missing_ref_retry_loop_legacy(
     opencti_stix2: OpenCTIStix2, monkeypatch, uniform_bounds
 ):
-    result, sleeps, attempts = _run_import_with_retries(
+    result, sleeps, attempts, error_adds = _run_import_with_retries(
         monkeypatch, opencti_stix2, failures=PROCESSING_COUNT
     )
     # Healed on the 5th call, after the 4 retries allowed by PROCESSING_COUNT.
     assert result is None
     assert sleeps == [2.0] * PROCESSING_COUNT
-    # attempt attribute is 1-based, whatever the schedule.
+    # The historical counter keeps its exact shape: one label-free add per retry.
+    assert error_adds == [(1, None)] * PROCESSING_COUNT
+    # attempt attribute is 1-based, on the dedicated counter, whatever the schedule.
     assert attempts == [1, 2, 3, 4]
 
 
@@ -117,11 +125,12 @@ def test_missing_ref_retry_loop_exponential(
     opencti_stix2: OpenCTIStix2, monkeypatch, uniform_bounds
 ):
     monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_EXPONENTIAL", True)
-    result, sleeps, attempts = _run_import_with_retries(
+    result, sleeps, attempts, error_adds = _run_import_with_retries(
         monkeypatch, opencti_stix2, failures=PROCESSING_COUNT
     )
     assert result is None
     assert sleeps == [0.5, 1.0, 2.0, 4.0]
+    assert error_adds == [(1, None)] * PROCESSING_COUNT
     assert attempts == [1, 2, 3, 4]
 
 
@@ -130,11 +139,12 @@ def test_missing_ref_retry_loop_stops_after_processing_count(
 ):
     # One failure too many: the missing-reference branch is no longer in retry, the item goes
     # to the terminal technical-error path (no more sleep) and is not re-attempted.
-    result, sleeps, attempts = _run_import_with_retries(
+    result, sleeps, attempts, error_adds = _run_import_with_retries(
         monkeypatch, opencti_stix2, failures=PROCESSING_COUNT + 1
     )
     assert result is None
     assert len(sleeps) == PROCESSING_COUNT
+    assert error_adds == [(1, None)] * PROCESSING_COUNT
     assert attempts == list(range(1, PROCESSING_COUNT + 1))
     assert opencti_stix2.import_item.calls == PROCESSING_COUNT + 1
 

--- a/client-python/tests/01-unit/utils/test_opencti_stix2_import_retries.py
+++ b/client-python/tests/01-unit/utils/test_opencti_stix2_import_retries.py
@@ -1,0 +1,191 @@
+import random
+import time
+
+import pytest
+
+from pycti import OpenCTIApiClient, OpenCTIStix2
+from pycti.utils import opencti_stix2 as stix2_module
+from pycti.utils.opencti_stix2 import (
+    ERROR_TYPE_MISSING_REFERENCE,
+    PROCESSING_COUNT,
+    _env_bool,
+    _env_float,
+    missing_ref_retry_delay,
+)
+
+
+@pytest.fixture
+def opencti_stix2():
+    api_client = OpenCTIApiClient(
+        "http://fake:4000", "fake", ssl_verify=False, perform_health_check=False
+    )
+    return OpenCTIStix2(api_client)
+
+
+@pytest.fixture
+def uniform_bounds(monkeypatch):
+    """Replace random.uniform by its midpoint and record the (low, high) bounds it was given."""
+    bounds = []
+
+    def fake_uniform(low, high):
+        bounds.append((low, high))
+        return (low + high) / 2
+
+    monkeypatch.setattr(random, "uniform", fake_uniform)
+    return bounds
+
+
+class _MissingRefThenSuccess:
+    """import_item stand-in: raises a missing-reference error `failures` times, then succeeds."""
+
+    def __init__(self, failures: int):
+        self.failures = failures
+        self.calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise Exception(ERROR_TYPE_MISSING_REFERENCE)
+        return None
+
+
+def _run_import_with_retries(monkeypatch, opencti_stix2, failures):
+    """Run import_item_with_retries against a failing import_item; capture sleeps and attempts."""
+    sleeps = []
+    attempts = []
+    monkeypatch.setattr(time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(
+        stix2_module.bundles_missing_reference_error_counter,
+        "add",
+        lambda amount, attributes=None: attempts.append(attributes["attempt"]),
+    )
+    monkeypatch.setattr(opencti_stix2, "import_item", _MissingRefThenSuccess(failures))
+    # No work_id: nothing is reported to the platform on the terminal path.
+    result = opencti_stix2.import_item_with_retries({"id": "x", "type": "report"})
+    return result, sleeps, attempts
+
+
+# --- schedule function -------------------------------------------------------------------------
+
+
+def test_default_schedule_is_legacy_flat_wait(monkeypatch, uniform_bounds):
+    # Flag off by default: the historical random.uniform(1, 3) on every attempt.
+    assert stix2_module.MISSING_REF_RETRY_EXPONENTIAL is False
+    delays = [missing_ref_retry_delay(i) for i in range(PROCESSING_COUNT)]
+    assert uniform_bounds == [(1, 3)] * PROCESSING_COUNT
+    assert delays == [2.0] * PROCESSING_COUNT
+
+
+def test_exponential_schedule_is_fast_first(monkeypatch, uniform_bounds):
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_EXPONENTIAL", True)
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_INITIAL_DELAY", 0.5)
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_FACTOR", 2.0)
+    delays = [missing_ref_retry_delay(i) for i in range(PROCESSING_COUNT)]
+    # +-50% jitter around 0.5s, 1s, 2s, 4s: mean total budget 7.5s.
+    assert uniform_bounds == [(0.25, 0.75), (0.5, 1.5), (1.0, 3.0), (2.0, 6.0)]
+    assert delays == [0.5, 1.0, 2.0, 4.0]
+    assert sum(delays) == 7.5
+
+
+def test_exponential_schedule_honors_knobs(monkeypatch, uniform_bounds):
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_EXPONENTIAL", True)
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_INITIAL_DELAY", 1.0)
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_FACTOR", 1.0)
+    delays = [missing_ref_retry_delay(i) for i in range(3)]
+    # factor 1 = constant delay
+    assert uniform_bounds == [(0.5, 1.5)] * 3
+    assert delays == [1.0] * 3
+
+
+# --- retry loop ---------------------------------------------------------------------------------
+
+
+def test_missing_ref_retry_loop_legacy(
+    opencti_stix2: OpenCTIStix2, monkeypatch, uniform_bounds
+):
+    result, sleeps, attempts = _run_import_with_retries(
+        monkeypatch, opencti_stix2, failures=PROCESSING_COUNT
+    )
+    # Healed on the 5th call, after the 4 retries allowed by PROCESSING_COUNT.
+    assert result is None
+    assert sleeps == [2.0] * PROCESSING_COUNT
+    # attempt attribute is 1-based, whatever the schedule.
+    assert attempts == [1, 2, 3, 4]
+
+
+def test_missing_ref_retry_loop_exponential(
+    opencti_stix2: OpenCTIStix2, monkeypatch, uniform_bounds
+):
+    monkeypatch.setattr(stix2_module, "MISSING_REF_RETRY_EXPONENTIAL", True)
+    result, sleeps, attempts = _run_import_with_retries(
+        monkeypatch, opencti_stix2, failures=PROCESSING_COUNT
+    )
+    assert result is None
+    assert sleeps == [0.5, 1.0, 2.0, 4.0]
+    assert attempts == [1, 2, 3, 4]
+
+
+def test_missing_ref_retry_loop_stops_after_processing_count(
+    opencti_stix2: OpenCTIStix2, monkeypatch, uniform_bounds
+):
+    # One failure too many: the missing-reference branch is no longer in retry, the item goes
+    # to the terminal technical-error path (no more sleep) and is not re-attempted.
+    result, sleeps, attempts = _run_import_with_retries(
+        monkeypatch, opencti_stix2, failures=PROCESSING_COUNT + 1
+    )
+    assert result is None
+    assert len(sleeps) == PROCESSING_COUNT
+    assert attempts == list(range(1, PROCESSING_COUNT + 1))
+    assert opencti_stix2.import_item.calls == PROCESSING_COUNT + 1
+
+
+# --- env parsing --------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,default,expected",
+    [
+        (None, False, False),  # unset
+        ("", False, False),  # empty -> default
+        ("true", False, True),
+        ("True", False, True),
+        ("1", False, True),
+        ("yes", False, True),
+        ("on", False, True),
+        ("false", True, False),
+        ("0", True, False),
+        ("off", True, False),
+        ("maybe", False, False),  # unknown -> default
+        ("maybe", True, True),
+    ],
+)
+def test_env_bool_is_tolerant(monkeypatch, raw, default, expected):
+    name = "OPENCTI_TEST_ENV_BOOL"
+    if raw is None:
+        monkeypatch.delenv(name, raising=False)
+    else:
+        monkeypatch.setenv(name, raw)
+    assert _env_bool(name, default=default) is expected
+
+
+@pytest.mark.parametrize(
+    "raw,default,minimum,expected",
+    [
+        (None, 0.5, 0.0, 0.5),  # unset
+        ("", 0.5, 0.0, 0.5),  # empty
+        ("abc", 0.5, 0.0, 0.5),  # malformed
+        ("nan", 0.5, 0.0, 0.5),  # not finite
+        ("inf", 0.5, 0.0, 0.5),  # not finite
+        ("-1", 0.5, 0.0, 0.0),  # clamped to minimum
+        ("0.25", 0.5, 0.0, 0.25),
+        ("0.5", 2.0, 1.0, 1.0),  # factor clamped to >= 1
+        ("3", 2.0, 1.0, 3.0),
+    ],
+)
+def test_env_float_is_tolerant(monkeypatch, raw, default, minimum, expected):
+    name = "OPENCTI_TEST_ENV_FLOAT"
+    if raw is None:
+        monkeypatch.delenv(name, raising=False)
+    else:
+        monkeypatch.setenv(name, raw)
+    assert _env_float(name, default=default, minimum=minimum) == expected

--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -525,6 +525,16 @@ Can be configured manually using the configuration file `config.yml` or through 
 |:------------------------|:------------------------|:--------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | worker:objects_max_refs | WORKER_OBJECTS_MAX_REFS | 0             | The refs amount threshold: if set to a value higher than 0, all objects that have a number of refs higher than this will be sent to a dead letter queue and not ingested |
 
+#### Missing-reference retry schedule
+
+When the platform rejects an object because a referenced entity is not ingested yet (`MISSING_REFERENCE_ERROR`), the worker waits and retries up to 4 times. By default it waits a flat random 1 to 3 seconds before each retry. The exponential schedule waits less on the first retry and more on the last ones (0.5 s, 1 s, 2 s, 4 s on average, with jitter), which fits the common case where the referenced entity lands a fraction of a second later. These settings are environment variables only (read by the `pycti` library, so they also apply to connectors importing bundles directly).
+
+| Parameter | Environment variable                      | Default value | Description                                                                                                      |
+|:----------|:------------------------------------------|:--------------|:-----------------------------------------------------------------------------------------------------------------|
+| -         | OPENCTI_MISSING_REF_RETRY_EXPONENTIAL     | false         | Enable the exponential retry schedule for missing references (`true` / `false`)                                  |
+| -         | OPENCTI_MISSING_REF_RETRY_INITIAL_DELAY   | 0.5           | Exponential schedule only: average wait in seconds before the first retry (minimum 0)                            |
+| -         | OPENCTI_MISSING_REF_RETRY_FACTOR          | 2             | Exponential schedule only: multiplier applied to the wait at each retry (minimum 1, 1 = constant wait)           |
+
 #### Telemetry
 
 | Parameter                          | Environment variable               | Default value | Description                               |


### PR DESCRIPTION
### Proposed changes

* Add an **opt-in** fast-first exponential schedule for the worker missing-reference retry wait,
  behind `OPENCTI_MISSING_REF_RETRY_EXPONENTIAL=true` (**default `false`: the current flat
  `random.uniform(1, 3)` s wait is unchanged**). When enabled: mean delays 0.5s, 1s, 2s, 4s with
  +-50% jitter, same 4 attempts, total wait budget ~7.5s close to today's ~8s, so slow
  dependencies keep their chances and only the first steps shrink. Rationale and measurements in
  #17395: the dominant missing-reference class is a short race (median unavailability window
  <= 0.3s), the current mean 2s sleep waits 10-40x longer than needed, inside a worker
  execution-pool slot.
* Tunables for the exponential schedule: `OPENCTI_MISSING_REF_RETRY_INITIAL_DELAY` (default 0.5,
  min 0) and `OPENCTI_MISSING_REF_RETRY_FACTOR` (default 2, min 1). Env parsing is tolerant:
  unset/empty/malformed/non-finite values fall back to the defaults (no crash at import),
  out-of-range values are clamped (no negative sleep).
* Add a dedicated counter `opencti_bundles_missing_reference_retry_attempt_counter` carrying the
  attempt number (1-based, 1 = first retry, 4 = last) as an attribute, in both modes, so the heal
  rate per attempt becomes observable on the current schedule too, and the switch can be decided
  on real distributions. The existing `opencti_bundles_missing_reference_error_counter` is
  untouched (same increments, no label), so existing dashboards and alert rules see no change.
* Unit tests on the schedule function, the retry loop (sleeps, attempt attribute, stop after
  `PROCESSING_COUNT`) and the env parsing. Docs: new rows in the worker configuration page.

Scope: the missing-reference branch only; the LOCK_ERROR branch keeps its current sleep. The
settings are environment variables read by pycti, so they apply to the worker and to connectors
importing bundles directly.

### Related issues

* closes #17395

### How to test this PR

* Unit: `cd client-python && python -m pytest tests/01-unit/utils/test_opencti_stix2_import_retries.py`.
  With the flag unset the sleep bounds are 1-3s on every attempt; with
  `OPENCTI_MISSING_REF_RETRY_EXPONENTIAL=true` they are 0.25-0.75s / 0.5-1.5s / 1-3s / 2-6s
  (mean total 7.5s over the 4 attempts).
* Runtime, flag off: no behaviour change; the new retry-attempt counter exposes the `attempt`
  attribute (1 to 4), the historical missing-reference counter is unchanged.
* Runtime, flag on: ingest a bundle set where relationships arrive before their targets (split
  bundles across several connectors/queues); per-item added latency on healed races drops from
  seconds to sub-second. Bench A/B numbers (exponential mode vs stock, single variable) are in
  the comment below: storm-window throughput dip eliminated (trough 71 -> 96 objects/s), same
  delivered objects and error counts.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
