### PR TITLE
fix(notify): real time update for security coverage (#14716)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/Root.tsx
@@ -31,6 +31,7 @@ const subscription = graphql`
             id
             external_uri
             ...SecurityCoverage_securityCoverage
+            ...GoToOpenAEVDrawerFragment
         }
     }
 `;

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-domain.ts
@@ -67,16 +67,11 @@ export const findById = async (
   user: AuthUser,
   SecurityCoverageId: string,
 ): Promise<BasicStoreEntitySecurityCoverage> => {
-  const store = storeLoadById<BasicStoreEntitySecurityCoverage>(
+  return storeLoadById<BasicStoreEntitySecurityCoverage>(
     context,
     user,
     SecurityCoverageId,
     ENTITY_TYPE_SECURITY_COVERAGE,
-  );
-  return notify(
-    BUS_TOPICS[ABSTRACT_STIX_DOMAIN_OBJECT].ADDED_TOPIC,
-    store,
-    user,
   );
 };
 
@@ -137,7 +132,7 @@ export const addSecurityCoverage = async (
   }
 
   return notify(
-    BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE].EDIT_TOPIC,
+    BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE].ADDED_TOPIC,
     createdSecurityCoverage,
     user,
   );

--- a/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
+++ b/opencti-platform/opencti-graphql/src/modules/securityCoverage/securityCoverage-resolver.ts
@@ -36,6 +36,7 @@ const SecurityCoverageResolvers: Resolvers = {
     toStixBundle: (securityCoverage, _, context) => securityCoverageStixBundle(context, context.user, securityCoverage.id),
     results: (securityCoverage, _, context) => loadSecurityCoverageResults(context, context.user, securityCoverage),
     // security coverage result info
+    external_uri: (securityCoverage, _, context) => loadSecurityCoverageResultProperty(context, context.user, securityCoverage, 'external_uri'),
     coverage_last_result: (securityCoverage, _, context) => loadMostRecentLastCoverageResult(context, context.user, securityCoverage),
     coverage_valid_from: (securityCoverage, _, context) => loadSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_from'),
     coverage_valid_to: (securityCoverage, _, context) => loadSecurityCoverageResultProperty(context, context.user, securityCoverage, 'coverage_valid_to'),
@@ -67,7 +68,7 @@ const SecurityCoverageResolvers: Resolvers = {
       },
       subscribe: (_: any, { id }: any, context: any) => {
         const bus = BUS_TOPICS[ENTITY_TYPE_SECURITY_COVERAGE];
-        return subscribeToInstanceEvents(_, context, id, [bus.EDIT_TOPIC], { type: ENTITY_TYPE_SECURITY_COVERAGE,
+        return subscribeToInstanceEvents(_, context, id, [bus.EDIT_TOPIC, bus.ADDED_TOPIC], { type: ENTITY_TYPE_SECURITY_COVERAGE,
           notifySelf: true,
         });
       },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix notify
* put back resolver of external_uri (since it's still in the graphql schema, at least have it return the first result uri)

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* task of #14716 
* closes #17048 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
to test locally:
- Create a report (or any covered entity)
- Create a security coverage manually from it
- Keep the security coverage page open
- Use this mutation to update the security coverage created (put the right id, and the right report id) :
```
mutation {
  securityCoverageAdd(input: {
    stix_id: "security-coverage--302e11bd-8897-5f9e-a419-1423f4e14d46",
    objectCovered: "report--ddec3740-f5c3-5ae3-a01b-280f75c080df",
    external_uri: "TEST-URI"
    name: "Report for SC 1"
    tenant_name: "tenant 1"
    auto_enrichment_disable: false
  }) {
    id
    name
    external_uri
  }
}
```
- you should see "go to openAEV" button appear on the page, without needing to refresh
