### PR TITLE
fix(xtm-hub): keep connectivity check alive when SMTP email fails (#15681)

### DIFF
--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -4891,6 +4891,7 @@
   "Types of the targeting": "Types of the targeting",
   "Types of the targets": "Types of the targets",
   "Unable to validate remote OpenCTI URL": "Unable to validate remote OpenCTI URL",
+  "Unable to check XTM Hub connectivity. Please try again later.": "Unable to check XTM Hub connectivity. Please try again later.",
   "Unauthorized action, please refresh your browser": "Unauthorized action, please refresh your browser",
   "Unfix the nodes and re-apply forces": "Unfix the nodes and re-apply forces",
   "Unique identifier": "Unique identifier",

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -1,6 +1,7 @@
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import React, { useEffect, useState, useContext } from 'react';
 import { HubOutlined, MapOutlined, RocketLaunchOutlined, VideoLibraryOutlined, WidgetsOutlined } from '@mui/icons-material';
+import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 import XtmHubTab from '@components/settings/xtm-hub/XtmHubTab';
 import Button from '@common/button/Button';
@@ -213,21 +214,44 @@ const XtmHubSettingsComponent = () => {
 };
 
 const XtmHubSettings: React.FC = () => {
+  const { t_i18n } = useFormatter();
+  const theme = useTheme<Theme>();
   const [commitCheckConnectivity] = useApiMutation(checkHubConnectivity);
   const [isCheckDone, setIsCheckDone] = useState(false);
+  const [checkError, setCheckError] = useState(false);
 
   useEffect(() => {
-    commitCheckConnectivity({ variables: {},
+    commitCheckConnectivity({
+      variables: {},
       onCompleted: () => {
         setIsCheckDone(true);
-      } });
+      },
+      onError: () => {
+        // Avoid infinite loading when the connectivity check fails (e.g. SMTP error).
+        setCheckError(true);
+        setIsCheckDone(true);
+      },
+    });
   }, []);
 
   if (!isCheckDone) {
     return <Loader variant={LoaderVariant.inElement} />;
   }
 
-  return <XtmHubSettingsComponent />;
+  return (
+    <>
+      {checkError && (
+        <Alert
+          severity="error"
+          variant="outlined"
+          style={{ width: '100%', marginBottom: theme.spacing(2) }}
+        >
+          {t_i18n('Unable to check XTM Hub connectivity. Please try again later or verify your platform configuration (including SMTP).')}
+        </Alert>
+      )}
+      <XtmHubSettingsComponent />
+    </>
+  );
 };
 
 export default XtmHubSettings;

--- a/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/xtm-hub/XtmHubSettings.tsx
@@ -227,7 +227,7 @@ const XtmHubSettings: React.FC = () => {
         setIsCheckDone(true);
       },
       onError: () => {
-        // Avoid infinite loading when the connectivity check fails (e.g. SMTP error).
+        // Avoid infinite loading when the connectivity check mutation fails.
         setCheckError(true);
         setIsCheckDone(true);
       },
@@ -246,7 +246,7 @@ const XtmHubSettings: React.FC = () => {
           variant="outlined"
           style={{ width: '100%', marginBottom: theme.spacing(2) }}
         >
-          {t_i18n('Unable to check XTM Hub connectivity. Please try again later or verify your platform configuration (including SMTP).')}
+          {t_i18n('Unable to check XTM Hub connectivity. Please try again later.')}
         </Alert>
       )}
       <XtmHubSettingsComponent />

