### PR TITLE
fix(graph): adjust toolbar and details sidebar to prevent chatbot overflow (#16192)

### DIFF
--- a/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/GraphToolbar.tsx
@@ -56,9 +56,10 @@ const GraphToolbar = ({
         style: {
           zIndex: 1,
           paddingLeft: navOpen ? OPEN_BAR_WIDTH : SMALL_BAR_WIDTH,
+          right: 'var(--chatbot-sidebar-width, 0px)',
+          transition: 'right 225ms cubic-bezier(0.4, 0, 0.2, 1), height 0.2s ease',
           height: showTimeRange ? 134 : 54,
           overflow: 'hidden',
-          transition: 'height 0.2s ease',
           marginBottom: bannerHeightNumber,
           bottom: posBottom,
         },

--- a/opencti-platform/opencti-front/src/components/graph/components/EntitiesDetailsRightBar.tsx
+++ b/opencti-platform/opencti-front/src/components/graph/components/EntitiesDetailsRightBar.tsx
@@ -28,7 +28,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
   drawerPaper: {
     position: 'fixed',
     top: '50%',
-    right: 20,
+    right: 'calc(20px + var(--chatbot-sidebar-width, 0px))',
+    transition: 'right 225ms cubic-bezier(0.4, 0, 0.2, 1)',
     transform: 'translateY(-50%)',
     width: 400,
     maxWidth: 400,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* move graph details panel and toolbar right limit by `chatbot-sidebar-width` to prevent chatbot to overflow them

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16192 

### How to test this PR
- Ensure you are on a platform connected to XTM Hub
- on a knowledge graph, open the details of an element
- click on "Ask Ariane"
- the details of the element should not be overflown by the chatbot, but moved on the left
- idem for graph toolbar

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
