### PR TITLE
feat(merge-users): feature flag, API surface and Bypass enforcement (#17493)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9655,15 +9655,6 @@ type Query {
   dataSanityOperations: [DataSanityOperation!]!
   dataSanityExecutions: [DataSanityExecution!]!
   dataSanityOperationDryRun(operation_name: String!): DataSanityDryRunOutput!
-
-  """
-  Execution journal of the merges. Reading it is how a run stays observable once the HTTP
-  connection is gone: the connection dying does not stop the merge, so the journal is the
-  only way to tell a dead connection from a failed merge.
-  
-  mergeId is optional on purpose — an operator who lost the connection also lost the id
-  returned by the mutation, so requiring it would defeat the point of the query.
-  """
   userMergeJournal(mergeId: ID, first: Int): [UserMergeJournalEntry!]!
   customFieldDefinition(id: String!): CustomFieldDefinition
   customFieldDefinitions(first: Int, after: ID, orderBy: CustomFieldDefinitionsOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): CustomFieldDefinitionConnection
@@ -10634,11 +10625,6 @@ type Mutation {
   retentionRuleEdit(id: ID!): RetentionRuleEditMutations
   dataSanityOperationRequestRun(operation_name: String!): ID
   dataSanityOperationStop(operation_name: String!): ID
-
-  """
-  Merges the source user into the target user. Runs synchronously and returns the result;
-  follow userMergeJournal to observe a run whose connection was cut.
-  """
   userMerge(sourceId: ID!, targetId: ID!, options: UserMergeOptions): UserMergeResult!
   customFieldDefinitionAdd(input: CustomFieldDefinitionAddInput!): CustomFieldDefinition
   customFieldDefinitionDelete(id: ID!): ID
@@ -17067,10 +17053,7 @@ type DataSanityDryRunOutput {
 }
 
 enum UserMergeRightsStrategy {
-  """Rights of the target are left untouched."""
   STRICT
-
-  """Rights of the source are added to those of the target."""
   UNION
 }
 
@@ -17081,21 +17064,10 @@ enum UserMergeStatus {
 }
 
 input UserMergeOptions {
-  """
-  Suppresses every write on a single execution path — it is not a separate estimation
-  endpoint. Defaults to true so that calling the mutation without options can never
-  rewrite data.
-  """
   dryRun: Boolean = true
-
-  """Defaults to the non-widening strategy."""
   rightsStrategy: UserMergeRightsStrategy = STRICT
 }
 
-"""
-Outcome of one merge execution. The shape is identical in dry and real mode, which is what
-makes "dry-run == real impact" verifiable from the API alone.
-"""
 type UserMergeResult {
   id: ID!
   source_id: ID!
@@ -17108,9 +17080,6 @@ type UserMergeResult {
   message: String
 }
 
-"""
-One entry of the execution journal, written per handler as the merge progresses.
-"""
 type UserMergeJournalEntry {
   id: ID!
   merge_id: ID!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9655,6 +9655,16 @@ type Query {
   dataSanityOperations: [DataSanityOperation!]!
   dataSanityExecutions: [DataSanityExecution!]!
   dataSanityOperationDryRun(operation_name: String!): DataSanityDryRunOutput!
+
+  """
+  Execution journal of the merges. Reading it is how a run stays observable once the HTTP
+  connection is gone: the connection dying does not stop the merge, so the journal is the
+  only way to tell a dead connection from a failed merge.
+  
+  mergeId is optional on purpose — an operator who lost the connection also lost the id
+  returned by the mutation, so requiring it would defeat the point of the query.
+  """
+  userMergeJournal(mergeId: ID, first: Int): [UserMergeJournalEntry!]!
   customFieldDefinition(id: String!): CustomFieldDefinition
   customFieldDefinitions(first: Int, after: ID, orderBy: CustomFieldDefinitionsOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): CustomFieldDefinitionConnection
   customFieldDefinitionsForEntityType(entityType: String!): CustomFieldDefinitionConnection
@@ -10624,6 +10634,12 @@ type Mutation {
   retentionRuleEdit(id: ID!): RetentionRuleEditMutations
   dataSanityOperationRequestRun(operation_name: String!): ID
   dataSanityOperationStop(operation_name: String!): ID
+
+  """
+  Merges the source user into the target user. Runs synchronously and returns the result;
+  follow userMergeJournal to observe a run whose connection was cut.
+  """
+  userMerge(sourceId: ID!, targetId: ID!, options: UserMergeOptions): UserMergeResult!
   customFieldDefinitionAdd(input: CustomFieldDefinitionAddInput!): CustomFieldDefinition
   customFieldDefinitionDelete(id: ID!): ID
   customFieldDefinitionFieldPatch(id: ID!, input: [EditInput!]!): CustomFieldDefinition
@@ -17048,6 +17064,64 @@ type DataSanityImpactedElement {
 
 type DataSanityDryRunOutput {
   estimated_impact: [DataSanityImpactedElement!]!
+}
+
+enum UserMergeRightsStrategy {
+  """Rights of the target are left untouched."""
+  STRICT
+
+  """Rights of the source are added to those of the target."""
+  UNION
+}
+
+enum UserMergeStatus {
+  RUNNING
+  SUCCESS
+  FAILED
+}
+
+input UserMergeOptions {
+  """
+  Suppresses every write on a single execution path — it is not a separate estimation
+  endpoint. Defaults to true so that calling the mutation without options can never
+  rewrite data.
+  """
+  dryRun: Boolean = true
+
+  """Defaults to the non-widening strategy."""
+  rightsStrategy: UserMergeRightsStrategy = STRICT
+}
+
+"""
+Outcome of one merge execution. The shape is identical in dry and real mode, which is what
+makes "dry-run == real impact" verifiable from the API alone.
+"""
+type UserMergeResult {
+  id: ID!
+  source_id: ID!
+  target_id: ID!
+  dry_run: Boolean!
+  rights_strategy: UserMergeRightsStrategy!
+  status: UserMergeStatus!
+  started_at: DateTime!
+  completed_at: DateTime
+  message: String
+}
+
+"""
+One entry of the execution journal, written per handler as the merge progresses.
+"""
+type UserMergeJournalEntry {
+  id: ID!
+  merge_id: ID!
+  source_id: ID!
+  target_id: ID!
+  handler: String!
+  dry_run: Boolean!
+  status: UserMergeStatus!
+  started_at: DateTime!
+  completed_at: DateTime
+  message: String
 }
 
 type CustomFieldValue {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9824,6 +9824,16 @@ type Query {
   dataSanityOperations: [DataSanityOperation!]!
   dataSanityExecutions: [DataSanityExecution!]!
   dataSanityOperationDryRun(operation_name: String!): DataSanityDryRunOutput!
+
+  """
+  Execution journal of the merges. Reading it is how a run stays observable once the HTTP
+  connection is gone: the connection dying does not stop the merge, so the journal is the
+  only way to tell a dead connection from a failed merge.
+  
+  mergeId is optional on purpose — an operator who lost the connection also lost the id
+  returned by the mutation, so requiring it would defeat the point of the query.
+  """
+  userMergeJournal(mergeId: ID, first: Int): [UserMergeJournalEntry!]!
   customFieldDefinition(id: String!): CustomFieldDefinition
   customFieldDefinitions(first: Int, after: ID, orderBy: CustomFieldDefinitionsOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): CustomFieldDefinitionConnection
 }
@@ -10799,6 +10809,12 @@ type Mutation {
   retentionRuleEdit(id: ID!): RetentionRuleEditMutations
   dataSanityOperationRequestRun(operation_name: String!): ID
   dataSanityOperationStop(operation_name: String!): ID
+
+  """
+  Merges the source user into the target user. Runs synchronously and returns the result;
+  follow userMergeJournal to observe a run whose connection was cut.
+  """
+  userMerge(sourceId: ID!, targetId: ID!, options: UserMergeOptions): UserMergeResult!
   customFieldDefinitionAdd(input: CustomFieldDefinitionAddInput!): CustomFieldDefinition
   customFieldDefinitionDelete(id: ID!): ID
   customFieldDefinitionFieldPatch(id: ID!, input: [EditInput!]!): CustomFieldDefinition
@@ -16970,6 +16986,64 @@ type DataSanityImpactedElement {
 
 type DataSanityDryRunOutput {
   estimated_impact: [DataSanityImpactedElement!]!
+}
+
+enum UserMergeRightsStrategy {
+  """Rights of the target are left untouched."""
+  STRICT
+
+  """Rights of the source are added to those of the target."""
+  UNION
+}
+
+enum UserMergeStatus {
+  RUNNING
+  SUCCESS
+  FAILED
+}
+
+input UserMergeOptions {
+  """
+  Suppresses every write on a single execution path — it is not a separate estimation
+  endpoint. Defaults to true so that calling the mutation without options can never
+  rewrite data.
+  """
+  dryRun: Boolean = true
+
+  """Defaults to the non-widening strategy."""
+  rightsStrategy: UserMergeRightsStrategy = STRICT
+}
+
+"""
+Outcome of one merge execution. The shape is identical in dry and real mode, which is what
+makes "dry-run == real impact" verifiable from the API alone.
+"""
+type UserMergeResult {
+  id: ID!
+  source_id: ID!
+  target_id: ID!
+  dry_run: Boolean!
+  rights_strategy: UserMergeRightsStrategy!
+  status: UserMergeStatus!
+  started_at: DateTime!
+  completed_at: DateTime
+  message: String
+}
+
+"""
+One entry of the execution journal, written per handler as the merge progresses.
+"""
+type UserMergeJournalEntry {
+  id: ID!
+  merge_id: ID!
+  source_id: ID!
+  target_id: ID!
+  handler: String!
+  dry_run: Boolean!
+  status: UserMergeStatus!
+  started_at: DateTime!
+  completed_at: DateTime
+  message: String
 }
 
 type CustomFieldValue {

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9824,15 +9824,6 @@ type Query {
   dataSanityOperations: [DataSanityOperation!]!
   dataSanityExecutions: [DataSanityExecution!]!
   dataSanityOperationDryRun(operation_name: String!): DataSanityDryRunOutput!
-
-  """
-  Execution journal of the merges. Reading it is how a run stays observable once the HTTP
-  connection is gone: the connection dying does not stop the merge, so the journal is the
-  only way to tell a dead connection from a failed merge.
-  
-  mergeId is optional on purpose — an operator who lost the connection also lost the id
-  returned by the mutation, so requiring it would defeat the point of the query.
-  """
   userMergeJournal(mergeId: ID, first: Int): [UserMergeJournalEntry!]!
   customFieldDefinition(id: String!): CustomFieldDefinition
   customFieldDefinitions(first: Int, after: ID, orderBy: CustomFieldDefinitionsOrdering, orderMode: OrderingMode, search: String, filters: FilterGroup): CustomFieldDefinitionConnection
@@ -10809,11 +10800,6 @@ type Mutation {
   retentionRuleEdit(id: ID!): RetentionRuleEditMutations
   dataSanityOperationRequestRun(operation_name: String!): ID
   dataSanityOperationStop(operation_name: String!): ID
-
-  """
-  Merges the source user into the target user. Runs synchronously and returns the result;
-  follow userMergeJournal to observe a run whose connection was cut.
-  """
   userMerge(sourceId: ID!, targetId: ID!, options: UserMergeOptions): UserMergeResult!
   customFieldDefinitionAdd(input: CustomFieldDefinitionAddInput!): CustomFieldDefinition
   customFieldDefinitionDelete(id: ID!): ID
@@ -16989,10 +16975,7 @@ type DataSanityDryRunOutput {
 }
 
 enum UserMergeRightsStrategy {
-  """Rights of the target are left untouched."""
   STRICT
-
-  """Rights of the source are added to those of the target."""
   UNION
 }
 
@@ -17003,21 +16986,10 @@ enum UserMergeStatus {
 }
 
 input UserMergeOptions {
-  """
-  Suppresses every write on a single execution path — it is not a separate estimation
-  endpoint. Defaults to true so that calling the mutation without options can never
-  rewrite data.
-  """
   dryRun: Boolean = true
-
-  """Defaults to the non-widening strategy."""
   rightsStrategy: UserMergeRightsStrategy = STRICT
 }
 
-"""
-Outcome of one merge execution. The shape is identical in dry and real mode, which is what
-makes "dry-run == real impact" verifiable from the API alone.
-"""
 type UserMergeResult {
   id: ID!
   source_id: ID!
@@ -17030,9 +17002,6 @@ type UserMergeResult {
   message: String
 }
 
-"""
-One entry of the execution journal, written per handler as the merge progresses.
-"""
 type UserMergeJournalEntry {
   id: ID!
   merge_id: ID!

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -595,6 +595,9 @@ export const isFeatureEnabled = (feature) => ENABLED_FEATURE_FLAGS.includes(FEAT
 // Custom fields feature flag (use isFeatureEnabled(CUSTOM_FIELDS_FEATURE_FLAG) to check activation)
 export const CUSTOM_FIELDS_FEATURE_FLAG = 'CUSTOM_FIELDS';
 
+// User merge feature flag (use isFeatureEnabled(MERGE_USERS_FEATURE_FLAG) to check activation)
+export const MERGE_USERS_FEATURE_FLAG = 'MERGE_USERS';
+
 export const REDIS_PREFIX = nconf.get('redis:namespace') ? `${nconf.get('redis:namespace')}:` : '';
 export const TOPIC_PREFIX = `${REDIS_PREFIX}_OPENCTI_DATA_`;
 export const TOPIC_CONTEXT_PREFIX = `${REDIS_PREFIX}_OPENCTI_CONTEXT_`;

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -595,6 +595,8 @@ export const isFeatureEnabled = (feature) => ENABLED_FEATURE_FLAGS.includes(FEAT
 // Custom fields feature flag (use isFeatureEnabled(CUSTOM_FIELDS_FEATURE_FLAG) to check activation)
 export const CUSTOM_FIELDS_FEATURE_FLAG = 'CUSTOM_FIELDS';
 
+// User merge feature flag (use isFeatureEnabled(MERGE_USERS_FEATURE_FLAG) to check activation)
+export const MERGE_USERS_FEATURE_FLAG = 'MERGE_USERS';
 export const REDIS_PREFIX = nconf.get('redis:namespace') ? `${nconf.get('redis:namespace')}:` : '';
 export const TOPIC_PREFIX = `${REDIS_PREFIX}_OPENCTI_DATA_`;
 export const TOPIC_CONTEXT_PREFIX = `${REDIS_PREFIX}_OPENCTI_CONTEXT_`;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17676,10 +17676,6 @@ export type Mutation = {
   userAdminTokenAdd: TokenGenerated;
   userAdminTokenRevoke?: Maybe<Scalars['ID']['output']>;
   userEdit?: Maybe<UserEditMutations>;
-  /**
-   * Merges the source user into the target user. Runs synchronously and returns the result;
-   * follow userMergeJournal to observe a run whose connection was cut.
-   */
   userMerge: UserMergeResult;
   userNoteAdd?: Maybe<Note>;
   userOpinionAdd?: Maybe<Opinion>;
@@ -25068,14 +25064,6 @@ export type Query = {
   unknownStixCoreObjects: Array<Scalars['String']['output']>;
   user?: Maybe<User>;
   userAlreadyExists?: Maybe<Scalars['Boolean']['output']>;
-  /**
-   * Execution journal of the merges. Reading it is how a run stays observable once the HTTP
-   * connection is gone: the connection dying does not stop the merge, so the journal is the
-   * only way to tell a dead connection from a failed merge.
-   *
-   * mergeId is optional on purpose — an operator who lost the connection also lost the id
-   * returned by the mutation, so requiring it would defeat the point of the query.
-   */
   userMergeJournal: Array<UserMergeJournalEntry>;
   users?: Maybe<UserConnection>;
   vocabularies?: Maybe<VocabularyConnection>;
@@ -37297,7 +37285,6 @@ export type UserLoginInput = {
   password: Scalars['String']['input'];
 };
 
-/** One entry of the execution journal, written per handler as the merge progresses. */
 export type UserMergeJournalEntry = {
   __typename?: 'UserMergeJournalEntry';
   completed_at?: Maybe<Scalars['DateTime']['output']>;
@@ -37313,20 +37300,10 @@ export type UserMergeJournalEntry = {
 };
 
 export type UserMergeOptions = {
-  /**
-   * Suppresses every write on a single execution path — it is not a separate estimation
-   * endpoint. Defaults to true so that calling the mutation without options can never
-   * rewrite data.
-   */
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Defaults to the non-widening strategy. */
   rightsStrategy?: InputMaybe<UserMergeRightsStrategy>;
 };
 
-/**
- * Outcome of one merge execution. The shape is identical in dry and real mode, which is what
- * makes "dry-run == real impact" verifiable from the API alone.
- */
 export type UserMergeResult = {
   __typename?: 'UserMergeResult';
   completed_at?: Maybe<Scalars['DateTime']['output']>;
@@ -37341,9 +37318,7 @@ export type UserMergeResult = {
 };
 
 export enum UserMergeRightsStrategy {
-  /** Rights of the target are left untouched. */
   Strict = 'STRICT',
-  /** Rights of the source are added to those of the target. */
   Union = 'UNION'
 }
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17676,6 +17676,11 @@ export type Mutation = {
   userAdminTokenAdd: TokenGenerated;
   userAdminTokenRevoke?: Maybe<Scalars['ID']['output']>;
   userEdit?: Maybe<UserEditMutations>;
+  /**
+   * Merges the source user into the target user. Runs synchronously and returns the result;
+   * follow userMergeJournal to observe a run whose connection was cut.
+   */
+  userMerge: UserMergeResult;
   userNoteAdd?: Maybe<Note>;
   userOpinionAdd?: Maybe<Opinion>;
   userSessionsKill?: Maybe<Array<Maybe<Scalars['ID']['output']>>>;
@@ -20336,6 +20341,13 @@ export type MutationUserAdminTokenRevokeArgs = {
 
 export type MutationUserEditArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationUserMergeArgs = {
+  options?: InputMaybe<UserMergeOptions>;
+  sourceId: Scalars['ID']['input'];
+  targetId: Scalars['ID']['input'];
 };
 
 
@@ -25056,6 +25068,15 @@ export type Query = {
   unknownStixCoreObjects: Array<Scalars['String']['output']>;
   user?: Maybe<User>;
   userAlreadyExists?: Maybe<Scalars['Boolean']['output']>;
+  /**
+   * Execution journal of the merges. Reading it is how a run stays observable once the HTTP
+   * connection is gone: the connection dying does not stop the merge, so the journal is the
+   * only way to tell a dead connection from a failed merge.
+   *
+   * mergeId is optional on purpose — an operator who lost the connection also lost the id
+   * returned by the mutation, so requiring it would defeat the point of the query.
+   */
+  userMergeJournal: Array<UserMergeJournalEntry>;
   users?: Maybe<UserConnection>;
   vocabularies?: Maybe<VocabularyConnection>;
   vocabulary?: Maybe<Vocabulary>;
@@ -28185,6 +28206,12 @@ export type QueryUserArgs = {
 
 export type QueryUserAlreadyExistsArgs = {
   name: Scalars['String']['input'];
+};
+
+
+export type QueryUserMergeJournalArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  mergeId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -37270,6 +37297,62 @@ export type UserLoginInput = {
   password: Scalars['String']['input'];
 };
 
+/** One entry of the execution journal, written per handler as the merge progresses. */
+export type UserMergeJournalEntry = {
+  __typename?: 'UserMergeJournalEntry';
+  completed_at?: Maybe<Scalars['DateTime']['output']>;
+  dry_run: Scalars['Boolean']['output'];
+  handler: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  merge_id: Scalars['ID']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  source_id: Scalars['ID']['output'];
+  started_at: Scalars['DateTime']['output'];
+  status: UserMergeStatus;
+  target_id: Scalars['ID']['output'];
+};
+
+export type UserMergeOptions = {
+  /**
+   * Suppresses every write on a single execution path — it is not a separate estimation
+   * endpoint. Defaults to true so that calling the mutation without options can never
+   * rewrite data.
+   */
+  dryRun?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Defaults to the non-widening strategy. */
+  rightsStrategy?: InputMaybe<UserMergeRightsStrategy>;
+};
+
+/**
+ * Outcome of one merge execution. The shape is identical in dry and real mode, which is what
+ * makes "dry-run == real impact" verifiable from the API alone.
+ */
+export type UserMergeResult = {
+  __typename?: 'UserMergeResult';
+  completed_at?: Maybe<Scalars['DateTime']['output']>;
+  dry_run: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  rights_strategy: UserMergeRightsStrategy;
+  source_id: Scalars['ID']['output'];
+  started_at: Scalars['DateTime']['output'];
+  status: UserMergeStatus;
+  target_id: Scalars['ID']['output'];
+};
+
+export enum UserMergeRightsStrategy {
+  /** Rights of the target are left untouched. */
+  Strict = 'STRICT',
+  /** Rights of the source are added to those of the target. */
+  Union = 'UNION'
+}
+
+export enum UserMergeStatus {
+  Failed = 'FAILED',
+  Running = 'RUNNING',
+  Success = 'SUCCESS'
+}
+
 export type UserOtpActivationInput = {
   code: Scalars['String']['input'];
   secret: Scalars['String']['input'];
@@ -40936,6 +41019,11 @@ export type ResolversTypes = ResolversObject<{
   UserInfoMapping: ResolverTypeWrapper<UserInfoMapping>;
   UserInfoMappingInput: UserInfoMappingInput;
   UserLoginInput: UserLoginInput;
+  UserMergeJournalEntry: ResolverTypeWrapper<UserMergeJournalEntry>;
+  UserMergeOptions: UserMergeOptions;
+  UserMergeResult: ResolverTypeWrapper<UserMergeResult>;
+  UserMergeRightsStrategy: UserMergeRightsStrategy;
+  UserMergeStatus: UserMergeStatus;
   UserOTPActivationInput: UserOtpActivationInput;
   UserOTPLoginInput: UserOtpLoginInput;
   UserSession: ResolverTypeWrapper<UserSession>;
@@ -41942,6 +42030,9 @@ export type ResolversParentTypes = ResolversObject<{
   UserInfoMapping: UserInfoMapping;
   UserInfoMappingInput: UserInfoMappingInput;
   UserLoginInput: UserLoginInput;
+  UserMergeJournalEntry: UserMergeJournalEntry;
+  UserMergeOptions: UserMergeOptions;
+  UserMergeResult: UserMergeResult;
   UserOTPActivationInput: UserOtpActivationInput;
   UserOTPLoginInput: UserOtpLoginInput;
   UserSession: UserSession;
@@ -48405,6 +48496,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   userAdminTokenAdd?: Resolver<ResolversTypes['TokenGenerated'], ParentType, ContextType, RequireFields<MutationUserAdminTokenAddArgs, 'input' | 'userId'>>;
   userAdminTokenRevoke?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationUserAdminTokenRevokeArgs, 'id' | 'userId'>>;
   userEdit?: Resolver<Maybe<ResolversTypes['UserEditMutations']>, ParentType, ContextType, RequireFields<MutationUserEditArgs, 'id'>>;
+  userMerge?: Resolver<ResolversTypes['UserMergeResult'], ParentType, ContextType, RequireFields<MutationUserMergeArgs, 'sourceId' | 'targetId'>>;
   userNoteAdd?: Resolver<Maybe<ResolversTypes['Note']>, ParentType, ContextType, RequireFields<MutationUserNoteAddArgs, 'input'>>;
   userOpinionAdd?: Resolver<Maybe<ResolversTypes['Opinion']>, ParentType, ContextType, RequireFields<MutationUserOpinionAddArgs, 'input'>>;
   userSessionsKill?: Resolver<Maybe<Array<Maybe<ResolversTypes['ID']>>>, ParentType, ContextType, RequireFields<MutationUserSessionsKillArgs, 'id'>>;
@@ -50249,6 +50341,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   unknownStixCoreObjects?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QueryUnknownStixCoreObjectsArgs, 'values'>>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
   userAlreadyExists?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryUserAlreadyExistsArgs, 'name'>>;
+  userMergeJournal?: Resolver<Array<ResolversTypes['UserMergeJournalEntry']>, ParentType, ContextType, Partial<QueryUserMergeJournalArgs>>;
   users?: Resolver<Maybe<ResolversTypes['UserConnection']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
   vocabularies?: Resolver<Maybe<ResolversTypes['VocabularyConnection']>, ParentType, ContextType, Partial<QueryVocabulariesArgs>>;
   vocabulary?: Resolver<Maybe<ResolversTypes['Vocabulary']>, ParentType, ContextType, RequireFields<QueryVocabularyArgs, 'id'>>;
@@ -53235,6 +53328,31 @@ export type UserInfoMappingResolvers<ContextType = any, ParentType extends Resol
   name_expr?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
+export type UserMergeJournalEntryResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserMergeJournalEntry'] = ResolversParentTypes['UserMergeJournalEntry']> = ResolversObject<{
+  completed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  dry_run?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  handler?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  merge_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  started_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['UserMergeStatus'], ParentType, ContextType>;
+  target_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type UserMergeResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserMergeResult'] = ResolversParentTypes['UserMergeResult']> = ResolversObject<{
+  completed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  dry_run?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  rights_strategy?: Resolver<ResolversTypes['UserMergeRightsStrategy'], ParentType, ContextType>;
+  source_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  started_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['UserMergeStatus'], ParentType, ContextType>;
+  target_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
 export type UserSessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserSession'] = ResolversParentTypes['UserSession']> = ResolversObject<{
   sessions?: Resolver<Maybe<Array<Maybe<ResolversTypes['SessionDetail']>>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['Creator']>, ParentType, ContextType>;
@@ -54576,6 +54694,8 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   UserEdge?: UserEdgeResolvers<ContextType>;
   UserEditMutations?: UserEditMutationsResolvers<ContextType>;
   UserInfoMapping?: UserInfoMappingResolvers<ContextType>;
+  UserMergeJournalEntry?: UserMergeJournalEntryResolvers<ContextType>;
+  UserMergeResult?: UserMergeResultResolvers<ContextType>;
   UserSession?: UserSessionResolvers<ContextType>;
   UserStatus?: UserStatusResolvers<ContextType>;
   VerifyOtp?: VerifyOtpResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17624,10 +17624,6 @@ export type Mutation = {
   userAdminTokenAdd: TokenGenerated;
   userAdminTokenRevoke?: Maybe<Scalars['ID']['output']>;
   userEdit?: Maybe<UserEditMutations>;
-  /**
-   * Merges the source user into the target user. Runs synchronously and returns the result;
-   * follow userMergeJournal to observe a run whose connection was cut.
-   */
   userMerge: UserMergeResult;
   userNoteAdd?: Maybe<Note>;
   userOpinionAdd?: Maybe<Opinion>;
@@ -25007,14 +25003,6 @@ export type Query = {
   unknownStixCoreObjects: Array<Scalars['String']['output']>;
   user?: Maybe<User>;
   userAlreadyExists?: Maybe<Scalars['Boolean']['output']>;
-  /**
-   * Execution journal of the merges. Reading it is how a run stays observable once the HTTP
-   * connection is gone: the connection dying does not stop the merge, so the journal is the
-   * only way to tell a dead connection from a failed merge.
-   *
-   * mergeId is optional on purpose — an operator who lost the connection also lost the id
-   * returned by the mutation, so requiring it would defeat the point of the query.
-   */
   userMergeJournal: Array<UserMergeJournalEntry>;
   users?: Maybe<UserConnection>;
   vocabularies?: Maybe<VocabularyConnection>;
@@ -37202,7 +37190,6 @@ export type UserLoginInput = {
   password: Scalars['String']['input'];
 };
 
-/** One entry of the execution journal, written per handler as the merge progresses. */
 export type UserMergeJournalEntry = {
   __typename?: 'UserMergeJournalEntry';
   completed_at?: Maybe<Scalars['DateTime']['output']>;
@@ -37218,20 +37205,10 @@ export type UserMergeJournalEntry = {
 };
 
 export type UserMergeOptions = {
-  /**
-   * Suppresses every write on a single execution path — it is not a separate estimation
-   * endpoint. Defaults to true so that calling the mutation without options can never
-   * rewrite data.
-   */
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Defaults to the non-widening strategy. */
   rightsStrategy?: InputMaybe<UserMergeRightsStrategy>;
 };
 
-/**
- * Outcome of one merge execution. The shape is identical in dry and real mode, which is what
- * makes "dry-run == real impact" verifiable from the API alone.
- */
 export type UserMergeResult = {
   __typename?: 'UserMergeResult';
   completed_at?: Maybe<Scalars['DateTime']['output']>;
@@ -37246,9 +37223,7 @@ export type UserMergeResult = {
 };
 
 export enum UserMergeRightsStrategy {
-  /** Rights of the target are left untouched. */
   Strict = 'STRICT',
-  /** Rights of the source are added to those of the target. */
   Union = 'UNION'
 }
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -17624,6 +17624,11 @@ export type Mutation = {
   userAdminTokenAdd: TokenGenerated;
   userAdminTokenRevoke?: Maybe<Scalars['ID']['output']>;
   userEdit?: Maybe<UserEditMutations>;
+  /**
+   * Merges the source user into the target user. Runs synchronously and returns the result;
+   * follow userMergeJournal to observe a run whose connection was cut.
+   */
+  userMerge: UserMergeResult;
   userNoteAdd?: Maybe<Note>;
   userOpinionAdd?: Maybe<Opinion>;
   userSessionsKill?: Maybe<Array<Maybe<Scalars['ID']['output']>>>;
@@ -20284,6 +20289,13 @@ export type MutationUserAdminTokenRevokeArgs = {
 
 export type MutationUserEditArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type MutationUserMergeArgs = {
+  options?: InputMaybe<UserMergeOptions>;
+  sourceId: Scalars['ID']['input'];
+  targetId: Scalars['ID']['input'];
 };
 
 
@@ -24995,6 +25007,15 @@ export type Query = {
   unknownStixCoreObjects: Array<Scalars['String']['output']>;
   user?: Maybe<User>;
   userAlreadyExists?: Maybe<Scalars['Boolean']['output']>;
+  /**
+   * Execution journal of the merges. Reading it is how a run stays observable once the HTTP
+   * connection is gone: the connection dying does not stop the merge, so the journal is the
+   * only way to tell a dead connection from a failed merge.
+   *
+   * mergeId is optional on purpose — an operator who lost the connection also lost the id
+   * returned by the mutation, so requiring it would defeat the point of the query.
+   */
+  userMergeJournal: Array<UserMergeJournalEntry>;
   users?: Maybe<UserConnection>;
   vocabularies?: Maybe<VocabularyConnection>;
   vocabulary?: Maybe<Vocabulary>;
@@ -28119,6 +28140,12 @@ export type QueryUserArgs = {
 
 export type QueryUserAlreadyExistsArgs = {
   name: Scalars['String']['input'];
+};
+
+
+export type QueryUserMergeJournalArgs = {
+  first?: InputMaybe<Scalars['Int']['input']>;
+  mergeId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -37175,6 +37202,62 @@ export type UserLoginInput = {
   password: Scalars['String']['input'];
 };
 
+/** One entry of the execution journal, written per handler as the merge progresses. */
+export type UserMergeJournalEntry = {
+  __typename?: 'UserMergeJournalEntry';
+  completed_at?: Maybe<Scalars['DateTime']['output']>;
+  dry_run: Scalars['Boolean']['output'];
+  handler: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  merge_id: Scalars['ID']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  source_id: Scalars['ID']['output'];
+  started_at: Scalars['DateTime']['output'];
+  status: UserMergeStatus;
+  target_id: Scalars['ID']['output'];
+};
+
+export type UserMergeOptions = {
+  /**
+   * Suppresses every write on a single execution path — it is not a separate estimation
+   * endpoint. Defaults to true so that calling the mutation without options can never
+   * rewrite data.
+   */
+  dryRun?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Defaults to the non-widening strategy. */
+  rightsStrategy?: InputMaybe<UserMergeRightsStrategy>;
+};
+
+/**
+ * Outcome of one merge execution. The shape is identical in dry and real mode, which is what
+ * makes "dry-run == real impact" verifiable from the API alone.
+ */
+export type UserMergeResult = {
+  __typename?: 'UserMergeResult';
+  completed_at?: Maybe<Scalars['DateTime']['output']>;
+  dry_run: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  rights_strategy: UserMergeRightsStrategy;
+  source_id: Scalars['ID']['output'];
+  started_at: Scalars['DateTime']['output'];
+  status: UserMergeStatus;
+  target_id: Scalars['ID']['output'];
+};
+
+export enum UserMergeRightsStrategy {
+  /** Rights of the target are left untouched. */
+  Strict = 'STRICT',
+  /** Rights of the source are added to those of the target. */
+  Union = 'UNION'
+}
+
+export enum UserMergeStatus {
+  Failed = 'FAILED',
+  Running = 'RUNNING',
+  Success = 'SUCCESS'
+}
+
 export type UserOtpActivationInput = {
   code: Scalars['String']['input'];
   secret: Scalars['String']['input'];
@@ -40839,6 +40922,11 @@ export type ResolversTypes = ResolversObject<{
   UserInfoMapping: ResolverTypeWrapper<UserInfoMapping>;
   UserInfoMappingInput: UserInfoMappingInput;
   UserLoginInput: UserLoginInput;
+  UserMergeJournalEntry: ResolverTypeWrapper<UserMergeJournalEntry>;
+  UserMergeOptions: UserMergeOptions;
+  UserMergeResult: ResolverTypeWrapper<UserMergeResult>;
+  UserMergeRightsStrategy: UserMergeRightsStrategy;
+  UserMergeStatus: UserMergeStatus;
   UserOTPActivationInput: UserOtpActivationInput;
   UserOTPLoginInput: UserOtpLoginInput;
   UserSession: ResolverTypeWrapper<UserSession>;
@@ -41844,6 +41932,9 @@ export type ResolversParentTypes = ResolversObject<{
   UserInfoMapping: UserInfoMapping;
   UserInfoMappingInput: UserInfoMappingInput;
   UserLoginInput: UserLoginInput;
+  UserMergeJournalEntry: UserMergeJournalEntry;
+  UserMergeOptions: UserMergeOptions;
+  UserMergeResult: UserMergeResult;
   UserOTPActivationInput: UserOtpActivationInput;
   UserOTPLoginInput: UserOtpLoginInput;
   UserSession: UserSession;
@@ -48267,6 +48358,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   userAdminTokenAdd?: Resolver<ResolversTypes['TokenGenerated'], ParentType, ContextType, RequireFields<MutationUserAdminTokenAddArgs, 'input' | 'userId'>>;
   userAdminTokenRevoke?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationUserAdminTokenRevokeArgs, 'id' | 'userId'>>;
   userEdit?: Resolver<Maybe<ResolversTypes['UserEditMutations']>, ParentType, ContextType, RequireFields<MutationUserEditArgs, 'id'>>;
+  userMerge?: Resolver<ResolversTypes['UserMergeResult'], ParentType, ContextType, RequireFields<MutationUserMergeArgs, 'sourceId' | 'targetId'>>;
   userNoteAdd?: Resolver<Maybe<ResolversTypes['Note']>, ParentType, ContextType, RequireFields<MutationUserNoteAddArgs, 'input'>>;
   userOpinionAdd?: Resolver<Maybe<ResolversTypes['Opinion']>, ParentType, ContextType, RequireFields<MutationUserOpinionAddArgs, 'input'>>;
   userSessionsKill?: Resolver<Maybe<Array<Maybe<ResolversTypes['ID']>>>, ParentType, ContextType, RequireFields<MutationUserSessionsKillArgs, 'id'>>;
@@ -50104,6 +50196,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   unknownStixCoreObjects?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QueryUnknownStixCoreObjectsArgs, 'values'>>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
   userAlreadyExists?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<QueryUserAlreadyExistsArgs, 'name'>>;
+  userMergeJournal?: Resolver<Array<ResolversTypes['UserMergeJournalEntry']>, ParentType, ContextType, Partial<QueryUserMergeJournalArgs>>;
   users?: Resolver<Maybe<ResolversTypes['UserConnection']>, ParentType, ContextType, Partial<QueryUsersArgs>>;
   vocabularies?: Resolver<Maybe<ResolversTypes['VocabularyConnection']>, ParentType, ContextType, Partial<QueryVocabulariesArgs>>;
   vocabulary?: Resolver<Maybe<ResolversTypes['Vocabulary']>, ParentType, ContextType, RequireFields<QueryVocabularyArgs, 'id'>>;
@@ -53072,6 +53165,31 @@ export type UserInfoMappingResolvers<ContextType = any, ParentType extends Resol
   name_expr?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
+export type UserMergeJournalEntryResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserMergeJournalEntry'] = ResolversParentTypes['UserMergeJournalEntry']> = ResolversObject<{
+  completed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  dry_run?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  handler?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  merge_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  started_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['UserMergeStatus'], ParentType, ContextType>;
+  target_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
+export type UserMergeResultResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserMergeResult'] = ResolversParentTypes['UserMergeResult']> = ResolversObject<{
+  completed_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  dry_run?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  message?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  rights_strategy?: Resolver<ResolversTypes['UserMergeRightsStrategy'], ParentType, ContextType>;
+  source_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  started_at?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['UserMergeStatus'], ParentType, ContextType>;
+  target_id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+}>;
+
 export type UserSessionResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserSession'] = ResolversParentTypes['UserSession']> = ResolversObject<{
   sessions?: Resolver<Maybe<Array<Maybe<ResolversTypes['SessionDetail']>>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['Creator']>, ParentType, ContextType>;
@@ -54411,6 +54529,8 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   UserEdge?: UserEdgeResolvers<ContextType>;
   UserEditMutations?: UserEditMutationsResolvers<ContextType>;
   UserInfoMapping?: UserInfoMappingResolvers<ContextType>;
+  UserMergeJournalEntry?: UserMergeJournalEntryResolvers<ContextType>;
+  UserMergeResult?: UserMergeResultResolvers<ContextType>;
   UserSession?: UserSessionResolvers<ContextType>;
   UserStatus?: UserStatusResolvers<ContextType>;
   VerifyOtp?: VerifyOtpResolvers<ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -170,6 +170,7 @@ import './dataSharing/feed-graphql';
 import './dataSharing/streamCollection-graphql';
 import './retentionRules/retentionRules-graphql';
 import './dataSanity/dataSanity-graphql';
+import './userMerge/userMerge-graphql';
 import './workflow/api/workflow-graphql';
 import './customField/custom-field-graphql';
 // endregion

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -169,6 +169,7 @@ import './dataSharing/feed-graphql';
 import './dataSharing/streamCollection-graphql';
 import './retentionRules/retentionRules-graphql';
 import './dataSanity/dataSanity-graphql';
+import './userMerge/userMerge-graphql';
 import './workflow/api/workflow-graphql';
 import './customField/custom-field-graphql';
 // endregion

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-domain.ts
@@ -85,6 +85,19 @@ export const userMerge = async (
   return executeUserMerge(sourceId, targetId, resolvedOptions);
 };
 
+// Bounds enforced here so that a future, real journal implementation cannot be abused
+// into a heavy read regardless of what a caller (GraphQL or otherwise) requests.
+const USER_MERGE_JOURNAL_DEFAULT_FIRST = 20;
+const USER_MERGE_JOURNAL_MIN_FIRST = 1;
+const USER_MERGE_JOURNAL_MAX_FIRST = 200;
+
+export const resolveUserMergeJournalFirst = (first?: number | null): number => {
+  if (first === undefined || first === null) {
+    return USER_MERGE_JOURNAL_DEFAULT_FIRST;
+  }
+  return Math.min(Math.max(first, USER_MERGE_JOURNAL_MIN_FIRST), USER_MERGE_JOURNAL_MAX_FIRST);
+};
+
 export const userMergeJournal = async (
   _context: AuthContext,
   user: AuthUser,
@@ -92,5 +105,5 @@ export const userMergeJournal = async (
   first?: number | null,
 ): Promise<UserMergeJournalEntry[]> => {
   assertUserMergeAllowed(user);
-  return readUserMergeJournal(mergeId ?? undefined, first ?? undefined);
+  return readUserMergeJournal(mergeId ?? undefined, resolveUserMergeJournalFirst(first));
 };

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-domain.ts
@@ -1,0 +1,96 @@
+import { isFeatureEnabled, MERGE_USERS_FEATURE_FLAG } from '../../config/conf';
+import { ForbiddenAccess, FunctionalError, UnsupportedError } from '../../config/errors';
+import { storeLoadById } from '../../database/middleware-loader';
+import { ENTITY_TYPE_USER } from '../../schema/internalObject';
+import type { BasicStoreCommon } from '../../types/store';
+import type { AuthContext, AuthUser } from '../../types/user';
+import { INTERNAL_USERS, isBypassUser } from '../../utils/access';
+import { executeUserMerge, readUserMergeJournal } from './userMerge-engine';
+import { type UserMergeJournalEntry, type UserMergeOptions, type UserMergeResult, UserMergeRightsStrategy } from './userMerge-types';
+
+/**
+ * Options as they arrive from GraphQL: every field is optional there, because the schema
+ * carries the defaults. They are re-applied here so that a caller that is not the GraphQL
+ * layer cannot end up with an undefined dry-run flag.
+ */
+export interface UserMergeOptionsInput {
+  dryRun?: boolean | null;
+  rightsStrategy?: UserMergeRightsStrategy | null;
+}
+
+/**
+ * Defaults are the safe ones and are applied here rather than trusted from the caller:
+ * a merge invoked with no options must be a dry-run, and must not widen rights.
+ */
+export const resolveUserMergeOptions = (options?: UserMergeOptionsInput | null): UserMergeOptions => {
+  return {
+    dryRun: options?.dryRun ?? true,
+    rightsStrategy: options?.rightsStrategy ?? UserMergeRightsStrategy.Strict,
+  };
+};
+
+/**
+ * Input guard-rails that need no database access, kept separate so they can be unit-tested
+ * without a running platform.
+ */
+export const assertValidUserMergeIds = (sourceId: string, targetId: string): void => {
+  if (!sourceId || !targetId) {
+    throw FunctionalError('Source and target users are required to merge', { sourceId, targetId });
+  }
+  if (sourceId === targetId) {
+    throw FunctionalError('Cannot merge a user into itself', { sourceId, targetId });
+  }
+  // Internal users (SYSTEM, RETENTION MANAGER, …) are platform machinery, not accounts.
+  if (INTERNAL_USERS[sourceId] || INTERNAL_USERS[targetId]) {
+    throw FunctionalError('Cannot merge an internal platform user', { sourceId, targetId });
+  }
+};
+
+/**
+ * Security boundary of the feature, enforced in the domain in addition to the schema
+ * directives. The directives cover the GraphQL path; this covers any other caller.
+ *
+ * It throws. It never returns early on an unauthorized call — reporting a success-shaped
+ * result to a caller that was refused is the behaviour this feature is specified against.
+ */
+export const assertUserMergeAllowed = (user: AuthUser): void => {
+  if (!isFeatureEnabled(MERGE_USERS_FEATURE_FLAG)) {
+    throw UnsupportedError('Feature is disabled', { flag: MERGE_USERS_FEATURE_FLAG });
+  }
+  if (!isBypassUser(user)) {
+    throw ForbiddenAccess('Merging users requires the BYPASS capability', { user_id: user.id });
+  }
+};
+
+const loadMergeableUser = async (context: AuthContext, user: AuthUser, userId: string, role: 'source' | 'target') => {
+  const found = await storeLoadById<BasicStoreCommon>(context, user, userId, ENTITY_TYPE_USER);
+  if (!found) {
+    throw FunctionalError(`Unknown ${role} user`, { user_id: userId });
+  }
+  return found;
+};
+
+export const userMerge = async (
+  context: AuthContext,
+  user: AuthUser,
+  sourceId: string,
+  targetId: string,
+  options?: UserMergeOptionsInput | null,
+): Promise<UserMergeResult> => {
+  assertUserMergeAllowed(user);
+  assertValidUserMergeIds(sourceId, targetId);
+  await loadMergeableUser(context, user, sourceId, 'source');
+  await loadMergeableUser(context, user, targetId, 'target');
+  const resolvedOptions = resolveUserMergeOptions(options);
+  return executeUserMerge(sourceId, targetId, resolvedOptions);
+};
+
+export const userMergeJournal = async (
+  _context: AuthContext,
+  user: AuthUser,
+  mergeId?: string | null,
+  first?: number | null,
+): Promise<UserMergeJournalEntry[]> => {
+  assertUserMergeAllowed(user);
+  return readUserMergeJournal(mergeId ?? undefined, first ?? undefined);
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-engine.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-engine.ts
@@ -1,0 +1,55 @@
+import { v4 as uuidv4 } from 'uuid';
+import { logApp } from '../../config/conf';
+import { type UserMergeJournalEntry, type UserMergeOptions, type UserMergeResult, UserMergeStatus } from './userMerge-types';
+
+const LOG_PREFIX = '[MERGE_USERS]';
+
+/**
+ * Stubbed merge engine.
+ *
+ * PR1 ships the API surface only, so this executes nothing. PR2 replaces this file with the
+ * handler registry and the dry-run/run framework; the signature below is the one it must
+ * honour, so the resolver and the domain guard-rails do not move when it lands.
+ *
+ * The placeholder deliberately reports FAILED rather than SUCCESS. Reporting success for
+ * work that was never done is exactly the `cleanInconsistency` behaviour this feature is
+ * specified against — an unimplemented engine must be impossible to mistake for a merge
+ * that happened.
+ */
+export const executeUserMerge = async (
+  sourceId: string,
+  targetId: string,
+  options: UserMergeOptions,
+): Promise<UserMergeResult> => {
+  const startedAt = new Date();
+  logApp.warn(`${LOG_PREFIX} merge requested but the engine is not implemented yet, nothing was executed`, {
+    source_id: sourceId,
+    target_id: targetId,
+    dry_run: options.dryRun,
+    rights_strategy: options.rightsStrategy,
+  });
+  return {
+    id: uuidv4(),
+    source_id: sourceId,
+    target_id: targetId,
+    dry_run: options.dryRun,
+    rights_strategy: options.rightsStrategy,
+    status: UserMergeStatus.Failed,
+    started_at: startedAt,
+    completed_at: new Date(),
+    message: 'Merge engine not implemented: this build ships the API surface only (PR1). No data was modified.',
+  };
+};
+
+/**
+ * Reads the execution journal. The journal entity itself is created by PR2, so this returns
+ * an empty list for now — typed, so the query contract is reviewable and the frontend or an
+ * operator script can be written against it before the engine exists.
+ */
+export const readUserMergeJournal = async (
+  mergeId?: string,
+  first?: number,
+): Promise<UserMergeJournalEntry[]> => {
+  logApp.debug(`${LOG_PREFIX} journal read but the journal is not implemented yet`, { merge_id: mergeId, first });
+  return [];
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-graphql.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-graphql.ts
@@ -1,0 +1,8 @@
+import { registerGraphqlSchema } from '../../graphql/schema';
+import userMergeTypeDefs from './userMerge.graphql';
+import userMergeResolvers from './userMerge-resolvers';
+
+registerGraphqlSchema({
+  schema: userMergeTypeDefs,
+  resolver: userMergeResolvers,
+});

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-resolvers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-resolvers.ts
@@ -1,0 +1,21 @@
+import type { AuthContext } from '../../types/user';
+import { userMerge, userMergeJournal, type UserMergeOptionsInput } from './userMerge-domain';
+
+const userMergeResolvers = {
+  Query: {
+    userMergeJournal: (
+      _: unknown,
+      { mergeId, first }: { mergeId?: string | null; first?: number | null },
+      context: AuthContext,
+    ) => userMergeJournal(context, context.user!, mergeId, first),
+  },
+  Mutation: {
+    userMerge: (
+      _: unknown,
+      { sourceId, targetId, options }: { sourceId: string; targetId: string; options?: UserMergeOptionsInput | null },
+      context: AuthContext,
+    ) => userMerge(context, context.user!, sourceId, targetId, options),
+  },
+};
+
+export default userMergeResolvers;

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-types.ts
@@ -1,0 +1,69 @@
+/**
+ * Contract of the user merge feature.
+ *
+ * PR1 ships this contract and a stubbed engine. PR2 replaces the stub with the real
+ * handler registry; nothing in this file is expected to change when it does, because the
+ * shape returned in dry mode and in real mode is deliberately identical.
+ */
+
+export const MERGE_USERS_MODULE_NAME = 'userMerge';
+
+export enum UserMergeRightsStrategy {
+  Strict = 'STRICT',
+  Union = 'UNION',
+}
+
+export enum UserMergeStatus {
+  Running = 'RUNNING',
+  Success = 'SUCCESS',
+  Failed = 'FAILED',
+}
+
+/**
+ * Options left to the operator.
+ *
+ * Kept minimal on purpose: every option multiplies the combinations the dry-run has to be
+ * proven against, and the promise of this feature is that the dry-run is trustworthy.
+ * Everything settled during spec review stays non-configurable.
+ */
+export interface UserMergeOptions {
+  /**
+   * Write-suppression flag on a single execution path, not a separate estimation endpoint.
+   * Defaults to true: calling the mutation without options must never rewrite data.
+   */
+  dryRun: boolean;
+  rightsStrategy: UserMergeRightsStrategy;
+}
+
+/**
+ * Result of one merge execution. Same shape in dry and real mode — that identity is what
+ * makes "dry-run == real impact" verifiable from the API alone.
+ */
+export interface UserMergeResult {
+  id: string;
+  source_id: string;
+  target_id: string;
+  dry_run: boolean;
+  rights_strategy: UserMergeRightsStrategy;
+  status: UserMergeStatus;
+  started_at: Date;
+  completed_at?: Date;
+  message?: string;
+}
+
+/**
+ * One entry of the execution journal, written per handler as the merge progresses (PR2).
+ * Reading it is how a run stays observable when the HTTP connection dies.
+ */
+export interface UserMergeJournalEntry {
+  id: string;
+  merge_id: string;
+  source_id: string;
+  target_id: string;
+  handler: string;
+  dry_run: boolean;
+  status: UserMergeStatus;
+  started_at: Date;
+  completed_at?: Date;
+  message?: string;
+}

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge.graphql
@@ -1,7 +1,9 @@
+# Rationale for the defaults and the guard-rails lives in userMerge-domain.ts, not here:
+# descriptions in this file are printed into the generated schema and exposed through
+# introspection, so they are kept to what an API consumer needs.
+
 enum UserMergeRightsStrategy {
-    """Rights of the target are left untouched."""
     STRICT
-    """Rights of the source are added to those of the target."""
     UNION
 }
 
@@ -12,20 +14,10 @@ enum UserMergeStatus {
 }
 
 input UserMergeOptions {
-    """
-    Suppresses every write on a single execution path — it is not a separate estimation
-    endpoint. Defaults to true so that calling the mutation without options can never
-    rewrite data.
-    """
     dryRun: Boolean = true
-    """Defaults to the non-widening strategy."""
     rightsStrategy: UserMergeRightsStrategy = STRICT
 }
 
-"""
-Outcome of one merge execution. The shape is identical in dry and real mode, which is what
-makes "dry-run == real impact" verifiable from the API alone.
-"""
 type UserMergeResult {
     id: ID!
     source_id: ID!
@@ -38,7 +30,6 @@ type UserMergeResult {
     message: String
 }
 
-"""One entry of the execution journal, written per handler as the merge progresses."""
 type UserMergeJournalEntry {
     id: ID!
     merge_id: ID!
@@ -53,21 +44,12 @@ type UserMergeJournalEntry {
 }
 
 extend type Query {
-    """
-    Execution journal of the merges. Reading it is how a run stays observable once the HTTP
-    connection is gone: the connection dying does not stop the merge, so the journal is the
-    only way to tell a dead connection from a failed merge.
-
-    mergeId is optional on purpose — an operator who lost the connection also lost the id
-    returned by the mutation, so requiring it would defeat the point of the query.
-    """
+    # mergeId is optional: an operator who lost the connection also lost the id returned by
+    # the mutation, so requiring it would defeat the point of the query.
     userMergeJournal(mergeId: ID, first: Int): [UserMergeJournalEntry!]! @auth(for: [BYPASS]) @ff(flags: ["MERGE_USERS"])
 }
 
 extend type Mutation {
-    """
-    Merges the source user into the target user. Runs synchronously and returns the result;
-    follow userMergeJournal to observe a run whose connection was cut.
-    """
+    # Runs synchronously; follow userMergeJournal to observe a run whose connection was cut.
     userMerge(sourceId: ID!, targetId: ID!, options: UserMergeOptions): UserMergeResult! @auth(for: [BYPASS]) @ff(flags: ["MERGE_USERS"])
 }

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge.graphql
@@ -1,0 +1,73 @@
+enum UserMergeRightsStrategy {
+    """Rights of the target are left untouched."""
+    STRICT
+    """Rights of the source are added to those of the target."""
+    UNION
+}
+
+enum UserMergeStatus {
+    RUNNING
+    SUCCESS
+    FAILED
+}
+
+input UserMergeOptions {
+    """
+    Suppresses every write on a single execution path — it is not a separate estimation
+    endpoint. Defaults to true so that calling the mutation without options can never
+    rewrite data.
+    """
+    dryRun: Boolean = true
+    """Defaults to the non-widening strategy."""
+    rightsStrategy: UserMergeRightsStrategy = STRICT
+}
+
+"""
+Outcome of one merge execution. The shape is identical in dry and real mode, which is what
+makes "dry-run == real impact" verifiable from the API alone.
+"""
+type UserMergeResult {
+    id: ID!
+    source_id: ID!
+    target_id: ID!
+    dry_run: Boolean!
+    rights_strategy: UserMergeRightsStrategy!
+    status: UserMergeStatus!
+    started_at: DateTime!
+    completed_at: DateTime
+    message: String
+}
+
+"""One entry of the execution journal, written per handler as the merge progresses."""
+type UserMergeJournalEntry {
+    id: ID!
+    merge_id: ID!
+    source_id: ID!
+    target_id: ID!
+    handler: String!
+    dry_run: Boolean!
+    status: UserMergeStatus!
+    started_at: DateTime!
+    completed_at: DateTime
+    message: String
+}
+
+extend type Query {
+    """
+    Execution journal of the merges. Reading it is how a run stays observable once the HTTP
+    connection is gone: the connection dying does not stop the merge, so the journal is the
+    only way to tell a dead connection from a failed merge.
+
+    mergeId is optional on purpose — an operator who lost the connection also lost the id
+    returned by the mutation, so requiring it would defeat the point of the query.
+    """
+    userMergeJournal(mergeId: ID, first: Int): [UserMergeJournalEntry!]! @auth(for: [BYPASS]) @ff(flags: ["MERGE_USERS"])
+}
+
+extend type Mutation {
+    """
+    Merges the source user into the target user. Runs synchronously and returns the result;
+    follow userMergeJournal to observe a run whose connection was cut.
+    """
+    userMerge(sourceId: ID!, targetId: ID!, options: UserMergeOptions): UserMergeResult! @auth(for: [BYPASS]) @ff(flags: ["MERGE_USERS"])
+}

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-validation-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-validation-test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { assertUserMergeAllowed, assertValidUserMergeIds, resolveUserMergeOptions } from '../../../../src/modules/userMerge/userMerge-domain';
+import { UserMergeRightsStrategy } from '../../../../src/modules/userMerge/userMerge-types';
+import { BYPASS, SYSTEM_USER } from '../../../../src/utils/access';
+import type { AuthUser } from '../../../../src/types/user';
+
+const userWith = (capabilities: string[], id = 'user-under-test'): AuthUser => ({
+  id,
+  capabilities: capabilities.map((name) => ({ name })),
+} as AuthUser);
+
+describe('resolveUserMergeOptions', () => {
+  it('should default to a dry-run so that a call without options never rewrites data', () => {
+    expect(resolveUserMergeOptions().dryRun).toBe(true);
+    expect(resolveUserMergeOptions(null).dryRun).toBe(true);
+    expect(resolveUserMergeOptions({}).dryRun).toBe(true);
+  });
+
+  it('should default to the non-widening rights strategy', () => {
+    expect(resolveUserMergeOptions().rightsStrategy).toBe(UserMergeRightsStrategy.Strict);
+    expect(resolveUserMergeOptions({ rightsStrategy: null }).rightsStrategy).toBe(UserMergeRightsStrategy.Strict);
+  });
+
+  it('should keep the values provided by the caller', () => {
+    const options = resolveUserMergeOptions({ dryRun: false, rightsStrategy: UserMergeRightsStrategy.Union });
+    expect(options.dryRun).toBe(false);
+    expect(options.rightsStrategy).toBe(UserMergeRightsStrategy.Union);
+  });
+});
+
+describe('assertValidUserMergeIds', () => {
+  it('should accept two distinct regular users', () => {
+    expect(() => assertValidUserMergeIds('source-id', 'target-id')).not.toThrow();
+  });
+
+  it('should reject a merge of a user into itself', () => {
+    expect(() => assertValidUserMergeIds('same-id', 'same-id')).toThrow('Cannot merge a user into itself');
+  });
+
+  it('should reject missing identifiers', () => {
+    expect(() => assertValidUserMergeIds('', 'target-id')).toThrow('Source and target users are required to merge');
+    expect(() => assertValidUserMergeIds('source-id', '')).toThrow('Source and target users are required to merge');
+  });
+
+  it('should reject internal platform users, as source or as target', () => {
+    expect(() => assertValidUserMergeIds(SYSTEM_USER.id, 'target-id')).toThrow('Cannot merge an internal platform user');
+    expect(() => assertValidUserMergeIds('source-id', SYSTEM_USER.id)).toThrow('Cannot merge an internal platform user');
+  });
+});
+
+describe('assertUserMergeAllowed', () => {
+  // The test configuration enables every dev feature, so the flag is on here and the
+  // capability is what this suite exercises. The flag-off path is covered by the directive.
+  it('should allow a user holding BYPASS', () => {
+    expect(() => assertUserMergeAllowed(userWith([BYPASS]))).not.toThrow();
+  });
+
+  it('should reject a user without BYPASS loudly, never by returning early', () => {
+    expect(() => assertUserMergeAllowed(userWith(['KNOWLEDGE']))).toThrow('Merging users requires the BYPASS capability');
+  });
+
+  it('should reject a user with no capability at all', () => {
+    expect(() => assertUserMergeAllowed(userWith([]))).toThrow('Merging users requires the BYPASS capability');
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/userMerge/userMerge-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/userMerge/userMerge-resolvers-test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { USER_EDITOR, USER_PARTICIPATE } from '../../../utils/testQuery';
+import { queryAsAdminWithError, queryAsAdminWithSuccess, queryAsUserIsExpectedForbidden } from '../../../utils/testQueryHelper';
+
+const USER_MERGE_MUTATION = gql`
+  mutation UserMerge($sourceId: ID!, $targetId: ID!, $options: UserMergeOptions) {
+    userMerge(sourceId: $sourceId, targetId: $targetId, options: $options) {
+      id
+      source_id
+      target_id
+      dry_run
+      rights_strategy
+      status
+      started_at
+      completed_at
+      message
+    }
+  }
+`;
+
+const USER_MERGE_JOURNAL_QUERY = gql`
+  query UserMergeJournal($mergeId: ID, $first: Int) {
+    userMergeJournal(mergeId: $mergeId, first: $first) {
+      id
+      merge_id
+      source_id
+      target_id
+      handler
+      dry_run
+      status
+      started_at
+      completed_at
+      message
+    }
+  }
+`;
+
+const readUser = async (userId: string) => {
+  const { data } = await queryAsAdminWithSuccess({
+    query: gql`query ReadUser($id: String!) { user(id: $id) { id name user_email } }`,
+    variables: { id: userId },
+  });
+  return data.user;
+};
+
+describe('User merge resolvers', () => {
+  describe('Access control - BYPASS capability required', () => {
+    it('should refuse the mutation to a user without BYPASS', async () => {
+      await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_EDITOR.id, targetId: USER_PARTICIPATE.id },
+      });
+    });
+
+    it('should refuse the journal query to a user without BYPASS', async () => {
+      await queryAsUserIsExpectedForbidden(USER_PARTICIPATE, {
+        query: USER_MERGE_JOURNAL_QUERY,
+        variables: {},
+      });
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should refuse to merge a user into itself', async () => {
+      await queryAsAdminWithError({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_PARTICIPATE.id },
+      }, 'Cannot merge a user into itself');
+    });
+
+    it('should refuse an unknown source user', async () => {
+      await queryAsAdminWithError({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: 'not-an-existing-user', targetId: USER_PARTICIPATE.id },
+      }, 'Unknown source user');
+    });
+
+    it('should refuse an unknown target user', async () => {
+      await queryAsAdminWithError({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: 'not-an-existing-user' },
+      }, 'Unknown target user');
+    });
+  });
+
+  describe('Contract of the stubbed engine', () => {
+    it('should default to a dry-run when no option is provided', async () => {
+      const { data } = await queryAsAdminWithSuccess({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_EDITOR.id },
+      });
+      expect(data.userMerge.dry_run).toBe(true);
+      expect(data.userMerge.rights_strategy).toBe('STRICT');
+    });
+
+    it('should return the same shape in dry and in real mode', async () => {
+      const dry = await queryAsAdminWithSuccess({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_EDITOR.id, options: { dryRun: true } },
+      });
+      const real = await queryAsAdminWithSuccess({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_EDITOR.id, options: { dryRun: false } },
+      });
+      expect(Object.keys(real.data.userMerge).sort()).toEqual(Object.keys(dry.data.userMerge).sort());
+      expect(real.data.userMerge.dry_run).toBe(false);
+      expect(dry.data.userMerge.dry_run).toBe(true);
+    });
+
+    it('should carry the requested rights strategy', async () => {
+      const { data } = await queryAsAdminWithSuccess({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_EDITOR.id, options: { rightsStrategy: 'UNION' } },
+      });
+      expect(data.userMerge.rights_strategy).toBe('UNION');
+    });
+
+    it('should not report a success for a merge that did not happen', async () => {
+      const { data } = await queryAsAdminWithSuccess({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_EDITOR.id, options: { dryRun: false } },
+      });
+      expect(data.userMerge.status).toBe('FAILED');
+      expect(data.userMerge.message).toContain('not implemented');
+    });
+
+    it('should leave both users untouched, even when asked for a real run', async () => {
+      const sourceBefore = await readUser(USER_PARTICIPATE.id);
+      const targetBefore = await readUser(USER_EDITOR.id);
+      await queryAsAdminWithSuccess({
+        query: USER_MERGE_MUTATION,
+        variables: { sourceId: USER_PARTICIPATE.id, targetId: USER_EDITOR.id, options: { dryRun: false } },
+      });
+      expect(await readUser(USER_PARTICIPATE.id)).toEqual(sourceBefore);
+      expect(await readUser(USER_EDITOR.id)).toEqual(targetBefore);
+    });
+  });
+
+  describe('Journal query', () => {
+    it('should be readable without a merge id', async () => {
+      const { data } = await queryAsAdminWithSuccess({ query: USER_MERGE_JOURNAL_QUERY, variables: {} });
+      expect(data.userMergeJournal).toEqual([]);
+    });
+
+    it('should accept a merge id', async () => {
+      const { data } = await queryAsAdminWithSuccess({
+        query: USER_MERGE_JOURNAL_QUERY,
+        variables: { mergeId: 'any-merge-id', first: 10 },
+      });
+      expect(data.userMergeJournal).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Adds the `MERGE_USERS` feature flag, off by default (`app:enabled_dev_features` is empty in `config/default.json`).
* Adds the `userMerge` mutation and the `userMergeJournal` query, both `@auth(for: [BYPASS])` and behind the flag. Bypass and the flag are enforced a second time in the domain with an explicit throw, so an internal caller cannot bypass the GraphQL directives and a refused call cannot come back shaped like a success.
* Adds the guard-rails: no self-merge, no unknown user, no internal platform user (SYSTEM, RETENTION MANAGER, …) as source or target.
* Ships the API surface only. The engine is a stub that returns `FAILED` with an explicit message, so deploying this chunk alone cannot let an operator believe a merge happened. The real engine lands in #17494.
* `dryRun` defaults to `true` and `rightsStrategy` to `STRICT`, so calling the mutation with no options can neither rewrite data nor widen rights.
* `userMergeJournal(mergeId: ID)` takes an optional id: the merge runs synchronously and a dead HTTP connection does not stop it, so an operator who lost the connection also lost the id returned by the mutation.

Two deviations from the specification: the return type is `UserMergeResult!` where the spec writes `UserMergeResult`, and the internal-user guard-rail is beyond the specified scope.

### Related issues

* closes #17493 — part of #17258

### How to test this PR

Enable the flag, then start the platform:

```bash
export APP__ENABLED_DEV_FEATURES='["MERGE_USERS"]'
yarn start
```

Call the mutation with a Bypass token. It must answer `FAILED` with the stub message, and never `SUCCESS`:

```bash
curl -s http://localhost:4000/graphql \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $OPENCTI_TOKEN" \
  -d '{"query":"mutation { userMerge(sourceId:\"<source>\", targetId:\"<target>\") { merge_id status message } }"}'
```

Then check the refusals:

* the same call with a non-Bypass token is rejected;
* the same call with the flag unset is rejected;
* `sourceId` equal to `targetId` is rejected;
* either id pointing at an internal platform user is rejected.

Automated coverage:

```bash
npx vitest run --config vitest.config.ci-unit.ts tests/01-unit/modules/userMerge
npx vitest run --config vitest.config.dev.ts tests/03-integration/10-modules/userMerge
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

This is the base of a stack of 11 branches (#17493 → #17503). Reviewing it in isolation is the point: everything after it assumes the flag, the capability check and the result shape are settled here.

The stub deliberately reports `FAILED` rather than `SUCCESS`. A stub answering SUCCESS is exactly the `cleanAllEntityInconsistencies` behaviour this feature is specified against.