### PR TITLE
fix(users): improve users edition for organizations administrators (#17466)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/settings/users/__tests__/UserEditionPassword.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/__tests__/UserEditionPassword.test.tsx
@@ -34,6 +34,13 @@ vi.mock('../../../common/form/PasswordPolicies', () => ({
   default: () => <div>PasswordPolicies</div>,
 }));
 
+vi.mock('../../../../../utils/hooks/useGranted', () => ({
+  default: () => true,
+  isBypassUser: () => true,
+  SETTINGS_SETACCESSES: 'SETTINGS_SETACCESSES',
+  KNOWLEDGE_KNUPDATE_KNORGARESTRICT: 'KNOWLEDGE_KNUPDATE_KNORGARESTRICT',
+}));
+
 describe('UserEditionPassword', () => {
   const baseUser = {
     id: 'user-1',

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionPassword.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionPassword.jsx
@@ -6,6 +6,8 @@ import { Stack, useTheme } from '@mui/material';
 import FormHelperText from '@mui/material/FormHelperText';
 import Button from '@common/button/Button';
 import { commitMutation, handleError, MESSAGING$ } from '../../../../../relay/environment';
+import useAuth from '../../../../../utils/hooks/useAuth.ts';
+import useGranted, { SETTINGS_SETACCESSES } from '../../../../../utils/hooks/useGranted';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';
 import PasswordPolicies from '../../../common/form/PasswordPolicies';
@@ -44,6 +46,9 @@ const formatExpiryDate = (value) => {
 const UserEditionPasswordComponent = ({ user }) => {
   const { t_i18n: t } = useFormatter();
   const theme = useTheme();
+  const hasSetAccess = useGranted([SETTINGS_SETACCESSES]);
+  const { me } = useAuth();
+  const isLoggedUser = user.id === me.id;
   const external = user.external === true;
   const isLocked = user.account_status === 'Locked';
   const formattedExpiry = formatExpiryDate(user.password_valid_until);
@@ -81,6 +86,21 @@ const UserEditionPasswordComponent = ({ user }) => {
       },
     });
   };
+  if (!hasSetAccess && !isLoggedUser) { // org admin only -> cannot change passwords for other users
+    return (
+      <div>
+        {!external && !isLocked && (
+          <Button
+            variant="primary"
+            onClick={handleForcePasswordChange}
+            style={{ marginLeft: theme.spacing(2) }}
+          >
+            {t('Force password change')}
+          </Button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <Formik

--- a/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionPassword.jsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/users/edition/UserEditionPassword.jsx
@@ -6,7 +6,7 @@ import { Stack, useTheme } from '@mui/material';
 import FormHelperText from '@mui/material/FormHelperText';
 import Button from '@common/button/Button';
 import { commitMutation, handleError, MESSAGING$ } from '../../../../../relay/environment';
-import useAuth from '../../../../../utils/hooks/useAuth.ts';
+import useAuth from '../../../../../utils/hooks/useAuth';
 import useGranted, { SETTINGS_SETACCESSES } from '../../../../../utils/hooks/useGranted';
 import { useFormatter } from '../../../../../components/i18n';
 import TextField from '../../../../../components/TextField';

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1087,6 +1087,10 @@ export const userEditField = async (context, user, userId, rawInputs) => {
       throw FunctionalError('Cannot force password change for external user', { userId });
     }
     if (input.key === 'password') {
+      // orgs admins can't update passwords
+      if (isOnlyOrgaAdmin(user) && user.id !== userId) {
+        throw ForbiddenAccess();
+      }
       const userServiceAccountInput = rawInputs.find((x) => x.key === 'user_service_account');
       if (userServiceAccountInput && userToUpdate.user_service_account !== userServiceAccountInput.value[0]) {
         skipThisInput = true;

--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -1087,8 +1087,8 @@ export const userEditField = async (context, user, userId, rawInputs) => {
       throw FunctionalError('Cannot force password change for external user', { userId });
     }
     if (input.key === 'password') {
-      // orgs admins can't update passwords
-      if (isOnlyOrgaAdmin(user) && user.id !== userId) {
+      // orgs admins can't update other users passwords
+      if (!isUserHasCapability(user, SETTINGS_SET_ACCESSES) && user.id !== userId) {
         throw ForbiddenAccess();
       }
       const userServiceAccountInput = rawInputs.find((x) => x.key === 'user_service_account');

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/user-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/user-test.ts
@@ -982,6 +982,18 @@ describe('User has no settings capability and is organization admin query behavi
     expect([userInternalId, userEditorId, userParticipateId].every((userId) => queryResult.data?.users.edges.map((n: any) => n.node.id).includes(userId)))
       .toBeTruthy();
   });
+  it('Org admins should NOT update password for other users', async () => {
+    const variables = {
+      id: userInternalId,
+      input: [
+        { key: 'password', value: 'new_password' },
+      ],
+    };
+    await queryAsUserIsExpectedForbidden(USER_EDITOR, {
+      query: UPDATE_QUERY,
+      variables,
+    });
+  });
   it('should update user from its own organization', async () => {
     const queryResult = await queryAsUserWithSuccess(USER_EDITOR, {
       query: UPDATE_QUERY,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Improve users edition (password management) for organizations administrators to keep only "Force password change"

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17466

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
- test password change for org admins (through graphql) & regular admins -> org admins should not change passwords
- org admins should only see "force password change" button for other users than themselves

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->