### PR TITLE
docs: clarify STIX IDs for imported objects (#10203)

### DIFF
--- a/docs/docs/usage/deduplication.md
+++ b/docs/docs/usage/deduplication.md
@@ -67,6 +67,22 @@ The deduplication process of relationships is based on the following criteria:
 
 For STIX Cyber Observables, OpenCTI also generate deterministic IDs based on the [STIX specification](https://docs.oasis-open.org/cti/stix/v2.1/csprd01/stix-v2.1-csprd01.html#_Toc16070607) using the "ID Contributing Properties" defined for each type of observable.
 
+### STIX IDs and imported objects
+
+The `Standard STIX ID` displayed by OpenCTI is the platform's canonical STIX
+identifier for the object. For imported data, this identifier may differ from the
+STIX ID used by the original source, such as a TAXII feed or an external CTI
+repository.
+
+This behavior is expected when OpenCTI needs to deduplicate and consolidate
+objects from multiple sources. Source STIX IDs can still be stored as additional
+OpenCTI STIX IDs when available, but users should not assume that the visible
+`Standard STIX ID` always matches the original source object's STIX ID.
+
+When correlating OpenCTI data with external sources, check the object's additional
+STIX IDs and external references when they are available, especially for data
+imported from TAXII feeds or third-party CTI repositories.
+
 ## Update behavior
 
 In cases where an entity already exists in the platform, incoming creations can trigger updates to the existing entity's attributes.

--- a/docs/docs/usage/deduplication.md
+++ b/docs/docs/usage/deduplication.md
@@ -75,12 +75,12 @@ STIX ID used by the original source, such as a TAXII feed or an external CTI
 repository.
 
 This behavior is expected when OpenCTI needs to deduplicate and consolidate
-objects from multiple sources. Source STIX IDs can still be stored as additional
-OpenCTI STIX IDs when available, but users should not assume that the visible
+objects from multiple sources. Source STIX IDs can still be stored under `Other
+STIX IDs` when available, but users should not assume that the visible
 `Standard STIX ID` always matches the original source object's STIX ID.
 
-When correlating OpenCTI data with external sources, check the object's additional
-STIX IDs and external references when they are available, especially for data
+When correlating OpenCTI data with external sources, check the object's `Other
+STIX IDs` and external references (if any), especially for data
 imported from TAXII feeds or third-party CTI repositories.
 
 ## Update behavior


### PR DESCRIPTION
### Proposed changes

* Clarifies that the `Standard STIX ID` displayed by OpenCTI is the platform's canonical STIX identifier for an object.
* Documents that imported/source STIX IDs may differ from the visible `Standard STIX ID`, especially for TAXII feeds or external CTI repositories.
* Adds guidance to check additional OpenCTI STIX IDs and external references when correlating OpenCTI data with external sources.

### Related issues

* closes #10203

### How to test this PR

Documentation-only change.

Reviewed the updated `docs/docs/usage/deduplication.md` section to confirm it is placed under the deduplication guidance and accurately describes the relationship between OpenCTI's canonical `Standard STIX ID`, imported/source STIX IDs, and external references.

Also ran:

`git diff --cached --check`

No output was returned.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

This is a documentation-only PR, so no new test cases were added. The change is intentionally narrow and avoids claiming that source STIX IDs are always preserved. Instead, it documents that source STIX IDs can be stored as additional OpenCTI STIX IDs when available and that users should also check external references when correlating with external sources.