### PR TITLE
feat(accessibility): Update Left nav to function with keyboard controls (#17548)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBar.jsx
@@ -38,7 +38,6 @@ import {
 } from '@mui/icons-material';
 import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
-import MenuList from '@mui/material/MenuList';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { createStyles, makeStyles, useTheme } from '@mui/styles';
@@ -121,6 +120,7 @@ import LeftBarItem from './LeftBarItem';
 import LogoTextOrange from '../../../static/images/logo_text_orange.svg';
 import LogoCollapsedOrange from '../../../static/images/logo_orange.svg';
 import { shouldOpenInNewTabMouseEvent } from 'src/utils/domEvent';
+import { List } from '@mui/material';
 
 export const SMALL_BAR_WIDTH = 55;
 export const OPEN_BAR_WIDTH = 180;
@@ -467,7 +467,7 @@ const LeftBarComponent = ({ queryRef }) => {
           backgroundColor: 'transparent',
         }}
       >
-        <MenuList disablePadding component="nav">
+        <List disablePadding component="nav">
           {!draftContext && (
             <LeftBarItem
               {...itemProps}
@@ -536,12 +536,12 @@ const LeftBarComponent = ({ queryRef }) => {
               />
             )}
           </Security>
-        </MenuList>
+        </List>
 
         <Separator />
 
         <Security needs={[KNOWLEDGE]}>
-          <MenuList component="nav">
+          <List component="nav">
             {!hideAnalyses && (
               <LeftBarItem
                 {...itemProps}
@@ -607,11 +607,11 @@ const LeftBarComponent = ({ queryRef }) => {
                 ]}
               />
             )}
-          </MenuList>
+          </List>
 
           <Separator />
 
-          <MenuList component="nav">
+          <List component="nav">
             {!hideThreats && (
               <LeftBarItem
                 {...itemProps}
@@ -702,13 +702,13 @@ const LeftBarComponent = ({ queryRef }) => {
                 ]}
               />
             )}
-          </MenuList>
+          </List>
         </Security>
 
         <Security needs={[MODULES, KNOWLEDGE, TAXIIAPI, CSVMAPPERS, INGESTION]}>
           <Separator />
 
