### PR TITLE
fix: use window.location.href instead of pathname to handle APP_BASE_PATH correctly (#17291)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/files/FileLine.tsx
@@ -234,7 +234,7 @@ const FileLineComponent: FunctionComponent<FileLineComponentProps> = ({
     if (inNewWindow) {
       window.open(url, '_blank', 'noopener,noreferrer');
     } else {
-      window.location.pathname = url;
+      window.location.href = url;
     }
   };
   const generateIcon = () => {


### PR DESCRIPTION
Fixes #17291

## Problem

When APP_BASE_PATH is configured, clicking download on a document creates a URL with a duplicated base path (e.g., /opencti_dev/opencti_dev/storage/get/...), causing the download to fail.

## Root Cause

The handleLink function in FileLine.tsx used window.location.pathname = url to navigate, which doesn't handle the base path correctly.

## Fix

Changed window.location.pathname = url to window.location.href = url, which correctly handles both absolute and relative URLs.