### PR TITLE
fix(frontend): opposite object in obs nested objects table (#16078)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/stix_cyber_observables/StixCyberObservableNestedEntitiesTable.tsx
@@ -65,6 +65,134 @@ const stixCyberObservableNestedEntitiesLineFragment = graphql`
           draft_id
           draft_operation
         }
+        creators {
+          id
+          name
+        }
+        ... on AttackPattern {
+          name
+          description
+        }
+        ... on Campaign {
+          name
+          description
+        }
+        ... on CourseOfAction {
+          name
+          description
+        }
+        ... on Individual {
+          name
+          description
+        }
+        ... on Organization {
+          name
+          description
+        }
+        ... on Sector {
+          name
+          description
+        }
+        ... on System {
+          name
+          description
+        }
+        ... on Indicator {
+          name
+        }
+        ... on Infrastructure {
+          name
+        }
+        ... on IntrusionSet {
+          name
+          description
+        }
+        ... on Position {
+          name
+          description
+        }
+        ... on City {
+          name
+          description
+        }
+        ... on AdministrativeArea {
+          name
+          description
+        }
+        ... on Country {
+          name
+          description
+        }
+        ... on Region {
+          name
+          description
+        }
+        ... on Malware {
+          name
+          description
+        }
+        ... on MalwareAnalysis {
+          result_name
+        }
+        ... on ThreatActor {
+          name
+          description
+        }
+        ... on Tool {
+          name
+          description
+        }
+        ... on Vulnerability {
+          name
+          description
+        }
+        ... on Incident {
+          name
+          description
+        }
+        ... on Event {
+          name
+          description
+        }
+        ... on Channel {
+          name
+          description
+        }
+        ... on Narrative {
+          name
+          description
+        }
+        ... on Language {
+          name
+        }
+        ... on DataComponent {
+          name
+        }
+        ... on DataSource {
+          name
+        }
+        ... on Case {
+          name
+        }
+        ... on StixCyberObservable {
+          observable_value
+        }
+        ... on Report {
+          name
+        }
+        ... on Grouping {
+          name
+        }
+        ... on Note {
+          attribute_abstract
+          content
+        }
+        ... on Opinion {
+          opinion
+        }
+        ... on ObservedData {
+          name
+        }
       }
     }
     to {
@@ -290,6 +418,13 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
     setNumberOfElements: helpers.handleSetNumberOfElements,
   } as UsePreloadedPaginationFragment<StixCyberObservableNestedEntitiesTablePaginationQuery>;
 
+  // The current observable can be on either side of the nested ref relationship
+  // (from or to), so the opposite object to display/link to must be resolved
+  // dynamically instead of always assuming it is `to`.
+  const getOppositeObject = (data: StixCyberObservableNestedEntitiesTable_node$data) => (
+    data.from?.id === stixCyberObservableId ? data.to : data.from
+  );
+
   const dataColumns = {
     relationship_type: {
       label: 'Attribute',
@@ -304,7 +439,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
       percentWidth: isInLine ? 20 : 10,
       isSortable: false,
       render: (data: StixCyberObservableNestedEntitiesTable_node$data) => (
-        <ItemEntityType entityType={data.to?.entity_type || ''} />
+        <ItemEntityType entityType={getOppositeObject(data)?.entity_type || ''} />
       ),
     },
     name: {
@@ -312,10 +447,11 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
       percentWidth: isInLine ? 35 : 22,
       isSortable: false,
       render: (data: StixCyberObservableNestedEntitiesTable_node$data) => {
+        const oppositeObject = getOppositeObject(data);
         return (
           <>
-            {data.to?.name || data.to?.observable_value || data.to?.attribute_abstract || data.to?.content}
-            {data.to?.draftVersion && <DraftChip />}
+            {oppositeObject?.name || oppositeObject?.observable_value || oppositeObject?.attribute_abstract || oppositeObject?.content}
+            {oppositeObject?.draftVersion && <DraftChip />}
           </>
         );
       },
@@ -340,7 +476,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
   };
 
   const getRedirectionLink = (stixObject: StixCyberObservableNestedEntitiesTable_node$data) => {
-    const targetObject = stixObject.from?.id === stixCyberObservableId ? stixObject.to : stixObject.from;
+    const targetObject = getOppositeObject(stixObject);
     if (targetObject) {
       return computeLink(targetObject as ComputeLinkNode);
     }
@@ -366,7 +502,7 @@ const StixCyberObservableNestedEntitiesTable: React.FC<StixCyberObservableNested
           hideHeaders={isInLine}
           disableLineSelection
           getComputeLink={getRedirectionLink}
-          icon={(data: StixCyberObservableNestedEntitiesTable_node$data) => <ItemIcon type={data.to?.entity_type} />}
+          icon={(data: StixCyberObservableNestedEntitiesTable_node$data) => <ItemIcon type={getOppositeObject(data)?.entity_type} />}
           actions={(data: StixCyberObservableNestedEntitiesTable_node$data) => {
             return (
               <div style={{ marginLeft: -10 }} onClick={(e) => stopEvent(e)}>


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* opposite object on observation nested object table

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16078 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