-          <MenuList component="nav">
+          <List component="nav">
             <Security needs={[MODULES, INGESTION, INGESTION_SETINGESTIONS]}>
               {!draftContext && (
                 <LeftBarItem
@@ -740,7 +740,7 @@ const LeftBarComponent = ({ queryRef }) => {
                 ]}
               />
             </Security>
-          </MenuList>
+          </List>
         </Security>
 
         <Security needs={[
@@ -764,7 +764,7 @@ const LeftBarComponent = ({ queryRef }) => {
         >
           <Separator />
           {!draftContext && (
-            <MenuList component="nav" style={{ marginBottom: 48 }}>
+            <List component="nav" style={{ marginBottom: 48 }}>
               <LeftBarItem
                 {...itemProps}
                 id="settings"
@@ -781,7 +781,7 @@ const LeftBarComponent = ({ queryRef }) => {
                   { granted: isGrantedToExperience, link: '/dashboard/settings/experience', label: t_i18n('Filigran Experience') },
                 ]}
               />
-            </MenuList>
+            </List>
           )}
         </Security>
       </div>
@@ -796,7 +796,8 @@ const LeftBarComponent = ({ queryRef }) => {
           width: navOpen ? OPEN_BAR_WIDTH : SMALL_BAR_WIDTH,
         }}
       >
-        <MenuList
+        <List
+          component="nav"
           sx={{
             display: 'flex',
             flexDirection: 'column',
@@ -847,7 +848,7 @@ const LeftBarComponent = ({ queryRef }) => {
               />
             </Stack>
           )}
-        </MenuList>
+        </List>
       </div>
     </Drawer>
   );

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
@@ -1,7 +1,7 @@
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
-import { alpha, Collapse, ListItemIcon, ListItemText, MenuItem, MenuList, Popover, SxProps, Tooltip } from '@mui/material';
+import { alpha, Collapse, List, ListItemButton, ListItemIcon, ListItemText, MenuItem, MenuList, Popover, SxProps, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/styles';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Theme } from '../../../components/Theme';
 import useDraftContext from '../../../utils/hooks/useDraftContext';
@@ -10,14 +10,14 @@ interface SubMenuItem {
   type?: string;
   link: string;
   label: string;
-  icon?: React.ReactNode;
+  icon?: React.ReactElement;
   exact?: boolean;
   granted?: boolean;
 }
 
 interface LeftBarItemProps {
   id: string;
-  icon: React.ReactNode;
+  icon: React.ReactElement;
   label: string;
   link: string;
   exact?: boolean;
@@ -32,6 +32,15 @@ interface LeftBarItemProps {
   isMobile: boolean;
   submenuShowIcons?: boolean;
   hiddenEntities?: string[];
+}
+
+interface RenderMenuItemParams {
+  itemLabel: string;
+  selected: boolean;
+  showIcon?: boolean;
+  fontSize?: 'default' | 'small';
+  forceShowText?: boolean;
+  itemIcon?: React.ReactElement;
 }
 
 const LeftBarItem: React.FC<LeftBarItemProps> = ({
@@ -55,7 +64,9 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   const location = useLocation();
   const theme = useTheme<Theme>();
   const draftContext = useDraftContext();
-  const anchorRef = useRef<HTMLLIElement | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [showSubItemMenu, setShowSubItemMenu] = useState<boolean>(false);
+  const [usingHover, setUsingHover] = useState<boolean>(false);
 
   const visibleSubItems = subItems.filter(
     (item) => item.granted !== false && (!item.type || !hiddenEntities.includes(item.type)),
@@ -63,6 +74,48 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
 
   const hasSubItems = visibleSubItems.length > 0;
   const isMenuOpen = selectedMenu.includes(id);
+
+  const handleHover = () => {
+    if (!isMenuOpen) {
+      setUsingHover(true);
+      handleSubMenuOpen();
+    }
+  };
+
+  const handleUnHover = () => {
+    if (isMenuOpen) {
+      setUsingHover(false);
+      handleSubMenuClose();
+    }
+  };
+
+  const handleSubMenuOpen = () => {
+    if (isMobile || navOpen) {
+      onMenuToggle(id);
+    } else {
+      onMenuOpen(id);
+    }
+    setShowSubItemMenu(true);
+  };
+
+  const handleSubMenuClose = () => {
+    onMenuClose();
+    setShowSubItemMenu(false);
+  };
+
+  const handleKeyboard = (event: React.KeyboardEvent) => {
+    if (hasSubItems && (event.code === 'Space' || event.code === 'Enter')) {
+      event.preventDefault();
+      event.stopPropagation();
+      handleSubMenuOpen();
+    }
+  };
+  const handleClick = (event: React.MouseEvent) => {
+    if (event.button !== undefined) {
+      onGoToPage(event, link);
+      setShowSubItemMenu(false);
+    }
+  };
 
   const isSelected = (itemLink: string, itemExact?: boolean) => {
     if (itemExact) {
@@ -88,16 +141,29 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
       } else {
         onGoToPage(e, link);
       }
+      setShowSubItemMenu(true);
     }
   };
 
-  const renderMenuItem = (
-    itemIcon: React.ReactNode,
-    itemLabel: string,
-    selected: boolean,
+  const handleListKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      onMenuClose();
+      setShowSubItemMenu(false);
+    } else if (event.key === 'Escape') {
+      onMenuClose();
+      setShowSubItemMenu(false);
+    }
+  };
+
+  const renderMenuItem = ({
+    itemLabel,
+    selected,
     showIcon = true,
-    fontSize: 'default' | 'small' = 'default',
+    fontSize = 'default',
     forceShowText = false, // For popover items
+    itemIcon = undefined,
+  }: RenderMenuItemParams,
   ) => {
     const isSubItem = fontSize === 'small';
     const iconColor = selected ? theme.palette.text.light : theme.palette.text.tertiary;
@@ -133,7 +199,9 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
               },
             }}
           >
-            {itemIcon}
+            <Tooltip key={itemLabel} title={itemLabel} placement="right">
+              {itemIcon}
+            </Tooltip>
           </ListItemIcon>
         )}
 
@@ -156,11 +224,11 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   };
 
   // Render submenu item
