### PR TITLE
fix(front): persist html source content on blur (#17590)

### DIFF
--- a/opencti-platform/opencti-front/src/components/fields/RichTextField.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/RichTextField.tsx
@@ -7,7 +7,7 @@ import InputLabel from '@mui/material/InputLabel';
 import { useTheme } from '@mui/styles';
 import { FieldProps, useField } from 'formik';
 import { isNil } from 'ramda';
-import { CSSProperties, useState } from 'react';
+import { CSSProperties, useEffect, useRef, useState } from 'react';
 import useAI from '../../utils/hooks/useAI';
 import { RichTextEditor } from '@filigran/rich-text-editor';
 import { useFormatter } from '../i18n';
@@ -47,6 +47,23 @@ const RichTextField = ({
   const [fullScreen, setFullScreen] = useState(false);
   const [, meta] = useField(name);
   const { enabled, configured } = useAI();
+  const editorAdapterRef = useRef<{ getData: () => string } | null>(null);
+  const latestEditorValueRef = useRef(value ?? '');
+
+  useEffect(() => {
+    latestEditorValueRef.current = value ?? '';
+  }, [value]);
+
+  useEffect(() => {
+    return () => {
+      const adapter = editorAdapterRef.current;
+      if (!adapter || !onSubmit) return;
+      const html = adapter.getData();
+      if (html !== latestEditorValueRef.current) {
+        onSubmit(name, html);
+      }
+    };
+  }, [name, onSubmit]);
 
   const fieldErrors = errors[name] as string;
   const showError = !isNil(meta.error) && (meta.touched || submitCount > 0);
@@ -58,13 +75,18 @@ const RichTextField = ({
         }
       }}
       data={value}
+      onReady={(adapter) => {
+        editorAdapterRef.current = adapter;
+      }}
       onChange={(_, adapter) => {
         const html = adapter.getData();
+        latestEditorValueRef.current = html;
         setFieldValue(name, html);
         onChange?.(name, html);
       }}
       onBlur={(_, adapter) => {
         const html = adapter.getData();
+        latestEditorValueRef.current = html;
         setFieldValue(name, html);
         setFieldTouched(name, true);
         onSubmit?.(name, html);

--- a/opencti-platform/opencti-front/src/components/fields/RichTextField.tsx
+++ b/opencti-platform/opencti-front/src/components/fields/RichTextField.tsx
@@ -63,9 +63,11 @@ const RichTextField = ({
         setFieldValue(name, html);
         onChange?.(name, html);
       }}
-      onBlur={() => {
+      onBlur={(_, adapter) => {
+        const html = adapter.getData();
+        setFieldValue(name, html);
         setFieldTouched(name, true);
-        onSubmit?.(name, value);
+        onSubmit?.(name, html);
       }}
       onFocus={() => onFocus?.(name)}
       disabled={disabled}

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
 import { Field, Form, Formik } from 'formik';
 import CommitMessage from '@components/common/form/CommitMessage';
 import * as Yup from 'yup';
@@ -94,17 +94,6 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
   const classes = useStyles();
   let { description, contentField } = containerData;
   const [draftContent, setDraftContent] = useState(contentField || '');
-  const latestDraftContentRef = useRef(draftContent);
-  const latestPersistedContentRef = useRef(containerData.contentField || '');
-  const persistFieldValueRef = useRef<(name: string, value: string) => void>(() => {});
-
-  useEffect(() => {
-    latestDraftContentRef.current = draftContent;
-  }, [draftContent]);
-
-  useEffect(() => {
-    latestPersistedContentRef.current = containerData.contentField || '';
-  }, [containerData.contentField]);
 
   useEffect(() => {
     // Reset local draft only when switching to another object.
@@ -163,7 +152,7 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
     });
   };
 
-  const persistFieldValue = (
+  const handleSubmitField = (
     name: string,
     value: string,
   ) => {
@@ -188,28 +177,6 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
         .catch(() => false);
     }
   };
-
-  useEffect(() => {
-    persistFieldValueRef.current = persistFieldValue;
-  });
-
-  const handleSubmitField = (
-    name: string,
-    value: string,
-  ) => {
-    persistFieldValue(name, value);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (!editionMode || enableReferences) return;
-      const latestDraftContent = latestDraftContentRef.current || '';
-      const latestPersistedContent = latestPersistedContentRef.current || '';
-      if (latestDraftContent !== latestPersistedContent) {
-        persistFieldValueRef.current('content', latestDraftContent);
-      }
-    };
-  }, [editionMode, enableReferences]);
 
   const matchCase = (text: string, pattern: string) => {
     let result = '';

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectMappableContent.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { Field, Form, Formik } from 'formik';
 import CommitMessage from '@components/common/form/CommitMessage';
 import * as Yup from 'yup';
@@ -94,6 +94,18 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
   const classes = useStyles();
   let { description, contentField } = containerData;
   const [draftContent, setDraftContent] = useState(contentField || '');
+  const latestDraftContentRef = useRef(draftContent);
+  const latestPersistedContentRef = useRef(containerData.contentField || '');
+  const persistFieldValueRef = useRef<(name: string, value: string) => void>(() => {});
+
+  useEffect(() => {
+    latestDraftContentRef.current = draftContent;
+  }, [draftContent]);
+
+  useEffect(() => {
+    latestPersistedContentRef.current = containerData.contentField || '';
+  }, [containerData.contentField]);
+
   useEffect(() => {
     // Reset local draft only when switching to another object.
     setDraftContent(containerData.contentField || '');
@@ -151,7 +163,7 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
     });
   };
 
-  const handleSubmitField = (
+  const persistFieldValue = (
     name: string,
     value: string,
   ) => {
@@ -176,6 +188,28 @@ const StixCoreObjectMappableContent: FunctionComponent<StixCoreObjectMappableCon
         .catch(() => false);
     }
   };
+
+  useEffect(() => {
+    persistFieldValueRef.current = persistFieldValue;
+  });
+
+  const handleSubmitField = (
+    name: string,
+    value: string,
+  ) => {
+    persistFieldValue(name, value);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (!editionMode || enableReferences) return;
+      const latestDraftContent = latestDraftContentRef.current || '';
+      const latestPersistedContent = latestPersistedContentRef.current || '';
+      if (latestDraftContent !== latestPersistedContent) {
+        persistFieldValueRef.current('content', latestDraftContent);
+      }
+    };
+  }, [editionMode, enableReferences]);
 
   const matchCase = (text: string, pattern: string) => {
     let result = '';


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Fixed HTML content persistence in the rich text editor: on `blur`, we now read the value **directly from the editor** (`adapter.getData()`) instead of relying on a potentially stale Formik value.
- Immediately synchronized Formik with that latest editor value (`setFieldValue(name, html)`).
- Triggered save with the fresh value (`onSubmit(name, html)`), preventing content loss when switching tabs right after editing HTML source.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->

### How to test this PR

1. Open a **Report** and go to the **Content** tab.  
2. Switch to **Editor view**.  
3. In the **Content** editor toolbar, click **HTML** (“source html”).  
4. Paste some HTML, for example:
   ```html
   <h1>Welcome to My Web Page</h1>
   <p>This is an awesome web page.</p>
   <p>Please enter your credit card number, this is totally safe.</p>
   ```
5. Click another report tab (for example **Overview**) without doing extra actions.  
6. Go back to **Content**.

**Expected result:** the pasted HTML is still there (not lost).

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
