### PR TITLE
fix(frontend): missing 'danger zone' within connector reset option (#17469)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/deployed/DeployedIntegrationPopover.tsx
@@ -3,10 +3,14 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContentText from '@mui/material/DialogContentText';
+import Alert from '@mui/material/Alert';
+import { useTheme } from '@mui/styles';
 import { MoreVert } from '@mui/icons-material';
 import Button from '@common/button/Button';
 import IconButton from '@common/button/IconButton';
 import Dialog from '@common/dialog/Dialog';
+import DangerZoneBlock from '@components/common/danger_zone/DangerZoneBlock';
+import DangerZoneChip from '@components/common/danger_zone/DangerZoneChip';
 import { connectorDeletionMutation, connectorResetStateMutation, connectorWorkDeleteMutation } from '@components/data/connectors/Connector';
 import canDeleteConnector from '@components/data/connectors/utils/canDeleteConnector';
 import { Connector_connector$data } from '@components/data/connectors/__generated__/Connector_connector.graphql';
@@ -16,7 +20,9 @@ import { DeployedIntegrationItem } from '@components/integrations/deployed/useDe
 import handleExportJson from '@components/data/forms/FormExportHandler';
 import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, MESSAGING$ } from '../../../../relay/environment';
+import type { Theme } from '../../../../components/Theme';
 import useGranted, { INGESTION_SETINGESTIONS, MODULES_MODMANAGE } from '../../../../utils/hooks/useGranted';
+import useSensitiveModifications from '../../../../utils/hooks/useSensitiveModifications';
 import stopEvent from '../../../../utils/domEvent';
 
 interface DeployedIntegrationPopoverProps {
@@ -28,6 +34,7 @@ interface DeployedIntegrationPopoverProps {
 // clear works and delete for connectors (same set as the detail page).
 const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopoverProps) => {
   const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [displayDelete, setDisplayDelete] = useState(false);
   const [displayReset, setDisplayReset] = useState(false);
@@ -36,6 +43,7 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
   const [submitting, setSubmitting] = useState(false);
   const isGrantedToModules = useGranted([MODULES_MODMANAGE]);
   const isGrantedToIngestion = useGranted([INGESTION_SETINGESTIONS]);
+  const { isSensitive } = useSensitiveModifications('connector_reset');
 
   const isConnector = item.kind === 'connector';
   const isForm = item.kind === 'form';
@@ -225,14 +233,34 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
           </MenuItem>
         )}
         {canManageConnector && (
-          <MenuItem
-            onClick={(event) => {
-              handleClose(event);
-              setDisplayReset(true);
-            }}
-          >
-            {t_i18n('Reset the connector state')}
-          </MenuItem>
+          isSensitive ? (
+            <DangerZoneBlock
+              type="connector_reset"
+              sx={{ title: { display: 'none' } }}
+              component={({ disabled }) => (
+                <MenuItem
+                  onClick={(event) => {
+                    handleClose(event);
+                    setDisplayReset(true);
+                  }}
+                  disabled={disabled}
+                  sx={{ color: theme.palette.dangerZone.main, gap: 1 }}
+                >
+                  <div>{t_i18n('Reset')}</div>
+                  <DangerZoneChip />
+                </MenuItem>
+              )}
+            />
+          ) : (
+            <MenuItem
+              onClick={(event) => {
+                handleClose(event);
+                setDisplayReset(true);
+              }}
+            >
+              {t_i18n('Reset the connector state')}
+            </MenuItem>
+          )
         )}
         {canManageConnector && (
           <MenuItem
@@ -320,11 +348,21 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
         onClose={() => setDisplayReset(false)}
         title={t_i18n('Are you sure?')}
       >
-        <DialogContentText>
-          {t_i18n('Do you want to reset the state and purge messages queue of this connector?')}
-        </DialogContentText>
-        <DialogContentText>
-          {t_i18n('Number of messages: ') + (item.messagesCount ?? 0)}
+        <DialogContentText component="div">
+          <Alert
+            severity={isSensitive ? 'warning' : 'info'}
+            variant="outlined"
+            color={isSensitive ? 'dangerZone' : undefined}
+            style={isSensitive ? {
+              borderColor: theme.palette.dangerZone.main,
+            } : {}}
+          >
+            <div>
+              {t_i18n('Do you want to reset the state and purge messages queue of this connector?')}
+              <br />
+              {t_i18n('Number of messages: ') + (item.messagesCount ?? 0)}
+            </div>
+          </Alert>
         </DialogContentText>
         <DialogActions>
           <Button
@@ -334,7 +372,11 @@ const DeployedIntegrationPopover = ({ item, onChange }: DeployedIntegrationPopov
           >
             {t_i18n('Cancel')}
           </Button>
-          <Button onClick={submitReset} disabled={submitting}>
+          <Button
+            onClick={submitReset}
+            disabled={submitting}
+            {...(isSensitive && { color: 'error' })}
+          >
             {t_i18n('Confirm')}
           </Button>
         </DialogActions>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add missing danger zone

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17469

### How to test this PR
Go to Integration and try to reset a connector you now should have Danger Zone:
<img width="663" height="346" alt="image" src="https://github.com/user-attachments/assets/232ad39b-0e44-4da6-945f-6049c949032c" />

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
