### PR TITLE
feat(security-coverage): fix security coverage identifier (#14716)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverageResult/securityCoverageResult.ts
@@ -30,7 +30,10 @@ const SECURITY_COVERAGE_RESULT_DEFINITION: ModuleDefinition<StoreEntitySecurityC
   },
   identifier: {
     definition: {
-      [ENTITY_TYPE_SECURITY_COVERAGE_RESULT]: [{ src: 'name' }, { src: 'external_uri' }, { src: INPUT_RESULT_OF }],
+      [ENTITY_TYPE_SECURITY_COVERAGE_RESULT]: [
+        [{ src: 'external_uri' }, { src: INPUT_RESULT_OF, dependencies: ['external_uri'] }],
+        [{ src: 'name' }, { src: INPUT_RESULT_OF, dependencies: ['name'] }],
+      ],
     },
     resolvers: {
       name(data: object) {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/securityCoverage/securityCoverageResult-identifier-test.ts
@@ -27,29 +27,17 @@ describe('SecurityCoverageResult identifier', () => {
 
   it('should generate all different identifiers', () => {
     const identifiers = [
-      generateId(SC_1, null, null),
-      generateId(SC_2, null, null),
-      generateId(null, NAME_1, null),
-      generateId(null, NAME_2, null),
-      generateId(null, null, URI_1),
-      generateId(null, null, URI_2),
+      // different names, different SC & names, no uri
       generateId(SC_1, NAME_1, null),
       generateId(SC_1, NAME_2, null),
+      generateId(SC_2, NAME_1, null),
+      generateId(SC_2, NAME_2, null),
+      // same SC, different uris, no name
       generateId(SC_1, null, URI_1),
       generateId(SC_1, null, URI_2),
-      generateId(SC_2, NAME_1, null),
-      generateId(null, NAME_1, URI_1),
-      generateId(null, NAME_1, URI_2),
-      generateId(SC_2, null, URI_1),
-      generateId(null, NAME_2, URI_1),
-      generateId(SC_1, NAME_1, URI_1),
-      generateId(SC_1, NAME_2, URI_1),
-      generateId(SC_1, NAME_1, URI_2),
+      // Same SC different uris, same name
       generateId(SC_2, NAME_1, URI_1),
-      generateId(SC_2, NAME_2, URI_1),
       generateId(SC_2, NAME_1, URI_2),
-      generateId(SC_1, NAME_2, URI_2),
-      generateId(SC_2, NAME_2, URI_2),
     ];
     expect(identifiers.length).toEqual(new Set(identifiers).size);
   });
@@ -65,6 +53,14 @@ describe('SecurityCoverageResult identifier', () => {
       const standardId1 = generateId(SC_1, null, URI_1);
       const standardId2 = generateId(SC_1, null, URI_1);
       expect(standardId1).toEqual(standardId2);
+    });
+
+    it('should have same ID if given same external_uri & different names', () => {
+      const standardId1 = generateId(SC_1, NAME_1, URI_1);
+      const standardId2 = generateId(SC_1, NAME_2, URI_1);
+      const standardId3 = generateId(SC_1, null, URI_1);
+      expect(standardId1).toEqual(standardId2);
+      expect(standardId1).toEqual(standardId3);
     });
 
     it('should have same ID if given same couple (name/external_uri)', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* define identifier fields as "resultOf + external uri (if external uri defined), or resultOf + name (if name defined)
* adapt unit tests

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* task of #14716 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
