### PR TITLE
docs: add PyCTI CSV mapper import example (#13515)

### DIFF
--- a/client-python/examples/import_csv_with_mapper.py
+++ b/client-python/examples/import_csv_with_mapper.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+import os
+import sys
+
+from pycti import OpenCTIApiClient
+
+# Variables
+api_url = os.getenv("OPENCTI_API_URL", "http://opencti:4000")
+api_token = os.getenv("OPENCTI_API_TOKEN")
+
+csv_file_path = os.getenv("OPENCTI_CSV_FILE_PATH")
+csv_mapper_name = os.getenv("OPENCTI_CSV_MAPPER_NAME")
+
+if not api_token:
+    sys.exit("Missing OPENCTI_API_TOKEN")
+
+if not csv_file_path:
+    sys.exit("Missing OPENCTI_CSV_FILE_PATH")
+
+if not csv_mapper_name:
+    sys.exit("Missing OPENCTI_CSV_MAPPER_NAME")
+
+# OpenCTI initialization
+opencti_api_client = OpenCTIApiClient(api_url, api_token)
+
+# Upload the CSV file to the import area.
+uploaded_file = opencti_api_client.upload_file(file_name=csv_file_path)
+uploaded_file_id = uploaded_file["data"]["uploadImport"]["id"]
+
+# Find the CSV mapper import connector and the requested mapper configuration.
+connectors_query = """
+query CsvMapperImportConnectors {
+  connectorsForImport {
+    id
+    name
+    active
+    configurations {
+      id
+      name
+      configuration
+    }
+  }
+}
+"""
+
+connectors_result = opencti_api_client.query(connectors_query)
+connectors = connectors_result["data"]["connectorsForImport"] or []
+
+csv_connector = next(
+    (
+        connector
+        for connector in connectors
+        if connector and connector["name"] == "[FILE] CSV Mapper import"
+    ),
+    None,
+)
+
+if csv_connector is None:
+    sys.exit("CSV mapper import connector was not found")
+
+if not csv_connector["active"]:
+    sys.exit("CSV mapper import connector is not active")
+
+csv_mapper = next(
+    (
+        configuration
+        for configuration in csv_connector.get("configurations", []) or []
+        if configuration["name"] == csv_mapper_name
+    ),
+    None,
+)
+
+if csv_mapper is None:
+    sys.exit(f"CSV mapper configuration was not found: {csv_mapper_name}")
+
+# Ask OpenCTI to import the uploaded CSV with the selected mapper.
+ask_import_mutation = """
+mutation AskCsvMapperImport(
+  $fileName: ID!
+  $connectorId: String
+  $configuration: String
+) {
+  askJobImport(
+    fileName: $fileName
+    connectorId: $connectorId
+    configuration: $configuration
+  ) {
+    id
+    name
+    uploadStatus
+  }
+}
+"""
+
+import_result = opencti_api_client.query(
+    ask_import_mutation,
+    {
+        "fileName": uploaded_file_id,
+        "connectorId": csv_connector["id"],
+        "configuration": csv_mapper["configuration"],
+    },
+)
+
+print(import_result)


### PR DESCRIPTION
### Proposed changes

* Adds a PyCTI example showing how to upload a CSV file to OpenCTI and trigger a CSV mapper import.
* Shows how to find the `[FILE] CSV Mapper import` connector and select a mapper configuration by name.
* Uses the existing mapper `configuration` returned by OpenCTI instead of manually building the CSV mapper payload.

### Related issues

* closes #13515

### How to test this PR

Documentation/example-only change.

Verified locally with:

`python3 -m py_compile client-python/examples/import_csv_with_mapper.py`

Also ran:

`git diff --cached --check`

No output was returned.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

This is a client-python example for the documented CSV mapper import workflow. It does not add product code or change runtime behavior.

The example intentionally reuses the CSV mapper configuration returned by the `[FILE] CSV Mapper import` connector, rather than constructing the mapper configuration manually. This keeps the example aligned with the same configuration flow used by the OpenCTI UI.