### PR TITLE
fix(connector): fix connector name collision during migration (#17564)

### DIFF
--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -1,9 +1,9 @@
-import { BUS_TOPICS } from '../config/conf';
+import { BUS_TOPICS, logApp } from '../config/conf';
 import { FunctionalError } from '../config/errors';
 import { patchAttribute } from '../database/middleware';
 import { fullEntitiesList } from '../database/middleware-loader';
 import { notify } from '../database/redis';
-import { completeConnector, connector } from '../database/repository';
+import { completeConnector, connector, connectors } from '../database/repository';
 import type { Connector, ConnectorContractConfiguration, ContractConfigInput } from '../generated/graphql';
 import { publishUserAction } from '../listener/UserActionListener';
 import { addConnectorDeployedCount } from '../manager/telemetryManager';
@@ -206,6 +206,42 @@ export const assessConnectorMigration = async (context: AuthContext, user: AuthU
   };
 };
 
+// Resolve a unique connector name to avoid collision with existing (managed) connectors.
+// The name collision is checked (and rejected) on managedConnectorAdd; during migration we
+// cannot simply reject, so on collision we prefix the name to keep it unique. Two managed
+// connectors sharing the same name make the composer fail to reconciliate and redeploy forever.
+const resolveUniqueConnectorName = async (
+  context: AuthContext,
+  user: AuthUser,
+  desiredName: string,
+  currentConnectorId: string,
+): Promise<string> => {
+  const existingConnectors = await connectors(context, user);
+  const usedNames = new Set(
+    existingConnectors
+      .filter((c) => c.internal_id !== currentConnectorId)
+      .map((c) => c.name),
+  );
+
+  if (!usedNames.has(desiredName)) {
+    return desiredName;
+  }
+
+  // First try a simple 'migrated-' prefix, then fall back to appending a timestamp.
+  const candidates = [
+    `migrated-${desiredName}`,
+    `migrated-${Date.now()}-${desiredName}`,
+  ];
+  const uniqueName = candidates.find((candidate) => !usedNames.has(candidate))
+    ?? `migrated-${Date.now()}-${Math.floor(Math.random() * 1e6)}-${desiredName}`;
+
+  logApp.info(
+    `[CONNECTOR] Name collision detected during migration: connector name '${desiredName}' already exists, renaming to '${uniqueName}'`,
+    { connector_id: currentConnectorId },
+  );
+  return uniqueName;
+};
+
 export const migrateConnectorToManaged = async (
   context: AuthContext,
   user: AuthUser,
@@ -329,6 +365,13 @@ export const migrateConnectorToManaged = async (
     manager_contract_configuration: filteredConfigurations,
     manager_requested_status: 'stopped',
   };
+
+  // Ensure the migrated connector name does not collide with an existing (managed) connector.
+  // Name collision is rejected on managedConnectorAdd; here we resolve it by prefixing the name.
+  const uniqueName = await resolveUniqueConnectorName(context, user, existingConnector.name, existingConnector.internal_id);
+  if (uniqueName !== existingConnector.name) {
+    managedConnectorData.name = uniqueName;
+  }
 
   // Reset connector state if requested
   if (resetConnectorState && existingConnector.connector_state) {

--- a/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector-migration.ts
@@ -371,6 +371,7 @@ export const migrateConnectorToManaged = async (
   const uniqueName = await resolveUniqueConnectorName(context, user, existingConnector.name, existingConnector.internal_id);
   if (uniqueName !== existingConnector.name) {
     managedConnectorData.name = uniqueName;
+    managedConnectorData.title = uniqueName;
   }
 
   // Reset connector state if requested

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -89,7 +89,7 @@ const READ_CONNECTOR_QUERY = gql`
 const TEST_CN_ID = '5ed680de-75e2-4aa0-bec0-4e8e5a0d1695';
 const TEST_CN_NAME = 'TestConnector';
 
-describe.todo('Check connector migration', () => {
+describe('Check connector migration', () => {
   let userId: string;
 
   /**

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -86,8 +86,8 @@ const READ_CONNECTOR_QUERY = gql`
   }
 `;
 
-const TEST_CN_ID = '5ed680de-75e2-4aa0-bec0-4e8e5a0d1695';
-const TEST_CN_NAME = 'TestConnector';
+const TEST_CN_MIGRATION_ID = '5ed680de-75e2-4aa0-bec0-4e8e5a0d1696';
+const TEST_CN_MIGRATION_NAME = 'TestConnectorMigration';
 
 describe('Check connector migration', () => {
   let userId: string;
@@ -113,8 +113,8 @@ describe('Check connector migration', () => {
     userId = user.data.userAdd.id;
 
     const connectorData = {
-      id: TEST_CN_ID,
-      name: TEST_CN_NAME,
+      id: TEST_CN_MIGRATION_ID,
+      name: TEST_CN_MIGRATION_NAME,
       type: ConnectorType.ExternalImport,
       scope: ['Observable'],
       auto: true,
@@ -136,8 +136,8 @@ describe('Check connector migration', () => {
     );
 
     expect(connector).not.toBeNull();
-    expect(connector.name).toEqual(TEST_CN_NAME);
-    expect(connector.id).toEqual(TEST_CN_ID);
+    expect(connector.name).toEqual(TEST_CN_MIGRATION_NAME);
+    expect(connector.id).toEqual(TEST_CN_MIGRATION_ID);
   });
 
   /**
@@ -146,9 +146,9 @@ describe('Check connector migration', () => {
    */
   afterAll(async () => {
     // Delete the connector
-    await queryAsAdminWithSuccess({ query: DELETE_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+    await queryAsAdminWithSuccess({ query: DELETE_CONNECTOR_QUERY, variables: { id: TEST_CN_MIGRATION_ID } });
     // Verify is no longer found
-    const queryResult = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+    const queryResult = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_MIGRATION_ID } });
 
     expect(queryResult).not.toBeNull();
     expect(queryResult.data?.connector).toBeNull();
@@ -159,7 +159,7 @@ describe('Check connector migration', () => {
   describe('migrate connector to managed', () => {
     describe('when migration is successful', () => {
       it('should migrate a standalone connector to managed, and user is now service account', async () => {
-        const queryConnectorRegistered = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
+        const queryConnectorRegistered = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_MIGRATION_ID } });
         const standaloneConnector = queryConnectorRegistered.data?.connector;
         expect(standaloneConnector).not.toBeNull();
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -157,7 +157,7 @@ describe('Check connector migration', () => {
   });
 
   describe('migrate connector to managed', () => {
-    describe('when migration is successful', () => {
+    describe.todo('when migration is successful', () => {
       it('should migrate a standalone connector to managed, and user is now service account', async () => {
         const queryConnectorRegistered = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
         const standaloneConnector = queryConnectorRegistered.data?.connector;

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -157,7 +157,7 @@ describe('Check connector migration', () => {
   });
 
   describe('migrate connector to managed', () => {
-    describe.todo('when migration is successful', () => {
+    describe('when migration is successful', () => {
       it('should migrate a standalone connector to managed, and user is now service account', async () => {
         const queryConnectorRegistered = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: TEST_CN_ID } });
         const standaloneConnector = queryConnectorRegistered.data?.connector;

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-migration-test.ts
@@ -226,6 +226,81 @@ describe.todo('Check connector migration', () => {
         expect(managedConnector.connector_user.user_service_account).toBeTruthy();
       });
     });
+
+    describe('when name collides with an existing connector', () => {
+      // Regression test: migrateConnectorToManaged must not create two connectors sharing
+      // the same name (which makes the composer fail to reconciliate and redeploy forever).
+      // On collision, the migrated connector name must be prefixed to stay unique.
+      const COLLISION_NAME = 'CollisionConnector';
+      const OCCUPYING_CN_ID = 'a1b2c3d4-0000-4aaa-bbbb-000000000001';
+      const MIGRATING_CN_ID = 'a1b2c3d4-0000-4aaa-bbbb-000000000002';
+
+      it('should rename the migrated connector with a prefix instead of duplicating the name', async () => {
+        // An existing connector already occupies COLLISION_NAME
+        const occupyingConnector = await registerConnector(
+          testContext,
+          ADMIN_USER,
+          {
+            id: OCCUPYING_CN_ID,
+            name: COLLISION_NAME,
+            type: ConnectorType.ExternalImport,
+            scope: ['Observable'],
+            auto: true,
+            only_contextual: true,
+          },
+          { connector_user_id: userId },
+        );
+        expect(occupyingConnector.name).toEqual(COLLISION_NAME);
+
+        // A standalone connector to migrate uses the exact same name
+        const connectorToMigrate = await registerConnector(
+          testContext,
+          ADMIN_USER,
+          {
+            id: MIGRATING_CN_ID,
+            name: COLLISION_NAME,
+            type: ConnectorType.ExternalImport,
+            scope: ['Observable'],
+            auto: true,
+            only_contextual: true,
+          },
+          { connector_user_id: userId },
+        );
+        expect(connectorToMigrate.name).toEqual(COLLISION_NAME);
+
+        try {
+          const migrationResult = await queryAsAdminWithSuccess({
+            query: MIGRATE_CONNECTOR_TO_MANAGED,
+            variables: {
+              input: {
+                connectorId: MIGRATING_CN_ID,
+                containerImage: 'opencti/connector-cve',
+                resetConnectorState: false,
+                convertUserToServiceAccount: true,
+                configuration: [
+                  { key: 'CVE_API_KEY', value: 'cve_api_key' },
+                ],
+              },
+            },
+          });
+
+          const managedConnector = migrationResult.data.connectorMigrateToManaged;
+          // The migrated connector keeps its id
+          expect(managedConnector.id).toEqual(MIGRATING_CN_ID);
+          // But its name must NOT collide with the existing connector anymore
+          expect(managedConnector.name).not.toEqual(COLLISION_NAME);
+          // The collision is resolved by prefixing with 'migrated-'
+          expect(managedConnector.name).toEqual(`migrated-${COLLISION_NAME}`);
+          // The occupying connector still owns the original name
+          const occupyingQuery = await queryAsAdmin({ query: READ_CONNECTOR_QUERY, variables: { id: OCCUPYING_CN_ID } });
+          expect(occupyingQuery.data?.connector?.name).toEqual(COLLISION_NAME);
+        } finally {
+          // Cleanup both connectors
+          await queryAsAdminWithSuccess({ query: DELETE_CONNECTOR_QUERY, variables: { id: MIGRATING_CN_ID } });
+          await queryAsAdminWithSuccess({ query: DELETE_CONNECTOR_QUERY, variables: { id: OCCUPYING_CN_ID } });
+        }
+      });
+    });
   });
 
   // it('should fail because the connector registered is not found', async () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
This pull request addresses a critical issue in the connector migration process by ensuring that migrated connectors do not end up with duplicate names, which previously could cause deployment failures. The main changes introduce logic to automatically resolve connector name collisions during migration, and add comprehensive tests to prevent regression.

**Connector migration improvements:**

* Added a new helper function `resolveUniqueConnectorName` in `connector-migration.ts` that checks for name collisions with existing connectors and, if necessary, prefixes the name (e.g., `migrated-<name>`) to ensure uniqueness during migration. This prevents deployment failures due to duplicate connector names.
* Updated the `migrateConnectorToManaged` function to use `resolveUniqueConnectorName`, so that migrated connectors are automatically renamed if a collision is detected.

**Testing enhancements:**

* Added a regression test in `connector-migration-test.ts` to verify that when a connector is migrated and its name collides with an existing connector, the migration process correctly renames the migrated connector with a `migrated-` prefix, ensuring no two connectors share the same name.

**Code and import updates:**

* Updated imports in `connector-migration.ts` to include `logApp` and `connectors` for logging and retrieving connector lists as part of the new collision resolution logic.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17564

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
