### PR TITLE
fix(client-python): fall back to default when a config value is explicitly None (#17672)

### DIFF
--- a/client-python/pycti/connector/opencti_connector_helper.py
+++ b/client-python/pycti/connector/opencti_connector_helper.py
@@ -150,6 +150,16 @@ def get_config_variable(
     else:
         return default
 
+    # A configuration key can be present but explicitly null (for example a
+    # Pydantic settings model that dumps every field, including unset Optional
+    # ones, as None). Treat an explicit None the same as an absent/empty value:
+    # honour `required`, otherwise fall back to `default` instead of letting it
+    # reach `int(None)` when isNumber=True and crash the connector at startup.
+    if result is None:
+        if required and default is None:
+            raise ValueError("The configuration " + env_var + " is required")
+        return default
+
     if result in TRUTHY:
         return True
     if result in FALSY:

--- a/client-python/tests/01-unit/connector_helper/test_get_config_variable.py
+++ b/client-python/tests/01-unit/connector_helper/test_get_config_variable.py
@@ -1,0 +1,68 @@
+"""Tests for get_config_variable handling of explicitly-null config values.
+
+Regression coverage for the case where a configuration key is present in the
+YAML/dict config but its value is explicitly ``None`` (e.g. a Pydantic settings
+model that dumps unset Optional fields as ``null``). Previously this reached
+``int(None)`` when ``isNumber=True`` and crashed the connector at startup.
+"""
+
+from unittest import TestCase
+
+from pycti.connector.opencti_connector_helper import get_config_variable
+
+
+class GetConfigVariableNoneTest(TestCase):
+    def test_explicit_none_number_falls_back_to_default(self):
+        # Reproduces the reported servicenow crash: the key exists but is None
+        # and isNumber=True should return the default instead of raising.
+        config = {"connector": {"send_to_directory_retention": None}}
+        result = get_config_variable(
+            "CONNECTOR_SEND_TO_DIRECTORY_RETENTION",
+            ["connector", "send_to_directory_retention"],
+            config,
+            isNumber=True,
+            default=7,
+        )
+        self.assertEqual(result, 7)
+
+    def test_explicit_none_non_number_falls_back_to_default(self):
+        config = {"connector": {"some_value": None}}
+        result = get_config_variable(
+            "CONNECTOR_SOME_VALUE",
+            ["connector", "some_value"],
+            config,
+            default="fallback",
+        )
+        self.assertEqual(result, "fallback")
+
+    def test_explicit_none_required_without_default_raises(self):
+        config = {"connector": {"mandatory": None}}
+        with self.assertRaises(ValueError):
+            get_config_variable(
+                "CONNECTOR_MANDATORY",
+                ["connector", "mandatory"],
+                config,
+                required=True,
+            )
+
+    def test_present_number_still_parsed(self):
+        # Guard against regressions: a real value must still be returned as int.
+        config = {"connector": {"send_to_directory_retention": 30}}
+        result = get_config_variable(
+            "CONNECTOR_SEND_TO_DIRECTORY_RETENTION",
+            ["connector", "send_to_directory_retention"],
+            config,
+            isNumber=True,
+            default=7,
+        )
+        self.assertEqual(result, 30)
+
+    def test_absent_key_still_returns_default(self):
+        result = get_config_variable(
+            "CONNECTOR_MISSING",
+            ["connector", "missing"],
+            {"connector": {}},
+            isNumber=True,
+            default=7,
+        )
+        self.assertEqual(result, 7)


### PR DESCRIPTION
## Proposed changes

Fixes #17672.

`get_config_variable()` only fell back to `default` when a config key was **absent**. When a key was **present but explicitly `None`** and `isNumber=True`, `result` became `None` and reached `int(None)`, raising an uncaught `TypeError` and crashing the connector at startup. This happens when a connector's Pydantic settings model dumps every field — including unset `Optional` ones — as `null` (reported for the `servicenow` connector: `send_to_directory_retention: None` with `get_config_variable(..., isNumber=True, default=7)`).

### Change

Added a guard right after the value is resolved from env/config: an explicit `None` is now treated the same as an absent/empty value — it honours `required` (raising `ValueError` when `required=True` and no default is set, matching the existing empty-string behaviour) and otherwise returns `default`.

```python
if result is None:
    if required and default is None:
        raise ValueError("The configuration " + env_var + " is required")
    return default
```

This is placed before the `TRUTHY`/`FALSY`/`isNumber` handling so `int(None)` can no longer be reached, and it mirrors the existing empty-string fallback logic below it, so the `required` semantics are preserved.

### Tests

Added `tests/01-unit/connector_helper/test_get_config_variable.py` (5 cases):
- explicit `None` + `isNumber=True` returns the default (the reported crash);
- explicit `None` (non-number) returns the default;
- explicit `None` + `required=True` without a default raises `ValueError`;
- a present number is still parsed to `int`;
- an absent key still returns the default.

Without the change the two explicit-`None` tests fail (one via the `int(None)` crash); with it, all pass. `black`, `isort`, and `flake8` (max line length 89) are clean on the changed files.
