### PR TITLE
fix(filters): Utils for filter operators allowing empty values (#17516)

### DIFF
--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -4,7 +4,10 @@ import { ChipOwnProps } from '@mui/material/Chip/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import React, { CSSProperties, Fragment, FunctionComponent, useContext, useEffect, useRef } from 'react';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
-import { convertOperatorToIcon, filterOperatorsWithIcon, FilterSearchContext, FiltersRestrictions, isFilterEditable, useFilterDefinition } from '../utils/filters/filtersUtils';
+import {
+  convertOperatorToIcon, filterOperatorsWithIcon, FilterSearchContext, FiltersRestrictions, isFilterEditable,
+  NO_VALUES_FILTER_OPERATORS, useFilterDefinition
+} from '../utils/filters/filtersUtils';
 import { truncate } from '../utils/String';
 import { FilterValuesContentQuery } from './__generated__/FilterValuesContentQuery.graphql';
 import FilterValues from './filters/FilterValues';
@@ -239,7 +242,7 @@ const FilterIconButtonContainer: FunctionComponent<
         );
         const isNotLastFilter = index < displayedFilters.length - 1;
 
-        const chipVariant = currentFilter.values.length === 0 && !['nil', 'not_nil', 'has_changed', 'not_has_changed'].includes(filterOperator ?? 'eq')
+        const chipVariant = currentFilter.values.length === 0 && !NO_VALUES_FILTER_OPERATORS.includes(filterOperator ?? 'eq')
           ? 'outlined'
           : 'filled';
         // darken the bg color when filled (quickfix for 'warning' and 'success' chipColor unreadable with regardingOf filter)

--- a/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
+++ b/opencti-platform/opencti-front/src/components/FilterIconButtonContainer.tsx
@@ -5,8 +5,13 @@ import Tooltip from '@mui/material/Tooltip';
 import React, { CSSProperties, Fragment, FunctionComponent, useContext, useEffect, useRef } from 'react';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
 import {
-  convertOperatorToIcon, filterOperatorsWithIcon, FilterSearchContext, FiltersRestrictions, isFilterEditable,
-  NO_VALUES_FILTER_OPERATORS, useFilterDefinition
+  convertOperatorToIcon,
+  filterOperatorsWithIcon,
+  FilterSearchContext,
+  FiltersRestrictions,
+  isFilterEditable,
+  NO_VALUES_FILTER_OPERATORS,
+  useFilterDefinition,
 } from '../utils/filters/filtersUtils';
 import { truncate } from '../utils/String';
 import { FilterValuesContentQuery } from './__generated__/FilterValuesContentQuery.graphql';

--- a/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
+++ b/opencti-platform/opencti-front/src/components/dataGrid/components/DataTableBody.tsx
@@ -9,6 +9,7 @@ import callbackResizeObserver from '../../../utils/resizeObservers';
 import { useDataTable } from '../dataTableHooks';
 import DataTableEmptyState from './DataTableEmptyState';
 import DataTableSearchEmptyState from './DataTableSearchEmptyState';
+import { removeEmptyFiltersFromList } from 'src/utils/filters/filtersUtils';
 
 const DataTableBody = ({
   settingsMessagesBannerHeight = 0,
@@ -185,9 +186,7 @@ const DataTableBody = ({
   }
 
   const isSearching = !!tableSearchTerm
-    || (filters?.filters ?? [])
-      .filter((f) => ['nil', 'not_nil', 'has_changed', 'not_has_changed'].includes(f.operator ?? 'eq') || f.values.length > 0)
-      .length > 0;
+    || removeEmptyFiltersFromList(filters?.filters ?? []).length > 0;
 
   return (
     <>

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -114,6 +114,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
   const filterKey = filter?.key ?? '';
   const filterOperator = filter?.operator ?? '';
   const filterValues = filter?.values ?? [];
+  const isOperatorRequiringValue = !NO_VALUES_FILTER_OPERATORS.includes(filterOperator);
   const filterDefinition = useFilterDefinition(filterKey, entityTypes);
   const filterLabel = filterKey ? t_i18n(filterDefinition?.label ?? filterKey) : '';
   const { typesWithFintelTemplates } = useAttributes();
@@ -236,7 +237,6 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     />
   );
 
-  const noValueOperator = !NO_VALUES_FILTER_OPERATORS.includes(filterOperator);
   const renderSearchScopeSelection = (key: string) => (
     <SearchScopeElement
       name={key}
@@ -488,10 +488,10 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
             ))}
           </Select>
         )}
