### PR TITLE
fix(client-python): omit createdBy from mutation input when created_by_ref is absent (#17512)

### DIFF
--- a/client-python/pycti/api/opencti_api_client.py
+++ b/client-python/pycti/api/opencti_api_client.py
@@ -85,7 +85,7 @@ from pycti.entities.opencti_vocabulary import Vocabulary
 from pycti.entities.opencti_vulnerability import Vulnerability
 from pycti.utils.opencti_logger import logger
 from pycti.utils.opencti_stix2 import OpenCTIStix2
-from pycti.utils.opencti_stix2_utils import OpenCTIStix2Utils
+from pycti.utils.opencti_stix2_utils import NOT_PROVIDED, OpenCTIStix2Utils
 
 # Global singleton variables for proxy certificate management
 _PROXY_CERT_BUNDLE = None
@@ -608,6 +608,10 @@ class OpenCTIApiClient:
             cleaned = {}
             files_vars = []
             for key, val in obj.items():
+                # NOT_PROVIDED marks a value never supplied by the
+                # caller (as opposed to an explicit None/null).
+                if val is NOT_PROVIDED:
+                    continue
                 new_path = f"{path_prefix}.{key}" if path_prefix else key
                 cleaned_val, nested_files = self._extract_files(val, new_path)
                 cleaned[key] = cleaned_val
@@ -721,11 +725,11 @@ class OpenCTIApiClient:
                 proxies=self.proxies,
                 timeout=self.session_requests_timeout,
             )