-  const renderSubMenuItem = (item: SubMenuItem, inCollapse: boolean) => {
+  const renderSubMenuItem = (item: SubMenuItem, inCollapse: boolean, index: number) => {
     const itemSelected = isSelected(item.link, item.exact);
-
-    const menuItem = (
-      <MenuItem
+    return inCollapse ? (
+      <ListItemButton
+        key={`sub-menu-${index}`}
         component={Link}
         to={item.link}
         dense
@@ -173,16 +241,25 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
           },
         }}
       >
-        {renderMenuItem(item.icon, item.label, itemSelected, submenuShowIcons, 'small', !inCollapse)}
-      </MenuItem>
-    );
-
-    return inCollapse ? (
-      <Tooltip key={item.label} title={item.label} placement="right">
-        {menuItem}
-      </Tooltip>
+        {renderMenuItem({ itemLabel: item.label, selected: itemSelected, showIcon: submenuShowIcons, fontSize: 'small', forceShowText: !inCollapse, itemIcon: item.icon })}
+      </ListItemButton>
     ) : (
-      <div key={item.label}>{menuItem}</div>
+      <MenuItem
+        key={`sub-menu-${index}`}
+        component={Link}
+        to={item.link}
+        dense
+        onClick={inCollapse ? undefined : handleSubMenuClose}
+        sx={{
+          px: 2.5,
+          py: 1,
+          '&:hover': {
+            backgroundColor: theme.palette.leftBar.hover,
+          },
+        }}
+      >
+        {renderMenuItem({ itemLabel: item.label, selected: itemSelected, showIcon: submenuShowIcons, fontSize: 'small', forceShowText: !inCollapse, itemIcon: item.icon })}
+      </MenuItem>
     );
   };
 
@@ -209,17 +286,15 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   // No Subitems
   if (!hasSubItems) {
     return (
-      <Tooltip title={!navOpen ? label : ''} placement="right">
-        <MenuItem
-          component={Link}
-          to={link}
-          dense
-          onClick={onClick}
-          sx={getMenuStyles(isParentSelected)}
-        >
-          {renderMenuItem(icon, label, isParentSelected)}
-        </MenuItem>
-      </Tooltip>
+      <ListItemButton
+        component={Link}
+        to={link}
+        dense
+        onClick={onClick}
+        sx={getMenuStyles(isParentSelected)}
+      >
+        {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon })}
+      </ListItemButton>
     );
   }
 
@@ -227,20 +302,28 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   if (navOpen) {
     return (
       <>
-        <MenuItem
-          ref={anchorRef}
+        <ListItemButton
+          id={`nav-button-${label}`}
           dense
+          aria-expanded={isMenuOpen}
+          aria-controls={`nav-${label}-collapse`}
           onClick={handleParentClick}
           sx={getMenuStyles(isParentSelected)}
         >
-          {renderMenuItem(icon, label, isParentSelected)}
+          {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon })}
           {isMenuOpen ? <ArrowDropUp sx={{ fontSize: '20px' }} /> : <ArrowDropDown sx={{ fontSize: '20px' }} />}
-        </MenuItem>
+        </ListItemButton>
 
         <Collapse in={isMenuOpen} timeout="auto" unmountOnExit>
-          <MenuList component="nav" disablePadding sx={{ backgroundColor: theme.palette.designSystem.background.main }}>
-            {visibleSubItems.map((item) => renderSubMenuItem(item, true))}
-          </MenuList>
+          <List
+            component="nav"
+            id={`nav-${label}-collapse`}
+            aria-labelledby={`nav-button-${label}`}
+            disablePadding
+            sx={{ backgroundColor: theme.palette.designSystem.background.main }}
+          >
+            {visibleSubItems.map((item, i) => renderSubMenuItem(item, true, i))}
+          </List>
         </Collapse>
       </>
     );
@@ -248,38 +331,36 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
 
   // Nav Closed, show popover with subitems
   return (
-    <>
-      <MenuItem
+    <span
+      onMouseEnter={handleHover}
+      onMouseLeave={handleUnHover}
+    >
+      <ListItemButton
         ref={anchorRef}
-        dense
-        onClick={handleParentClick}
-        onMouseEnter={() => onMenuOpen(id)}
-        onMouseLeave={() => onMenuClose()}
+        tabIndex={0}
+        id={`nav-${label}`}
+        aria-expanded={isMenuOpen}
+        aria-haspopup="menu"
+        aria-controls={isMenuOpen ? `${label}-sub-menu` : undefined}
+        onClick={handleClick}
+        onKeyDown={handleKeyboard}
         sx={getMenuStyles(isParentSelected)}
       >
-        {renderMenuItem(icon, label, isParentSelected)}
-      </MenuItem>
-
-      {
-        /*
-        * Popover has pointerEvents: 'none' and Paper has pointerEvents: 'auto'
-        * This keeps the popover open when the mouse moves from the menu item to the popover
-        */
-      }
+        {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon })}
+      </ListItemButton>
       <Popover
         sx={{ pointerEvents: 'none' }}
