### PR TITLE
fix(access): minor refactor of access utils (#17756)

### DIFF
--- a/opencti-platform/opencti-graphql/src/utils/access.ts
+++ b/opencti-platform/opencti-graphql/src/utils/access.ts
@@ -688,7 +688,7 @@ export const isServiceAccountUser = (user: AuthUser): boolean => {
 export const isUserHasCapability = (user: AuthUser, capability: string, options?: { forceCapabilityInDraft?: boolean }): boolean => {
   const isInDraftContext = !!user.draft_context;
   const isIncludedInCapabilities = (user.capabilities || []).some((s) => capability !== BYPASS && s.name.includes(capability));
-  const isIncludedInDraftCapabilities = (user.capabilitiesInDraft || []).some((s) => s.name.includes(capability));
+  const isIncludedInDraftCapabilities = (user.capabilitiesInDraft || []).some((s) => capability !== BYPASS && s.name.includes(capability));
   const checkCapabilitiesInDraft = !!options?.forceCapabilityInDraft || isInDraftContext;
   return isBypassUser(user) || isIncludedInCapabilities || (checkCapabilitiesInDraft && isIncludedInDraftCapabilities);
 };


### PR DESCRIPTION
### Proposed changes

* Align capability matching logic between draft and standard capability checks in `opencti-platform/opencti-graphql/src/utils/access.ts`
* Ensure capability name comparisons use consistent matching semantics across both code paths

### Related issues

* closes #17756

### How to test this PR

* Run the backend unit test suite covering capability checks: `yarn test:ci-unit` (or target `opencti-platform/opencti-graphql/tests/**/access*`)
* Verify existing capability-based access checks behave as before (draft and non-draft contexts) on a running instance

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

Context are tracked in the linked private issue.