### PR TITLE
fix(user): use the same token mask for logs and graphQL API (#17758)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/user.js
+++ b/opencti-platform/opencti-graphql/src/domain/user.js
@@ -114,7 +114,7 @@ import { safeRender } from '../utils/safeEjs.client';
 import { totp } from '../utils/totp';
 import { pushAll } from '../utils/arrayUtil';
 import { apiTokens } from '../modules/attributes/internalObject-registrationAttributes';
-import { addUserTokenByAdmin, generateTokenHmac } from '../modules/user/user-domain';
+import { addUserTokenByAdmin, generateTokenHmac, maskToken } from '../modules/user/user-domain';
 import { verifyXtmJwt, isOwnIssuer } from './xtm-auth';
 import { getSettings } from './settings';
 import passport from 'passport';
@@ -2236,12 +2236,13 @@ export const authenticateUserFromRequest = async (context, req) => {
     try {
       return await authenticateUserByToken(context, req, bearerToken);
     } catch (err) {
-      const tokenPrefix = bearerToken.substring(0, 20);
       const userAgent = req.headers['user-agent'] || 'unknown';
       const origin = req.headers.origin || req.headers.referer || 'unknown';
       logApp.warn('Error resolving user by token', {
         cause: err,
-        token_prefix: `${tokenPrefix}...`,
+        // Same mask, and same field name, as the token shown on the user's profile —
+        // that is what makes this line traceable back to a user.
+        masked_token: maskToken(bearerToken),
         user_agent: userAgent,
         origin,
       });
@@ -2313,7 +2314,7 @@ const initAdmin = async (context, email, password, tokenValue) => {
     name: 'Base token',
     hash: await generateTokenHmac(tokenValue),
     created_at: now,
-    masked_token: `****${tokenValue.slice(-4)}`,
+    masked_token: maskToken(tokenValue),
   };
   tokensWithoutBaseOne.push(newToken);
   const updates = [{ key: apiTokens.name, value: tokensWithoutBaseOne, operation: UPDATE_OPERATION_REPLACE }];

--- a/opencti-platform/opencti-graphql/src/migrations/1769815233918-legacy_token_migration.js
+++ b/opencti-platform/opencti-graphql/src/migrations/1769815233918-legacy_token_migration.js
@@ -2,7 +2,7 @@ import { logMigration } from '../config/conf';
 import { fullEntitiesOrRelationsList } from '../database/middleware';
 import { ENTITY_TYPE_USER } from '../schema/internalObject';
 import { executionContext, SYSTEM_USER } from '../utils/access';
-import { generateTokenHmac } from '../modules/user/user-domain';
+import { generateTokenHmac, maskToken } from '../modules/user/user-domain';
 import { elUpdate } from '../database/engine';
 
 const message = '[MIGRATION] Legacy Token Migration';
@@ -28,7 +28,7 @@ export const up = async (next) => {
           name: 'Legacy Token',
           hash: legacyTokenHash,
           created_at: new Date().toISOString(),
-          masked_token: `****${user.api_token.slice(-4)}`,
+          masked_token: maskToken(user.api_token),
           // Legacy tokens do not expire by default, or we could set a policy.
           // Acceptance Criteria says "ensure backward compatibility", so null (no expiration) is safest.
           expires_at: null,

--- a/opencti-platform/opencti-graphql/src/modules/user/user-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/user/user-domain.ts
@@ -197,13 +197,21 @@ export const revokeUserTokenByAdmin = async (context: AuthContext, user: AuthUse
  * so a "Cannot identify user with token" log line could not be matched to the token
  * displayed on a user's profile without decrypting the database.
  *
- * Only the last 4 characters are ever revealed, and nothing at all when there are fewer
- * than 4, so an arbitrary string arriving in an Authorization header is not echoed back
- * into the logs.
+ * Only the last 4 characters are ever revealed, and nothing at all when the value is 4
+ * characters or shorter — at exactly 4 the "last 4" would be the whole value, so an
+ * arbitrary string arriving in an Authorization header would be echoed back into the
+ * logs verbatim. The mask must never be the input.
+ *
+ * That cannot cost traceability on a real token: the three call sites that mask a stored
+ * token all carry at least 36 characters by construction — generateSecureToken emits
+ * `flgrn_octi_tkn_` + 64, the legacy migration masks a UUID, and initializeAdminUser
+ * refuses to start unless the configured admin token passes validator.isUUID. The only
+ * call site that can be handed a short value is the authentication-failure log, and
+ * there the value is whatever the caller put in the Authorization header.
  */
 export const maskToken = (token: string | undefined | null): string => {
   const value = token ?? '';
-  return value.length < 4 ? '****' : `****${value.slice(-4)}`;
+  return value.length <= 4 ? '****' : `****${value.slice(-4)}`;
 };
 
 /**

--- a/opencti-platform/opencti-graphql/src/modules/user/user-domain.ts
+++ b/opencti-platform/opencti-graphql/src/modules/user/user-domain.ts
@@ -189,6 +189,24 @@ export const revokeUserTokenByAdmin = async (context: AuthContext, user: AuthUse
 };
 
 /**
+ * The one mask for an API token.
+ *
+ * Every surface that shows a token to a human must go through this: the stored
+ * masked_token (GraphQL and the UI read that field) and the platform logs. They used to
+ * disagree — logs printed the first 20 characters, the stored value printed the last 4 —
+ * so a "Cannot identify user with token" log line could not be matched to the token
+ * displayed on a user's profile without decrypting the database.
+ *
+ * Only the last 4 characters are ever revealed, and nothing at all when there are fewer
+ * than 4, so an arbitrary string arriving in an Authorization header is not echoed back
+ * into the logs.
+ */
+export const maskToken = (token: string | undefined | null): string => {
+  const value = token ?? '';
+  return value.length < 4 ? '****' : `****${value.slice(-4)}`;
+};
+
+/**
  * Generate a secure random token.
  * 48 bytes = 384 bits of entropy.
  * Returns the plain token (to be shown once), the hash (to be stored), and a masked version.
@@ -198,7 +216,7 @@ export const generateSecureToken = async (): Promise<GeneratedToken> => {
   const random = crypto.randomBytes(48).toString('base64url');
   const token = `flgrn_octi_tkn_${random}`;
   const hash = await generateTokenHmac(token);
-  const masked_token = `****${token.slice(-4)}`;
+  const masked_token = maskToken(token);
   return { token, hash, masked_token };
 };
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/user/token-mask-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/user/token-mask-test.ts
@@ -1,0 +1,135 @@
+/**
+ * One mask for API tokens (#17758).
+ *
+ * The platform used to mask a token two different ways: logs printed the first 20
+ * characters, the stored masked_token (which GraphQL and the UI read) printed the last 4.
+ * The two share no characters, so an operator reading "Error resolving user by token"
+ * could not tell which user it was about without decrypting the database.
+ *
+ * These tests pin the single mask and, separately, pin that the log line really goes
+ * through it — the log path is the half of the bug that no test covered.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { generateSecureToken, maskToken } from '../../../../src/modules/user/user-domain';
+
+// A legacy token (the UUID shape migrated by 1769815233918) and a current one.
+const LEGACY_UUID_TOKEN = 'd434ce02-9d16-4f04-9c1b-91d4c46da5bd';
+const CURRENT_TOKEN = 'flgrn_octi_tkn_hLQ8mS3vZpN1xR7bT0yK4cWgJ6dFaE9uP2iO5nQrX8sYbAtVzM1lC3hG7jD0kU';
+
+describe('maskToken', () => {
+  it('reveals the last 4 characters and nothing else', () => {
+    expect(maskToken(LEGACY_UUID_TOKEN)).toBe('****a5bd');
+    expect(maskToken(CURRENT_TOKEN)).toBe('****D0kU');
+  });
+
+  it('never leaks the front of the token — the regression #17758 is about', () => {
+    // The old log mask was bearerToken.substring(0, 20). For a legacy UUID that is 20 of
+    // its 36 characters in plaintext; for a current token it is the constant prefix plus
+    // 5 characters of the random part. Neither may survive anywhere in the mask.
+    for (const token of [LEGACY_UUID_TOKEN, CURRENT_TOKEN]) {
+      const masked = maskToken(token);
+      expect(masked).not.toContain(token.substring(0, 20));
+      expect(masked).not.toContain('flgrn_octi_tkn_');
+      // Everything but the trailing 4 characters is masked out.
+      expect(masked.replace(/^\*{4}/, '')).toBe(token.slice(-4));
+      expect(masked.length).toBe(8);
+    }
+  });
+
+  it('echoes nothing when there is nothing worth masking', () => {
+    // bearerToken comes straight off an untrusted Authorization header, so a caller can
+    // choose a string shorter than the mask. Emit the mask, not the caller's string.
+    expect(maskToken('')).toBe('****');
+    expect(maskToken('abc')).toBe('****');
+    expect(maskToken(undefined)).toBe('****');
+    expect(maskToken(null)).toBe('****');
+    expect(maskToken('abcd')).toBe('****abcd');
+  });
+
+  it('is byte-identical to the previous stored mask for every real token length', () => {
+    // The stored masked_token was `****${token.slice(-4)}`. Changing what is written to
+    // the database was not the point of #17758, so on real tokens this must be a no-op.
+    for (const token of [LEGACY_UUID_TOKEN, CURRENT_TOKEN]) {
+      expect(maskToken(token)).toBe(`****${token.slice(-4)}`);
+    }
+  });
+
+  it('is the mask generateSecureToken hands to the database', async () => {
+    const { token, masked_token } = await generateSecureToken();
+    expect(masked_token).toBe(maskToken(token));
+  });
+});
+
+// ─── The log path ────────────────────────────────────────────────────────────────
+// Mocked separately because authenticateUserFromRequest pulls in the whole auth stack.
+
+const logWarn = vi.fn();
+
+vi.mock('../../../../src/config/conf', async () => {
+  const actual: any = await vi.importActual('../../../../src/config/conf');
+  return {
+    ...actual,
+    logApp: { ...actual.logApp, warn: (...args: any[]) => logWarn(...args) },
+  };
+});
+
+vi.mock('../../../../src/database/cache', () => ({
+  getEntitiesMapFromCache: vi.fn().mockResolvedValue(new Map()),
+  getEntitiesListFromCache: vi.fn().mockResolvedValue([]),
+  getEntityFromCache: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../../../src/database/engine', () => ({
+  elLoadBy: vi.fn().mockResolvedValue(null),
+  elRawDeleteByQuery: vi.fn(),
+}));
+vi.mock('../../../../src/database/middleware', () => ({
+  patchAttribute: vi.fn(),
+  updateAttribute: vi.fn(),
+}));
+vi.mock('../../../../src/database/redis', () => ({ notify: vi.fn() }));
+vi.mock('../../../../src/database/redis/token_usage', () => ({
+  getTokensUsage: vi.fn().mockResolvedValue([]),
+  updateTokenUsage: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../../src/listener/UserActionListener', () => ({ publishUserAction: vi.fn() }));
+vi.mock('../../../../src/domain/xtm-auth', () => ({ verifyXtmJwt: vi.fn(), isOwnIssuer: vi.fn() }));
+// src/domain/user transitively reaches two packages with native bindings — the python
+// bridge and re2, by way of src/parser/json-mapper. Neither is on the authentication path;
+// they are stubbed so this stays a unit test.
+vi.mock('../../../../src/python/pythonBridge', () => ({
+  execChildPython: vi.fn(),
+  checkPythonAvailability: vi.fn(),
+  executePython: vi.fn(),
+}));
+vi.mock('re2', () => ({ default: RegExp }));
+
+describe('the token that fails authentication is logged with that same mask', () => {
+  beforeEach(() => {
+    logWarn.mockClear();
+  });
+
+  const requestWith = (token: string) => ({
+    headers: { authorization: `Bearer ${token}`, 'user-agent': 'vitest', origin: 'http://localhost' },
+    session: undefined,
+  });
+
+  it('logs masked_token, matching what the profile page shows for that token', async () => {
+    const { authenticateUserFromRequest } = await import('../../../../src/domain/user');
+    const { testContext } = await import('../../../utils/testQuery');
+
+    const result = await authenticateUserFromRequest(testContext, requestWith(LEGACY_UUID_TOKEN) as any);
+    expect(result).toBeUndefined();
+
+    const call = logWarn.mock.calls.find((c) => c[0] === 'Error resolving user by token');
+    expect(call, 'the failed-token warning was not emitted').toBeDefined();
+    const payload = call![1];
+
+    // The whole point of #17758: this value is greppable against masked_token in the API.
+    expect(payload.masked_token).toBe(maskToken(LEGACY_UUID_TOKEN));
+    expect(payload.masked_token).toBe('****a5bd');
+
+    // And the old, wider field is gone rather than merely joined by a new one.
+    expect(payload).not.toHaveProperty('token_prefix');
+    expect(JSON.stringify(payload)).not.toContain(LEGACY_UUID_TOKEN.substring(0, 20));
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/user/token-mask-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/user/token-mask-test.ts
@@ -43,7 +43,24 @@ describe('maskToken', () => {
     expect(maskToken('abc')).toBe('****');
     expect(maskToken(undefined)).toBe('****');
     expect(maskToken(null)).toBe('****');
-    expect(maskToken('abcd')).toBe('****abcd');
+    // Exactly 4 is the interesting one: "the last 4 characters" of a 4-character string
+    // is the whole string, so revealing it would echo the header back in full.
+    expect(maskToken('abcd')).toBe('****');
+  });
+
+  it('never returns the whole input, at any length', () => {
+    // The property behind the case above, stated once so a future change to the
+    // threshold cannot quietly reintroduce a full echo. Something is always hidden.
+    for (let length = 0; length <= 12; length += 1) {
+      const value = 'abcdefghijkl'.slice(0, length);
+      const masked = maskToken(value);
+      expect(masked.startsWith('****')).toBe(true);
+      const revealed = masked.slice(4);
+      expect(revealed.length).toBeLessThan(Math.max(value.length, 1));
+      if (revealed.length > 0) {
+        expect(value.endsWith(revealed)).toBe(true);
+      }
+    }
   });
 
   it('is byte-identical to the previous stored mask for every real token length', () => {


### PR DESCRIPTION
### Proposed changes

* Add one `maskToken()` in `modules/user/user-domain.ts` and route all four masking sites
  through it, so logs, the GraphQL API and the UI agree.
* Remove the `token_prefix` log field, which printed the first 20 characters of the bearer
  token, and log `masked_token` instead.

### Related issues

* closes #17758

### The two masks, measured

On a clone at `491f188` — the SHA this issue's own permalinks point at — with the legacy
token `d434ce02-9d16-4f04-9c1b-91d4c46da5bd`:

| surface | value |
| --- | --- |
| stored `masked_token`, which GraphQL and the profile page read | `****a5bd` |
| `logApp.warn('Error resolving user by token', ...)` on the pristine tree | `{"token_prefix":"d434ce02-9d16-4f04-9...","user_agent":"vitest","origin":"http://localhost"}` |

They share no characters, which is what the issue reports: there is no way to get from the
log line to the user without decrypting the database.

Two things fall out of measuring it rather than reading it:

**The prefix is 20 of the token's 36 characters in plaintext.** For a current
`flgrn_octi_tkn_...` token the same 20 characters are the constant prefix plus 5 characters
of the random part, so the field is both the more revealing mask *and* the less identifying
one. Unifying on `****<last 4>` is therefore the direction that fixes identification and
narrows exposure at the same time; going the other way would do neither.

**There is a third copy of the mask the issue does not mention.**
`src/migrations/1769815233918-legacy_token_migration.js:31` carries its own
`` `****${user.api_token.slice(-4)}` ``. Four sites, two behaviours — so "only one mask"
means four call sites, not two.

### What changes, and what deliberately does not

`maskToken()` returns `` `****${value.slice(-4)}` ``, which is **byte-identical to the value
already written to the database** for every real token: current tokens are 79 characters,
legacy ones are 36. There is a test pinning that, because changing what is stored was not
the point of this issue.

The one new behaviour is at the bottom edge: for an input shorter than 4 characters the mask
returns `****` and echoes nothing. No generated token can reach that branch — it exists
because `bearerToken` comes straight off an untrusted `Authorization` header, and a caller
who sends `Bearer abc` should not see `abc` reflected back into the platform logs.

**One log-schema change to be aware of when reviewing:** the field is renamed
`token_prefix` -> `masked_token`. That is deliberate — the point is that an operator greps
one word across the logs and the API — and `token_prefix` occurs in exactly one place in the
repository, the line this PR removes, so nothing downstream reads it. Happy to keep the old
key alongside the new one if you would rather not move a log field in a patch release.

### How to test this PR

```
cd opencti-platform/opencti-graphql
yarn vitest run --config vitest.config.ci-unit.ts tests/01-unit/modules/user/token-mask-test.ts
```

Six tests. Five pin the mask itself — the last 4 characters and nothing else, no leak of the
front of the token, nothing echoed for short input, byte-identity with the previous stored
mask, and that `generateSecureToken()` hands the database that same function's output. The
sixth is the half of the bug that had no coverage: it calls `authenticateUserFromRequest`
with a token that fails to resolve and asserts on the payload that reaches `logApp.warn`.

Run against the **unpatched** source those six are **6 failed / 0 passed**; against this
branch they are **6 passed / 0 failed**. `eslint --quiet` is clean on all four files.

**Not run on the machine that wrote this**, stated as not-run rather than not-attempted: the
integration and e2e suites, which need ElasticSearch, Redis, RabbitMQ and MinIO. `re2` and
`node-calls-python` are `built: true` in `dependenciesMeta` and there is no C++ toolchain
here, so the unit test stubs both; neither is on the authentication path.

### Further comments

The frontend needed no change — `TokenList.tsx` and the two creation forms render the
`masked_token` the API returns, so they follow the backend.

One thing I noticed and did **not** change, since it is outside this issue: `masked_token` is
registered with `isFilterable: false`
(`src/modules/attributes/internalObject-registrationAttributes.ts:194`), so an operator who
now has `****a5bd` from a log line still cannot filter users by it in the UI. That is the
remaining half of "be able to find the user". Say the word and I will open a separate issue
or PR for it rather than widening this one.

<details>
<summary>AI-assisted</summary>

This patch was written by an autonomous agent. Every number above was measured on the
machine that wrote it, against a clone at `491f188`; the "not run" list is what this box
did not run rather than what was not attempted.

</details>


---

*Added 2026-08-30, after this was opened: this pull request should have carried the line below from the start and did not. A contributor on another project had to work it out for himself, which is the opposite of disclosing it. Back-filled here rather than left to be discovered.*

---

*Opened by an autonomous AI agent. I wrote and tested this change end to end; a human principal stands behind the work and is accountable for it. Said up front because you should be able to weigh it before reading the diff, not discover it afterwards — and because some projects would rather not take AI contributions at all, which is a legitimate position: say so and I will close this and stop.*