-        open={isMenuOpen}
+        open={showSubItemMenu}
         anchorEl={anchorRef.current}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         onClose={onMenuClose}
-        disableRestoreFocus
         disableScrollLock
         elevation={0}
         slotProps={{
           paper: {
-            onMouseEnter: () => onMenuOpen(id),
-            onMouseLeave: onMenuClose,
+            onMouseEnter: handleHover,
+            onMouseLeave: handleUnHover,
             sx: {
               pointerEvents: 'auto',
               width: 180,
@@ -288,11 +369,17 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
           },
         }}
       >
-        <MenuList component="nav" disablePadding>
-          {visibleSubItems.map((item) => renderSubMenuItem(item, false))}
+        <MenuList
+          variant="menu"
+          autoFocusItem={!usingHover}
+          disablePadding
+          id={`${label}-sub-menu`}
+          onKeyDown={handleListKeyDown}
+        >
+          {visibleSubItems.map((item, i) => renderSubMenuItem(item, false, i))}
         </MenuList>
       </Popover>
-    </>
+    </span>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
@@ -1,7 +1,7 @@
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material';
-import { alpha, Collapse, ListItemIcon, ListItemText, MenuItem, MenuList, Popover, SxProps, Tooltip } from '@mui/material';
+import { alpha, Collapse, List, ListItemButton, ListItemIcon, ListItemText, MenuItem, MenuList, Popover, SxProps, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/styles';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Theme } from '../../../components/Theme';
 import useDraftContext from '../../../utils/hooks/useDraftContext';
@@ -10,14 +10,14 @@ interface SubMenuItem {
   type?: string;
   link: string;
   label: string;
-  icon?: React.ReactNode;
+  icon?: React.ReactElement;
   exact?: boolean;
   granted?: boolean;
 }
 
 interface LeftBarItemProps {
   id: string;
-  icon: React.ReactNode;
+  icon: React.ReactElement;
   label: string;
   link: string;
   exact?: boolean;
@@ -32,6 +32,16 @@ interface LeftBarItemProps {
   isMobile: boolean;
   submenuShowIcons?: boolean;
   hiddenEntities?: string[];
+}
+
+interface RenderMenuItemParams {
+  itemLabel: string;
+  selected: boolean;
+  showIcon?: boolean;
+  fontSize?: 'default' | 'small';
+  forceShowText?: boolean;
+  itemIcon?: React.ReactElement;
+  showTooltip?: boolean;
 }
 
 const LeftBarItem: React.FC<LeftBarItemProps> = ({
@@ -55,7 +65,9 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   const location = useLocation();
   const theme = useTheme<Theme>();
   const draftContext = useDraftContext();
-  const anchorRef = useRef<HTMLLIElement | null>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const [showSubItemMenu, setShowSubItemMenu] = useState<boolean>(false);
+  const [usingHover, setUsingHover] = useState<boolean>(false);
 
   const visibleSubItems = subItems.filter(
     (item) => item.granted !== false && (!item.type || !hiddenEntities.includes(item.type)),
@@ -63,6 +75,48 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
 
   const hasSubItems = visibleSubItems.length > 0;
   const isMenuOpen = selectedMenu.includes(id);
+
+  const handleHover = () => {
+    if (!isMenuOpen) {
+      setUsingHover(true);
+      handleSubMenuOpen();
+    }
+  };
+
+  const handleUnHover = () => {
+    if (isMenuOpen) {
+      setUsingHover(false);
+      handleSubMenuClose();
+    }
+  };
+
+  const handleSubMenuOpen = () => {
+    if (isMobile || navOpen) {
+      onMenuToggle(id);
+    } else {
+      onMenuOpen(id);
+    }
+    setShowSubItemMenu(true);
+  };
+
+  const handleSubMenuClose = () => {
+    onMenuClose();
+    setShowSubItemMenu(false);
+  };
+
+  const handleKeyboard = (event: React.KeyboardEvent) => {
+    if (hasSubItems && (event.code === 'Space' || event.code === 'Enter')) {
+      event.preventDefault();
+      event.stopPropagation();
+      handleSubMenuOpen();
+    }
+  };
+  const handleClick = (event: React.MouseEvent) => {
+    if (event.button !== undefined) {
+      onGoToPage(event, link);
+      setShowSubItemMenu(false);
+    }
+  };
 
   const isSelected = (itemLink: string, itemExact?: boolean) => {
     if (itemExact) {
@@ -88,16 +142,40 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
       } else {
         onGoToPage(e, link);
       }
+      setShowSubItemMenu(true);
     }
   };
 
-  const renderMenuItem = (
-    itemIcon: React.ReactNode,
-    itemLabel: string,
-    selected: boolean,
+  const handleListKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      onMenuClose();
+      setShowSubItemMenu(false);
+    } else if (event.key === 'Escape') {
+      onMenuClose();
+      setShowSubItemMenu(false);
+    }
+  };
+
+  // return focus to the button when we transitioned from !open -> open
+  const prevOpen = React.useRef(showSubItemMenu);
+  React.useEffect(() => {
+    if (prevOpen.current === true && showSubItemMenu === false) {
+      anchorRef.current!.focus();
+    }
+
+    prevOpen.current = showSubItemMenu;
+  }, [showSubItemMenu]);
+
+  const renderMenuItem = ({
+    itemLabel,
+    selected,
     showIcon = true,
-    fontSize: 'default' | 'small' = 'default',
+    fontSize = 'default',
     forceShowText = false, // For popover items
+    itemIcon = undefined,
+    showTooltip = true,
+  }: RenderMenuItemParams,
   ) => {
     const isSubItem = fontSize === 'small';
     const iconColor = selected ? theme.palette.text.light : theme.palette.text.tertiary;
@@ -133,7 +211,14 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
               },
             }}
           >
-            {itemIcon}
+            {showTooltip ? (
+              <Tooltip key={itemLabel} title={itemLabel} aria-hidden="true" placement="right">
+                {itemIcon}
+              </Tooltip>
+            ) : (
+              itemIcon
+            )
+            }
           </ListItemIcon>
         )}
 