--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -176,8 +176,14 @@ const handleLostConnectivityEmail = async (context: AuthContext, settings: Basic
     && isEmailEnabled;
   const attributeUpdates: AttributeUpdate[] = [];
   if (shouldSendLostConnectivityEmail) {
-    await sendAdministratorsLostConnectivityEmail(context, settings);
-    attributeUpdates.push({ key: 'xtm_hub_should_send_connectivity_email', value: [false] });
+    try {
+      await sendAdministratorsLostConnectivityEmail(context, settings);
+      attributeUpdates.push({ key: 'xtm_hub_should_send_connectivity_email', value: [false] });
+    } catch (e) {
+      // SMTP misconfiguration (or any mail failure) must not abort the connectivity check.
+      // Keep xtm_hub_should_send_connectivity_email=true so the next successful check can retry.
+      logApp.error(e, { message: '[XTMH] Failed to send lost-connectivity email; continuing connectivity check' });
+    }
   }
 
   const shouldAllowConnectivityLostEmailAgain = isConnectivityActive && !settings.xtm_hub_should_send_connectivity_email;

--- a/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
+++ b/opencti-platform/opencti-graphql/src/domain/xtm-hub.ts
@@ -181,8 +181,8 @@ const handleLostConnectivityEmail = async (context: AuthContext, settings: Basic
       attributeUpdates.push({ key: 'xtm_hub_should_send_connectivity_email', value: [false] });
     } catch (e) {
       // SMTP misconfiguration (or any mail failure) must not abort the connectivity check.
-      // Keep xtm_hub_should_send_connectivity_email=true so the next successful check can retry.
-      logApp.error(e, { message: '[XTMH] Failed to send lost-connectivity email; continuing connectivity check' });
+      // Keep xtm_hub_should_send_connectivity_email=true so the next connectivity check can retry.
+      logApp.error('[XTMH] Failed to send lost-connectivity email; continuing connectivity check', { cause: e });
     }
   }
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/xtm-hub-test.ts
@@ -292,6 +292,41 @@ describe('XTM hub', () => {
 
         expect(sendAdministratorsLostConnectivityEmailSpy).not.toHaveBeenCalled();
       });
+
+      it('should complete connectivity check when lost-connectivity email sending fails', async () => {
+        const settings: Partial<BasicStoreSettings> = {
+          id: 'id',
+          xtm_hub_token,
+          xtm_hub_registration_status: XtmHubRegistrationStatus.Registered,
+          xtm_hub_last_connectivity_check: new Date(new Date().getTime() - 1000 * 60 * 60 * 24),
+          xtm_hub_should_send_connectivity_email: true,
+        };
+        getEntityFromCacheSpy.mockResolvedValue(settings);
+        xtmHubClientRefreshStatusSpy.mockResolvedValue('inactive');
+        sendAdministratorsLostConnectivityEmailSpy.mockRejectedValue(new Error('SMTP send failed'));
+
+        const result = await checkXTMHubConnectivity(testContext, HUB_REGISTRATION_MANAGER_USER);
+
+        expect(result.status).toBe(XtmHubRegistrationStatus.LostConnectivity);
+        expect(sendAdministratorsLostConnectivityEmailSpy).toHaveBeenCalled();
+        // Registration status still updates; email flag is left true so the next check can retry.
+        expect(updateAttributeSpy).toHaveBeenCalledWith(
+          testContext,
+          HUB_REGISTRATION_MANAGER_USER,
+          'id',
+          ENTITY_TYPE_SETTINGS,
+          [{ key: 'xtm_hub_registration_status', value: [XtmHubRegistrationStatus.LostConnectivity] }],
+        );
+        expect(updateAttributeSpy).not.toHaveBeenCalledWith(
+          testContext,
+          HUB_REGISTRATION_MANAGER_USER,
+          'id',
+          ENTITY_TYPE_SETTINGS,
+          expect.arrayContaining([
+            { key: 'xtm_hub_should_send_connectivity_email', value: [false] },
+          ]),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Backend: wrap `sendAdministratorsLostConnectivityEmail` in try/catch inside `handleLostConnectivityEmail` so a SMTP failure no longer aborts `checkXTMHubConnectivity`. The email flag stays `true` so the next check can retry.
- Frontend: handle `onError` for the connectivity mutation in `XtmHubSettings` — show an error Alert instead of infinite loading.
- Test: add coverage that connectivity status still updates when email sending rejects.

Fixes #15681

## Type

- [x] Bug fix

## How to test

1. **Backend unit/integration**: run the XTM hub connectivity suite and confirm the new case passes:
   ```bash
   cd opencti-platform/opencti-graphql
   yarn test tests/03-integration/01-database/xtm-hub-test.ts
   ```
2. **Reproduce frontend infinite load (before) / error Alert (after)**:
   - Register a platform with XTM Hub (or mock `checkXTMHubConnectivity` to throw).
   - Force SMTP failure (bad SMTP config, or temporarily throw inside `sendAdministratorsLostConnectivityEmail`) while lost-connectivity email conditions are met (inactive hub + 24h since last check + email flag true).
   - Open **Settings → Filigran Experience → XTM Hub**.
   - Expect: page renders with an error Alert (no infinite Loader); GraphQL check still returns registration status when only the email step fails.
3. **Happy path**: with working SMTP / no email needed, XTM Hub card still loads normally after the connectivity check.

## Related Issue

Closes #15681

Made with [Cursor](https://cursor.com)