### PR TITLE
feat(merge-users): Scalar user references and public sharing user rewrite (#17495)

### DIFF
--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -16989,6 +16989,7 @@ enum UserMergeStatus {
 input UserMergeOptions {
   dryRun: Boolean = true
   rightsStrategy: UserMergeRightsStrategy = STRICT
+  acknowledgeExposureChange: Boolean = false
 }
 
 enum UserMergeDisposition {
@@ -17011,6 +17012,7 @@ type UserMergeRightsAlert {
   register_row_id: String!
   kind: String!
   message: String!
+  blocking: Boolean
 }
 
 type UserMergeHandlerOutcome {

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -37256,6 +37256,7 @@ export type UserMergeJournalEntry = {
 };
 
 export type UserMergeOptions = {
+  acknowledgeExposureChange?: InputMaybe<Scalars['Boolean']['input']>;
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   rightsStrategy?: InputMaybe<UserMergeRightsStrategy>;
 };
@@ -37285,6 +37286,7 @@ export type UserMergeResult = {
 
 export type UserMergeRightsAlert = {
   __typename?: 'UserMergeRightsAlert';
+  blocking?: Maybe<Scalars['Boolean']['output']>;
   kind: Scalars['String']['output'];
   message: Scalars['String']['output'];
   register_row_id: Scalars['String']['output'];
@@ -53290,6 +53292,7 @@ export type UserMergeResultResolvers<ContextType = any, ParentType extends Resol
 }>;
 
 export type UserMergeRightsAlertResolvers<ContextType = any, ParentType extends ResolversParentTypes['UserMergeRightsAlert'] = ResolversParentTypes['UserMergeRightsAlert']> = ResolversObject<{
+  blocking?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   register_row_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/modules/index.ts
+++ b/opencti-platform/opencti-graphql/src/modules/index.ts
@@ -1,4 +1,5 @@
 // region registration attributes, need to be imported before any other modules
+import { registerUserMergeHandlers } from './userMerge/userMerge-handlers';
 import './attributes/basicObject-registrationAttributes';
 import './attributes/stixObject-registrationAttributes';
 import './attributes/stixCoreObject-registrationAttributes';
@@ -173,3 +174,7 @@ import './userMerge/userMerge-graphql';
 import './workflow/api/workflow-graphql';
 import './customField/custom-field-graphql';
 // endregion
+
+// The scalar handler derives its targets from the schema, so it can only be registered once
+// every module above has declared its attributes.
+registerUserMergeHandlers();

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-domain.ts
@@ -17,6 +17,7 @@ import { type UserMergeJournalEntry, type UserMergeOptions, type UserMergeResult
 export interface UserMergeOptionsInput {
   dryRun?: boolean | null;
   rightsStrategy?: UserMergeRightsStrategy | null;
+  acknowledgeExposureChange?: boolean | null;
 }
 
 /**
@@ -27,6 +28,7 @@ export const resolveUserMergeOptions = (options?: UserMergeOptionsInput | null):
   return {
     dryRun: options?.dryRun ?? true,
     rightsStrategy: options?.rightsStrategy ?? UserMergeRightsStrategy.Strict,
+    acknowledgeExposureChange: options?.acknowledgeExposureChange ?? false,
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-engine.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-engine.ts
@@ -55,6 +55,25 @@ const applyHandler = async (
 };
 
 /**
+ * Gate placed between the two passes, which is where the human decision belongs.
+ *
+ * Blocking on the dry pass would hide the difference from the report the operator needs to
+ * decide with; blocking inside a handler's write would stop the merge after earlier handlers
+ * already wrote.
+ */
+const assertBlockingAlertsAcknowledged = (outcomes: UserMergeHandlerOutcome[], options: UserMergeOptions): void => {
+  if (options.acknowledgeExposureChange) {
+    return;
+  }
+  const blocking = outcomes.flatMap((outcome) => outcome.alerts.filter((alert) => alert.blocking));
+  if (blocking.length > 0) {
+    throw UnsupportedError('Merge blocked by unacknowledged alerts, nothing was written', {
+      alerts: blocking.map((alert) => ({ register_row_id: alert.register_row_id, kind: alert.kind, message: alert.message })),
+    });
+  }
+};
+
+/**
  * Two full passes, never interleaved.
  *
  * Every handler computes first, the complete report is produced, and only then does any
@@ -100,6 +119,7 @@ export const executeUserMerge = async (
     if (options.dryRun) {
       return { ...baseResult, status: UserMergeStatus.Success, completed_at: new Date(), report: buildReport(mergeId, dryOutcomes) };
     }
+    assertBlockingAlertsAcknowledged(dryOutcomes, options);
 
     const outcomes: UserMergeHandlerOutcome[] = [];
     for (let i = 0; i < handlers.length; i += 1) {

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-handler.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-handler.ts
@@ -32,6 +32,15 @@ export interface UserMergeRightsAlert {
   register_row_id: string;
   kind: 'rights' | 'marking' | 'organization' | 'exposure';
   message: string;
+  /**
+   * When true, the real pass refuses to write until the operator acknowledges the change.
+   *
+   * The refusal belongs to the engine rather than to `apply()`: raising it there would stop
+   * the merge after earlier handlers already wrote, and raising it in `compute()` would keep
+   * the difference out of the dry-run report — which is the one place the operator can read
+   * it before deciding.
+   */
+  blocking?: boolean;
 }
 
 /**
@@ -108,7 +117,7 @@ export const planFingerprint = (plan: UserMergeHandlerPlan): string => {
     .map((change) => `${change.register_row_id}|${change.entity_type}|${change.count}|${change.exact}`)
     .sort();
   const alerts = [...plan.alerts]
-    .map((alert) => `${alert.register_row_id}|${alert.kind}|${alert.message}`)
+    .map((alert) => `${alert.register_row_id}|${alert.kind}|${alert.message}|${alert.blocking === true}`)
     .sort();
   return JSON.stringify({ handler: plan.handler, changes, alerts });
 };

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-handlers.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-handlers.ts
@@ -1,0 +1,12 @@
+import { registerUserMergeHandler } from './userMerge-registry';
+import { userMergePublicSharingHandler } from './userMerge-publicSharingHandler';
+import { userMergeScalarHandler } from './userMerge-scalarHandler';
+
+/**
+ * Single registration point. Exported rather than run as a side effect of the import so that
+ * suites resetting the registry can put it back in a known state.
+ */
+export const registerUserMergeHandlers = (): void => {
+  registerUserMergeHandler(userMergeScalarHandler);
+  registerUserMergeHandler(userMergePublicSharingHandler);
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-publicSharingHandler.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-publicSharingHandler.ts
@@ -1,0 +1,171 @@
+import { getEntitiesMapFromCache } from '../../database/cache';
+import { elRawCount } from '../../database/engine';
+import { ENTITY_TYPE_USER } from '../../schema/internalObject';
+import type { AuthContext, AuthUser } from '../../types/user';
+import { SYSTEM_USER } from '../../utils/access';
+import { ENTITY_TYPE_FEED } from '../dataSharing/feed-types';
+import { ENTITY_TYPE_STREAM_COLLECTION } from '../dataSharing/streamCollection-types';
+import { ENTITY_TYPE_TAXII_COLLECTION } from '../dataSharing/taxiiCollection-types';
+import { userMergeBulkUpdate } from './userMerge-bulk';
+import {
+  type UserMergeHandler,
+  type UserMergeHandlerContext,
+  type UserMergeHandlerPlan,
+  type UserMergePlannedChange,
+  type UserMergeRightsAlert,
+  USER_MERGE_TARGET_INDICES,
+} from './userMerge-handler';
+import { USER_MERGE_REGISTRY_VERSION } from './userMerge-register';
+
+export const USER_MERGE_PUBLIC_SHARING_HANDLER = 'public-sharing-user';
+
+interface PublicSharingTarget {
+  registerRow: string;
+  entityType: string;
+  userIdField: string;
+  label: string;
+}
+
+/**
+ * Mirrors the sharing configuration of the dataSharing module, which does not export it.
+ * The list is asserted against the module's own entity types by the handler tests.
+ */
+const PUBLIC_SHARING_TARGETS: PublicSharingTarget[] = [
+  { registerRow: 'feed.public-user-id', entityType: ENTITY_TYPE_FEED, userIdField: 'feed_public_user_id', label: 'csv feed' },
+  { registerRow: 'taxii-collection.public-user-id', entityType: ENTITY_TYPE_TAXII_COLLECTION, userIdField: 'taxii_public_user_id', label: 'Taxii collection' },
+  { registerRow: 'stream-collection.public-user-id', entityType: ENTITY_TYPE_STREAM_COLLECTION, userIdField: 'stream_public_user_id', label: 'live stream' },
+];
+
+const fieldPaths = PUBLIC_SHARING_TARGETS.map((target) => `${target.entityType}.${target.userIdField}`);
+
+const sharingQuery = (target: PublicSharingTarget, sourceId: string): Record<string, unknown> => ({
+  bool: {
+    must: [
+      { term: { [`${target.userIdField}.keyword`]: sourceId } },
+      { terms: { 'entity_type.keyword': [target.entityType] } },
+    ],
+  },
+});
+
+export interface UserMergeExposureDiff {
+  addedMarkings: string[];
+  removedMarkings: string[];
+  addedOrganizations: string[];
+  removedOrganizations: string[];
+}
+
+const names = (values: { id: string; name?: string; definition?: string }[]): string[] => {
+  return values.map((value) => value.definition ?? value.name ?? value.id);
+};
+
+const difference = (left: string[], right: string[]): string[] => left.filter((value) => !right.includes(value));
+
+/**
+ * What anonymous consumers of the endpoint would see after the merge, compared to before.
+ *
+ * A public sharing endpoint serves data through the configured user's own access, so moving
+ * the reference moves the exposure with it.
+ */
+export const userMergeExposureDiff = (source: AuthUser, target: AuthUser): UserMergeExposureDiff => {
+  const sourceMarkings = names(source.allowed_marking ?? []);
+  const targetMarkings = names(target.allowed_marking ?? []);
+  const sourceOrganizations = names(source.organizations ?? []);
+  const targetOrganizations = names(target.organizations ?? []);
+  return {
+    addedMarkings: difference(targetMarkings, sourceMarkings),
+    removedMarkings: difference(sourceMarkings, targetMarkings),
+    addedOrganizations: difference(targetOrganizations, sourceOrganizations),
+    removedOrganizations: difference(sourceOrganizations, targetOrganizations),
+  };
+};
+
+export const isExposureWidening = (diff: UserMergeExposureDiff): boolean => diff.addedMarkings.length > 0;
+
+const exposureMessage = (target: PublicSharingTarget, count: number, diff: UserMergeExposureDiff): string => {
+  const parts = [
+    diff.addedMarkings.length > 0 ? `markings gained: ${diff.addedMarkings.join(', ')}` : undefined,
+    diff.removedMarkings.length > 0 ? `markings lost: ${diff.removedMarkings.join(', ')}` : undefined,
+    diff.addedOrganizations.length > 0 ? `organizations gained: ${diff.addedOrganizations.join(', ')}` : undefined,
+    diff.removedOrganizations.length > 0 ? `organizations lost: ${diff.removedOrganizations.join(', ')}` : undefined,
+  ].filter((part) => part !== undefined);
+  return `${count} ${target.label}(s) will be served with the target user access (${parts.join('; ')})`;
+};
+
+const loadUser = async (context: AuthContext, userId: string): Promise<AuthUser | undefined> => {
+  const users = await getEntitiesMapFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  return users.get(userId);
+};
+
+/**
+ * Moves the user reference of the public sharing endpoints.
+ *
+ * Split from the scalar handler because the work is not the same: the value is rewritten the
+ * same way, but the decision attached to it is a change in what anonymous consumers can read.
+ * Clearing the field instead — the behaviour applied when a user is deleted — would leave the
+ * endpoints public while falling back to SYSTEM_USER, which is the worst of both outcomes.
+ */
+export const userMergePublicSharingHandler: UserMergeHandler = {
+  identifier: USER_MERGE_PUBLIC_SHARING_HANDLER,
+  covers: PUBLIC_SHARING_TARGETS.map((target) => target.registerRow),
+  registryVersion: USER_MERGE_REGISTRY_VERSION,
+  reads: fieldPaths,
+  writes: fieldPaths,
+  compute: async ({ context, sourceId, targetId }: UserMergeHandlerContext): Promise<UserMergeHandlerPlan> => {
+    const changes: UserMergePlannedChange[] = [];
+    const alerts: UserMergeRightsAlert[] = [];
+    const sourceUser = await loadUser(context, sourceId);
+    const targetUser = await loadUser(context, targetId);
+    const diff = sourceUser && targetUser ? userMergeExposureDiff(sourceUser, targetUser) : undefined;
+    for (let i = 0; i < PUBLIC_SHARING_TARGETS.length; i += 1) {
+      const target = PUBLIC_SHARING_TARGETS[i];
+      const count = await elRawCount({
+        index: USER_MERGE_TARGET_INDICES,
+        body: { query: sharingQuery(target, sourceId) },
+      });
+      changes.push({
+        register_row_id: target.registerRow,
+        entity_type: target.entityType,
+        count,
+        exact: true,
+        detail: target.userIdField,
+      });
+      // Reported per endpoint: the decision is about a given endpoint becoming more exposed,
+      // not about an abstract difference between two accounts.
+      if (count > 0 && diff) {
+        const widening = isExposureWidening(diff);
+        if (widening || diff.removedMarkings.length > 0 || diff.addedOrganizations.length > 0 || diff.removedOrganizations.length > 0) {
+          alerts.push({
+            register_row_id: target.registerRow,
+            kind: 'exposure',
+            message: exposureMessage(target, count, diff),
+            blocking: widening,
+          });
+        }
+      }
+    }
+    return { handler: USER_MERGE_PUBLIC_SHARING_HANDLER, changes, alerts };
+  },
+  apply: async ({ sourceId, targetId }: UserMergeHandlerContext, plan: UserMergeHandlerPlan): Promise<number> => {
+    const planned = new Set(plan.changes.filter((change) => change.count > 0).map((change) => change.register_row_id));
+    let updated = 0;
+    for (let i = 0; i < PUBLIC_SHARING_TARGETS.length; i += 1) {
+      const target = PUBLIC_SHARING_TARGETS[i];
+      if (planned.has(target.registerRow)) {
+        const result = await userMergeBulkUpdate(
+          `${USER_MERGE_PUBLIC_SHARING_HANDLER}:${target.registerRow}`,
+          USER_MERGE_TARGET_INDICES,
+          {
+            query: sharingQuery(target, sourceId),
+            script: {
+              source: `if (params.source.equals(ctx._source.${target.userIdField})) { ctx._source.${target.userIdField} = params.target; }`,
+              lang: 'painless',
+              params: { source: sourceId, target: targetId },
+            },
+          },
+        );
+        updated += result.updated;
+      }
+    }
+    return updated;
+  },
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarDiscovery.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarDiscovery.ts
@@ -1,0 +1,44 @@
+import { isAbstract } from '../../schema/general';
+import { ENTITY_TYPE_USER } from '../../schema/internalObject';
+import { schemaAttributesDefinition } from '../../schema/schema-attributes';
+
+/**
+ * An attribute the schema declares as pointing to a User, and the entity types carrying it.
+ *
+ * `entityTypes` is undefined when the attribute is declared on an abstract root, which makes it
+ * global: every document may carry it and no type filter is needed.
+ */
+export interface DiscoveredUserAttribute {
+  name: string;
+  multiple: boolean;
+  entityTypes?: string[];
+}
+
+/**
+ * Walks the schema type by type rather than through `getIdAttributes()`, which deduplicates by
+ * attribute name and would collapse the several entities declaring `user_id` into one entry.
+ */
+export const discoverUserIdAttributes = (): DiscoveredUserAttribute[] => {
+  const carriers = new Map<string, { multiple: boolean; entityTypes: string[]; global: boolean }>();
+  schemaAttributesDefinition.getRegisteredTypes().forEach((entityType) => {
+    const attributes = Array.from(schemaAttributesDefinition.getAttributes(entityType).values());
+    attributes.forEach((attribute) => {
+      if (attribute.type !== 'string' || attribute.format !== 'id') {
+        return;
+      }
+      if (!(attribute.entityTypes ?? []).includes(ENTITY_TYPE_USER)) {
+        return;
+      }
+      const carrier = carriers.get(attribute.name) ?? { multiple: attribute.multiple === true, entityTypes: [], global: false };
+      if (isAbstract(entityType)) {
+        carrier.global = true;
+      } else if (!carrier.entityTypes.includes(entityType)) {
+        carrier.entityTypes.push(entityType);
+      }
+      carriers.set(attribute.name, carrier);
+    });
+  });
+  return Array.from(carriers.entries())
+    .map(([name, carrier]) => ({ name, multiple: carrier.multiple, entityTypes: carrier.global ? undefined : carrier.entityTypes.sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarHandler.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarHandler.ts
@@ -1,0 +1,92 @@
+import { elRawCount } from '../../database/engine';
+import { USER_MERGE_REGISTRY_VERSION } from './userMerge-register';
+import { userMergeBulkUpdate } from './userMerge-bulk';
+import {
+  type UserMergeHandler,
+  type UserMergeHandlerContext,
+  type UserMergeHandlerPlan,
+  type UserMergePlannedChange,
+  type UserMergeRightsAlert,
+  USER_MERGE_TARGET_INDICES,
+} from './userMerge-handler';
+import { userMergeScalarQuery, userMergeScalarUpdateBody } from './userMerge-scalarQueries';
+import { userMergeScalarCoveredRows, userMergeScalarFieldPaths, userMergeScalarTargets, type UserMergeScalarTarget } from './userMerge-scalarTargets';
+
+export const USER_MERGE_SCALAR_HANDLER = 'scalar-user-references';
+
+const entityTypeLabel = (target: UserMergeScalarTarget): string => {
+  return target.entityTypes ? target.entityTypes.join(', ') : '*';
+};
+
+const countTarget = async (target: UserMergeScalarTarget, sourceId: string): Promise<number> => {
+  return elRawCount({
+    index: USER_MERGE_TARGET_INDICES,
+    body: { query: userMergeScalarQuery(target, sourceId) },
+  });
+};
+
+const atRestAlert = (target: UserMergeScalarTarget, count: number): UserMergeRightsAlert => ({
+  register_row_id: target.registerRow,
+  kind: 'rights',
+  message: `${count} document(s) matched ${target.id} while the platform was expected to be at rest`,
+});
+
+/**
+ * Rewrites the user references held as plain fields on a document.
+ *
+ * Targets come from the schema: every attribute declared with format `id` and pointing at User.
+ * The register cannot be derived from it, so a table alongside says what each discovered
+ * attribute becomes — covered here, split on a lifecycle state, or left to another chunk — and
+ * adds back the handful of fields the declarations do not expose.
+ */
+export const userMergeScalarHandler: UserMergeHandler = {
+  identifier: USER_MERGE_SCALAR_HANDLER,
+  get covers() {
+    return userMergeScalarCoveredRows();
+  },
+  registryVersion: USER_MERGE_REGISTRY_VERSION,
+  get reads() {
+    return userMergeScalarFieldPaths();
+  },
+  get writes() {
+    return userMergeScalarFieldPaths();
+  },
+  compute: async ({ sourceId }: UserMergeHandlerContext): Promise<UserMergeHandlerPlan> => {
+    const changes: UserMergePlannedChange[] = [];
+    const alerts: UserMergeRightsAlert[] = [];
+    const targets = userMergeScalarTargets();
+    for (let i = 0; i < targets.length; i += 1) {
+      const target = targets[i];
+      const count = await countTarget(target, sourceId);
+      // Emitted even at zero: the report has to name what was examined, not only what moved.
+      changes.push({
+        register_row_id: target.registerRow,
+        entity_type: entityTypeLabel(target),
+        count,
+        exact: true,
+        detail: target.path,
+      });
+      if (target.unexpectedAtRest && count > 0) {
+        alerts.push(atRestAlert(target, count));
+      }
+    }
+    return { handler: USER_MERGE_SCALAR_HANDLER, changes, alerts };
+  },
+  apply: async ({ sourceId, targetId }: UserMergeHandlerContext, plan: UserMergeHandlerPlan): Promise<number> => {
+    const planned = new Set(plan.changes.filter((change) => change.count > 0).map((change) => `${change.register_row_id}|${change.detail}`));
+    let updated = 0;
+    const targets = userMergeScalarTargets();
+    for (let i = 0; i < targets.length; i += 1) {
+      const target = targets[i];
+      if (planned.has(`${target.registerRow}|${target.path}`)) {
+        const result = await userMergeBulkUpdate(
+          `${USER_MERGE_SCALAR_HANDLER}:${target.id}`,
+          USER_MERGE_TARGET_INDICES,
+          userMergeScalarUpdateBody(target, sourceId, targetId),
+        );
+        updated += result.updated;
+      }
+    }
+    return updated;
+  },
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarQueries.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarQueries.ts
@@ -1,0 +1,107 @@
+import type { UserMergeScalarTarget } from './userMerge-scalarTargets';
+
+/**
+ * Elasticsearch term key for a path.
+ *
+ * `format: 'id'` and `format: 'short'` both map to `text` with a `keyword` sub-field, so a
+ * term query on the bare path never matches. Booleans map to `boolean` and must stay bare.
+ */
+const termKey = (path: string, value: string | boolean): string => {
+  return typeof value === 'boolean' ? path : `${path}.keyword`;
+};
+
+const conditionClause = (target: UserMergeScalarTarget): Record<string, unknown> | undefined => {
+  if (!target.condition) {
+    return undefined;
+  }
+  const { path, equals } = target.condition;
+  return { term: { [termKey(path, equals)]: equals } };
+};
+
+/**
+ * Query selecting the documents this target has to rewrite.
+ *
+ * A negated condition goes to `must_not`, which also selects documents where the field is
+ * absent — an unfinished work has no `status` yet and is still an active work.
+ */
+export const userMergeScalarQuery = (target: UserMergeScalarTarget, sourceId: string): Record<string, unknown> => {
+  const valueClause = { term: { [termKey(target.path, sourceId)]: sourceId } };
+  const must: Record<string, unknown>[] = [
+    target.nestedRoot ? { nested: { path: target.nestedRoot, query: valueClause } } : valueClause,
+  ];
+  const mustNot: Record<string, unknown>[] = [];
+  if (target.entityTypes) {
+    must.push({ terms: { 'entity_type.keyword': target.entityTypes } });
+  }
+  const condition = conditionClause(target);
+  if (condition) {
+    if (target.condition?.negate) {
+      mustNot.push(condition);
+    } else {
+      must.push(condition);
+    }
+  }
+  return { bool: mustNot.length > 0 ? { must, must_not: mustNot } : { must } };
+};
+
+const traversalPrelude = (segments: string[]): string => {
+  return segments
+    .map((segment) => `holder = holder.${segment}; if (!(holder instanceof Map)) { return; }`)
+    .join(' ');
+};
+
+const singleScript = (path: string): string => {
+  const segments = path.split('.');
+  const leaf = segments.pop() as string;
+  const prelude = segments.length > 0 ? `${traversalPrelude(segments)} ` : '';
+  return `def holder = ctx._source; ${prelude}if (params.source.equals(holder.${leaf})) { holder.${leaf} = params.target; }`;
+};
+
+/**
+ * Removal then guarded append rather than a replacement in place: this is what makes a
+ * replay a no-op on a `multiple:true` field instead of a second append.
+ */
+const multipleScript = (path: string): string => {
+  const segments = path.split('.');
+  const leaf = segments.pop() as string;
+  const prelude = segments.length > 0 ? `${traversalPrelude(segments)} ` : '';
+  return `def holder = ctx._source; ${prelude}def values = holder.${leaf};`
+    + ' if (values instanceof List) { values.removeIf(value -> params.source.equals(value));'
+    + ' if (!values.contains(params.target)) { values.add(params.target); } }';
+};
+
+const objectArrayScript = (path: string): string => {
+  const segments = path.split('.');
+  const leaf = segments.pop() as string;
+  const root = segments.pop() as string;
+  const prelude = segments.length > 0 ? `${traversalPrelude(segments)} ` : '';
+  return `def holder = ctx._source; ${prelude}def items = holder.${root};`
+    + ' if (items instanceof List) { for (def item : items) {'
+    + ` if (item instanceof Map && params.source.equals(item.${leaf})) { item.${leaf} = params.target; } } }`;
+};
+
+export const userMergeScalarScript = (target: UserMergeScalarTarget): string => {
+  if (target.shape === 'multiple') {
+    return multipleScript(target.path);
+  }
+  if (target.shape === 'object-array') {
+    return objectArrayScript(target.path);
+  }
+  return singleScript(target.path);
+};
+
+/** Body for `_update_by_query`, paired with the very query the plan was counted from. */
+export const userMergeScalarUpdateBody = (
+  target: UserMergeScalarTarget,
+  sourceId: string,
+  targetId: string,
+): Record<string, unknown> => {
+  return {
+    query: userMergeScalarQuery(target, sourceId),
+    script: {
+      source: userMergeScalarScript(target),
+      lang: 'painless',
+      params: { source: sourceId, target: targetId },
+    },
+  };
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarRules.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarRules.ts
@@ -1,0 +1,169 @@
+import { ENTITY_TYPE_BACKGROUND_TASK, ENTITY_TYPE_CONNECTOR, ENTITY_TYPE_INTERNAL_FILE, ENTITY_TYPE_WORK } from '../../schema/internalObject';
+import { ENTITY_TYPE_NOTIFICATION } from '../notification/notification-types';
+import { ENTITY_TYPE_PUBLIC_DASHBOARD } from '../publicDashboard/publicDashboard-types';
+import { ENTITY_TYPE_NEWS_FEED_ITEM } from '../xtm/hub/news-feed/news-feed-types';
+import { ENTITY_TYPE_WORKFLOW_DEFINITION } from '../workflow/types/workflow-types';
+import { ENTITY_USER_ACCOUNT } from '../../schema/stixCyberObservable';
+import type { UserMergeScalarCondition, UserMergeScalarTarget } from './userMerge-scalarTargets';
+
+/**
+ * Why a discovered attribute is not rewritten by this handler.
+ *
+ * `not-a-platform-user` means the schema is wrong: the attribute is declared as referencing a
+ * User but holds something else entirely.
+ */
+export type UserMergeScalarExclusionReason = 'not-a-platform-user' | 'another-chunk' | 'another-handler';
+
+export interface UserMergeScalarExclusion {
+  reason: UserMergeScalarExclusionReason;
+  detail: string;
+}
+
+export interface UserMergeScalarSplit {
+  id: string;
+  registerRow: string;
+  condition: UserMergeScalarCondition;
+  unexpectedAtRest?: boolean;
+}
+
+export type UserMergeScalarDisposition
+  = | ({ kind: 'excluded' } & UserMergeScalarExclusion)
+    | { kind: 'covered'; registerRow: string }
+    | { kind: 'split'; variants: UserMergeScalarSplit[] };
+
+/**
+ * Disposition of every attribute the schema discovers, keyed by `<entity type>.<attribute>`.
+ *
+ * A `*.<attribute>` key applies to every carrying type. Discovering an attribute absent from this
+ * table is a hard error: the register has not been consulted for it.
+ */
+export const USER_MERGE_SCALAR_DISPOSITIONS: Record<string, UserMergeScalarDisposition> = {
+  '*.creator_id': { kind: 'covered', registerRow: 'basic-object.creator-id' },
+  '*.applicant_id': { kind: 'excluded', reason: 'another-chunk', detail: 'History, Activity and PirHistory are rewritten by the history chunk' },
+  '*.xtm_hub_registration_user_id': { kind: 'covered', registerRow: 'settings.xtm-hub-registration-user-id' },
+  '*.platform_ip_whitelist_exclusion_ids': { kind: 'excluded', reason: 'another-chunk', detail: 'Register asks to invalidate the entry, not to transfer it' },
+  '*.recipients': { kind: 'excluded', reason: 'another-chunk', detail: 'Trigger recipients are rewritten by the notification chunk' },
+  '*.feed_public_user_id': { kind: 'excluded', reason: 'another-handler', detail: 'Public sharing handler, which also reports the exposure change' },
+  '*.taxii_public_user_id': { kind: 'excluded', reason: 'another-handler', detail: 'Public sharing handler, which also reports the exposure change' },
+  '*.stream_public_user_id': { kind: 'excluded', reason: 'another-handler', detail: 'Public sharing handler, which also reports the exposure change' },
+  'Sync.user_id': { kind: 'covered', registerRow: 'sync.user-id' },
+  'IngestionCsv.user_id': { kind: 'covered', registerRow: 'ingestion.user-id' },
+  'IngestionJson.user_id': { kind: 'covered', registerRow: 'ingestion.user-id' },
+  'IngestionRss.user_id': { kind: 'covered', registerRow: 'ingestion.user-id' },
+  'IngestionTaxii.user_id': { kind: 'covered', registerRow: 'ingestion.user-id' },
+  'IngestionTaxiiCollection.user_id': { kind: 'covered', registerRow: 'ingestion.user-id' },
+  'History.user_id': { kind: 'excluded', reason: 'another-chunk', detail: 'History is rewritten by the history chunk' },
+  'PirHistory.user_id': { kind: 'excluded', reason: 'another-chunk', detail: 'PirHistory is rewritten by the history chunk' },
+  'Activity.user_id': { kind: 'excluded', reason: 'another-chunk', detail: 'Activity is rewritten by the history chunk' },
+  [`${ENTITY_USER_ACCOUNT}.user_id`]: {
+    kind: 'excluded',
+    reason: 'not-a-platform-user',
+    detail: 'STIX user-account property holding the account identifier on the observed system, next to credential and account_login',
+  },
+  [`${ENTITY_TYPE_WORK}.user_id`]: {
+    kind: 'split',
+    variants: [
+      { id: 'work-terminal-user-id', registerRow: 'work-terminal.user-id', condition: { path: 'status', equals: 'complete' } },
+      { id: 'work-active-user-id', registerRow: 'work-active.user-id', condition: { path: 'status', equals: 'complete', negate: true }, unexpectedAtRest: true },
+    ],
+  },
+  [`${ENTITY_TYPE_NOTIFICATION}.user_id`]: {
+    kind: 'split',
+    variants: [
+      { id: 'notification-read-user-id', registerRow: 'notification-terminal.user-id', condition: { path: 'is_read', equals: true } },
+      { id: 'notification-unread-user-id', registerRow: 'notification-unread.user-id', condition: { path: 'is_read', equals: true, negate: true } },
+    ],
+  },
+};
+
+/**
+ * Targets the schema cannot yield, each with the reason it is missing.
+ *
+ * These are gaps in the attribute declarations, not deliberate register choices. Fixing a
+ * declaration changes how filters and history diffs behave platform-wide, so the fix belongs
+ * outside this feature; the guard test flags the entry once the schema starts yielding it.
+ */
+export interface UserMergeScalarComplement extends UserMergeScalarTarget {
+  missingBecause: string;
+}
+
+export const USER_MERGE_SCALAR_COMPLEMENTS: UserMergeScalarComplement[] = [
+  {
+    id: 'connector-user-id',
+    registerRow: 'connector.user-id',
+    entityTypes: [ENTITY_TYPE_CONNECTOR],
+    path: 'connector_user_id',
+    shape: 'single',
+    missingBecause: "declared with format 'short'",
+  },
+  {
+    id: 'news-feed-item-user-id',
+    registerRow: 'news-feed-item.user-id',
+    entityTypes: [ENTITY_TYPE_NEWS_FEED_ITEM],
+    path: 'user_id',
+    shape: 'single',
+    missingBecause: "declared with format 'short'",
+  },
+  {
+    id: 'public-dashboard-user-id',
+    registerRow: 'public-dashboard.user-id',
+    entityTypes: [ENTITY_TYPE_PUBLIC_DASHBOARD],
+    path: 'user_id',
+    shape: 'single',
+    missingBecause: 'not declared at all, though the entity stores it',
+  },
+  {
+    id: 'background-task-terminal-initiator-id',
+    registerRow: 'background-task-terminal.initiator-id',
+    entityTypes: [ENTITY_TYPE_BACKGROUND_TASK],
+    path: 'initiator_id',
+    shape: 'single',
+    condition: { path: 'completed', equals: true },
+    missingBecause: "declared with format 'short'",
+  },
+  {
+    id: 'background-task-pending-initiator-id',
+    registerRow: 'background-task-pending.initiator-id',
+    entityTypes: [ENTITY_TYPE_BACKGROUND_TASK],
+    path: 'initiator_id',
+    shape: 'single',
+    condition: { path: 'completed', equals: true, negate: true },
+    unexpectedAtRest: true,
+    missingBecause: "declared with format 'short'",
+  },
+  {
+    id: 'internal-file-metadata-creator-id',
+    registerRow: 'internal-file.metadata-creator-id',
+    entityTypes: [ENTITY_TYPE_INTERNAL_FILE],
+    path: 'metaData.creator_id',
+    shape: 'single',
+    missingBecause: "held under metaData, declared with format 'standard' and no attribute definitions",
+  },
+  {
+    id: 'workflow-definition-published-version-created-by',
+    registerRow: 'workflow-definition.versions-created-by',
+    entityTypes: [ENTITY_TYPE_WORKFLOW_DEFINITION],
+    path: 'published_version.createdBy',
+    shape: 'single',
+    nestedRoot: 'published_version',
+    missingBecause: 'nested mapping child declared without entityTypes',
+  },
+  {
+    id: 'workflow-definition-draft-version-created-by',
+    registerRow: 'workflow-definition.versions-created-by',
+    entityTypes: [ENTITY_TYPE_WORKFLOW_DEFINITION],
+    path: 'draft_version.createdBy',
+    shape: 'single',
+    nestedRoot: 'draft_version',
+    missingBecause: 'nested mapping child declared without entityTypes',
+  },
+  {
+    id: 'workflow-definition-all-versions-created-by',
+    registerRow: 'workflow-definition.versions-created-by',
+    entityTypes: [ENTITY_TYPE_WORKFLOW_DEFINITION],
+    path: 'all_versions.createdBy',
+    shape: 'object-array',
+    nestedRoot: 'all_versions',
+    missingBecause: 'nested mapping child declared without entityTypes',
+  },
+];

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarTargets.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-scalarTargets.ts
@@ -1,0 +1,141 @@
+import { discoverUserIdAttributes } from './userMerge-scalarDiscovery';
+import { USER_MERGE_SCALAR_COMPLEMENTS, USER_MERGE_SCALAR_DISPOSITIONS, type UserMergeScalarExclusion } from './userMerge-scalarRules';
+
+/**
+ * How the value sits in the document, which decides the rewrite script.
+ *
+ * `multiple` is the one that makes idempotence non-trivial: an unguarded append duplicates
+ * the target id on every replay.
+ */
+export type UserMergeScalarShape = 'single' | 'multiple' | 'object-array';
+
+/**
+ * Extra predicate narrowing a target to a lifecycle state.
+ *
+ * `negate` matches the complement, which also covers documents where the field is absent —
+ * an unfinished work has no `status` yet, and it is still an active work.
+ */
+export interface UserMergeScalarCondition {
+  path: string;
+  equals: string | boolean;
+  negate?: boolean;
+}
+
+/** One rewrite to plan and apply. */
+export interface UserMergeScalarTarget {
+  /** Stable identifier, reported as the change detail. */
+  id: string;
+  /** Register row this target answers for. Several targets may share one row. */
+  registerRow: string;
+  /** Entity types carrying the field. Undefined when the attribute is declared on an abstract root. */
+  entityTypes?: string[];
+  path: string;
+  shape: UserMergeScalarShape;
+  /** Root of the Elasticsearch `nested` mapping the path lives under, if any. */
+  nestedRoot?: string;
+  condition?: UserMergeScalarCondition;
+  /**
+   * The merge runs on an idle platform, so a non-zero count here means something was
+   * running that should not have been. Reported as an alert, not as a failure.
+   */
+  unexpectedAtRest?: boolean;
+}
+
+export interface UserMergeScalarResolution {
+  targets: UserMergeScalarTarget[];
+  excluded: (UserMergeScalarExclusion & { key: string })[];
+  /** Discovered attributes with no disposition. Non-empty means the register was not consulted. */
+  unassigned: string[];
+}
+
+const targetIdFromRow = (registerRow: string) => registerRow.replace(/\./g, '-');
+
+const dispositionFor = (entityType: string | undefined, name: string) => {
+  const scoped = entityType ? USER_MERGE_SCALAR_DISPOSITIONS[`${entityType}.${name}`] : undefined;
+  return scoped ?? USER_MERGE_SCALAR_DISPOSITIONS[`*.${name}`];
+};
+
+/**
+ * Derives the rewrite targets from the schema, then applies the register dispositions.
+ *
+ * Targets sharing a register row, an attribute and a condition are merged into a single one
+ * carrying every entity type, so the five ingestion entities cost one query rather than five.
+ */
+export const resolveUserMergeScalarTargets = (): UserMergeScalarResolution => {
+  const targets: UserMergeScalarTarget[] = [];
+  const excluded: (UserMergeScalarExclusion & { key: string })[] = [];
+  const unassigned: string[] = [];
+  const grouped = new Map<string, UserMergeScalarTarget>();
+  discoverUserIdAttributes().forEach((attribute) => {
+    const carriers = attribute.entityTypes ?? [undefined];
+    carriers.forEach((entityType) => {
+      const key = `${entityType ?? '*'}.${attribute.name}`;
+      const disposition = dispositionFor(entityType, attribute.name);
+      if (!disposition) {
+        unassigned.push(key);
+        return;
+      }
+      if (disposition.kind === 'excluded') {
+        excluded.push({ key, reason: disposition.reason, detail: disposition.detail });
+        return;
+      }
+      const shape = attribute.multiple ? 'multiple' : 'single';
+      const variants = disposition.kind === 'split'
+        ? disposition.variants
+        : [{ id: targetIdFromRow(disposition.registerRow), registerRow: disposition.registerRow, condition: undefined, unexpectedAtRest: undefined }];
+      variants.forEach((variant) => {
+        const existing = grouped.get(variant.id);
+        if (existing) {
+          existing.entityTypes = entityType && existing.entityTypes ? [...existing.entityTypes, entityType] : existing.entityTypes;
+          return;
+        }
+        const target: UserMergeScalarTarget = { id: variant.id, registerRow: variant.registerRow, path: attribute.name, shape };
+        if (entityType) {
+          target.entityTypes = [entityType];
+        }
+        if (variant.condition) {
+          target.condition = variant.condition;
+        }
+        if (variant.unexpectedAtRest) {
+          target.unexpectedAtRest = true;
+        }
+        grouped.set(variant.id, target);
+        targets.push(target);
+      });
+    });
+  });
+  USER_MERGE_SCALAR_COMPLEMENTS.forEach((complement) => {
+    const { id, registerRow, entityTypes, path, shape, nestedRoot, condition, unexpectedAtRest } = complement;
+    targets.push({ id, registerRow, entityTypes, path, shape, nestedRoot, condition, unexpectedAtRest });
+  });
+  return { targets, excluded, unassigned };
+};
+
+let resolution: UserMergeScalarResolution | undefined;
+
+/** Memoised because the schema is immutable once the modules are registered. */
+export const userMergeScalarResolution = (): UserMergeScalarResolution => {
+  if (!resolution) {
+    resolution = resolveUserMergeScalarTargets();
+  }
+  return resolution;
+};
+
+export const userMergeScalarTargets = (): UserMergeScalarTarget[] => userMergeScalarResolution().targets;
+
+/** Register rows the scalar handler answers for, deduplicated. */
+export const userMergeScalarCoveredRows = (): string[] => [...new Set(userMergeScalarTargets().map((target) => target.registerRow))];
+
+/**
+ * Field paths qualified by entity type, for the registry disjointness check.
+ *
+ * The check compares literal strings, so a bare `user_id` here would collide with the
+ * history chunk even though the two never touch the same document.
+ */
+export const userMergeScalarFieldPaths = (): string[] => {
+  const paths = userMergeScalarTargets().flatMap((target) => {
+    const types = target.entityTypes ?? ['*'];
+    return types.map((entityType) => `${entityType}.${target.path}`);
+  });
+  return [...new Set(paths)];
+};

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge-types.ts
@@ -33,6 +33,11 @@ export interface UserMergeOptions {
    */
   dryRun: boolean;
   rightsStrategy: UserMergeRightsStrategy;
+  /**
+   * Lets the real pass proceed despite a blocking alert. Defaults to false: a merge that
+   * widens what the source's data is exposed under has to be decided, not discovered.
+   */
+  acknowledgeExposureChange: boolean;
 }
 
 /**

--- a/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/userMerge/userMerge.graphql
@@ -16,6 +16,8 @@ enum UserMergeStatus {
 input UserMergeOptions {
     dryRun: Boolean = true
     rightsStrategy: UserMergeRightsStrategy = STRICT
+    # Required to run for real when the dry-run reported a blocking alert.
+    acknowledgeExposureChange: Boolean = false
 }
 
 enum UserMergeDisposition {
@@ -39,6 +41,8 @@ type UserMergeRightsAlert {
     register_row_id: String!
     kind: String!
     message: String!
+    # True when the real pass refuses to run until acknowledgeExposureChange is set.
+    blocking: Boolean
 }
 
 type UserMergeHandlerOutcome {

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-engine-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-engine-test.ts
@@ -23,6 +23,12 @@ const plan = (handler: string, count: number): UserMergeHandlerPlan => ({
   alerts: [],
 });
 
+const blockingPlan = (handler: string): UserMergeHandlerPlan => ({
+  handler,
+  changes: [{ register_row_id: 'user.password', entity_type: 'User', count: 1, exact: true }],
+  alerts: [{ register_row_id: 'user.password', kind: 'exposure', message: 'exposure widens', blocking: true }],
+});
+
 const mockHandler = (identifier: string, overrides: Partial<UserMergeHandler> = {}): UserMergeHandler => ({
   identifier,
   covers: ['user.password'],
@@ -34,12 +40,12 @@ const mockHandler = (identifier: string, overrides: Partial<UserMergeHandler> = 
   ...overrides,
 });
 
-const execute = (dryRun: boolean) => executeUserMerge(
+const execute = (dryRun: boolean, acknowledgeExposureChange = false) => executeUserMerge(
   {} as never,
   {} as never,
   'source-id',
   'target-id',
-  { dryRun, rightsStrategy: UserMergeRightsStrategy.Strict },
+  { dryRun, rightsStrategy: UserMergeRightsStrategy.Strict, acknowledgeExposureChange },
 );
 
 describe('userMerge engine', () => {
@@ -152,5 +158,29 @@ describe('userMerge engine', () => {
     expect(result.status).toEqual(UserMergeStatus.Success);
     expect(result.report?.handlers).toEqual([]);
     expect(result.report?.registry_version).toEqual(USER_MERGE_REGISTRY_VERSION);
+  });
+
+  it('should report a blocking alert in dry mode instead of failing', async () => {
+    registerUserMergeHandler(mockHandler('handler-a', { compute: async () => blockingPlan('handler-a') }));
+    const result = await execute(true);
+    expect(result.status).toEqual(UserMergeStatus.Success);
+    expect(result.report?.handlers[0].alerts[0].blocking).toEqual(true);
+  });
+
+  it('should refuse to write when a blocking alert is not acknowledged', async () => {
+    const apply = vi.fn(async () => 3);
+    registerUserMergeHandler(mockHandler('handler-a', { compute: async () => blockingPlan('handler-a'), apply }));
+    const result = await execute(false);
+    expect(result.status).toEqual(UserMergeStatus.Failed);
+    expect(result.message).toContain('unacknowledged');
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('should write when the blocking alert is acknowledged', async () => {
+    const apply = vi.fn(async () => 3);
+    registerUserMergeHandler(mockHandler('handler-a', { compute: async () => blockingPlan('handler-a'), apply }));
+    const result = await execute(false, true);
+    expect(result.status).toEqual(UserMergeStatus.Success);
+    expect(apply).toHaveBeenCalled();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-registry-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-registry-test.ts
@@ -15,7 +15,7 @@ const handlerContext = {
   context: {} as never,
   sourceId: 'source',
   targetId: 'target',
-  options: { dryRun: true, rightsStrategy: UserMergeRightsStrategy.Strict },
+  options: { dryRun: true, rightsStrategy: UserMergeRightsStrategy.Strict, acknowledgeExposureChange: false },
 } as UserMergeHandlerContext;
 
 const mockHandler = (overrides: Partial<UserMergeHandler> = {}): UserMergeHandler => ({

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-scalar-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-scalar-test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import '../../../../src/modules/index';
+import { findRegisterRow } from '../../../../src/modules/userMerge/userMerge-register';
+import { userMergeScalarCoveredRows, userMergeScalarFieldPaths, userMergeScalarTargets } from '../../../../src/modules/userMerge/userMerge-scalarTargets';
+import { userMergeScalarQuery, userMergeScalarScript, userMergeScalarUpdateBody } from '../../../../src/modules/userMerge/userMerge-scalarQueries';
+
+const targetById = (id: string) => {
+  const target = userMergeScalarTargets().find((candidate) => candidate.id === id);
+  if (!target) {
+    throw new Error(`Unknown target ${id}`);
+  }
+  return target;
+};
+
+describe('userMerge scalar targets', () => {
+  it('should reference existing register rows', () => {
+    userMergeScalarCoveredRows().forEach((rowId) => {
+      expect(findRegisterRow(rowId), rowId).toBeDefined();
+    });
+  });
+
+  it('should give every target a unique identifier', () => {
+    const ids = userMergeScalarTargets().map((target) => target.id);
+    expect(new Set(ids).size).toEqual(ids.length);
+  });
+
+  it('should scope every target to entity types except the genuinely global one', () => {
+    const unscoped = userMergeScalarTargets().filter((target) => !target.entityTypes).map((target) => target.id);
+    expect(unscoped).toEqual(['basic-object-creator-id']);
+  });
+
+  it('should group the entities sharing a register row into a single target', () => {
+    expect(targetById('ingestion-user-id').entityTypes).toHaveLength(5);
+  });
+
+  it('should read the cardinality from the schema rather than from a declaration', () => {
+    expect(targetById('basic-object-creator-id').shape).toEqual('multiple');
+    expect(targetById('sync-user-id').shape).toEqual('single');
+  });
+
+  it('should qualify field paths by entity type so two chunks sharing a field name stay disjoint', () => {
+    const paths = userMergeScalarFieldPaths();
+    expect(paths).toContain('Sync.user_id');
+    expect(paths).toContain('*.creator_id');
+    expect(paths).not.toContain('user_id');
+  });
+
+  it('should split each lifecycle pair into the two register rows it answers for', () => {
+    expect(targetById('work-terminal-user-id').condition).toEqual({ path: 'status', equals: 'complete' });
+    expect(targetById('work-active-user-id').condition).toEqual({ path: 'status', equals: 'complete', negate: true });
+    expect(targetById('work-active-user-id').registerRow).not.toEqual(targetById('work-terminal-user-id').registerRow);
+  });
+});
+
+describe('userMerge scalar queries', () => {
+  it('should target the keyword sub-field of a text mapping', () => {
+    const query = userMergeScalarQuery(targetById('sync-user-id'), 'source-id') as never;
+    expect(query).toEqual({
+      bool: {
+        must: [
+          { term: { 'user_id.keyword': 'source-id' } },
+          { terms: { 'entity_type.keyword': ['Sync'] } },
+        ],
+      },
+    });
+  });
+
+  it('should keep a boolean condition on the bare path', () => {
+    const query = userMergeScalarQuery(targetById('notification-read-user-id'), 'source-id') as { bool: { must: unknown[] } };
+    expect(query.bool.must).toContainEqual({ term: { is_read: true } });
+  });
+
+  it('should push a negated condition to must_not so documents missing the field are selected', () => {
+    const query = userMergeScalarQuery(targetById('background-task-pending-initiator-id'), 'source-id') as {
+      bool: { must: unknown[]; must_not: unknown[] };
+    };
+    expect(query.bool.must_not).toEqual([{ term: { completed: true } }]);
+    expect(query.bool.must).not.toContainEqual({ term: { completed: true } });
+  });
+
+  it('should wrap a nested path in a nested query', () => {
+    const query = userMergeScalarQuery(targetById('workflow-definition-all-versions-created-by'), 'source-id') as {
+      bool: { must: unknown[] };
+    };
+    expect(query.bool.must[0]).toEqual({
+      nested: { path: 'all_versions', query: { term: { 'all_versions.createdBy.keyword': 'source-id' } } },
+    });
+  });
+
+  it('should remove before appending on a multiple field so a replay is a no-op', () => {
+    const script = userMergeScalarScript(targetById('basic-object-creator-id'));
+    expect(script).toContain('values.removeIf(value -> params.source.equals(value))');
+    expect(script).toContain('if (!values.contains(params.target))');
+  });
+
+  it('should guard the traversal of a nested single path', () => {
+    const script = userMergeScalarScript(targetById('internal-file-metadata-creator-id'));
+    expect(script).toContain('holder = holder.metaData; if (!(holder instanceof Map)) { return; }');
+    expect(script).toContain('holder.creator_id = params.target');
+  });
+
+  it('should iterate the items of an object array', () => {
+    const script = userMergeScalarScript(targetById('workflow-definition-all-versions-created-by'));
+    expect(script).toContain('for (def item : items)');
+    expect(script).toContain('item.createdBy = params.target');
+  });
+
+  it('should apply on the very query the count was taken from', () => {
+    const target = targetById('work-terminal-user-id');
+    const body = userMergeScalarUpdateBody(target, 'source-id', 'target-id') as { query: unknown; script: { params: unknown } };
+    expect(body.query).toEqual(userMergeScalarQuery(target, 'source-id'));
+    expect(body.script.params).toEqual({ source: 'source-id', target: 'target-id' });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-schemaDiscovery-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/userMerge/userMerge-schemaDiscovery-test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import '../../../../src/modules/index';
+import { findRegisterRow } from '../../../../src/modules/userMerge/userMerge-register';
+import { discoverUserIdAttributes } from '../../../../src/modules/userMerge/userMerge-scalarDiscovery';
+import { USER_MERGE_SCALAR_COMPLEMENTS } from '../../../../src/modules/userMerge/userMerge-scalarRules';
+import { userMergeScalarResolution } from '../../../../src/modules/userMerge/userMerge-scalarTargets';
+
+describe('userMerge schema discovery', () => {
+  it('should give a disposition to every attribute the schema declares as a user reference', () => {
+    expect(userMergeScalarResolution().unassigned).toEqual([]);
+  });
+
+  it('should distinguish the entities carrying the same attribute name', () => {
+    const userId = discoverUserIdAttributes().find((attribute) => attribute.name === 'user_id');
+    expect(userId?.entityTypes).toContain('Sync');
+    expect(userId?.entityTypes).toContain('User-Account');
+  });
+
+  it('should treat an attribute declared on an abstract root as global', () => {
+    const creatorId = discoverUserIdAttributes().find((attribute) => attribute.name === 'creator_id');
+    expect(creatorId?.entityTypes).toBeUndefined();
+    expect(creatorId?.multiple).toEqual(true);
+  });
+
+  it('should answer for an existing register row on every target', () => {
+    userMergeScalarResolution().targets.forEach((target) => {
+      expect(findRegisterRow(target.registerRow), target.id).toBeDefined();
+    });
+  });
+
+  it('should say why each excluded attribute is not rewritten here', () => {
+    userMergeScalarResolution().excluded.forEach((exclusion) => {
+      expect(exclusion.detail.length, exclusion.key).toBeGreaterThan(0);
+    });
+  });
+
+  /**
+   * A complement exists because a declaration is missing or wrong. Once it is fixed the
+   * attribute arrives through discovery and the complement becomes a duplicate.
+   */
+  it('should drop a complement once the schema starts yielding it', () => {
+    const discovered = discoverUserIdAttributes().flatMap((attribute) => {
+      return (attribute.entityTypes ?? ['*']).map((entityType) => `${entityType}.${attribute.name}`);
+    });
+    const redundant = USER_MERGE_SCALAR_COMPLEMENTS
+      .flatMap((complement) => (complement.entityTypes ?? ['*']).map((entityType) => `${entityType}.${complement.path}`))
+      .filter((key) => discovered.includes(key));
+    expect(redundant).toEqual([]);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/userMerge/userMerge-resolvers-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/userMerge/userMerge-resolvers-test.ts
@@ -140,6 +140,9 @@ describe('User merge resolvers', () => {
       expect(Object.keys(real.data.userMerge).sort()).toEqual(Object.keys(dry.data.userMerge).sort());
       expect(real.data.userMerge.dry_run).toBe(false);
       expect(dry.data.userMerge.dry_run).toBe(true);
+      // These two accounts own nothing in the test dataset; asserting it keeps a real merge
+      // from quietly rewriting shared fixtures if that ever stops being true.
+      expect(real.data.userMerge.report.total_updated).toEqual(0);
     });
 
     it('should carry the coverage in the report of every execution', async () => {
@@ -163,7 +166,7 @@ describe('User merge resolvers', () => {
       expect(data.userMerge.rights_strategy).toBe('UNION');
     });
 
-    it('should leave both users untouched while no handler covers them', async () => {
+    it('should leave the user entities themselves untouched', async () => {
       const sourceBefore = await readUser(USER_PARTICIPATE.id);
       const targetBefore = await readUser(USER_EDITOR.id);
       await queryAsAdminWithSuccess({
@@ -180,8 +183,9 @@ describe('User merge resolvers', () => {
       const { data } = await queryAsAdminWithSuccess({ query: USER_MERGE_COVERAGE_QUERY, variables: {} });
       expect(data.userMergeCoverage.total).toEqual(100);
       expect(data.userMergeCoverage.rows.length).toEqual(100);
-      // No handler ships in this chunk, so nothing may be reported as covered.
-      expect(data.userMergeCoverage.covered_count).toEqual(0);
+      // The register is what says the merge is incomplete, whatever the handlers claim.
+      expect(data.userMergeCoverage.covered_count).toBeGreaterThan(0);
+      expect(data.userMergeCoverage.uncovered_count).toEqual(100 - data.userMergeCoverage.covered_count);
       expect(data.userMergeCoverage.is_complete).toBe(false);
     });
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/userMerge/userMerge-scalarHandler-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/userMerge/userMerge-scalarHandler-test.ts
@@ -1,0 +1,120 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { elIndex, elRawDeleteByQuery, elRawGet } from '../../../../src/database/engine';
+import { INDEX_INTERNAL_OBJECTS, READ_INDEX_INTERNAL_OBJECTS } from '../../../../src/database/utils';
+import { executeUserMerge } from '../../../../src/modules/userMerge/userMerge-engine';
+import { registerUserMergeHandler, resetUserMergeHandlers } from '../../../../src/modules/userMerge/userMerge-registry';
+import { userMergeScalarHandler, USER_MERGE_SCALAR_HANDLER } from '../../../../src/modules/userMerge/userMerge-scalarHandler';
+import { UserMergeRightsStrategy, UserMergeStatus } from '../../../../src/modules/userMerge/userMerge-types';
+
+const SOURCE_ID = 'user--merge-source-0000-0000-000000000001';
+const TARGET_ID = 'user--merge-target-0000-0000-000000000002';
+const OTHER_ID = 'user--merge-other-0000-0000-0000000000003';
+
+const TEST_DOCUMENT_IDS = [
+  'merge-test-sync-1',
+  'merge-test-sync-2',
+  'merge-test-work-done',
+  'merge-test-work-running',
+  'merge-test-connector',
+  'merge-test-creators',
+];
+
+const document = (internalId: string, entityType: string, extra: Record<string, unknown>) => ({
+  internal_id: internalId,
+  standard_id: internalId,
+  entity_type: entityType,
+  parent_types: [],
+  ...extra,
+});
+
+const merge = (dryRun: boolean) => executeUserMerge(
+  {} as never,
+  {} as never,
+  SOURCE_ID,
+  TARGET_ID,
+  { dryRun, rightsStrategy: UserMergeRightsStrategy.Strict, acknowledgeExposureChange: false },
+);
+
+const readDocument = async (internalId: string) => {
+  const found = await elRawGet({ id: internalId, index: INDEX_INTERNAL_OBJECTS });
+  return (found as { _source: Record<string, unknown> })._source;
+};
+
+const changeFor = (report: { handlers: { handler: string; changes: { register_row_id: string; count: number }[] }[] } | undefined, rowId: string) => {
+  const handler = report?.handlers.find((entry) => entry.handler === USER_MERGE_SCALAR_HANDLER);
+  return handler?.changes.find((change) => change.register_row_id === rowId);
+};
+
+describe('userMerge scalar handler', () => {
+  beforeAll(async () => {
+    resetUserMergeHandlers();
+    registerUserMergeHandler(userMergeScalarHandler);
+    await elIndex(INDEX_INTERNAL_OBJECTS, document('merge-test-sync-1', 'Sync', { user_id: SOURCE_ID }));
+    await elIndex(INDEX_INTERNAL_OBJECTS, document('merge-test-sync-2', 'Sync', { user_id: OTHER_ID }));
+    await elIndex(INDEX_INTERNAL_OBJECTS, document('merge-test-work-done', 'work', { user_id: SOURCE_ID, status: 'complete' }));
+    await elIndex(INDEX_INTERNAL_OBJECTS, document('merge-test-work-running', 'work', { user_id: SOURCE_ID, status: 'progress' }));
+    await elIndex(INDEX_INTERNAL_OBJECTS, document('merge-test-connector', 'Connector', { connector_user_id: SOURCE_ID }));
+    await elIndex(INDEX_INTERNAL_OBJECTS, document('merge-test-creators', 'Sync', { user_id: OTHER_ID, creator_id: [SOURCE_ID, OTHER_ID] }));
+  });
+
+  afterAll(async () => {
+    resetUserMergeHandlers();
+    await elRawDeleteByQuery({
+      index: READ_INDEX_INTERNAL_OBJECTS,
+      refresh: true,
+      body: { query: { ids: { values: TEST_DOCUMENT_IDS } } },
+    });
+  });
+
+  it('should count what it would rewrite without writing anything', async () => {
+    const result = await merge(true);
+    expect(result.status).toEqual(UserMergeStatus.Success);
+    expect(changeFor(result.report, 'sync.user-id')?.count).toEqual(1);
+    expect(changeFor(result.report, 'work-terminal.user-id')?.count).toEqual(1);
+    expect(changeFor(result.report, 'work-active.user-id')?.count).toEqual(1);
+    expect(changeFor(result.report, 'connector.user-id')?.count).toEqual(1);
+    expect(changeFor(result.report, 'basic-object.creator-id')?.count).toEqual(1);
+    expect(result.report?.total_updated).toEqual(0);
+    const untouched = await readDocument('merge-test-sync-1') as { user_id: string };
+    expect(untouched.user_id).toEqual(SOURCE_ID);
+  });
+
+  it('should report a target left running as an alert rather than a failure', async () => {
+    const result = await merge(true);
+    const handler = result.report?.handlers.find((entry) => entry.handler === USER_MERGE_SCALAR_HANDLER);
+    const alertRows = handler?.alerts.map((alert) => alert.register_row_id);
+    expect(alertRows).toContain('work-active.user-id');
+  });
+
+  it('should rewrite every matched reference', async () => {
+    const result = await merge(false);
+    expect(result.status).toEqual(UserMergeStatus.Success);
+    expect(result.report?.total_updated).toEqual(5);
+    const sync = await readDocument('merge-test-sync-1') as { user_id: string };
+    const workDone = await readDocument('merge-test-work-done') as { user_id: string };
+    const workRunning = await readDocument('merge-test-work-running') as { user_id: string };
+    const connector = await readDocument('merge-test-connector') as { connector_user_id: string };
+    expect(sync.user_id).toEqual(TARGET_ID);
+    expect(workDone.user_id).toEqual(TARGET_ID);
+    expect(workRunning.user_id).toEqual(TARGET_ID);
+    expect(connector.connector_user_id).toEqual(TARGET_ID);
+  });
+
+  it('should leave documents referencing another user alone', async () => {
+    const other = await readDocument('merge-test-sync-2') as { user_id: string };
+    expect(other.user_id).toEqual(OTHER_ID);
+  });
+
+  it('should replace rather than append on a multiple field', async () => {
+    const creators = await readDocument('merge-test-creators') as { creator_id: string[] };
+    expect(creators.creator_id.sort()).toEqual([OTHER_ID, TARGET_ID].sort());
+  });
+
+  it('should be a no-op when replayed', async () => {
+    const result = await merge(false);
+    expect(result.status).toEqual(UserMergeStatus.Success);
+    expect(result.report?.total_updated).toEqual(0);
+    const creators = await readDocument('merge-test-creators') as { creator_id: string[] };
+    expect(creators.creator_id.sort()).toEqual([OTHER_ID, TARGET_ID].sort());
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Adds the scalar user reference handler, the first one that writes. Its targets are derived from the schema: every attribute declared with format `id` and pointing at User. Discovery walks the entity types one by one rather than through `getIdAttributes()`, which deduplicates by attribute name and would collapse the several entities declaring `user_id` into a single entry.
* Adds a table alongside supplying what the schema cannot say. **Dispositions**: whether a discovered attribute is rewritten here or left to another chunk — `History`, `Activity` and `PirHistory` belong to the history chunk, `platform_ip_whitelist_exclusion_ids` is invalidated rather than transferred, and `User-Account.user_id` is the STIX observable property holding an account identifier on the observed system, declared as a user reference by mistake. **Lifecycle splits**: `work.status`, `BackgroundTask.completed` and `Notification.is_read` each split one attribute into two register rows with different dispositions. **Complements**: nine paths the declarations do not expose, each recording why it is missing.
* Reports a discovered attribute with no disposition as unassigned, failing a test rather than rewriting it silently.
* Shares one query builder between counting and updating, so what the dry run reported is what the real pass writes. `creator_id` is `multiple`, so the script removes the source before appending the target, which makes a replay a no-op.
* Adds the public sharing handler. `feed_public_user_id`, `taxii_public_user_id` and `stream_public_user_id` are transferred, and the handler reports what each endpoint exposes anonymously before and after the transfer.
* Adds a `blocking` flag on `UserMergeRightsAlert`, raised by the public sharing handler when the target user carries markings or organizations the source did not have. The engine checks it between the two passes and refuses the real pass until `acknowledgeExposureChange` is set.
* Moves handler registration from the userMerge module to the end of `modules/index.ts`, since the scalar handler reads the schema and userMerge is imported before the workflow and custom field modules.

The nine complements exist because `connector_user_id`, `NewsFeedItem.user_id` and `initiator_id` are declared with format `short`, `PublicDashboard.user_id` is not declared at all, `InternalFile.metaData.creator_id` sits under an object with no attribute definitions, and the workflow version `createdBy` fields are nested children declared without `entityTypes`. Fixing those declarations is out of scope: `format: 'id'` drives filter representative resolution, the filter key schema and history diff rendering, so changing it has effects well beyond this feature. A test fails once the schema starts yielding a complement, so the entry gets dropped rather than silently duplicating a discovered target.

Filters, JSON manifests, STIX relations and RBAC have their own chunks. Hardening `resolveValidUser` against a disabled account serving a public endpoint is tracked separately; transferring `*_public_user_id` means no endpoint points at the merged-away source, so that check is defence in depth.

### Related issues

* closes #17495 — part of #17258

### How to test this PR

Stacked on #17535, so review the last 7 commits only. Enable the flag and start the platform:

```bash
export APP__ENABLED_DEV_FEATURES='["MERGE_USERS"]'
yarn start
```

Create some data owned by a source user — a few entities, an ingestion, a public feed — then run a dry merge. Each target reports a count, including the ones at zero, so the report names what was examined and not only what moved:

```bash
curl -s http://localhost:4000/graphql \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $OPENCTI_TOKEN" \
  -d '{"query":"mutation { userMerge(sourceId:\"<source>\", targetId:\"<target>\", options:{dryRun:true}) { merge_id status report { changes { register_row_id entity_type count exact detail } alerts { register_row_id kind message blocking } coverage { covered_count is_complete } } } }"}'
```

With a target user holding markings the source does not have, the public sharing handler must raise a `blocking` alert, and the real run must refuse:

```bash
curl -s http://localhost:4000/graphql \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $OPENCTI_TOKEN" \
  -d '{"query":"mutation { userMerge(sourceId:\"<source>\", targetId:\"<target>\", options:{dryRun:false}) { status message } }"}'
```

The same call with `acknowledgeExposureChange: true` proceeds. Replaying it must report zero updates, since the rewrite is idempotent — worth checking specifically on `creator_id`, which is a multi-valued field.

Automated coverage:

```bash
npx vitest run --config vitest.config.ci-unit.ts tests/01-unit/modules/userMerge
npx vitest run --config vitest.config.dev.ts tests/03-integration/10-modules/userMerge
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

72 unit tests and 27 integration tests. Discovery resolves to 17 targets, 12 motivated exclusions and no unassigned attribute — the same coverage an enumerated list would give, derived rather than written down, so a properly declared attribute added later is covered without touching this code.

The blocking refusal sits in the engine rather than in the handler. Raising it in `apply()` would stop the merge after earlier handlers already wrote, and raising it in `compute()` would keep the difference out of the dry run report, which is the one place the operator can read it before deciding.