### PR TITLE
fix(dashboard): Improve label management for custom dashboard distribution widgets (#17546)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/charts/Chart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/charts/Chart.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ApexOptions } from 'apexcharts';
+import Chart from './Chart';
+
+let receivedOptions: ApexOptions | undefined;
+
+vi.mock('react-apexcharts', () => ({
+  default: ({ options }: { options: ApexOptions }) => {
+    receivedOptions = options;
+    return <div data-testid="apex-chart" />;
+  },
+}));
+
+const renderChart = (options: ApexOptions) => {
+  render(<Chart options={options} series={[]} type="bar" />);
+  return receivedOptions as ApexOptions;
+};
+
+// Formatters are declared with a loose signature by ApexCharts, calling them in tests requires a cast.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const callFormatter = (formatter: unknown, value: unknown) => (formatter as any)(value);
+
+describe('Component: Chart', () => {
+  beforeEach(() => {
+    receivedOptions = undefined;
+  });
+
+  it('should keep the mounted callback and the given options', () => {
+    const onMounted = vi.fn();
+    render(<Chart options={{ chart: { type: 'donut' } }} series={[]} type="donut" onMounted={onMounted} />);
+    expect(receivedOptions?.chart?.type).toEqual('donut');
+    expect(receivedOptions?.chart?.events?.mounted).toEqual(onMounted);
+  });
+
+  describe('Legend labels', () => {
+    it('should escape markup in a legend label', () => {
+      const options = renderChart({});
+      const label = callFormatter(options.legend?.formatter, '<img src=x onerror=alert(1)>');
+      expect(label).not.toContain('<img');
+      expect(label).toEqual('&lt;img src=x onerror=alert(1)&gt;');
+    });
+
+    it('should display a label containing an ampersand as is', () => {
+      const options = renderChart({});
+      // '&amp;' is decoded back to '&' by the browser when the legend is rendered
+      expect(callFormatter(options.legend?.formatter, 'AT&T')).toEqual('AT&amp;T');
+    });
+
+    it('should keep the formatter already configured on the chart', () => {
+      const options = renderChart({ legend: { formatter: (value) => `[${value}]` } });
+      expect(callFormatter(options.legend?.formatter, 'ACME')).toEqual('[ACME]');
+      expect(callFormatter(options.legend?.formatter, '<b>ACME</b>')).toEqual('[&lt;b&gt;ACME&lt;/b&gt;]');
+    });
+
+    it('should join the parts of a multiline label', () => {
+      const options = renderChart({});
+      expect(callFormatter(options.legend?.formatter, ['ACME', 'Corp'])).toEqual('ACME Corp');
+    });
+  });
+
+  describe('Tooltip labels', () => {
+    it('should escape markup in the tooltip title', () => {
+      const options = renderChart({});
+      const title = callFormatter(options.tooltip?.x?.formatter, '<img src=x onerror=alert(1)>');
+      expect(title).not.toContain('<img');
+      expect(title).toEqual('&lt;img src=x onerror=alert(1)&gt;');
+    });
+
+    it('should keep the axis formatting of the tooltip title of an horizontal bars chart', () => {
+      const options = renderChart({
+        plotOptions: { bar: { horizontal: true } },
+        yaxis: { labels: { formatter: (value) => `${value}!` } },
+      });
+      expect(callFormatter(options.tooltip?.x?.formatter, 'ACME')).toEqual('ACME!');
+      expect(callFormatter(options.tooltip?.x?.formatter, '<b>ACME</b>')).toEqual('&lt;b&gt;ACME&lt;/b&gt;!');
+    });
+
+    it('should not format the tooltip title of a datetime chart', () => {
+      const options = renderChart({ xaxis: { type: 'datetime' } });
+      expect(options.tooltip?.x?.formatter).toBeUndefined();
+    });
+
+    it('should escape markup in a series name', () => {
+      const options = renderChart({});
+      const name = callFormatter(options.tooltip?.y?.title?.formatter, '<b>ACME</b>');
+      expect(name).toEqual('&lt;b&gt;ACME&lt;/b&gt;: ');
+    });
+
+    it('should keep an empty series name empty', () => {
+      const options = renderChart({});
+      expect(callFormatter(options.tooltip?.y?.title?.formatter, '')).toEqual('');
+    });
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/common/charts/Chart.test.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/charts/Chart.test.tsx
@@ -84,13 +84,15 @@ describe('Component: Chart', () => {
 
     it('should escape markup in a series name', () => {
       const options = renderChart({});
-      const name = callFormatter(options.tooltip?.y?.title?.formatter, '<b>ACME</b>');
+      const tooltipY = Array.isArray(options.tooltip?.y) ? options.tooltip?.y[0] : options.tooltip?.y;
+      const name = callFormatter(tooltipY?.title?.formatter, '<b>ACME</b>');
       expect(name).toEqual('&lt;b&gt;ACME&lt;/b&gt;: ');
     });
 
     it('should keep an empty series name empty', () => {
       const options = renderChart({});
-      expect(callFormatter(options.tooltip?.y?.title?.formatter, '')).toEqual('');
+      const tooltipY = Array.isArray(options.tooltip?.y) ? options.tooltip?.y[0] : options.tooltip?.y;
+      expect(callFormatter(tooltipY?.title?.formatter, '')).toEqual('');
     });
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/common/charts/Chart.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/charts/Chart.tsx
@@ -1,10 +1,63 @@
 import { useMemo } from 'react';
 import ApexChart, { Props as ApexProps } from 'react-apexcharts';
 import ApexCharts from 'apexcharts';
+import { sanitize } from '../../../../utils/String';
 
 export interface OpenCTIChartProps extends ApexProps {
   onMounted?: (chart: ApexCharts) => void;
 }
+
+type ApexOptions = NonNullable<ApexProps['options']>;
+type ApexFormatter = (value: never, options?: never) => string;
+
+const toDisplayString = (value: unknown): string => {
+  if (Array.isArray(value)) return value.join(' ');
+  return String(value ?? '');
+};
+
+/**
+ * Legend items and tooltips are the only parts of a chart that ApexCharts renders through
+ * `innerHTML`; axis labels, data labels and exports all go through SVG text nodes. Escaping is
+ * applied here, on the values on their way to those HTML outputs, so labels keep their original
+ * characters (`&`, `<`, `>`) everywhere else.
+ *
+ * @param value Value about to be rendered as HTML.
+ * @returns The escaped value.
+ */
+const escapeForHtmlOutput = (value: unknown): string => sanitize(toDisplayString(value), true);
+
+/**
+ * Build a formatter escaping the output of the formatter already configured on the chart, or the
+ * output of `fallback` when no formatter is configured, so the displayed value stays the same.
+ *
+ * @param formatter Formatter configured on the chart, if any.
+ * @param fallback Formatting applied by ApexCharts when no formatter is configured.
+ * @returns The wrapped formatter.
+ */
+const wrapFormatter = (formatter: unknown, fallback?: (value: unknown) => unknown) => {
+  return (value: unknown, formatterOptions: unknown) => {
+    if (typeof formatter === 'function') {
+      return escapeForHtmlOutput((formatter as ApexFormatter)(value as never, formatterOptions as never));
+    }
+    return escapeForHtmlOutput(fallback ? fallback(value) : value);
+  };
+};
+
+/**
+ * Resolve the formatter ApexCharts applies to a category before displaying it as the tooltip
+ * title, so wrapping the tooltip preserves the formatting configured on the axis (date
+ * conversion, truncation, ...) instead of falling back to the raw value.
+ *
+ * @param options Chart options.
+ * @returns The axis formatter used for the tooltip title, if any.
+ */
+const getCategoryFormatter = (options: ApexOptions | undefined) => {
+  if (options?.plotOptions?.bar?.horizontal !== true) {
+    return options?.xaxis?.labels?.formatter;
+  }
+  const yaxis = Array.isArray(options.yaxis) ? options.yaxis[0] : options.yaxis;
+  return yaxis?.labels?.formatter;
+};
 
 const Chart = ({
   options,
@@ -16,16 +69,49 @@ const Chart = ({
 }: OpenCTIChartProps) => {
   // Add in config a callback on 'mounted event' to retrieve chart context.
   // This context is used to export in different format.
-  const apexOptions: ApexProps['options'] = useMemo(() => ({
-    ...options,
-    chart: {
-      ...options?.chart,
-      events: {
-        ...options?.chart?.events,
-        mounted: onMounted,
+  const apexOptions: ApexProps['options'] = useMemo(() => {
+    const categoryFormatter = getCategoryFormatter(options);
+    // A datetime axis builds its tooltip title through a dedicated path that a custom formatter
+    // would bypass, and displays timestamps, so it is left untouched.
+    const isDateTimeAxis = options?.xaxis?.type === 'datetime';
+    const tooltipY = Array.isArray(options?.tooltip?.y) ? options?.tooltip?.y[0] : options?.tooltip?.y;
+    return {
+      ...options,
+      chart: {
+        ...options?.chart,
+        events: {
+          ...options?.chart?.events,
+          mounted: onMounted,
+        },
       },
-    },
-  }), [options]);
+      legend: {
+        ...options?.legend,
+        formatter: wrapFormatter(options?.legend?.formatter),
+      },
+      tooltip: {
+        ...options?.tooltip,
+        x: {
+          ...options?.tooltip?.x,
+          ...(isDateTimeAxis ? {} : {
+            formatter: wrapFormatter(
+              options?.tooltip?.x?.formatter,
+              categoryFormatter && ((value: unknown) => (categoryFormatter as ApexFormatter)(value as never)),
+            ),
+          }),
+        },
+        y: {
+          ...tooltipY,
+          title: {
+            ...tooltipY?.title,
+            formatter: wrapFormatter(
+              tooltipY?.title?.formatter,
+              (value) => (value ? `${toDisplayString(value)}: ` : ''),
+            ),
+          },
+        },
+      },
+    } as ApexOptions;
+  }, [options]);
 
   return (
     <ApexChart


### PR DESCRIPTION
## Description

Custom dashboard distribution widgets could display entity names inconsistently depending on the widget, because chart legends and tooltips are rendered as HTML by ApexCharts while axis labels, data labels and word clouds are rendered as SVG text.

Values are now prepared for each output where they are actually rendered, instead of being altered in the widget data.

## Changes

- `Chart.tsx`: the shared chart wrapper now prepares label values on their way to the two outputs ApexCharts renders as HTML (legend items, tooltip title and series name), by wrapping the formatters already configured on the chart so the existing formatting is preserved (date conversion, truncation, ...).
- Datetime axes are left untouched: they build their tooltip title through a dedicated path and display timestamps.
- Widget data is unchanged, so labels keep their original characters on axis labels, data labels, word clouds and exports, and grouping/sorting keys stay intact.
- Added unit tests covering legend and tooltip label rendering.

## Testing

- `tsc --noEmit`: clean
- `eslint` on changed files: clean
- `vitest run` on `utils/Charts`, `components/dashboard` and `private/components/common`: 252 tests passing
- Checked the rendered DOM of a chart mounted with labels such as `Johnson & Johnson`, `AT&T` and `R&D <core>`: displayed as typed in legend, tooltip and axis.

Closes #17546.
