### PR TITLE
fix(security-coverage): scope queries to the coverage results (#14716)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -20,7 +20,7 @@ import {
 import { notify } from '../../database/redis';
 import { BUS_TOPICS, logApp } from '../../config/conf';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
-import { createEntity, deleteElementById, storeLoadByIdsWithRefs, storeLoadByIdWithRefs } from '../../database/middleware';
+import { createEntity, deleteElementById, distributionRelations, storeLoadByIdsWithRefs, storeLoadByIdWithRefs } from '../../database/middleware';
 import { type SecurityCoverageAddInput } from '../../generated/graphql';
 import type { BasicStoreEntity, BasicStoreObject, BasicStoreRelation, StoreObject, StoreRelation } from '../../types/store';
 import { convertStoreToStix_2_1 } from '../../database/stix-2-1-converter';
@@ -50,6 +50,7 @@ import { stixCoreRelationshipsPaginated } from '../../domain/stixCoreObject';
 import { getAverageCoverageInformation, getMostRecentLastCoverageResult, internalCreateSecurityCoverageResult } from './securityCoverageResult/securityCoverageResult-utils';
 import { splitSecurityCoverageInput } from './securityCoverage-utils';
 import { addRelatedCoveredEntities } from './securityCoverageResult/securityCoverageResult-domain';
+import { emptyPaginationResult } from '../../database/utils';
 
 export const COVERED_ENTITIES_TYPE = [
   ENTITY_TYPE_INTRUSION_SET,
@@ -226,12 +227,42 @@ export const deleteSecurityCoverageResultsByResultOf = async (
   return deletedIds;
 };
 
+export const getSecurityCoverageResultIds = (securityCoverage: BasicStoreEntitySecurityCoverage): string[] => {
+  return securityCoverage[RELATION_RESULT_OF] ?? [];
+};
+
+export const findCoveredEntitiesDistribution = async (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverage: BasicStoreEntitySecurityCoverage,
+  args: Record<string, unknown>,
+) => {
+  const resultIds = getSecurityCoverageResultIds(securityCoverage);
+  if (resultIds.length === 0) {
+    return [];
+  }
+  return distributionRelations(context, user, { ...args, fromOrToId: resultIds } as never);
+};
+
+export const findResultsRelationshipsPaginated = (
+  context: AuthContext,
+  user: AuthUser,
+  securityCoverage: BasicStoreEntitySecurityCoverage,
+  args: EntityOptions<BasicStoreRelation>,
+): ReturnType<typeof stixCoreRelationshipsPaginated> => {
+  const resultIds = getSecurityCoverageResultIds(securityCoverage);
+  if (resultIds.length === 0) {
+    return Promise.resolve(emptyPaginationResult<BasicStoreRelation>());
+  }
+  return stixCoreRelationshipsPaginated(context, user, resultIds, args);
+};
+
 export const listSecurityCoverageResults = (
   context: AuthContext,
   user: AuthUser,
   securityCoverage: BasicStoreEntitySecurityCoverage,
 ): Promise<BasicStoreEntitySecurityCoverageResult[]> => {
-  return internalFindByIds(context, user, securityCoverage[RELATION_RESULT_OF]) as Promise<BasicStoreEntitySecurityCoverageResult[]>;
+  return internalFindByIds(context, user, getSecurityCoverageResultIds(securityCoverage)) as Promise<BasicStoreEntitySecurityCoverageResult[]>;
 };
 
 export const loadSecurityCoverageResults = async (
@@ -250,7 +281,11 @@ export const findCoveredEntities = async (
   toType: string,
   args: EntityOptions<BasicStoreEntity>,
 ): Promise<{ count: number; entities: CoveredEntity[] }> => {
-  const relationships = await stixCoreRelationshipsPaginated(context, user, securityCoverage[RELATION_RESULT_OF], {
+  const resultIds = getSecurityCoverageResultIds(securityCoverage);
+  if (resultIds.length === 0) {
+    return { count: 0, entities: [] };
+  }
+  const relationships = await stixCoreRelationshipsPaginated(context, user, resultIds, {
     ...args,
     relationship_type: RELATION_HAS_COVERED,
     toTypes: [toType],

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -10,6 +10,8 @@ import {
   loadMostRecentLastCoverageResult,
   loadSecurityCoverageResults,
   findCoveredEntities,
+  findCoveredEntitiesDistribution,
+  findResultsRelationshipsPaginated,
 } from './securityCoverage-domain';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_VULNERABILITY } from '../../schema/stixDomainObject';
 import {
@@ -23,9 +25,6 @@ import type { Resolvers } from '../../generated/graphql';
 import { BUS_TOPICS } from '../../config/conf';
 import { subscribeToInstanceEvents } from '../../graphql/subscriptionWrapper';
 import { ENTITY_TYPE_SECURITY_COVERAGE } from './securityCoverage-types';
-import { distributionRelations } from '../../database/middleware';
-import { RELATION_RESULT_OF } from './securityCoverageResult/securityCoverageResult-types';
-import { stixCoreRelationshipsPaginated } from '../../domain/stixCoreObject';
 
 const SecurityCoverageResolvers: Resolvers = {
   Query: {
@@ -41,9 +40,8 @@ const SecurityCoverageResolvers: Resolvers = {
     coverage_valid_from: (securityCoverage, _, context) => loadSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_from'),
     coverage_valid_to: (securityCoverage, _, context) => loadSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_to'),
     coverage_information: (securityCoverage, _, context) => loadAverageCoverageInformation(context, context.user, securityCoverage),
-    coveredEntitiesDistribution: (securityCoverage, args, context) =>
-      distributionRelations(context, context.user, { ...args, fromOrToId: securityCoverage[RELATION_RESULT_OF] } as any),
-    stixCoreRelationshipsFromResults: (securityCoverage, args, context) => stixCoreRelationshipsPaginated(context, context.user, securityCoverage[RELATION_RESULT_OF], args),
+    coveredEntitiesDistribution: (securityCoverage, args, context) => findCoveredEntitiesDistribution(context, context.user, securityCoverage, args),
+    stixCoreRelationshipsFromResults: (securityCoverage, args, context) => findResultsRelationshipsPaginated(context, context.user, securityCoverage, args as any),
     coveredAttackPatterns: (securityCoverage, args, context) =>
       findCoveredEntities(context, context.user, securityCoverage, ENTITY_TYPE_ATTACK_PATTERN, args),
     coveredVulnerabilities: (securityCoverage, args, context) =>

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/securityCoverage/securityCoverage-test.ts
@@ -103,6 +103,21 @@ const COVERED_ENTITIES_QUERY = gql`
     }
   }
 `;
+const RESULTS_RELATIONSHIPS_QUERY = gql`
+  query ResultsRelationships($id: String!) {
+    securityCoverage(id: $id) {
+      coveredEntitiesDistribution(field: "entity_type", relationship_type: ["has-covered"], operation: count) {
+        label
+        value
+      }
+      stixCoreRelationshipsFromResults(first: 100, relationship_type: "has-covered") {
+        pageInfo { globalCount }
+      }
+      coveredAttackPatterns(first: 100) { count }
+      coveredVulnerabilities(first: 100) { count }
+    }
+  }
+`;
 const GENERIC_DELETE = gql`
   mutation GenericDelete($id: ID!) {
     stixCoreObjectEdit(id: $id) { delete }
@@ -123,15 +138,21 @@ describe('SecurityCoverage covered entities resolvers', () => {
   let coverageId: string;
   let resultId: string;
   let malwareId: string;
+  let malwareWithoutResultId: string;
   let attackPatternId: string;
   let vulnerabilityId: string;
   let attackPatternRelId: string;
   let vulnerabilityRelId: string;
+  let coverageWithoutResultId: string;
 
   beforeAll(async () => {
     malwareId = (await queryAsAdmin({
       query: MALWARE_ADD,
       variables: { input: { name: 'SC covered-entities malware' } },
+    })).data?.malwareAdd.id;
+    malwareWithoutResultId = (await queryAsAdmin({
+      query: MALWARE_ADD,
+      variables: { input: { name: 'SC covered-entities malware without result' } },
     })).data?.malwareAdd.id;
     attackPatternId = (await queryAsAdmin({
       query: ATTACK_PATTERN_ADD,
@@ -158,6 +179,11 @@ describe('SecurityCoverage covered entities resolvers', () => {
       query: HAS_COVERED_ADD,
       variables: { input: { fromId: resultId, toId: vulnerabilityId, relationship_type: 'has-covered', coverage_information: [{ coverage_name: 'detection', coverage_score: 7 }] } },
     })).data?.stixCoreRelationshipAdd.id;
+
+    coverageWithoutResultId = (await queryAsAdmin({
+      query: SECURITY_COVERAGE_ADD,
+      variables: { input: { name: 'SC covered-entities coverage without result', objectCovered: malwareWithoutResultId, auto_enrichment_disable: true } },
+    })).data?.securityCoverageAdd.id;
   });
 
   afterAll(async () => {
@@ -166,7 +192,10 @@ describe('SecurityCoverage covered entities resolvers', () => {
     }
     if (resultId) await queryAsAdmin({ query: SECURITY_COVERAGE_RESULT_DELETE, variables: { id: resultId } });
     if (coverageId) await queryAsAdmin({ query: SECURITY_COVERAGE_DELETE, variables: { id: coverageId } });
-    if (malwareId) await queryAsAdmin({ query: GENERIC_DELETE, variables: { id: malwareId } });
+    if (coverageWithoutResultId) await queryAsAdmin({ query: SECURITY_COVERAGE_DELETE, variables: { id: coverageWithoutResultId } });
+    for (const id of [malwareId, malwareWithoutResultId]) {
+      if (id) await queryAsAdmin({ query: GENERIC_DELETE, variables: { id } });
+    }
   });
 
   it('should return covered attack patterns with concrete node and relationship_id', async () => {
@@ -190,6 +219,25 @@ describe('SecurityCoverage covered entities resolvers', () => {
     const [entity] = vulnerabilities.entities;
     expect(entity.relationship_id).toEqual(vulnerabilityRelId);
     expect(entity.to.id).toEqual(vulnerabilityId);
+  });
+
+  it('should return the has-covered relationships of a coverage that has a result', async () => {
+    const { data } = await queryAsAdmin({ query: RESULTS_RELATIONSHIPS_QUERY, variables: { id: coverageId } });
+    const coverage = data?.securityCoverage;
+    expect(coverage.stixCoreRelationshipsFromResults.pageInfo.globalCount).toEqual(2);
+    expect(coverage.coveredAttackPatterns.count).toEqual(1);
+    expect(coverage.coveredVulnerabilities.count).toEqual(1);
+    const distributionTotal = coverage.coveredEntitiesDistribution.reduce((sum: number, d: { value: number }) => sum + d.value, 0);
+    expect(distributionTotal).toEqual(2);
+  });
+
+  it('should return no has-covered relationship for a coverage without result', async () => {
+    const { data } = await queryAsAdmin({ query: RESULTS_RELATIONSHIPS_QUERY, variables: { id: coverageWithoutResultId } });
+    const coverage = data?.securityCoverage;
+    expect(coverage.stixCoreRelationshipsFromResults.pageInfo.globalCount).toEqual(0);
+    expect(coverage.coveredAttackPatterns.count).toEqual(0);
+    expect(coverage.coveredVulnerabilities.count).toEqual(0);
+    expect(coverage.coveredEntitiesDistribution).toEqual([]);
   });
 });
 // endregion


### PR DESCRIPTION
### Proposed changes

* An empty `result-of` ref was passed as `fromOrToId`; `buildRelationsFilter` drops an empty value instead of matching nothing, so the queries lost their scope and returned `has-covered` relationships from **every other coverage**

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* #14716 

### How to test this PR
1. Open an Intrusion Set → **Add security coverage** → **Automated using enrichment**.
2. The coverage is created without a result 
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->