-        {noValueOperator && isSpecificFilter(finalFilterDefinition) && (
+        {isOperatorRequiringValue && isSpecificFilter(finalFilterDefinition) && (
           <>{getSpecificFilter(finalFilterDefinition, subKey, disabled)}</>
         )}
-        {noValueOperator && !isSpecificFilter(finalFilterDefinition) && (
+        {isOperatorRequiringValue && !isSpecificFilter(finalFilterDefinition) && (
           <>{buildAutocompleteFilter(subKey ?? fKey, finalFilterDefinition?.label ?? t_i18n(fKey), subKey, disabled)}</>
         )}
       </>

--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -21,6 +21,7 @@ import {
   isBasicTextFilter,
   isNumericFilter,
   isStixObjectTypes,
+  NO_VALUES_FILTER_OPERATORS,
   SELF_ID,
   SELF_ID_VALUE,
   useFilterDefinition,
@@ -235,7 +236,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     />
   );
 
-  const noValueOperator = !['not_nil', 'nil', 'has_changed', 'not_has_changed'].includes(filterOperator);
+  const noValueOperator = !NO_VALUES_FILTER_OPERATORS.includes(filterOperator);
   const renderSearchScopeSelection = (key: string) => (
     <SearchScopeElement
       name={key}

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -3,6 +3,7 @@ import {
   buildFiltersAndOptionsForWidgets,
   buildFiltersForCustomView,
   emptyFilterGroup,
+  findFilterFromKey,
   findFiltersFromKeys,
   formatFiltersInPirContext,
   getEntityTypeThreeFirstLevelsFilterValues,
@@ -705,8 +706,37 @@ describe('Filters utils', () => {
   });
 });
 
-describe('Function findFilterFromKey: should return the filters of the specified keys among a filters list', () => {
-  it('findFilterFromKey without specifying an operator', () => {
+describe('Function findFilterFromKey', () => {
+  it('findFilterFromKey should return the first filter matching key and operator', () => {
+    const filtersList = [
+      { key: 'name', values: ['name1'], operator: 'eq' },
+      { key: 'name', values: ['name2'], operator: 'eq' },
+      { key: 'name', values: ['name3'], operator: 'not_eq' },
+    ];
+    const result = findFilterFromKey(filtersList, 'name');
+    expect(result).toEqual({ key: 'name', values: ['name1'], operator: 'eq' });
+  });
+
+  it('findFilterFromKey should return null when key is not found', () => {
+    const filtersList = [
+      { key: 'value', values: ['value1'], operator: 'eq' },
+    ];
+    const result = findFilterFromKey(filtersList, 'name');
+    expect(result).toBeNull();
+  });
+
+  it('findFilterFromKey should treat missing operator as eq', () => {
+    const filtersList = [
+      { key: 'name', values: ['name1'] },
+      { key: 'name', values: ['name2'], operator: 'not_eq' },
+    ];
+    const result = findFilterFromKey(filtersList, 'name');
+    expect(result).toEqual({ key: 'name', values: ['name1'] });
+  });
+});
+
+describe('Function findFiltersFromKeys: should return the filters of the specified keys among a filters list', () => {
+  it('findFiltersFromKey without specifying an operator', () => {
     const filtersList = [
       { key: 'value', values: [], operator: 'nil' },
       { key: 'name', values: ['name1', 'name2'], operator: 'eq' },
@@ -714,7 +744,7 @@ describe('Function findFilterFromKey: should return the filters of the specified
     const result = findFiltersFromKeys(filtersList, ['value']);
     expect(result).toEqual([]);
   });
-  it('findFilterFromKey with several results', () => {
+  it('findFiltersFromKey with several results', () => {
     const filtersList = [
       { key: 'value', values: [], operator: 'nil' },
       { key: 'name', values: ['name1', 'name2'], operator: 'eq' },
@@ -724,7 +754,7 @@ describe('Function findFilterFromKey: should return the filters of the specified
     expect(result).toEqual([{ key: 'name', values: ['name1', 'name2'], operator: 'eq' },
       { key: 'name', values: ['name3'], operator: 'eq' }]);
   });
-  it('findFilterFromKey with operator specified', () => {
+  it('findFiltersFromKey with operator specified', () => {
     const filtersList = [
       { key: 'value', values: [], operator: 'nil' },
       { key: 'name', values: ['name1', 'name2'], operator: 'eq' },
@@ -732,7 +762,7 @@ describe('Function findFilterFromKey: should return the filters of the specified
     const result = findFiltersFromKeys(filtersList, ['value'], 'nil');
     expect(result).toEqual([{ key: 'value', values: [], operator: 'nil' }]);
   });
-  it('findFilterFromKey with several keys', () => {
+  it('findFiltersFromKey with several keys', () => {
     const filtersList = [
       { key: 'value', values: ['value1'], operator: 'eq' },
       { key: 'created_at', values: ['XX', 'YY'], mode: 'or' },

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -11,6 +11,7 @@ import {
   isRegardingOfFilterWarning,
   normalizeFilterGroupForBackend,
   normalizeFilterGroupForFrontend,
+  removeEmptyFiltersFromList,
   removeFrontendIdAndEmptyFiltersFromFilterGroupObject,
   removeIdAndIncorrectKeysFromFilterGroupObject,
   serializeFilterGroupForBackend,
@@ -23,6 +24,41 @@ import filterKeysSchema from '../tests/FilterUtilsConstants';
 import { FilterGroup } from './filtersHelpers-types';
 
 describe('Filters utils', () => {
+  describe('removeEmptyFiltersFromList', () => {
+    it('should remove filters with empty values when operator requires values', () => {
+      const filtersList = [
+        { key: 'name', values: [], operator: 'eq' },
+        { key: 'entity_type', values: ['Malware'], operator: 'eq' },
+      ];
+
+      expect(removeEmptyFiltersFromList(filtersList)).toEqual([
+        { key: 'entity_type', values: ['Malware'], operator: 'eq' },
+      ]);
+    });
+
+    it('should keep filters with no-value operators even when values are empty', () => {
+      const filtersList = [
+        { key: 'description', values: [], operator: 'nil' },
+        { key: 'objectMarking', values: [], operator: 'not_nil' },
+        { key: 'confidence', values: [], operator: 'has_changed' },
+        { key: 'workflow_id', values: [], operator: 'not_has_changed' },
+      ];
+
+      expect(removeEmptyFiltersFromList(filtersList)).toEqual(filtersList);
+    });
+
+    it('should treat missing operator as eq and remove empty filter', () => {
+      const filtersList = [
+        { key: 'name', values: [] },
+        { key: 'entity_type', values: ['Report'] },
+      ];
+
+      expect(removeEmptyFiltersFromList(filtersList)).toEqual([
+        { key: 'entity_type', values: ['Report'] },
+      ]);
+    });
+  });
+
   describe('useBuildFilterKeysMapFromEntityType', () => {
     it('should list filter definitions by given entity types attributes', () => {
       const stixCoreObjectKey = 'Stix-Core-Object';

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -736,7 +736,7 @@ describe('Function findFilterFromKey', () => {
 });
 
 describe('Function findFiltersFromKeys: should return the filters of the specified keys among a filters list', () => {
-  it('findFiltersFromKey without specifying an operator', () => {
+  it('findFiltersFromKeys without specifying an operator', () => {
     const filtersList = [
       { key: 'value', values: [], operator: 'nil' },
       { key: 'name', values: ['name1', 'name2'], operator: 'eq' },
@@ -744,7 +744,7 @@ describe('Function findFiltersFromKeys: should return the filters of the specifi
     const result = findFiltersFromKeys(filtersList, ['value']);
     expect(result).toEqual([]);
   });
-  it('findFiltersFromKey with several results', () => {
+  it('findFiltersFromKeys with several results', () => {
     const filtersList = [
       { key: 'value', values: [], operator: 'nil' },
       { key: 'name', values: ['name1', 'name2'], operator: 'eq' },
@@ -754,7 +754,7 @@ describe('Function findFiltersFromKeys: should return the filters of the specifi
     expect(result).toEqual([{ key: 'name', values: ['name1', 'name2'], operator: 'eq' },
       { key: 'name', values: ['name3'], operator: 'eq' }]);
   });
-  it('findFiltersFromKey with operator specified', () => {
+  it('findFiltersFromKeys with operator specified', () => {
     const filtersList = [
       { key: 'value', values: [], operator: 'nil' },
       { key: 'name', values: ['name1', 'name2'], operator: 'eq' },
@@ -762,7 +762,7 @@ describe('Function findFiltersFromKeys: should return the filters of the specifi
     const result = findFiltersFromKeys(filtersList, ['value'], 'nil');
     expect(result).toEqual([{ key: 'value', values: [], operator: 'nil' }]);
   });
-  it('findFiltersFromKey with several keys', () => {
+  it('findFiltersFromKeys with several keys', () => {
     const filtersList = [
       { key: 'value', values: ['value1'], operator: 'eq' },
       { key: 'created_at', values: ['XX', 'YY'], mode: 'or' },

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -230,7 +230,9 @@ export const removeEmptyFiltersFromList = (filtersList: Filter[]) => {
   return filtersList.filter((f) => NO_VALUES_FILTER_OPERATORS.includes(f.operator ?? 'eq') || f.values.length > 0);
 };
 
-// return the values of the filters of a specific key among a filters list
+/**
+ * Return the values of the filters of a specific key among a filters list
+ */
 export const findFilterFromKey = (
   filters: Filter[],
   key: string,
@@ -247,6 +249,9 @@ export const findFilterFromKey = (
   return null;
 };
 
+/**
+ * Return all filters whose key is in `keys` and whose operator matches.
+ */
 export const findFiltersFromKeys = (
   filters: Filter[],
   keys: string[],

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -41,7 +41,7 @@ export const SELF_ID_VALUE = 'CURRENT ENTITY';
 
 export const ME_FILTER_VALUE = '@me';
 
-// filter operator requiring nothing in filter values
+// Filter operators that do not require any values in filter.values
 export const NO_VALUES_FILTER_OPERATORS = ['nil', 'not_nil', 'has_changed', 'not_has_changed'];
 
 // 'within' operator filter constants

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -41,6 +41,9 @@ export const SELF_ID_VALUE = 'CURRENT ENTITY';
 
 export const ME_FILTER_VALUE = '@me';
 
+// filter operator requiring nothing in filter values
+export const NO_VALUES_FILTER_OPERATORS = ['nil', 'not_nil', 'has_changed', 'not_has_changed'];
+
 // 'within' operator filter constants
 export const DEFAULT_WITHIN_FILTER_VALUES = ['now-1d', 'now'];
 
@@ -218,6 +221,13 @@ export const isNumericFilter = (
   filterType?: string,
 ) => {
   return filterType === 'integer' || filterType === 'float';
+};
+
+/**
+ * Remove filters that have no values, except those whose operators are valid without values
+ */
+export const removeEmptyFiltersFromList = (filtersList: Filter[]) => {
+  return filtersList.filter((f) => NO_VALUES_FILTER_OPERATORS.includes(f.operator ?? 'eq') || f.values.length > 0);
 };
 
 // return the values of the filters of a specific key among a filters list
@@ -912,9 +922,7 @@ const removeFrontendIdAndEmptyFiltersFromFiltersArray = (filtersArray: Filter[])
     return newFilter;
   };
 
-  return filtersArray
-    .filter((f) => ['nil', 'not_nil', 'has_changed', 'not_has_changed'].includes(f.operator ?? 'eq') || f.values.length > 0)
-    .map((f) => removeFrontendIdFromFilter(f));
+  return removeEmptyFiltersFromList(filtersArray).map((f) => removeFrontendIdFromFilter(f));
 };
 
 // TODO use useRemoveIdAndIncorrectKeysFromFilterGroupObject instead when all the calling files are in pure function

--- a/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
+++ b/opencti-platform/opencti-front/src/utils/hooks/useLocalStorage.ts
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction, SyntheticEvent, useCallback, useState } from 
 import { v4 as uuid } from 'uuid';
 import { type SavedFiltersSelectionData } from 'src/components/saved_filters/SavedFilterSelection';
 import { OrderMode, PaginationOptions } from '../../components/list_lines';
-import { emptyFilterGroup, findFilterFromKey, isFilterGroupNotEmpty, isUniqFilter, useFetchFilterKeysSchema } from '../filters/filtersUtils';
+import { emptyFilterGroup, findFilterFromKey, isFilterGroupNotEmpty, isUniqFilter, removeEmptyFiltersFromList, useFetchFilterKeysSchema } from '../filters/filtersUtils';
 import { isEmptyField, isNotEmptyField, removeEmptyFields } from '../utils';
 import { MESSAGING$ } from '../../relay/environment';
 import {
@@ -777,13 +777,12 @@ export const usePaginationLocalStorage = <U>(
     },
   };
 
-  const removeEmptyFilter = paginationOptions.filters?.filters
-    ?.filter((f) => ['nil', 'not_nil'].includes(f.operator ?? 'eq') || f.values.length > 0) ?? [];
+  const notEmptyFiltersList = removeEmptyFiltersFromList(paginationOptions.filters?.filters ?? []);
   let filters;
-  if (removeEmptyFilter.length > 0) {
+  if (notEmptyFiltersList.length > 0) {
     filters = {
       ...paginationOptions.filters,
-      filters: removeEmptyFilter.map((filter: Filter) => {
+      filters: notEmptyFiltersList.map((filter: Filter) => {
         const removeIdFromFilter = { ...filter };
         delete removeIdFromFilter.id;
         return removeIdFromFilter;
@@ -793,7 +792,7 @@ export const usePaginationLocalStorage = <U>(
     // In case where filter is empty but filterGroup exist
     const newFilters = {
       ...paginationOptions.filters,
-      filters: removeEmptyFilter,
+      filters: notEmptyFiltersList,
     } as FilterGroup;
     filters = isFilterGroupNotEmpty(newFilters) ? newFilters : undefined;
   }


### PR DESCRIPTION
### Proposed changes
- Add constant for filter operator requiring nothing in filter values
- Add tests for findFilterFromKey

### Related issues
fixes #17516