### PR TITLE
fix(frontend): coverage last result should not be sortable in SC view (#14716)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/SecurityCoverages.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/SecurityCoverages.tsx
@@ -175,7 +175,10 @@ const SecurityCoverages: FunctionComponent = () => {
       percentWidth: 35,
       isSortable: true,
     },
-    coverage_last_result: { percentWidth: 15 },
+    coverage_last_result: {
+      percentWidth: 15,
+      isSortable: false,
+    },
     coverage_information: { percentWidth: 15 },
     creator: {
       percentWidth: 12,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added isSortable : false for coverage last result

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* fix #14716 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
