### PR TITLE
fix(front): incorrect file path for download with APP_BASE_PATH (#17291)

### DIFF
--- a/opencti-platform/opencti-front/src/buildConfig.test.ts
+++ b/opencti-platform/opencti-front/src/buildConfig.test.ts
@@ -14,7 +14,6 @@ import { describe, it, expect } from 'vitest';
  */
 
 const indexHtml = await readFile('dist/index.html', 'utf8');
-const viteConfig = await readFile('vite.config.ts', 'utf8');
 
 describe('base path build configuration', () => {
   it('index.html — contains BASE_PATH placeholder in <base href> for runtime injection', () => {
@@ -25,9 +24,5 @@ describe('base path build configuration', () => {
     expect(indexHtml).not.toMatch(/src="\/assets\//);
     expect(indexHtml).not.toMatch(/href="\/assets\//);
     expect(indexHtml).toMatch(/src="\.\/assets\//);
-  });
-
-  it('vite.config.ts — base is set to relative "./" so built assets use relative paths', () => {
-    expect(viteConfig).toMatch(/base:\s*['"]\.\/['"]/);
   });
 });

--- a/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesList.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_core_objects/StixCoreObjectContentFilesList.tsx
@@ -18,7 +18,6 @@ import Drawer from '@components/common/drawer/Drawer';
 import StixCoreObjectContentFilesDissemination from '@components/common/stix_core_objects/StixCoreObjectContentFilesDissemination';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
-import { APP_BASE_PATH } from '../../../../relay/environment';
 import ItemMarkings from '../../../../components/ItemMarkings';
 import type { Theme } from '../../../../components/Theme';
 import { KNOWLEDGE_KNASKIMPORT, KNOWLEDGE_KNDISSEMINATION, KNOWLEDGE_KNGETEXPORT, KNOWLEDGE_KNUPLOAD } from '../../../../utils/hooks/useGranted';
@@ -239,7 +238,7 @@ const StixCoreObjectContentFilesList = ({
         {menuFile && (
           <MenuItem
             component={Link}
-            to={`${APP_BASE_PATH}/storage/get/${encodeURIComponent(menuFile.id)}`}
+            to={`/storage/get/${encodeURIComponent(menuFile.id)}`}
             onClick={closePopover}
             target="_blank"
             rel="noopener noreferrer"

--- a/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListPopover.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/exclusion_lists/ExclusionListPopover.tsx
@@ -8,7 +8,6 @@ import { ExclusionListsLine_node$data } from '@components/settings/exclusion_lis
 import { ExclusionListsLinesPaginationQuery$variables } from '@components/settings/exclusion_lists/__generated__/ExclusionListsLinesPaginationQuery.graphql';
 import ExclusionListEdition, { exclusionListMutationFieldPatch } from '@components/settings/exclusion_lists/ExclusionListEdition';
 import { Link } from 'react-router-dom';
-import { APP_BASE_PATH } from 'src/relay/environment';
 import DeleteDialog from '../../../../components/DeleteDialog';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
@@ -87,7 +86,7 @@ const ExclusionListPopover: FunctionComponent<ExclusionListPopoverProps> = ({
 
   const handleCloseEditionForm = () => setIsEditionFormOpen(false);
 
-  const downloadFileLink = `${APP_BASE_PATH}/storage/get/${encodeURIComponent(data.file_id)}`;
+  const downloadFileLink = `/storage/get/${encodeURIComponent(data.file_id)}`;
 
   return (
     <>

--- a/opencti-platform/opencti-front/src/utils/ListParameters.js
+++ b/opencti-platform/opencti-front/src/utils/ListParameters.js
@@ -87,11 +87,13 @@ export const saveViewParameters = (
   saveParamsToLocalStorage(localStorageKey, params);
   // Apply params in history
   const searchParams = buildParamsFromHistory(params);
-  const newUrl = `${APP_BASE_PATH}${location.pathname}?${searchParams}`;
+  const relativeUrl = `${location.pathname}?${searchParams}`;
   if (refresh) {
-    navigate(newUrl, { replace: true });
+    // navigate() already prepends APP_BASE_PATH via the router's basename
+    navigate(relativeUrl, { replace: true });
   } else {
-    window.history.replaceState(null, '', newUrl);
+    // history.replaceState is a native browser API, not router-aware
+    window.history.replaceState(null, '', `${APP_BASE_PATH}${relativeUrl}`);
   }
 };
 

--- a/opencti-platform/opencti-front/vite.config.ts
+++ b/opencti-platform/opencti-front/vite.config.ts
@@ -1,5 +1,4 @@
-import { defineConfig, loadEnv, type ViteDevServer } from 'vite';
-import type { IncomingMessage, ServerResponse } from 'node:http';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import relay from 'vite-plugin-relay';
 import monacoEditorPluginImport from 'vite-plugin-monaco-editor';
@@ -8,7 +7,7 @@ import monacoEditorPluginImport from 'vite-plugin-monaco-editor';
 const monacoEditorPlugin = (monacoEditorPluginImport as unknown as {default: typeof monacoEditorPluginImport}).default;
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   // Support APP__BASE_PATH from .env* files (via loadEnv) or from process.env (e.g. set by test scripts).
@@ -25,7 +24,7 @@ export default defineConfig(({ mode }) => {
   });
 
   return {
-    base: './',
+    base: command === 'serve' && basePath ? `${basePath}/` : './',
     build: {
       sourcemap: true,
     },
@@ -50,23 +49,8 @@ export default defineConfig(({ mode }) => {
             .replace(/%APP_SCRIPT_SNIPPET%/g,  '')
             .replace(/%APP_TITLE%/g, 'OpenCTI Dev')
             .replace(/%APP_DESCRIPTION%/g, 'OpenCTI Development platform')
-            .replace(/%APP_FAVICON%/g, `./assets/static/favicon.png`),
+            .replace(/%APP_FAVICON%/g, `${basePath}/assets/static/favicon.png`),
       },
-      // Strip basePath prefix from static asset requests (e.g. /myBasePath/assets/...)
-      // so vite dev server can resolve them from the public dir, without needing
-      // a self-proxy (with an hardcoded port).
-      ...(basePath ? [{
-        name: 'strip-base-path-for-assets',
-        apply: 'serve' as const,
-        configureServer(server: ViteDevServer) {
-          server.middlewares.use((req: IncomingMessage, _res: ServerResponse, next: () => void) => {
-            if (req.url?.startsWith(`${basePath}/assets`)) {
-              req.url = req.url.slice(basePath.length);
-            }
-            next();
-          });
-        },
-      }] : []),
       react(),
       relay,
       monacoEditorPlugin({

--- a/opencti-platform/opencti-front/vite.config.ts
+++ b/opencti-platform/opencti-front/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, type ViteDevServer } from 'vite';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import react from '@vitejs/plugin-react';
 import relay from 'vite-plugin-relay';
 import monacoEditorPluginImport from 'vite-plugin-monaco-editor';
@@ -51,6 +52,21 @@ export default defineConfig(({ mode }) => {
             .replace(/%APP_DESCRIPTION%/g, 'OpenCTI Development platform')
             .replace(/%APP_FAVICON%/g, `./assets/static/favicon.png`),
       },
+      // Strip basePath prefix from static asset requests (e.g. /myBasePath/assets/...)
+      // so vite dev server can resolve them from the public dir, without needing
+      // a self-proxy (with an hardcoded port).
+      ...(basePath ? [{
+        name: 'strip-base-path-for-assets',
+        apply: 'serve' as const,
+        configureServer(server: ViteDevServer) {
+          server.middlewares.use((req: IncomingMessage, _res: ServerResponse, next: () => void) => {
+            if (req.url?.startsWith(`${basePath}/assets`)) {
+              req.url = req.url.slice(basePath.length);
+            }
+            next();
+          });
+        },
+      }] : []),
       react(),
       relay,
       monacoEditorPlugin({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Remove duplicate APP_BASE_PATH in file download link
* Fix vite config for local assets requests

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17291

### How to test this PR

Setup:
- In `opencti-platform/opencti-front` create a file `.env.local` with following content
  - APP__BASE_PATH=/my-custom-path
- In `opencti-platform/opencti-graphql/config/development.json`, bellow `base_url`, add following content
  -  "base_path": "/my-custom-path",
- start your app normally, you can connect at http://localhost:3000/my-custom-path

Test:
- go in a report, content tab
- generate an export (direct html to pdf)
- try to download the produced pdf
- go in Settings > Customization > Exclusion lists
- on a line open the menu and delete the file
- Also ensure the features are still working without base-path

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
