### PR TITLE
fix(frontend): add a11y eslint plugin and fix accessibility violations (#16818)

### DIFF
--- a/opencti-platform/opencti-front/eslint.config.js
+++ b/opencti-platform/opencti-front/eslint.config.js
@@ -8,6 +8,7 @@ import importPlugin from 'eslint-plugin-import';
 import importNewlines from 'eslint-plugin-import-newlines';
 import customRules from 'eslint-plugin-custom-rules';
 import stylistic from '@stylistic/eslint-plugin';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default defineConfig([
   {
@@ -32,6 +33,36 @@ export default defineConfig([
 
   // Typescript rules
   tseslint.configs.recommended,
+
+  // a11y rules
+  {
+    plugins: {
+      'jsx-a11y': jsxA11y,
+    },
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    rules: {
+      ...jsxA11y.configs.recommended.rules,
+    },
+    settings: {
+      'jsx-a11y': {
+        // Maps MUI components to semantic HTML tags
+        components: {
+          Button: 'button',
+          IconButton: 'button',
+          TextField: 'input',
+          Select: 'select',
+          Switch: 'input',
+        },
+      },
+    },
+  },
 
   // React rules
   {

--- a/opencti-platform/opencti-front/eslint.config.js
+++ b/opencti-platform/opencti-front/eslint.config.js
@@ -8,6 +8,7 @@ import importPlugin from 'eslint-plugin-import';
 import importNewlines from 'eslint-plugin-import-newlines';
 import customRules from 'eslint-plugin-custom-rules';
 import stylistic from '@stylistic/eslint-plugin';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default defineConfig([
   {
@@ -34,6 +35,36 @@ export default defineConfig([
 
   // Typescript rules
   tseslint.configs.recommended,
+
+  // a11y rules
+  {
+    plugins: {
+      'jsx-a11y': jsxA11y,
+    },
+    files: ['**/*.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    rules: {
+      ...jsxA11y.configs.recommended.rules,
+    },
+    settings: {
+      'jsx-a11y': {
+        // Maps MUI components to semantic HTML tags
+        components: {
+          Button: 'button',
+          IconButton: 'button',
+          TextField: 'input',
+          Select: 'select',
+          Switch: 'input',
+        },
+      },
+    },
+  },
 
   // React rules
   {

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3524,6 +3524,7 @@
   "Platform group": "Plattformgruppe",
   "Platform identifier": "Plattform-Kennung",
   "Platform login message": "Plattform-Anmeldenachricht",
+  "Platform logo": "Plattform-Logo",
   "Platform mailer": "Plattform Mailer",
   "Platform main organization": "Plattform Hauptorganisation",
   "Platform Message Configuration": "Plattform Nachrichtenkonfiguration",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -3681,6 +3681,7 @@
   "Platform group": "Plattformgruppe",
   "Platform identifier": "Plattform-Kennung",
   "Platform login message": "Plattform-Anmeldenachricht",
+  "Platform logo": "Plattform-Logo",
   "Platform mailer": "Plattform Mailer",
   "Platform main organization": "Plattform Hauptorganisation",
   "Platform Message Configuration": "Plattform Nachrichtenkonfiguration",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3524,6 +3524,7 @@
   "Platform group": "Platform group",
   "Platform identifier": "Platform identifier",
   "Platform login message": "Platform login message",
+  "Platform logo": "Platform logo",
   "Platform mailer": "Platform mailer",
   "Platform main organization": "Platform main organization",
   "Platform Message Configuration": "Platform Message Configuration",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -3681,6 +3681,7 @@
   "Platform group": "Platform group",
   "Platform identifier": "Platform identifier",
   "Platform login message": "Platform login message",
+  "Platform logo": "Platform logo",
   "Platform mailer": "Platform mailer",
   "Platform main organization": "Platform main organization",
   "Platform Message Configuration": "Platform Message Configuration",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3524,6 +3524,7 @@
   "Platform group": "Grupo de plataforma",
   "Platform identifier": "Identificador de plataforma",
   "Platform login message": "Mensaje de inicio de sesión de la plataforma",
+  "Platform logo": "Logotipo de la plataforma",
   "Platform mailer": "Plataforma de correo",
   "Platform main organization": "Plataforma organización principal",
   "Platform Message Configuration": "Configuración de mensajes de la plataforma",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -3681,6 +3681,7 @@
   "Platform group": "Grupo de plataforma",
   "Platform identifier": "Identificador de plataforma",
   "Platform login message": "Mensaje de inicio de sesión de la plataforma",
+  "Platform logo": "Logotipo de la plataforma",
   "Platform mailer": "Plataforma de correo",
   "Platform main organization": "Plataforma organización principal",
   "Platform Message Configuration": "Configuración de mensajes de la plataforma",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3524,6 +3524,7 @@
   "Platform group": "Groupe de la plateforme",
   "Platform identifier": "Identifiant de plateforme",
   "Platform login message": "Message de connexion à la plateforme",
+  "Platform logo": "Logo de la plateforme",
   "Platform mailer": "Mail de la plateforme",
   "Platform main organization": "Plateforme de l'organisation principale",
   "Platform Message Configuration": "Configuration des messages de la plateforme",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -3681,6 +3681,7 @@
   "Platform group": "Groupe de la plateforme",
   "Platform identifier": "Identifiant de plateforme",
   "Platform login message": "Message de connexion à la plateforme",
+  "Platform logo": "Logo de la plateforme",
   "Platform mailer": "Mail de la plateforme",
   "Platform main organization": "Plateforme de l'organisation principale",
   "Platform Message Configuration": "Configuration des messages de la plateforme",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3524,6 +3524,7 @@
   "Platform group": "Gruppo piattaforma",
   "Platform identifier": "Identificatore della piattaforma",
   "Platform login message": "Messaggio di accesso della piattaforma",
+  "Platform logo": "Logo della piattaforma",
   "Platform mailer": "Mailer della piattaforma",
   "Platform main organization": "Organizzazione principale della piattaforma",
   "Platform Message Configuration": "Configurazione del messaggio della piattaforma",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -3681,6 +3681,7 @@
   "Platform group": "Gruppo piattaforma",
   "Platform identifier": "Identificatore della piattaforma",
   "Platform login message": "Messaggio di accesso della piattaforma",
+  "Platform logo": "Logo della piattaforma",
   "Platform mailer": "Mailer della piattaforma",
   "Platform main organization": "Organizzazione principale della piattaforma",
   "Platform Message Configuration": "Configurazione del messaggio della piattaforma",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3524,6 +3524,7 @@
   "Platform group": "プラットフォームグループ",
   "Platform identifier": "プラットフォーム名",
   "Platform login message": "ログインメッセージ",
+  "Platform logo": "プラットフォームのロゴ",
   "Platform mailer": "プラットフォームメーラー",
   "Platform main organization": "プラットフォーム主組織",
   "Platform Message Configuration": "プラットフォームメッセージの構成",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -3681,6 +3681,7 @@
   "Platform group": "プラットフォームグループ",
   "Platform identifier": "プラットフォーム名",
   "Platform login message": "ログインメッセージ",
+  "Platform logo": "プラットフォームのロゴ",
   "Platform mailer": "プラットフォームメーラー",
   "Platform main organization": "プラットフォーム主組織",
   "Platform Message Configuration": "プラットフォームメッセージの構成",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3524,6 +3524,7 @@
   "Platform group": "플랫폼 그룹",
   "Platform identifier": "플랫폼 식별자",
   "Platform login message": "플랫폼 로그인 메시지",
+  "Platform logo": "플랫폼 로고",
   "Platform mailer": "플랫폼 메일러",
   "Platform main organization": "플랫폼 주요 조직",
   "Platform Message Configuration": "플랫폼 메시지 구성",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -3681,6 +3681,7 @@
   "Platform group": "플랫폼 그룹",
   "Platform identifier": "플랫폼 식별자",
   "Platform login message": "플랫폼 로그인 메시지",
+  "Platform logo": "플랫폼 로고",
   "Platform mailer": "플랫폼 메일러",
   "Platform main organization": "플랫폼 주요 조직",
   "Platform Message Configuration": "플랫폼 메시지 구성",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3524,6 +3524,7 @@
   "Platform group": "Группа платформы",
   "Platform identifier": "Идентификатор платформы",
   "Platform login message": "Сообщение о входе в систему платформы",
+  "Platform logo": "Логотип платформы",
   "Platform mailer": "Платформа рассылки",
   "Platform main organization": "Главная организация платформы",
   "Platform Message Configuration": "Конфигурация сообщений платформы",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -3681,6 +3681,7 @@
   "Platform group": "Группа платформы",
   "Platform identifier": "Идентификатор платформы",
   "Platform login message": "Сообщение о входе в систему платформы",
+  "Platform logo": "Логотип платформы",
   "Platform mailer": "Платформа рассылки",
   "Platform main organization": "Главная организация платформы",
   "Platform Message Configuration": "Конфигурация сообщений платформы",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3524,6 +3524,7 @@
   "Platform group": "平台组",
   "Platform identifier": "平台标识符",
   "Platform login message": "平台登陆信息",
+  "Platform logo": "平台徽标",
   "Platform mailer": "平台邮件程序",
   "Platform main organization": "平台主组织",
   "Platform Message Configuration": "平台消息配置",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -3681,6 +3681,7 @@
   "Platform group": "平台组",
   "Platform identifier": "平台标识符",
   "Platform login message": "平台登陆信息",
+  "Platform logo": "平台徽标",
   "Platform mailer": "平台邮件程序",
   "Platform main organization": "平台主组织",
   "Platform Message Configuration": "平台消息配置",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -156,6 +156,7 @@
     "eslint-plugin-custom-rules": "workspace:*",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-import-newlines": "2.0.0",
+    "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-react": "7.37.5",
     "globals": "17.7.0",
     "i18n-auto-translation": "2.2.3",

--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -163,6 +163,7 @@
     "eslint-plugin-custom-rules": "workspace:*",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-import-newlines": "2.0.0",
+    "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-react": "7.37.5",
     "globals": "17.12.0",
     "i18n-auto-translation": "2.2.3",

--- a/opencti-platform/opencti-front/src/components/ColumnsLinesTitles.tsx
+++ b/opencti-platform/opencti-front/src/components/ColumnsLinesTitles.tsx
@@ -76,6 +76,14 @@ const ColumnsLinesTitles: FunctionComponent<TriggerLineTitlesProps> = ({
           className={classes.sortableHeaderItem}
           style={{ width }}
           onClick={() => reverseBy(field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              reverseBy(field);
+            }
+          }}
         >
           <span>{t_i18n(label)}</span>
           {sortBy === field ? orderComponent : ''}

--- a/opencti-platform/opencti-front/src/components/SimpleMarkdownField.jsx
+++ b/opencti-platform/opencti-front/src/components/SimpleMarkdownField.jsx
@@ -77,13 +77,11 @@ const MarkdownField = (props) => {
           : setSelectedTab(tab))
         }
         generateMarkdownPreview={(markdown) => Promise.resolve(
-          <div onMouseUp={() => internalOnSelect()}>
-            <MarkdownDisplay
-              content={markdown}
-              remarkGfmPlugin={true}
-              commonmark={true}
-            />
-          </div>,
+          <MarkdownDisplay
+            content={markdown}
+            remarkGfmPlugin={true}
+            commonmark={true}
+          />,
         )
         }
         l18n={{

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
@@ -107,7 +107,21 @@ const DataTableHeader: FunctionComponent<DataTableHeaderProps> = ({
       className={classes.headerContainer}
       style={{ width: cellWidth }}
     >
-      <div className={classes.label} onClick={throttleSortColumn}>
+      <div
+        className={classes.label}
+        onClick={throttleSortColumn}
+        role={column.isSortable ? 'button' : undefined}
+        tabIndex={column.isSortable ? 0 : -1}
+        onKeyDown={(event) => {
+          if (!column.isSortable) {
+            return;
+          }
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onSort(column.id, !orderAsc);
+          }
+        }}
+      >
         <Tooltip title={t_i18n(column.label)}>
           <span>{t_i18n(column.label)}</span>
         </Tooltip>

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableHeader.tsx
@@ -111,7 +111,7 @@ const DataTableHeader: FunctionComponent<DataTableHeaderProps> = ({
         className={classes.label}
         onClick={throttleSortColumn}
         role={column.isSortable ? 'button' : undefined}
-        tabIndex={column.isSortable ? 0 : -1}
+        tabIndex={column.isSortable ? 0 : undefined}
         onKeyDown={(event) => {
           if (!column.isSortable) {
             return;

--- a/opencti-platform/opencti-front/src/components/fields/EntitySelectWithTypes.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/EntitySelectWithTypes.tsx
@@ -44,6 +44,11 @@ const EntitySelectWithTypes: FunctionComponent<EntitySelectWithTypesProps> = ({
       noOptionsText={t_i18n('No available options')}
       options={options}
       value={value}
+      onChange={(_, newValue) => {
+        if (newValue) {
+          handleChange(newValue);
+        }
+      }}
       groupBy={(option) => t_i18n(option?.group ? option?.group : label)}
       onInputChange={(event) => searchEntities('id', cacheEntities, setCacheEntities, event)}
       isOptionEqualToValue={(option, val) => option.value === val.value}
@@ -83,12 +88,6 @@ const EntitySelectWithTypes: FunctionComponent<EntitySelectWithTypesProps> = ({
         <Tooltip title={option.label} key={option.label} followCursor>
           <li
             {...props}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.stopPropagation();
-              }
-            }}
-            onClick={() => handleChange(option)}
             style={{
               whiteSpace: 'nowrap',
               overflow: 'hidden',

--- a/opencti-platform/opencti-front/src/components/fields/markdownField/MarkdownFieldBase.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/markdownField/MarkdownFieldBase.tsx
@@ -243,15 +243,13 @@ const MarkdownFieldBase = ({
           }
         }}
         generateMarkdownPreview={(markdown) => Promise.resolve(
-          <div onMouseUp={() => internalOnSelect()}>
-            <MarkdownDisplay
-              content={markdown}
-              remarkGfmPlugin={true}
-              commonmark={true}
-              resolveImageUrl={markdownPreviewResolver}
-              enableImagePreviewModal={true}
-            />
-          </div>,
+          <MarkdownDisplay
+            content={markdown}
+            remarkGfmPlugin={true}
+            commonmark={true}
+            resolveImageUrl={markdownPreviewResolver}
+            enableImagePreviewModal={true}
+          />,
         )}
         toolbarCommands={toolbarCommands}
         l18n={{

--- a/opencti-platform/opencti-front/src/components/filters/BasicFilterInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/BasicFilterInput.tsx
@@ -28,7 +28,6 @@ const BasicFilterInput: FunctionComponent<BasicFilterInputProps> = ({
       label={label}
       type={type}
       defaultValue={filterValues[0]}
-      autoFocus={true}
       onKeyDown={(event) => {
         if (event.key === 'Enter') {
           helpers?.handleAddSingleValueFilter(

--- a/opencti-platform/opencti-front/src/components/filters/BasicFilterInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/BasicFilterInput.tsx
@@ -29,7 +29,6 @@ const BasicFilterInput: FunctionComponent<BasicFilterInputProps> = ({
       label={label}
       type={type}
       defaultValue={filterValues[0]}
-      autoFocus={true}
       onKeyDown={(event) => {
         if (event.key === 'Enter') {
           helpers?.handleAddSingleValueFilter(

--- a/opencti-platform/opencti-front/src/components/filters/DateRangeFilter.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/DateRangeFilter.tsx
@@ -26,7 +26,6 @@ const DateRangeFilter: FunctionComponent<DateRangeFilterProps> = ({
         helpers={helpers}
         label={t_i18n('From')}
         valueOrder={0}
-        autoFocus
         dateInput={dateInput}
         setDateInput={setDateInput}
       />

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -361,7 +361,6 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
             variant="outlined"
             size="small"
             fullWidth={true}
-            autoFocus={true}
             onFocus={(event) => {
               searchEntities(
                 fKey,
@@ -385,7 +384,6 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
             <Tooltip title={option.label} key={key || option.value} followCursor>
               <li
                 {...otherProps}
-                aria-disabled={disabledOptions}
                 style={{
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -384,7 +384,6 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
             variant="outlined"
             size="small"
             fullWidth={true}
-            autoFocus={true}
             onFocus={(event) => {
               searchEntities(
                 fKey,
@@ -408,7 +407,6 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
             <Tooltip title={option.label} key={key || option.value} followCursor>
               <li
                 {...otherProps}
-                aria-disabled={disabledOptions}
                 style={{
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -61,21 +61,21 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   const isOperatorNil = ['nil', 'not_nil'].includes(filterOperator ?? 'eq');
   const isOperatorChange = ['has_changed', 'not_has_changed'].includes(filterOperator ?? 'eq');
   const deactivatePopoverMenu = !isFilterEditable(filtersRestrictions, filterKey, filterValues) || !isReadWriteFilter;
-  const onCLick = deactivatePopoverMenu ? undefined : onClickLabel;
+  const onClick = deactivatePopoverMenu ? undefined : onClickLabel;
   const labelButtonStyle = {
     all: 'unset',
     cursor: 'pointer',
     fontWeight: 'bold',
   } as const;
   const renderLabel = () => {
-    if (!onCLick) {
+    if (!onClick) {
       return <strong>{label}</strong>;
     }
     return (
       <button
         type="button"
         style={labelButtonStyle}
-        onClick={onCLick}
+        onClick={onClick}
       >
         {label}
       </button>

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -61,26 +61,32 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   const isOperatorNil = ['nil', 'not_nil'].includes(filterOperator ?? 'eq');
   const isOperatorChange = ['has_changed', 'not_has_changed'].includes(filterOperator ?? 'eq');
   const deactivatePopoverMenu = !isFilterEditable(filtersRestrictions, filterKey, filterValues) || !isReadWriteFilter;
-  const onCLick = deactivatePopoverMenu ? () => {} : onClickLabel;
-  const labelStyle = deactivatePopoverMenu
-    ? undefined
-    : {
-        cursor: 'pointer',
-        '&:hover': {
-          textDecorationLine: 'underline',
-        },
-      };
+  const onCLick = deactivatePopoverMenu ? undefined : onClickLabel;
+  const labelButtonStyle = {
+    all: 'unset',
+    cursor: 'pointer',
+    fontWeight: 'bold',
+  } as const;
+  const renderLabel = () => {
+    if (!onCLick) {
+      return <strong>{label}</strong>;
+    }
+    return (
+      <button
+        type="button"
+        style={labelButtonStyle}
+        onClick={onCLick}
+      >
+        {label}
+      </button>
+    );
+  };
 
   // special case for nil/not_nil
   if (isOperatorNil) {
     return (
       <>
-        <strong
-          style={labelStyle}
-          onClick={onCLick}
-        >
-          {label}
-        </strong>{' '}
+        {renderLabel()}{' '}
         <span>
           {filterOperator === 'nil' ? t_i18n('is empty') : t_i18n('is not empty')}
         </span>
@@ -92,12 +98,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   if (isOperatorChange) {
     return (
       <>
-        <strong
-          style={labelStyle}
-          onClick={onCLick}
-        >
-          {label}
-        </strong>{' '}
+        {renderLabel()}{' '}
         <span>
           {filterOperator === 'has_changed' ? t_i18n('has changed') : t_i18n('has not changed')}
         </span>
@@ -112,12 +113,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
     const relativeValue = translateDateInterval(filterValues, t_i18n);
     return (
       <>
-        <strong
-          style={labelStyle}
-          onClick={onCLick}
-        >
-          {label}
-        </strong>{' '}
+        {renderLabel()}{' '}
         <span>
           {relativeValue}
         </span>
@@ -193,25 +189,38 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                 />
                 {last(filterValues) !== id && isRegardingOfFilter
                   && (
-                    <div
+                    <button
+                      type="button"
                       style={{
                         display: 'inline-block',
                         height: '100%',
                         borderRadius: 0,
                         margin: '0 2px 0 0',
                         fontFamily: 'Consolas, monaco, monospace',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: operatorOnClick ? 'pointer' : 'default',
                       }}
                       onClick={operatorOnClick}
                     >
                       ,
-                    </div>
+                    </button>
                   )
                 }
                 {last(filterValues) !== id && !isRegardingOfFilter
                   && (
-                    <div style={localModeStyle} onClick={operatorOnClick}>
+                    <button
+                      type="button"
+                      style={{
+                        ...localModeStyle,
+                        border: 'none',
+                        cursor: operatorOnClick ? 'pointer' : 'default',
+                      }}
+                      onClick={operatorOnClick}
+                    >
                       {t_i18n((currentFilter.mode ?? 'or').toUpperCase())}
-                    </div>
+                    </button>
                   )
                 }
               </>
@@ -249,12 +258,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
             />
           </Tooltip>
         )}
-        <strong
-          style={labelStyle}
-          onClick={onCLick}
-        >
-          {label}
-        </strong>{' '}
+        {renderLabel()}{' '}
         <Box sx={{ display: 'flex', flexDirection: 'row', overflow: 'hidden' }}>
           {sortedFilterValues
             .map((val) => {
@@ -325,12 +329,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   if (filterKey === 'dynamicFrom' || filterKey === 'dynamicTo') {
     return (
       <>
-        <strong
-          style={labelStyle}
-          onClick={onCLick}
-        >
-          {label}
-        </strong>{' '}
+        {renderLabel()}{' '}
         <Chip
           label={t_i18n('Dynamic filter')}
           color={chipColor}
@@ -340,12 +339,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   }
   return (
     <>
-      <strong
-        style={labelStyle}
-        onClick={onCLick}
-      >
-        {label}
-      </strong>{' '}
+      {renderLabel()}{' '}
       {values}
     </>
   );

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -191,6 +191,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                   && (
                     <button
                       type="button"
+                      disabled={!operatorOnClick}
                       style={{
                         display: 'inline-block',
                         height: '100%',
@@ -212,6 +213,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                   && (
                     <button
                       type="button"
+                      disabled={!operatorOnClick}
                       style={{
                         ...localModeStyle,
                         border: 'none',

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -240,9 +240,6 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                         borderRadius: 0,
                         margin: '0 2px 0 0',
                         fontFamily: 'Consolas, monaco, monospace',
-                        background: 'none',
-                        border: 'none',
-                        padding: 0,
                         cursor: operatorOnClick ? 'pointer' : 'default',
                       }}
                       onClick={operatorOnClick}
@@ -302,7 +299,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
         <Button
           type="button"
           sx={buttonStyles}
-          onClick={onCLick}
+          onClick={onClick}
         >
           <strong>
             {label}
@@ -381,7 +378,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
         <Button
           type="button"
           sx={buttonStyles}
-          onClick={onCLick}
+          onClick={onClick}
         >
           <strong>
             {label}
@@ -399,7 +396,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
       <Button
         type="button"
         sx={buttonStyles}
-        onClick={onCLick}
+        onClick={onClick}
       >
         <strong>
           {label}

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -70,7 +70,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
   const isOperatorNil = ['nil', 'not_nil'].includes(filterOperator ?? 'eq');
   const isOperatorChange = ['has_changed', 'not_has_changed'].includes(filterOperator ?? 'eq');
   const deactivatePopoverMenu = !isFilterEditable(filtersRestrictions, filterKey, filterValues) || !isReadWriteFilter;
-  const onCLick = deactivatePopoverMenu ? () => { } : onClickLabel;
+  const onClick = deactivatePopoverMenu ? () => { } : onClickLabel;
 
   const buttonStyles = {
     minWidth: 'unset',
@@ -100,7 +100,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
         <Button
           type="button"
           sx={buttonStyles}
-          onClick={onCLick}
+          onClick={onClick}
         >
           <strong>
             {label}
@@ -120,7 +120,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
         <Button
           type="button"
           sx={buttonStyles}
-          onClick={onCLick}
+          onClick={onClick}
         >
           <strong>
             {label}
@@ -143,7 +143,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
         <Button
           type="button"
           sx={buttonStyles}
-          onClick={onCLick}
+          onClick={onClick}
         >
           <strong>
             {label}
@@ -246,6 +246,7 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                         cursor: operatorOnClick ? 'pointer' : 'default',
                       }}
                       onClick={operatorOnClick}
+                      disabled={!operatorOnClick}
                     >
                       ,
                     </Button>
@@ -253,7 +254,12 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                 }
                 {last(filterValues) !== id && !isRegardingOfFilter
                   && (
-                    <Button type="button" sx={localModeStyle} onClick={operatorOnClick}>
+                    <Button
+                      type="button"
+                      sx={localModeStyle}
+                      onClick={operatorOnClick}
+                      disabled={!operatorOnClick}
+                    >
                       {t_i18n((currentFilter.mode ?? 'or').toUpperCase())}
                     </Button>
                   )

--- a/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterValues.tsx
@@ -240,6 +240,10 @@ const FilterValues: FunctionComponent<FilterValuesProps> = ({
                         borderRadius: 0,
                         margin: '0 2px 0 0',
                         fontFamily: 'Consolas, monaco, monospace',
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: operatorOnClick ? 'pointer' : 'default',
                       }}
                       onClick={operatorOnClick}
                     >

--- a/opencti-platform/opencti-front/src/components/filters/ImbricatedFilterGroupDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ImbricatedFilterGroupDisplay.tsx
@@ -105,7 +105,7 @@ const ImbricatedFilterGroupDisplay: FunctionComponent<ImbricatedFilterGroupDispl
           />
         </DialogContent>
         <DialogActions sx={{ mr: 2, mb: 2 }}>
-          <Button onClick={handleClose} autoFocus>
+          <Button onClick={handleClose}>
             {t_i18n('Close')}
           </Button>
         </DialogActions>

--- a/opencti-platform/opencti-front/src/components/filters/ImbricatedFilterGroupDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/ImbricatedFilterGroupDisplay.tsx
@@ -89,7 +89,7 @@ const ImbricatedFilterGroupDisplay: FunctionComponent<ImbricatedFilterGroupDispl
           />
         </DialogContent>
         <DialogActions sx={{ mr: 2, mb: 2 }}>
-          <Button onClick={handleClose} autoFocus>
+          <Button onClick={handleClose}>
             {t_i18n('Close')}
           </Button>
         </DialogActions>

--- a/opencti-platform/opencti-front/src/components/filters/RelativeDateInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/RelativeDateInput.tsx
@@ -105,7 +105,6 @@ const RelativeDateInput: FunctionComponent<RelativeDateInputProps> = ({
         label={label}
         value={dateInput[valueOrder]}
         onChange={(event) => handleChangeValue(event.target.value)}
-        autoFocus={true}
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
             handleChangeRangeDateFilter((event.target as HTMLInputElement).value);

--- a/opencti-platform/opencti-front/src/components/filters/RelativeDateInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/RelativeDateInput.tsx
@@ -16,8 +16,6 @@ interface RelativeDateInputProps {
   valueOrder: number;
   dateInput: string[];
   setDateInput: (value: string[]) => void;
-  /** Only ONE field in the popover may claim focus. */
-  autoFocus?: boolean;
 }
 
 const RelativeDateInput: FunctionComponent<RelativeDateInputProps> = ({
@@ -28,7 +26,6 @@ const RelativeDateInput: FunctionComponent<RelativeDateInputProps> = ({
   valueOrder,
   dateInput,
   setDateInput,
-  autoFocus = false,
 }) => {
   const { t_i18n } = useFormatter();
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
@@ -106,7 +103,6 @@ const RelativeDateInput: FunctionComponent<RelativeDateInputProps> = ({
         label={label}
         value={dateInput[valueOrder]}
         onChange={(event) => handleChangeValue(event.target.value)}
-        autoFocus={autoFocus}
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
             handleChangeRangeDateFilter((event.target as HTMLInputElement).value);

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -142,6 +142,14 @@ class ListLines extends Component {
           className={classes.sortableHeaderItem}
           style={{ width }}
           onClick={this.reverseBy.bind(this, field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              this.reverseBy(field);
+            }
+          }}
         >
           <div className={classes.headerItemText}>{t(label)}</div>
           {sortBy === field ? orderComponent : ''}

--- a/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
+++ b/opencti-platform/opencti-front/src/components/list_lines/ListLines.jsx
@@ -140,6 +140,14 @@ class ListLines extends Component {
           className={classes.sortableHeaderItem}
           style={{ width }}
           onClick={this.reverseBy.bind(this, field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              this.reverseBy(field);
+            }
+          }}
         >
           <div className={classes.headerItemText}>{t(label)}</div>
           {sortBy === field ? orderComponent : ''}

--- a/opencti-platform/opencti-front/src/components/markdownDisplay/MarkdownDisplay.tsx
+++ b/opencti-platform/opencti-front/src/components/markdownDisplay/MarkdownDisplay.tsx
@@ -147,7 +147,7 @@ const MarkdownDisplay: FunctionComponent<MarkdownWithRedirectionWarningProps> = 
       const imageIndex = previewImages.findIndex((image) => image.src === resolvedUrl);
       const canOpenPreview = enableImagePreviewModal && imageIndex >= 0;
 
-      return (
+      const imageNode = (
         <img
           src={resolvedUrl}
           alt={alt || ''}
@@ -156,15 +156,30 @@ const MarkdownDisplay: FunctionComponent<MarkdownWithRedirectionWarningProps> = 
             maxHeight: '200px',
             cursor: canOpenPreview ? 'zoom-in' : undefined,
           }}
+          {...imgProps}
+        />
+      );
+
+      if (!canOpenPreview) {
+        return imageNode;
+      }
+
+      return (
+        <button
+          type="button"
           onClick={(event) => {
-            if (!canOpenPreview) {
-              return;
-            }
             event.stopPropagation();
             setPreviewImageIndex(imageIndex);
           }}
-          {...imgProps}
-        />
+          style={{
+            border: 'none',
+            padding: 0,
+            background: 'none',
+            cursor: 'zoom-in',
+          }}
+        >
+          {imageNode}
+        </button>
       );
     },
   }), [enableImagePreviewModal, previewImages, resolveMarkdownImageUrl]);
@@ -267,7 +282,7 @@ const MarkdownDisplay: FunctionComponent<MarkdownWithRedirectionWarningProps> = 
   } else {
     markdownDisplayContent = (
       <>
-        <div onClick={(event) => browseLinkWarning(event)}>
+        <div onClickCapture={(event) => browseLinkWarning(event)}>
           {markdownRender}
         </div>
         <ExternalLinkPopover

--- a/opencti-platform/opencti-front/src/components/markdownDisplay/MarkdownImagePreviewModal.tsx
+++ b/opencti-platform/opencti-front/src/components/markdownDisplay/MarkdownImagePreviewModal.tsx
@@ -150,15 +150,15 @@ const MarkdownImagePreviewModal: FunctionComponent<MarkdownImagePreviewModalProp
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}
+                onClickCapture={(event) => event.stopPropagation()}
               >
                 <img
                   src={image.src}
                   alt={image.alt}
                   style={{ maxWidth: '90vw', maxHeight: image.alt ? '74vh' : '80vh' }}
-                  onClick={(event) => event.stopPropagation()}
                 />
                 {image.alt && (
-                  <Box sx={captionStyle} onClick={(event) => event.stopPropagation()}>
+                  <Box sx={captionStyle}>
                     {image.alt}
                   </Box>
                 )}
@@ -176,15 +176,15 @@ const MarkdownImagePreviewModal: FunctionComponent<MarkdownImagePreviewModalProp
                 alignItems: 'center',
                 justifyContent: 'center',
               }}
+              onClickCapture={(event) => event.stopPropagation()}
             >
               <img
                 src={images[0].src}
                 alt={images[0].alt}
                 style={{ maxWidth: '90vw', maxHeight: images[0].alt ? '74vh' : '80vh' }}
-                onClick={(event) => event.stopPropagation()}
               />
               {images[0].alt && (
-                <Box sx={captionStyle} onClick={(event) => event.stopPropagation()}>
+                <Box sx={captionStyle}>
                   {images[0].alt}
                 </Box>
               )}

--- a/opencti-platform/opencti-front/src/components/markdownDisplay/MarkdownImagePreviewModal.tsx
+++ b/opencti-platform/opencti-front/src/components/markdownDisplay/MarkdownImagePreviewModal.tsx
@@ -189,6 +189,7 @@ const MarkdownImagePreviewModal: FunctionComponent<MarkdownImagePreviewModalProp
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}
+                onClickCapture={(event) => event.stopPropagation()}
               >
                 <img
                   src={images[0].src}

--- a/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/cases/tasks/TaskPopover.tsx
@@ -99,7 +99,7 @@ const TaskPopover = ({
   };
 
   return (
-    <div className={classes.container} onClick={(e) => e.stopPropagation()}>
+    <div className={classes.container} onClickCapture={(e) => e.stopPropagation()}>
       {variant === 'inLine' ? (
         <IconButton
           onClick={handleOpen}

--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerStixCyberObservables.tsx
@@ -352,7 +352,7 @@ const ContainerStixCyberObservablesComponent: FunctionComponent<
             )}
             actions={(row) => {
               return (
-                <div onClick={(e) => e.stopPropagation()}>
+                <div onClickCapture={(e) => e.stopPropagation()}>
                   <ContainerStixCoreObjectPopover
                     containerId={container.id}
                     toId={row.id}

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/TruncatedRawValue.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/TruncatedRawValue.tsx
@@ -102,6 +102,7 @@ const TruncatedRawValue: FunctionComponent<TruncatedRawValueProps> = ({ value, v
             padding: 0,
             background: 'none',
             textAlign: 'left',
+            whiteSpace: 'pre-wrap',
           }}
         >
           {value.substring(0, MAX_LENGTH)}...

--- a/opencti-platform/opencti-front/src/private/components/common/drawer/TruncatedRawValue.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/drawer/TruncatedRawValue.tsx
@@ -93,12 +93,19 @@ const TruncatedRawValue: FunctionComponent<TruncatedRawValueProps> = ({ value, v
   return (
     <>
       <Tooltip title={t_i18n('Click to view full value')}>
-        <pre
+        <button
+          type="button"
           onClick={() => setOpen(true)}
-          style={codeStyle}
+          style={{
+            ...codeStyle,
+            border: 'none',
+            padding: 0,
+            background: 'none',
+            textAlign: 'left',
+          }}
         >
           {value.substring(0, MAX_LENGTH)}...
-        </pre>
+        </button>
       </Tooltip>
       {dialog}
     </>

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EEChip.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, MouseEvent, useState } from 'react';
+import React, { CSSProperties, SyntheticEvent, useState } from 'react';
 import FeedbackCreation from '@components/cases/feedbacks/FeedbackCreation';
 import EnterpriseEditionAgreement from '@components/common/entreprise_edition/EnterpriseEditionAgreement';
 import { useFormatter } from '../../../../components/i18n';
@@ -16,7 +16,7 @@ const EEChip = React.forwardRef<HTMLDivElement, { feature?: string; clickable?: 
   const isAdmin = useGranted([SETTINGS_SETPARAMETERS]);
   const { settings: { id: settingsId } } = useAuth();
 
-  const onClick = (e: MouseEvent<HTMLDivElement>) => {
+  const onClick = (e: SyntheticEvent) => {
     e.stopPropagation();
     e.preventDefault();
     return clickable && setDisplayDialog(true);
@@ -59,6 +59,14 @@ const EEChip = React.forwardRef<HTMLDivElement, { feature?: string; clickable?: 
         ref={ref}
         style={divStyle}
         onClick={(e) => onClick(e)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClick(e);
+          }
+        }}
       >
         EE
       </div>

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EETooltip.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EETooltip.tsx
@@ -62,11 +62,21 @@ const EETooltip = ({
     return (
       <>
         <EETooltipComponent title={title ? t_i18n(title) : undefined}>
-          <span onClick={(e) => {
-            setOpenConfigAI(true);
-            e.preventDefault();
-            e.stopPropagation();
-          }}
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              setOpenConfigAI(true);
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                setOpenConfigAI(true);
+              }
+            }}
           >
             {children}
           </span>
@@ -90,11 +100,21 @@ const EETooltip = ({
   return (
     <>
       <EETooltipComponent title={title ? t_i18n(title) : undefined}>
-        <span onClickCapture={(e) => {
-          setFeedbackCreation(true);
-          e.preventDefault();
-          e.stopPropagation();
-        }}
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={(e) => {
+            setFeedbackCreation(true);
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.stopPropagation();
+              setFeedbackCreation(true);
+            }
+          }}
         >
           {children}
         </span>

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
@@ -62,7 +62,6 @@ const ImportFilesFreeText = ({ onSubmit, onClose, initialContent }: ImportFilesF
               label={t_i18n('Content')}
               fullWidth
               multiline
-              autoFocus
               name="content"
               rows="10"
               variant="standard"

--- a/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/import_files/ImportFilesFreeText.tsx
@@ -62,7 +62,6 @@ const ImportFilesFreeText = ({ onSubmit, onClose, initialContent }: ImportFilesF
               label={t_i18n('Content')}
               fullWidth
               multiline
-              autoFocus
               name="content"
               rows="10"
               variant="outlined"

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -1692,6 +1692,14 @@ const WorkbenchFileContentComponent = ({
         <div
           style={inlineStylesHeaders[field]}
           onClick={() => reverseBy(field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              reverseBy(field);
+            }
+          }}
         >
           <span>{t_i18n(label)}</span>
           {sortBy === field ? sortComponent : ''}
@@ -1719,6 +1727,14 @@ const WorkbenchFileContentComponent = ({
         <div
           style={inlineStylesHeaders[field]}
           onClick={() => containerReverseBy(field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              containerReverseBy(field);
+            }
+          }}
         >
           <span>{t_i18n(label)}</span>
           {containerSortBy === field ? sortComponent : ''}

--- a/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/workbench/WorkbenchFileContent.jsx
@@ -1693,6 +1693,14 @@ const WorkbenchFileContentComponent = ({
         <div
           style={inlineStylesHeaders[field]}
           onClick={() => reverseBy(field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              reverseBy(field);
+            }
+          }}
         >
           <span>{t_i18n(label)}</span>
           {sortBy === field ? sortComponent : ''}
@@ -1720,6 +1728,14 @@ const WorkbenchFileContentComponent = ({
         <div
           style={inlineStylesHeaders[field]}
           onClick={() => containerReverseBy(field)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              containerReverseBy(field);
+            }
+          }}
         >
           <span>{t_i18n(label)}</span>
           {containerSortBy === field ? sortComponent : ''}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.tsx
@@ -479,6 +479,14 @@ const StixCoreRelationshipCreation = ({
               key={relation.node.id}
               className={classes.relation}
               onClick={() => handleSelectRelation(relation.node as unknown as ObjectToParse)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  handleSelectRelation(relation.node as unknown as ObjectToParse);
+                }
+              }}
             >
               <div
                 className={classes.item}
@@ -585,6 +593,14 @@ const StixCoreRelationshipCreation = ({
           <div
             className={classes.relationCreation}
             onClick={handleChangeStep}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                handleChangeStep();
+              }
+            }}
           >
             <div
               className={classes.item}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_relationships/StixCoreRelationshipCreation.tsx
@@ -482,6 +482,14 @@ const StixCoreRelationshipCreation = ({
               key={relation.node.id}
               className={classes.relation}
               onClick={() => handleSelectRelation(relation.node as unknown as ObjectToParse)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  handleSelectRelation(relation.node as unknown as ObjectToParse);
+                }
+              }}
             >
               <div
                 className={classes.item}
@@ -589,6 +597,14 @@ const StixCoreRelationshipCreation = ({
             focusVisibleClassName="focus-visible"
             className={classes.relationCreation}
             onClick={handleChangeStep}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                handleChangeStep();
+              }
+            }}
           >
             <div
               className={classes.item}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -688,7 +688,6 @@ const StixDomainObjectHeader = (props) => {
                   component={TextField}
                   variant="standard"
                   name="new_alias"
-                  autoFocus={true}
                   placeholder={t_i18n('New alias')}
                   onChange={handleChangeNewAlias}
                   value={newAlias}
@@ -763,7 +762,6 @@ const StixDomainObjectHeader = (props) => {
                     component={TextField}
                     variant="standard"
                     name="new_alias"
-                    autoFocus={true}
                     fullWidth={true}
                     placeholder={t_i18n('New aliases')}
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectHeader.jsx
@@ -692,7 +692,6 @@ const StixDomainObjectHeader = (props) => {
                   component={TextField}
                   variant="outlined"
                   name="new_alias"
-                  autoFocus={true}
                   placeholder={t_i18n('New alias')}
                   onChange={handleChangeNewAlias}
                   value={newAlias}
@@ -767,7 +766,6 @@ const StixDomainObjectHeader = (props) => {
                     component={TextField}
                     variant="outlined"
                     name="new_alias"
-                    autoFocus={true}
                     fullWidth={true}
                     placeholder={t_i18n('New aliases')}
                     sx={{

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
@@ -614,6 +614,14 @@ class StixNestedRefRelationshipCreation extends Component {
               key={relation.node.id}
               className={classes.relation}
               onClick={this.handleSelectRelation.bind(this, relation.node)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  this.handleSelectRelation(relation.node);
+                }
+              }}
             >
               <div
                 className={classes.item}
@@ -720,6 +728,14 @@ class StixNestedRefRelationshipCreation extends Component {
           <div
             className={classes.relationCreation}
             onClick={this.handleChangeStep.bind(this)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                this.handleChangeStep();
+              }
+            }}
           >
             <div
               className={classes.item}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_nested_ref_relationships/StixNestedRefRelationshipCreation.jsx
@@ -616,6 +616,14 @@ class StixNestedRefRelationshipCreation extends Component {
               key={relation.node.id}
               className={classes.relation}
               onClick={this.handleSelectRelation.bind(this, relation.node)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  this.handleSelectRelation(relation.node);
+                }
+              }}
             >
               <div
                 className={classes.item}
@@ -723,6 +731,14 @@ class StixNestedRefRelationshipCreation extends Component {
             focusVisibleClassName="focus-visible"
             className={classes.relationCreation}
             onClick={this.handleChangeStep.bind(this)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                this.handleChangeStep();
+              }
+            }}
           >
             <div
               className={classes.item}

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
@@ -287,7 +287,6 @@ export const WorkflowTransitions: FunctionComponent<WorkflowTransitionsProps> = 
             : t_i18n('You can optionally add a comment before changing the status.')}
         </DialogContentText>
         <TextField
-          autoFocus
           fullWidth
           multiline
           minRows={3}

--- a/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/workflow/WorkflowTransitions.tsx
@@ -291,7 +291,6 @@ export const WorkflowTransitions: FunctionComponent<WorkflowTransitionsProps> = 
             : t_i18n('You can optionally add a comment before changing the status.')}
         </DialogContentText>
         <TextField
-          autoFocus
           fullWidth
           multiline
           minRows={3}

--- a/opencti-platform/opencti-front/src/private/components/data/Stream.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/Stream.tsx
@@ -261,7 +261,7 @@ const Stream = () => {
             />
           )}
           actions={(node) => (
-            <div onClick={(event) => stopEvent(event)}>
+            <div onClickCapture={(event) => stopEvent(event)}>
               <Security needs={[TAXIIAPI]}>
                 <StreamPopover
                   streamCollection={node}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationDialogOption.tsx
@@ -53,7 +53,7 @@ const CsvMapperRepresentationDialogOption: FunctionComponent<CsvMapperRepresenta
       >
         {children}
         <DialogActions>
-          <Button onClick={handleClose} autoFocus>
+          <Button onClick={handleClose}>
             {t_i18n('Close')}
           </Button>
         </DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/data/jsonMapper/representations/attributes/JsonMapperRepresentationDialogOption.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/jsonMapper/representations/attributes/JsonMapperRepresentationDialogOption.tsx
@@ -50,7 +50,7 @@ const JsonMapperRepresentationDialogOption: FunctionComponent<JsonMapperRepresen
       >
         {children}
         <DialogActions>
-          <Button onClick={handleClose} autoFocus>
+          <Button onClick={handleClose}>
             {t_i18n('Close')}
           </Button>
         </DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodePlaceholder.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/playbooks/types/nodes/NodePlaceholder.tsx
@@ -41,7 +41,18 @@ const NodePlaceholder = ({ id, data }: NodeProps) => {
   const classes = useStyles();
   const { getNode } = useReactFlow();
   return (
-    <div className={classes.node} onClick={() => data.openConfig(getNode(id))}>
+    <div
+      className={classes.node}
+      onClick={() => data.openConfig(getNode(id))}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          data.openConfig(getNode(id));
+        }
+      }}
+    >
       {data.name}
       <Handle
         className={classes.handle}

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationKnowledge.jsx
@@ -120,6 +120,7 @@ const OrganizationKnowledgeComponent = ({
               key={location.pathname}
               entityId={organization.id}
               relationshipTypes={['part-of', 'derived-from']}
+              // eslint-disable-next-line jsx-a11y/aria-role
               role="part-of_to"
               stixCoreObjectTypes={['Organization']}
               entityLink={link}

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreation.jsx
@@ -407,6 +407,14 @@ class StixSightingRelationshipCreation extends Component {
               key={sighting.node.id}
               className={classes.relation}
               onClick={this.handleSelectSighting.bind(this, sighting.node)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  this.handleSelectSighting(sighting.node);
+                }
+              }}
             >
               <div
                 className={classes.item}
@@ -513,6 +521,14 @@ class StixSightingRelationshipCreation extends Component {
           <div
             className={classes.relationCreation}
             onClick={this.handleChangeStep.bind(this)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                this.handleChangeStep();
+              }
+            }}
           >
             <div
               className={classes.item}

--- a/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreation.jsx
+++ b/opencti-platform/opencti-front/src/private/components/events/stix_sighting_relationships/StixSightingRelationshipCreation.jsx
@@ -410,6 +410,14 @@ class StixSightingRelationshipCreation extends Component {
               key={sighting.node.id}
               className={classes.relation}
               onClick={this.handleSelectSighting.bind(this, sighting.node)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  this.handleSelectSighting(sighting.node);
+                }
+              }}
             >
               <div
                 className={classes.item}
@@ -517,6 +525,14 @@ class StixSightingRelationshipCreation extends Component {
             focusVisibleClassName="focus-visible"
             className={classes.relationCreation}
             onClick={this.handleChangeStep.bind(this)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                this.handleChangeStep();
+              }
+            }}
           >
             <div
               className={classes.item}

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
@@ -197,7 +197,7 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
   }
 
   return (
-    <div onClick={stopEvent}>
+    <div onClickCapture={stopEvent}>
       <IconButton
         aria-label={t_i18n('Open menu')}
         onClick={handleOpen}

--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
@@ -180,7 +180,7 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
   }
 
   return (
-    <div onClick={stopEvent}>
+    <div onClickCapture={stopEvent}>
       <IconButton
         aria-label={t_i18n('Open menu')}
         onClick={handleOpen}

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
@@ -31,6 +31,7 @@ export const PopoverListItem: React.FC<PopoverListItemProps> = ({
   external,
   onClick,
 }) => {
+  const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
   const Component = href ? 'a' : to ? Link : 'div';
 

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarHeader.tsx
@@ -63,6 +63,7 @@ export const PopoverListItem: React.FC<PopoverListItemProps> = ({
         >
           <img
             src={logoSrc}
+            alt={t_i18n('Platform logo')}
             style={{
               width: '100%',
               height: 'auto',

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
@@ -186,6 +186,14 @@ class StixCyberObservableEntities extends Component {
         <div
           style={inlineStylesHeaders[field]}
           onClick={this.handleSort.bind(this, field, !this.state.orderAsc)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              this.handleSort(field, !this.state.orderAsc);
+            }
+          }}
         >
           <span>{t(label)}</span>
           {this.state.sortBy === field ? sortComponent : ''}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableEntities.jsx
@@ -179,6 +179,14 @@ class StixCyberObservableEntities extends Component {
         <div
           style={inlineStylesHeaders[field]}
           onClick={this.handleSort.bind(this, field, !this.state.orderAsc)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              this.handleSort(field, !this.state.orderAsc);
+            }
+          }}
         >
           <span>{t(label)}</span>
           {this.state.sortBy === field ? sortComponent : ''}

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
@@ -369,7 +369,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
           icon={(data: StixCyberObservableNestedEntitiesTable_node$data) => <ItemIcon type={data.to?.entity_type} />}
           actions={(data: StixCyberObservableNestedEntitiesTable_node$data) => {
             return (
-              <div style={{ marginLeft: -10 }} onClick={(e) => stopEvent(e)}>
+              <div style={{ marginLeft: -10 }} onClickCapture={(e) => stopEvent(e)}>
                 <StixNestedRefRelationshipPopover
                   stixNestedRefRelationshipId={data.id}
                   paginationOptions={{

--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
@@ -505,7 +505,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
           icon={(data: StixCyberObservableNestedEntitiesTable_node$data) => <ItemIcon type={getOppositeObject(data)?.entity_type} />}
           actions={(data: StixCyberObservableNestedEntitiesTable_node$data) => {
             return (
-              <div style={{ marginLeft: -10 }} onClick={(e) => stopEvent(e)}>
+              <div style={{ marginLeft: -10 }} onClickCapture={(e) => stopEvent(e)}>
                 <StixNestedRefRelationshipPopover
                   stixNestedRefRelationshipId={data.id}
                   paginationOptions={{

--- a/opencti-platform/opencti-front/src/private/components/pir/pir_overview/pir_threat_map/PirThreatMapLegend.tsx
+++ b/opencti-platform/opencti-front/src/private/components/pir/pir_overview/pir_threat_map/PirThreatMapLegend.tsx
@@ -56,6 +56,14 @@ const PirThreatMapLegend = ({ entityTypes, onFilter }: PirThreatMapLegendProps) 
           }}
           key={type}
           onClick={() => toggleType(type)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleType(type);
+            }
+          }}
         >
           <div
             style={{

--- a/opencti-platform/opencti-front/src/private/components/profile/api_tokens/TokenDeleteDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/profile/api_tokens/TokenDeleteDialog.tsx
@@ -35,7 +35,6 @@ const TokenDeleteDialog = ({ open, token, onDelete, onClose }: TokenDeleteDialog
         <Button
           intent="destructive"
           onClick={onDelete}
-          autoFocus
         >
           {t_i18n('Revoke')}
         </Button>

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SSODefinitions.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SSODefinitions.tsx
@@ -294,7 +294,7 @@ const SSODefinitions = () => {
                   : undefined
               }
             />
-            {!isEnterpriseEdition && <span onClick={(e) => e.stopPropagation()}><EEChip /></span>}
+            {!isEnterpriseEdition && <span onClickCapture={(e) => e.stopPropagation()}><EEChip /></span>}
           </Box>
         );
       },

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SSOSingletonStrategies.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/SSOSingletonStrategies.tsx
@@ -100,7 +100,7 @@ const SSOSingletonStrategiesContent = () => {
               label={isEnabled ? t_i18n('Active') : t_i18n('Disabled')}
               status={isEnabled}
             />
-            {showEE && <span onClick={(e) => e.stopPropagation()}><EEChip /></span>}
+            {showEE && <span onClickCapture={(e) => e.stopPropagation()}><EEChip /></span>}
             {showCertHttpsInfo && (
               <Tooltip title={t_i18n('Client certificate requires the platform to be configured with HTTPS')}>
                 <IconButton

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
@@ -112,7 +112,6 @@ const CustomViewDuplicationDialog: FunctionComponent<
     >
       <TextField
         error={!newName}
-        autoFocus
         margin="dense"
         id="duplicated_dashboard_name"
         label={t_i18n('New name')}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
@@ -112,7 +112,6 @@ const CustomViewDuplicationDialog: FunctionComponent<
     >
       <Input
         error={!newName ? t_i18n('This field is required') : undefined}
-        autoFocus
         id="duplicated_dashboard_name"
         label={t_i18n('New name')}
         type="text"

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewForm.tsx
@@ -74,7 +74,6 @@ const CustomViewForm = ({
           <Form>
             <Stack gap={1}>
               <Field
-                autoFocus
                 component={TextField}
                 name="name"
                 label={t_i18n('Name')}

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/ConfirmationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/ConfirmationDialog.tsx
@@ -39,7 +39,7 @@ const ConfirmationDialog: FunctionComponent<ConfirmationDialogProps> = ({
         <Button variant="secondary" onClick={onCancel} color="primary">
           {cancelButtonText}
         </Button>
-        <Button onClick={onConfirm} color="error" autoFocus>
+        <Button onClick={onConfirm} color="error">
           {confirmButtonText}
         </Button>
       </DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubTab.tsx
@@ -398,7 +398,7 @@ const XtmHubTab: React.FC<XtmHubTabProps> = ({ registrationStatus, renderTrigger
           <Button variant="secondary" onClick={handleCancelAutoRegistration} color="primary">
             {t_i18n('Cancel')}
           </Button>
-          <Button onClick={handleConfirmAutoRegistration} color="primary" autoFocus>
+          <Button onClick={handleConfirmAutoRegistration} color="primary">
             {t_i18n('Continue')}
           </Button>
         </DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -122,7 +122,6 @@ const WorkspaceDuplicationDialog: FunctionComponent<
     >
       <TextField
         error={!newName}
-        autoFocus
         margin="dense"
         id="duplicated_dashboard_name"
         label={t_i18n('New name')}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -122,7 +122,6 @@ const WorkspaceDuplicationDialog: FunctionComponent<
     >
       <Input
         error={!newName ? t_i18n('This field is required') : undefined}
-        autoFocus
         id="duplicated_dashboard_name"
         label={t_i18n('New name')}
         type="text"

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
@@ -125,7 +125,6 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
                     variant="standard"
                     name="newTag"
                     aria-label="tag field"
-                    autoFocus
                     placeholder={t_i18n('New tag')}
                     onChange={handleChangeNewTag}
                     value={newTag}
@@ -149,7 +148,6 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
                   component={TextField}
                   variant="standard"
                   name="newTag"
-                  autoFocus
                   placeholder={t_i18n('New tag')}
                   onChange={handleChangeNewTag}
                   value={newTag}

--- a/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/workspaceHeader/WorkspaceHeaderTagManager.tsx
@@ -134,7 +134,6 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
                     variant="outlined"
                     name="newTag"
                     aria-label="tag field"
-                    autoFocus
                     placeholder={t_i18n('New tag')}
                     onChange={handleChangeNewTag}
                     value={newTag}
@@ -159,7 +158,6 @@ const WorkspaceHeaderTagManager = ({ tags, workspaceId, canEdit }: WorkspaceHead
                   component={TextField}
                   variant="outlined"
                   name="newTag"
-                  autoFocus
                   placeholder={t_i18n('New tag')}
                   onChange={handleChangeNewTag}
                   value={newTag}

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -5398,7 +5398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.0.0":
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
@@ -5479,7 +5479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.3.3":
+"array.prototype.flatmap@npm:^1.3.2, array.prototype.flatmap@npm:^1.3.3":
   version: 1.3.3
   resolution: "array.prototype.flatmap@npm:1.3.3"
   dependencies:
@@ -5540,6 +5540,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types-flow@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "ast-types-flow@npm:0.0.8"
+  checksum: 10c0/f2a0ba8055353b743c41431974521e5e852a9824870cd6fce2db0e538ac7bf4da406bbd018d109af29ff3f8f0993f6a730c9eddbd0abd031fbcb29ca75c1014e
+  languageName: node
+  linkType: hard
+
 "ast-v8-to-istanbul@npm:^1.0.0":
   version: 1.0.5
   resolution: "ast-v8-to-istanbul@npm:1.0.5"
@@ -5581,6 +5588,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:^4.10.0":
+  version: 4.12.1
+  resolution: "axe-core@npm:4.12.1"
+  checksum: 10c0/03438bd98cef38ad57554feea0d8de21705001db2655c27e0c33ff55e16dd7d6f49c28fb420dc93f7532e68ff363c0953056a5836e6f47068f193eb1765c7db7
+  languageName: node
+  linkType: hard
+
 "axios@npm:1.18.1":
   version: 1.18.1
   resolution: "axios@npm:1.18.1"
@@ -5590,6 +5604,13 @@ __metadata:
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
   checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
+  languageName: node
+  linkType: hard
+
+"axobject-query@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "axobject-query@npm:4.1.0"
+  checksum: 10c0/c470e4f95008f232eadd755b018cb55f16c03ccf39c027b941cd8820ac6b68707ce5d7368a46756db4256fbc91bb4ead368f84f7fb034b2b7932f082f6dc0775
   languageName: node
   linkType: hard
 
@@ -6599,6 +6620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"damerau-levenshtein@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "damerau-levenshtein@npm:1.0.8"
+  checksum: 10c0/4c2647e0f42acaee7d068756c1d396e296c3556f9c8314bac1ac63ffb236217ef0e7e58602b18bb2173deec7ec8e0cac8e27cccf8f5526666b4ff11a13ad54a3
+  languageName: node
+  linkType: hard
+
 "data-bind-mapper@npm:1":
   version: 1.0.3
   resolution: "data-bind-mapper@npm:1.0.3"
@@ -7496,6 +7524,31 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
   checksum: 10c0/bfb1b8fc8800398e62ddfefbf3638d185286edfed26dfe00875cc2846d954491b4f5112457831588b757fa789384e1ae585f812614c4797f0499fa234fd4a48b
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsx-a11y@npm:6.10.2":
+  version: 6.10.2
+  resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
+  dependencies:
+    aria-query: "npm:^5.3.2"
+    array-includes: "npm:^3.1.8"
+    array.prototype.flatmap: "npm:^1.3.2"
+    ast-types-flow: "npm:^0.0.8"
+    axe-core: "npm:^4.10.0"
+    axobject-query: "npm:^4.1.0"
+    damerau-levenshtein: "npm:^1.0.8"
+    emoji-regex: "npm:^9.2.2"
+    hasown: "npm:^2.0.2"
+    jsx-ast-utils: "npm:^3.3.5"
+    language-tags: "npm:^1.0.9"
+    minimatch: "npm:^3.1.2"
+    object.fromentries: "npm:^2.0.8"
+    safe-regex-test: "npm:^1.0.3"
+    string.prototype.includes: "npm:^2.0.1"
+  peerDependencies:
+    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+  checksum: 10c0/d93354e03b0cf66f018d5c50964e074dffe4ddf1f9b535fa020d19c4ae45f89c1a16e9391ca61ac3b19f7042c751ac0d361a056a65cbd1de24718a53ff8daa6e
   languageName: node
   linkType: hard
 
@@ -9850,7 +9903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsx-ast-utils@npm:^2.4.1 || ^3.0.0":
+"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.5":
   version: 3.3.5
   resolution: "jsx-ast-utils@npm:3.3.5"
   dependencies:
@@ -9992,6 +10045,22 @@ __metadata:
     type-is: "npm:^2.0.1"
     vary: "npm:^1.1.2"
   checksum: 10c0/84352ef0ec0f54898f119ac589c7d96442ac21f494f3e1abca55d19c0cd51177f43b75440092d74730261d4d91270b5ba0396156e04b21132ab2251f8b4d2cde
+  languageName: node
+  linkType: hard
+
+"language-subtag-registry@npm:^0.3.20":
+  version: 0.3.23
+  resolution: "language-subtag-registry@npm:0.3.23"
+  checksum: 10c0/e9b05190421d2cd36dd6c95c28673019c927947cb6d94f40ba7e77a838629ee9675c94accf897fbebb07923187deb843b8fbb8935762df6edafe6c28dcb0b86c
+  languageName: node
+  linkType: hard
+
+"language-tags@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "language-tags@npm:1.0.9"
+  dependencies:
+    language-subtag-registry: "npm:^0.3.20"
+  checksum: 10c0/9ab911213c4bd8bd583c850201c17794e52cb0660d1ab6e32558aadc8324abebf6844e46f92b80a5d600d0fbba7eface2c207bfaf270a1c7fd539e4c3a880bff
   languageName: node
   linkType: hard
 
@@ -11810,6 +11879,7 @@ __metadata:
     eslint-plugin-custom-rules: "workspace:*"
     eslint-plugin-import: "npm:2.32.0"
     eslint-plugin-import-newlines: "npm:2.0.0"
+    eslint-plugin-jsx-a11y: "npm:6.10.2"
     eslint-plugin-react: "npm:7.37.5"
     extract-files: "npm:14.0.0"
     filigran-icon: "npm:0.21.0"
@@ -13851,7 +13921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-regex-test@npm:^1.1.0":
+"safe-regex-test@npm:^1.0.3, safe-regex-test@npm:^1.1.0":
   version: 1.1.0
   resolution: "safe-regex-test@npm:1.1.0"
   dependencies:
@@ -14380,6 +14450,17 @@ __metadata:
     get-east-asian-width: "npm:^1.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
+  languageName: node
+  linkType: hard
+
+"string.prototype.includes@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "string.prototype.includes@npm:2.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+  checksum: 10c0/25ce9c9b49128352a2618fbe8758b46f945817a58a4420f4799419e40a8d28f116e176c7590d767d5327a61e75c8f32c86171063f48e389b9fdd325f1bd04ee5
   languageName: node
   linkType: hard
 

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -5557,7 +5557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.0.0":
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
@@ -5638,7 +5638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flatmap@npm:^1.3.3":
+"array.prototype.flatmap@npm:^1.3.2, array.prototype.flatmap@npm:^1.3.3":
   version: 1.3.3
   resolution: "array.prototype.flatmap@npm:1.3.3"
   dependencies:
@@ -5699,6 +5699,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types-flow@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "ast-types-flow@npm:0.0.8"
+  checksum: 10c0/f2a0ba8055353b743c41431974521e5e852a9824870cd6fce2db0e538ac7bf4da406bbd018d109af29ff3f8f0993f6a730c9eddbd0abd031fbcb29ca75c1014e
+  languageName: node
+  linkType: hard
+
 "ast-v8-to-istanbul@npm:^1.0.0":
   version: 1.0.5
   resolution: "ast-v8-to-istanbul@npm:1.0.5"
@@ -5740,6 +5747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axe-core@npm:^4.10.0":
+  version: 4.13.0
+  resolution: "axe-core@npm:4.13.0"
+  checksum: 10c0/0e3be8be10eea64beddefd3007e1425424ff60c26c5f4d5f748ec48c2825356839c02ad4167fc1f03a6d84ecd82108f49fb2846ab7fe949273787391745561ca
+  languageName: node
+  linkType: hard
+
 "axios@npm:1.20.0":
   version: 1.20.0
   resolution: "axios@npm:1.20.0"
@@ -5749,6 +5763,13 @@ __metadata:
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
   checksum: 10c0/976088acf532286356f4c2e65df1ef47ba7da3936d83e928d0d64357bbf5370456abd3eb5826c15df322335fcb1fe200d4a84b4fcf20ffccdd63b40d80fa495c
+  languageName: node
+  linkType: hard
+
+"axobject-query@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "axobject-query@npm:4.1.0"
+  checksum: 10c0/c470e4f95008f232eadd755b018cb55f16c03ccf39c027b941cd8820ac6b68707ce5d7368a46756db4256fbc91bb4ead368f84f7fb034b2b7932f082f6dc0775
   languageName: node
   linkType: hard
 
@@ -6746,6 +6767,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"damerau-levenshtein@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "damerau-levenshtein@npm:1.0.8"
+  checksum: 10c0/4c2647e0f42acaee7d068756c1d396e296c3556f9c8314bac1ac63ffb236217ef0e7e58602b18bb2173deec7ec8e0cac8e27cccf8f5526666b4ff11a13ad54a3
+  languageName: node
+  linkType: hard
+
 "data-bind-mapper@npm:1":
   version: 1.0.3
   resolution: "data-bind-mapper@npm:1.0.3"
@@ -7640,6 +7668,31 @@ __metadata:
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
   checksum: 10c0/bfb1b8fc8800398e62ddfefbf3638d185286edfed26dfe00875cc2846d954491b4f5112457831588b757fa789384e1ae585f812614c4797f0499fa234fd4a48b
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-jsx-a11y@npm:6.10.2":
+  version: 6.10.2
+  resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
+  dependencies:
+    aria-query: "npm:^5.3.2"
+    array-includes: "npm:^3.1.8"
+    array.prototype.flatmap: "npm:^1.3.2"
+    ast-types-flow: "npm:^0.0.8"
+    axe-core: "npm:^4.10.0"
+    axobject-query: "npm:^4.1.0"
+    damerau-levenshtein: "npm:^1.0.8"
+    emoji-regex: "npm:^9.2.2"
+    hasown: "npm:^2.0.2"
+    jsx-ast-utils: "npm:^3.3.5"
+    language-tags: "npm:^1.0.9"
+    minimatch: "npm:^3.1.2"
+    object.fromentries: "npm:^2.0.8"
+    safe-regex-test: "npm:^1.0.3"
+    string.prototype.includes: "npm:^2.0.1"
+  peerDependencies:
+    eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+  checksum: 10c0/d93354e03b0cf66f018d5c50964e074dffe4ddf1f9b535fa020d19c4ae45f89c1a16e9391ca61ac3b19f7042c751ac0d361a056a65cbd1de24718a53ff8daa6e
   languageName: node
   linkType: hard
 
@@ -9979,7 +10032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsx-ast-utils@npm:^2.4.1 || ^3.0.0":
+"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.5":
   version: 3.3.5
   resolution: "jsx-ast-utils@npm:3.3.5"
   dependencies:
@@ -10128,6 +10181,22 @@ __metadata:
     type-is: "npm:^2.0.1"
     vary: "npm:^1.1.2"
   checksum: 10c0/84352ef0ec0f54898f119ac589c7d96442ac21f494f3e1abca55d19c0cd51177f43b75440092d74730261d4d91270b5ba0396156e04b21132ab2251f8b4d2cde
+  languageName: node
+  linkType: hard
+
+"language-subtag-registry@npm:^0.3.20":
+  version: 0.3.23
+  resolution: "language-subtag-registry@npm:0.3.23"
+  checksum: 10c0/e9b05190421d2cd36dd6c95c28673019c927947cb6d94f40ba7e77a838629ee9675c94accf897fbebb07923187deb843b8fbb8935762df6edafe6c28dcb0b86c
+  languageName: node
+  linkType: hard
+
+"language-tags@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "language-tags@npm:1.0.9"
+  dependencies:
+    language-subtag-registry: "npm:^0.3.20"
+  checksum: 10c0/9ab911213c4bd8bd583c850201c17794e52cb0660d1ab6e32558aadc8324abebf6844e46f92b80a5d600d0fbba7eface2c207bfaf270a1c7fd539e4c3a880bff
   languageName: node
   linkType: hard
 
@@ -11933,6 +12002,7 @@ __metadata:
     eslint-plugin-custom-rules: "workspace:*"
     eslint-plugin-import: "npm:2.32.0"
     eslint-plugin-import-newlines: "npm:2.0.0"
+    eslint-plugin-jsx-a11y: "npm:6.10.2"
     eslint-plugin-react: "npm:7.37.5"
     extract-files: "npm:14.0.0"
     filigran-icon: "npm:0.21.0"
@@ -13993,7 +14063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-regex-test@npm:^1.1.0":
+"safe-regex-test@npm:^1.0.3, safe-regex-test@npm:^1.1.0":
   version: 1.1.0
   resolution: "safe-regex-test@npm:1.1.0"
   dependencies:
@@ -14500,6 +14570,17 @@ __metadata:
     get-east-asian-width: "npm:^1.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
+  languageName: node
+  linkType: hard
+
+"string.prototype.includes@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "string.prototype.includes@npm:2.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.3"
+  checksum: 10c0/25ce9c9b49128352a2618fbe8758b46f945817a58a4420f4799419e40a8d28f116e176c7590d767d5327a61e75c8f32c86171063f48e389b9fdd325f1bd04ee5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Proposed changes

* Adds `a11y` eslint plugin
* Fixes `autofocus` violations
* Fixes interactive a11y violations

Validation from UX required before removing the autofocus setups.

### Related issues
* closes #16818 

### How to test this PR

#### 1) Global list/table headers (shared components)

**Where to test**
- Any page with sortable list/table headers (DataTable/ListLines/Columns headers).

**What to test**
- Sortable headers are reachable with keyboard (`Tab`).
- Sorting works with `Enter` and `Space`.
- Click sorting still works.
- No unexpected focus trap or double-trigger.

#### 2) Global filters (shared components)

**Where to test**
- Any page using filter chips/popovers/basic filters (especially entity list pages).

**What to test**
- Filter labels/mode toggles are keyboard reachable and operable.
- Filter popover options still select/unselect correctly.
- Disabled options remain non-interactive.
- Multi-value filter separators/mode controls still behave as before.

#### 3) Global markdown editors and previews (shared components)

**Where to test**
- Any page with markdown input + preview.

**What to test**
- Markdown preview renders correctly.
- Link warning popover still appears when clicking links in markdown content.
- Image preview opens from keyboard/click and closes normally.
- No broken click propagation in modal/carousel image preview.

#### 4) Data sharing streams

**Route**
- `/dashboard/data/sharing/streams`

**What to test**
- Row action popover opens from icon and does not trigger row click.
- Keyboard interaction in row actions still works.

#### 5) Data processing tasks

**Route**
- `/dashboard/data/processing/tasks`

**What to test**
- Task row popover opens/closes correctly.
- Clicking popover actions does not trigger parent row navigation/select.

#### 6) Data import (files/workbench)

**Routes**
- `/dashboard/data/import/file`
- `/dashboard/data/import/workbench`
- `/dashboard/data/import/workbench/:fileId`

**What to test**
- Free text import form still submits/cancels correctly (without `autoFocus`).
- Workbench sortable headers are keyboard accessible (`Enter`/`Space`).
- Workbench actions still function with mouse and keyboard.

#### 7) Integrations deployed

**Route**
- `/dashboard/integrations/deployed`

**What to test**
- Deployed integration popover opens correctly.
- Popover interactions do not trigger parent card/line click.
- Start/Stop/Update actions still execute normally.

#### 8) Settings → Authentications (SSO)

**Route**
- `/dashboard/settings/accesses/authentications`

**What to test**
- SSO lines still open/edit as expected.
- EE chip interactions do not trigger row click unintentionally.
- Singleton strategy lines behave the same with keyboard/mouse.

#### 9) Settings → XTM Hub

**Where to test**
- XTM Hub settings page (`XtmHubTab` flows).

**What to test**
- Confirmation dialog buttons still work as expected.
- Focus order remains usable after removing `autoFocus`.

#### 10) Profile and user API tokens

**Where to test**
- `/dashboard/profile` (personal API tokens)
- User admin page token list (`UserTokenList`)

**What to test**
- Revoke/delete token dialog opens and confirms correctly.
- Keyboard navigation to destructive action works.

#### 11) Workspaces (dashboards/investigations)

**Routes**
- `/dashboard/dashboards`
- `/dashboard/dashboards/:workspaceId/*`
- `/dashboard/investigations`
- `/dashboard/investigations/:workspaceId/*`

**What to test**
- Workspace duplication dialog still saves/cancels properly.
- Header tag manager add/edit interactions still work (keyboard + mouse).
- Kebab/popover actions do not leak click events to parent containers.

#### 12) Organizations entity page

**Route**
- `/dashboard/entities/organizations/:organizationId/*`

**What to test**
- Header quick actions (aliases, relationship creation) still work.
- Knowledge tab relation widgets keep expected behavior.

#### 13) Observables entity pages

**Route**
- `/dashboard/observations/observables/:observableId/*`

**What to test**
- Entities/nested entities tables action popovers work.
- Sort headers are keyboard operable.
- Nested relationship popover does not trigger parent row click.

#### 14) PIR overview threat map

**Where to test**
- PIR overview (`PirThreatMapLegend` area).

**What to test**
- Legend items are keyboard reachable.
- `Enter`/`Space` toggles filtering as click does.
- Visual disabled state remains coherent with applied filter.

#### 15) Container observable tabs embedded in container pages

**Where to test**
- Container pages embedding `ContainerStixCyberObservables`:
  - Reports
  - Groupings
  - Case Incident / RFI / RFT
  - Observed Data

**What to test**
- Row action popovers open without triggering row/container click.
- Relationship/object popover actions still execute correctly.

#### 16) Relationship/sighting creation dialogs

**Where to test**
- Any page exposing:
  - STIX core relationship creation
  - STIX nested ref relationship creation
  - STIX sighting relationship creation

**What to test**
- Selectable relationship cards are keyboard accessible.
- `Enter`/`Space` activates selection and “create relation/sighting” blocks.
- No regressions in step navigation and final submission.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
