### PR TITLE
fix(client-python): accept scope as string or list in OpenCTIConnector (#17414)

### DIFF
--- a/client-python/pycti/connector/opencti_connector.py
+++ b/client-python/pycti/connector/opencti_connector.py
@@ -48,7 +48,9 @@ class OpenCTIConnector:
     :type connector_name: str
     :param connector_type: Type of connector (see :class:`ConnectorType`)
     :type connector_type: str
-    :param scope: Connector scope as a comma-separated string (e.g., "Report,Indicator")
+    :param scope: Connector scope, either as a comma-separated string
+    (e.g. ``"Artifact,Url"``) or as a list of strings
+    (e.g. ``["Artifact", "Url"]``. Both forms are normalized to a list.
     :type scope: str or list[str]
     :param auto: Whether the connector runs automatically on matching entities
     :type auto: bool
@@ -104,7 +106,7 @@ class OpenCTIConnector:
         :param scope: Connector scope, either as a comma-separated string
         (e.g. ``"Artifact,Url"``) or as a list of strings
         (e.g. ``["Artifact", "Url"]``. Both forms are normalized to a list.
-        :type scope: str
+        :type scope: str or list[str]
         :param auto: Whether the connector runs automatically
         :type auto: bool
         :param only_contextual: Whether to process only contextual data
@@ -128,7 +130,7 @@ class OpenCTIConnector:
         elif isinstance(scope, str):
             self.scope = scope.split(",")
         else:
-            # already a list/tuple (e.g. from the ListFromString Pydantic model)
+            # already a list/tuple
             self.scope = list(scope)
         self.auto = auto
         self.auto_update = auto_update

--- a/client-python/pycti/connector/opencti_connector.py
+++ b/client-python/pycti/connector/opencti_connector.py
@@ -127,11 +127,13 @@ class OpenCTIConnector:
         self.type = ConnectorType(connector_type)
         if not scope:
             self.scope = []
-        elif isinstance(scope, str):
-            self.scope = scope.split(",")
         else:
-            # already a list/tuple
-            self.scope = list(scope)
+            if isinstance(scope, str):
+                raw = scope.split(",")
+            else:
+                # already a list/tuple
+                raw = list(scope)
+            self.scope = [s.strip() for s in raw]
         self.auto = auto
         self.auto_update = auto_update
         self.enrichment_resolution = enrichment_resolution

--- a/client-python/pycti/connector/opencti_connector.py
+++ b/client-python/pycti/connector/opencti_connector.py
@@ -5,6 +5,7 @@ used to register and configure connectors with the OpenCTI platform.
 """
 
 from enum import Enum
+from typing import List, Union
 
 
 class ConnectorType(Enum):
@@ -48,7 +49,7 @@ class OpenCTIConnector:
     :param connector_type: Type of connector (see :class:`ConnectorType`)
     :type connector_type: str
     :param scope: Connector scope as a comma-separated string (e.g., "Report,Indicator")
-    :type scope: str
+    :type scope: str or list[str]
     :param auto: Whether the connector runs automatically on matching entities
     :type auto: bool
     :param only_contextual: Whether the connector only processes contextual data
@@ -83,7 +84,7 @@ class OpenCTIConnector:
         connector_id: str,
         connector_name: str,
         connector_type: str,
-        scope: str,
+        scope: Union[str, List[str]],
         auto: bool,
         only_contextual: bool,
         playbook_compatible: bool,
@@ -100,7 +101,9 @@ class OpenCTIConnector:
         :type connector_name: str
         :param connector_type: Type of connector (see :class:`ConnectorType`)
         :type connector_type: str
-        :param scope: Connector scope as a comma-separated string
+        :param scope: Connector scope, either as a comma-separated string
+        (e.g. ``"Artifact,Url"``) or as a list of strings
+        (e.g. ``["Artifact", "Url"]``. Both forms are normalized to a list.
         :type scope: str
         :param auto: Whether the connector runs automatically
         :type auto: bool
@@ -120,10 +123,13 @@ class OpenCTIConnector:
         self.id = connector_id
         self.name = connector_name
         self.type = ConnectorType(connector_type)
-        if scope:
+        if not scope:
+            self.scope = []
+        elif isinstance(scope, str):
             self.scope = scope.split(",")
         else:
-            self.scope = []
+            # already a list/tuple (e.g. from the ListFromString Pydantic model)
+            self.scope = list(scope)
         self.auto = auto
         self.auto_update = auto_update
         self.enrichment_resolution = enrichment_resolution

--- a/client-python/pyproject.toml
+++ b/client-python/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+
 [tool.isort]
 profile = "black"
 

--- a/client-python/tests/01-unit/connector/test_opencti_connector_scope.py
+++ b/client-python/tests/01-unit/connector/test_opencti_connector_scope.py
@@ -1,0 +1,73 @@
+"""Tests for scope normalization in OpenCTIConnector.
+
+Verifies that ``scope`` accepts either a comma-separated string or a
+list/tuple of strings, and is always normalized to a ``list`` on the
+resulting instance.
+"""
+
+from unittest import TestCase
+
+from pycti.connector.opencti_connector import OpenCTIConnector
+
+BASE_KWARGS = {
+    "connector_id": "550e8400-e29b-41d4-a716-446655440000",
+    "connector_name": "TestConnector",
+    "connector_type": "EXTERNAL_IMPORT",
+    "auto": False,
+    "only_contextual": False,
+    "playbook_compatible": False,
+    "auto_update": False,
+    "enrichment_resolution": "none",
+}
+
+
+class TestOpenCTIConnectorScope(TestCase):
+    """Test that scope is normalized regardless of the input type."""
+
+    def test_scope_as_comma_separated_string(self):
+        """A comma-separated string should be split into a list."""
+        connector = OpenCTIConnector(scope="Report,Indicator", **BASE_KWARGS)
+        self.assertEqual(connector.scope, ["Report", "Indicator"])
+
+    def test_scope_as_single_string(self):
+        """A single scope string without commas should become a one-item list."""
+        connector = OpenCTIConnector(scope="Report", **BASE_KWARGS)
+        self.assertEqual(connector.scope, ["Report"])
+
+    def test_scope_as_list(self):
+        """A list of strings should be kept as-is (copied into a list)."""
+        connector = OpenCTIConnector(scope=["Report", "Indicator"], **BASE_KWARGS)
+        self.assertEqual(connector.scope, ["Report", "Indicator"])
+
+    def test_scope_as_tuple(self):
+        """A tuple of strings should be normalized to a list."""
+        connector = OpenCTIConnector(scope=("Report", "Indicator"), **BASE_KWARGS)
+        self.assertEqual(connector.scope, ["Report", "Indicator"])
+        self.assertIsInstance(connector.scope, list)
+
+    def test_scope_empty_string(self):
+        """An empty string should result in an empty list."""
+        connector = OpenCTIConnector(scope="", **BASE_KWARGS)
+        self.assertEqual(connector.scope, [])
+
+    def test_scope_none(self):
+        """None should result in an empty list."""
+        connector = OpenCTIConnector(scope=None, **BASE_KWARGS)
+        self.assertEqual(connector.scope, [])
+
+    def test_scope_empty_list(self):
+        """An empty list should result in an empty list."""
+        connector = OpenCTIConnector(scope=[], **BASE_KWARGS)
+        self.assertEqual(connector.scope, [])
+
+    def test_to_input_reflects_normalized_scope(self):
+        """to_input() should expose the normalized list, regardless of input type."""
+        connector_from_str = OpenCTIConnector(scope="Report,Indicator", **BASE_KWARGS)
+        connector_from_list = OpenCTIConnector(
+            scope=["Report", "Indicator"], **BASE_KWARGS
+        )
+
+        self.assertEqual(
+            connector_from_str.to_input()["input"]["scope"],
+            connector_from_list.to_input()["input"]["scope"],
+        )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This PR widens the constructor to accept either form:
- a comma-separated `str` (legacy behavior, unchanged)
- an already-normalized `list`/`tuple`

* `client-python/pycti/connector/opencti_connector.py`: updated the `scope` handling in `OpenCTIConnector.__init__` to branch on type instead of assuming a string.
* Updated the  scope  docstring/type hints to document that  str ,  list , or  tuple  are now accepted.
* Updated tests

**Backwards compatibility**

• String input behaves exactly as before ( split(",") ).
• Empty/ None  input behaves exactly as before ( [] ).
• Only the list/tuple branch is new; no existing call sites are affected.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17414

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

Additional changes

- Add in the TOML file `--import-mode=importlib` gives every test file a unique module identity (keyed by file path, not by constructing a dotted package name), so the two same-named packages no longer collide.