### PR TITLE
fix(import): clarify draft access error for non-service-account connectors (#17384)

### DIFF
--- a/opencti-platform/opencti-graphql/src/http/httpServer-draft.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpServer-draft.ts
@@ -33,7 +33,10 @@ export const checkDraftInContext = async (executeContext: AuthContext) => {
             value: '',
           }]);
         }
-        throw FunctionalError(`Draft ${executeContext.draft_context} cannot be found`);
+        const serviceAccountHint = executeContext.user.user_service_account
+          ? ''
+          : ', consider switching your connector to a service account (instead of a user)';
+        throw FunctionalError(`Draft ${executeContext.draft_context} cannot be found${serviceAccountHint}`);
       }
 
       if (draftWorkspace.draft_status !== DRAFT_STATUS_OPEN) {

--- a/opencti-platform/opencti-graphql/src/http/httpServer-draft.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpServer-draft.ts
@@ -33,9 +33,9 @@ export const checkDraftInContext = async (executeContext: AuthContext) => {
             value: '',
           }]);
         }
-        const serviceAccountHint = executeContext.user.user_service_account
+        const serviceAccountHint = executeContext.user.user_service_account === true
           ? ''
-          : ', consider switching your connector to a service account (instead of a user)';
+          : ', consider switching the user associated to your connector to a service account (instead of a user)';
         throw FunctionalError(`Draft ${executeContext.draft_context} cannot be found${serviceAccountHint}`);
       }
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpServer-draft-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpServer-draft-test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AuthContext, AuthUser } from '../../../src/types/user';
+
+const { mockGetEntitiesMapFromCache, mockIsUserCanAccessStoreElement, mockUserEditField } = vi.hoisted(() => ({
+  mockGetEntitiesMapFromCache: vi.fn(),
+  mockIsUserCanAccessStoreElement: vi.fn(),
+  mockUserEditField: vi.fn(),
+}));
+
+vi.mock('../../../src/database/cache', () => ({
+  getEntitiesMapFromCache: mockGetEntitiesMapFromCache,
+}));
+
+vi.mock('../../../src/utils/access', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    isUserCanAccessStoreElement: mockIsUserCanAccessStoreElement,
+  };
+});
+
+vi.mock('../../../src/domain/user', () => ({
+  userEditField: mockUserEditField,
+}));
+
+import { checkDraftInContext } from '../../../src/http/httpServer-draft';
+
+describe('checkDraftInContext service account hint', () => {
+  const draftId = 'draft-under-test';
+  const draftWorkspace = { id: draftId };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEntitiesMapFromCache.mockResolvedValue(new Map([[draftId, draftWorkspace]]));
+    mockIsUserCanAccessStoreElement.mockResolvedValue(false);
+    mockUserEditField.mockResolvedValue(undefined);
+  });
+
+  const buildContext = (user: Partial<AuthUser>): AuthContext => ({
+    user: { id: 'user-id', draft_context: '', ...user } as AuthUser,
+    draft_context: draftId,
+  } as unknown as AuthContext);
+
+  it('should suggest switching to a service account when the connector user is not one', async () => {
+    const executeContext = buildContext({ user_service_account: false });
+
+    await expect(checkDraftInContext(executeContext)).rejects.toThrowError(
+      `Draft ${draftId} cannot be found, consider switching your connector to a service account (instead of a user)`,
+    );
+  });
+
+  it('should not suggest switching to a service account when user_service_account is undefined', async () => {
+    const executeContext = buildContext({});
+
+    await expect(checkDraftInContext(executeContext)).rejects.toThrowError(
+      `Draft ${draftId} cannot be found, consider switching your connector to a service account (instead of a user)`,
+    );
+  });
+
+  it('should not append the hint when the connector user is already a service account', async () => {
+    const executeContext = buildContext({ user_service_account: true });
+
+    await expect(checkDraftInContext(executeContext)).rejects.toThrowError(`Draft ${draftId} cannot be found`);
+
+    try {
+      await checkDraftInContext(executeContext);
+      throw new Error('checkDraftInContext should have thrown');
+    } catch (e) {
+      expect((e as Error).message).toBe(`Draft ${draftId} cannot be found`);
+      expect((e as Error).message).not.toContain('service account');
+    }
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpServer-draft-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpServer-draft-test.ts
@@ -45,15 +45,15 @@ describe('checkDraftInContext service account hint', () => {
     const executeContext = buildContext({ user_service_account: false });
 
     await expect(checkDraftInContext(executeContext)).rejects.toThrowError(
-      `Draft ${draftId} cannot be found, consider switching your connector to a service account (instead of a user)`,
+      `Draft ${draftId} cannot be found, consider switching the user associated to your connector to a service account (instead of a user)`,
     );
   });
 
-  it('should not suggest switching to a service account when user_service_account is undefined', async () => {
+  it('should suggest switching to a service account when user_service_account is undefined', async () => {
     const executeContext = buildContext({});
 
     await expect(checkDraftInContext(executeContext)).rejects.toThrowError(
-      `Draft ${draftId} cannot be found, consider switching your connector to a service account (instead of a user)`,
+      `Draft ${draftId} cannot be found, consider switching the user associated to your connector to a service account (instead of a user)`,
     );
   });
 


### PR DESCRIPTION
### Proposed changes

* Append a hint to the "Draft cannot be found" error when the connector's associated user is not a service account, pointing users to the actual root cause.
* Add unit tests covering both the service-account and non-service-account cases.

### Related issues
* closes #17384

### How to test this PR
Create a draft with access restriction enabled, then trigger an import into that draft using a connector whose associated user is not a service account and is not part of the draft's authorized members. The import should fail with:
`Draft <id> cannot be found, consider switching your connector to a service account (instead of a user)`

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

No documentation changes needed — this is a user-facing error message clarification with no behavioral or API changes.