### PR TITLE
docs: explain bulk observable creation (#17354)

### DIFF
--- a/docs/docs/usage/exploring-observations.md
+++ b/docs/docs/usage/exploring-observations.md
@@ -20,6 +20,25 @@ When clicking on the Observables tab at the top left, you see the list of all th
 
 ![Observables list](assets/observables-list-view.png)
 
+### Creating multiple observables
+
+When creating Observables manually, some observable types support multiple
+creation by pasting one value per line. This is available when OpenCTI can map
+each line to a single identifying field for the selected observable type, such
+as a domain name, an IP address, a URL, or a file hash.
+
+Some observable types cannot be created this way because they are identified
+by several fields rather than one pasted value. For example, `Software` can
+require information such as a name, vendor, version, Common Platform
+Enumeration (CPE), or Software Identification (SWID), so a single line of text
+cannot reliably describe one complete `Software` observable.
+
+For these observable types, use the standard creation form for individual
+observables. If you need to create many structured observables at once, use a
+CSV mapper and import a CSV file with columns mapped to the required fields.
+For more information, see [CSV Mappers](../administration/csv-mappers.md) and
+[Import files](import-files.md).
+
 ### Visualizing Knowledge associated with an Observable
 
 When clicking on an `Observable` in the list, you land on its Overview tab. For an Observable, the following tabs are accessible:


### PR DESCRIPTION
### Proposed changes

* Adds a new section to the Observables documentation explaining manual multiple observable creation.
* Clarifies that multiple creation is available when OpenCTI can map each input line to a clear identifying field, and that multi-field observable types such as `Software` should be created individually or imported with a CSV mapper.

### Related issues

* closes #17354

### How to test this PR

This is a documentation-only change.

Review the updated Observables documentation page and confirm that the new "Creating multiple observables" section explains:
* why some observable types support multiple creation
* why multi-field observable types such as `Software` do not support single-value bulk creation
* when to use CSV mappers for structured bulk imports

I also ran:

```bash
git diff --check
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

This PR is documentation-only, so automated test cases and code refactoring are not applicable.