### PR TITLE
fix(data-sharing): ignore unknown workflow ids in synchronized upsert (#10633)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
+++ b/opencti-platform/opencti-graphql/src/utils/upsert-utils.js
@@ -8,7 +8,7 @@ import { computeDateFromEventId, truncate, utcDate } from './format';
 import { isEmptyField, isNotEmptyField, UPDATE_OPERATION_ADD, UPDATE_OPERATION_REPLACE } from '../database/utils';
 import { hasSameSourceAlreadyUpdateThisScore, INDICATOR_DEFAULT_SCORE } from '../modules/indicator/indicator-utils';
 import { creators as creatorsAttribute, iAttributes, xOpenctiStixIds } from '../schema/attribute-definition';
-import { generateStandardId } from '../schema/identifier';
+import { generateStandardId, X_WORKFLOW_ID } from '../schema/identifier';
 import { ENTITY_TYPE_INDICATOR } from '../modules/indicator/indicator-types';
 import { isObjectAttribute, schemaAttributesDefinition } from '../schema/schema-attributes';
 import { schemaRelationsRefDefinition } from '../schema/schema-relationsRef';
@@ -21,6 +21,8 @@ import { FunctionalError } from '../config/errors';
 import { getDraftContext } from './draftContext';
 import { getDraftFilePrefix } from '../database/draft-utils';
 import { pushAll } from './arrayUtil';
+import { getEntitiesListFromCache } from '../database/cache';
+import { ENTITY_TYPE_STATUS } from '../schema/internalObject';
 
 const ALIGN_OLDEST = 'oldest';
 const ALIGN_NEWEST = 'newest';
@@ -565,6 +567,20 @@ export const generateRefsInputsForUpsert = (context, user, resolvedElement, _typ
   return inputs;
 };
 
+export const sanitizeSynchronizedWorkflowInputs = (inputs, workflowId, validStatusIdsByType) => {
+  if (!isNotEmptyField(workflowId) || validStatusIdsByType.has(workflowId)) {
+    return inputs;
+  }
+  return inputs.filter((input) => input.key !== X_WORKFLOW_ID);
+};
+
+export const sanitizeSynchronizedWorkflowUpsertOperations = (upsertOperations, workflowId, validStatusIdsByType) => {
+  if (!isNotEmptyField(workflowId) || validStatusIdsByType.has(workflowId)) {
+    return upsertOperations;
+  }
+  return (upsertOperations ?? []).filter((operation) => operation.key !== X_WORKFLOW_ID);
+};
+
 export const generateInputsForUpsert = async (context, user, resolvedElement, type, updatePatch, confidenceForUpsert, validEnterpriseEdition) => {
   const inputs = []; // All inputs impacted by modifications (+inner)
   // if file(s) in updatePatch, we need to upload them and update x_opencti_files
@@ -572,14 +588,31 @@ export const generateInputsForUpsert = async (context, user, resolvedElement, ty
   const fileInputs = await generateFileInputsForUpsert(context, user, resolvedElement, updatePatch, confidenceForUpsert);
   pushAll(inputs, fileInputs);
   // -- Upsert attributes
-  const attributesInputs = generateAttributesInputsForUpsert(context, user, resolvedElement, type, updatePatch, confidenceForUpsert);
+  let attributesInputs = generateAttributesInputsForUpsert(context, user, resolvedElement, type, updatePatch, confidenceForUpsert);
+  let upsertOperations = updatePatch.upsertOperations;
+  if (context.synchronizedUpsert === true && Object.hasOwn(updatePatch, X_WORKFLOW_ID)) {
+    const inputWorkflowId = Array.isArray(updatePatch[X_WORKFLOW_ID]) ? updatePatch[X_WORKFLOW_ID][0] : updatePatch[X_WORKFLOW_ID];
+    if (isNotEmptyField(inputWorkflowId)) {
+      const platformStatuses = await getEntitiesListFromCache(context, user, ENTITY_TYPE_STATUS);
+      const validStatusIdsByType = new Set(platformStatuses.filter((status) => status.type === type).map((status) => status.id));
+      attributesInputs = sanitizeSynchronizedWorkflowInputs(attributesInputs, inputWorkflowId, validStatusIdsByType);
+      upsertOperations = sanitizeSynchronizedWorkflowUpsertOperations(upsertOperations, inputWorkflowId, validStatusIdsByType);
+      if (!validStatusIdsByType.has(inputWorkflowId)) {
+        logApp.info('Discarding synchronized workflow status update with unknown local status id', {
+          workflow_id: inputWorkflowId,
+          entity_id: resolvedElement.id,
+          entity_type: type,
+        });
+      }
+    }
+  }
   pushAll(inputs, attributesInputs);
   // -- Upsert refs
   const refsInputs = generateRefsInputsForUpsert(context, user, resolvedElement, type, updatePatch, confidenceForUpsert, validEnterpriseEdition);
   pushAll(inputs, refsInputs);
   // -- merge inputs with upsertOperations
-  if (updatePatch.upsertOperations?.length > 0 && !isBypassUser(user)) {
+  if (upsertOperations?.length > 0 && !isBypassUser(user)) {
     throw FunctionalError('User has insufficient rights to use upsertOperations', { user_id: user.id, element_id: resolvedElement.id });
   }
-  return mergeUpsertInputs(resolvedElement, updatePatch, inputs, updatePatch.upsertOperations);
+  return mergeUpsertInputs(resolvedElement, updatePatch, inputs, upsertOperations);
 };

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { hashMergeValidation } from '../../../src/database/middleware';
 import {
   generateAttributesInputsForUpsert,
+  generateInputsForUpsert,
   generateRefsInputsForUpsert,
   mergeUpsertInput,
   mergeUpsertInputs,
@@ -10,6 +11,11 @@ import {
 } from '../../../src/utils/upsert-utils';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { ENTITY_DOMAIN_NAME } from '../../../src/schema/stixCyberObservable';
+import * as cacheModule from '../../../src/database/cache';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('middleware hashMergeValidation test', () => {
   it('should hashes allowed to merge', () => {
@@ -127,6 +133,60 @@ describe('middleware upsertElement test', () => {
       inputs = generateAttributesInputsForUpsert(testContext, ADMIN_USER, resolvedElement, type, updatePatchWithTypes, confidenceForUpsert);
 
       expect(inputs.length).toEqual(0); // no changes since confidenceMatch is false, we don't replace existing description
+    });
+  });
+  describe('middleware generateInputsForUpsert synchronized workflow status filtering', () => {
+    const resolvedIndicator = {
+      id: 'indicator2-uuid-internal',
+      internal_id: 'indicator2-uuid-internal',
+      standard_id: 'indicator2-uuid-standard',
+      entity_type: 'Indicator',
+      description: 'existing description',
+      pattern: '[domain-name:value = \'filigran.dev\']',
+      pattern_type: 'stix',
+      x_opencti_main_observable_type: ENTITY_DOMAIN_NAME,
+    };
+
+    it('should remove unknown workflow id update in synchronized mode', async () => {
+      vi.spyOn(cacheModule, 'getEntitiesListFromCache').mockResolvedValue([{ id: 'local-status-id', type: 'Indicator' }]);
+      const synchronizedContext = { ...testContext, synchronizedUpsert: true };
+      const updatePatch = {
+        description: 'updated description',
+        x_opencti_workflow_id: 'remote-status-id',
+      };
+
+      const inputs = await generateInputsForUpsert(
+        synchronizedContext,
+        ADMIN_USER,
+        resolvedIndicator,
+        'Indicator',
+        updatePatch,
+        { isConfidenceMatch: true, isConfidenceUpper: true },
+        true
+      );
+      expect(inputs.find((n) => n.key === 'x_opencti_workflow_id')).toBeUndefined();
+      expect(inputs.find((n) => n.key === 'description')).toEqual({ key: 'description', value: ['updated description'] });
+    });
+
+    it('should keep known workflow id update in synchronized mode', async () => {
+      vi.spyOn(cacheModule, 'getEntitiesListFromCache').mockResolvedValue([{ id: 'local-status-id', type: 'Indicator' }]);
+      const synchronizedContext = { ...testContext, synchronizedUpsert: true };
+      const updatePatch = {
+        description: 'updated description',
+        x_opencti_workflow_id: 'local-status-id',
+      };
+
+      const inputs = await generateInputsForUpsert(
+        synchronizedContext,
+        ADMIN_USER,
+        resolvedIndicator,
+        'Indicator',
+        updatePatch,
+        { isConfidenceMatch: true, isConfidenceUpper: true },
+        true
+      );
+      expect(inputs.find((n) => n.key === 'x_opencti_workflow_id')).toEqual({ key: 'x_opencti_workflow_id', value: ['local-status-id'] });
+      expect(inputs.find((n) => n.key === 'description')).toEqual({ key: 'description', value: ['updated description'] });
     });
   });
   describe('middleware generateAttributesInputsForUpsert with opencti_upsert_operations test', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/middleware-test.js
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { hashMergeValidation } from '../../../src/database/middleware';
-import { generateAttributesInputsForUpsert, generateRefsInputsForUpsert, mergeUpsertInput, mergeUpsertInputs } from '../../../src/utils/upsert-utils';
+import {
+  generateAttributesInputsForUpsert,
+  generateRefsInputsForUpsert,
+  mergeUpsertInput,
+  mergeUpsertInputs,
+  sanitizeSynchronizedWorkflowInputs,
+  sanitizeSynchronizedWorkflowUpsertOperations
+} from '../../../src/utils/upsert-utils';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { ENTITY_DOMAIN_NAME } from '../../../src/schema/stixCyberObservable';
 
@@ -56,6 +63,40 @@ describe('middleware upsertElement test', () => {
 
       expect(inputs.length).toEqual(1); // we still update description since no existing
       expect(inputs[0]).toEqual({ key: 'description', value: ['indicator1 new description'] });
+    });
+    describe('middleware synchronized workflow status input sanitization', () => {
+      it('should discard x_opencti_workflow_id input if workflow id is unknown locally', () => {
+        const inputs = [
+          { key: 'x_opencti_workflow_id', value: ['remote-status-id'] },
+          { key: 'description', value: ['updated'] },
+        ];
+        const validStatusIdsByType = new Set(['local-status-id']);
+
+        const sanitizedInputs = sanitizeSynchronizedWorkflowInputs(inputs, 'remote-status-id', validStatusIdsByType);
+        expect(sanitizedInputs).toEqual([{ key: 'description', value: ['updated'] }]);
+      });
+
+      it('should keep x_opencti_workflow_id input if workflow id exists locally', () => {
+        const inputs = [
+          { key: 'x_opencti_workflow_id', value: ['local-status-id'] },
+          { key: 'description', value: ['updated'] },
+        ];
+        const validStatusIdsByType = new Set(['local-status-id']);
+
+        const sanitizedInputs = sanitizeSynchronizedWorkflowInputs(inputs, 'local-status-id', validStatusIdsByType);
+        expect(sanitizedInputs).toEqual(inputs);
+      });
+
+      it('should drop workflow upsert operations if workflow id is unknown locally', () => {
+        const upsertOperations = [
+          { key: 'x_opencti_workflow_id', operation: 'replace', value: ['remote-status-id'] },
+          { key: 'indicator_types', operation: 'add', value: ['malicious-activity'] },
+        ];
+        const validStatusIdsByType = new Set(['local-status-id']);
+
+        const sanitizedOperations = sanitizeSynchronizedWorkflowUpsertOperations(upsertOperations, 'remote-status-id', validStatusIdsByType);
+        expect(sanitizedOperations).toEqual([{ key: 'indicator_types', operation: 'add', value: ['malicious-activity'] }]);
+      });
     });
     it('should generateAttributesInputsForUpsert with indicator description update', () => {
       const resolvedElement = { ...indicator1, description: 'indicator1 old description' }; // existing description


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Prevent synchronized upsert from overriding local workflow status with an invalid remote `x_opencti_workflow_id` during perfect synchronization.
* In synchronized mode, when the incoming workflow ID does not exist locally for the current entity type, discard the workflow status update instead of applying it.
* Keep other field updates unchanged (only workflow status update is filtered in this invalid-ID case).
* Add unit tests for workflow status sanitization logic (keep valid local IDs, drop unknown remote IDs, and drop related upsert operations).

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #10633 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
Tu peux mettre :

1. Checkout the branch:
   - `git checkout issue/10633`

2. Run the targeted unit tests:
   - `cd opencti-platform/opencti-graphql`
   - `cp ../.yarnrc.yml .yarnrc.yml` (if missing)
   - `yarn install` (if needed)
   - `yarn get-connectors-manifest`
   - `python3 -m venv ../.python-venv && . ../.python-venv/bin/activate && pip install -r src/python/requirements.txt` (if Python deps are missing)
   - `yarn test:ci-unit tests/01-unit/database/middleware-test.js`

3. Validate expected behavior:
   - Tests for synchronized workflow sanitization pass:
     - unknown remote workflow ID is discarded,
     - valid local workflow ID is kept,
     - workflow upsert operations are removed when ID is unknown.
     
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
