### PR TITLE
fix(backend): draft upsert of existing entity crashes with TypeError in getConsolidatedUpdatePatch (#17421)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/draft-utils.ts
+++ b/opencti-platform/opencti-graphql/src/database/draft-utils.ts
@@ -132,11 +132,25 @@ export const buildUpdateFieldPatch = (rawUpdatePatch: string): InternalEditInput
   return resultFieldPatch;
 };
 
+// Some resolved inputs can carry a non-array value/previous (e.g. a single scalar) depending on their origin.
+// Coerce to an array defensively so downstream consolidation logic never crashes with a "map is not a function" error.
+const asArray = (value: unknown): any[] => {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
 export const getConsolidatedUpdatePatch = (currentUpdatePatch: UpdatePatch, updatedInputsResolved: InternalEditInput[]): UpdatePatch => {
   const newUpdatePatch = currentUpdatePatch;
   const nonResolvedInput = updatedInputsResolved
     .map((i) => {
-      return { key: i.key, value: i.value?.map((v) => ((v && typeof v !== 'string' && v.standard_id) ? v.standard_id : v)), operation: i.operation ?? UPDATE_OPERATION_REPLACE, previous: i.previous ?? [] };
+      return {
+        key: i.key,
+        value: asArray(i.value).map((v) => ((v && typeof v !== 'string' && v.standard_id) ? v.standard_id : v)),
+        operation: i.operation ?? UPDATE_OPERATION_REPLACE,
+        previous: asArray(i.previous),
+      };
     });
   for (let i = 0; i < nonResolvedInput.length; i += 1) {
     const currentNonResolvedInput = nonResolvedInput[i];

--- a/opencti-platform/opencti-graphql/src/database/middleware.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware.ts
@@ -2161,7 +2161,8 @@ const getPreviousInstanceValue = (key: string, instance: Record<string, any>) =>
   if (key.includes('.')) {
     const [base, target] = key.split('.');
     const data = instance[base]?.[target];
-    return data ? [data] : data;
+    // Always return an array (or undefined) so callers relying on Array methods (e.g. draft consolidation) never crash on falsy scalars
+    return isEmptyField(data) ? undefined : [data];
   }
   const data = instance[key];
   if (isEmptyField(data)) {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/draft-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/draft-utils-test.ts
@@ -62,6 +62,69 @@ describe('draft-utils', () => {
     expect(consolidated.nonArrayValueKey.initial_value).toEqual([false]);
   });
 
+  describe('getConsolidatedUpdatePatch edge cases on "previous"', () => {
+    it.each([
+      { label: 'false', previous: false, expected: [false] },
+      { label: '0', previous: 0, expected: [0] },
+      { label: 'empty string', previous: '', expected: [''] },
+      { label: 'null', previous: null, expected: [] },
+      { label: 'undefined', previous: undefined, expected: [] },
+      { label: 'already an array', previous: ['existingValue'], expected: ['existingValue'] },
+    ])('should not throw and normalize initial_value when previous is $label', ({ previous, expected }) => {
+      const update = [{ key: 'edgeKey', value: ['newValue'], operation: EditOperation.Replace, previous }];
+      expect(() => getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[])).not.toThrow();
+      const consolidated = getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[]);
+      expect(consolidated.edgeKey.initial_value).toEqual(expected);
+    });
+  });
+
+  describe('getConsolidatedUpdatePatch edge cases on "value"', () => {
+    it.each([
+      { label: 'a plain string', value: 'aStringValue', expected: ['aStringValue'] },
+      { label: 'the number 0', value: 0, expected: [0] },
+      { label: 'false', value: false, expected: [false] },
+      { label: 'null', value: null, expected: [] },
+      { label: 'undefined', value: undefined, expected: [] },
+      { label: 'a resolved ref object with standard_id', value: { standard_id: 'identity--abc', name: 'ACME' }, expected: ['identity--abc'] },
+      { label: 'already an array', value: ['valueA', 'valueB'], expected: ['valueA', 'valueB'] },
+    ])('should not throw and normalize replaced_value when value is $label', ({ value, expected }) => {
+      const update = [{ key: 'edgeKey', value, operation: EditOperation.Replace }];
+      expect(() => getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[])).not.toThrow();
+      const consolidated = getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[]);
+      expect(consolidated.edgeKey.replaced_value).toEqual(expected);
+    });
+  });
+
+  describe('getConsolidatedUpdatePatch wrong/unexpected input paths', () => {
+    it('should default to a replace operation when operation is missing', () => {
+      const update = [{ key: 'noOperationKey', value: ['someValue'] }];
+      const consolidated = getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[]);
+      expect(consolidated.noOperationKey.replaced_value).toEqual(['someValue']);
+      expect(consolidated.noOperationKey.added_value).toEqual([]);
+      expect(consolidated.noOperationKey.removed_value).toEqual([]);
+    });
+
+    it('should not crash and return an empty updates map when given an empty input list', () => {
+      expect(() => getConsolidatedUpdatePatch({}, [])).not.toThrow();
+      expect(getConsolidatedUpdatePatch({}, [])).toEqual({});
+    });
+
+    it('should handle an add operation whose value is a non-array scalar without crashing', () => {
+      const update = [{ key: 'addScalarKey', value: 'onlyOneAdd', operation: EditOperation.Add }];
+      expect(() => getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[])).not.toThrow();
+      const consolidated = getConsolidatedUpdatePatch({}, update as unknown as InternalEditInput[]);
+      expect(consolidated.addScalarKey.added_value).toEqual(['onlyOneAdd']);
+    });
+
+    it('should still work when consolidating a second update where previous input value was a scalar (dedup path)', () => {
+      let patch = getConsolidatedUpdatePatch({}, [{ key: 'dedupKey', value: 'scalarAdd', operation: EditOperation.Add }] as unknown as InternalEditInput[]);
+      expect(patch.dedupKey.added_value).toEqual(['scalarAdd']);
+      // Second add on the same key should hit the "currentUpdates" branch and still not crash
+      patch = getConsolidatedUpdatePatch(patch, [{ key: 'dedupKey', value: 'scalarAdd2', operation: EditOperation.Add }] as unknown as InternalEditInput[]);
+      expect(patch.dedupKey.added_value.sort()).toEqual(['scalarAdd', 'scalarAdd2']);
+    });
+  });
+
   it('should buildUpdateFieldPatch build a correct field patch input', () => {
     const stringifiedUpdatePatch = JSON.stringify(currentUpdatePatch);
     const fieldPatchResult = buildUpdateFieldPatch(stringifiedUpdatePatch);

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/draft-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/draft-utils-test.ts
@@ -54,6 +54,14 @@ describe('draft-utils', () => {
     expect(currentUpdatePatch.keyB.removed_value[0]).toBe(valueB);
   });
 
+  it('should getConsolidatedUpdatePatch not crash when value or previous is not an array', () => {
+    const scalarValueUpdate = [{ key: 'nonArrayValueKey', value: 'singleValue', operation: EditOperation.Replace, previous: false }];
+    expect(() => getConsolidatedUpdatePatch({}, scalarValueUpdate as unknown as InternalEditInput[])).not.toThrow();
+    const consolidated = getConsolidatedUpdatePatch({}, scalarValueUpdate as unknown as InternalEditInput[]);
+    expect(consolidated.nonArrayValueKey.replaced_value).toEqual(['singleValue']);
+    expect(consolidated.nonArrayValueKey.initial_value).toEqual([false]);
+  });
+
   it('should buildUpdateFieldPatch build a correct field patch input', () => {
     const stringifiedUpdatePatch = JSON.stringify(currentUpdatePatch);
     const fieldPatchResult = buildUpdateFieldPatch(stringifiedUpdatePatch);

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/safeEjs-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/safeEjs-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import ejs from 'ejs';
@@ -539,9 +539,17 @@ describe('check safeRender on real files', () => {
       const templateFile = `${testFilePath.substring(0, testFilePath.lastIndexOf('.'))}.${name}`;
       const template = await fs.readFile(templateFile, 'utf8');
       const escape = name.includes('.json') ? customEscapeFunction : undefined;
-      const safeRendered = await safeRender(template, data, { useNotificationTool: true, escape });
-      const unsafeRendered = ejs.render(template, data);
-      expect(safeRendered).toEqual(unsafeRendered);
+      // Some templates embed a live `new Date()`/timestamp. Freeze the clock so both renders
+      // below see the exact same instant, avoiding a flaky 1-second drift across the second boundary.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date());
+      try {
+        const safeRendered = await safeRender(template, data, { useNotificationTool: true, escape });
+        const unsafeRendered = ejs.render(template, data);
+        expect(safeRendered).toEqual(unsafeRendered);
+      } finally {
+        vi.useRealTimers();
+      }
     },
   );
 });


### PR DESCRIPTION
### Proposed changes

* Normalize `getPreviousInstanceValue` in middleware.ts to always return an array (or undefined) instead of an unwrapped falsy scalar for dotted attribute keys
* Harden `getConsolidatedUpdatePatch` in draft-utils.ts to defensively coerce `value`/`previous` to arrays before calling `.map`, so a malformed input can never crash the draft write path
* Add unit tests covering the happy path, edge cases (falsy scalars, null/undefined, ref objects) and wrong/error input paths for `getConsolidatedUpdatePatch`

### Related issues
* closes #17421

### How to test this PR

* Run `npx vitest run tests/01-unit/database/draft-utils-test.ts` in opencti-platform/opencti-graphql
* create an entity (e.g. Attack Pattern) already existing in the platform, then submit a form intake/draft that upserts the same entity plus related objects; the draft should be created without a WRITE_ERROR

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

The crash was state-dependent because it only triggered when a falsy scalar (e.g. `false`/`0`) reached `previous` via a dotted attribute key path, which is rare but reproducible with certain pre-existing entity states.