### PR TITLE
fix(indicator): preserve lifecycle metadata on low-confidence upsert (#13628)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
+++ b/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
@@ -82,6 +82,22 @@ const buildAttributeUpdate = (isFullSync, attribute, currentData, inputData) => 
   return inputs;
 };
 
+const preserveIndicatorLifecycleAndValidityMetadata = (updatePatch, resolvedElement) => {
+  Object.assign(updatePatch, {
+    x_opencti_score: resolvedElement.x_opencti_score,
+    valid_from: resolvedElement.valid_from,
+    valid_until: resolvedElement.valid_until,
+    revoked: resolvedElement.revoked,
+    decay_base_score: resolvedElement.decay_base_score,
+    decay_base_score_date: resolvedElement.decay_base_score_date,
+    decay_applied_rule: resolvedElement.decay_applied_rule,
+    decay_next_reaction_date: resolvedElement.decay_next_reaction_date,
+    decay_exclusion_applied_rule: resolvedElement.decay_exclusion_applied_rule,
+  });
+  // Do not include decay_history in this guard to avoid accidental replace-to-empty in synchronized upsert.
+  delete updatePatch.decay_history;
+};
+
 export const buildUpdatePatchForUpsert = (user, resolvedElement, type, basePatch, confidenceForUpsert) => {
   const updatePatch = { ...basePatch };
   const { confidenceLevelToApply, isConfidenceMatch } = confidenceForUpsert;
@@ -134,16 +150,7 @@ export const buildUpdatePatchForUpsert = (user, resolvedElement, type, basePatch
           patchScore: updatePatch.x_opencti_score,
         },
       );
-      updatePatch.x_opencti_score = resolvedElement.x_opencti_score;
-      updatePatch.valid_from = resolvedElement.valid_from;
-      updatePatch.valid_until = resolvedElement.valid_until;
-      updatePatch.revoked = resolvedElement.revoked;
-      updatePatch.decay_base_score = resolvedElement.decay_base_score;
-      updatePatch.decay_base_score_date = resolvedElement.decay_base_score_date;
-      updatePatch.decay_applied_rule = resolvedElement.decay_applied_rule;
-      updatePatch.decay_history = [];
-      updatePatch.decay_next_reaction_date = resolvedElement.decay_next_reaction_date;
-      updatePatch.decay_exclusion_applied_rule = resolvedElement.decay_exclusion_applied_rule;
+      preserveIndicatorLifecycleAndValidityMetadata(updatePatch, resolvedElement);
     }
     // Guard for decay-excluded indicators: when the score is unchanged, preserve valid_until,
     // revoked and x_opencti_score. Mirrors the editField early-return in indicator-domain.ts

--- a/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
+++ b/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
@@ -126,6 +126,25 @@ export const buildUpdatePatchForUpsert = (user, resolvedElement, type, basePatch
     }
   }
   if (type === ENTITY_TYPE_INDICATOR) {
+    if (!isConfidenceMatch) {
+      logApp.debug(
+        '[OPENCTI][DECAY] on upsert indicator with insufficient confidence, preserve lifecycle and validity metadata',
+        {
+          elementScore: resolvedElement.x_opencti_score,
+          patchScore: updatePatch.x_opencti_score,
+        },
+      );
+      updatePatch.x_opencti_score = resolvedElement.x_opencti_score;
+      updatePatch.valid_from = resolvedElement.valid_from;
+      updatePatch.valid_until = resolvedElement.valid_until;
+      updatePatch.revoked = resolvedElement.revoked;
+      updatePatch.decay_base_score = resolvedElement.decay_base_score;
+      updatePatch.decay_base_score_date = resolvedElement.decay_base_score_date;
+      updatePatch.decay_applied_rule = resolvedElement.decay_applied_rule;
+      updatePatch.decay_history = [];
+      updatePatch.decay_next_reaction_date = resolvedElement.decay_next_reaction_date;
+      updatePatch.decay_exclusion_applied_rule = resolvedElement.decay_exclusion_applied_rule;
+    }
     // Guard for decay-excluded indicators: when the score is unchanged, preserve valid_until,
     // revoked and x_opencti_score. Mirrors the editField early-return in indicator-domain.ts
     // for excluded indicators (asymmetry reported in issue #16365).

--- a/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
+++ b/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
@@ -151,6 +151,8 @@ export const buildUpdatePatchForUpsert = (user, resolvedElement, type, basePatch
         },
       );
       preserveIndicatorLifecycleAndValidityMetadata(updatePatch, resolvedElement);
