### PR TITLE
fix(graph): add missing security platform and coverage fragments (#16759)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/KnowledgeGraphQuery.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/KnowledgeGraphQuery.tsx
@@ -68,6 +68,12 @@ export const knowledgeGraphStixCoreObjectQuery = graphql`
             ... on System {
                 name
             }
+            ... on SecurityPlatform {
+                name
+            }
+            ... on SecurityCoverage {
+                name
+            }
             ... on Indicator {
                 name
                 valid_from

--- a/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/investigations/InvestigationGraph.tsx
@@ -151,6 +151,12 @@ const investigationGraphObjectsFragment = graphql`
             ... on System {
               name
             }
+            ... on SecurityPlatform {
+              name
+            }
+            ... on SecurityCoverage {
+              name
+            }
             ... on Indicator {
               name
               valid_from


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

This pull request updates GraphQL fragments in the knowledge graph and investigation graph components to support two new object types: `SecurityPlatform` and `SecurityCoverage`. These additions ensure that the `name` field is available when querying these types, improving data consistency and enabling new use cases.

**GraphQL Schema Updates:**

* Added fragment support for `SecurityPlatform` and `SecurityCoverage` types, including their `name` fields, in the `knowledgeGraphStixCoreObjectQuery` fragment in `KnowledgeGraphQuery.tsx`.
* Added fragment support for `SecurityPlatform` and `SecurityCoverage` types, including their `name` fields, in the `investigationGraphObjectsFragment` fragment in `InvestigationGraph.tsx`.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16759

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
