### PR TITLE
fix(formintake): add back ability to export form intake in popover (#17440)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
@@ -13,6 +13,7 @@ import { Connector_connector$data } from '@components/data/connectors/__generate
 import { FEED_MUTATIONS } from '@components/integrations/feeds/feedMutations';
 import FeedUpdateDrawer from '@components/integrations/feeds/FeedUpdateDrawer';
 import { DeployedIntegrationItem } from '@components/integrations/deployed/useDeployedIntegrations';
+import handleExportJson from '@components/data/forms/FormExportHandler';
 import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
 import useGranted, { INGESTION_SETINGESTIONS, MODULES_MODMANAGE } from '../../../../utils/hooks/useGranted';
@@ -37,6 +38,7 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
   const isGrantedToIngestion = useGranted([INGESTION_SETINGESTIONS]);
 
   const isConnector = item.kind === 'connector';
+  const isForm = item.kind === 'form';
   const feedConfig = !isConnector ? FEED_MUTATIONS[item.kind] : null;
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -166,6 +168,13 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
     });
   };
 
+  // Form intakes can be exported as a JSON configuration file (same as the
+  // legacy forms list popover).
+  const handleExportForm = (event: React.MouseEvent) => {
+    handleClose(event);
+    handleExportJson({ id: item.id, name: item.name });
+  };
+
   const canManageConnector = isConnector && isGrantedToModules;
   // Deletion has extra conditions (e.g. built-in or active connectors cannot
   // be deleted): like the legacy popover, it only disables the Delete item.
@@ -208,6 +217,11 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
             }}
           >
             {t_i18n('Update')}
+          </MenuItem>
+        )}
+        {canManageFeed && isForm && (
+          <MenuItem onClick={handleExportForm}>
+            {t_i18n('Export')}
           </MenuItem>
         )}
         {canManageConnector && (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request adds support for exporting deployed "form" integrations as JSON configuration files from the `DeployedIntegrationPopover` component, aligning the behavior with the legacy forms list popover. It introduces a new export option in the UI for form intakes, and updates the logic to distinguish "form" items from connectors.

**Form integration export support:**

* Added a new `handleExportForm` function to export form intake configurations as JSON, reusing the existing `handleExportJson` utility.
* Updated the UI to display an "Export" menu item for form integrations when the user has management permissions; this triggers the export handler.
* Imported `handleExportJson` from the shared form export handler module.
* Added logic to identify "form" items with a new `isForm` variable.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17440

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
