### PR TITLE
docs: document Elasticsearch storage performance (#16942)

### DIFF
--- a/docs/docs/deployment/advanced/troubleshooting.md
+++ b/docs/docs/deployment/advanced/troubleshooting.md
@@ -57,14 +57,20 @@ The workers can have more or less verbose outputs:
 
 !!! warning "Execution timeout, too many concurrent call on the same entities"
     
-	The platform supports multi workers and multiple parallel creation but different parameters can lead to some locking timeout in the execution. 
+    The platform supports multiple workers and parallel creation, but different
+    parameters can lead to locking timeouts during execution.
 
-	* Throughput capacity of your ElasticSearch
-	* Number of workers started at the same time
-	* Dependencies between data
-	* Merging capacity of OpenCTI
+    * Throughput capacity of your ElasticSearch / OpenSearch cluster
+    * Disk I/O performance of the ElasticSearch / OpenSearch storage
+    * Number of workers started at the same time
+    * Dependencies between data
+    * Merging capacity of OpenCTI
 
-	If you have this kind of error, limit the number of workers deployed. Try to find the right balance of the number of workers, connectors and elasticsearch sizing.
+    If this error appears while ingestion queues keep growing and adding workers
+    does not drain them, check ElasticSearch / OpenSearch sizing and storage
+    performance first. Slow disks or slow network-attached storage can make
+    indexing disk-bound. In that case, reducing the number of workers can lower
+    contention, but the long-term fix is to move the cluster to faster storage.
 
 
 ### Ingestion functional errors

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -56,9 +56,9 @@ roles on the platform:
 
     Use SSD-backed storage for ElasticSearch / OpenSearch in production.
     For large or extra-large deployments, NVMe storage is recommended. OpenCTI
-    queries current and historical knowledge data, so storage performance affects
-    both ingestion and analysis. Slower disks or slow network-attached storage can
-    limit indexing throughput before CPU or RAM are saturated.
+    queries current and historical knowledge data (no hot/warm/cold tiering), so
+    storage performance affects both ingestion and analysis. Slower disks or slow
+    network-attached storage can limit indexing throughput before CPU or RAM are saturated.
 
     For more information about indices that can grow rapidly, see the
     [indices and rollover policies](advanced/rollover.md).

--- a/docs/docs/deployment/overview.md
+++ b/docs/docs/deployment/overview.md
@@ -52,6 +52,16 @@ roles on the platform:
 | RabbitMQ                   | >= 3.11            | 1 core    | ≥ 512MB      | Standard                     | ≥ 2GB           |
 | S3 / MinIO                 | >= RELEASE.2023-02 | 1 core    | ≥ 128MB      | SSD                          | ≥ 16GB          |
 
+!!! note "ElasticSearch / OpenSearch storage performance"
+
+    Use SSD-backed storage for ElasticSearch / OpenSearch in production.
+    For large or extra-large deployments, NVMe storage is recommended. OpenCTI
+    queries current and historical knowledge data, so storage performance affects
+    both ingestion and analysis. Slower disks or slow network-attached storage can
+    limit indexing throughput before CPU or RAM are saturated.
+
+    For more information about indices that can grow rapidly, see the
+    [indices and rollover policies](advanced/rollover.md).
 
 ### Platform
 


### PR DESCRIPTION
### Proposed changes

* Add an ElasticSearch / OpenSearch storage performance note to the deployment overview, clarifying that production deployments should use SSD-backed storage and that NVMe is recommended for large or extra-large deployments.
* Update the ingestion timeout troubleshooting guidance to include ElasticSearch / OpenSearch disk I/O performance as a possible bottleneck when ingestion queues keep growing and adding workers does not help.

### Related issues

* Closes #16942

### How to test this PR

Review the updated documentation pages:

* `docs/docs/deployment/overview.md`
* `docs/docs/deployment/advanced/troubleshooting.md`

Validation run locally:

* `git diff --check`

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

This is a documentation-only PR, so no source-code changes or test cases were added. The change stays scoped to storage type/performance guidance for ElasticSearch / OpenSearch and does not add storage capacity-planning numbers, which are tracked separately in #16943.