@@ -156,11 +241,12 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   };
 
   // Render submenu item
-  const renderSubMenuItem = (item: SubMenuItem, inCollapse: boolean) => {
+  const renderSubMenuItem = (item: SubMenuItem, inCollapse: boolean, index: number) => {
     const itemSelected = isSelected(item.link, item.exact);
-
-    const menuItem = (
-      <MenuItem
+    return inCollapse ? (
+      <ListItemButton
+        key={`sub-menu-${index}`}
+        data-testid={`sub-menu-${item.label.toLowerCase()}`}
         component={Link}
         to={item.link}
         dense
@@ -173,16 +259,26 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
           },
         }}
       >
-        {renderMenuItem(item.icon, item.label, itemSelected, submenuShowIcons, 'small', !inCollapse)}
-      </MenuItem>
-    );
-
-    return inCollapse ? (
-      <Tooltip key={item.label} title={item.label} placement="right">
-        {menuItem}
-      </Tooltip>
+        {renderMenuItem({ itemLabel: item.label, selected: itemSelected, showIcon: submenuShowIcons, fontSize: 'small', forceShowText: !inCollapse, itemIcon: item.icon })}
+      </ListItemButton>
     ) : (
-      <div key={item.label}>{menuItem}</div>
+      <MenuItem
+        key={`sub-menu-${index}`}
+        data-testid={`sub-menu-${item.label.toLowerCase()}`}
+        component={Link}
+        to={item.link}
+        dense
+        onClick={inCollapse ? undefined : handleSubMenuClose}
+        sx={{
+          px: 2.5,
+          py: 1,
+          '&:hover': {
+            backgroundColor: theme.palette.leftBar.hover,
+          },
+        }}
+      >
+        {renderMenuItem({ itemLabel: item.label, selected: itemSelected, showIcon: submenuShowIcons, fontSize: 'small', forceShowText: !inCollapse, itemIcon: item.icon })}
+      </MenuItem>
     );
   };
 
@@ -209,17 +305,17 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   // No Subitems
   if (!hasSubItems) {
     return (
-      <Tooltip title={!navOpen ? label : ''} placement="right">
-        <MenuItem
-          component={Link}
-          to={link}
-          dense
-          onClick={onClick}
-          sx={getMenuStyles(isParentSelected)}
-        >
-          {renderMenuItem(icon, label, isParentSelected)}
-        </MenuItem>
-      </Tooltip>
+      <ListItemButton
+        component={Link}
+        to={link}
+        aria-label={label}
+        data-testid={`nav-button-${label.toLowerCase()}`}
+        dense
+        onClick={onClick}
+        sx={getMenuStyles(isParentSelected)}
+      >
+        {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon })}
+      </ListItemButton>
     );
   }
 
