### PR TITLE
feat(security-coverage): manual creation of SC creates has-covered relationships (#14716)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageCreation.tsx
@@ -448,6 +448,7 @@ const SecurityCoverageCreationFormInner: FunctionComponent<SecurityCoverageFormI
       objectMarking: values.objectMarking.map((v) => v.value),
       objectLabel: values.objectLabel.map((v) => v.value),
       confidence: parseInt(String(values.confidence), 10),
+      add_related_entities: mode === 'manual',
     };
 
     commit({

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -16104,6 +16104,7 @@ input SecurityCoverageAddInput {
   coverage_information: [SecurityCoverageExpectation!]
   tenant_id: String
   tenant_name: String
+  add_related_entities: Boolean
 }
 
 type CoverageResult {

--- a/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
+++ b/opencti-platform/opencti-graphql/src/domain/stixCoreRelationship.js
@@ -17,7 +17,7 @@ import { stixObjectOrRelationshipAddRefRelation, stixObjectOrRelationshipAddRefR
 import { addDynamicFromAndToToFilters, addFilter } from '../utils/filtering/filtering-utils';
 import { stixRelationshipsDistribution } from './stixRelationship';
 import { elRemoveElementFromDraft } from '../database/draft-engine';
-import { shouldHandleHasCoveredRel, transformHasCoveredFromId } from '../modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils';
+import { shouldHandleHasCoveredRel, transformHasCoveredFromId } from '../modules/securityCoverage/securityCoverage-utils';
 
 export const findStixCoreRelationshipsPaginated = async (context, user, args) => {
   const filters = addDynamicFromAndToToFilters(args);

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -30316,6 +30316,7 @@ export type SecurityCoverageToStixArgs = {
 };
 
 export type SecurityCoverageAddInput = {
+  add_related_entities?: InputMaybe<Scalars['Boolean']['input']>;
   auto_enrichment_disable: Scalars['Boolean']['input'];
   confidence?: InputMaybe<Scalars['Int']['input']>;
   coverage_information?: InputMaybe<Array<SecurityCoverageExpectation>>;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-converter.ts
@@ -14,7 +14,7 @@ const convertSecurityCoverageToStix = (instance: StoreEntitySecurityCoverage): S
     type_affinity: instance.type_affinity,
     platforms_affinity: instance.platforms_affinity,
     duration: instance.duration,
-    [ATTRIBUTE_COVERED]: instance[INPUT_COVERED].standard_id,
+    [ATTRIBUTE_COVERED]: instance[INPUT_COVERED]?.standard_id,
     [ATTRIBUTE_RESULT_OF]: (instance[INPUT_RESULT_OF] ?? []).map((scr) => scr.standard_id),
     extensions: {
       [STIX_EXT_OCTI]: cleanObject({

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -131,7 +131,7 @@ export const addSecurityCoverage = async (
         { securityCoverageResultInput, shouldCreateResult },
       );
     } else {
-      await addRelatedCoveredEntities(context, user, result.id, securityCoverageInput.objectCovered);
+      await addRelatedCoveredEntities(context, user, result.id);
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -132,7 +132,7 @@ export const addSecurityCoverage = async (
       let targets: string[] = [];
       if (isContainer) {
         // In case of containers add entities from the ones contained.
-        targets = coveredEntity.objects.flatMap((o) => {
+        targets = (coveredEntity.objects ?? []).flatMap((o) => {
           if (!HAS_COVERED_TARGETS_TYPE.includes(o.entity_type)) return [];
           return o.id;
         });

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -1,9 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
   type EntityOptions,
+  findEntitiesIdsWithRelations,
   fullRelationsList,
   internalFindByIds,
   internalFindByIdsMapped,
+  internalLoadById,
   loadEntityThroughRelationsPaginated,
   pageEntitiesConnection,
   storeLoadById,
@@ -22,7 +24,7 @@ import { BUS_TOPICS, logApp } from '../../config/conf';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import { createEntity, deleteElementById, storeLoadByIdsWithRefs, storeLoadByIdWithRefs } from '../../database/middleware';
 import { type SecurityCoverageAddInput } from '../../generated/graphql';
-import type { BasicStoreEntity, BasicStoreObject, BasicStoreRelation, StoreObject, StoreRelation } from '../../types/store';
+import type { BasicStoreEntity, BasicStoreObject, BasicStoreRelation, StoreEntity, StoreObject, StoreRelation } from '../../types/store';
 import { convertStoreToStix_2_1 } from '../../database/stix-2-1-converter';
 import { STIX_SPEC_VERSION } from '../../database/stix';
 import { RELATION_HAS_COVERED, RELATION_TARGETS, RELATION_USES } from '../../schema/stixCoreRelationship';
@@ -47,15 +49,26 @@ import {
 } from './securityCoverageResult/securityCoverageResult-types';
 import { loadThroughDenormalized } from '../../resolvers/stix';
 import { stixCoreRelationshipsPaginated } from '../../domain/stixCoreObject';
-import { getAverageCoverageInformation, getMostRecentLastCoverageResult } from './securityCoverageResult/securityCoverageResult-utils';
+import {
+  getAverageCoverageInformation,
+  getMostRecentLastCoverageResult,
+  HAS_COVERED_TARGETS_TYPE,
+  internalCreateSecurityCoverageResult,
+} from './securityCoverageResult/securityCoverageResult-utils';
+import { splitSecurityCoverageInput } from './securityCoverage-utils';
+import { RELATION_OBJECT } from '../../schema/stixRefRelationship';
+import { objects } from '../../domain/container';
 
+const COVERED_CONTAINERS_TYPE = [
+  ENTITY_TYPE_CONTAINER_REPORT,
+  ENTITY_TYPE_CONTAINER_GROUPING,
+  ENTITY_TYPE_CONTAINER_CASE_INCIDENT,
+];
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
   ENTITY_TYPE_CAMPAIGN,
   ENTITY_TYPE_INCIDENT,
-  ENTITY_TYPE_CONTAINER_REPORT,
-  ENTITY_TYPE_CONTAINER_GROUPING,
-  ENTITY_TYPE_CONTAINER_CASE_INCIDENT,
+  ...COVERED_CONTAINERS_TYPE,
 ];
 
 // region CRUD
@@ -88,70 +101,49 @@ export const findSecurityCoverageByCoveredId = async (context: AuthContext, user
 export const addSecurityCoverage = async (
   context: AuthContext,
   user: AuthUser,
-  securityCoverageInput: SecurityCoverageAddInput,
+  input: SecurityCoverageAddInput,
 ): Promise<BasicStoreEntitySecurityCoverage> => {
   const {
-    coverage_information,
-    coverage_last_result,
-    coverage_valid_from,
-    coverage_valid_to,
-    external_uri,
-    tenant_name,
-    tenant_id,
-    ...onlySecurityCoverageInput
-  } = securityCoverageInput;
+    securityCoverageInput,
+    securityCoverageResultInput,
+  } = splitSecurityCoverageInput(input);
   const createdSecurityCoverage: BasicStoreEntitySecurityCoverage = await createEntity(
     context,
     user,
-    onlySecurityCoverageInput,
+    securityCoverageInput,
     ENTITY_TYPE_SECURITY_COVERAGE,
   );
 
-  if (external_uri || (coverage_information ?? []).length > 0) {
-    const {
-      confidence,
-      created,
-      createdBy,
-      fileMarkings,
-      filesMarkings,
-      modified,
-      objectLabel,
-      objectMarking,
-      x_opencti_modified_at,
-    } = onlySecurityCoverageInput;
-    const securityCoverageResultInput = {
-      name: tenant_name || external_uri || tenant_id || `Result of ${createdSecurityCoverage.name}`,
+  // We have also input for the sc result when receiving bundles from OpenAEV.
+  if (securityCoverageResultInput) {
+    const result = await internalCreateSecurityCoverageResult(context, user, {
+      ...securityCoverageResultInput,
       [INPUT_RESULT_OF]: createdSecurityCoverage.id,
-      coverage_information,
-      coverage_last_result,
-      coverage_valid_from,
-      coverage_valid_to,
-      external_uri,
-      confidence,
-      created,
-      createdBy,
-      fileMarkings,
-      filesMarkings,
-      modified,
-      objectLabel,
-      objectMarking,
-      x_opencti_modified_at,
-    };
-    const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
-      context,
-      user,
-      securityCoverageResultInput,
-      ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
-    );
+      name: `${securityCoverageResultInput.name ?? ''} Result of ${createdSecurityCoverage.name}`.trim(),
+    });
     // Manually add it here to be able to resolve dynamic attributes
-    createdSecurityCoverage['result-of'] = [result.id];
-    logApp.info(
-      `[SECURITY-COVERAGE-RESULT][${createdSecurityCoverage.id}] SCR created: ${result.standard_id}`,
-      {
-        result: JSON.stringify(result),
-        input: JSON.stringify(securityCoverageInput),
-      },
-    );
+    createdSecurityCoverage[RELATION_RESULT_OF] = [result.id];
+  }
+
+  // In case of manual creation, need to create associated has-covered relationships.
+  const isManualCreation = !input.external_uri;
+  if (isManualCreation) {
+    const coveredEntity = await internalLoadById<BasicStoreEntity>(context, user, securityCoverageInput.objectCovered);
+    const isContainer = COVERED_CONTAINERS_TYPE.includes(coveredEntity.entity_type);
+    let targets: string[] = [];
+    if (isContainer) {
+      targets = coveredEntity.object;
+    } else {
+      targets = [];
+      const relationsCallback = async (relationships: StoreRelation[]) => {
+        console.log('-------pouet----------', relationships);
+      };
+      await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
+        fromId: coveredEntity.id,
+        toTypes: HAS_COVERED_TARGETS_TYPE,
+        callback: relationsCallback,
+      });
+    }
   }
 
   return notify(

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -1,11 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
   type EntityOptions,
-  findEntitiesIdsWithRelations,
   fullRelationsList,
   internalFindByIds,
   internalFindByIdsMapped,
-  internalLoadById,
   loadEntityThroughRelationsPaginated,
   pageEntitiesConnection,
   storeLoadById,
@@ -56,8 +54,7 @@ import {
   internalCreateSecurityCoverageResult,
 } from './securityCoverageResult/securityCoverageResult-utils';
 import { splitSecurityCoverageInput } from './securityCoverage-utils';
-import { RELATION_OBJECT } from '../../schema/stixRefRelationship';
-import { objects } from '../../domain/container';
+import { addStixCoreRelationship } from '../../domain/stixCoreRelationship';
 
 const COVERED_CONTAINERS_TYPE = [
   ENTITY_TYPE_CONTAINER_REPORT,
@@ -115,8 +112,9 @@ export const addSecurityCoverage = async (
   );
 
   // We have also input for the sc result when receiving bundles from OpenAEV.
+  let result: BasicStoreEntitySecurityCoverageResult | undefined;
   if (securityCoverageResultInput) {
-    const result = await internalCreateSecurityCoverageResult(context, user, {
+    result = await internalCreateSecurityCoverageResult(context, user, {
       ...securityCoverageResultInput,
       [INPUT_RESULT_OF]: createdSecurityCoverage.id,
       name: `${securityCoverageResultInput.name ?? ''} Result of ${createdSecurityCoverage.name}`.trim(),
@@ -127,22 +125,38 @@ export const addSecurityCoverage = async (
 
   // In case of manual creation, need to create associated has-covered relationships.
   const isManualCreation = !input.external_uri;
-  if (isManualCreation) {
-    const coveredEntity = await internalLoadById<BasicStoreEntity>(context, user, securityCoverageInput.objectCovered);
-    const isContainer = COVERED_CONTAINERS_TYPE.includes(coveredEntity.entity_type);
-    let targets: string[] = [];
-    if (isContainer) {
-      targets = coveredEntity.object;
-    } else {
-      targets = [];
-      const relationsCallback = async (relationships: StoreRelation[]) => {
-        console.log('-------pouet----------', relationships);
-      };
-      await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
-        fromId: coveredEntity.id,
-        toTypes: HAS_COVERED_TARGETS_TYPE,
-        callback: relationsCallback,
-      });
+  if (isManualCreation && result) {
+    const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, securityCoverageInput.objectCovered);
+    if (coveredEntity) {
+      const isContainer = COVERED_CONTAINERS_TYPE.includes(coveredEntity.entity_type);
+      let targets: string[] = [];
+      if (isContainer) {
+        // In case of containers add entities from the ones contained.
+        targets = coveredEntity.objects.flatMap((o) => {
+          if (!HAS_COVERED_TARGETS_TYPE.includes(o.entity_type)) return [];
+          return o.id;
+        });
+      } else {
+        // In case of non-containers add entities from targets and uses relationships.
+        await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
+          fromId: coveredEntity.id,
+          toTypes: HAS_COVERED_TARGETS_TYPE,
+          callback: async (relationships: StoreRelation[]) => {
+            targets.push(...relationships.map((r) => r.toId));
+          },
+        });
+      }
+      logApp.info(`[SECURITY-COVERAGE] addSecurityCoverage: Manual creation, ${targets.length} entities found for has-covered relationships`, { targets });
+      await Promise.all(
+        targets.map((target) => {
+          return addStixCoreRelationship(context, user, {
+            relationship_type: RELATION_HAS_COVERED,
+            fromId: result.id,
+            toId: target,
+            coverage_information: [],
+          });
+        }),
+      );
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -22,7 +22,7 @@ import { BUS_TOPICS, logApp } from '../../config/conf';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import { createEntity, deleteElementById, storeLoadByIdsWithRefs, storeLoadByIdWithRefs } from '../../database/middleware';
 import { type SecurityCoverageAddInput } from '../../generated/graphql';
-import type { BasicStoreEntity, BasicStoreObject, BasicStoreRelation, StoreEntity, StoreObject, StoreRelation } from '../../types/store';
+import type { BasicStoreEntity, BasicStoreObject, BasicStoreRelation, StoreObject, StoreRelation } from '../../types/store';
 import { convertStoreToStix_2_1 } from '../../database/stix-2-1-converter';
 import { STIX_SPEC_VERSION } from '../../database/stix';
 import { RELATION_HAS_COVERED, RELATION_TARGETS, RELATION_USES } from '../../schema/stixCoreRelationship';
@@ -47,25 +47,17 @@ import {
 } from './securityCoverageResult/securityCoverageResult-types';
 import { loadThroughDenormalized } from '../../resolvers/stix';
 import { stixCoreRelationshipsPaginated } from '../../domain/stixCoreObject';
-import {
-  getAverageCoverageInformation,
-  getMostRecentLastCoverageResult,
-  HAS_COVERED_TARGETS_TYPE,
-  internalCreateSecurityCoverageResult,
-} from './securityCoverageResult/securityCoverageResult-utils';
+import { getAverageCoverageInformation, getMostRecentLastCoverageResult, internalCreateSecurityCoverageResult } from './securityCoverageResult/securityCoverageResult-utils';
 import { splitSecurityCoverageInput } from './securityCoverage-utils';
-import { addStixCoreRelationship } from '../../domain/stixCoreRelationship';
+import { addRelatedCoveredEntities } from './securityCoverageResult/securityCoverageResult-domain';
 
-const COVERED_CONTAINERS_TYPE = [
-  ENTITY_TYPE_CONTAINER_REPORT,
-  ENTITY_TYPE_CONTAINER_GROUPING,
-  ENTITY_TYPE_CONTAINER_CASE_INCIDENT,
-];
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
   ENTITY_TYPE_CAMPAIGN,
   ENTITY_TYPE_INCIDENT,
-  ...COVERED_CONTAINERS_TYPE,
+  ENTITY_TYPE_CONTAINER_REPORT,
+  ENTITY_TYPE_CONTAINER_GROUPING,
+  ENTITY_TYPE_CONTAINER_CASE_INCIDENT,
 ];
 
 // region CRUD
@@ -129,48 +121,17 @@ export const addSecurityCoverage = async (
     createdSecurityCoverage[RELATION_RESULT_OF] = [result.id];
   }
 
-  // In case of manual creation, need to create associated has-covered relationships.
+  // 3. In case of manual creation, need to create associated has-covered relationships.
   if (add_related_entities) {
     if (!result) {
-      // We should not arrive here, if asked to add related entities a SecurityCoverageResult
+      // We should not arrive here. If asked to add related entities, a SecurityCoverageResult
       // should have been created, otherwise there was an error.
       logApp.error(
         `[SECURITY-COVERAGE] Error while trying to add related entities to the created SecurityCoverage ${createdSecurityCoverage.id}, no SecurityCoverageResult was created.`,
         { securityCoverageResultInput, shouldCreateResult },
       );
     } else {
-      const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, securityCoverageInput.objectCovered);
-      if (coveredEntity) {
-        const isContainer = COVERED_CONTAINERS_TYPE.includes(coveredEntity.entity_type);
-        let targets: string[] = [];
-        if (isContainer) {
-          // In case of containers add entities from the ones contained.
-          targets = (coveredEntity.objects ?? []).flatMap((o) => {
-            if (!HAS_COVERED_TARGETS_TYPE.includes(o.entity_type)) return [];
-            return o.id;
-          });
-        } else {
-          // In case of non-containers add entities from targets and uses relationships.
-          await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
-            fromId: coveredEntity.id,
-            toTypes: HAS_COVERED_TARGETS_TYPE,
-            callback: async (relationships: StoreRelation[]) => {
-              targets.push(...relationships.map((r) => r.toId));
-            },
-          });
-        }
-        logApp.info(`[SECURITY-COVERAGE] addSecurityCoverage: Manual creation, ${targets.length} entities found for has-covered relationships`, { targets });
-        await Promise.all(
-          targets.map((target) => {
-            return addStixCoreRelationship(context, user, {
-              relationship_type: RELATION_HAS_COVERED,
-              fromId: result.id,
-              toId: target,
-              coverage_information: [],
-            });
-          }),
-        );
-      }
+      await addRelatedCoveredEntities(context, user, result.id, securityCoverageInput.objectCovered);
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -103,7 +103,11 @@ export const addSecurityCoverage = async (
   const {
     securityCoverageInput,
     securityCoverageResultInput,
+    add_related_entities,
+    shouldCreateResult,
   } = splitSecurityCoverageInput(input);
+
+  // 1. Create the SecurityCoverage entity.
   const createdSecurityCoverage: BasicStoreEntitySecurityCoverage = await createEntity(
     context,
     user,
@@ -111,52 +115,62 @@ export const addSecurityCoverage = async (
     ENTITY_TYPE_SECURITY_COVERAGE,
   );
 
-  // We have also input for the sc result when receiving bundles from OpenAEV.
+  // 2. Create an associated SecurityCoverageResult if we also
+  // have data for it (when receiving bundles from OpenAEV) or manual creation.
   let result: BasicStoreEntitySecurityCoverageResult | undefined;
-  if (securityCoverageResultInput) {
+  if (shouldCreateResult) {
     result = await internalCreateSecurityCoverageResult(context, user, {
       ...securityCoverageResultInput,
+      // Add extra attributes based on created SecurityCoverage
       [INPUT_RESULT_OF]: createdSecurityCoverage.id,
       name: `${securityCoverageResultInput.name ?? ''} Result of ${createdSecurityCoverage.name}`.trim(),
     });
-    // Manually add it here to be able to resolve dynamic attributes
+    // Manually add the ref here to be able to resolve dynamic attributes in GraphQL response
     createdSecurityCoverage[RELATION_RESULT_OF] = [result.id];
   }
 
   // In case of manual creation, need to create associated has-covered relationships.
-  const isManualCreation = !input.external_uri;
-  if (isManualCreation && result) {
-    const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, securityCoverageInput.objectCovered);
-    if (coveredEntity) {
-      const isContainer = COVERED_CONTAINERS_TYPE.includes(coveredEntity.entity_type);
-      let targets: string[] = [];
-      if (isContainer) {
-        // In case of containers add entities from the ones contained.
-        targets = (coveredEntity.objects ?? []).flatMap((o) => {
-          if (!HAS_COVERED_TARGETS_TYPE.includes(o.entity_type)) return [];
-          return o.id;
-        });
-      } else {
-        // In case of non-containers add entities from targets and uses relationships.
-        await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
-          fromId: coveredEntity.id,
-          toTypes: HAS_COVERED_TARGETS_TYPE,
-          callback: async (relationships: StoreRelation[]) => {
-            targets.push(...relationships.map((r) => r.toId));
-          },
-        });
-      }
-      logApp.info(`[SECURITY-COVERAGE] addSecurityCoverage: Manual creation, ${targets.length} entities found for has-covered relationships`, { targets });
-      await Promise.all(
-        targets.map((target) => {
-          return addStixCoreRelationship(context, user, {
-            relationship_type: RELATION_HAS_COVERED,
-            fromId: result.id,
-            toId: target,
-            coverage_information: [],
-          });
-        }),
+  if (add_related_entities) {
+    if (!result) {
+      // We should not arrive here, if asked to add related entities a SecurityCoverageResult
+      // should have been created, otherwise there was an error.
+      logApp.error(
+        `[SECURITY-COVERAGE] Error while trying to add related entities to the created SecurityCoverage ${createdSecurityCoverage.id}, no SecurityCoverageResult was created.`,
+        { securityCoverageResultInput, shouldCreateResult },
       );
+    } else {
+      const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, securityCoverageInput.objectCovered);
+      if (coveredEntity) {
+        const isContainer = COVERED_CONTAINERS_TYPE.includes(coveredEntity.entity_type);
+        let targets: string[] = [];
+        if (isContainer) {
+          // In case of containers add entities from the ones contained.
+          targets = (coveredEntity.objects ?? []).flatMap((o) => {
+            if (!HAS_COVERED_TARGETS_TYPE.includes(o.entity_type)) return [];
+            return o.id;
+          });
+        } else {
+          // In case of non-containers add entities from targets and uses relationships.
+          await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
+            fromId: coveredEntity.id,
+            toTypes: HAS_COVERED_TARGETS_TYPE,
+            callback: async (relationships: StoreRelation[]) => {
+              targets.push(...relationships.map((r) => r.toId));
+            },
+          });
+        }
+        logApp.info(`[SECURITY-COVERAGE] addSecurityCoverage: Manual creation, ${targets.length} entities found for has-covered relationships`, { targets });
+        await Promise.all(
+          targets.map((target) => {
+            return addStixCoreRelationship(context, user, {
+              relationship_type: RELATION_HAS_COVERED,
+              fromId: result.id,
+              toId: target,
+              coverage_information: [],
+            });
+          }),
+        );
+      }
     }
   }
 

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-utils.ts
@@ -1,0 +1,111 @@
+import { logApp } from '../../config/conf';
+import { FunctionalError } from '../../config/errors';
+import type { SecurityCoverageAddInput, SecurityCoverageResultAddInput, StixCoreRelationshipAddInput } from '../../generated/graphql';
+import { RELATION_HAS_COVERED } from '../../schema/stixCoreRelationship';
+import type { AuthContext, AuthUser } from '../../types/user';
+import { findById, listSecurityCoverageResults } from './securityCoverage-domain';
+
+/**
+ * Checks if the relationship fromId should be changed.
+ * If the rel is 'has-covered' with a fromId of a securityCoverage,
+ * Then changes fromId to the id of the associated securityCoverageResult.
+ *
+ * @param relInput Relationship input to check.
+ * @returns True if the fromId of the input should be changed.
+ */
+export const shouldHandleHasCoveredRel = (relInput: StixCoreRelationshipAddInput): boolean => {
+  return relInput.relationship_type === RELATION_HAS_COVERED
+    && relInput.fromId.startsWith('security-coverage--');
+};
+
+/**
+ * Replaces securityCoverage fromId to ID of associated securityCoverageResult.
+ *
+ * @param context To make the request to engine.
+ * @param user To make the request to engine.
+ * @param relInput Relationship input to manipulate.
+ * @returns Transformed input.
+ */
+export const transformHasCoveredFromId = async (
+  context: AuthContext,
+  user: AuthUser,
+  relInput: StixCoreRelationshipAddInput,
+) => {
+  const securityCoverage = await findById(context, user, relInput.fromId);
+  const securityCoverageResults = await listSecurityCoverageResults(context, user, securityCoverage);
+  const matchingSCR = relInput.external_uri
+    ? securityCoverageResults.filter((scr) => scr.external_uri === relInput.external_uri)
+    // Retro compatibility : only for old OEAV version without external_uri
+    : securityCoverageResults;
+
+  if (matchingSCR.length !== 1) {
+    logApp.error(
+      `[SECURITY-COVERAGE-RESULT] Invalid number of SCR found: ${relInput.external_uri}`,
+      {
+        relInput,
+        matchingSCRStandardIds: matchingSCR.map((scr) => scr.standard_id),
+      },
+    );
+    throw FunctionalError('Cannot find SecurityCoverageResult for this has-covered relationship');
+  }
+  return {
+    ...relInput,
+    fromId: matchingSCR[0].standard_id,
+  };
+};
+
+/**
+ * Helper function to split the input of security coverage creation.
+ *
+ * @param input Input received to create a new security coverage.
+ * @returns The input splitted into the part for SC and the part for SCR.
+ */
+export const splitSecurityCoverageInput = (input: SecurityCoverageAddInput) => {
+  const {
+    coverage_information,
+    coverage_last_result,
+    coverage_valid_from,
+    coverage_valid_to,
+    external_uri,
+    tenant_name,
+    tenant_id,
+    ...securityCoverageInput
+  } = input;
+
+  let securityCoverageResultInput: Partial<SecurityCoverageResultAddInput> | undefined;
+  if (external_uri || (coverage_information ?? []).length > 0) {
+    const {
+      confidence,
+      created,
+      createdBy,
+      fileMarkings,
+      filesMarkings,
+      modified,
+      objectLabel,
+      objectMarking,
+      x_opencti_modified_at,
+    } = securityCoverageInput;
+    securityCoverageResultInput = {
+      name: tenant_name || external_uri || tenant_id,
+      coverage_information,
+      coverage_last_result,
+      coverage_valid_from,
+      coverage_valid_to,
+      external_uri,
+      confidence,
+      created,
+      createdBy,
+      fileMarkings,
+      filesMarkings,
+      modified,
+      objectLabel,
+      objectMarking,
+      x_opencti_modified_at,
+    };
+  }
+
+  return {
+    securityCoverageInput,
+    securityCoverageResultInput,
+  };
+};

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-utils.ts
@@ -104,8 +104,8 @@ export const splitSecurityCoverageInput = (input: SecurityCoverageAddInput) => {
 
   // We should create a SecurityCoverageResult associated to the SecurityCoverage in two cases:
   // 1. We explicitly ask for with add_related_entities (manual creation),
-  // 2. The input contains an external_uri, meaning the input came from OpenAEV.
-  const shouldCreateResult = add_related_entities || !!external_uri;
+  // 2. The input contains result data, meaning the input came from OpenAEV.
+  const shouldCreateResult = add_related_entities || !!external_uri || (coverage_information ?? []).length > 0;
 
   return {
     securityCoverageInput,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-utils.ts
@@ -1,6 +1,6 @@
 import { logApp } from '../../config/conf';
 import { FunctionalError } from '../../config/errors';
-import type { SecurityCoverageAddInput, SecurityCoverageResultAddInput, StixCoreRelationshipAddInput } from '../../generated/graphql';
+import type { SecurityCoverageAddInput, StixCoreRelationshipAddInput } from '../../generated/graphql';
 import { RELATION_HAS_COVERED } from '../../schema/stixCoreRelationship';
 import type { AuthContext, AuthUser } from '../../types/user';
 import { findById, listSecurityCoverageResults } from './securityCoverage-domain';
@@ -69,43 +69,48 @@ export const splitSecurityCoverageInput = (input: SecurityCoverageAddInput) => {
     external_uri,
     tenant_name,
     tenant_id,
+    add_related_entities,
     ...securityCoverageInput
   } = input;
 
-  let securityCoverageResultInput: Partial<SecurityCoverageResultAddInput> | undefined;
-  if (external_uri || (coverage_information ?? []).length > 0) {
-    const {
-      confidence,
-      created,
-      createdBy,
-      fileMarkings,
-      filesMarkings,
-      modified,
-      objectLabel,
-      objectMarking,
-      x_opencti_modified_at,
-    } = securityCoverageInput;
-    securityCoverageResultInput = {
-      name: tenant_name || external_uri || tenant_id,
-      coverage_information,
-      coverage_last_result,
-      coverage_valid_from,
-      coverage_valid_to,
-      external_uri,
-      confidence,
-      created,
-      createdBy,
-      fileMarkings,
-      filesMarkings,
-      modified,
-      objectLabel,
-      objectMarking,
-      x_opencti_modified_at,
-    };
-  }
+  const {
+    confidence,
+    created,
+    createdBy,
+    fileMarkings,
+    filesMarkings,
+    modified,
+    objectLabel,
+    objectMarking,
+    x_opencti_modified_at,
+  } = securityCoverageInput;
+  const securityCoverageResultInput = {
+    name: tenant_name || external_uri || tenant_id,
+    coverage_information,
+    coverage_last_result,
+    coverage_valid_from,
+    coverage_valid_to,
+    external_uri,
+    confidence,
+    created,
+    createdBy,
+    fileMarkings,
+    filesMarkings,
+    modified,
+    objectLabel,
+    objectMarking,
+    x_opencti_modified_at,
+  };
+
+  // We should create a SecurityCoverageResult associated to the SecurityCoverage in two cases:
+  // 1. We explicitly ask for with add_related_entities (manual creation),
+  // 2. The input contains an external_uri, meaning the input came from OpenAEV.
+  const shouldCreateResult = add_related_entities || !!external_uri;
 
   return {
     securityCoverageInput,
     securityCoverageResultInput,
+    shouldCreateResult,
+    add_related_entities,
   };
 };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage.graphql
@@ -323,6 +323,7 @@ input SecurityCoverageAddInput {
   coverage_information: [SecurityCoverageExpectation!]
   tenant_id: String
   tenant_name: String
+  add_related_entities: Boolean
 }
 
 type Mutation {

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -1,14 +1,23 @@
-import { BUS_TOPICS } from '../../../config/conf';
+import { BUS_TOPICS, logApp } from '../../../config/conf';
 import { FunctionalError } from '../../../config/errors';
-import { deleteElementById } from '../../../database/middleware';
-import { pageEntitiesConnection, storeLoadById, type EntityOptions } from '../../../database/middleware-loader';
+import { deleteElementById, storeLoadByIdWithRefs } from '../../../database/middleware';
+import { fullRelationsList, pageEntitiesConnection, storeLoadById, type EntityOptions } from '../../../database/middleware-loader';
 import { notify } from '../../../database/redis';
+import { addStixCoreRelationship } from '../../../domain/stixCoreRelationship';
 import { type SecurityCoverageResultAddInput } from '../../../generated/graphql';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../../schema/general';
+import { RELATION_HAS_COVERED, RELATION_TARGETS, RELATION_USES } from '../../../schema/stixCoreRelationship';
+import { isStixDomainObjectContainer } from '../../../schema/stixDomainObject';
+import type { StoreEntity } from '../../../types/store';
 import type { AuthContext, AuthUser } from '../../../types/user';
-import { ENTITY_TYPE_SECURITY_COVERAGE, type BasicStoreEntitySecurityCoverage } from '../securityCoverage-types';
-import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, type BasicStoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
-import { internalCreateSecurityCoverageResult } from './securityCoverageResult-utils';
+import { ENTITY_TYPE_SECURITY_COVERAGE, RELATION_COVERED, type BasicStoreEntitySecurityCoverage } from '../securityCoverage-types';
+import {
+  ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  INPUT_RESULT_OF,
+  type BasicStoreEntitySecurityCoverageResult,
+  type StoreEntitySecurityCoverageResult,
+} from './securityCoverageResult-types';
+import { HAS_COVERED_TARGETS_TYPE, internalCreateSecurityCoverageResult } from './securityCoverageResult-utils';
 
 /**
  * Find a security coverage results by its ID.
@@ -105,4 +114,70 @@ export const deleteSecurityCoverageResult = async (
   const deleted = await deleteElementById(context, user, id, ENTITY_TYPE_SECURITY_COVERAGE_RESULT);
   await notify(BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].DELETE_TOPIC, id, user);
   return deleted.id;
+};
+
+/**
+ * /!\ This function could take quite a long time to execute, better to use it with background tasks.
+ *
+ * Creates a has-covered relationship between a security coverage result and each entities of
+ * a covered entity.
+ *
+ * @param context
+ * @param user User making the request.
+ * @param securityCoverageResultId ID of the security coverage result to populate.
+ * @param coveredEntityId ID of the entity covered by the security coverage.
+ */
+export const addRelatedCoveredEntities = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverageResultId: string,
+  coveredEntityId: string,
+) => {
+  const securityCoverageResult = await storeLoadByIdWithRefs<StoreEntitySecurityCoverageResult>(context, user, securityCoverageResultId);
+  const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, coveredEntityId);
+
+  // Verify the given IDs.
+  if (!securityCoverageResult) {
+    throw FunctionalError(`No security coverage result found for the id ${securityCoverageResultId}`);
+  }
+  if (!coveredEntity) {
+    throw FunctionalError(`No covered entity found for the id ${coveredEntityId}`);
+  }
+  if (securityCoverageResult[INPUT_RESULT_OF][RELATION_COVERED] !== coveredEntity.id) {
+    throw FunctionalError(`Entity ${coveredEntityId} is not covered by the security coverage result ${securityCoverageResultId}`);
+  }
+
+  let targets: string[] = [];
+  if (isStixDomainObjectContainer(coveredEntity.entity_type)) {
+    // In case of containers add entities from the ones contained.
+    targets = (coveredEntity.objects ?? []).flatMap((o) => {
+      if (!HAS_COVERED_TARGETS_TYPE.includes(o.entity_type)) return [];
+      return o.id;
+    });
+  } else {
+    // In case of non-containers add entities from targets and uses relationships.
+    await fullRelationsList(context, user, [RELATION_TARGETS, RELATION_USES], {
+      fromId: coveredEntity.id,
+      toTypes: HAS_COVERED_TARGETS_TYPE,
+      callback: async (relationships) => {
+        targets.push(...relationships.map((r) => r.toId));
+      },
+    });
+  }
+
+  logApp.info(
+    `[SECURITY-COVERAGE] addSecurityCoverage: Manual creation, ${targets.length} entities found for has-covered relationships`,
+    { targets },
+  );
+  // Create all the has-covered relationships.
+  return Promise.all(
+    targets.map((target) => {
+      return addStixCoreRelationship(context, user, {
+        relationship_type: RELATION_HAS_COVERED,
+        fromId: securityCoverageResultId,
+        toId: target,
+        coverage_information: [],
+      });
+    }),
+  );
 };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -1,6 +1,6 @@
 import { BUS_TOPICS } from '../../../config/conf';
 import { FunctionalError } from '../../../config/errors';
-import { createEntity, deleteElementById } from '../../../database/middleware';
+import { deleteElementById } from '../../../database/middleware';
 import { pageEntitiesConnection, storeLoadById, type EntityOptions } from '../../../database/middleware-loader';
 import { notify } from '../../../database/redis';
 import { type SecurityCoverageResultAddInput } from '../../../generated/graphql';
@@ -8,6 +8,7 @@ import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../../schema/general';
 import type { AuthContext, AuthUser } from '../../../types/user';
 import { ENTITY_TYPE_SECURITY_COVERAGE, type BasicStoreEntitySecurityCoverage } from '../securityCoverage-types';
 import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, type BasicStoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
+import { internalCreateSecurityCoverageResult } from './securityCoverageResult-utils';
 
 /**
  * Find a security coverage results by its ID.
@@ -80,12 +81,7 @@ export const addSecurityCoverageResult = async (
   if (!securityCoverageResultInput.name) {
     input.name = `Result of ${securityCoverage.name}`;
   }
-  const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
-    context,
-    user,
-    input,
-    ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
-  );
+  const result = await internalCreateSecurityCoverageResult(context, user, input);
   return notify(
     BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE_RESULT].ADDED_TOPIC,
     result,

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain.ts
@@ -125,26 +125,21 @@ export const deleteSecurityCoverageResult = async (
  * @param context
  * @param user User making the request.
  * @param securityCoverageResultId ID of the security coverage result to populate.
- * @param coveredEntityId ID of the entity covered by the security coverage.
  */
 export const addRelatedCoveredEntities = async (
   context: AuthContext,
   user: AuthUser,
   securityCoverageResultId: string,
-  coveredEntityId: string,
 ) => {
   const securityCoverageResult = await storeLoadByIdWithRefs<StoreEntitySecurityCoverageResult>(context, user, securityCoverageResultId);
-  const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, coveredEntityId);
-
-  // Verify the given IDs.
   if (!securityCoverageResult) {
     throw FunctionalError(`No security coverage result found for the id ${securityCoverageResultId}`);
   }
+
+  const coveredId = securityCoverageResult[INPUT_RESULT_OF][RELATION_COVERED];
+  const coveredEntity = await storeLoadByIdWithRefs<StoreEntity>(context, user, coveredId);
   if (!coveredEntity) {
-    throw FunctionalError(`No covered entity found for the id ${coveredEntityId}`);
-  }
-  if (securityCoverageResult[INPUT_RESULT_OF][RELATION_COVERED] !== coveredEntity.id) {
-    throw FunctionalError(`Entity ${coveredEntityId} is not covered by the security coverage result ${securityCoverageResultId}`);
+    throw FunctionalError(`No covered entity found for the id ${coveredId}`);
   }
 
   let targets: string[] = [];

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -1,10 +1,18 @@
 import { logApp } from '../../../config/conf';
-import { FunctionalError } from '../../../config/errors';
-import { type StixCoreRelationshipAddInput } from '../../../generated/graphql';
-import { RELATION_HAS_COVERED } from '../../../schema/stixCoreRelationship';
+import { createEntity } from '../../../database/middleware';
+import type { SecurityCoverageResultAddInput } from '../../../generated/graphql';
+import { ENTITY_HASHED_OBSERVABLE_ARTIFACT } from '../../../schema/stixCyberObservable';
+import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_VULNERABILITY } from '../../../schema/stixDomainObject';
 import type { AuthContext, AuthUser } from '../../../types/user';
-import { findById, listSecurityCoverageResults } from '../securityCoverage-domain';
-import type { StoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
+import { ENTITY_TYPE_INDICATOR } from '../../indicator/indicator-types';
+import { ENTITY_TYPE_SECURITY_COVERAGE_RESULT, type BasicStoreEntitySecurityCoverageResult, type StoreEntitySecurityCoverageResult } from './securityCoverageResult-types';
+
+export const HAS_COVERED_TARGETS_TYPE = [
+  ENTITY_TYPE_ATTACK_PATTERN,
+  ENTITY_TYPE_VULNERABILITY,
+  ENTITY_HASHED_OBSERVABLE_ARTIFACT,
+  ENTITY_TYPE_INDICATOR,
+];
 
 /**
  * Compute the average coverage information of an array of securityCoverageResult.
@@ -42,50 +50,32 @@ export const getMostRecentLastCoverageResult = async (results: StoreEntitySecuri
 };
 
 /**
- * Checks if the relationship fromId should be changed.
- * If the rel is 'has-covered' with a fromId of a securityCoverage,
- * Then changes fromId to the id of the associated securityCoverageResult.
+ * Internal function to create a security coverage result.
  *
- * @param relInput Relationship input to check.
- * @returns True if the fromId of the input should be changed.
- */
-export const shouldHandleHasCoveredRel = (relInput: StixCoreRelationshipAddInput): boolean => {
-  return relInput.relationship_type === RELATION_HAS_COVERED
-    && relInput.fromId.startsWith('security-coverage--');
-};
-
-/**
- * Replaces securityCoverage fromId to ID of associated securityCoverageResult.
+ * /!\ This function is not directly available through the API.
+ * The API one is making extra checks, this one exists to avoid duplicating code.
  *
- * @param context To make the request to engine.
- * @param user To make the request to engine.
- * @param relInput Relationship input to manipulate.
- * @returns Transformed input.
+ * @param context
+ * @param user user making the request.
+ * @param securityCoverageResultInput Input to create the security coverage result.
  */
-export const transformHasCoveredFromId = async (
+export const internalCreateSecurityCoverageResult = async (
   context: AuthContext,
   user: AuthUser,
-  relInput: StixCoreRelationshipAddInput,
+  securityCoverageResultInput: SecurityCoverageResultAddInput,
 ) => {
-  const securityCoverage = await findById(context, user, relInput.fromId);
-  const securityCoverageResults = await listSecurityCoverageResults(context, user, securityCoverage);
-  const matchingSCR = relInput.external_uri
-    ? securityCoverageResults.filter((scr) => scr.external_uri === relInput.external_uri)
-    // Retro compatibility : only for old OEAV version without external_uri
-    : securityCoverageResults;
-
-  if (matchingSCR.length !== 1) {
-    logApp.error(
-      `[SECURITY-COVERAGE-RESULT] Invalid number of SCR found: ${relInput.external_uri}`,
-      {
-        relInput,
-        matchingSCRStandardIds: matchingSCR.map((scr) => scr.standard_id),
-      },
-    );
-    throw FunctionalError('Cannot find SecurityCoverageResult for this has-covered relationship');
-  }
-  return {
-    ...relInput,
-    fromId: matchingSCR[0].standard_id,
-  };
+  const result: BasicStoreEntitySecurityCoverageResult = await createEntity(
+    context,
+    user,
+    securityCoverageResultInput,
+    ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
+  );
+  logApp.info(
+    `[SECURITY-COVERAGE-RESULT][${securityCoverageResultInput.resultOf}] SCR created: ${result.standard_id}`,
+    {
+      result: JSON.stringify(result),
+      input: JSON.stringify(securityCoverageResultInput),
+    },
+  );
+  return result;
 };

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils.ts
@@ -70,12 +70,6 @@ export const internalCreateSecurityCoverageResult = async (
     securityCoverageResultInput,
     ENTITY_TYPE_SECURITY_COVERAGE_RESULT,
   );
-  logApp.info(
-    `[SECURITY-COVERAGE-RESULT][${securityCoverageResultInput.resultOf}] SCR created: ${result.standard_id}`,
-    {
-      result: JSON.stringify(result),
-      input: JSON.stringify(securityCoverageResultInput),
-    },
-  );
+  logApp.info(`[SECURITY-COVERAGE-RESULT][${securityCoverageResultInput.resultOf}] SCR created: ${result.standard_id}`);
   return result;
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverage-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverage-utils-test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { shouldHandleHasCoveredRel } from '../../../../src/modules/securityCoverage/securityCoverage-utils';
+
+describe('Function shouldHandleHasCoveredRel()', () => {
+  it('should return false if not has-covered relationship', () => {
+    expect(shouldHandleHasCoveredRel({
+      relationship_type: 'uses',
+      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
+      fromId: 'security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f',
+      toId: 'intrusion-set--d12c5319-f308-5fef-9336-20484af42084',
+    })).toEqual(false);
+  });
+
+  it('should return false if not securityCoverage', () => {
+    expect(shouldHandleHasCoveredRel({
+      relationship_type: 'has-covered',
+      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
+      fromId: 'security-coverage-result--c76bfcfe-2be5-500f-9b81-367457f1088f',
+      toId: 'intrusion-set--d12c5319-f308-5fef-9336-20484af42084',
+    })).toEqual(false);
+  });
+
+  it('should return true if all conditions respected', () => {
+    expect(shouldHandleHasCoveredRel({
+      relationship_type: 'has-covered',
+      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
+      fromId: 'security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f',
+      toId: 'intrusion-set--d12c5319-f308-5fef-9336-20484af42084',
+    })).toEqual(true);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-utils-test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  getAverageCoverageInformation,
-  getMostRecentLastCoverageResult,
-  shouldHandleHasCoveredRel,
-} from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils';
+import { getAverageCoverageInformation, getMostRecentLastCoverageResult } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils';
 import type { StoreEntitySecurityCoverageResult } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 
 describe('Function getMostRecentLastCoverageResult()', () => {
@@ -73,34 +69,5 @@ describe('Function getAverageCoverageInformation()', () => {
       { coverage_name: 'vulnerability', coverage_score: 50 },
       { coverage_name: 'detection', coverage_score: 18 },
     ]);
-  });
-});
-
-describe('Function shouldHandleHasCoveredRel()', () => {
-  it('should return false if not has-covered relationship', () => {
-    expect(shouldHandleHasCoveredRel({
-      relationship_type: 'uses',
-      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
-      fromId: 'security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f',
-      toId: 'intrusion-set--d12c5319-f308-5fef-9336-20484af42084',
-    })).toEqual(false);
-  });
-
-  it('should return false if not securityCoverage', () => {
-    expect(shouldHandleHasCoveredRel({
-      relationship_type: 'has-covered',
-      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
-      fromId: 'security-coverage-result--c76bfcfe-2be5-500f-9b81-367457f1088f',
-      toId: 'intrusion-set--d12c5319-f308-5fef-9336-20484af42084',
-    })).toEqual(false);
-  });
-
-  it('should return true if all conditions respected', () => {
-    expect(shouldHandleHasCoveredRel({
-      relationship_type: 'has-covered',
-      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
-      fromId: 'security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f',
-      toId: 'intrusion-set--d12c5319-f308-5fef-9336-20484af42084',
-    })).toEqual(true);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
@@ -39,7 +39,7 @@ describe('SecurityCoverage domain', () => {
       const results = await listSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage);
       expect(results.length).toEqual(1);
       // Name should be the external_uri when it is defined
-      expect(results[0].name).toEqual(externalUri);
+      expect(results[0].name).toEqual(`${externalUri} Result of sc1`);
       await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
     });
 
@@ -53,7 +53,7 @@ describe('SecurityCoverage domain', () => {
       const results = await listSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage);
       expect(results.length).toEqual(1);
       // Name should be the tenant_name when it is defined
-      expect(results[0].name).toEqual('Super Coverage');
+      expect(results[0].name).toEqual('Super Coverage Result of sc1');
       await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
     });
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-domain-test.ts
@@ -25,7 +25,20 @@ describe('SecurityCoverage domain', () => {
   });
 
   describe('Function addSecurityCoverage()', () => {
-    it('should create coverage result if contains coverage information', async () => {
+    it('should create coverage result if explicitly asked for', async () => {
+      const input = {
+        ...BASE_INPUT(),
+        add_related_entities: true,
+      };
+      const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
+      const results = await listSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage);
+      expect(results.length).toEqual(1);
+      // Name should be the external_uri when it is defined
+      expect(results[0].name).toEqual('Result of sc1');
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+    });
+
+    it('should create coverage result if contains eternal uri', async () => {
       const externalUri = 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a131';
       const input = {
         ...BASE_INPUT(),
@@ -43,7 +56,7 @@ describe('SecurityCoverage domain', () => {
       await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
     });
 
-    it('should create coverage result if contains no information but external_uri', async () => {
+    it('should create coverage result if contains external_uri without coverage info', async () => {
       const input = {
         ...BASE_INPUT(),
         tenant_name: 'Super Coverage',
@@ -57,7 +70,7 @@ describe('SecurityCoverage domain', () => {
       await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
     });
 
-    it('should not create coverage result if no coverage info neither external_uri', async () => {
+    it('should not create coverage result if no manual neither external_uri', async () => {
       const input = {
         ...BASE_INPUT(),
       };
@@ -77,6 +90,7 @@ describe('SecurityCoverage domain', () => {
           coverage_name: 'prevention',
           coverage_score: 10,
         }],
+        add_related_entities: true,
       };
       const securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, input);
       let results = await listSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage);

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
@@ -18,7 +18,7 @@ describe('Function transformHasCoveredFromId', () => {
     expect(newInput).toEqual({
       relationship_type: 'has-covered',
       external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
-      fromId: 'security-coverage-result--687bfcc3-4917-5ab9-8233-dfa1f3c69850',
+      fromId: 'security-coverage-result--90727e33-b5b6-54f4-8d17-ed5c68288553',
       toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
     });
   });
@@ -49,7 +49,7 @@ describe('Function transformHasCoveredFromId', () => {
     );
     expect(newInput).toEqual({
       relationship_type: 'has-covered',
-      fromId: 'security-coverage-result--687bfcc3-4917-5ab9-8233-dfa1f3c69850',
+      fromId: 'security-coverage-result--90727e33-b5b6-54f4-8d17-ed5c68288553',
       toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
     });
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { transformHasCoveredFromId } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-utils';
+import { transformHasCoveredFromId } from '../../../../src/modules/securityCoverage/securityCoverage-utils';
 import { SYSTEM_USER } from '../../../../src/utils/access';
 import { testContext } from '../../../utils/testQuery';
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
@@ -10,15 +10,15 @@ describe('Function transformHasCoveredFromId', () => {
       SYSTEM_USER,
       {
         relationship_type: 'has-covered',
-        external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
-        fromId: 'security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175',
+        fromId: 'security-coverage--9a2d4fa8-403c-5e15-ad4b-0f2909885db8',
         toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
       },
     );
     expect(newInput).toEqual({
       relationship_type: 'has-covered',
-      external_uri: 'http://192.168.1.150:8080/admin/scenarios/001d6ae0-4344-4467-99d5-eb4b6962fd4b',
-      fromId: 'security-coverage-result--90727e33-b5b6-54f4-8d17-ed5c68288553',
+      external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175',
+      fromId: 'security-coverage-result--cd293e6b-384f-596d-b72d-4c47509553da',
       toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
     });
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverage-utils-test.ts
@@ -1,24 +1,44 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { transformHasCoveredFromId } from '../../../../src/modules/securityCoverage/securityCoverage-utils';
 import { SYSTEM_USER } from '../../../../src/utils/access';
-import { testContext } from '../../../utils/testQuery';
+import { ADMIN_USER, testContext } from '../../../utils/testQuery';
+import { addSecurityCoverage, listSecurityCoverageResults, securityCoverageDelete } from '../../../../src/modules/securityCoverage/securityCoverage-domain';
+import type { BasicStoreEntitySecurityCoverage } from '../../../../src/modules/securityCoverage/securityCoverage-types';
+import type { BasicStoreEntitySecurityCoverageResult } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-types';
 
 describe('Function transformHasCoveredFromId', () => {
+  let securityCoverage: BasicStoreEntitySecurityCoverage;
+  let result: BasicStoreEntitySecurityCoverageResult;
+
+  beforeEach(async () => {
+    securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, {
+      name: 'sc1',
+      objectCovered: 'report--a445d22a-db0c-4b5d-9ec8-e9ad0b6dbdd7',
+      auto_enrichment_disable: true,
+      external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a999',
+    });
+    result = (await listSecurityCoverageResults(testContext, ADMIN_USER, securityCoverage))[0];
+  });
+
+  afterEach(async () => {
+    await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.standard_id);
+  });
+
   it('should replace security coverage id by security coverage result id when valid external_uri', async () => {
     const newInput = await transformHasCoveredFromId(
       testContext,
       SYSTEM_USER,
       {
         relationship_type: 'has-covered',
-        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175',
-        fromId: 'security-coverage--9a2d4fa8-403c-5e15-ad4b-0f2909885db8',
+        external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a999',
+        fromId: securityCoverage.standard_id,
         toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
       },
     );
     expect(newInput).toEqual({
       relationship_type: 'has-covered',
-      external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175',
-      fromId: 'security-coverage-result--cd293e6b-384f-596d-b72d-4c47509553da',
+      external_uri: 'http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a999',
+      fromId: result.standard_id,
       toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
     });
   });
@@ -43,13 +63,13 @@ describe('Function transformHasCoveredFromId', () => {
       SYSTEM_USER,
       {
         relationship_type: 'has-covered',
-        fromId: 'security-coverage--c76bfcfe-2be5-500f-9b81-367457f1088f',
+        fromId: securityCoverage.standard_id,
         toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
       },
     );
     expect(newInput).toEqual({
       relationship_type: 'has-covered',
-      fromId: 'security-coverage-result--90727e33-b5b6-54f4-8d17-ed5c68288553',
+      fromId: result.standard_id,
       toId: 'attack-pattern--2fc04aa5-48c1-49ec-919a-b88241ef1d17',
     });
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverageResult-domain-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/securityCoverage/securityCoverageResult-domain-test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { addRelatedCoveredEntities } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain';
+import { addSecurityCoverage, securityCoverageDelete } from '../../../../src/modules/securityCoverage/securityCoverage-domain';
+import { addSecurityCoverageResult } from '../../../../src/modules/securityCoverage/securityCoverageResult/securityCoverageResult-domain';
+import type { BasicStoreEntitySecurityCoverage } from '../../../../src/modules/securityCoverage/securityCoverage-types';
+import { addReport, reportDeleteWithElements } from '../../../../src/domain/report';
+import { addAttackPattern } from '../../../../src/domain/attackPattern';
+import { addVulnerability } from '../../../../src/domain/vulnerability';
+import { addIntrusionSet } from '../../../../src/domain/intrusionSet';
+import { createRelation, deleteElementById } from '../../../../src/database/middleware';
+import { fullRelationsList } from '../../../../src/database/middleware-loader';
+import { RELATION_HAS_COVERED, RELATION_TARGETS, RELATION_USES } from '../../../../src/schema/stixCoreRelationship';
+import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_INTRUSION_SET, ENTITY_TYPE_VULNERABILITY } from '../../../../src/schema/stixDomainObject';
+import { ADMIN_USER, testContext } from '../../../utils/testQuery';
+
+describe('Function: addRelatedCoveredEntities()', () => {
+  let securityCoverage: BasicStoreEntitySecurityCoverage | undefined;
+
+  afterEach(async () => {
+    if (securityCoverage) {
+      await securityCoverageDelete(testContext, ADMIN_USER, securityCoverage.id);
+      securityCoverage = undefined;
+    }
+  });
+
+  it('should create has-covered relationships for entities contained in a covered container', async () => {
+    const attackPattern = await addAttackPattern(testContext, ADMIN_USER, { name: 'AP for addRelatedCoveredEntities test' });
+    const vulnerability = await addVulnerability(testContext, ADMIN_USER, { name: 'Vuln for addRelatedCoveredEntities test' });
+    const report = await addReport(testContext, ADMIN_USER, {
+      name: 'Report for addRelatedCoveredEntities test',
+      published: '2026-01-01T00:00:00.000Z',
+      objects: [attackPattern.id, vulnerability.id],
+    });
+
+    securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, {
+      name: 'SC container test',
+      objectCovered: report.standard_id,
+      auto_enrichment_disable: true,
+    });
+    const result = await addSecurityCoverageResult(testContext, ADMIN_USER, { resultOf: securityCoverage.id });
+
+    const created = await addRelatedCoveredEntities(testContext, ADMIN_USER, result.id);
+    expect(created.length).toEqual(2);
+
+    const relations = await fullRelationsList(testContext, ADMIN_USER, RELATION_HAS_COVERED, { fromId: result.id });
+    expect(relations.map((r) => r.toId).sort()).toEqual([attackPattern.id, vulnerability.id].sort());
+
+    await deleteElementById(testContext, ADMIN_USER, attackPattern.id, ENTITY_TYPE_ATTACK_PATTERN);
+    await deleteElementById(testContext, ADMIN_USER, vulnerability.id, ENTITY_TYPE_VULNERABILITY);
+    await deleteElementById(testContext, ADMIN_USER, report.id, report.entity_type);
+  });
+
+  it('should create has-covered relationships for targeted/used entities of a covered non-container', async () => {
+    const attackPattern = await addAttackPattern(testContext, ADMIN_USER, { name: 'AP for addRelatedCoveredEntities non-container test' });
+    const vulnerability = await addVulnerability(testContext, ADMIN_USER, { name: 'Vuln for addRelatedCoveredEntities non-container test' });
+    const intrusionSet = await addIntrusionSet(testContext, ADMIN_USER, { name: 'Intrusion set for addRelatedCoveredEntities test' });
+
+    await createRelation(testContext, ADMIN_USER, {
+      fromId: intrusionSet.id,
+      toId: attackPattern.id,
+      relationship_type: RELATION_USES,
+    });
+    await createRelation(testContext, ADMIN_USER, {
+      fromId: intrusionSet.id,
+      toId: vulnerability.id,
+      relationship_type: RELATION_TARGETS,
+    });
+
+    securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, {
+      name: 'SC non-container test',
+      objectCovered: intrusionSet.standard_id,
+      auto_enrichment_disable: true,
+    });
+    const result = await addSecurityCoverageResult(testContext, ADMIN_USER, { resultOf: securityCoverage.id });
+
+    const created = await addRelatedCoveredEntities(testContext, ADMIN_USER, result.id);
+    expect(created.length).toEqual(2);
+
+    const relations = await fullRelationsList(testContext, ADMIN_USER, RELATION_HAS_COVERED, { fromId: result.id });
+    expect(relations.map((r) => r.toId).sort()).toEqual([attackPattern.id, vulnerability.id].sort());
+
+    await deleteElementById(testContext, ADMIN_USER, attackPattern.id, ENTITY_TYPE_ATTACK_PATTERN);
+    await deleteElementById(testContext, ADMIN_USER, vulnerability.id, ENTITY_TYPE_VULNERABILITY);
+    await deleteElementById(testContext, ADMIN_USER, intrusionSet.id, ENTITY_TYPE_INTRUSION_SET);
+  });
+
+  it('should throw a FunctionalError when no security coverage result is found for the given id', async () => {
+    const fakeId = 'security-coverage-result--00000000-0000-0000-0000-000000000000';
+    await expect(addRelatedCoveredEntities(testContext, ADMIN_USER, fakeId))
+      .rejects.toThrow(`No security coverage result found for the id ${fakeId}`);
+  });
+
+  it('should throw a FunctionalError when the covered entity no longer exists', async () => {
+    const report = await addReport(testContext, ADMIN_USER, {
+      name: 'Report to delete for addRelatedCoveredEntities test',
+      published: '2026-01-01T00:00:00.000Z',
+    });
+
+    securityCoverage = await addSecurityCoverage(testContext, ADMIN_USER, {
+      name: 'SC dangling covered test',
+      objectCovered: report.standard_id,
+      auto_enrichment_disable: true,
+    });
+    const result = await addSecurityCoverageResult(testContext, ADMIN_USER, { resultOf: securityCoverage.id });
+
+    await reportDeleteWithElements(testContext, ADMIN_USER, report.standard_id);
+
+    await expect(addRelatedCoveredEntities(testContext, ADMIN_USER, result.id))
+      .rejects.toThrow('No covered entity found for the id undefined');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
@@ -42,7 +42,6 @@ describe('SecurityCoverage resolver', () => {
     });
 
     const securityCoverageData = securityCoverage.data?.securityCoverageAdd;
-    console.log(securityCoverageData);
     expect(securityCoverageData).toBeDefined();
     expect(securityCoverageData.name).toEqual('SC name');
     expect(securityCoverageData.coverage_last_result.toISOString()).toEqual('2023-08-06T11:39:36.949Z');

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
@@ -42,12 +42,12 @@ describe('SecurityCoverage resolver', () => {
     });
 
     const securityCoverageData = securityCoverage.data?.securityCoverageAdd;
+    console.log(securityCoverageData);
     expect(securityCoverageData).toBeDefined();
     expect(securityCoverageData.name).toEqual('SC name');
     expect(securityCoverageData.coverage_last_result.toISOString()).toEqual('2023-08-06T11:39:36.949Z');
     expect(securityCoverageData.coverage_valid_from.toISOString()).toEqual('2023-07-06T11:39:36.949Z');
     expect(securityCoverageData.coverage_valid_to.toISOString()).toEqual('2023-12-06T11:39:36.949Z');
-    expect(securityCoverageData.external_uri).toEqual('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
     expect(securityCoverageData.coverage_information[0].coverage_name).toEqual('prevention');
     expect(securityCoverageData.coverage_information[0].coverage_score).toEqual(10);
   });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverageResult-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverageResult-test.ts
@@ -118,7 +118,7 @@ describe('SecurityCoverageResult resolver', () => {
 
     const securityCoverageResultsData = securityCoverageResults.data?.securityCoverageResults;
     expect(securityCoverageResultsData).toBeDefined();
-    expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(2);
+    expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(3); // 1 from DATA-STIX-V2, 1 from securityCoverage-test.ts, 1 from previous test
     const uris = securityCoverageResultsData.edges.map((e: any) => e.node.external_uri);
     expect(uris).toContain('http://localhost/admin/scenarios/a2166709-be41-48bf-9ce1-51bb2fd3a175');
     expect(uris).toContain('http://localhost/admin/scenarios/d49dd003-3498-441f-96a8-a533067b1322');
@@ -155,7 +155,7 @@ describe('SecurityCoverageResult resolver', () => {
 
     const deletedId = result.data?.securityCoverageResultDelete;
     const securityCoverageResultsData = securityCoverageResults.data?.securityCoverageResults;
-    expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(1);
+    expect(securityCoverageResultsData.pageInfo.globalCount).toEqual(2);
     expect(deletedId).toEqual(createdScrId);
   });
 });


### PR DESCRIPTION
### Proposed changes

* Creates automatically has-covered relationships on manual creation of SC
* For containers: adds contained entities
* For others: adds entities with relationship `targets` or `uses`

### Related issues

* #14716
* closes

### How to test this PR

Create a SC from a Report containing Attack Patterns and Vulnerabilities
Create a SC from a Campaign targeting Vulnerabilities and using Attack Patterns

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality