### PR TITLE
chore(design-system): isolated visual test of FDS Navbar/ProductSwitcher components

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -35,6 +35,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
+    "@filigran/design-system": "file:.yalc/@filigran/design-system",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/_fdsSpike/FdsComponentsSpikeScreen.tsx
+++ b/opencti-platform/opencti-front/src/_fdsSpike/FdsComponentsSpikeScreen.tsx
@@ -1,0 +1,235 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { StyledEngineProvider, ThemeProvider, createTheme } from '@mui/material/styles';
+import type { ThemeOptions } from '@mui/material/styles/createTheme';
+import CssBaseline from '@mui/material/CssBaseline';
+import GlobalStyles from '@mui/material/GlobalStyles';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import { Navbar, NavbarItem, NavbarSeparator, NavbarSubmenu, NavbarSubmenuItem, ProductSwitcher, Icon } from '@filigran/design-system';
+// Pre-built, self-contained stylesheet (tokens + Tailwind utilities used by
+// the library's own components). No preflight/reset included, so this is
+// safe to load alongside MUI's baseline (see the package's tokens/index.css
+// source comment: "A distributed component library must never impose a
+// global CSS reset. Host apps ... include their own preflight.").
+import '@filigran/design-system/dist/index.css';
+import ThemeDark from '../components/ThemeDark';
+import ThemeLight from '../components/ThemeLight';
+import useFdsThemeScope from '../utils/hooks/useFdsThemeScope';
+
+/**
+ * ============================================================================
+ * TEMPORARY SPIKE — NOT PRODUCTION CODE — SAFE TO DELETE AFTER REVIEW.
+ * ============================================================================
+ *
+ * Purpose: an isolated, throwaway visual test of the @filigran/design-system
+ * `Navbar` / `NavbarItem` / `NavbarSubmenu` / `ProductSwitcher` components
+ * rendered inside OpenCTI's real build/toolchain (Vite, MUI theme tokens),
+ * using only fake/representative data — no GraphQL/API integration.
+ *
+ * This is deliberately NOT wired into the real navigation:
+ *  - LeftBar.jsx / LeftBarItem.tsx (production nav) are untouched.
+ *  - This screen is only reachable by directly visiting its own route
+ *    (see `app.tsx`); it is not linked from any menu.
+ *  - `useFdsThemeScope` is used exactly as documented in its own file
+ *    (imported and called here, with a local `containerRef`) — the hook
+ *    itself is untouched, as are ThemeDark.ts/ThemeLight.ts/
+ *    AppThemeProvider.tsx/fds-tokens.generated.ts (consumed only).
+ *
+ * ⚠ ProductSwitcher color caveat (see ProductSwitcher.rfc.md in the
+ * filigran-design-system repo): every color token on ProductSwitcher is
+ * REUSED from NavbarItem/NavbarSubmenuItem, flagged "to revalidate" rather
+ * than final — there is no dedicated Figma symbol for this component yet.
+ * Do not treat the colors rendered below as a reliable reference.
+ *
+ * ⚠ Finding surfaced by this spike (not fixed here — lives in
+ * filigran-design-system, not opencti): toggling light/dark via
+ * `useFdsThemeScope` correctly re-themes solid-color tokens (text, icons,
+ * borders), but `Navbar`'s own background — `bg-gradient-default`
+ * (Navbar.tsx) — stays frozen on its dark-mode gradient in light mode too.
+ * Root cause appears to be that `--gradient-default` (theme.css) embeds
+ * nested `var()` references that don't re-resolve against the `.light`/
+ * `.dark` overrides of their sub-tokens the way plain solid tokens do.
+ * Navbar.rfc.md §"cross-component inconsistency" still describes the
+ * older flat-color implementation and says light/dark is mode-agnostic;
+ * the component was since changed to this gradient (see fidelity re-pass
+ * comments in Navbar.tsx), so that RFC note is stale. Not resolved here —
+ * flagged for the design-system team.
+ */
+
+const FAKE_USER_NAME = 'Jane Doe (Analyst)';
+
+const fakeProductOptions = [
+  {
+    id: 'openaev',
+    label: 'OpenAEV',
+    logo: <Icon name="custom/openaev" size={20} />,
+    tooltip: 'Breach and attack simulation platform (fake link — spike only)',
+    href: 'https://openaev.example.invalid',
+  },
+  {
+    id: 'opengrc',
+    label: 'OpenGRC',
+    logo: <Icon name="custom/opengrc" size={20} />,
+    tooltip: 'Governance, risk and compliance platform (fake link — spike only)',
+    href: 'https://opengrc.example.invalid',
+  },
+  {
+    id: 'xtmhub',
+    label: 'XTM Hub',
+    logo: <Icon name="custom/xtmhub" size={20} />,
+    tooltip: 'Central hub for connectors and integrations (fake link — spike only)',
+    href: 'https://xtmhub.example.invalid',
+  },
+];
+
+const preventDefault = (e: React.MouseEvent) => e.preventDefault();
+
+interface SpikeContentProps {
+  mode: 'dark' | 'light';
+  onToggleMode: () => void;
+}
+
+/**
+ * Rendered as a child of the local `ThemeProvider` below so that
+ * `useFdsThemeScope` (which reads `theme.palette.mode` via `useTheme`) sees
+ * the right MUI theme context — mirrors the pattern already validated in
+ * `useFdsThemeScope.test.tsx`.
+ */
+const SpikeContent = ({ mode, onToggleMode }: SpikeContentProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Bridges theme.palette.mode -> .dark/.light classes on containerRef, so
+  // FDS components' CSS custom properties resolve to the right mode. Used
+  // as-is, per the hook's own docstring instructions.
+  useFdsThemeScope(containerRef);
+
+  return (
+    <Box sx={{ display: 'flex', height: '100vh', width: '100%', bgcolor: 'background.default' }}>
+      {/* dist/index.css intentionally ships without Tailwind preflight (see
+          import comment above), so native <button> elements keep the
+          browser's default appearance/background unless the host resets
+          them. This mirrors Tailwind preflight's own button rule, scoped to
+          this spike's container only — never applied globally. */}
+      <GlobalStyles
+        styles={{
+          '.fds-spike-scope button': {
+            appearance: 'none',
+            WebkitAppearance: 'none',
+            backgroundColor: 'transparent',
+            backgroundImage: 'none',
+          },
+        }}
+      />
+      <Box
+        ref={containerRef}
+        className="fds-spike-scope"
+        sx={{ height: '100%', flexShrink: 0 }}
+      >
+        <Navbar
+          aria-label="FDS spike navigation"
+          header={(
+            <ProductSwitcher
+              label="Switch product"
+              logo={<Icon name="custom/opencti" size={20} />}
+              options={fakeProductOptions}
+            />
+          )}
+          footer={(
+            <NavbarItem icon={<Icon name="user" size={16} />} onClick={preventDefault}>
+              {FAKE_USER_NAME}
+            </NavbarItem>
+          )}
+        >
+          <NavbarItem
+            icon={<Icon name="layout-dashboard" size={16} />}
+            onClick={preventDefault}
+          >
+            Dashboard
+          </NavbarItem>
+          <NavbarItem
+            icon={<Icon name="activity" size={16} />}
+            aria-current="page"
+            onClick={preventDefault}
+          >
+            Investigations
+          </NavbarItem>
+          <NavbarItem
+            icon={<Icon name="database" size={16} />}
+            onClick={preventDefault}
+          >
+            Data
+          </NavbarItem>
+          <NavbarSeparator />
+          <NavbarSubmenu
+            label="Entities"
+            icon={<Icon name="box" size={16} />}
+            defaultOpen
+          >
+            <NavbarSubmenuItem href="#" onClick={preventDefault}>Sectors</NavbarSubmenuItem>
+            <NavbarSubmenuItem href="#" onClick={preventDefault}>Organizations</NavbarSubmenuItem>
+            <NavbarSubmenuItem href="#" onClick={preventDefault}>Individuals</NavbarSubmenuItem>
+          </NavbarSubmenu>
+        </Navbar>
+      </Box>
+      <Box sx={{ flex: 1, overflow: 'auto', p: 3 }}>
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          <strong>Temporary spike — not production code.</strong> This screen only
+          renders design-system components with fake data to visually check
+          Navbar/NavbarItem/NavbarSubmenu/ProductSwitcher. It is not linked from
+          any real navigation and should be deleted after review.
+          <br />
+          ⚠ ProductSwitcher colors are reused/unvalidated tokens (see this
+          component&apos;s .rfc.md in the filigran-design-system repo) — not a
+          reliable reference yet.
+        </Alert>
+        <Button variant="outlined" onClick={onToggleMode} sx={{ mb: 2 }}>
+          Toggle theme (currently: {mode})
+        </Button>
+        <Typography variant="h4" gutterBottom>
+          FDS components spike
+        </Typography>
+        <Typography variant="body1">
+          Placeholder content area — the sidebar on the left is the real
+          `@filigran/design-system` Navbar, composed with fake menu items, a
+          fake user row, and a fake product list for ProductSwitcher.
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+/**
+ * Route entry point. Builds a local MUI theme directly from `ThemeDark`/
+ * `ThemeLight` (no GraphQL `settings` fragment involved, per the
+ * no-real-integration requirement) and toggles between them with local
+ * state only — this never touches the app-wide `AppThemeProvider`/
+ * `useDocumentThemeModifier` state, keeping the spike fully isolated.
+ */
+const FdsComponentsSpikeScreen = () => {
+  const [mode, setMode] = useState<'dark' | 'light'>('dark');
+
+  const muiTheme = useMemo(
+    () => createTheme((mode === 'dark' ? ThemeDark() : ThemeLight()) as ThemeOptions),
+    [mode],
+  );
+
+  return (
+    <StyledEngineProvider injectFirst>
+      <ThemeProvider theme={muiTheme}>
+        {/* Same convention as other top-level route roots (private/Index.tsx,
+            public/PublicRoot.tsx): a fresh top-level route needs its own
+            CssBaseline. Without it, native elements (e.g. NavbarItem's
+            underlying <button>) keep the browser's default chrome/background,
+            since dist/index.css deliberately ships without Tailwind preflight. */}
+        <CssBaseline />
+        <SpikeContent
+          mode={mode}
+          onToggleMode={() => setMode((current) => (current === 'dark' ? 'light' : 'dark'))}
+        />
+      </ThemeProvider>
+    </StyledEngineProvider>
+  );
+};
+
+export default FdsComponentsSpikeScreen;

--- a/opencti-platform/opencti-front/src/app.tsx
+++ b/opencti-platform/opencti-front/src/app.tsx
@@ -9,6 +9,9 @@ import Loader from './components/Loader';
 const PublicRoot = lazy(() => import('./public/PublicRoot'));
 const PrivateRoot = lazy(() => import('./private/Root'));
 const RedirectByPath = lazy(() => import('./private/components/RedirectByPath'));
+// TEMPORARY SPIKE — not part of production navigation, safe to remove after
+// review. See src/_fdsSpike/FdsComponentsSpikeScreen.tsx for details.
+const FdsComponentsSpikeScreen = lazy(() => import('./_fdsSpike/FdsComponentsSpikeScreen'));
 
 const App = () => (
   <CookiesProvider>
@@ -20,6 +23,10 @@ const App = () => (
               <Route path="/dashboard/*" Component={PrivateRoot} />
               <Route path="/public/*" Component={PublicRoot} />
               <Route path="/redirect/*" element={<RedirectByPath />} />
+              {/* TEMPORARY SPIKE route — isolated design-system component
+                  visual test, not linked from any real menu/navigation.
+                  Safe to remove after review (see FdsComponentsSpikeScreen). */}
+              <Route path="/fds-spike" Component={FdsComponentsSpikeScreen} />
               {/* By default, redirect to dashboard */}
               <Route
                 path="/*"

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -948,6 +948,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@filigran/design-system@file:.yalc/@filigran/design-system::locator=opencti-front%40workspace%3A.":
+  version: 0.1.0
+  resolution: "@filigran/design-system@file:.yalc/@filigran/design-system#.yalc/@filigran/design-system::hash=a386f9&locator=opencti-front%40workspace%3A."
+  dependencies:
+    "@radix-ui/react-accordion": "npm:^1.2.18"
+    "@radix-ui/react-dialog": "npm:^1.1.22"
+    "@radix-ui/react-dropdown-menu": "npm:^2.1.22"
+    "@radix-ui/react-slot": "npm:^1.1.0"
+    "@radix-ui/react-switch": "npm:^1.3.7"
+    "@radix-ui/react-tabs": "npm:^1.1.16"
+    "@radix-ui/react-tooltip": "npm:^1.2.13"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    lucide-react: "npm:1.23.0"
+    tailwind-merge: "npm:^3.3.1"
+  peerDependencies:
+    react: ^19.0.0
+    react-dom: ^19.0.0
+  checksum: 10c0/9f307949c69c538d72eb257c0695807d57a5d605965efbb2f97f8fe339a7cb219be6719df2d19c21ce45e406e3c0a2ab5998611ecbfd94aba0b20209b99beb68
+  languageName: node
+  linkType: hard
+
 "@filigran/rich-text-editor@npm:1.2.0":
   version: 1.2.0
   resolution: "@filigran/rich-text-editor@npm:1.2.0"
@@ -2740,6 +2762,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-accordion@npm:^1.2.18":
+  version: 1.2.20
+  resolution: "@radix-ui/react-accordion@npm:1.2.20"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-collapsible": "npm:1.1.20"
+    "@radix-ui/react-collection": "npm:1.1.15"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-direction": "npm:1.1.4"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/610cbc3155ccc1f3da4b0a85eee009f482ff807e0729d7023b2b3315a6abff75ec6d50b56d53778d069ac61a9bf74670622f9ebe0dd243750ed7e77964ab700c
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-arrow@npm:1.1.14":
   version: 1.1.14
   resolution: "@radix-ui/react-arrow@npm:1.1.14"
@@ -2756,6 +2805,51 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/1de6cc38145d7573e105714e139a9abc507af8e40a31de77f237f5036688c3b8809c2974e500ae6819212763f1fce7058397bc15711109aaccbe9c59ab18b539
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-arrow@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-arrow@npm:1.1.15"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.10"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/06fa0a29ae332617d7912e4f25e952d110905264362e7266d2aa423e81aff492d0f1eaa7dd834b3271e6f5d45f56c8c54585d10d771356fb789e50c959f555ca
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-collapsible@npm:1.1.20":
+  version: 1.1.20
+  resolution: "@radix-ui/react-collapsible@npm:1.1.20"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-presence": "npm:1.1.10"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/ead7072ddbc13d2419af216f2184d81f4211b4bce57e739ed347dcae07897e0cc1e0210cbe66c612c653abd15e46f6fa5832693274aa3f8eff092fd27c22ac08
   languageName: node
   linkType: hard
 
@@ -2781,6 +2875,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-collection@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-collection@npm:1.1.15"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-slot": "npm:1.3.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/9f9d3f6290026fd383503ebc260d698d59287016e90a3bd5aa4a9696b8cab733b207e5558ddffa3bb877c68f8658c4a3a52fb9314c7cbc83a4b6349808c5bf4c
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-compose-refs@npm:1.1.4":
   version: 1.1.4
   resolution: "@radix-ui/react-compose-refs@npm:1.1.4"
@@ -2794,6 +2910,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-compose-refs@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/ab5cc8cc2f5be285981cffb64aa956d3a28427c649a953d125e900e1befb8b9a55f2d7a31bc01059d29df43ff4ae14ebc6cca7e4c2084d638cef5e5aef7cc263
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-context@npm:1.2.1":
   version: 1.2.1
   resolution: "@radix-ui/react-context@npm:1.2.1"
@@ -2804,6 +2933,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/21ab49cd3350a9f37fdcbcc5f2425351982f85fe0b5414c88a8feab240b24cd979b137a8959e7e513041a6fe7cac98b9a40c77cfaf373270320fe8962e8508d6
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-context@npm:1.2.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/f5c15339558d64901c99f243a2538be9b28eb20e0dae1e44c8872ed12580ec27f5f309fd491f85f1b0dcb214c90fdae7eede7fe2b0d26569c4dbeffbeff451c0
   languageName: node
   linkType: hard
 
@@ -2840,6 +2982,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dialog@npm:^1.1.22":
+  version: 1.1.23
+  resolution: "@radix-ui/react-dialog@npm:1.1.23"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.19"
+    "@radix-ui/react-focus-guards": "npm:1.1.6"
+    "@radix-ui/react-focus-scope": "npm:1.1.16"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-portal": "npm:1.1.17"
+    "@radix-ui/react-presence": "npm:1.1.10"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-slot": "npm:1.3.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.7.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/647e2b3a05826ddab72c68d04b842de47594f8b9c78131ef64a8f94b6e04e311abbe6c2919d645941e2646d8fd5f1d4e9ae9ce65c6492237e180a1d005eddc23
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-direction@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-direction@npm:1.1.3"
@@ -2850,6 +3025,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/6b4ea44620b193b9ca4432578c29d9c99aa642c6b5491bb8a4f31337d93ad3ac92c676a1f5826202453c8be015fd971f6108cca5eb3de819defc82c7ced97302
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-direction@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-direction@npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/505e6e45b53f2b6a98c82895e1fe0b04c048bf70dbcabe2e3a4bbc05e3cf4759a5e7d9865360eac78da5c56ed3fdd82efce1511179f397525d14de614181de61
   languageName: node
   linkType: hard
 
@@ -2873,6 +3061,29 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/bfef8260ebe223a5ddf6d3e88a986e51265fcd0bf2ea804a1437d0335ffc075a031eea8e429804eb0ff9674c354167e2a4ef9f591b924a48b6c4c9adb43e892b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dismissable-layer@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.19"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+    "@radix-ui/react-use-effect-event": "npm:0.0.5"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/205f2fded4a9e303fcc0d67b78274db84d37d0d35177bb99602c72202a6dcadc39f4cbf936a09e1303b4b42a2b494a279ead9e626cb1a41015152a91ad069fc5
   languageName: node
   linkType: hard
 
@@ -2901,6 +3112,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dropdown-menu@npm:^2.1.22":
+  version: 2.1.24
+  resolution: "@radix-ui/react-dropdown-menu@npm:2.1.24"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-menu": "npm:2.1.24"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/bdf10d0f1c3cee34a661a33b0f6effaec26586ed2ebd8fd2214e38c5ba226579c86bd86e68af5a2bd750ab3f09b9e5efb908063c0f4cb0fc228343c0159179d2
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-focus-guards@npm:1.1.5":
   version: 1.1.5
   resolution: "@radix-ui/react-focus-guards@npm:1.1.5"
@@ -2911,6 +3147,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/27160aade8cb2af5f38a67ebdcdf7e0ac3311068d0911abcbc1063a7866d4eee06f90adce788230d2a8410b6bde75c9c75e248ea82912612c3b94faf770491c6
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-guards@npm:1.1.6":
+  version: 1.1.6
+  resolution: "@radix-ui/react-focus-guards@npm:1.1.6"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/5579dfe369f254183a010964e6df8b74c7b36e50189aef18c92538d0196785d68869e3170af77005276f393cd112b7711d5c7cb9e7ec2ca1e0b4794157447978
   languageName: node
   linkType: hard
 
@@ -2935,6 +3184,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-focus-scope@npm:1.1.16":
+  version: 1.1.16
+  resolution: "@radix-ui/react-focus-scope@npm:1.1.16"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/2c86dafac81a73295f81834ff85c4af4456671f7d26631cb800837b284318d181c5de043cac2e17bedd6e8a009e3de907ef9435ea9ec5a94518cbaf656368550
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-id@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-id@npm:1.1.3"
@@ -2947,6 +3217,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/8d0b13e4fb7a4f381ddc789b709fdb0a1d57fbe731e9cce71e9e5cebcf54840f67fc6f880d2d96f04f53808527ab45f58531a22e4c0442ad60d2c563a4ff4c3b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-id@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-id@npm:1.1.4"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7afa00d12d7f52b5067034108eb7d5551928f9d52875589f858ea1d5117cac3684f8ea291d4f09a88b9499bc4bb6e3279e4a9073d7c8feb15a855d28656b53a4
   languageName: node
   linkType: hard
 
@@ -2986,6 +3271,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-menu@npm:2.1.24":
+  version: 2.1.24
+  resolution: "@radix-ui/react-menu@npm:2.1.24"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-collection": "npm:1.1.15"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-direction": "npm:1.1.4"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.19"
+    "@radix-ui/react-focus-guards": "npm:1.1.6"
+    "@radix-ui/react-focus-scope": "npm:1.1.16"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-popper": "npm:1.3.7"
+    "@radix-ui/react-portal": "npm:1.1.17"
+    "@radix-ui/react-presence": "npm:1.1.10"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-roving-focus": "npm:1.1.19"
+    "@radix-ui/react-slot": "npm:1.3.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.7.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/01fd48bf24c4a43e799a9f0d4b4dc5b2bde57cd56307d0bb179c97dab99b902f5edb8f48899c21b623bcdfbc80d59e8a9ca5670b86c40f0b8ca4b90712bc3bcc
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-popper@npm:1.3.6":
   version: 1.3.6
   resolution: "@radix-ui/react-popper@npm:1.3.6"
@@ -3014,6 +3335,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-popper@npm:1.3.7":
+  version: 1.3.7
+  resolution: "@radix-ui/react-popper@npm:1.3.7"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.0.0"
+    "@radix-ui/react-arrow": "npm:1.1.15"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+    "@radix-ui/react-use-rect": "npm:1.1.4"
+    "@radix-ui/react-use-size": "npm:1.1.4"
+    "@radix-ui/rect": "npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/f32e85f70d2161d724df4adae4103d5c1f61ff344d25ad51c4f3d0a02b6251890b864dde3313093d748efe824dc9cceb40a068ac68b10bd1163d4b678e01d6e3
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-portal@npm:1.1.16":
   version: 1.1.16
   resolution: "@radix-ui/react-portal@npm:1.1.16"
@@ -3034,6 +3383,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-portal@npm:1.1.17":
+  version: 1.1.17
+  resolution: "@radix-ui/react-portal@npm:1.1.17"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/f3358ef906582ee8dd8ae62db1f1c1e9810e0554ff8e1a887c731fb35d3b673791e9d338cab884f3eddd74e24afd8e21679b1cc24fd035c68ad71dd09ed71bae
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-presence@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@radix-ui/react-presence@npm:1.1.10"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/5ef8048ea02ecfd11284e229efa33f75074189788b68edb9fe38140cbc56cc40ee77f017f34e3c3d3a5dbc1fb12b5a18d5a9ef2a84ef966a1d90502be5a84617
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-presence@npm:1.1.9":
   version: 1.1.9
   resolution: "@radix-ui/react-presence@npm:1.1.9"
@@ -3050,6 +3438,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/42e36a9ec216b2a6e0876a12fe7cd19fa7e024c170088f56db6c765e42dc7e51275c10bc13e35d8a6bb044adaf1e8a1e2bf7b09f5051ce885bd0cd86d45f7094
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.10":
+  version: 2.1.10
+  resolution: "@radix-ui/react-primitive@npm:2.1.10"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.3.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/3be05e842d20a5eb08cebbc1d4d08f24a4c09af8cb864e1d1dddf27f362b739ce0edc1c9fc188a7c734cecd8f5df21e379c15774230f4ab11ce2a8229d3598da
   languageName: node
   linkType: hard
 
@@ -3101,6 +3508,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-roving-focus@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-roving-focus@npm:1.1.19"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-collection": "npm:1.1.15"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-direction": "npm:1.1.4"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+    "@radix-ui/react-use-is-hydrated": "npm:0.1.3"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/b11083f923635d4cddd5a45c5145e8684ac8311b7a9e3970cb60a0a4f5c1ab692b502a732f02f716560e1308c2d5e9b6925fe8a9479d7aadfe0f6156809eeafb
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:1.3.2":
   version: 1.3.2
   resolution: "@radix-ui/react-slot@npm:1.3.2"
@@ -3114,6 +3550,71 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/a4765e446a3057542dbbc1f02b31fa003d53992efdb0b586fc9d0d3062226c69d5e1429aa9f46ca93a5db8976b4ff5289be922cc61791cf9327c880ff45e8c65
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.3.3, @radix-ui/react-slot@npm:^1.1.0":
+  version: 1.3.3
+  resolution: "@radix-ui/react-slot@npm:1.3.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7ed356819bbb40415ccd16bc8a8da3162966e827ea8fa404c2ae547518777aa193b0aad07f139f3c9d3280f51433e1cc4fa4cfd8dc7e8e6215e7b0d7a25e4b39
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-switch@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@radix-ui/react-switch@npm:1.3.7"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+    "@radix-ui/react-use-size": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/cc2d3670f78a14eb558a50b9979568ac2439551b4487cbf83f25b7f5cd2859d29672fab7fc8c97e16b9ee9420b4fd0a103f1bd409bb172a14ee8528aaec59fff
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-tabs@npm:^1.1.16":
+  version: 1.1.21
+  resolution: "@radix-ui/react-tabs@npm:1.1.21"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-direction": "npm:1.1.4"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-presence": "npm:1.1.10"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-roving-focus": "npm:1.1.19"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/9ed747ec592b04efc57bc1b124b9b4b4bb80011167ea5d87ea99955a88fa3a84df2e78a8ffaa1a15e2ba3d9598b6d8a8c28664fc3712aa8627c0e37267389652
   languageName: node
   linkType: hard
 
@@ -3148,6 +3649,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-tooltip@npm:^1.2.13":
+  version: 1.2.16
+  resolution: "@radix-ui/react-tooltip@npm:1.2.16"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.19"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-popper": "npm:1.3.7"
+    "@radix-ui/react-portal": "npm:1.1.17"
+    "@radix-ui/react-presence": "npm:1.1.10"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-slot": "npm:1.3.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+    "@radix-ui/react-visually-hidden": "npm:1.2.11"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/4ddd4051433c11172218971b2788ca34d53440db7e78e2144107b09e500bbac52893b534ab23c85fd5ae4e68f1d7c750c7987033c7e167c804b2aa0047b50cb8
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-callback-ref@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-use-callback-ref@npm:1.1.3"
@@ -3158,6 +3690,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/9a2d0dc51c9606d37a664b83d3aabe7645ec99dd716094963a11b5c386de1c792ff504c4eba3c326f206952a046c64d734d4d130fd5d00ebcc263d59d8549fc3
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d5cc1248ab6a58b12eefd3115c98fb438b74b2e6dec463d2e097d27df8e9f40b9d8693ee10a422da4f7a688fbe52c62cc2fe3aa5972020b9425b86a2a28f5f01
   languageName: node
   linkType: hard
 
@@ -3178,6 +3723,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-controllable-state@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.6"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-use-effect-event": "npm:0.0.5"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/1672c3fa5c1f2dbc354db4d403523eef15bcbe24448b911e67e3e95f351b72ffc1dc1021a225d98116cd78d1c96e6280f1645ac6d6b9930df46b180b8a6f11a5
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-effect-event@npm:0.0.4":
   version: 0.0.4
   resolution: "@radix-ui/react-use-effect-event@npm:0.0.4"
@@ -3190,6 +3752,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/5973def9e1891b2881ac7d3ad82128d8e0c5010ccf9a46d71b0976715cb5ade690caebee00ced766d9682cfa70f754ae563d214fca271d49d372d7f389f6bf6e
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.5":
+  version: 0.0.5
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.5"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/36eb3523d3c30e88615e0492aed5c644e61eb4fec98097de0fb2ee1cf33d7684b76e8a34bedb0aa7c25b412e0ef56c83b16772e9716d03d61901bc1b98cb1993
   languageName: node
   linkType: hard
 
@@ -3206,6 +3783,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-is-hydrated@npm:0.1.3":
+  version: 0.1.3
+  resolution: "@radix-ui/react-use-is-hydrated@npm:0.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/ec5d8cd7dcb825d23c9e622cb78605242ae6ae5744549f4713fd543a2a2003c356031bac3bd8db353579e6cd9f71798b59915f54de7b78b442e847024f2a5ff9
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-layout-effect@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-use-layout-effect@npm:1.1.3"
@@ -3216,6 +3806,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/0375e41adcce9f81bd2551e7b15ea3cf066f1f207828f6502103240e1633d859edd54ea2b66eec8d456fe33e61b9b5931809b11f061398132970c7d40f5efcc5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/427df10bb3c55de36afd6b9a749fb4b72b0f78840ae4abb5dda24aa09d653ede2d264c96a8030f58db353498f42b2bce929510c777004e250f7845b06c782bcf
   languageName: node
   linkType: hard
 
@@ -3234,6 +3837,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-use-rect@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-use-rect@npm:1.1.4"
+  dependencies:
+    "@radix-ui/rect": "npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/3acfe9265f9fbdcdead05ec4540a95d8932fb53e9eabd73c080650122424d3d5247260d349ea2d91b2712af9670a27ac2110400671b98d061b2347390fe29490
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-size@npm:1.1.3":
   version: 1.1.3
   resolution: "@radix-ui/react-use-size@npm:1.1.3"
@@ -3246,6 +3864,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/9eeaab67723f6afbea847f7b8d594ab4d6b49eedd221420b21ebceaf347681f69528484f1cbb8d5df8fe82f3cf97cb162fc63a7eaf4ebf286493e47a931b3619
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-size@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-use-size@npm:1.1.4"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/ebb4a0c6e71768ae231635cc721d7f01de0a31637e73cccea095ad63921bfece9635eb9500cbe32504585380910f578216fb3eebdfc21b511f6dd6df81659f75
   languageName: node
   linkType: hard
 
@@ -3265,6 +3898,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/051776e80bd96634713afb564d82fa0f9c85b585017f8955c0971bd0936ee125dc62c84725f467eeaa6fa48289cabcd36f04c62273f93af03c819a947591dad8
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-visually-hidden@npm:1.2.11":
+  version: 1.2.11
+  resolution: "@radix-ui/react-visually-hidden@npm:1.2.11"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.10"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/053fe28a279d37ad826970ffcaf93bdf029831e7aba8f34e0cdeecbd45a360b56c2f548b49e8a6bcbf484ceb3389bee2642dece754e59d63c14fb36c1a36a1a4
   languageName: node
   linkType: hard
 
@@ -5949,6 +6601,15 @@ __metadata:
   version: 1.0.4
   resolution: "chrome-trace-event@npm:1.0.4"
   checksum: 10c0/3058da7a5f4934b87cf6a90ef5fb68ebc5f7d06f143ed5a4650208e5d7acae47bc03ec844b29fbf5ba7e46e8daa6acecc878f7983a4f4bb7271593da91e61ff5
+  languageName: node
+  linkType: hard
+
+"class-variance-authority@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "class-variance-authority@npm:0.7.1"
+  dependencies:
+    clsx: "npm:^2.1.1"
+  checksum: 10c0/0f438cea22131808b99272de0fa933c2532d5659773bfec0c583de7b3f038378996d3350683426b8e9c74a6286699382106d71fbec52f0dd5fbb191792cccb5b
   languageName: node
   linkType: hard
 
@@ -10291,6 +10952,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lucide-react@npm:1.23.0":
+  version: 1.23.0
+  resolution: "lucide-react@npm:1.23.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/1cb2108d81c9713e20dd1beb7b6ac5bfc17307d5f38388f84921cf6a124efb4b933c73929bede42f00bd08aa2df340b0904acdf4fb90206ccd52971e943e775b
+  languageName: node
+  linkType: hard
+
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -11757,6 +12427,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
+    "@filigran/design-system": "file:.yalc/@filigran/design-system"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"
@@ -14605,6 +15276,13 @@ __metadata:
   version: 6.5.0
   resolution: "tabbable@npm:6.5.0"
   checksum: 10c0/7d778af05a3093800265831198cad9d0024f3d65cdd4405007490f7430b42ff4e80060b4679f45281fb96ddbddc5fb895e8ea36e3ebdc811051e14acc9c7c02c
+  languageName: node
+  linkType: hard
+
+"tailwind-merge@npm:^3.3.1":
+  version: 3.6.0
+  resolution: "tailwind-merge@npm:3.6.0"
+  checksum: 10c0/a728d929f4786bcb48641db4228cc8c006a7545491783a658fb4d24d177dab960620991d17805a047309228de50ab949ca8d9e112c30183da0432367796ae186
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Purpose

Isolated, throwaway spike to visually validate the `@filigran/design-system` `Navbar`, `NavbarItem`, `NavbarSubmenu` and `ProductSwitcher` components rendered inside OpenCTI's real build toolchain (Vite + MUI theme tokens), using fake/representative data only — **no GraphQL/API integration**.

This is **not** a real navigation integration. Nothing under production navigation (`LeftBar.jsx`, `LeftBarItem.tsx`) was touched.

## What was added

- `src/_fdsSpike/FdsComponentsSpikeScreen.tsx` — new, self-contained screen:
  - Builds its own local MUI theme directly from `ThemeDark()`/`ThemeLight()` (no relay/GraphQL dependency).
  - Uses the existing `useFdsThemeScope` hook exactly as documented in its own docstring (imported and called here with a local `containerRef`) — the hook itself was **not modified**.
  - Renders a fake Navbar: fake menu items (Dashboard / Investigations / Data), a fake "Entities" submenu (Sectors / Organizations / Individuals), a fake user footer row, and a `ProductSwitcher` with 3 fake product options (OpenAEV / OpenGRC / XTM Hub, `.invalid` placeholder links).
  - On-page banner marking the screen as temporary/disposable and restating the ProductSwitcher color caveat (see below).
  - Local theme toggle button to switch dark/light for manual testing.
- `src/app.tsx` — one new top-level route `/fds-spike` (lazy-loaded), clearly commented as temporary, kept separate from `/dashboard/*` and `/public/*`. Not linked from any menu.
- `package.json` / `yarn.lock` — adds `@filigran/design-system` as a **yalc** `file:` dependency (built + published locally from the `filigran-design-system` repo). `.yalc/` itself is gitignored and not committed, so **reviewers who want to run this locally need to redo the yalc steps** (`pnpm install && pnpm build && yalc publish` in the lib repo, then `yalc add @filigran/design-system` in `opencti-front`).

**Not modified** (consumed only, per instructions): `useFdsThemeScope.ts`, `ThemeDark.ts`, `ThemeLight.ts`, `AppThemeProvider.tsx`, `fds-tokens.generated.ts`, `LeftBar.jsx`, `LeftBarItem.tsx`.

## What was tested

Rendered at `/fds-spike` via local dev server (Vite + `yarn relay`), verified with Playwright in both dark and light mode, `ProductSwitcher` dropdown opened and inspected. No console errors other than expected `/graphql` 502s (no backend running locally — unrelated to this screen, which makes zero GraphQL calls).

**Dark mode**: Navbar renders with fake Dashboard/Investigations (active)/Data items, the "Entities" submenu expanded (Sectors/Organizations/Individuals), a fake user footer row, and the `ProductSwitcher` trigger in the header — all readable, correctly styled, matching the design system's dark tokens.

**Light mode** (via the on-page toggle): text/icon/border colors correctly switch to light tokens. See caveat #3 below for one exception (Navbar's background gradient).

**ProductSwitcher dropdown**: opens correctly, shows the 3 fake product options with icons; see caveat #2 below on label visibility.

Screenshots (dark, light, and ProductSwitcher-open) were captured during development and are included in the accompanying session report — happy to attach them here too on request if useful for the review.

## ⚠️ Caveats / findings (not resolved here — reporting only)

1. **ProductSwitcher colors are not final.** Per `ProductSwitcher.rfc.md` in `filigran-design-system`: every color token used by `ProductSwitcher` is reused from `NavbarItem`/`NavbarSubmenuItem` and flagged "to revalidate" — there's no dedicated Figma symbol for this component yet. Do not treat the colors as a reliable reference.
2. **ProductSwitcher dropdown option labels are screen-reader-only.** In the current `ProductSwitcher.tsx` source, each option's visible row is icon + "opens in new tab" indicator only; the text label (`option.label`) is wrapped in a `sr-only` span. Likely intentional (works with the `tooltip` prop), but flagging since it's a visible behavior surprise compared to `NavbarItem`'s full text labels.
3. **`Navbar`'s background gradient does not follow the light/dark toggle.** Confirmed via computed styles: solid-color tokens (text, icons, borders) correctly re-theme when toggling `useFdsThemeScope`'s `.dark`/`.light` scope class, but `Navbar`'s own `bg-gradient-default` background stays frozen on its dark-mode gradient even in light mode. Root cause appears to be that `--gradient-default` (in `theme.css`) embeds nested `var()` references to sub-tokens that don't re-resolve against `.light`/`.dark` overrides the way plain solid tokens do. Note: `Navbar.rfc.md`'s existing "cross-component inconsistency" section says the rendered code is mode-agnostic, but that referred to an older flat-color implementation — the component was since changed to this gradient (see the fidelity re-pass comments in `Navbar.tsx`), so that RFC note is now stale. This is a `filigran-design-system` finding, out of scope to fix from this PR.

None of the above were resolved in this PR — they're flagged for the design-system team / Sandy to decide, per instructions.

## Not merging

Please do **not** merge this yourselves — leaving it for Sandy to review, since merging into `design-system/current` also triggers an AWX redeploy of the shared demo environment.