@@ -227,20 +323,30 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
   if (navOpen) {
     return (
       <>
-        <MenuItem
-          ref={anchorRef}
+        <ListItemButton
+          id={`nav-button-${label}`}
           dense
+          aria-expanded={isMenuOpen}
+          aria-controls={`nav-${label}-collapse`}
+          aria-label={label}
+          data-testid={`nav-button-${label.toLowerCase()}`}
           onClick={handleParentClick}
           sx={getMenuStyles(isParentSelected)}
         >
-          {renderMenuItem(icon, label, isParentSelected)}
+          {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon, showTooltip: false })}
           {isMenuOpen ? <ArrowDropUp sx={{ fontSize: '20px' }} /> : <ArrowDropDown sx={{ fontSize: '20px' }} />}
-        </MenuItem>
+        </ListItemButton>
 
         <Collapse in={isMenuOpen} timeout="auto" unmountOnExit>
-          <MenuList component="nav" disablePadding sx={{ backgroundColor: theme.palette.designSystem.background.main }}>
-            {visibleSubItems.map((item) => renderSubMenuItem(item, true))}
-          </MenuList>
+          <List
+            component="nav"
+            id={`nav-${label}-collapse`}
+            aria-labelledby={`nav-button-${label}`}
+            disablePadding
+            sx={{ backgroundColor: theme.palette.designSystem.background.main }}
+          >
+            {visibleSubItems.map((item, i) => renderSubMenuItem(item, true, i))}
+          </List>
         </Collapse>
       </>
     );
@@ -248,38 +354,41 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
 
   // Nav Closed, show popover with subitems
   return (
-    <>
-      <MenuItem
+    <span
+      onMouseEnter={handleHover}
+      onMouseLeave={handleUnHover}
+    >
+      <ListItemButton
         ref={anchorRef}
-        dense
-        onClick={handleParentClick}
-        onMouseEnter={() => onMenuOpen(id)}
-        onMouseLeave={() => onMenuClose()}
+        tabIndex={0}
+        id={`nav-${label}`}
+        data-testid={`nav-button-${label.toLowerCase()}`}
+        aria-expanded={isMenuOpen ? 'true' : undefined}
+        aria-controls={isMenuOpen ? `${label}-sub-menu` : undefined}
+        aria-haspopup="true"
+        onClick={handleClick}
+        onKeyDown={handleKeyboard}
         sx={getMenuStyles(isParentSelected)}
+        aria-label={label}
       >
-        {renderMenuItem(icon, label, isParentSelected)}
-      </MenuItem>
-
-      {
-        /*
-        * Popover has pointerEvents: 'none' and Paper has pointerEvents: 'auto'
-        * This keeps the popover open when the mouse moves from the menu item to the popover
-        */
-      }
+        {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon, showTooltip: false })}
+      </ListItemButton>
       <Popover
         sx={{ pointerEvents: 'none' }}
-        open={isMenuOpen}
+        role="menu"
+        open={showSubItemMenu}
         anchorEl={anchorRef.current}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         onClose={onMenuClose}
-        disableRestoreFocus
+        aria-expanded={showSubItemMenu}
+        aria-hidden={!showSubItemMenu}
         disableScrollLock
         elevation={0}
         slotProps={{
           paper: {
-            onMouseEnter: () => onMenuOpen(id),
-            onMouseLeave: onMenuClose,
+            onMouseEnter: handleHover,
+            onMouseLeave: handleUnHover,
             sx: {
               pointerEvents: 'auto',
               width: 180,
@@ -288,11 +397,18 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
           },
         }}
       >
-        <MenuList component="nav" disablePadding>
-          {visibleSubItems.map((item) => renderSubMenuItem(item, false))}
+        <MenuList
+          variant="menu"
+          aria-labelledby={`nav-${label}`}
+          autoFocusItem={!usingHover}
+          disablePadding
+          id={`${label}-sub-menu`}
+          onKeyDown={handleListKeyDown}
+        >
+          {visibleSubItems.map((item, i) => renderSubMenuItem(item, false, i))}
         </MenuList>
       </Popover>
-    </>
+    </span>
   );
 };
 

--- a/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
+++ b/opencti-platform/opencti-front/src/private/components/nav/LeftBarItem.tsx
@@ -41,6 +41,7 @@ interface RenderMenuItemParams {
   fontSize?: 'default' | 'small';
   forceShowText?: boolean;
   itemIcon?: React.ReactElement;
+  showTooltip?: boolean;
 }
 
 const LeftBarItem: React.FC<LeftBarItemProps> = ({
@@ -156,6 +157,16 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
     }
   };
 
