### PR TITLE
fix(stream): add OTP validation check in sseMiddleware (#17431)

### DIFF
--- a/opencti-platform/opencti-graphql/src/graphql/authDirective.ts
+++ b/opencti-platform/opencti-graphql/src/graphql/authDirective.ts
@@ -1,11 +1,11 @@
 import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
-import { defaultFieldResolver } from 'graphql';
 import type { GraphQLFieldConfig, GraphQLSchema } from 'graphql';
+import { defaultFieldResolver } from 'graphql';
 import { AuthRequired, ForbiddenAccess, LtsRequiredActivation, OtpRequired, OtpRequiredActivation, UnsupportedError } from '../config/errors';
 import { Capabilities } from '../generated/graphql';
 import { OPENCTI_ADMIN_UUID } from '../schema/general';
-import type { AuthContext } from '../types/user';
-import { BYPASS, SETTINGS_SET_ACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../utils/access';
+import type { AuthContext, AuthUser } from '../types/user';
+import { BYPASS, checkOTPValidationStatus, OTPValidationStatus, SETTINGS_SET_ACCESSES, VIRTUAL_ORGANIZATION_ADMIN } from '../utils/access';
 import { getDraftContext } from '../utils/draftContext';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../modules/organization/organization-types';
 
@@ -91,30 +91,21 @@ export const authDirectiveBuilder = (directiveName: string): AuthDirectiveBuilde
 
             fieldConfig.resolve = (source: any, args: any, context: AuthContext, info: any) => {
               // Get user from the session
-              const { user, otp_mandatory, user_otp_validated, blocked_for_lts_validation } = context;
-              // User must be authenticated.
-              if (!user) {
-                throw AuthRequired();
-              }
+              const { user, blocked_for_lts_validation } = context;
+              // Check user OTP status
               const allowUnprotectedOTP = !!getDirective(schema, fieldConfig, OTP_PROTECT_DIRECTIVE)?.[0];
-              if (!allowUnprotectedOTP) {
-                // If the platform enforce OTP
-                if (otp_mandatory) {
-                  // If user have not validated is OTP in session
-                  // by default user_otp_validated is true for direct api usage
-                  if (!user_otp_validated) {
-                    // If OTP is not setup, return a specific error
-                    if (!user.otp_activated) {
-                      throw OtpRequiredActivation();
-                    }
-                    // If already setup but not validated, return the validation screen
-                    throw OtpRequired();
-                  }
-                } else if (user.otp_activated && !user_otp_validated) {
-                  // If user self activate OTP, session must be validated
+              const otpStatus = checkOTPValidationStatus(context, allowUnprotectedOTP);
+              switch (otpStatus) {
+                case OTPValidationStatus.AUTHENTICATION_REQUIRED:
+                  throw AuthRequired();
+                case OTPValidationStatus.VALIDATION_REQUIRED:
                   throw OtpRequired();
-                }
+                case OTPValidationStatus.ACTIVATION_REQUIRED:
+                  throw OtpRequiredActivation();
+                default:
+                  break;
               }
+              const authenticatedUser = user as AuthUser;
               // LTS version must be validated
               const allowUnlicensedLTS = !!getDirective(schema, fieldConfig, LTS_PROTECT_DIRECTIVE)?.[0];
               if (blocked_for_lts_validation && !allowUnlicensedLTS) {
@@ -125,11 +116,11 @@ export const authDirectiveBuilder = (directiveName: string): AuthDirectiveBuilde
                 return resolve(source, args, context, info);
               }
 
-              const userBaseCapabilities = user.capabilities.map((c) => c.name);
-              const userCapabilitiesInDraft = user.capabilitiesInDraft?.map((c) => c.name) ?? [];
+              const userBaseCapabilities = authenticatedUser.capabilities.map((c) => c.name);
+              const userCapabilitiesInDraft = authenticatedUser.capabilitiesInDraft?.map((c) => c.name) ?? [];
 
               // Accept everything if bypass capability or the system user (protection).
-              const shouldBypass = userBaseCapabilities.includes(BYPASS) || user.id === OPENCTI_ADMIN_UUID;
+              const shouldBypass = userBaseCapabilities.includes(BYPASS) || authenticatedUser.id === OPENCTI_ADMIN_UUID;
               if (shouldBypass) {
                 return resolve(source, args, context, info);
               }
@@ -154,7 +145,7 @@ export const authDirectiveBuilder = (directiveName: string): AuthDirectiveBuilde
               if (typeName === ENTITY_TYPE_IDENTITY_ORGANIZATION
                 && requiredCapabilitiesBase.includes(VIRTUAL_ORGANIZATION_ADMIN)
                 && !userBaseCapabilities.includes(SETTINGS_SET_ACCESSES)) {
-                if (user.administrated_organizations.some(({ id }) => id === source.id)) {
+                if (authenticatedUser.administrated_organizations.some(({ id }) => id === source.id)) {
                   return resolve(source, args, context, info);
                 }
                 return null;

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -26,11 +26,13 @@ import {
 } from '../database/utils';
 import {
   BYPASS,
+  checkOTPValidationStatus,
   computeUserMemberAccessIds,
   isUserCanAccessStixElement,
   isUserHasCapability,
   isUserInPlatformOrganization,
   KNOWLEDGE_ORGANIZATION_RESTRICT,
+  OTPValidationStatus,
   SYSTEM_USER,
 } from '../utils/access';
 import { FROM_START_STR, streamEventId, utcDate } from '../utils/format';
@@ -79,21 +81,6 @@ const sendErrorStatus = (_req, res, httpStatus) => {
   }
 };
 
-// Ensure that OTP has been validated
-export const isOtpValidationPending = (context) => {
-  const { user, otp_mandatory, user_otp_validated } = context;
-  if (!user) {
-    return false;
-  }
-  // By default user_otp_validated is true for direct API usage (token based).
-  // It is only set to false for session based users that have not validated OTP yet.
-  if (otp_mandatory) {
-    return !user_otp_validated;
-  }
-  // If user self activated OTP, the session must be validated.
-  return user.otp_activated === true && !user_otp_validated;
-};
-
 const createBroadcastClient = (channel) => {
   return {
     id: channel.id,
@@ -112,8 +99,19 @@ const authenticate = async (req, res, next) => {
   try {
     const context = await createAuthenticatedContext(req, res, 'stream');
     if (context.user) {
-      if (isOtpValidationPending(context)) {
-        res.statusMessage = 'You must validate your two-factor authentication to access this resource';
+      const otpStatus = checkOTPValidationStatus(context);
+      if (otpStatus !== OTPValidationStatus.VALID) {
+        switch (otpStatus) {
+          case OTPValidationStatus.ACTIVATION_REQUIRED:
+            res.statusMessage = 'You must activate your two-factor authentication to access this resource';
+            break;
+          case OTPValidationStatus.VALIDATION_REQUIRED:
+            res.statusMessage = 'You must validate your two-factor authentication to access this resource';
+            break;
+          default:
+            res.statusMessage = 'You are not authenticated, please check your credentials';
+            break;
+        }
         sendErrorStatus(req, res, 401);
         return;
       }
@@ -206,11 +204,22 @@ export const authenticateForPublic = async (req, res, next) => {
     user: context.user ?? SYSTEM_USER,
     id: req.params.id,
   });
+  const otpValidationStatus = checkOTPValidationStatus(context);
   if (error || (!collection?.stream_public && !context.user)) {
     res.statusMessage = 'You are not authenticated, please check your credentials';
     sendErrorStatus(req, res, 401);
-  } else if (!collection?.stream_public && isOtpValidationPending(context)) {
-    res.statusMessage = 'You must validate your two-factor authentication to access this resource';
+  } else if (!collection?.stream_public && otpValidationStatus !== OTPValidationStatus.VALID) {
+    switch (otpValidationStatus) {
+      case OTPValidationStatus.ACTIVATION_REQUIRED:
+        res.statusMessage = 'You must activate your two-factor authentication to access this resource';
+        break;
+      case OTPValidationStatus.VALIDATION_REQUIRED:
+        res.statusMessage = 'You must validate your two-factor authentication to access this resource';
+        break;
+      default:
+        res.statusMessage = 'You are not authenticated, please check your credentials';
+        break;
+    }
     sendErrorStatus(req, res, 401);
   } else {
     try {

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -95,7 +95,7 @@ const createBroadcastClient = (channel) => {
   };
 };
 
-const authenticate = async (req, res, next) => {
+export const authenticate = async (req, res, next) => {
   try {
     const context = await createAuthenticatedContext(req, res, 'stream');
     if (context.user) {

--- a/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
+++ b/opencti-platform/opencti-graphql/src/graphql/sseMiddleware.js
@@ -79,6 +79,21 @@ const sendErrorStatus = (_req, res, httpStatus) => {
   }
 };
 
+// Ensure that OTP has been validated
+export const isOtpValidationPending = (context) => {
+  const { user, otp_mandatory, user_otp_validated } = context;
+  if (!user) {
+    return false;
+  }
+  // By default user_otp_validated is true for direct API usage (token based).
+  // It is only set to false for session based users that have not validated OTP yet.
+  if (otp_mandatory) {
+    return !user_otp_validated;
+  }
+  // If user self activated OTP, the session must be validated.
+  return user.otp_activated === true && !user_otp_validated;
+};
+
 const createBroadcastClient = (channel) => {
   return {
     id: channel.id,
@@ -97,6 +112,11 @@ const authenticate = async (req, res, next) => {
   try {
     const context = await createAuthenticatedContext(req, res, 'stream');
     if (context.user) {
+      if (isOtpValidationPending(context)) {
+        res.statusMessage = 'You must validate your two-factor authentication to access this resource';
+        sendErrorStatus(req, res, 401);
+        return;
+      }
       req.context = context;
       req.userId = context.user.id;
       req.user = context.user;
@@ -188,6 +208,9 @@ export const authenticateForPublic = async (req, res, next) => {
   });
   if (error || (!collection?.stream_public && !context.user)) {
     res.statusMessage = 'You are not authenticated, please check your credentials';
+    sendErrorStatus(req, res, 401);
+  } else if (!collection?.stream_public && isOtpValidationPending(context)) {
+    res.statusMessage = 'You must validate your two-factor authentication to access this resource';
     sendErrorStatus(req, res, 401);
   } else {
     try {

--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -638,6 +638,40 @@ export const INTERNAL_USERS_WITHOUT_REDACTED = {
   [WORKFLOW_MANAGER_USER.id]: WORKFLOW_MANAGER_USER,
 };
 
+export enum OTPValidationStatus {
+  VALID,
+  AUTHENTICATION_REQUIRED,
+  ACTIVATION_REQUIRED,
+  VALIDATION_REQUIRED,
+}
+export const checkOTPValidationStatus = (context: AuthContext, allowUnprotectedOTP?: boolean): OTPValidationStatus => {
+  // Get user from the session
+  const { user, otp_mandatory, user_otp_validated } = context;
+  // User must be authenticated.
+  if (!user) {
+    return OTPValidationStatus.AUTHENTICATION_REQUIRED;
+  }
+  if (!allowUnprotectedOTP) {
+    // If the platform enforce OTP
+    if (otp_mandatory) {
+      // If user have not validated is OTP in session
+      // by default user_otp_validated is true for direct api usage
+      if (!user_otp_validated) {
+        // If OTP is not setup, return a specific error
+        if (!user.otp_activated) {
+          return OTPValidationStatus.ACTIVATION_REQUIRED;
+        }
+        // If already setup but not validated, return the validation screen
+        return OTPValidationStatus.VALIDATION_REQUIRED;
+      }
+    } else if (user.otp_activated && !user_otp_validated) {
+      // If user self activate OTP, session must be validated
+      return OTPValidationStatus.VALIDATION_REQUIRED;
+    }
+  }
+  return OTPValidationStatus.VALID;
+};
+
 export const isInternalUser = (user: AuthUser): boolean => {
   return INTERNAL_USERS[user.id] !== undefined;
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/dataSharing/dataSharing-http-middleware-test.ts
@@ -46,7 +46,7 @@ import { createAuthenticatedContext } from '../../../../src/http/httpAuthenticat
 import { getEntitiesListFromCache, getEntityFromCache } from '../../../../src/database/cache';
 import { resolvePublicUser } from '../../../../src/modules/dataSharing/dataSharing-utils';
 import { findById as findTaxiiCollection } from '../../../../src/modules/dataSharing/taxiiCollection-domain';
-import { authenticateForPublic } from '../../../../src/graphql/sseMiddleware.js';
+import { authenticate, authenticateForPublic } from '../../../../src/graphql/sseMiddleware.js';
 import { extractUserAndCollection } from '../../../../src/http/httpTaxii.js';
 import { resolveUserForFeed } from '../../../../src/http/httpRollingFeed.js';
 import { emptyFilterGroup } from '../../../../src/utils/filtering/filtering-utils';
@@ -214,6 +214,121 @@ describe('authenticateForPublic middleware', () => {
 
     expect(next).toHaveBeenCalled();
     expect(req.user).toBe(mockAuthUser);
+  });
+});
+
+// ─── authenticate (sseMiddleware, private stream token auth) ─────────────────
+
+describe('authenticate middleware (OTP enforcement)', () => {
+  const AUTH_USER = { id: 'auth-user', user_email: 'auth@test.com', capabilities: [{ name: 'KNOWLEDGE' }], allowed_marking: [] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when otp_mandatory is true and user_otp_validated is false (OTP already activated)', async () => {
+    // Regression: a stream must not be accessible when the platform enforces OTP
+    // and the session has not validated it -> checkOTPValidationStatus => VALIDATION_REQUIRED
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({
+      user: { ...AUTH_USER, otp_activated: true },
+      otp_mandatory: true,
+      user_otp_validated: false,
+    } as any);
+
+    const req = makeMockReq();
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.statusMessage).toContain('validate your two-factor authentication');
+    expect(req.user).toBeUndefined();
+  });
+
+  it('returns 401 when otp_mandatory is true, user_otp_validated is false and OTP is not yet activated', async () => {
+    // checkOTPValidationStatus => ACTIVATION_REQUIRED
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({
+      user: { ...AUTH_USER, otp_activated: false },
+      otp_mandatory: true,
+      user_otp_validated: false,
+    } as any);
+
+    const req = makeMockReq();
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.statusMessage).toContain('activate your two-factor authentication');
+  });
+
+  it('calls next() and populates req when OTP is validated', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({
+      user: { ...AUTH_USER, otp_activated: true },
+      otp_mandatory: true,
+      user_otp_validated: true,
+    } as any);
+
+    const req = makeMockReq();
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(req.user).toEqual({ ...AUTH_USER, otp_activated: true });
+    expect(req.userId).toBe('auth-user');
+    expect(req.capabilities).toEqual(AUTH_USER.capabilities);
+  });
+
+  it('calls next() when otp_mandatory is false and user has not self-activated OTP', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({
+      user: { ...AUTH_USER, otp_activated: false },
+      otp_mandatory: false,
+      user_otp_validated: false,
+    } as any);
+
+    const req = makeMockReq();
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when no user is resolved from the context', async () => {
+    vi.mocked(createAuthenticatedContext).mockResolvedValue({ user: null } as any);
+
+    const req = makeMockReq();
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.statusMessage).toContain('not authenticated');
+  });
+
+  it('returns 500 when context resolution throws', async () => {
+    vi.mocked(createAuthenticatedContext).mockRejectedValue(new Error('boom'));
+
+    const req = makeMockReq();
+    const res = makeMockRes();
+    const next = vi.fn();
+
+    await authenticate(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.statusMessage).toContain('boom');
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/access-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/access-test.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import {
   ADMINISTRATOR_ROLE,
   BYPASS,
+  checkOTPValidationStatus,
   checkUserCanAccessStixElement,
   checkUserFilterStoreElements,
   DEFAULT_ROLE,
@@ -15,8 +16,10 @@ import {
   MEMBER_ACCESS_RIGHT_ADMIN,
   MEMBER_ACCESS_RIGHT_EDIT,
   MEMBER_ACCESS_RIGHT_VIEW,
+  OTPValidationStatus,
   SYSTEM_USER,
 } from '../../../src/utils/access';
+import type { AuthContext } from '../../../src/types/user';
 import type { BasicStoreCommon, StoreMarkingDefinition } from '../../../src/types/store';
 import { MARKING_TLP_AMBER, MARKING_TLP_CLEAR, MARKING_TLP_GREEN, MARKING_TLP_RED } from '../../../src/schema/identifier';
 import type { AuthUser } from '../../../src/types/user';
@@ -26,7 +29,7 @@ import { RELATION_GRANTED_TO } from '../../../src/schema/stixRefRelationship';
 import type { BasicStoreEntityOrganization } from '../../../src/modules/organization/organization-types';
 import type { StixObject, StixOpenctiExtension } from '../../../src/types/stix-2-1-common';
 import type { Group } from '../../../src/types/group';
-import type { Change, UpdateEvent } from '../../../src/types/event';
+import type { UpdateEvent } from '../../../src/types/event';
 
 const inPlatformContext = { ...testContext, user_inside_platform_organization: true };
 
@@ -500,6 +503,84 @@ describe('getUserAccessRight testing - service account behavior', () => {
     const element = { restricted_members, authorized_authorities: [] };
     const expected = getUserAccessRight(serviceAccount as AuthUser, element);
     expect(expected).toEqual(MEMBER_ACCESS_RIGHT_EDIT);
+  });
+});
+
+describe('checkOTPValidationStatus testing', () => {
+  const buildContext = (overrides: Partial<AuthContext>): AuthContext => ({
+    otp_mandatory: false,
+    source: 'test',
+    user: undefined,
+    user_inside_platform_organization: false,
+    ...overrides,
+  } as AuthContext);
+
+  it('should require authentication when no user is set', () => {
+    const context = buildContext({ user: undefined });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.AUTHENTICATION_REQUIRED);
+  });
+
+  it('should be valid when allowUnprotectedOTP is true even if OTP is not validated', () => {
+    const context = buildContext({
+      user: { otp_activated: true } as AuthUser,
+      otp_mandatory: true,
+      user_otp_validated: false,
+    });
+    expect(checkOTPValidationStatus(context, true)).toEqual(OTPValidationStatus.VALID);
+  });
+
+  it('should require activation when OTP is mandatory, not validated and not activated', () => {
+    const context = buildContext({
+      user: { otp_activated: false } as AuthUser,
+      otp_mandatory: true,
+      user_otp_validated: false,
+    });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.ACTIVATION_REQUIRED);
+  });
+
+  it('should require validation when OTP is mandatory, activated but not validated', () => {
+    const context = buildContext({
+      user: { otp_activated: true } as AuthUser,
+      otp_mandatory: true,
+      user_otp_validated: false,
+    });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.VALIDATION_REQUIRED);
+  });
+
+  it('should be valid when OTP is mandatory and session is validated', () => {
+    const context = buildContext({
+      user: { otp_activated: true } as AuthUser,
+      otp_mandatory: true,
+      user_otp_validated: true,
+    });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.VALID);
+  });
+
+  it('should require validation when OTP self-activated but session not validated', () => {
+    const context = buildContext({
+      user: { otp_activated: true } as AuthUser,
+      otp_mandatory: false,
+      user_otp_validated: false,
+    });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.VALIDATION_REQUIRED);
+  });
+
+  it('should be valid when OTP is not mandatory and not activated', () => {
+    const context = buildContext({
+      user: { otp_activated: false } as AuthUser,
+      otp_mandatory: false,
+      user_otp_validated: false,
+    });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.VALID);
+  });
+
+  it('should be valid when OTP is self-activated and session is validated', () => {
+    const context = buildContext({
+      user: { otp_activated: true } as AuthUser,
+      otp_mandatory: false,
+      user_otp_validated: true,
+    });
+    expect(checkOTPValidationStatus(context)).toEqual(OTPValidationStatus.VALID);
   });
 });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request refactors and centralizes the logic for OTP (One-Time Password) validation across the authentication and authorization layers of the platform. It introduces a new utility function to consistently check OTP requirements, updates the GraphQL authentication directive and SSE middleware to use this function, and adds comprehensive unit tests to ensure correct behavior. This change improves maintainability and ensures OTP enforcement is handled uniformly.

**OTP Validation Refactoring and Centralization:**

- Added a new utility function `checkOTPValidationStatus` and enum `OTPValidationStatus` in `utils/access.ts` to encapsulate all OTP validation logic in one place. This function determines whether authentication, OTP activation, or OTP validation is required, or if access is valid.
- Updated the GraphQL `authDirective` to use `checkOTPValidationStatus`, replacing inline OTP checks with calls to the centralized function. This makes the directive logic cleaner and more consistent.
- Updated the SSE middleware (`sseMiddleware.js`) to use `checkOTPValidationStatus` for both standard and public authentication flows, ensuring OTP requirements are enforced for streaming endpoints. [[1]](diffhunk://#diff-a8540b940acadcb4d5451d87b017eb606127dc51774b4b03b2fdfdf624406b0cR102-R117) [[2]](diffhunk://#diff-a8540b940acadcb4d5451d87b017eb606127dc51774b4b03b2fdfdf624406b0cR207-R223)

**Testing Improvements:**

- Added a comprehensive test suite for `checkOTPValidationStatus` in `access-test.ts`, covering all combinations of OTP enforcement, activation, and validation scenarios.

**Code Consistency and Minor Refactoring:**

- Refactored code in `authDirective.ts` to use a local `authenticatedUser` variable for improved type safety and readability. [[1]](diffhunk://#diff-cb1a2e3afa46dd5e5969ed4339943b7aaac4c32b7f3c6bde07c4685908b1e5faL128-R123) [[2]](diffhunk://#diff-cb1a2e3afa46dd5e5969ed4339943b7aaac4c32b7f3c6bde07c4685908b1e5faL157-R148)
- Updated imports and minor type adjustments to support the new utility and improve code clarity. [[1]](diffhunk://#diff-cb1a2e3afa46dd5e5969ed4339943b7aaac4c32b7f3c6bde07c4685908b1e5faL2-R8) [[2]](diffhunk://#diff-67048904314555dcdc3d3587a14e47b64a32f1dbe590c8a9d0fe739250e5fb72R19-R22) [[3]](diffhunk://#diff-67048904314555dcdc3d3587a14e47b64a32f1dbe590c8a9d0fe739250e5fb72L29-R32) [[4]](diffhunk://#diff-67048904314555dcdc3d3587a14e47b64a32f1dbe590c8a9d0fe739250e5fb72R6) [[5]](diffhunk://#diff-a8540b940acadcb4d5451d87b017eb606127dc51774b4b03b2fdfdf624406b0cR29-R35)

These changes collectively improve the security, maintainability, and testability of OTP enforcement throughout the platform.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17431

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
