### PR TITLE
feat(build): show build commit hash in the UI (#17710)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,10 +310,10 @@ jobs:
             LATEST_SEMANTIC_VERSION=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
             DOCKER_TAGS="-t opencti/platform:${CIRCLE_TAG}"
             [ "$CIRCLE_TAG" = "$LATEST_SEMANTIC_VERSION" ] && DOCKER_TAGS="$DOCKER_TAGS -t opencti/platform:latest"
-            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile $DOCKER_TAGS --push .
+            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --build-arg BUILD_COMMIT=${CIRCLE_SHA1} --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile $DOCKER_TAGS --push .
             GHCR_TAGS="-t ghcr.io/opencti-platform/opencti/platform:${CIRCLE_TAG}"
             [ "$CIRCLE_TAG" = "$LATEST_SEMANTIC_VERSION" ] && GHCR_TAGS="$GHCR_TAGS -t ghcr.io/opencti-platform/opencti/platform:latest"
-            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile $GHCR_TAGS --push .
+            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --build-arg BUILD_COMMIT=${CIRCLE_SHA1} --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile $GHCR_TAGS --push .
           no_output_timeout: 30m
       - slack/notify:
           event: fail
@@ -403,10 +403,10 @@ jobs:
             LATEST_SEMANTIC_VERSION=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
             DOCKER_TAGS="-t opencti/platform:${CIRCLE_TAG}-fips"
             [ "$CIRCLE_TAG" = "$LATEST_SEMANTIC_VERSION" ] && DOCKER_TAGS="$DOCKER_TAGS -t opencti/platform:latest-fips"
-            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_fips $DOCKER_TAGS --push .
+            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --build-arg BUILD_COMMIT=${CIRCLE_SHA1} --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_fips $DOCKER_TAGS --push .
             GHCR_TAGS="-t ghcr.io/opencti-platform/opencti/platform:${CIRCLE_TAG}-fips"
             [ "$CIRCLE_TAG" = "$LATEST_SEMANTIC_VERSION" ] && GHCR_TAGS="$GHCR_TAGS -t ghcr.io/opencti-platform/opencti/platform:latest-fips"
-            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_fips $GHCR_TAGS --push .
+            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --build-arg BUILD_COMMIT=${CIRCLE_SHA1} --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_fips $GHCR_TAGS --push .
           no_output_timeout: 30m
       - slack/notify:
           event: fail
@@ -496,10 +496,10 @@ jobs:
             LATEST_SEMANTIC_VERSION=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
             DOCKER_TAGS="-t opencti/platform:${CIRCLE_TAG}-ubi9"
             [ "$CIRCLE_TAG" = "$LATEST_SEMANTIC_VERSION" ] && DOCKER_TAGS="$DOCKER_TAGS -t opencti/platform:latest-ubi9"
-            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_ubi9 $DOCKER_TAGS --push .
+            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --build-arg BUILD_COMMIT=${CIRCLE_SHA1} --platform $BUILDX_PLATFORMS --cache-to=type=local,dest=.cache -f Dockerfile_ubi9 $DOCKER_TAGS --push .
             GHCR_TAGS="-t ghcr.io/opencti-platform/opencti/platform:${CIRCLE_TAG}-ubi9"
             [ "$CIRCLE_TAG" = "$LATEST_SEMANTIC_VERSION" ] && GHCR_TAGS="$GHCR_TAGS -t ghcr.io/opencti-platform/opencti/platform:latest-ubi9"
-            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_ubi9 $GHCR_TAGS --push .
+            docker buildx build --pull --progress=plain --build-arg TAG_VERSION=${CIRCLE_TAG} --build-arg BUILD_COMMIT=${CIRCLE_SHA1} --platform $BUILDX_PLATFORMS --cache-from=type=local,src=.cache -f Dockerfile_ubi9 $GHCR_TAGS --push .
           no_output_timeout: 30m
       - slack/notify:
           event: fail

--- a/opencti-platform/Dockerfile
+++ b/opencti-platform/Dockerfile
@@ -67,6 +67,8 @@ RUN yarn build
 
 FROM base AS app
 
+ARG BUILD_COMMIT
+
 RUN <<EOT
   set -euxo pipefail
 
@@ -95,6 +97,7 @@ COPY --from=builder-front /opt/opencti/opencti-front/dist/ ./public/
 ENV PYTHONUNBUFFERED="1"
 ENV NODE_OPTIONS="--max_old_space_size=12288"
 ENV NODE_ENV="production"
+ENV BUILD_COMMIT="${BUILD_COMMIT}"
 
 RUN <<EOT
   set -euxo pipefail

--- a/opencti-platform/Dockerfile_fips
+++ b/opencti-platform/Dockerfile_fips
@@ -84,6 +84,8 @@ RUN yarn build
 
 FROM base AS app
 
+ARG BUILD_COMMIT
+
 RUN <<EOT
   set -euxo pipefail
 
@@ -110,6 +112,7 @@ COPY --from=builder-front /opt/opencti/opencti-front/dist/ ./public/
 ENV PYTHONUNBUFFERED="1"
 ENV NODE_OPTIONS="--max_old_space_size=12288"
 ENV NODE_ENV="production"
+ENV BUILD_COMMIT="${BUILD_COMMIT}"
 
 RUN <<EOT
   set -euxo pipefail

--- a/opencti-platform/Dockerfile_ubi9
+++ b/opencti-platform/Dockerfile_ubi9
@@ -72,6 +72,8 @@ RUN yarn build
 
 FROM base AS app
 
+ARG BUILD_COMMIT
+
 RUN <<EOT
   set -euxo pipefail
 
@@ -105,6 +107,7 @@ COPY --from=builder-front /opt/opencti/opencti-front/dist/ ./public/
 ENV PYTHONUNBUFFERED="1"
 ENV NODE_OPTIONS="--max_old_space_size=12288"
 ENV NODE_ENV="production"
+ENV BUILD_COMMIT="${BUILD_COMMIT}"
 
 RUN <<EOT
   set -euxo pipefail

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
@@ -118,6 +118,7 @@ const settingsQuery = graphql`
     }
     about {
       version
+      build_commit
       dependencies {
         name
         version
@@ -214,7 +215,8 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
   };
 
   const modules = settings.platform_modules;
-  const { version, dependencies } = about || { version: '', dependencies: [] };
+  const { version, build_commit: buildCommit, dependencies } = about || { version: '', build_commit: null, dependencies: [] };
+  const displayedVersion = buildCommit ? `${version} (${buildCommit})` : version;
   const isEnterpriseEditionActivated = settings.platform_enterprise_edition.license_enterprise;
   const isEnterpriseEditionByConfig = settings.platform_enterprise_edition.license_by_configuration;
   const isEnterpriseEditionValid = settings.platform_enterprise_edition.license_validated;
@@ -592,7 +594,7 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
                     <ListItem divider={true}>
                       <ListItemText primary={t_i18n('Version')} />
                       <ItemBoolean
-                        neutralLabel={version}
+                        neutralLabel={displayedVersion}
                         status={null}
                       />
                     </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
@@ -118,7 +118,7 @@ const settingsQuery = graphql`
     }
     about {
       version
-      build_commit
+      buildCommit
       dependencies {
         name
         version
@@ -215,7 +215,7 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
   };
 
   const modules = settings.platform_modules;
-  const { version, build_commit: buildCommit, dependencies } = about || { version: '', build_commit: null, dependencies: [] };
+  const { version, buildCommit, dependencies } = about || { version: '', buildCommit: null, dependencies: [] };
   const displayedVersion = buildCommit ? `${version} (${buildCommit})` : version;
   const isEnterpriseEditionActivated = settings.platform_enterprise_edition.license_enterprise;
   const isEnterpriseEditionByConfig = settings.platform_enterprise_edition.license_by_configuration;

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -289,6 +289,9 @@ type AppInfo {
   """The OpenCTI application version"""
   version: String!
 
+  """The short commit hash used to build the OpenCTI application"""
+  build_commit: String
+
   """The OpenCTI api current memory usage"""
   memory: AppMemory
 

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -290,7 +290,7 @@ type AppInfo {
   version: String!
 
   """The short commit hash used to build the OpenCTI application"""
-  build_commit: String
+  buildCommit: String
 
   """The OpenCTI api current memory usage"""
   memory: AppMemory

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -281,6 +281,10 @@ type AppInfo {
   """
   version: String! @auth
   """
+  The short commit hash used to build the OpenCTI application
+  """
+  build_commit: String @auth
+  """
   The OpenCTI api current memory usage
   """
   memory: AppMemory @auth(for: [SETTINGS_SETPARAMETERS])

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -283,7 +283,7 @@ type AppInfo {
   """
   The short commit hash used to build the OpenCTI application
   """
-  build_commit: String @auth
+  buildCommit: String @auth
   """
   The OpenCTI api current memory usage
   """

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -60,6 +60,7 @@ const LINUX_CERTFILES = [
 const DEFAULT_ENV = 'production';
 export const OPENCTI_SESSION = 'opencti_session';
 export const PLATFORM_VERSION = pjson.version;
+export const BUILD_COMMIT = process.env.BUILD_COMMIT?.slice(0, 7);
 const LOG_APP = 'APP';
 const LOG_AUDIT = 'AUDIT';
 

--- a/opencti-platform/opencti-graphql/src/config/conf.js
+++ b/opencti-platform/opencti-graphql/src/config/conf.js
@@ -60,7 +60,10 @@ const LINUX_CERTFILES = [
 const DEFAULT_ENV = 'production';
 export const OPENCTI_SESSION = 'opencti_session';
 export const PLATFORM_VERSION = pjson.version;
-export const BUILD_COMMIT = process.env.BUILD_COMMIT?.slice(0, 7);
+const buildCommit = process.env.BUILD_COMMIT?.trim();
+export const BUILD_COMMIT = buildCommit && /^[0-9a-f]{7,40}$/i.test(buildCommit)
+  ? buildCommit.slice(0, 7)
+  : undefined;
 const LOG_APP = 'APP';
 const LOG_AUDIT = 'AUDIT';
 

--- a/opencti-platform/opencti-graphql/src/domain/settings.js
+++ b/opencti-platform/opencti-graphql/src/domain/settings.js
@@ -51,7 +51,7 @@ export const getMemoryStatistics = () => {
 
 export const getApplicationInfo = () => ({
   version: PLATFORM_VERSION,
-  build_commit: BUILD_COMMIT,
+  buildCommit: BUILD_COMMIT,
   debugStats: {}, // Lazy loaded
 });
 

--- a/opencti-platform/opencti-graphql/src/domain/settings.js
+++ b/opencti-platform/opencti-graphql/src/domain/settings.js
@@ -2,7 +2,17 @@ import { getHeapStatistics } from 'node:v8';
 import nconf from 'nconf';
 import ipaddr from 'ipaddr.js';
 import { createEntity, fullEntitiesOrRelationsList, loadEntity, patchAttribute, updateAttribute } from '../database/middleware';
-import conf, { ACCOUNT_STATUSES, booleanConf, BUS_TOPICS, ENABLED_DEMO_MODE, ENABLED_FEATURE_FLAGS, getBaseUrl, PLATFORM_VERSION, PLAYGROUND_ENABLED } from '../config/conf';
+import conf, {
+  ACCOUNT_STATUSES,
+  booleanConf,
+  BUILD_COMMIT,
+  BUS_TOPICS,
+  ENABLED_DEMO_MODE,
+  ENABLED_FEATURE_FLAGS,
+  getBaseUrl,
+  PLATFORM_VERSION,
+  PLAYGROUND_ENABLED,
+} from '../config/conf';
 import { delEditContext, getRedisVersion, notify, setEditContext } from '../database/redis';
 import { isRuntimeSortEnable, searchEngineVersion } from '../database/engine';
 import { getRabbitMQVersion } from '../database/rabbitmq';
@@ -41,6 +51,7 @@ export const getMemoryStatistics = () => {
 
 export const getApplicationInfo = () => ({
   version: PLATFORM_VERSION,
+  build_commit: BUILD_COMMIT,
   debugStats: {}, // Lazy loaded
 });
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -652,7 +652,7 @@ export type AppDebugStatistics = {
 export type AppInfo = {
   __typename?: 'AppInfo';
   /** The short commit hash used to build the OpenCTI application */
-  build_commit?: Maybe<Scalars['String']['output']>;
+  buildCommit?: Maybe<Scalars['String']['output']>;
   /** The objects statistics */
   debugStats?: Maybe<AppDebugStatistics>;
   /** The list of OpenCTI software dependencies */
@@ -42153,7 +42153,7 @@ export type AppDebugStatisticsResolvers<ContextType = any, ParentType extends Re
 }>;
 
 export type AppInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['AppInfo'] = ResolversParentTypes['AppInfo']> = ResolversObject<{
-  build_commit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  buildCommit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   debugStats?: Resolver<Maybe<ResolversTypes['AppDebugStatistics']>, ParentType, ContextType>;
   dependencies?: Resolver<Array<ResolversTypes['DependencyVersion']>, ParentType, ContextType>;
   memory?: Resolver<Maybe<ResolversTypes['AppMemory']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -651,6 +651,8 @@ export type AppDebugStatistics = {
 /** Retrieve the application information version add dependencies */
 export type AppInfo = {
   __typename?: 'AppInfo';
+  /** The short commit hash used to build the OpenCTI application */
+  build_commit?: Maybe<Scalars['String']['output']>;
   /** The objects statistics */
   debugStats?: Maybe<AppDebugStatistics>;
   /** The list of OpenCTI software dependencies */
@@ -42151,6 +42153,7 @@ export type AppDebugStatisticsResolvers<ContextType = any, ParentType extends Re
 }>;
 
 export type AppInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['AppInfo'] = ResolversParentTypes['AppInfo']> = ResolversObject<{
+  build_commit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   debugStats?: Resolver<Maybe<ResolversTypes['AppDebugStatistics']>, ParentType, ContextType>;
   dependencies?: Resolver<Array<ResolversTypes['DependencyVersion']>, ParentType, ContextType>;
   memory?: Resolver<Maybe<ResolversTypes['AppMemory']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.js
@@ -10,6 +10,7 @@ const ABOUT_QUERY = gql`
   query about {
     about {
       version
+      build_commit
       dependencies {
         name
         version
@@ -93,6 +94,7 @@ describe('Settings resolver standard behavior', () => {
     expect(queryResult).not.toBeNull();
     const { about } = queryResult.data;
     expect(about).not.toBeNull();
+    expect(about).toHaveProperty('build_commit');
     expect(about.dependencies.length).toEqual(4);
   });
   it('should settings information', async () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.js
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.js
@@ -10,7 +10,7 @@ const ABOUT_QUERY = gql`
   query about {
     about {
       version
-      build_commit
+      buildCommit
       dependencies {
         name
         version
@@ -94,7 +94,7 @@ describe('Settings resolver standard behavior', () => {
     expect(queryResult).not.toBeNull();
     const { about } = queryResult.data;
     expect(about).not.toBeNull();
-    expect(about).toHaveProperty('build_commit');
+    expect(about.buildCommit === null || /^[0-9a-f]{7}$/i.test(about.buildCommit)).toBe(true);
     expect(about.dependencies.length).toEqual(4);
   });
   it('should settings information', async () => {


### PR DESCRIPTION
### Proposed changes

* Inject the CircleCI commit SHA into all OpenCTI platform image variants and expose its short form through the `about` GraphQL API.
* Display the short build commit next to the platform version in Settings, while preserving the existing version-only display for builds without commit metadata.

### Related issues

Fixes: #17710

### How to test this PR

Build a platform image with `--build-arg BUILD_COMMIT=<full-sha>`, start it, and confirm Settings displays the platform version followed by the seven-character commit hash in parentheses. Start without the build argument and confirm only the version is displayed.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The build commit is optional so local and custom builds remain backward compatible.