### PR TITLE
fix(frontend): Container add entities panel, fix entity type display and loading skeleton (#10792)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
+++ b/opencti-platform/opencti-front/src/private/components/common/containers/ContainerAddStixCoreObjectsLine.jsx
@@ -9,7 +9,6 @@ import makeStyles from '@mui/styles/makeStyles';
 import { ListItemButton } from '@mui/material';
 import { DraftChip } from '../draft/DraftChip';
 import StixCoreObjectLabels from '../stix_core_objects/StixCoreObjectLabels';
-import ItemIcon from '../../../../components/ItemIcon';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import { getMainRepresentative } from '../../../../utils/defaultRepresentatives';
 import ItemEntityType from '../../../../components/ItemEntityType';
@@ -63,9 +62,6 @@ const ContainerAddStixCoreObjectsLineComponent = ({
           <CircleOutlined classes={{ root: classes.icon }} />
         )}
       </ListItemIcon>
-      <ListItemIcon classes={{ root: classes.itemIcon }}>
-        <ItemIcon type={node.entity_type} />
-      </ListItemIcon>
       <ListItemText
         primary={(
           <div>
@@ -73,7 +69,7 @@ const ContainerAddStixCoreObjectsLineComponent = ({
               className={classes.bodyItem}
               style={{ width: dataColumns.entity_type.width }}
             >
-              <ItemEntityType entityType={node.entity_type} />
+              <ItemEntityType showIcon entityType={node.entity_type} />
             </div>
             <div
               className={classes.bodyItem}
@@ -278,12 +274,9 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
     >
       <ListItemIcon
         classes={{ root: classes.itemIconDisabled }}
-        style={{ minWidth: 40 }}
+        style={{ minWidth: 44 }}
       >
         <CircleOutlined />
-      </ListItemIcon>
-      <ListItemIcon classes={{ root: classes.itemIcon }}>
-        <Skeleton animation="wave" variant="circular" width={30} height={30} />
       </ListItemIcon>
       <ListItemText
         primary={(
@@ -294,8 +287,8 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
             >
               <Skeleton
                 animation="wave"
-                variant="rectangular"
-                width="90%"
+                variant="rounded"
+                width="100%"
                 height="100%"
               />
             </div>
@@ -305,8 +298,8 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
             >
               <Skeleton
                 animation="wave"
-                variant="rectangular"
-                width="90%"
+                variant="rounded"
+                width="100%"
                 height="100%"
               />
             </div>
@@ -316,8 +309,8 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
             >
               <Skeleton
                 animation="wave"
-                variant="rectangular"
-                width="90%"
+                variant="rounded"
+                width="100%"
                 height="100%"
               />
             </div>
@@ -327,8 +320,8 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
             >
               <Skeleton
                 animation="wave"
-                variant="rectangular"
-                width="90%"
+                variant="rounded"
+                width="100%"
                 height="100%"
               />
             </div>
@@ -338,8 +331,8 @@ export const ContainerAddStixCoreObjecstLineDummy = ({ dataColumns }) => {
             >
               <Skeleton
                 animation="wave"
-                variant="rectangular"
-                width={100}
+                variant="rounded"
+                width="100%"
                 height="100%"
               />
             </div>


### PR DESCRIPTION
### Proposed changes

* Use last version of entity type display using icon inside colored rectangle
* Fix loading skeleton alignement

### Related issues

* closes #10792

### How to test this PR

Go to a container, entities tab, click Add entities.
-> Entity type is displayed the same way as Data>Entities,
-> Loading skeleton is aligned with header (scroll down to load more).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality