### PR TITLE
feat(background-tasks): ability to update relations start/stop time via mass operation (#16216)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -614,8 +614,6 @@ class DataTableToolBar extends Component {
     const { value } = event.target;
     const { actionsInputs } = this.state;
     const currentActionInput = actionsInputs[i] || {};
-    const previousType = currentActionInput.type;
-    const previousField = currentActionInput.field;
 
     actionsInputs[i] = R.assoc(key, value, currentActionInput);
     if (key === 'field') {
@@ -648,14 +646,6 @@ class DataTableToolBar extends Component {
           'ATTRIBUTE',
           actionsInputs[i] || {},
         );
-      }
-    }
-    if (key === 'type') {
-      if (value === 'REMOVE' && ['start_time', 'stop_time'].includes(previousField)) {
-        actionsInputs[i] = R.assoc('values', [''], actionsInputs[i] || {});
-      }
-      if (previousType === 'REMOVE' && value !== 'REMOVE' && ['start_time', 'stop_time'].includes(previousField)) {
-        actionsInputs[i] = R.assoc('values', [], actionsInputs[i] || {});
       }
     }
     this.setState({ actionsInputs });

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -2142,6 +2142,19 @@ class DataTableToolBar extends Component {
           />
         );
       case 'account_lock_after_date':
+        return (
+          <DateTimePicker
+            disabled={disabled}
+            variant="inline"
+            disableToolbar={false}
+            autoOk={true}
+            allowKeyboardControl={true}
+            onChange={this.handleChangeDate.bind(this, i)}
+            onAccept={this.handleAcceptDate.bind(this, i)}
+            views={['year', 'month', 'day', 'hours', 'minutes', 'seconds']}
+            format="yyyy-MM-dd hh:mm:ss a"
+          />
+        );
       case 'start_time':
       case 'stop_time':
         return (
@@ -2923,6 +2936,16 @@ class DataTableToolBar extends Component {
                           <Grid item xs={6} style={{ display: 'flex', flexDirection: 'column-reverse' }}>
                             {this.renderValuesOptions(i, selectedTypes, settings.platform_user_statuses)}
                           </Grid>
+                          {['start_time', 'stop_time'].includes(actionsInputs[i]?.field) && actionsInputs[i]?.type !== 'REMOVE' && (
+                            <Grid item xs={12}>
+                              <Alert
+                                severity="info"
+                                variant="outlined"
+                              >
+                                {t('The "start time" must be earlier than the "stop time".')}
+                              </Alert>
+                            </Grid>
+                          )}
                         </Grid>
                       </div>
                     ))}

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -263,6 +263,7 @@ const typesWithDetection = ['Indicator'];
 const typesWithKillChains = ['Indicator'];
 const typesWithIndicatorTypes = ['Indicator'];
 const typesWithPlatforms = ['Indicator'];
+const typesWithTemporalRange = ['stix-core-relationship'];
 
 const typesWithoutStatus = ['Stix-Core-Object', 'Stix-Domain-Object', 'Stix-Cyber-Observable', 'Artifact', 'ExternalReference'];
 const notShareableTypes = ['Playbook', 'Label', 'Vocabulary', 'Case-Template', 'DeleteOperation', 'InternalFile', 'PublicDashboard', 'Workspace', 'DraftWorkspace', 'Notification'];
