### PR TITLE
fix(ui): Internal enrichment connectors icon (#17404)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/integrations/catalog/utils/ingestionConnectorTypeMetadata.ts
+++ b/opencti-platform/opencti-front/src/private/components/integrations/catalog/utils/ingestionConnectorTypeMetadata.ts
@@ -1,9 +1,9 @@
 import {
-  AutoAwesomeOutlined,
   CloudDownloadOutlined,
   ExtensionOutlined,
   FileDownloadOutlined,
   InputOutlined,
+  PostAdd,
   StreamOutlined,
   TroubleshootOutlined,
   UploadFileOutlined,
@@ -21,7 +21,7 @@ export type IngestionConnectorType
 
 const CONNECTOR_TYPE_ICONS: Record<IngestionConnectorType, SvgIconComponent> = {
   EXTERNAL_IMPORT: CloudDownloadOutlined,
-  INTERNAL_ENRICHMENT: AutoAwesomeOutlined,
+  INTERNAL_ENRICHMENT: PostAdd,
   INTERNAL_ANALYSIS: TroubleshootOutlined,
   INTERNAL_EXPORT_FILE: FileDownloadOutlined,
   INTERNAL_IMPORT_FILE: UploadFileOutlined,


### PR DESCRIPTION
### Proposed changes
Change the icon before the 'internal enrichment' connector in the Integration section

<img width="952" height="440" alt="image" src="https://github.com/user-attachments/assets/7a4418fb-b1c2-41c6-a39b-6b4919fb3a14" />


<img width="953" height="451" alt="image" src="https://github.com/user-attachments/assets/d7efe767-e2b1-4e35-81a3-c5ce5be5ca16" />


### Related issues
fixes #17404