### PR TITLE
feat(ingestion): add ingestion logs for CSV feeds (#17528)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvLogsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvLogsTab.tsx
@@ -1,0 +1,97 @@
+import React, { Suspense, useEffect, useState } from 'react';
+import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { RefreshOutlined } from '@mui/icons-material';
+import { useFormatter } from '../../../../components/i18n';
+import type { IngestionCsvLogsTabQuery } from './__generated__/IngestionCsvLogsTabQuery.graphql';
+import IngestionLogTab from '../IngestionLogTab';
+
+export const ingestionCsvLogsTabQuery = graphql`
+  query IngestionCsvLogsTabQuery($id: String!) {
+    ingestionCsvLogs(id: $id) {
+      timestamp
+      level
+      type
+      identifier
+      message
+      meta
+    }
+  }
+`;
+
+interface IngestionCsvLogsTabProps {
+  feedId: string;
+  feedName: string;
+}
+
+const IngestionCsvLogsTabBody: React.FC<{
+  queryRef: PreloadedQuery<IngestionCsvLogsTabQuery>;
+  feedName: string;
+}> = ({ queryRef, feedName }) => {
+  const data = usePreloadedQuery(ingestionCsvLogsTabQuery, queryRef);
+  const logs = (data?.ingestionCsvLogs ?? []).filter((e): e is NonNullable<typeof e> => e != null);
+
+  return <IngestionLogTab name={feedName} logHistory={logs} />;
+};
+
+// Displays the CSV feed ingestion logs directly in the feed detail page's "Logs" tab.
+const IngestionCsvLogsTab: React.FC<IngestionCsvLogsTabProps> = ({ feedId, feedName }) => {
+  const { t_i18n } = useFormatter();
+  const [queryRef, loadQuery] = useQueryLoader<IngestionCsvLogsTabQuery>(ingestionCsvLogsTabQuery);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    loadQuery({ id: feedId }, { fetchPolicy: 'network-only' });
+  }, [feedId, loadQuery]);
+
+  // Clear the refreshing state once the new query reference has arrived,
+  // instead of synchronously right after triggering the (async) reload.
+  useEffect(() => {
+    setRefreshing(false);
+  }, [queryRef]);
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    loadQuery({ id: feedId }, { fetchPolicy: 'network-only' });
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="flex-end" sx={{ mb: 1 }}>
+        <Tooltip title={t_i18n('Refresh')}>
+          <span>
+            <IconButton
+              size="small"
+              onClick={handleRefresh}
+              disabled={refreshing || !queryRef}
+              aria-label={t_i18n('Refresh')}
+            >
+              <RefreshOutlined fontSize="small" sx={{ opacity: refreshing ? 0.6 : 1 }} />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Stack>
+      {queryRef ? (
+        <Suspense
+          fallback={(
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={32} />
+            </Box>
+          )}
+        >
+          <IngestionCsvLogsTabBody queryRef={queryRef} feedName={feedName} />
+        </Suspense>
+      ) : (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={32} />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default IngestionCsvLogsTab;

--- a/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
@@ -14,6 +14,7 @@ import IngestionJsonPopover from '@components/data/ingestionJson/IngestionJsonPo
 import FormView from '@components/data/forms/view/FormView';
 import { BuiltInIntegrationKind, getBuiltInIntegration, isBuiltInIntegrationKind } from '@components/integrations/available/builtInIntegrations';
 import IngestionTaxiiLogsTab from '@components/data/ingestionTaxii/IngestionTaxiiLogsTab';
+import IngestionCsvLogsTab from '@components/data/ingestionCsv/IngestionCsvLogsTab';
 import { ConnectorWorksSection } from '@components/data/connectors/Connector';
 import { connectorIdFromIngestId } from '@components/integrations/deployed/useDeployedIntegrations';
 import useHelper from '../../../../utils/hooks/useHelper';
@@ -284,8 +285,9 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
   const { setTitle } = useConnectedDocumentModifier();
   const { isFeatureEnable } = useHelper();
   const definition = getBuiltInIntegration(kind);
-  // Only TAXII feeds get the Overview / Works / Logs tabs, mirroring the
-  // connector detail page. Other feed kinds keep the single-page layout.
+  // Only TAXII and CSV feeds get the Overview / Works / Logs tabs, mirroring
+  // the connector detail page. Other feed kinds keep the single-page layout.
+  const hasTabs = kind === 'taxii' || kind === 'csv';
   const [tabValue, setTabValue] = useState(0);
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
@@ -410,7 +412,7 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
         </Stack>
       </Stack>
 
-      {kind === 'taxii' && (
+      {hasTabs && (
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={tabValue} onChange={handleTabChange}>
             <Tab label={t_i18n('Overview')} />
@@ -420,7 +422,7 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
         </Box>
       )}
 
-      {(kind !== 'taxii' || tabValue === 0) && (
+      {(!hasTabs || tabValue === 0) && (
         <Grid container spacing={3}>
           <Grid size={{ xs: 12, md: 7 }}>
             <Card title={t_i18n('Configuration')}>
@@ -559,15 +561,19 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
 
       {/* Works of the feed's technical queue connector (in progress and
           completed), exactly like the connector detail pages. Synchronizers
-          consume streams directly and never register works. For TAXII feeds
-          this now lives in its own "Works" tab instead of the single page. */}
-      {isConnectorReader && kind !== 'sync' && (kind !== 'taxii' || tabValue === 1) && (
+          consume streams directly and never register works. For TAXII and
+          CSV feeds this now lives in its own "Works" tab instead of the
+          single page. */}
+      {isConnectorReader && kind !== 'sync' && (!hasTabs || tabValue === 1) && (
         <ConnectorWorksSection connectorId={connectorIdFromIngestId(node.id)} />
       )}
 
-      {/* "Logs" tab content, TAXII feeds only. */}
-      {isIngestionFeedLogsEnabled && kind === 'taxii' && tabValue === 2 && (
-        <IngestionTaxiiLogsTab feedId={node.id} feedName={node.name} />
+      {/* "Logs" tab content, TAXII and CSV feeds only. */}
+      {isIngestionFeedLogsEnabled && hasTabs && tabValue === 2 && (
+        <>
+          {kind === 'taxii' && <IngestionTaxiiLogsTab feedId={node.id} feedName={node.name} />}
+          {kind === 'csv' && <IngestionCsvLogsTab feedId={node.id} feedName={node.name} />}
+        </>
       )}
     </PageContainer>
   );

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9552,6 +9552,7 @@ type Query {
   csvFeedAddInputFromImport(file: Upload!): CSVFeedAddInputFromImport!
   defaultIngestionGroupCount: Int
   userAlreadyExists(name: String!): Boolean
+  ingestionCsvLogs(id: String!): [IngestionEntry]
   ingestionJson(id: String!): IngestionJson
   ingestionJsons(first: Int, after: ID, orderBy: IngestionJsonOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionJsonConnection
   indicator(id: String!): Indicator
@@ -13899,6 +13900,8 @@ type IngestionCsv implements InternalObject & BasicObject {
   current_state_hash: String
   current_state_date: DateTime
   last_execution_date: DateTime
+  last_execution_status: String
+  ingestionLogs: [IngestionEntry]
   markings: [String!]
   toConfigurationExport: String!
   duplicateCsvMapper: CsvMapper!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -9722,6 +9722,7 @@ type Query {
   csvFeedAddInputFromImport(file: Upload!): CSVFeedAddInputFromImport!
   defaultIngestionGroupCount: Int
   userAlreadyExists(name: String!): Boolean
+  ingestionCsvLogs(id: String!): [IngestionEntry]
   ingestionJson(id: String!): IngestionJson
   ingestionJsons(first: Int, after: ID, orderBy: IngestionJsonOrdering, orderMode: OrderingMode, filters: FilterGroup, includeAuthorities: Boolean, search: String): IngestionJsonConnection
   indicator(id: String!): Indicator
@@ -14052,6 +14053,8 @@ type IngestionCsv implements InternalObject & BasicObject {
   current_state_hash: String
   current_state_date: DateTime
   last_execution_date: DateTime
+  last_execution_status: String
+  ingestionLogs: [IngestionEntry]
   markings: [String!]
   toConfigurationExport: String!
   duplicateCsvMapper: CsvMapper!

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -13865,8 +13865,10 @@ export type IngestionCsv = BasicObject & InternalObject & {
   duplicateCsvMapper: CsvMapper;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  ingestionLogs?: Maybe<Array<Maybe<IngestionEntry>>>;
   ingestion_running?: Maybe<Scalars['Boolean']['output']>;
   last_execution_date?: Maybe<Scalars['DateTime']['output']>;
+  last_execution_status?: Maybe<Scalars['String']['output']>;
   markings?: Maybe<Array<Scalars['String']['output']>>;
   metrics?: Maybe<Array<Maybe<Metric>>>;
   name: Scalars['String']['output'];
@@ -24757,6 +24759,7 @@ export type Query = {
   infrastructure?: Maybe<Infrastructure>;
   infrastructures?: Maybe<InfrastructureConnection>;
   ingestionCsv?: Maybe<IngestionCsv>;
+  ingestionCsvLogs?: Maybe<Array<Maybe<IngestionEntry>>>;
   ingestionCsvs?: Maybe<IngestionCsvConnection>;
   ingestionJson?: Maybe<IngestionJson>;
   ingestionJsons?: Maybe<IngestionJsonConnection>;
@@ -26153,6 +26156,11 @@ export type QueryInfrastructuresArgs = {
 
 
 export type QueryIngestionCsvArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryIngestionCsvLogsArgs = {
   id: Scalars['String']['input'];
 };
 
@@ -46441,8 +46449,10 @@ export type IngestionCsvResolvers<ContextType = any, ParentType extends Resolver
   duplicateCsvMapper?: Resolver<ResolversTypes['CsvMapper'], ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  ingestionLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['IngestionEntry']>>>, ParentType, ContextType>;
   ingestion_running?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   last_execution_date?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  last_execution_status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   markings?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -49872,6 +49882,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   infrastructure?: Resolver<Maybe<ResolversTypes['Infrastructure']>, ParentType, ContextType, RequireFields<QueryInfrastructureArgs, 'id'>>;
   infrastructures?: Resolver<Maybe<ResolversTypes['InfrastructureConnection']>, ParentType, ContextType, Partial<QueryInfrastructuresArgs>>;
   ingestionCsv?: Resolver<Maybe<ResolversTypes['IngestionCsv']>, ParentType, ContextType, RequireFields<QueryIngestionCsvArgs, 'id'>>;
+  ingestionCsvLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['IngestionEntry']>>>, ParentType, ContextType, RequireFields<QueryIngestionCsvLogsArgs, 'id'>>;
   ingestionCsvs?: Resolver<Maybe<ResolversTypes['IngestionCsvConnection']>, ParentType, ContextType, Partial<QueryIngestionCsvsArgs>>;
   ingestionJson?: Resolver<Maybe<ResolversTypes['IngestionJson']>, ParentType, ContextType, RequireFields<QueryIngestionJsonArgs, 'id'>>;
   ingestionJsons?: Resolver<Maybe<ResolversTypes['IngestionJsonConnection']>, ParentType, ContextType, Partial<QueryIngestionJsonsArgs>>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -13900,8 +13900,10 @@ export type IngestionCsv = BasicObject & InternalObject & {
   duplicateCsvMapper: CsvMapper;
   entity_type: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  ingestionLogs?: Maybe<Array<Maybe<IngestionEntry>>>;
   ingestion_running?: Maybe<Scalars['Boolean']['output']>;
   last_execution_date?: Maybe<Scalars['DateTime']['output']>;
+  last_execution_status?: Maybe<Scalars['String']['output']>;
   markings?: Maybe<Array<Scalars['String']['output']>>;
   metrics?: Maybe<Array<Maybe<Metric>>>;
   name: Scalars['String']['output'];
@@ -24825,6 +24827,7 @@ export type Query = {
   infrastructure?: Maybe<Infrastructure>;
   infrastructures?: Maybe<InfrastructureConnection>;
   ingestionCsv?: Maybe<IngestionCsv>;
+  ingestionCsvLogs?: Maybe<Array<Maybe<IngestionEntry>>>;
   ingestionCsvs?: Maybe<IngestionCsvConnection>;
   ingestionJson?: Maybe<IngestionJson>;
   ingestionJsons?: Maybe<IngestionJsonConnection>;
@@ -26223,6 +26226,11 @@ export type QueryInfrastructuresArgs = {
 
 
 export type QueryIngestionCsvArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryIngestionCsvLogsArgs = {
   id: Scalars['String']['input'];
 };
 
@@ -46633,8 +46641,10 @@ export type IngestionCsvResolvers<ContextType = any, ParentType extends Resolver
   duplicateCsvMapper?: Resolver<ResolversTypes['CsvMapper'], ParentType, ContextType>;
   entity_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  ingestionLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['IngestionEntry']>>>, ParentType, ContextType>;
   ingestion_running?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   last_execution_date?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  last_execution_status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   markings?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   metrics?: Resolver<Maybe<Array<Maybe<ResolversTypes['Metric']>>>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -50083,6 +50093,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   infrastructure?: Resolver<Maybe<ResolversTypes['Infrastructure']>, ParentType, ContextType, RequireFields<QueryInfrastructureArgs, 'id'>>;
   infrastructures?: Resolver<Maybe<ResolversTypes['InfrastructureConnection']>, ParentType, ContextType, Partial<QueryInfrastructuresArgs>>;
   ingestionCsv?: Resolver<Maybe<ResolversTypes['IngestionCsv']>, ParentType, ContextType, RequireFields<QueryIngestionCsvArgs, 'id'>>;
+  ingestionCsvLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['IngestionEntry']>>>, ParentType, ContextType, RequireFields<QueryIngestionCsvLogsArgs, 'id'>>;
   ingestionCsvs?: Resolver<Maybe<ResolversTypes['IngestionCsvConnection']>, ParentType, ContextType, Partial<QueryIngestionCsvsArgs>>;
   ingestionJson?: Resolver<Maybe<ResolversTypes['IngestionJson']>, ParentType, ContextType, RequireFields<QueryIngestionJsonArgs, 'id'>>;
   ingestionJsons?: Resolver<Maybe<ResolversTypes['IngestionJsonConnection']>, ParentType, ContextType, Partial<QueryIngestionJsonsArgs>>;

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -587,7 +587,7 @@ const csvDataHandler = async (context: AuthContext, ingestion: BasicStoreEntityI
   try {
     logApp.info(`[OPENCTI-MODULE] Executing CSV ingestion for ${ingestion.name}`);
     const { csvLines, addedLast } = await fetchCsvFromUrl(csvMapperParsed, ingestion, { timeout: FEED_REQUEST_TIMEOUT });
-    await processCsvLines(context, ingestion, csvMapperParsed, csvLines, addedLast);
+    return await processCsvLines(context, ingestion, csvMapperParsed, csvLines, addedLast);
   } catch (e: any) {
     throw UnknownError(e, { ingestionName: ingestion.name, ingestionId: ingestion.id });
   }
@@ -609,6 +609,8 @@ export const csvExecutor = async (context: AuthContext) => {
       // If ingestion have remaining messages in the queue dont fetch any new data
       if (messages_number > 0) {
         logApp.info(`[OPENCTI-MODULE] INGESTION Csv, skipping ${ingestion.name} - queue already filled with messages (${messages_number})`);
+        const ingestionLogger = createIngestionLogger(ingestion.internal_id, ingestion.name, 'csv');
+        ingestionLogger.info('Feed is buffering, waiting for queue to drain', { messages_number, messages_size });
         const ingestionPromise = updateBuiltInConnectorInfo(context, ingestion.user_id, ingestion.id, { buffering: true, messages_size });
         ingestionPromises.push(ingestionPromise);
         // If last execution was done before CSV_FEED_MIN_INTERVAL_MINUTES minutes, dont fetch any new data
@@ -618,12 +620,26 @@ export const csvExecutor = async (context: AuthContext) => {
         ingestionPromises.push(ingestionPromise);
         // If no message in queue and last execution is old enough, fetch new data
       } else {
+        const ingestionLogger = createIngestionLogger(ingestion.internal_id, ingestion.name, 'csv');
+        ingestionLogger.info('Feed execution started', { uri: ingestion.uri });
         const ingestionPromise = csvDataHandler(context, ingestion)
-          .catch((e) => {
+          .then(async ({ objectsInBundleCount }) => {
+            try {
+              await patchCsvIngestion(context, SYSTEM_USER, ingestion.internal_id, { last_execution_status: 'success' });
+            } catch (patchErr) {
+              logApp.warn('[OPENCTI-MODULE] Failed to patch csv ingestion success status', { cause: patchErr });
+            }
+            await ingestionLogger.success('Feed fetched successfully', { objects_count: objectsInBundleCount, uri: ingestion.uri });
+          })
+          .catch(async (e) => {
             logApp.warn('[OPENCTI-MODULE] INGESTION - Csv ingestion execution', { cause: e, name: ingestion.name });
             // In case of error we need also to take in account the min_interval_minutes with last_execution_date update.
-            patchCsvIngestion(context, SYSTEM_USER, ingestion.internal_id, { last_execution_date: now() })
-              .catch((reason) => logApp.error('[OPENCTI-MODULE] INGESTION Csv, Error on updating ingestion status in database', { cause: reason }));
+            try {
+              await patchCsvIngestion(context, SYSTEM_USER, ingestion.internal_id, { last_execution_date: now(), last_execution_status: 'error' });
+            } catch (reason) {
+              logApp.error('[OPENCTI-MODULE] INGESTION Csv, Error on updating ingestion status in database', { cause: reason });
+            }
+            await ingestionLogger.error('Feed fetch failed', buildIngestionErrorMeta(e));
           });
         ingestionPromises.push(ingestionPromise);
       }

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -625,7 +625,7 @@ export const csvExecutor = async (context: AuthContext) => {
         const ingestionPromise = csvDataHandler(context, ingestion)
           .then(async ({ objectsInBundleCount }) => {
             try {
-              await patchCsvIngestion(context, SYSTEM_USER, ingestion.internal_id, { last_execution_status: 'success' });
+              await patchCsvIngestion(context, SYSTEM_USER, ingestion.internal_id, { last_execution_status: 'success', last_execution_date: now() });
             } catch (patchErr) {
               logApp.warn('[OPENCTI-MODULE] Failed to patch csv ingestion success status', { cause: patchErr });
             }

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-common.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-common.ts
@@ -1,9 +1,10 @@
-import { IngestionAuthType } from '../../generated/graphql';
-import { FunctionalError } from '../../config/errors';
+import { IngestionAuthType, IngestionLogLevel } from '../../generated/graphql';
+import { DatabaseError, FunctionalError } from '../../config/errors';
 import { decryptValue, encryptValue, getPlatformCrypto } from '../../utils/platformCrypto';
 import { memoize } from '../../utils/memoize';
 import { verifyUriWithDenyList } from '../../utils/uriDenyList';
 import { uriDenyList } from '../../config/uriDenyList';
+import { type IngestionLogEntry, redisGetIngestionLogHistory } from '../../database/redis';
 
 export const verifyIngestionUri = (uri: string): void => {
   verifyUriWithDenyList(uri, uriDenyList(), 'This URI is not allowed for ingestion.');
@@ -95,3 +96,29 @@ export const addAuthenticationCredentials = (currentValue: string | undefined | 
 
   return currentValue;
 };
+
+// region ingestion feed logs (shared across TAXII, CSV, RSS, JSON... feed types)
+const ingestionLogLevelFromString = (level: string): IngestionLogLevel => {
+  switch (level) {
+    case 'success':
+      return IngestionLogLevel.Success;
+    case 'info':
+      return IngestionLogLevel.Info;
+    case 'warn':
+      return IngestionLogLevel.Warn;
+    case 'error':
+      return IngestionLogLevel.Error;
+    default:
+      throw DatabaseError('Unknown ingestion log level', { level });
+  }
+};
+
+export const findIngestionLogsForFeed = async (feedId: string) => {
+  const entries: IngestionLogEntry[] = await redisGetIngestionLogHistory(feedId);
+  return entries.map(({ timestamp, level, ...others }) => ({
+    timestamp: new Date(timestamp),
+    level: ingestionLogLevelFromString(level),
+    ...others,
+  }));
+};
+// endregion

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
@@ -14,10 +14,11 @@ import {
   ingestionCsvResetState,
   testCsvIngestionMapping,
 } from './ingestion-csv-domain';
-import { removeAuthenticationCredentials } from './ingestion-common';
+import { findIngestionLogsForFeed, removeAuthenticationCredentials } from './ingestion-common';
 import { decryptIngestionCredential } from './ingestion-common';
 import { userAlreadyExists } from '../user/user-domain';
 import { loadCreator } from '../../database/members';
+import type { BasicStoreEntityIngestionCsv } from './ingestion-types';
 
 const ingestionCsvResolvers: Resolvers = {
   Query: {
@@ -26,6 +27,7 @@ const ingestionCsvResolvers: Resolvers = {
     csvFeedAddInputFromImport: (_, { file }, context) => csvFeedAddInputFromImport(context, context.user, file),
     defaultIngestionGroupCount: (_, __, context) => defaultIngestionGroupsCount(context),
     userAlreadyExists: (_, { name }, context) => userAlreadyExists(context, name),
+    ingestionCsvLogs: async (_: unknown, { id }: { id: string }) => findIngestionLogsForFeed(id),
   },
   IngestionCsv: {
     authentication_value: async (ingestionCsv) => {
@@ -36,6 +38,7 @@ const ingestionCsvResolvers: Resolvers = {
     csvMapper: (ingestionCsv, _, context) => csvFeedGetCsvMapper(context, context.user, ingestionCsv),
     toConfigurationExport: (ingestionCsv, _, context) => csvFeedMapperExport(context, context.user, ingestionCsv),
     duplicateCsvMapper: (ingestionCsv, _, context) => csvFeedGetNewDuplicatedCsvMapper(context, context.user, ingestionCsv),
+    ingestionLogs: (ingestionCsv: BasicStoreEntityIngestionCsv) => findIngestionLogsForFeed(ingestionCsv.internal_id),
   },
   Mutation: {
     ingestionCsvTester: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv-resolver.ts
@@ -27,7 +27,10 @@ const ingestionCsvResolvers: Resolvers = {
     csvFeedAddInputFromImport: (_, { file }, context) => csvFeedAddInputFromImport(context, context.user, file),
     defaultIngestionGroupCount: (_, __, context) => defaultIngestionGroupsCount(context),
     userAlreadyExists: (_, { name }, context) => userAlreadyExists(context, name),
-    ingestionCsvLogs: async (_: unknown, { id }: { id: string }) => findIngestionLogsForFeed(id),
+    ingestionCsvLogs: async (_: unknown, { id }: { id: string }, context) => {
+      await findById(context, context.user, id);
+      return findIngestionLogsForFeed(id);
+    },
   },
   IngestionCsv: {
     authentication_value: async (ingestionCsv) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-csv.graphql
@@ -24,6 +24,8 @@ type IngestionCsv implements InternalObject & BasicObject {
     current_state_hash: String
     current_state_date: DateTime
     last_execution_date: DateTime
+    last_execution_status: String
+    ingestionLogs: [IngestionEntry] @ff(flags: ["INGESTION_FEED_LOGS"])
     markings: [String!]
     toConfigurationExport: String!
     duplicateCsvMapper: CsvMapper!
@@ -83,6 +85,7 @@ type Query {
     ): CSVFeedAddInputFromImport! @auth(for: [INGESTION, CSVMAPPERS])
     defaultIngestionGroupCount: Int @auth(for: [INGESTION])
     userAlreadyExists(name: String!): Boolean @auth(for: [INGESTION])
+    ingestionCsvLogs(id: String!): [IngestionEntry] @auth(for: [INGESTION]) @ff(flags: ["INGESTION_FEED_LOGS"])
 }
 
 # Mutations

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii-resolver.ts
@@ -9,46 +9,18 @@ import {
   taxiiFeedAddInputFromImport,
   taxiiFeedExport,
 } from './ingestion-taxii-domain';
-import { removeAuthenticationCredentials } from './ingestion-common';
-import { IngestionLogLevel, type Resolvers } from '../../generated/graphql';
+import { findIngestionLogsForFeed, removeAuthenticationCredentials } from './ingestion-common';
+import type { Resolvers } from '../../generated/graphql';
 import { decryptIngestionCredential } from './ingestion-common';
 import { loadCreator } from '../../database/members';
-import { type IngestionLogEntry, redisGetIngestionLogHistory } from '../../database/redis';
 import type { BasicStoreEntityIngestionTaxii } from './ingestion-types';
-import { DatabaseError } from '../../config/errors';
-
-const levelToLevel = (level: string): IngestionLogLevel => {
-  switch (level) {
-    case 'success':
-      return IngestionLogLevel.Success;
-    case 'info':
-      return IngestionLogLevel.Info;
-    case 'warn':
-      return IngestionLogLevel.Warn;
-    case 'error':
-      return IngestionLogLevel.Error;
-    default:
-      throw DatabaseError('Unknown ingestion log level', { level });
-  }
-};
-
-const logsToLogs = (logs: IngestionLogEntry[]) => {
-  return logs.map(({ timestamp, level, ...others }) => ({
-    timestamp: new Date(timestamp),
-    level: levelToLevel(level),
-    ...others,
-  }));
-};
 
 const ingestionTaxiiResolvers: Resolvers = {
   Query: {
     ingestionTaxii: (_, { id }, context) => findTaxiiIngestionById(context, context.user, id),
     ingestionTaxiis: (_, args, context) => findTaxiiIngestionPaginated(context, context.user, args),
     taxiiFeedAddInputFromImport: (_, { file }) => taxiiFeedAddInputFromImport(file),
-    ingestionTaxiiLogs: async (_: unknown, { id }: { id: string }) => {
-      const entries = await redisGetIngestionLogHistory(id);
-      return logsToLogs(entries);
-    },
+    ingestionTaxiiLogs: async (_: unknown, { id }: { id: string }) => findIngestionLogsForFeed(id),
   },
   IngestionTaxii: {
     authentication_value: async (ingestionTaxii) => {
@@ -57,10 +29,7 @@ const ingestionTaxiiResolvers: Resolvers = {
     },
     user: (ingestionTaxii, _, context) => loadCreator(context, context.user, ingestionTaxii.user_id),
     toConfigurationExport: (ingestionTaxii) => taxiiFeedExport(ingestionTaxii),
-    ingestionLogs: async (ingestionTaxii: BasicStoreEntityIngestionTaxii) => {
-      const entries = await redisGetIngestionLogHistory(ingestionTaxii.internal_id);
-      return logsToLogs(entries);
-    },
+    ingestionLogs: (ingestionTaxii: BasicStoreEntityIngestionTaxii) => findIngestionLogsForFeed(ingestionTaxii.internal_id),
   },
   Mutation: {
     ingestionTaxiiAdd: (_, { input }, context) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-taxii-resolver.ts
@@ -20,7 +20,10 @@ const ingestionTaxiiResolvers: Resolvers = {
     ingestionTaxii: (_, { id }, context) => findTaxiiIngestionById(context, context.user, id),
     ingestionTaxiis: (_, args, context) => findTaxiiIngestionPaginated(context, context.user, args),
     taxiiFeedAddInputFromImport: (_, { file }) => taxiiFeedAddInputFromImport(file),
-    ingestionTaxiiLogs: async (_: unknown, { id }: { id: string }) => findIngestionLogsForFeed(id),
+    ingestionTaxiiLogs: async (_: unknown, { id }: { id: string }, context) => {
+      await findTaxiiIngestionById(context, context.user, id);
+      return findIngestionLogsForFeed(id);
+    },
   },
   IngestionTaxii: {
     authentication_value: async (ingestionTaxii) => {

--- a/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-types.ts
+++ b/opencti-platform/opencti-graphql/src/modules/ingestion/ingestion-types.ts
@@ -108,6 +108,7 @@ export interface StixIngestionTaxii extends StixObject {
 export const ENTITY_TYPE_INGESTION_CSV = 'IngestionCsv';
 
 export interface BasicStoreEntityIngestionCsv extends BasicStoreEntity {
+  kind: 'csv';
   current_state_hash: string;
   name: string;
   description: string;
@@ -121,6 +122,7 @@ export interface BasicStoreEntityIngestionCsv extends BasicStoreEntity {
   user_id: string | undefined;
   ingestion_running: boolean;
   last_execution_date: Date | undefined;
+  last_execution_status: string | undefined;
   markings?: string[];
   ssl_verify?: boolean;
 }

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/platformCrypto-database-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/platformCrypto-database-test.ts
@@ -5,23 +5,37 @@ import { encryptSynchronizerCredential, decryptSynchronizerCredential, isSynchro
 // Mock nconf with a valid 32-byte encryption key (base64-encoded)
 // "0123456789abcdef0123456789abcdef" = 32 bytes
 vi.mock('nconf', () => ({
-  default: {
-    get: (key: string) => {
-      if (key === 'app:encryption_key') return 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
-      return undefined;
-    },
-  },
+  default: (() => {
+    const api = {
+      get: (key: string) => {
+        if (key === 'app:encryption_key') return 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+        if (key === 'env' || key === 'node_env') return 'test';
+        return undefined;
+      },
+      env: () => api,
+      add: () => api,
+      file: () => api,
+      path: (confName: string, separator: string) => confName.split(separator),
+    };
+    return api;
+  })(),
 }));
 
-vi.mock('../../../src/config/conf', () => ({
-  default: {
-    get: (key: string) => {
-      if (key === 'app:encryption_key') return 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
-      return undefined;
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/config/conf')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: (key: string) => {
+        if (key === 'app:encryption_key') return 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
+        if (key === 'redis:ca') return [];
+        return (actual.default as { get: (k: string) => unknown }).get(key);
+      },
     },
-  },
-  confNameToEnvName: () => 'APP__ENCRYPTION_KEY',
-}));
+    confNameToEnvName: () => 'APP__ENCRYPTION_KEY',
+  };
+});
 
 vi.mock('../../../src/config/credentials', () => ({
   enrichWithRemoteCredentials: vi.fn().mockResolvedValue({ value: undefined }),

--- a/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-csv-resolver-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/10-modules/ingestion/ingestion-csv-resolver-test.ts
@@ -11,6 +11,7 @@ import { IngestionAuthType, type IngestionCsvAddInput, IngestionCsvMapperType } 
 import { findById as findUserById } from '../../../../src/domain/user';
 import { regenerateCsvMapperUUID } from '../../../../src/modules/ingestion/ingestion-converter';
 import type { CsvMapperResolved } from '../../../../src/modules/internal/csvMapper/csvMapper-types';
+import { getClientBase, redisDeleteIngestionLogHistory, redisPushIngestionLog } from '../../../../src/database/redis';
 
 const DELETE_USER_QUERY = gql`
     mutation userDelete($id: ID!) {
@@ -778,5 +779,150 @@ describe('CSV ingestion resolver standard behavior', () => {
       },
     });
     expect(csvMapperId).not.toEqual(getCsvFeedForDuplication?.data?.ingestionCsv.duplicateCsvMapper.id);
+  });
+});
+
+describe('CSV ingestion resolver — ingestion logs', () => {
+  let csvLogsIngestionId: string;
+  const csvLogsIngestionName = 'CSV logs resolver test';
+  const csvLogsIngestionMapper = JSON.stringify({
+    has_header: false,
+    name: 'CSV logs mapper',
+    separator: ',',
+    representations: [{ id: '75c3c21c-0a92-497f-962d-4e6e1a488482', type: 'entity', target: { entity_type: 'IPv4-Addr' }, attributes: [{ key: 'value', column: { column_name: 'A' }, based_on: null }] }],
+    skipLineChar: '',
+  });
+
+  it('should create a CSV ingestion for logs tests', async () => {
+    const input: IngestionCsvAddInput = {
+      authentication_type: IngestionAuthType.None,
+      name: csvLogsIngestionName,
+      uri: 'http://csvserver.invalid',
+      csv_mapper: csvLogsIngestionMapper,
+      csv_mapper_type: IngestionCsvMapperType.Inline,
+      user_id: ADMIN_USER.id,
+      scheduling_period: 'PT1H',
+    };
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        mutation createCsvIngesterForLogs($input: IngestionCsvAddInput!) {
+          ingestionCsvAdd(input: $input) {
+            id
+            name
+          }
+        }
+      `,
+      variables: { input },
+    });
+    csvLogsIngestionId = result.data?.ingestionCsvAdd.id;
+    expect(csvLogsIngestionId).toBeDefined();
+  });
+
+  it('should resolve logs from ingestionCsvLogs query and ingestionLogs field', async () => {
+    await redisDeleteIngestionLogHistory(csvLogsIngestionId);
+    await redisPushIngestionLog(csvLogsIngestionId, {
+      level: 'info',
+      type: 'csv',
+      identifier: csvLogsIngestionName,
+      message: 'info-log',
+      meta: { step: 1 },
+    });
+    await redisPushIngestionLog(csvLogsIngestionId, {
+      level: 'success',
+      type: 'csv',
+      identifier: csvLogsIngestionName,
+      message: 'success-log',
+      meta: { step: 2 },
+    });
+    await redisPushIngestionLog(csvLogsIngestionId, {
+      level: 'warn',
+      type: 'csv',
+      identifier: csvLogsIngestionName,
+      message: 'warn-log',
+      meta: { step: 3 },
+    });
+    await redisPushIngestionLog(csvLogsIngestionId, {
+      level: 'error',
+      type: 'csv',
+      identifier: csvLogsIngestionName,
+      message: 'error-log',
+      meta: { step: 4 },
+    });
+
+    const queryLogsResult = await queryAsAdminWithSuccess({
+      query: gql`
+        query readCsvLogs($id: String!) {
+          ingestionCsvLogs(id: $id) {
+            level
+            message
+            type
+            identifier
+            meta
+          }
+        }
+      `,
+      variables: { id: csvLogsIngestionId },
+    });
+    expect(queryLogsResult.data?.ingestionCsvLogs).toHaveLength(4);
+    expect(queryLogsResult.data?.ingestionCsvLogs.map((l: { level: string }) => l.level)).toEqual(['error', 'warn', 'success', 'info']);
+    expect(queryLogsResult.data?.ingestionCsvLogs[0].message).toBe('error-log');
+
+    const fieldLogsResult = await queryAsAdminWithSuccess({
+      query: gql`
+        query readCsvLogsField($id: String!) {
+          ingestionCsv(id: $id) {
+            id
+            ingestionLogs {
+              level
+              message
+            }
+          }
+        }
+      `,
+      variables: { id: csvLogsIngestionId },
+    });
+    expect(fieldLogsResult.data?.ingestionCsv.ingestionLogs).toHaveLength(4);
+    expect(fieldLogsResult.data?.ingestionCsv.ingestionLogs.map((l: { level: string }) => l.level)).toEqual(['error', 'warn', 'success', 'info']);
+  });
+
+  it('should fail when encountering an unknown log level', async () => {
+    await redisDeleteIngestionLogHistory(csvLogsIngestionId);
+    await getClientBase().lpush(`ingestion-log-${csvLogsIngestionId}-history`, JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: 'unknown_level',
+      type: 'csv',
+      identifier: csvLogsIngestionName,
+      message: 'bad-level',
+      meta: {},
+    }));
+
+    const result = await queryAsAdmin({
+      query: gql`
+        query readCsvLogsWithBadLevel($id: String!) {
+          ingestionCsvLogs(id: $id) {
+            level
+            message
+          }
+        }
+      `,
+      variables: { id: csvLogsIngestionId },
+    });
+    expect(result.errors).toBeDefined();
+    if (result.errors) {
+      expect(result.errors[0].message).toContain('Unknown ingestion log level');
+    }
+  });
+
+  it('should delete the CSV ingestion used for logs tests', async () => {
+    await redisDeleteIngestionLogHistory(csvLogsIngestionId);
+    const result = await queryAsAdminWithSuccess({
+      query: gql`
+        mutation deleteCsvIngesterForLogs($id: ID!) {
+          ingestionCsvDelete(id: $id)
+        }
+      `,
+      variables: { id: csvLogsIngestionId },
+    });
+    expect(result.data?.ingestionCsvDelete).toEqual(csvLogsIngestionId);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Backend: new `ingestionCsvLogs` query and `ingestionLogs` field on `IngestionCsv`, gated behind `INGESTION_FEED_LOGS`. `csvExecutor` now logs execution start/success/error to Redis and patches `last_execution_status`.
- Factored out the shared log-resolution logic (`findIngestionLogsForFeed`) so it's reused by both TAXII and CSV resolvers, avoiding duplication.
- Frontend: new `IngestionCsvLogsTab` component (reusing the generic `IngestionLogTab`), and the Overview/Works/Logs tabs on the feed detail page are now available for CSV feeds too, not just TAXII.
- Added integration test coverage mirroring the TAXII logs test suite.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17528 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

1. Enable the `INGESTION_FEED_LOGS` feature flag (already enabled by default in dev via `config/default.json`).
2. Create a CSV feed (**Data > Ingestion > Feeds > Create > CSV Feed**) with a valid URI and mapper.
3. Start the feed and wait for execution (config `ingestion_manager:csv_feed:min_interval_minutes`, 5min by default — lower it in dev to speed things up).
4. Open the feed detail page > **Logs** tab: check that `Feed execution started` then `Feed fetched successfully` (with `objects_count`) appear.
5. Test the error case: set an invalid URI, restart the feed, verify the `Feed fetch failed` log with error metadata.
6. Verify the **Refresh** button on the Logs tab reloads the list without a page reload.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