+  // return focus to the button when we transitioned from !open -> open
+  const prevOpen = React.useRef(showSubItemMenu);
+  React.useEffect(() => {
+    if (prevOpen.current === true && showSubItemMenu === false) {
+      anchorRef.current!.focus();
+    }
+
+    prevOpen.current = showSubItemMenu;
+  }, [showSubItemMenu]);
+
   const renderMenuItem = ({
     itemLabel,
     selected,
@@ -163,6 +174,7 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
     fontSize = 'default',
     forceShowText = false, // For popover items
     itemIcon = undefined,
+    showTooltip = true,
   }: RenderMenuItemParams,
   ) => {
     const isSubItem = fontSize === 'small';
@@ -199,9 +211,14 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
               },
             }}
           >
-            <Tooltip key={itemLabel} title={itemLabel} placement="right">
-              {itemIcon}
-            </Tooltip>
+            {showTooltip ? (
+              <Tooltip key={itemLabel} title={itemLabel} aria-hidden="true" placement="right">
+                {itemIcon}
+              </Tooltip>
+            ) : (
+              itemIcon
+            )
+            }
           </ListItemIcon>
         )}
 
@@ -289,6 +306,7 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
       <ListItemButton
         component={Link}
         to={link}
+        aria-label={label}
         dense
         onClick={onClick}
         sx={getMenuStyles(isParentSelected)}
@@ -307,10 +325,11 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
           dense
           aria-expanded={isMenuOpen}
           aria-controls={`nav-${label}-collapse`}
+          aria-label={label}
           onClick={handleParentClick}
           sx={getMenuStyles(isParentSelected)}
         >
-          {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon })}
+          {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon, showTooltip: false })}
           {isMenuOpen ? <ArrowDropUp sx={{ fontSize: '20px' }} /> : <ArrowDropDown sx={{ fontSize: '20px' }} />}
         </ListItemButton>
 
@@ -339,22 +358,26 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
         ref={anchorRef}
         tabIndex={0}
         id={`nav-${label}`}
-        aria-expanded={isMenuOpen}
-        aria-haspopup="menu"
+        aria-expanded={isMenuOpen ? 'true' : undefined}
         aria-controls={isMenuOpen ? `${label}-sub-menu` : undefined}
+        aria-haspopup="true"
         onClick={handleClick}
         onKeyDown={handleKeyboard}
         sx={getMenuStyles(isParentSelected)}
+        aria-label={label}
       >
-        {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon })}
+        {renderMenuItem({ itemLabel: label, selected: isParentSelected, itemIcon: icon, showTooltip: false })}
       </ListItemButton>
       <Popover
         sx={{ pointerEvents: 'none' }}
+        role="menu"
         open={showSubItemMenu}
         anchorEl={anchorRef.current}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         onClose={onMenuClose}