-        # If no
+        # If no files, send a normal request
         else:
             r = self.session.post(
                 self.api_url,
-                json={"query": query, "variables": variables},
+                json={"query": query, "variables": query_var},
                 headers=query_headers,
                 verify=self.ssl_verify,
                 cert=self.cert,

--- a/client-python/pycti/utils/opencti_stix2.py
+++ b/client-python/pycti/utils/opencti_stix2.py
@@ -33,6 +33,7 @@ from pycti.utils.opencti_stix2_markdown_embedded_file_utils import (
 from pycti.utils.opencti_stix2_splitter import OpenCTIStix2Splitter
 from pycti.utils.opencti_stix2_update import OpenCTIStix2Update
 from pycti.utils.opencti_stix2_utils import (
+    NOT_PROVIDED,
     OBSERVABLES_VALUE_INT,
     STIX_CORE_OBJECTS,
     STIX_CYBER_OBSERVABLE_MAPPING,
@@ -501,7 +502,7 @@ class OpenCTIStix2:
         """
 
         # Created By Ref
-        created_by_id = None
+        created_by_id = NOT_PROVIDED
         if "created_by_ref" in stix_object:
             created_by_id = stix_object["created_by_ref"]
         elif "x_opencti_created_by_ref" in stix_object:

--- a/client-python/pycti/utils/opencti_stix2_utils.py
+++ b/client-python/pycti/utils/opencti_stix2_utils.py
@@ -12,6 +12,13 @@ from stix2 import EqualityComparisonExpression, ObjectPath, ObservationExpressio
 ALIASES_FIELD = "aliases"
 X_OPENCTI_ALIASES_FIELD = "x_opencti_aliases"
 
+# Sentinel used to distinguish "value not provided by the caller" from an
+# explicit ``None``/``null``. Any dict value equal (by identity) to this
+# sentinel is stripped from GraphQL mutation variables before the request
+# is sent, so the corresponding key is entirely omitted from the payload
+# instead of being sent as ``null``.
+NOT_PROVIDED = object()
+
 SUPPORTED_INTERNAL_OBJECTS = [
     "user",
     "group",

--- a/client-python/tests/01-unit/utils/test_created_by_ref_omission.py
+++ b/client-python/tests/01-unit/utils/test_created_by_ref_omission.py
@@ -1,0 +1,134 @@
+# coding: utf-8
+"""Regression tests for https://github.com/OpenCTI-Platform/opencti/issues/17512.
+
+When a STIX object omits ``created_by_ref``, pycti must not turn that absence
+into an explicit ``createdBy: null`` in the GraphQL mutation input: the
+platform's confidence-based upsert logic treats an explicitly-provided
+``null`` as "the connector wants to clear the author", which is not the same
+as "the connector did not provide an author at all".
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pycti import OpenCTIApiClient, OpenCTIStix2
+from pycti.entities.opencti_vulnerability import Vulnerability
+from pycti.utils.opencti_stix2_utils import NOT_PROVIDED
+
+
+@pytest.fixture
+def local_api_client():
+    """A real OpenCTIApiClient instance, without hitting the network.
+
+    Named ``local_api_client`` (rather than ``api_client``) to avoid shadowing
+    the session-scoped, network-backed ``api_client`` fixture defined in
+    ``tests/conftest.py``.
+    """
+    with patch.object(OpenCTIApiClient, "_setup_proxy_certificates"):
+        client = OpenCTIApiClient(
+            url="http://localhost:4000",
+            token="test-token",
+            ssl_verify=False,
+            perform_health_check=False,
+        )
+        client.app_logger = MagicMock()
+        return client
+
+
+@pytest.fixture
+def opencti_stix2(local_api_client):
+    instance = OpenCTIStix2(local_api_client)
+    # Pre-seed the vocabulary cache so extract_embedded_relationships() does
+    # not attempt a network call to fetch vocabulary categories.
+    instance.mapping_cache_permanent["vocabularies_definition_fields"] = []
+    return instance
+
+
+def stix_vulnerability_without_created_by_ref():
+    return {
+        "type": "vulnerability",
+        "id": "vulnerability--3ba4b52a-3c26-4dab-8791-e73a2c7bbc78",
+        "name": "CVE-2024-99999",
+        # Deliberately no "created_by_ref" (and no extension variant either).
+    }
+
+
+def test_extract_embedded_relationships_marks_created_by_as_not_provided_when_absent(
+    opencti_stix2: OpenCTIStix2,
+):
+    """The "created_by" key is always present in the returned dict, but its
+    value is the NOT_PROVIDED sentinel (not None) when the ref is absent, so
+    downstream code can distinguish "absent" from "explicitly cleared"."""
+    stix_object = stix_vulnerability_without_created_by_ref()
+
+    result = opencti_stix2.extract_embedded_relationships(stix_object)
+
+    assert "created_by" in result
+    assert result["created_by"] is NOT_PROVIDED
+
+
+def test_import_vulnerability_without_created_by_ref_should_not_send_null_createdby(
+    opencti_stix2: OpenCTIStix2,
+):
+    """Regression test for https://github.com/OpenCTI-Platform/opencti/issues/17512.
+
+    Importing a Vulnerability STIX object that omits created_by_ref must not
+    result in an explicit "createdBy": None in the mutation input sent to the
+    platform: the key must be omitted entirely so the platform can
+    distinguish "no author supplied" from "author explicitly cleared".
+    """
+    stix_object = stix_vulnerability_without_created_by_ref()
+    embedded_relationships = opencti_stix2.extract_embedded_relationships(stix_object)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {"vulnerabilityAdd": {"id": "vulnerability--fake-id"}}
+    }
+
+    with patch.object(
+        opencti_stix2.opencti.session, "post", return_value=mock_response
+    ) as mocked_post:
+        vulnerability = Vulnerability(opencti_stix2.opencti)
+        vulnerability.import_from_stix2(
+            stixObject=stix_object,
+            extras={"created_by_id": embedded_relationships["created_by"]},
+        )
+
+    sent_variables = mocked_post.call_args.kwargs["json"]["variables"]
+    # The key must be entirely absent from the mutation input when the
+    # source STIX object did not provide created_by_ref, so the platform can
+    # distinguish "no author supplied" from "remove the author".
+    assert "createdBy" not in sent_variables["input"]
+
+
+def test_import_vulnerability_with_created_by_ref_still_sends_it(
+    opencti_stix2: OpenCTIStix2,
+):
+    """Sanity check: when created_by_ref IS provided, createdBy must still be
+    forwarded in the mutation input."""
+    stix_object = stix_vulnerability_without_created_by_ref()
+    stix_object["created_by_ref"] = "identity--fdd447a8-5588-4be7-9c66-53fe2d6d1424"
+    embedded_relationships = opencti_stix2.extract_embedded_relationships(stix_object)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {"vulnerabilityAdd": {"id": "vulnerability--fake-id"}}
+    }
+
+    with patch.object(
+        opencti_stix2.opencti.session, "post", return_value=mock_response
+    ) as mocked_post:
+        vulnerability = Vulnerability(opencti_stix2.opencti)
+        vulnerability.import_from_stix2(
+            stixObject=stix_object,
+            extras={"created_by_id": embedded_relationships["created_by"]},
+        )
+
+    sent_variables = mocked_post.call_args.kwargs["json"]["variables"]
+    assert (
+        sent_variables["input"]["createdBy"]
+        == "identity--fdd447a8-5588-4be7-9c66-53fe2d6d1424"
+    )


### PR DESCRIPTION
### Proposed changes

* pycti was always sending `createdBy` (or `null`) in creation/upsert mutation input, even when the STIX object had no `created_by_ref`. The backend's confidence-based upsert treats an explicit `null` as "clear the author", so importing an object without an author was silently wiping the author set by a previous import.
* Introduce a `NOT_PROVIDED` sentinel (`pycti/utils/opencti_stix2_utils.py`) to mark "value not supplied by the caller", distinct from an explicit `None`.
* `extract_embedded_relationships()` now defaults `created_by_id` to `NOT_PROVIDED` instead of `None`.
* `OpenCTIApiClient._extract_files()` strips any key whose value is `NOT_PROVIDED` before building the GraphQL variables, so the key is omitted from the payload entirely rather than sent as `null`.
* Fixed the non-multipart branch of `query()`, which was sending the raw `variables` dict instead of the cleaned `query_var` returned by `_extract_files()` — required for the strip to actually apply on the common (non-file-upload) request path.

### Related issues
* closes #17512

### How to test this PR

1. Import an entity (e.g. a Vulnerability) with `created_by_ref` set — confirm `createdBy` is created/updated as before.
2. Re-import the same entity via a source that omits `created_by_ref` — confirm the author is preserved, not cleared.
3. Run `pytest tests/01-unit/utils/test_created_by_ref_omission.py -v` — covers both the omission and explicit-author cases at the GraphQL payload level (mocked HTTP layer).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

Considered stripping `NOT_PROVIDED` at each entity's `create()` call site instead, but that would touch every entity module. Reusing `_extract_files()`'s existing recursive traversal (already needed for file uploads) keeps the fix to three files with no duplicated logic.