+      updatePatch.confidence = confidenceLevelToApply;
+      return updatePatch;
     }
     // Guard for decay-excluded indicators: when the score is unchanged, preserve valid_until,
     // revoked and x_opencti_score. Mirrors the editField early-return in indicator-domain.ts

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/upsert-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/upsert-utils-test.ts
@@ -53,11 +53,11 @@ describe('buildUpdatePatchForUpsert - indicator confidence gating', () => {
     expect(result.decay_base_score_date).toBe(existingIndicator.decay_base_score_date);
     expect(result.decay_applied_rule).toEqual(existingIndicator.decay_applied_rule);
     expect(result.decay_next_reaction_date).toBe(existingIndicator.decay_next_reaction_date);
-    expect(result.decay_history).toEqual([]);
+    expect(result).not.toHaveProperty('decay_history');
     expect(result.confidence).toBe(50);
   });
 
-  it('should keep incoming indicator lifecycle and metadata fields when confidence matches', () => {
+  it('should keep incoming indicator lifecycle and metadata fields when confidence is sufficient', () => {
     const existingIndicator = {
       entity_type: ENTITY_TYPE_INDICATOR,
       standard_id: 'indicator--existing',

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/upsert-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/upsert-utils-test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { buildUpdatePatchForUpsert } from '../../../src/utils/upsert-utils';
+import { ENTITY_TYPE_INDICATOR } from '../../../src/modules/indicator/indicator-types';
+
+const makeUser = () => ({
+  id: 'test-user',
+  no_creators: true,
+});
+
+describe('buildUpdatePatchForUpsert - indicator confidence gating', () => {
+  it('should preserve lifecycle and metadata fields when confidence is lower', () => {
+    const existingIndicator = {
+      entity_type: ENTITY_TYPE_INDICATOR,
+      standard_id: 'indicator--existing',
+      confidence: 70,
+      x_opencti_score: 70,
+      valid_from: '2024-01-01T00:00:00.000Z',
+      valid_until: '2024-03-01T00:00:00.000Z',
+      revoked: true,
+      decay_base_score: 70,
+      decay_base_score_date: '2024-01-01T00:00:00.000Z',
+      decay_applied_rule: { decay_rule_id: 'rule-existing' },
+      decay_exclusion_applied_rule: undefined,
+      decay_history: [{ score: 70, updated_by: 'source-a', updated_at: '2024-01-01T00:00:00.000Z' }],
+      decay_next_reaction_date: '2024-01-15T00:00:00.000Z',
+    };
+    const incomingPatch = {
+      confidence: 50,
+      x_opencti_score: 80,
+      valid_from: '2025-01-01T00:00:00.000Z',
+      valid_until: '2025-04-01T00:00:00.000Z',
+      revoked: false,
+      decay_base_score: 80,
+      decay_base_score_date: '2025-01-01T00:00:00.000Z',
+      decay_applied_rule: { decay_rule_id: 'rule-new' },
+      decay_history: [{ score: 80, updated_by: 'source-b', updated_at: '2025-01-01T00:00:00.000Z' }],
+      decay_next_reaction_date: '2025-01-15T00:00:00.000Z',
+    };
+
+    const result = buildUpdatePatchForUpsert(
+      makeUser(),
+      existingIndicator,
+      ENTITY_TYPE_INDICATOR,
+      incomingPatch,
+      { confidenceLevelToApply: 50, isConfidenceMatch: false, isConfidenceUpper: false },
+    );
+
+    expect(result.x_opencti_score).toBe(existingIndicator.x_opencti_score);
+    expect(result.valid_from).toBe(existingIndicator.valid_from);
+    expect(result.valid_until).toBe(existingIndicator.valid_until);
+    expect(result.revoked).toBe(existingIndicator.revoked);
+    expect(result.decay_base_score).toBe(existingIndicator.decay_base_score);
+    expect(result.decay_base_score_date).toBe(existingIndicator.decay_base_score_date);
+    expect(result.decay_applied_rule).toEqual(existingIndicator.decay_applied_rule);
+    expect(result.decay_next_reaction_date).toBe(existingIndicator.decay_next_reaction_date);
+    expect(result.decay_history).toEqual([]);
+    expect(result.confidence).toBe(50);
+  });
+
+  it('should keep incoming indicator lifecycle and metadata fields when confidence matches', () => {
+    const existingIndicator = {
+      entity_type: ENTITY_TYPE_INDICATOR,
+      standard_id: 'indicator--existing',
+      confidence: 70,
+      x_opencti_score: 70,
+      valid_from: '2024-01-01T00:00:00.000Z',
+      valid_until: '2024-03-01T00:00:00.000Z',
+      revoked: true,
+    };
+    const incomingPatch = {
+      confidence: 80,
+      x_opencti_score: 80,
+      valid_from: '2025-01-01T00:00:00.000Z',
+      valid_until: '2025-04-01T00:00:00.000Z',
+      revoked: false,
+      decay_base_score: 80,
+      decay_base_score_date: '2025-01-01T00:00:00.000Z',
+      decay_applied_rule: { decay_rule_id: 'rule-new' },
+      decay_history: [{ score: 80, updated_by: 'source-b', updated_at: '2025-01-01T00:00:00.000Z' }],
+      decay_next_reaction_date: '2025-01-15T00:00:00.000Z',
+    };
+
+    const result = buildUpdatePatchForUpsert(
+      makeUser(),
+      existingIndicator,
+      ENTITY_TYPE_INDICATOR,
+      incomingPatch,
+      { confidenceLevelToApply: 80, isConfidenceMatch: true, isConfidenceUpper: true },
+    );
+
+    expect(result.x_opencti_score).toBe(incomingPatch.x_opencti_score);
+    expect(result.valid_from).toBe(incomingPatch.valid_from);
+    expect(result.valid_until).toBe(incomingPatch.valid_until);
+    expect(result.revoked).toBe(incomingPatch.revoked);
+    expect(result.decay_base_score).toBe(incomingPatch.decay_base_score);
+    expect(result.decay_base_score_date).toBe(incomingPatch.decay_base_score_date);
+    expect(result.decay_applied_rule).toEqual(incomingPatch.decay_applied_rule);
+    expect(result.decay_history).toEqual(incomingPatch.decay_history);
+    expect(result.decay_next_reaction_date).toBe(incomingPatch.decay_next_reaction_date);
+    expect(result.confidence).toBe(80);
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a confidence guard in buildUpdatePatchForUpsert for Indicator to preserve lifecycle and validity metadata when incoming confidence is lower than the existing indicator confidence.
* Add a unit test file tests/01-unit/utils/upsert-utils-test.ts

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #13628 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
* Manual negative scenario (should not update):
Start from an existing Indicator (e.g. confidence 70)
Create/import same pattern with confidence 50, different valid_from, valid_until, and x_opencti_score
Expected: existing indicator keeps its previous valid_from, valid_until, x_opencti_score, revoked, and decay lifecycle data

* Manual positive scenario (should update):
Create/import same pattern with confidence 80 (or >= 70) and different lifecycle/metadata values
Expected: existing indicator is updated consistently with incoming values (according to normal decay/upsert behavior)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