+        aria-expanded={showSubItemMenu}
+        aria-hidden={!showSubItemMenu}
         disableScrollLock
         elevation={0}
         slotProps={{
@@ -371,6 +394,7 @@ const LeftBarItem: React.FC<LeftBarItemProps> = ({
       >
         <MenuList
           variant="menu"
+          aria-labelledby={`nav-${label}`}
           autoFocusItem={!usingHover}
           disablePadding
           id={`${label}-sub-menu`}

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationPerspective.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationPerspective.tsx
@@ -131,6 +131,7 @@ const WidgetCreationPerspective = () => {
       {getCurrentIsEntities() && (
         <Grid item xs={xs}>
           <Card
+            data-testid="entities-widget-perspective"
             padding="none"
             aria-label={t_i18n('Entities')}
             onClick={() => handleSelectPerspective('entities')}
@@ -159,6 +160,7 @@ const WidgetCreationPerspective = () => {
       {getCurrentIsRelationships() && (
         <Grid item xs={xs}>
           <Card
+            data-testid="relationships-widget-perspective"
             padding="none"
             aria-label={t_i18n('Knowledge graph')}
             onClick={() => handleSelectPerspective('relationships')}
@@ -189,6 +191,7 @@ const WidgetCreationPerspective = () => {
       {getCurrentIsAudits() && (
         <Grid item xs={xs}>
           <Card
+            data-testid="audits-widget-perspective"
             padding="none"
             aria-label={t_i18n('Activity & history')}
             onClick={() => handleSelectPerspective('audits')}

--- a/opencti-platform/opencti-front/tests_e2e/model/DashboardWidgets.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/DashboardWidgets.pageModel.ts
@@ -39,10 +39,24 @@ export default class DashboardWidgetsPageModel {
   }
 
   selectPerspective(perspective: WidgetPerspective) {
-    if (perspective === 'Entities') this.labelPerspective = 'entities';
-    if (perspective === 'Knowledge graph') this.labelPerspective = 'relationships';
-    if (perspective === 'Activity & history') this.labelPerspective = 'audits';
-    return this.page.getByLabel(perspective, { exact: true }).click();
+    let testId: string | undefined = undefined;
+    if (perspective === 'Entities') {
+      testId = 'entities-widget-perspective';
+      this.labelPerspective = 'entities';
+    }
+    if (perspective === 'Knowledge graph') {
+      testId = 'relationships-widget-perspective';
+      this.labelPerspective = 'relationships';
+    }
+    if (perspective === 'Activity & history') {
+      testId = 'audits-widget-perspective';
+      this.labelPerspective = 'audits';
+    }
+    if (testId) {
+      return this.page.getByTestId(testId).click();
+    } else {
+      return undefined;
+    }
   }
 
   fillLabel(label: string) {

--- a/opencti-platform/opencti-front/tests_e2e/model/menu/leftBar.pageModel.ts
+++ b/opencti-platform/opencti-front/tests_e2e/model/menu/leftBar.pageModel.ts
@@ -14,6 +14,7 @@ export default class LeftBarPage {
     const isOpenButtonVisible = await this.page.getByTestId('ChevronRightIcon').isVisible();
     if (isOpenButtonVisible) {
       await this.page.getByTestId('ChevronRightIcon').click();
+      await expect(this.page.getByTestId('ChevronLeftIcon')).toBeVisible();
     }
   }
 
@@ -24,8 +25,8 @@ export default class LeftBarPage {
     // Here to be sure we are opening the menu instead of closing it, we open
     // an other one before, as we can have only one menu open at a time.
     const otherMenu = menuName === 'Threats' ? 'Arsenal' : 'Threats';
-    const otherMenuLocator = this.page.getByRole('menuitem', { name: otherMenu, exact: true });
-    const menuLocator = this.page.getByRole('menuitem', { name: menuName, exact: true });
+    const otherMenuLocator = this.page.getByTestId(`nav-button-${otherMenu.toLowerCase()}`);
+    const menuLocator = this.page.getByTestId(`nav-button-${menuName.toLowerCase()}`);
 
     if (!subMenuItem) {
       await otherMenuLocator.click();
@@ -39,7 +40,7 @@ export default class LeftBarPage {
     // the click silently lands on the neighbouring row without navigating anywhere.
     // Retry the whole sequence - reopening the menu from a known state on each attempt -
     // until the navigation actually happened.
-    const subMenuItemLocator = this.page.getByRole('menuitem', { name: subMenuItem, exact: true });
+    const subMenuItemLocator = this.page.getByTestId(`sub-menu-${subMenuItem.toLowerCase()}`);
     await expect(async () => {
       await otherMenuLocator.click({ timeout: STEP_TIMEOUT });
       await menuLocator.click({ timeout: STEP_TIMEOUT });
@@ -60,7 +61,8 @@ export default class LeftBarPage {
   }
 
   async getSubItem(subMenuItem: string) {
-    await this.page.getByLabel(subMenuItem, { exact: true }).click();
+    expect(await this.page.getByTestId(`sub-menu-${subMenuItem.toLowerCase()}`).isVisible());
+    await this.page.getByTestId(`sub-menu-${subMenuItem.toLowerCase()}`).click();
   }
 
   async expectBreadcrumb(...items: string[]) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update component to use List components to align with documentation that Menu isn't meant for navigation
* Update collapsible sections to have appropriate aria attributes to provide information for screen readers
* Update functionality of collapsed menu to align with how the uncollapsed menu works. The user needs to click the icon to view the available page options and does not automatically navigate to the first option.
* Nested the tooltip within the rendered label to resolve dom structure issues
* Removed disableRestoreFocus so keyboard users stay focused on the correct item in the menu
* Added necessary aria attributes for popover menu
* Added necessary attributes to allow tabbing through the left nav  
### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17548 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

- Use keyboard controls to navigate through the left nav, expanding and collapsing sections, and following the links
- repeat the process with the nav collapsed and ensure can navigate through the nav and open menus using only keyboard controls
- confirm labeling using screen reader  

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