@@ -612,13 +613,18 @@ class DataTableToolBar extends Component {
   handleChangeActionInput(i, key, event) {
     const { value } = event.target;
     const { actionsInputs } = this.state;
+    const currentActionInput = actionsInputs[i] || {};
+    const previousType = currentActionInput.type;
+    const previousField = currentActionInput.field;
 
-    actionsInputs[i] = R.assoc(key, value, actionsInputs[i] || {});
+    actionsInputs[i] = R.assoc(key, value, currentActionInput);
     if (key === 'field') {
       if (value === 'x_opencti_detection') {
         actionsInputs[i] = R.assoc('values', ['false'], actionsInputs[i] || {});
       } else if (value === 'password_valid_until') {
         actionsInputs[i] = R.assoc('values', [new Date().toISOString()], actionsInputs[i] || {});
+      } else if (['start_time', 'stop_time'].includes(value) && actionsInputs[i]?.type === 'REMOVE') {
+        actionsInputs[i] = R.assoc('values', [''], actionsInputs[i] || {});
       } else {
         const values = [];
         actionsInputs[i] = R.assoc('values', values, actionsInputs[i] || {});
@@ -642,6 +648,14 @@ class DataTableToolBar extends Component {
           'ATTRIBUTE',
           actionsInputs[i] || {},
         );
+      }
+    }
+    if (key === 'type') {
+      if (value === 'REMOVE' && ['start_time', 'stop_time'].includes(previousField)) {
+        actionsInputs[i] = R.assoc('values', [''], actionsInputs[i] || {});
+      }
+      if (previousType === 'REMOVE' && value !== 'REMOVE' && ['start_time', 'stop_time'].includes(previousField)) {
+        actionsInputs[i] = R.assoc('values', [], actionsInputs[i] || {});
       }
     }
     this.setState({ actionsInputs });
@@ -841,6 +855,19 @@ class DataTableToolBar extends Component {
     return type;
   }
 
+  static normalizeActionValue(element) {
+    if (element?.id) return element.id;
+    if (element?.value) return element.value;
+    if (typeof element?.toISOString === 'function') return element.toISOString();
+    return element;
+  }
+
+  static displayActionValue(element) {
+    if (typeof element === 'string') return element;
+    if (typeof element?.toISOString === 'function') return element.toISOString();
+    return getMainRepresentative(element);
+  }
+
   getUserDatatableFinalActions(actions) {
     return actions.map((action) => {
       const currentType = this.constructor.getActionType(action.type, action.context.field);
@@ -848,7 +875,7 @@ class DataTableToolBar extends Component {
         type: currentType,
         context: {
           ...action.context,
-          values: action.context.values.map((element) => element.id || element.value || element),
+          values: action.context.values.map((element) => this.constructor.normalizeActionValue(element)),
         },
         containerId: null,
       };
@@ -884,7 +911,7 @@ class DataTableToolBar extends Component {
             context: n.context
               ? {
                   ...n.context,
-                  values: n.context.values.map((o) => o.id || o.value || o),
+                  values: n.context.values.map((o) => this.constructor.normalizeActionValue(o)),
                 }
               : null,
             containerId: n.type === 'PROMOTE' && promoteToContainer && container?.id ? container.id : null,
@@ -960,6 +987,9 @@ class DataTableToolBar extends Component {
     const disabled = actionsInputs[i]?.type == null || actionsInputs[i]?.type === '';
     const checkTypes = (typesList) => selectedTypes.every((type) => typesList.includes(type))
       && entityTypeFilterValues.every((type) => typesList.includes(type));
+    const hasTemporalRangeField = entityTypeFilterValues.some((type) => typesWithTemporalRange.includes(type))
+      || (this.props.types ?? []).some((type) => typesWithTemporalRange.includes(type))
+      || checkTypes(typesWithTemporalRange);
 
     let options = [];
     if (isUserDatatable) {
@@ -1002,6 +1032,14 @@ class DataTableToolBar extends Component {
         checkTypes(typesWithPlatforms) && (actionsInputs[i]?.type === 'ADD' || actionsInputs[i]?.type === 'REPLACE' || actionsInputs[i]?.type === 'REMOVE') && {
           label: t('Platforms'),
           value: 'platforms_ov',
+        },
+        hasTemporalRangeField && (actionsInputs[i]?.type === 'ADD' || actionsInputs[i]?.type === 'REPLACE' || actionsInputs[i]?.type === 'REMOVE') && {
+          label: t('Start time'),
+          value: 'start_time',
+        },
+        hasTemporalRangeField && (actionsInputs[i]?.type === 'ADD' || actionsInputs[i]?.type === 'REPLACE' || actionsInputs[i]?.type === 'REMOVE') && {
+          label: t('Stop time'),
+          value: 'stop_time',
         },
         ...(actionsInputs[i]?.type === 'REPLACE' ? [
           { label: t('Author'), value: 'created-by' },
@@ -1473,6 +1511,9 @@ class DataTableToolBar extends Component {
 
   handleChangeDate(i, newValue) {
     const { actionsInputs } = this.state;
+    if (actionsInputs[i]?.type === 'REMOVE' && ['start_time', 'stop_time'].includes(actionsInputs[i]?.field)) {
+      return;
+    }
     actionsInputs[i] = R.assoc(
       'inputValue',
       newValue && newValue.length > 0 ? newValue : '',
@@ -1483,6 +1524,9 @@ class DataTableToolBar extends Component {
 
   handleAcceptDate(i, newValue) {
     const { actionsInputs } = this.state;
+    if (actionsInputs[i]?.type === 'REMOVE' && ['start_time', 'stop_time'].includes(actionsInputs[i]?.field)) {
+      return;
+    }
     actionsInputs[i] = R.assoc(
       'values',
       Array.isArray(newValue) ? newValue : [newValue],
@@ -2097,8 +2141,11 @@ class DataTableToolBar extends Component {
           />
         );
       case 'account_lock_after_date':
+      case 'start_time':
+      case 'stop_time':
         return (
           <DateTimePicker
+            disabled={disabled || (actionsInputs[i]?.type === 'REMOVE' && ['start_time', 'stop_time'].includes(selectedField))}
             variant="inline"
             disableToolbar={false}
             autoOk={true}
@@ -2797,9 +2844,7 @@ class DataTableToolBar extends Component {
                                 R.join(
                                   ', ',
                                   R.map(
-                                    (p) => (typeof p === 'string'
-                                      ? p
-                                      : getMainRepresentative(p)),
+                                    (p) => this.constructor.displayActionValue(p),
                                     R.pathOr([], ['context', 'values'], o),
                                   ),
                                 ),

--- a/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/data/DataTableToolBar.jsx
@@ -989,6 +989,7 @@ class DataTableToolBar extends Component {
       && entityTypeFilterValues.every((type) => typesList.includes(type));
     const hasTemporalRangeField = entityTypeFilterValues.some((type) => typesWithTemporalRange.includes(type))
       || (this.props.types ?? []).some((type) => typesWithTemporalRange.includes(type))
+      || typesWithTemporalRange.includes(this.props.type)
       || checkTypes(typesWithTemporalRange);
 
     let options = [];

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -170,15 +170,7 @@ export const baseOperationBuilder = (actionType, operations, element) => {
       if (isStixCyberObservable(element.entity_type) && attrKey === 'description') {
         attrKey = 'x_opencti_description';
       }
-      let operation = action.type.toLowerCase();
-      let value = action.context.values;
-      // For single-valued temporal bounds, REMOVE must clear the field.
-      // Converting to REPLACE [null] makes the update deterministic regardless of displayed/input format.
-      if (action.type === ACTION_TYPE_REMOVE && ['start_time', 'stop_time'].includes(attrKey)) {
-        operation = 'replace';
-        value = [null];
-      }
-      return { key: attrKey, value, operation };
+      return { key: attrKey, value: action.context.values, operation: action.type.toLowerCase() };
     });
   }
   if (actionType === 'KNOWLEDGE_TRASH') {

--- a/opencti-platform/opencti-graphql/src/manager/taskManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/taskManager.js
@@ -170,7 +170,15 @@ export const baseOperationBuilder = (actionType, operations, element) => {
       if (isStixCyberObservable(element.entity_type) && attrKey === 'description') {
         attrKey = 'x_opencti_description';
       }
-      return { key: attrKey, value: action.context.values, operation: action.type.toLowerCase() };
+      let operation = action.type.toLowerCase();
+      let value = action.context.values;
+      // For single-valued temporal bounds, REMOVE must clear the field.
+      // Converting to REPLACE [null] makes the update deterministic regardless of displayed/input format.
+      if (action.type === ACTION_TYPE_REMOVE && ['start_time', 'stop_time'].includes(attrKey)) {
+        operation = 'replace';
+        value = [null];
+      }
+      return { key: attrKey, value, operation };
     });
   }
   if (actionType === 'KNOWLEDGE_TRASH') {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added bulk update support for relationship start_time and stop_time with add, replace, and remove.

* Enabled this behavior in both standard and draft contexts.

* Added backend-safe patch handling for remove on start_time/stop_time to ensure values are properly cleared.

* Disabled the datetime input for remove on these fields because they are single-valued (not multiple), which avoids requiring an exact date and lets users clear the field on many relationships at once.

* Added an informational alert when editing start_time/stop_time to remind users that start_time must be earlier than stop_time, helping prevent invalid date ranges during bulk updates.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes https://github.com/OpenCTI-Platform/opencti/issues/16216

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
• Go to Data > Relationships.
• Select one or more relationships.
• Click Update.
• Test the start time and stop time fields with ADD, REPLACE, and REMOVE actions.
• Repeat the same checks in Drafts.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
