### PR TITLE
fix(search): Update of search query processing (#17754)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -2183,7 +2183,9 @@ type ProcessSearchArgs = {
   historyFiltering?: boolean;
 };
 
+// Hard cap user-provided search input to limit normalization + query parsing cost
 const MAX_SEARCH_LENGTH = 512;
+
 function processSearch(
   search: string,
   args: ProcessSearchArgs,

--- a/opencti-platform/opencti-graphql/src/database/engine.ts
+++ b/opencti-platform/opencti-graphql/src/database/engine.ts
@@ -2182,17 +2182,21 @@ type ProcessSearchArgs = {
   useWildcardPrefix?: boolean;
   historyFiltering?: boolean;
 };
+
+const MAX_SEARCH_LENGTH = 512;
 function processSearch(
   search: string,
   args: ProcessSearchArgs,
 ): { exactSearch: string[]; querySearch: string[] } {
   const { useWildcardPrefix } = args;
+  const boundedSearch = search.length > MAX_SEARCH_LENGTH ? search.slice(0, MAX_SEARCH_LENGTH) : search;
+
   let decodedSearch;
   try {
-    decodedSearch = decodeURIComponent(refang(search))
+    decodedSearch = decodeURIComponent(refang(boundedSearch))
       .trim();
   } catch (_e) {
-    decodedSearch = refang(search).trim();
+    decodedSearch = refang(boundedSearch).trim();
   }
   let remainingSearch = decodedSearch;
   const exactSearch = (decodedSearch.match(/"[^"]+"/g) || []) //

--- a/opencti-platform/opencti-graphql/src/utils/refang.js
+++ b/opencti-platform/opencti-graphql/src/utils/refang.js
@@ -46,12 +46,31 @@ export function refang(input) {
     .replace(/\[([a-zA-Z0-9])\]/g, '$1')
     // [:/] should map to /
     // eslint-disable-next-line no-useless-escape
-    .replace(/\[:\/\]/g, '/')
-    // // Remove literal ellipsis character
-    // .replace(/\u2026/g, '')
-    // Remove common placeholder endings (e.g., trailing [.] or ...)
-    // eslint-disable-next-line no-useless-escape
-    .replace(/(\[\.\]|\.{2,}|…)+$/g, '');
+    .replace(/\[:\/\]/g, '/');
+
+  // Remove common placeholder endings (e.g., trailing ... or …) in guaranteed
+  // linear time via a manual scan instead of a backtracking regex (a
+  // nested-quantifier regex here was the source of a ReDoS vulnerability).
+  // Mirrors the previous `(\.{2,}|…)+$` semantics: a run of 2+ dots, or a
+  // single ellipsis character, is stripped from the end (repeatedly), but a
+  // single lone trailing dot is left untouched.
+  let end = output.length;
+  for (;;) {
+    let dotRunStart = end;
+    while (dotRunStart > 0 && output[dotRunStart - 1] === '.') {
+      dotRunStart -= 1;
+    }
+    if (end - dotRunStart >= 2) {
+      end = dotRunStart;
+      continue;
+    }
+    if (end > 0 && output[end - 1] === '\u2026') {
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  output = output.slice(0, end);
 
   // Extract valid URL if present and sanitize
   const urlRegex = /https?:\/\/[^\s'"<>[\](){},;!?…]+/gi;

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/search-test.js
@@ -119,3 +119,28 @@ it('should generate search clauses for both activity and history fields in histo
   expect(topLevelActivityAndHistoryQueryString).toBeDefined();
   expect(nestedHistoryQueryString).toBeDefined();
 });
+
+it('should bound overlong search input instead of processing it in full', () => {
+  const MAX_SEARCH_LENGTH = 512;
+  const marker = 'shouldBeTruncatedAway';
+  // Marker sits well beyond the bound, so it must not survive into the query.
+  const overlongSearch = `${'a'.repeat(MAX_SEARCH_LENGTH + 50)}${marker}`;
+  const shouldSearch = elGenerateFullTextSearchShould(overlongSearch);
+  const queriesString = shouldSearch
+    .map((e) => e?.query_string?.query)
+    .filter((f) => isNotEmptyField(f))
+    .join(' ');
+  const matchesString = shouldSearch
+    .map((e) => e?.multi_match?.query)
+    .filter((f) => isNotEmptyField(f))
+    .join(' ');
+  expect(queriesString).not.toContain(marker);
+  expect(matchesString).not.toContain(marker);
+});
+
+it('should not throw when a percent-encoded sequence straddles the search length boundary', () => {
+  const MAX_SEARCH_LENGTH = 512;
+  // Place a percent-encoded byte so it gets cut mid-sequence by the length bound.
+  const searchWithSplitEncoding = `${'a'.repeat(MAX_SEARCH_LENGTH - 1)}%E0%A4%A`;
+  expect(() => elGenerateFullTextSearchShould(searchWithSplitEncoding)).not.toThrow();
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts
@@ -53,7 +53,9 @@ describe('refang tests', () => {
     const output = refang(input);
     const duration = performance.now() - start;
     expect(output).toBe(input);
-    expect(duration).toBeLessThan(50);
+    // Loose bound: this only needs to catch pathological (exponential/quadratic)
+    // backtracking, not enforce a tight timing budget on shared CI runners.
+    expect(duration).toBeLessThan(500);
   });
 
   it('should strip long runs of trailing dots in linear time', () => {
@@ -62,7 +64,9 @@ describe('refang tests', () => {
     const output = refang(input);
     const duration = performance.now() - start;
     expect(output).toBe('http://site.com');
-    expect(duration).toBeLessThan(50);
+    // Loose bound: this only needs to catch pathological (exponential/quadratic)
+    // backtracking, not enforce a tight timing budget on shared CI runners.
+    expect(duration).toBeLessThan(500);
   });
 
   it('should handle mixed defanging styles in a single string', () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts
@@ -41,6 +41,30 @@ describe('refang tests', () => {
     expect(output).toBe('http://site.com');
   });
 
+  it('should strip a trailing ellipsis without affecting the rest of the string', () => {
+    const input = 'hxxp://site[.]com…';
+    const output = refang(input);
+    expect(output).toBe('http://site.com');
+  });
+
+  it('should handle long sequences of trailing dots without ReDoS backtracking', () => {
+    const start = performance.now();
+    const input = `${'.'.repeat(200_000)}x`;
+    const output = refang(input);
+    const duration = performance.now() - start;
+    expect(output).toBe(input);
+    expect(duration).toBeLessThan(50);
+  });
+
+  it('should strip long runs of trailing dots in linear time', () => {
+    const start = performance.now();
+    const input = `hxxp://site[.]com${'.'.repeat(200_000)}`;
+    const output = refang(input);
+    const duration = performance.now() - start;
+    expect(output).toBe('http://site.com');
+    expect(duration).toBeLessThan(50);
+  });
+
   it('should handle mixed defanging styles in a single string', () => {
     const input = 'hxxp://example[.]com and hxxps://secure[.]site/path';
     const output = refang(input);


### PR DESCRIPTION
### Proposed changes

* Refactor trailing-character cleanup logic in the search input normalization utility to use a more efficient, deterministic algorithm
* Add an explicit bound on search input length before normalization/processing
* Add unit test coverage for the updated normalization behavior

### Related issues
* closes #17754

### How to test this PR
* Run the backend unit test suite: `yarn test:ci-unit` (or target the specific file: `opencti-platform/opencti-graphql/tests/01-unit/utils/refang-test.ts`)
* Verify existing search functionality (IOC defanging, GraphQL search bar) behaves as before on a running instance

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Context and rationale are tracked in the linked private issue.