### PR TITLE
docs(client-python): document that update flag only affects entity merge collisions (#13377)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -2614,7 +2614,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :type bundle: str
         :param entities_types: List of entity types in the bundle
         :type entities_types: list
-        :param update: Whether this is an update operation
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation. Has no effect on the standard single-match
+            upsert path, as OpenCTI always upserts by standard id/hash regardless of this flag.
         :type update: bool
         :return: Message bundle dictionary
         :rtype: dict
@@ -3508,7 +3510,10 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :type draft_id: str, optional
         :param entities_types: List of entity types to filter (default: None)
         :type entities_types: list, optional
-        :param update: Whether to update existing data in the database (default: False)
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation (default: False). OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param event_version: Event version for the bundle (default: None)
         :type event_version: str, optional
@@ -3790,7 +3795,10 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         :type sequence: int, optional
         :param entities_types: List of entity types to filter (default: None)
         :type entities_types: list, optional
-        :param update: Whether to update existing data in the database (default: False)
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation (default: False). OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param draft_id: Draft context ID for the bundle (default: None)
         :type draft_id: str, optional

--- a/client-python/pycti/entities/opencti_stix_cyber_observable.py
+++ b/client-python/pycti/entities/opencti_stix_cyber_observable.py
@@ -300,7 +300,10 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
         :type externalReferences: list
         :param objectOrganization: (optional) list of organization IDs
         :type objectOrganization: list
-        :param update: (optional) whether to update if exists (default: False)
+        :param update: (optional) whether to force-merge entities that ambiguously match
+            multiple existing records during creation (default: False). OpenCTI always
+            upserts data by standard id/hash regardless of this flag; it only affects the
+            rare case where a single incoming entity matches more than one existing entity.
         :type update: bool
         :param resolve_result_indicators: (optional) resolve result indicators (default: True)
         :type resolve_result_indicators: bool

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -379,7 +379,10 @@ class OpenCTIStix2:
 
         :param file_path: Valid path to the file
         :type file_path: str
-        :param update: Whether to update data in the database, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: list, optional
@@ -405,7 +408,10 @@ class OpenCTIStix2:
 
         :param json_data: JSON data as string or bytes
         :type json_data: str or bytes
-        :param update: Whether to update data in the database, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: list, optional
@@ -1268,7 +1274,10 @@ class OpenCTIStix2:
 
         :param stix_object: Valid STIX2 object to import
         :type stix_object: Dict
-        :param update: Whether to update data in the database, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: list, optional
@@ -1398,7 +1407,10 @@ class OpenCTIStix2:
 
         :param stix_object: Valid STIX2 cyber observable object
         :type stix_object: Dict
-        :param update: Whether to update existing data in the database, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: list, optional
@@ -1610,7 +1622,10 @@ class OpenCTIStix2:
 
         :param stix_relation: Valid STIX2 relationship object
         :type stix_relation: Dict
-        :param update: Whether to update existing data in the database, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: list, optional
@@ -1723,7 +1738,10 @@ class OpenCTIStix2:
         :type from_id: str
         :param to_id: ID of the target entity (where_sighted_ref)
         :type to_id: str
-        :param update: Whether to update existing data in the database, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: list, optional
@@ -3389,7 +3407,10 @@ class OpenCTIStix2:
 
         :param item: STIX2 item to import
         :type item: dict
-        :param update: Whether to update existing data, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: List, optional
@@ -3540,7 +3561,10 @@ class OpenCTIStix2:
 
         :param item: STIX2 item to import
         :type item: dict
-        :param update: Whether to update existing data, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: List, optional
@@ -3671,7 +3695,10 @@ class OpenCTIStix2:
 
         :param stix_bundle: STIX2 bundle dictionary to import
         :type stix_bundle: Dict
-        :param update: Whether to update existing data, defaults to False
+        :param update: Whether to force-merge entities that ambiguously match multiple
+            existing records during creation, defaults to False. OpenCTI always upserts
+            data by standard id/hash regardless of this flag; it only affects the rare
+            case where a single incoming entity matches more than one existing entity.
         :type update: bool, optional
         :param types: List of STIX2 types to filter, defaults to None
         :type types: List, optional


### PR DESCRIPTION
### Proposed changes

* Clarify `update` parameter docstrings in `send_stix2_bundle`, `send_stix2_bundle_to_worker`, `_create_message_bundle` (opencti_connector_helper.py)
* Clarify `update` parameter docstrings in `import_bundle`, `import_bundle_from_json`, `import_object`, `import_observable` and related methods (opencti_stix2.py)
* Clarify `update` parameter docstring in `create` (opencti_stix_cyber_observable.py)

### Related issues
* closes #13377

### How to test this PR
Docs-only change, no behavior modified. Verify docstrings render correctly and accurately describe behavior: OpenCTI always upserts entities by standard id/hash regardless of `update`; the flag only affects the rare case where a single incoming entity ambiguously matches multiple existing entities (forces a merge vs. picking one target).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Original issue proposed a `DeprecationWarning` for `update`, but tracing the code path (send_bundle → worker → import_bundle_from_json → create mutation → middleware.ts) shows the flag isn't fully dead: it still controls merge behavior when a single entity ambiguously matches multiple existing records. Deprecating it outright would be misleading. This PR scopes the fix to correcting the misleading docstrings instead, which addresses the reporter's core confusion without changing runtime behavior.
