### PR TITLE
docs(fds): add the implementation playbook pointer (#17539)

### DIFF
--- a/fds-migration/IMPLEMENTATION-PLAYBOOK.md
+++ b/fds-migration/IMPLEMENTATION-PLAYBOOK.md
@@ -1,0 +1,36 @@
+# Implementation playbook — it lives in the design-system repository
+
+**The playbook for adopting a `@filigran/design-system` component in this
+product is in `XTM-Foundation/filigran-design-system`:**
+
+**➜ [`process/PRODUCT-IMPLEMENTATION-PLAYBOOK.md`](https://github.com/XTM-Foundation/filigran-design-system/blob/main/process/PRODUCT-IMPLEMENTATION-PLAYBOOK.md)**
+
+## Why it is not here
+
+It was written in the OpenAEV repository by the first pilot. This product's own
+pilot then found no reference to it anywhere in this repository and had to be
+told where it was — a document you have to announce is not findable. The library
+is the one repository every pilot already has to look at, so the playbook moved
+next to the library it describes. This file is the pointer this repository was
+missing.
+
+## What is there
+
+| Document | What it is |
+| --- | --- |
+| `process/PRODUCT-IMPLEMENTATION-PLAYBOOK.md` | The playbook: prerequisites through to a green CI on a pull request shipping a library component |
+| `process/PRODUCT-IMPLEMENTATION-PLAYBOOK-DEFECTS.md` | Every defect found by running the playbook against a real product, with severity and status |
+| `process/artifacts/ci-design-system-secret.test.ts` | The CI credential guard to copy into a product's test suite (Step 2) |
+
+The index of previous pilots is the table in the playbook's step 0.5, so it
+travelled inside the document. **A new pilot adds its row there**, in a pull
+request to the design-system repository, opened alongside the one that ships it.
+
+## What stays here
+
+[`LIBRARY-FEEDBACK.md`](./LIBRARY-FEEDBACK.md) — it records what this product
+found missing in the library while integrating it. It is this product's
+observation and it belongs to this product.
+
+The rest of `fds-migration/` is unchanged: it is this repository's own migration
+state, mapping and log, not the general playbook.


### PR DESCRIPTION
### Proposed changes

* Adds `fds-migration/IMPLEMENTATION-PLAYBOOK.md`, a redirection file pointing to `process/PRODUCT-IMPLEMENTATION-PLAYBOOK.md` in the design-system repository.
* OpenCTI carried no reference to that playbook: the pilot that used it here had to be told where it was. OpenAEV carries the same redirection file; this closes the gap on this side.

### Related issues

* #17539

### How to test this PR

Documentation only — no code, no CI wiring, no dependency change. Read the file and follow the three links it lists; all three paths exist on `XTM-Foundation/filigran-design-system@main`.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Targets `design-system/current`, not `master`. The design-system work is not merged upstream yet.