### PR TITLE
fix(playbook): fix manipulate knowledge and other components playbook with "score has changed" filters (#17752)

### DIFF
--- a/opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-0-converter.ts
@@ -355,6 +355,7 @@ export const convertIntrusionSetToStix = (instance: StoreEntity): SDO.StixIntrus
     resource_level: instance.resource_level,
     primary_motivation: instance.primary_motivation,
     secondary_motivations: instance.secondary_motivations,
+    x_opencti_score: instance.x_opencti_score,
   };
 };
 
@@ -376,6 +377,7 @@ export const convertThreatActorGroupToStix = (instance: StoreEntity): SDO.StixTh
     secondary_motivations: instance.secondary_motivations,
     personal_motivations: instance.personal_motivations,
     threat_actor_group: instance.name,
+    x_opencti_score: instance.x_opencti_score,
   };
 };
 
@@ -396,6 +398,7 @@ export const convertMalwareToStix = (instance: StoreEntity): SDO.StixMalware => 
     capabilities: instance.capabilities,
     operating_system_refs: (instance[INPUT_OPERATING_SYSTEM] ?? []).map((m) => m.standard_id),
     sample_refs: (instance[INPUT_SAMPLE] ?? []).map((m) => m.standard_id),
+    x_opencti_score: instance.x_opencti_score,
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
+++ b/opencti-platform/opencti-graphql/src/database/stix-2-1-converter.ts
@@ -514,8 +514,9 @@ const convertVulnerabilityToStix = (instance: StoreEntity, type: string): SDO.St
 };
 const convertThreatActorGroupToStix = (instance: StoreEntity, type: string): SDO.StixThreatActor => {
   assertType(ENTITY_TYPE_THREAT_ACTOR_GROUP, type);
+  const threatActorGroup = buildStixDomain(instance);
   return {
-    ...buildStixDomain(instance),
+    ...threatActorGroup,
     name: instance.name,
     description: instance.description,
     threat_actor_types: instance.threat_actor_types,
@@ -529,6 +530,12 @@ const convertThreatActorGroupToStix = (instance: StoreEntity, type: string): SDO
     primary_motivation: instance.primary_motivation,
     secondary_motivations: instance.secondary_motivations,
     personal_motivations: instance.personal_motivations,
+    extensions: {
+      [STIX_EXT_OCTI]: cleanObject({
+        ...threatActorGroup.extensions[STIX_EXT_OCTI],
+        score: instance.x_opencti_score,
+      }),
+    },
   };
 };
 const convertInfrastructureToStix = (instance: StoreEntity, type: string): SDO.StixInfrastructure => {
@@ -546,8 +553,9 @@ const convertInfrastructureToStix = (instance: StoreEntity, type: string): SDO.S
 };
 const convertIntrusionSetToStix = (instance: StoreEntity, type: string): SDO.StixIntrusionSet => {
   assertType(ENTITY_TYPE_INTRUSION_SET, type);
+  const intrusionSet = buildStixDomain(instance);
   return {
-    ...buildStixDomain(instance),
+    ...intrusionSet,
     name: instance.name,
     description: instance.description,
     aliases: instance.aliases,
@@ -557,6 +565,12 @@ const convertIntrusionSetToStix = (instance: StoreEntity, type: string): SDO.Sti
     resource_level: instance.resource_level,
     primary_motivation: instance.primary_motivation,
     secondary_motivations: instance.secondary_motivations,
+    extensions: {
+      [STIX_EXT_OCTI]: cleanObject({
+        ...intrusionSet.extensions[STIX_EXT_OCTI],
+        score: instance.x_opencti_score,
+      }),
+    },
   };
 };
 
@@ -575,8 +589,9 @@ const convertCourseOfActionToStix = (instance: StoreEntity, type: string): SDO.S
 };
 const convertMalwareToStix = (instance: StoreEntity, type: string): SDO.StixMalware => {
   assertType(ENTITY_TYPE_MALWARE, type);
+  const malware = buildStixDomain(instance);
   return {
-    ...buildStixDomain(instance),
+    ...malware,
     name: instance.name,
     description: instance.description,
     malware_types: instance.malware_types,
@@ -590,6 +605,12 @@ const convertMalwareToStix = (instance: StoreEntity, type: string): SDO.StixMalw
     capabilities: instance.capabilities,
     operating_system_refs: (instance[INPUT_OPERATING_SYSTEM] ?? []).map((m) => m.standard_id),
     sample_refs: (instance[INPUT_SAMPLE] ?? []).map((m) => m.standard_id),
+    extensions: {
+      [STIX_EXT_OCTI]: cleanObject({
+        ...malware.extensions[STIX_EXT_OCTI],
+        score: instance.x_opencti_score,
+      }),
+    },
   };
 };
 const convertAttackPatternToStix = (instance: StoreEntity, type: string): SDO.StixAttackPattern => {

--- a/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/playbookManager/playbookManager.ts
@@ -23,7 +23,7 @@ import { lockResources } from '../../lock/master-lock';
 import conf, { booleanConf, logApp } from '../../config/conf';
 import { FunctionalError, TYPE_LOCK_ERROR } from '../../config/errors';
 import { AUTOMATION_MANAGER_USER, executionContext, RETENTION_MANAGER_USER, SYSTEM_USER } from '../../utils/access';
-import type { SseEvent, StreamDataEvent, UpdateEvent } from '../../types/event';
+import type { SseEvent, StreamDataEvent } from '../../types/event';
 import type { StixBundle, StixObject } from '../../types/stix-2-1-common';
 import { streamEventId, utcDate } from '../../utils/format';
 import { findById, findPlaybooksForEntity } from '../../modules/playbook/playbook-domain';
@@ -44,7 +44,8 @@ import { stixLoadByFilters, stixLoadById } from '../../database/middleware';
 import { convertRelationRefsFilterKeys } from '../../utils/filtering/filtering-utils';
 import { isEnterpriseEdition, isEnterpriseEditionFromSettings } from '../../enterprise-edition/ee';
 import { listenPirEvents } from './listenPirEventsUtils';
-import { buildFilterEventContext, isDebugPlaybook, isValidEventType, StreamDataEventTypeEnum } from './playbookManagerUtils';
+import { isDebugPlaybook, isValidEventType } from './playbookManagerUtils';
+import { buildPlaybookEventContext } from '../../modules/playbook/playbook-utils';
 import { playbookExecutor } from './playbookExecutor';
 import type { BasicConnection, BasicStoreBase } from '../../types/store';
 import { InterruptibleTimer } from '../interruptible-timer';
@@ -120,12 +121,7 @@ const playbookStreamHandler = async (streamEvents: Array<SseEvent<StreamDataEven
                 const jsonFilters = filters ? JSON.parse(filters) : null;
 
                 const isValidEvent = isValidEventType(type, configuration);
-                // Build event context for has_changed/not_has_changed filter evaluation
-                const eventContext = type === StreamDataEventTypeEnum.UPDATE
-                  ? buildFilterEventContext(streamEvent.data as UpdateEvent)
-                  : type === StreamDataEventTypeEnum.CREATE
-                    ? { changedAttributes: [], isCreation: true }
-                    : undefined;
+                const eventContext = buildPlaybookEventContext(streamEvent.data);
                 const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, data, jsonFilters, eventContext);
 
                 if (currentPlaybookInDebug) {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/access-restrictions-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/access-restrictions-component.ts
@@ -10,7 +10,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../organization/organizati
 import { isNotEmptyField } from '../../../database/utils';
 import { EditOperation } from '../../../generated/graphql';
 import { AUTHORIZED_MEMBERS_SUPPORTED_ENTITY_TYPES, buildRestrictedMembers } from '../../../utils/authorizedMembers';
-import { applyOperationFieldPatch, extractBundleBaseElement, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
+import { applyOperationFieldPatch, buildPlaybookEventContext, extractBundleBaseElement, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
 
 export interface AccessRestrictionsConfiguration {
   applyToElements: PlaybookBundleElementsToApply;
@@ -72,9 +72,10 @@ export const PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT: PlaybookComponent<AccessRes
   ports: [{ id: 'out', type: 'out' }],
   configuration_schema: PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT_SCHEMA,
-  executor: async ({ dataInstanceId, playbookNode, bundle }) => {
+  executor: async ({ dataInstanceId, playbookNode, bundle, event }) => {
     const context = executionContext('playbook_components');
     const { access_restrictions: accessRestrictions, applyToElements, applyWithFilters } = playbookNode.configuration;
+    const eventContext = buildPlaybookEventContext(event);
     // Resolve potential dynamic access rights
     const baseData = extractBundleBaseElement(dataInstanceId, bundle) as StixObject;
     const finalAccessRestrictions = [];
@@ -126,7 +127,7 @@ export const PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT: PlaybookComponent<AccessRes
       const element = bundle.objects[index];
       const internalType = generateInternalType(element);
       const isTypeCompatible = AUTHORIZED_MEMBERS_SUPPORTED_ENTITY_TYPES.includes(internalType);
-      const isFilteredElement = (await isBundleElementMatchFilters(context, element, applyWithFilters));
+      const isFilteredElement = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       const isElementInScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
 
       if (isTypeCompatible && isFilteredElement && isElementInScope) {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/create-observable-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/create-observable-component.ts
@@ -13,7 +13,7 @@ import { RELATION_BASED_ON } from '../../../schema/stixCoreRelationship';
 import type { StixRelation } from '../../../types/stix-2-1-sro';
 import { extractValidObservablesFromIndicatorPattern } from '../../../utils/syntax';
 import { type StixIndicator } from '../../indicator/indicator-types';
-import { extractBundleBaseElement, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
+import { buildPlaybookEventContext, extractBundleBaseElement, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
 import { convertStoreToStix_2_1 } from '../../../database/stix-2-1-converter';
 import { pushAll } from '../../../utils/arrayUtil';
 import { executionContext } from '../../../utils/access';
@@ -58,9 +58,10 @@ export const PLAYBOOK_CREATE_OBSERVABLE_COMPONENT: PlaybookComponent<CreateObser
   ports: [{ id: 'out', type: 'out' }, { id: 'unmodified', type: 'out' }],
   configuration_schema: PLAYBOOK_CREATE_OBSERVABLE_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_CREATE_OBSERVABLE_COMPONENT_SCHEMA,
-  executor: async ({ playbookNode, dataInstanceId, bundle }) => {
+  executor: async ({ playbookNode, dataInstanceId, bundle, event }) => {
     const context = executionContext('playbook_components');
     const { applyToElements, applyWithFilters, wrap_in_container } = playbookNode.configuration;
+    const eventContext = buildPlaybookEventContext(event);
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
 
     const { type: baseDataType } = baseData.extensions[STIX_EXT_OCTI];
@@ -70,7 +71,7 @@ export const PLAYBOOK_CREATE_OBSERVABLE_COMPONENT: PlaybookComponent<CreateObser
     for (let indexIndicator = 0; indexIndicator < bundle.objects.length; indexIndicator += 1) {
       const element = bundle.objects[indexIndicator];
       const isElementInScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
-      const isFilteredElement = await isBundleElementMatchFilters(context, element, applyWithFilters);
+      const isFilteredElement = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
 
       if (isElementInScope && isFilteredElement && element.type === 'indicator') {
         const indicator = element as StixIndicator;

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -198,12 +198,12 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
       const isMatchingScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
-        const entityType = generateInternalType(element);
+        const { type } = element.extensions[STIX_EXT_OCTI];
         const elementOperations = actions
           .map((action) => {
-            const attrPath = computeAttributePath(entityType, action.attribute);
-            const multiple = isAttributeMultiple(entityType, action.attribute);
-            const attributeType = getAttributeType(entityType, action.attribute);
+            const attrPath = computeAttributePath(type, action.attribute);
+            const multiple = isAttributeMultiple(type, action.attribute);
+            const attributeType = getAttributeType(type, action.attribute);
             return ({ action, multiple, attributeType, attrPath, path: `/objects/${index}${attrPath}` });
           })
           // Unrecognized attributes must be filtered

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -199,14 +199,11 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
         const { type, id } = element.extensions[STIX_EXT_OCTI];
-        const entityType = (type === 'identity' && (element as any).identity_class === 'organization')
-          ? ENTITY_TYPE_IDENTITY_ORGANIZATION
-          : type;
         const elementOperations = actions
           .map((action) => {
-            const attrPath = computeAttributePath(entityType, action.attribute);
-            const multiple = isAttributeMultiple(entityType, action.attribute);
-            const attributeType = getAttributeType(entityType, action.attribute);
+            const attrPath = computeAttributePath(type, action.attribute);
+            const multiple = isAttributeMultiple(type, action.attribute);
+            const attributeType = getAttributeType(type, action.attribute);
             return ({ action, multiple, attributeType, attrPath, path: `/objects/${index}${attrPath}` });
           })
           // Unrecognized attributes must be filtered

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -25,7 +25,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../organization/organizati
 import { ENTITY_TYPE_INCIDENT } from '../../../schema/stixDomainObject';
 import { playbookBundleElementsToApply, type PlaybookBundleElementsToApply, type PlaybookComponent } from '../playbook-types';
 import { AUTOMATION_MANAGER_USER, executionContext } from '../../../utils/access';
-import { generateInternalType, getParentTypes } from '../../../schema/schemaUtils';
+import { getParentTypes } from '../../../schema/schemaUtils';
 import * as jsonpatch from 'fast-json-patch';
 import { isNotEmptyField } from '../../../database/utils';
 import { EditOperation } from '../../../generated/graphql';
@@ -199,11 +199,14 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
         const { type, id } = element.extensions[STIX_EXT_OCTI];
+        const entityType = (type === 'identity' && (element as any).identity_class === 'organization')
+          ? ENTITY_TYPE_IDENTITY_ORGANIZATION
+          : type;
         const elementOperations = actions
           .map((action) => {
-            const attrPath = computeAttributePath(type, action.attribute);
-            const multiple = isAttributeMultiple(type, action.attribute);
-            const attributeType = getAttributeType(type, action.attribute);
+            const attrPath = computeAttributePath(entityType, action.attribute);
+            const multiple = isAttributeMultiple(entityType, action.attribute);
+            const attributeType = getAttributeType(entityType, action.attribute);
             return ({ action, multiple, attributeType, attrPath, path: `/objects/${index}${attrPath}` });
           })
           // Unrecognized attributes must be filtered

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -194,22 +194,11 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
 
     const patchOperations: jsonpatch.Operation[] = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
-      const element = bundle.objects[index] as any;
+      const element = bundle.objects[index];
       const isMatchingScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
-        const { id } = element.extensions[STIX_EXT_OCTI];
-        const entityType = (() => {
-          const octiType = element.extensions?.[STIX_EXT_OCTI]?.type;
-          const stixType = octiType ?? element.type;
-          if (stixType === 'identity' && element.identity_class === 'organization') {
-            return ENTITY_TYPE_IDENTITY_ORGANIZATION;
-          }
-          if (isNotEmptyField(octiType)) {
-            return octiType;
-          }
-          return generateInternalType(element);
-        })();
+        const entityType = generateInternalType(element);
         const elementOperations = actions
           .map((action) => {
             const attrPath = computeAttributePath(entityType, action.attribute);
@@ -276,9 +265,7 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
           const operationObject = elementOperations.map((op) => {
             return { key: op.attribute, value: Array.isArray(op.value) ? op.value : [op.value], operation: op.op };
           });
-          if (id) {
-            applyOperationFieldPatch(element, operationObject);
-          }
+          applyOperationFieldPatch(element, operationObject);
           pushAll(patchOperations, elementOperations.map((e) => e.patchOperation));
         }
       }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -29,7 +29,7 @@ import { getParentTypes } from '../../../schema/schemaUtils';
 import * as jsonpatch from 'fast-json-patch';
 import { isNotEmptyField } from '../../../database/utils';
 import { EditOperation } from '../../../generated/graphql';
-import { applyOperationFieldPatch, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
+import { applyOperationFieldPatch, buildPlaybookEventContext, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
 import { pushAll } from '../../../utils/arrayUtil';
 
 const attributePathMapping: any = {
@@ -155,10 +155,11 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
   ports: [{ id: 'out', type: 'out' }, { id: 'unmodified', type: 'out' }],
   configuration_schema: PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT_SCHEMA,
-  executor: async ({ dataInstanceId, playbookNode, bundle }) => {
+  executor: async ({ dataInstanceId, playbookNode, bundle, event }) => {
     const context = executionContext('playbook_components');
     const cacheIds = await getEntitiesMapFromCache(context, AUTOMATION_MANAGER_USER, ENTITY_TYPE_MARKING_DEFINITION);
     const { actions, applyToElements, applyWithFilters } = playbookNode.configuration;
+    const eventContext = buildPlaybookEventContext(event);
 
     // Compute if the attribute is defined as multiple in schema definition
     const isAttributeMultiple = (entityType: string, attribute: string) => {
@@ -195,7 +196,7 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const element = bundle.objects[index];
       const isMatchingScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
-      const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters);
+      const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
         const { type, id } = element.extensions[STIX_EXT_OCTI];
         const elementOperations = actions

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -25,7 +25,7 @@ import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../organization/organizati
 import { ENTITY_TYPE_INCIDENT } from '../../../schema/stixDomainObject';
 import { playbookBundleElementsToApply, type PlaybookBundleElementsToApply, type PlaybookComponent } from '../playbook-types';
 import { AUTOMATION_MANAGER_USER, executionContext } from '../../../utils/access';
-import { getParentTypes } from '../../../schema/schemaUtils';
+import { generateInternalType, getParentTypes } from '../../../schema/schemaUtils';
 import * as jsonpatch from 'fast-json-patch';
 import { isNotEmptyField } from '../../../database/utils';
 import { EditOperation } from '../../../generated/graphql';
@@ -208,7 +208,7 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
           if (isNotEmptyField(octiType)) {
             return octiType;
           }
-          return element.type;
+          return generateInternalType(element);
         })();
         const elementOperations = actions
           .map((action) => {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -198,7 +198,7 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
       const isMatchingScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
-        const { type } = element.extensions[STIX_EXT_OCTI];
+        const { type, id } = element.extensions[STIX_EXT_OCTI];
         const elementOperations = actions
           .map((action) => {
             const attrPath = computeAttributePath(type, action.attribute);
@@ -265,7 +265,9 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
           const operationObject = elementOperations.map((op) => {
             return { key: op.attribute, value: Array.isArray(op.value) ? op.value : [op.value], operation: op.op };
           });
-          applyOperationFieldPatch(element, operationObject);
+          if (id) {
+            applyOperationFieldPatch(element, operationObject);
+          }
           pushAll(patchOperations, elementOperations.map((e) => e.patchOperation));
         }
       }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/manipulate-knowledge-component.ts
@@ -194,16 +194,27 @@ export const PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT: PlaybookComponent<Manipula
 
     const patchOperations: jsonpatch.Operation[] = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
-      const element = bundle.objects[index];
+      const element = bundle.objects[index] as any;
       const isMatchingScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
       const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isMatchingScope && isMatchingFilters) {
-        const { type, id } = element.extensions[STIX_EXT_OCTI];
+        const { id } = element.extensions[STIX_EXT_OCTI];
+        const entityType = (() => {
+          const octiType = element.extensions?.[STIX_EXT_OCTI]?.type;
+          const stixType = octiType ?? element.type;
+          if (stixType === 'identity' && element.identity_class === 'organization') {
+            return ENTITY_TYPE_IDENTITY_ORGANIZATION;
+          }
+          if (isNotEmptyField(octiType)) {
+            return octiType;
+          }
+          return element.type;
+        })();
         const elementOperations = actions
           .map((action) => {
-            const attrPath = computeAttributePath(type, action.attribute);
-            const multiple = isAttributeMultiple(type, action.attribute);
-            const attributeType = getAttributeType(type, action.attribute);
+            const attrPath = computeAttributePath(entityType, action.attribute);
+            const multiple = isAttributeMultiple(entityType, action.attribute);
+            const attributeType = getAttributeType(entityType, action.attribute);
             return ({ action, multiple, attributeType, attrPath, path: `/objects/${index}${attrPath}` });
           })
           // Unrecognized attributes must be filtered

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/remove-access-restrictions-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/remove-access-restrictions-component.ts
@@ -7,7 +7,7 @@ import { STIX_EXT_OCTI } from '../../../types/stix-2-1-extensions';
 import { isNotEmptyField } from '../../../database/utils';
 import { EditOperation } from '../../../generated/graphql';
 import { AUTHORIZED_MEMBERS_SUPPORTED_ENTITY_TYPES } from '../../../utils/authorizedMembers';
-import { applyOperationFieldPatch, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
+import { applyOperationFieldPatch, buildPlaybookEventContext, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
 import { executionContext } from '../../../utils/access';
 
 export interface RemoveAccessRestrictionsConfiguration {
@@ -46,15 +46,16 @@ export const PLAYBOOK_REMOVE_ACCESS_RESTRICTIONS_COMPONENT: PlaybookComponent<Re
   ports: [{ id: 'out', type: 'out' }],
   configuration_schema: PLAYBOOK_REMOVE_ACCESS_RESTRICTIONS_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_REMOVE_ACCESS_RESTRICTIONS_COMPONENT_SCHEMA,
-  executor: async ({ dataInstanceId, playbookNode, bundle }) => {
+  executor: async ({ dataInstanceId, playbookNode, bundle, event }) => {
     const context = executionContext('playbook_components');
     const { applyToElements, applyWithFilters } = playbookNode.configuration;
+    const eventContext = buildPlaybookEventContext(event);
     const patchOperations = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const element = bundle.objects[index];
       const internalType = generateInternalType(element);
       const isTypeCompatible = AUTHORIZED_MEMBERS_SUPPORTED_ENTITY_TYPES.includes(internalType);
-      const isFilteredElement = await isBundleElementMatchFilters(context, element, applyWithFilters);
+      const isFilteredElement = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       const isElementInScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
 
       if (isTypeCompatible && isFilteredElement && isElementInScope) {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/components/unsharing-component.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/components/unsharing-component.ts
@@ -8,7 +8,7 @@ import { internalFindByIds } from '../../../database/middleware-loader';
 import { type BasicStoreEntityOrganization, ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../organization/organization-types';
 import { isNotEmptyField } from '../../../database/utils';
 import { EditOperation } from '../../../generated/graphql';
-import { applyOperationFieldPatch, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
+import { applyOperationFieldPatch, buildPlaybookEventContext, isBundleElementInScope, isBundleElementMatchFilters } from '../playbook-utils';
 
 export interface UnsharingConfiguration {
   organizations: string[] | { label: string; value: string }[];
@@ -54,9 +54,10 @@ export const PLAYBOOK_UNSHARING_COMPONENT: PlaybookComponent<UnsharingConfigurat
   ports: [{ id: 'out', type: 'out' }],
   configuration_schema: PLAYBOOK_UNSHARING_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_UNSHARING_COMPONENT_SCHEMA,
-  executor: async ({ dataInstanceId, playbookNode, bundle }) => {
+  executor: async ({ dataInstanceId, playbookNode, bundle, event }) => {
     const context = executionContext('playbook_components', AUTOMATION_MANAGER_USER);
     const { organizations, applyToElements, applyWithFilters } = playbookNode.configuration;
+    const eventContext = buildPlaybookEventContext(event);
     const organizationsValues = organizations.map((o) => (typeof o !== 'string' ? o.value : o));
     const organizationsByIds = await internalFindByIds<BasicStoreEntityOrganization>(context, SYSTEM_USER, organizationsValues, {
       type: ENTITY_TYPE_IDENTITY_ORGANIZATION,
@@ -72,7 +73,7 @@ export const PLAYBOOK_UNSHARING_COMPONENT: PlaybookComponent<UnsharingConfigurat
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const element = bundle.objects[index];
       const isInScope = isBundleElementInScope(element, applyToElements, dataInstanceId);
-      const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters);
+      const isMatchingFilters = await isBundleElementMatchFilters(context, element, applyWithFilters, eventContext);
       if (isInScope && isMatchingFilters) {
         const currentElementGrantedRefs = element.extensions[STIX_EXT_OCTI].granted_refs ?? [];
         const newGrantedRefs = currentElementGrantedRefs.filter((o) => !organizationIds.includes(o));

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -37,7 +37,6 @@ import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/sti
 import { ENTITY_TYPE_INDICATOR } from '../indicator/indicator-types';
 import { FilterMode } from '../../generated/graphql';
 import { PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT } from './components/send-email-template-component';
-import { buildPlaybookEventContext, extractBundleBaseElement } from './playbook-utils';
 import { PLAYBOOK_DATA_STREAM_PIR } from './components/data-stream-pir-component';
 import { pushAll } from '../../utils/arrayUtil';
 import { PLAYBOOK_CONTAINER_WRAPPER_COMPONENT } from './components/container-wrapper-component';
@@ -52,6 +51,7 @@ import { PLAYBOOK_CREATE_OBSERVABLE_COMPONENT } from './components/create-observ
 import { PLAYBOOK_AI_AGENT_TRANSFORM_COMPONENT } from './components/ai-agent-component';
 import { PLAYBOOK_AI_AGENT_SEND_COMPONENT } from './components/ai-agent-send-component';
 import { PLAYBOOK_NOTIFIER_COMPONENT } from './components/notifier-component';
+import { buildPlaybookEventContext, extractBundleBaseElement } from './playbook-utils';
 
 // region built in playbook components
 interface LoggerConfiguration {

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-components.ts
@@ -37,7 +37,7 @@ import { isStixMatchFilterGroup } from '../../utils/filtering/filtering-stix/sti
 import { ENTITY_TYPE_INDICATOR } from '../indicator/indicator-types';
 import { FilterMode } from '../../generated/graphql';
 import { PLAYBOOK_SEND_EMAIL_TEMPLATE_COMPONENT } from './components/send-email-template-component';
-import { extractBundleBaseElement } from './playbook-utils';
+import { buildPlaybookEventContext, extractBundleBaseElement } from './playbook-utils';
 import { PLAYBOOK_DATA_STREAM_PIR } from './components/data-stream-pir-component';
 import { pushAll } from '../../utils/arrayUtil';
 import { PLAYBOOK_CONTAINER_WRAPPER_COMPONENT } from './components/container-wrapper-component';
@@ -239,23 +239,24 @@ export const PLAYBOOK_MATCHING_COMPONENT: PlaybookComponent<MatchConfiguration> 
   ports: [{ id: 'out', type: 'out' }, { id: 'no-match', type: 'out' }],
   configuration_schema: PLAYBOOK_MATCHING_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_MATCHING_COMPONENT_SCHEMA,
-  executor: async ({ playbookNode, dataInstanceId, bundle }) => {
+  executor: async ({ playbookNode, dataInstanceId, bundle, event }) => {
     const context = executionContext('playbook_components');
     const { filters, all } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
+    const eventContext = buildPlaybookEventContext(event);
     // Checking on all bundle elements
     if (all) {
       let matchedElements = 0;
       for (let index = 0; index < bundle.objects.length; index += 1) {
         const bundleElement = bundle.objects[index];
-        const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
+        const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters, eventContext);
         if (isMatch) matchedElements += 1;
       }
       return { output_port: matchedElements > 0 ? 'out' : 'no-match', bundle };
     }
     // Only checking base data
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
-    const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, baseData, jsonFilters);
+    const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, baseData, jsonFilters, eventContext);
     return { output_port: isMatch ? 'out' : 'no-match', bundle };
   },
 };
@@ -281,15 +282,16 @@ export const PLAYBOOK_REDUCING_COMPONENT: PlaybookComponent<ReduceConfiguration>
   ports: [{ id: 'out', type: 'out' }, { id: 'unmatch', type: 'out' }],
   configuration_schema: PLAYBOOK_REDUCING_COMPONENT_SCHEMA,
   schema: async () => PLAYBOOK_REDUCING_COMPONENT_SCHEMA,
-  executor: async ({ playbookNode, dataInstanceId, bundle }) => {
+  executor: async ({ playbookNode, dataInstanceId, bundle, event }) => {
     const context = executionContext('playbook_components');
     const baseData = extractBundleBaseElement(dataInstanceId, bundle);
     const { filters } = playbookNode.configuration;
     const jsonFilters = JSON.parse(filters);
+    const eventContext = buildPlaybookEventContext(event);
     const matchedElements = [];
     for (let index = 0; index < bundle.objects.length; index += 1) {
       const bundleElement = bundle.objects[index];
-      const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters);
+      const isMatch = await isStixMatchFilterGroup(context, SYSTEM_USER, bundleElement, jsonFilters, eventContext);
       if (isMatch) {
         matchedElements.push(bundleElement);
       }

--- a/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
+++ b/opencti-platform/opencti-graphql/src/modules/playbook/playbook-utils.ts
@@ -14,9 +14,12 @@ import { PLAYBOOK_INTERNAL_DATA_CRON } from './playbook-components';
 import { elFindByIds } from '../../database/engine';
 import { checkAndConvertFilters, type FiltersIdsFinder } from '../../utils/filtering/filtering-utils';
 import { isStixMatchFilterGroup, validateFilterGroupForStixMatch } from '../../utils/filtering/filtering-stix/stix-filtering';
+import type { FilterEventContext } from '../../utils/filtering/boolean-logic-engine';
 import { playbookBundleElementsToApply, type ComponentDefinition, type LinkDefinition, type NodeDefinition, type PlaybookBundleElementsToApply } from './playbook-types';
 import { logApp } from '../../config/conf';
 import { pushAll } from '../../utils/arrayUtil';
+import { buildFilterEventContext, StreamDataEventTypeEnum } from '../../manager/playbookManager/playbookManagerUtils';
+import type { StreamDataEvent, UpdateEvent } from '../../types/event';
 import { PLAYBOOK_ACCESS_RESTRICTIONS_COMPONENT } from './components/access-restrictions-component';
 import { PLAYBOOK_CONTAINER_WRAPPER_COMPONENT } from './components/container-wrapper-component';
 import { PLAYBOOK_CREATE_INDICATOR_COMPONENT } from './components/create-indicator-component';
@@ -31,6 +34,17 @@ export const extractBundleBaseElement = (instanceId: string, bundle: StixBundle)
   const baseData = bundle.objects.find((o) => o.id === instanceId);
   if (!baseData) throw FunctionalError('Playbook base element no longer accessible');
   return baseData;
+};
+
+/**
+ * Rebuild the has_changed/not_has_changed evaluation context from the original stream event.
+ * Needed because that context is not carried by the STIX bundle itself as it flows through playbook nodes.
+ */
+export const buildPlaybookEventContext = (event?: StreamDataEvent): FilterEventContext | undefined => {
+  if (!event) return undefined;
+  if (event.type === StreamDataEventTypeEnum.UPDATE) return buildFilterEventContext(event as UpdateEvent);
+  if (event.type === StreamDataEventTypeEnum.CREATE) return { changedAttributes: [], isCreation: true };
+  return undefined;
 };
 
 export const isBundleElementInScope = (
@@ -57,6 +71,7 @@ export const isBundleElementMatchFilters = async (
   context: AuthContext,
   bundleElement: StixObject,
   filters: string | undefined,
+  eventContext?: FilterEventContext,
 ): Promise<boolean> => {
   if (!filters || isEmptyField(filters)) return true;
   const jsonFilters = JSON.parse(filters);
@@ -65,6 +80,7 @@ export const isBundleElementMatchFilters = async (
     SYSTEM_USER,
     bundleElement,
     jsonFilters,
+    eventContext,
   );
 };
 

--- a/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual-converter.ts
+++ b/opencti-platform/opencti-graphql/src/modules/threatActorIndividual/threatActorIndividual-converter.ts
@@ -76,6 +76,7 @@ export const convertThreatActorIndividualToStix_2_0 = (instance: StoreEntity): S
     primary_motivation: instance.primary_motivation ?? (threatActorIndividual as any).primary_motivations,
     secondary_motivations: instance.secondary_motivations,
     personal_motivations: instance.personal_motivations,
+    x_opencti_score: instance.x_opencti_score,
     date_of_birth: convertToStixDate(threatActorIndividual.date_of_birth),
     gender: threatActorIndividual.gender,
     job_title: threatActorIndividual.job_title,

--- a/opencti-platform/opencti-graphql/src/types/stix-2-0-sdo.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/stix-2-0-sdo.d.ts
@@ -44,6 +44,7 @@ export interface StixIntrusionSet extends StixDomainObject {
   resource_level: string;
   primary_motivation: string;
   secondary_motivations: Array<string>;
+  x_opencti_score: number;
 }
 
 export interface StixThreatActor extends StixDomainObject {
@@ -60,6 +61,7 @@ export interface StixThreatActor extends StixDomainObject {
   primary_motivation: string;
   secondary_motivations: Array<string>;
   personal_motivations: Array<string>;
+  x_opencti_score: number;
 }
 
 export interface StixMalware extends StixDomainObject {
@@ -76,6 +78,7 @@ export interface StixMalware extends StixDomainObject {
   capabilities: Array<string>; // optional
   operating_system_refs: Array<StixId>; // optional
   sample_refs: Array<StixId>; // optional
+  x_opencti_score: number;
 }
 
 export interface StixTool extends StixDomainObject {

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-1-converter-score-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/stix-2-1-converter-score-test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import '../../../src/modules/index';
+import { convertStoreToStix_2_1 } from '../../../src/database/stix-2-1-converter';
+import { STIX_EXT_OCTI } from '../../../src/types/stix-2-1-extensions';
+import type { StixMalware, StixThreatActor, StixIntrusionSet, StixIncident, StixIdentity } from '../../../src/types/stix-2-1-sdo';
+import type { StixEvent } from '../../../src/modules/event/event-types';
+import { MALWARE_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/arsenal/malware';
+import { THREAT_ACTOR_GROUP_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/threats/threat-actor-group';
+import { INTRUSION_SET_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/threats/intrusion-set';
+import { INCIDENT_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/threats/incident';
+import { ORGANIZATION_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/entities/organization';
+import { EVENT_INSTANCE } from './stix-2-0-converter-fixtures/SDOs/entities/event';
+
+// Regression test for #17752: Malware, Threat-Actor-Group and Intrusion-Set
+// used to omit x_opencti_score from their STIX 2.1 extensions, breaking the
+// "Score has changed" playbook filter for these entity types.
+describe('STIX 2.1 converter - score propagation', () => {
+  it('should expose x_opencti_score on Malware', () => {
+    const stix = convertStoreToStix_2_1({ ...MALWARE_INSTANCE, x_opencti_score: 42 } as any) as StixMalware;
+    expect((stix.extensions[STIX_EXT_OCTI] as Record<string, any>).score).toBe(42);
+  });
+
+  it('should expose x_opencti_score on Threat-Actor-Group', () => {
+    const stix = convertStoreToStix_2_1({ ...THREAT_ACTOR_GROUP_INSTANCE, x_opencti_score: 55 } as any) as StixThreatActor;
+    expect((stix.extensions[STIX_EXT_OCTI] as Record<string, any>).score).toBe(55);
+  });
+
+  it('should expose x_opencti_score on Intrusion-Set', () => {
+    const stix = convertStoreToStix_2_1({ ...INTRUSION_SET_INSTANCE, x_opencti_score: 63 } as any) as StixIntrusionSet;
+    expect((stix.extensions[STIX_EXT_OCTI] as Record<string, any>).score).toBe(63);
+  });
+
+  it('should expose x_opencti_score on Incident', () => {
+    const stix = convertStoreToStix_2_1({ ...INCIDENT_INSTANCE, x_opencti_score: 71 } as any) as StixIncident;
+    expect((stix.extensions[STIX_EXT_OCTI] as Record<string, any>).score).toBe(71);
+  });
+
+  it('should expose x_opencti_score on Organization', () => {
+    const stix = convertStoreToStix_2_1({ ...ORGANIZATION_INSTANCE, x_opencti_score: 88 } as any) as StixIdentity;
+    expect((stix.extensions[STIX_EXT_OCTI] as Record<string, any>).score).toBe(88);
+  });
+
+  it('should expose x_opencti_score on Event', () => {
+    const stix = convertStoreToStix_2_1({ ...EVENT_INSTANCE, x_opencti_score: 33 } as any) as StixEvent;
+    expect((stix.extensions[STIX_EXT_OCTI] as Record<string, any>).score).toBe(33);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/playbook-utils-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/modules/playbook/playbook-utils-test.ts
@@ -6,6 +6,7 @@ import {
   isBundleElementMatchFilters,
   convertMembersToUsersFromElements,
   MINIMAL_COMPATIBLE_SCOPE_VERSION,
+  buildPlaybookEventContext,
   updateImportedPlaybookDefinitionScope,
 } from '../../../../src/modules/playbook/playbook-utils';
 import { testContext } from '../../../utils/testQuery';
@@ -16,6 +17,8 @@ import { convertMembersToUsers, extractBundleBaseElement } from '../../../../src
 import type { StixBundle, StixDomainObject } from '../../../../src/types/stix-2-1-common';
 import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../../src/modules/organization/organization-types';
 import { STIX_EXT_OCTI } from '../../../../src/types/stix-2-1-extensions';
+import { PLAYBOOK_MATCHING_COMPONENT } from '../../../../src/modules/playbook/playbook-components';
+import { StreamDataEventTypeEnum } from '../../../../src/manager/playbookManager/playbookManagerUtils';
 
 describe('Playbook utils unit tests', () => {
   const matchingFilter = JSON.stringify({
@@ -276,6 +279,98 @@ describe('Playbook utils unit tests', () => {
         spec_version: '2.1',
         type: 'malware',
       });
+    });
+  });
+
+  describe('Function: buildPlaybookEventContext()', () => {
+    it('should return changed attributes on update event', () => {
+      const event = {
+        type: StreamDataEventTypeEnum.UPDATE,
+        context: {
+          changes: [
+            { field: 'Malware--x_opencti_score' },
+            { field: 'Malware--name' },
+            { field: 'Malware--x_opencti_score' },
+          ],
+        },
+      } as any;
+
+      const result = buildPlaybookEventContext(event);
+      expect(result).toEqual({ changedAttributes: ['x_opencti_score', 'name'] });
+    });
+
+    it('should return creation context on create event', () => {
+      const event = { type: StreamDataEventTypeEnum.CREATE } as any;
+      const result = buildPlaybookEventContext(event);
+      expect(result).toEqual({ changedAttributes: [], isCreation: true });
+    });
+
+    it('should return undefined when event is missing', () => {
+      expect(buildPlaybookEventContext(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('PLAYBOOK_MATCHING_COMPONENT executor', () => {
+    it('should pass update event context to stix filtering in base element mode', async () => {
+      const bundle = {
+        id: 'bundle--match-1',
+        spec_version: '2.1',
+        type: 'bundle',
+        objects: [{ id: 'malware--id-14', spec_version: '2.1', type: 'malware' }],
+      } as unknown as StixBundle;
+
+      await PLAYBOOK_MATCHING_COMPONENT.executor({
+        dataInstanceId: 'malware--id-14',
+        bundle,
+        playbookNode: {
+          id: 'node-1',
+          component_id: PLAYBOOK_MATCHING_COMPONENT.id,
+          name: 'Match knowledge',
+          configuration: {
+            all: false,
+            filters: JSON.stringify({ mode: FilterMode.And, filters: [], filterGroups: [] }),
+          },
+        },
+        event: {
+          type: StreamDataEventTypeEnum.UPDATE,
+          context: { changes: [{ field: 'Malware--x_opencti_score' }] },
+        },
+      } as any);
+
+      const calls = vi.mocked(stixFiltering.isStixMatchFilterGroup).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall?.[4]).toEqual({ changedAttributes: ['x_opencti_score'] });
+    });
+
+    it('should pass creation event context to stix filtering in all-elements mode', async () => {
+      const bundle = {
+        id: 'bundle--match-2',
+        spec_version: '2.1',
+        type: 'bundle',
+        objects: [
+          { id: 'malware--id-14', spec_version: '2.1', type: 'malware' },
+          { id: 'campaign--id-15', spec_version: '2.1', type: 'campaign' },
+        ],
+      } as unknown as StixBundle;
+
+      await PLAYBOOK_MATCHING_COMPONENT.executor({
+        dataInstanceId: 'malware--id-14',
+        bundle,
+        playbookNode: {
+          id: 'node-2',
+          component_id: PLAYBOOK_MATCHING_COMPONENT.id,
+          name: 'Match knowledge',
+          configuration: {
+            all: true,
+            filters: JSON.stringify({ mode: FilterMode.And, filters: [], filterGroups: [] }),
+          },
+        },
+        event: { type: StreamDataEventTypeEnum.CREATE },
+      } as any);
+
+      const calls = vi.mocked(stixFiltering.isStixMatchFilterGroup).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall?.[4]).toEqual({ changedAttributes: [], isCreation: true });
     });
   });
 

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -2,7 +2,6 @@ import { assert, describe, expect, it } from 'vitest';
 import { STIX_EXT_OCTI } from '../../../../../src/types/stix-2-1-extensions';
 import type { StixThreatActor } from '../../../../../src/types/stix-2-1-sdo';
 import { ENTITY_TYPE_THREAT_ACTOR } from '../../../../../src/schema/general';
-import { ENTITY_TYPE_INCIDENT } from '../../../../../src/schema/stixDomainObject';
 import { PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT, type ManipulateConfiguration } from '../../../../../src/modules/playbook/components/manipulate-knowledge-component';
 import { testBundleObject, testExecutor } from './playbook-components-test-utils';
 import type { StixDomainObject } from '../../../../../src/types/stix-2-1-common';
@@ -352,41 +351,6 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect(objectExtensions.opencti_upsert_operations[0].key).toBe('x_opencti_score');
     expect(objectExtensions.opencti_upsert_operations[0].value[0]).toBe('42');
     expect((malwareResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
-  });
-
-  it('should update x_opencti_score on an Incident', async () => {
-    const INCIDENT_ID = 'incident--09bd862a-f030-55f2-920a-900c4913d9aa';
-    const bundleObjects = [testBundleObject<StixDomainObject>({
-      id: INCIDENT_ID,
-      type: ENTITY_TYPE_INCIDENT,
-    })];
-
-    const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
-      mainId: INCIDENT_ID,
-      bundleObjects,
-      configuration: {
-        applyToElements: 'only-main',
-        actions: [{
-          op: 'replace' as const,
-          attribute: 'x_opencti_score',
-          value: [{
-            label: 'Set score to 88',
-            value: '88',
-            patch_value: '88',
-          }],
-        }],
-      },
-    }));
-
-    const updatedIncident = result.bundle.objects.find((o) => o.id === INCIDENT_ID);
-    const objectExtensions = updatedIncident?.extensions[STIX_EXT_OCTI] as Record<string, any>;
-    if (!objectExtensions.opencti_upsert_operations || !objectExtensions.opencti_upsert_operations[0]) {
-      assert.fail('Field patch missing');
-    }
-    expect(objectExtensions.opencti_upsert_operations[0].operation).toBe('replace');
-    expect(objectExtensions.opencti_upsert_operations[0].key).toBe('x_opencti_score');
-    expect(objectExtensions.opencti_upsert_operations[0].value[0]).toBe('88');
-    expect(objectExtensions.score).toBe(88);
   });
 
   describe('Bundle scope', () => {

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -354,6 +354,41 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect((malwareResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
   });
 
+  it('should update x_opencti_score on an Incident', async () => {
+    const INCIDENT_ID = 'incident--09bd862a-f030-55f2-920a-900c4913d9aa';
+    const bundleObjects = [testBundleObject<StixDomainObject>({
+      id: INCIDENT_ID,
+      type: ENTITY_TYPE_INCIDENT,
+    })];
+
+    const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
+      mainId: INCIDENT_ID,
+      bundleObjects,
+      configuration: {
+        applyToElements: 'only-main',
+        actions: [{
+          op: 'replace' as const,
+          attribute: 'x_opencti_score',
+          value: [{
+            label: 'Set score to 88',
+            value: '88',
+            patch_value: '88',
+          }],
+        }],
+      },
+    }));
+
+    const updatedIncident = result.bundle.objects.find((o) => o.id === INCIDENT_ID);
+    const objectExtensions = updatedIncident?.extensions[STIX_EXT_OCTI] as Record<string, any>;
+    if (!objectExtensions.opencti_upsert_operations || !objectExtensions.opencti_upsert_operations[0]) {
+      assert.fail('Field patch missing');
+    }
+    expect(objectExtensions.opencti_upsert_operations[0].operation).toBe('replace');
+    expect(objectExtensions.opencti_upsert_operations[0].key).toBe('x_opencti_score');
+    expect(objectExtensions.opencti_upsert_operations[0].value[0]).toBe('88');
+    expect(objectExtensions.score).toBe(88);
+  });
+
   describe('Bundle scope', () => {
     it('should add label only on main element', async () => {
       const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -314,6 +314,46 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect((organizationResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
   });
 
+  it('should replace score using fallback on stix type when OCTI type is missing', async () => {
+    const fallbackMalwareId = 'malware--09bd862a-f030-55f2-920a-900c4913d9ab';
+    const malware = testBundleObject<StixDomainObject>({
+      id: fallbackMalwareId,
+      type: 'Malware',
+      octiExtension: {
+        type: undefined,
+      },
+    });
+
+    const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
+      mainId: fallbackMalwareId,
+      bundleObjects: [malware],
+      configuration: {
+        applyToElements: 'only-main',
+        actions: [{
+          op: 'replace' as const,
+          attribute: 'x_opencti_score',
+          value: [
+            {
+              label: 'Set score to 42',
+              value: '42',
+              patch_value: '42',
+            },
+          ],
+        }],
+      },
+    }));
+
+    const malwareResult = result.bundle.objects.find((o) => o.id === fallbackMalwareId) as StixDomainObject;
+    const objectExtensions = malwareResult.extensions[STIX_EXT_OCTI];
+    if (!objectExtensions.opencti_upsert_operations || !objectExtensions.opencti_upsert_operations[0]) {
+      assert.fail('Field patch missing');
+    }
+    expect(objectExtensions.opencti_upsert_operations[0].operation).toBe('replace');
+    expect(objectExtensions.opencti_upsert_operations[0].key).toBe('x_opencti_score');
+    expect(objectExtensions.opencti_upsert_operations[0].value[0]).toBe('42');
+    expect((malwareResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
+  });
+
   describe('Bundle scope', () => {
     it('should add label only on main element', async () => {
       const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -2,6 +2,7 @@ import { assert, describe, expect, it } from 'vitest';
 import { STIX_EXT_OCTI } from '../../../../../src/types/stix-2-1-extensions';
 import type { StixThreatActor } from '../../../../../src/types/stix-2-1-sdo';
 import { ENTITY_TYPE_THREAT_ACTOR } from '../../../../../src/schema/general';
+import { ENTITY_TYPE_INCIDENT } from '../../../../../src/schema/stixDomainObject';
 import { PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT, type ManipulateConfiguration } from '../../../../../src/modules/playbook/components/manipulate-knowledge-component';
 import { testBundleObject, testExecutor } from './playbook-components-test-utils';
 import type { StixDomainObject } from '../../../../../src/types/stix-2-1-common';

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -318,7 +318,7 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     const fallbackMalwareId = 'malware--09bd862a-f030-55f2-920a-900c4913d9ab';
     const malware = testBundleObject<StixDomainObject>({
       id: fallbackMalwareId,
-      type: 'Malware',
+      type: 'malware',
       octiExtension: {
         type: undefined,
       },

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -3,6 +3,7 @@ import { STIX_EXT_OCTI } from '../../../../../src/types/stix-2-1-extensions';
 import type { StixThreatActor } from '../../../../../src/types/stix-2-1-sdo';
 import { ENTITY_TYPE_THREAT_ACTOR } from '../../../../../src/schema/general';
 import { ENTITY_TYPE_INCIDENT } from '../../../../../src/schema/stixDomainObject';
+import { ENTITY_TYPE_IDENTITY_ORGANIZATION } from '../../../../../src/modules/organization/organization-types';
 import { PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT, type ManipulateConfiguration } from '../../../../../src/modules/playbook/components/manipulate-knowledge-component';
 import { testBundleObject, testExecutor } from './playbook-components-test-utils';
 import type { StixDomainObject } from '../../../../../src/types/stix-2-1-common';
@@ -276,7 +277,7 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
       id: organizationId,
       type: 'identity',
       octiExtension: {
-        type: 'identity',
+        type: ENTITY_TYPE_IDENTITY_ORGANIZATION,
       },
     });
     (organization as any).identity_class = 'organization';

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -315,14 +315,11 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect((organizationResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
   });
 
-  it('should replace score using fallback on stix type when OCTI type is missing', async () => {
+  it('should replace score on Malware entity by field patch', async () => {
     const fallbackMalwareId = 'malware--09bd862a-f030-55f2-920a-900c4913d9ab';
     const malware = testBundleObject<StixDomainObject>({
       id: fallbackMalwareId,
       type: 'malware',
-      octiExtension: {
-        type: undefined,
-      },
     });
 
     const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -315,43 +315,6 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect((organizationResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
   });
 
-  it('should replace score on Malware entity by field patch', async () => {
-    const fallbackMalwareId = 'malware--09bd862a-f030-55f2-920a-900c4913d9ab';
-    const malware = testBundleObject<StixDomainObject>({
-      id: fallbackMalwareId,
-      type: 'malware',
-    });
-
-    const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
-      mainId: fallbackMalwareId,
-      bundleObjects: [malware],
-      configuration: {
-        applyToElements: 'only-main',
-        actions: [{
-          op: 'replace' as const,
-          attribute: 'x_opencti_score',
-          value: [
-            {
-              label: 'Set score to 42',
-              value: '42',
-              patch_value: '42',
-            },
-          ],
-        }],
-      },
-    }));
-
-    const malwareResult = result.bundle.objects.find((o) => o.id === fallbackMalwareId) as StixDomainObject;
-    const objectExtensions = malwareResult.extensions[STIX_EXT_OCTI];
-    if (!objectExtensions.opencti_upsert_operations || !objectExtensions.opencti_upsert_operations[0]) {
-      assert.fail('Field patch missing');
-    }
-    expect(objectExtensions.opencti_upsert_operations[0].operation).toBe('replace');
-    expect(objectExtensions.opencti_upsert_operations[0].key).toBe('x_opencti_score');
-    expect(objectExtensions.opencti_upsert_operations[0].value[0]).toBe('42');
-    expect((malwareResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
-  });
-
   describe('Bundle scope', () => {
     it('should add label only on main element', async () => {
       const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({

--- a/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/01-database/playbook/playbookComponents/manipulate-knowledge-component-test.ts
@@ -270,6 +270,50 @@ describe('PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT', () => {
     expect(objectExtensions.score).toBe(88);
   });
 
+  it('should replace score on Organization identity by field patch', async () => {
+    const organizationId = 'identity--09bd862a-f030-55f2-920a-900c4913d9fe';
+    const organization = testBundleObject<StixDomainObject>({
+      id: organizationId,
+      type: 'identity',
+      octiExtension: {
+        type: 'identity',
+      },
+    });
+    (organization as any).identity_class = 'organization';
+    const bundleObjects = [organization];
+
+    const configuration: ManipulateConfiguration = {
+      applyToElements: 'only-main',
+      actions: [{
+        op: 'replace' as const,
+        attribute: 'x_opencti_score',
+        value: [
+          {
+            label: 'Set score to 42',
+            value: '42',
+            patch_value: '42',
+          },
+        ],
+      }],
+    };
+
+    const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({
+      mainId: organizationId,
+      bundleObjects,
+      configuration,
+    }));
+
+    const organizationResult = result.bundle.objects.find((o) => o.id === organizationId) as StixDomainObject;
+    const objectExtensions = organizationResult.extensions[STIX_EXT_OCTI];
+    if (!objectExtensions.opencti_upsert_operations || !objectExtensions.opencti_upsert_operations[0]) {
+      assert.fail('Field patch missing');
+    }
+    expect(objectExtensions.opencti_upsert_operations[0].operation).toBe('replace');
+    expect(objectExtensions.opencti_upsert_operations[0].key).toBe('x_opencti_score');
+    expect(objectExtensions.opencti_upsert_operations[0].value[0]).toBe('42');
+    expect((organizationResult.extensions[STIX_EXT_OCTI] as any).score).toBe(42);
+  });
+
   describe('Bundle scope', () => {
     it('should add label only on main element', async () => {
       const result = await PLAYBOOK_MANIPULATE_KNOWLEDGE_COMPONENT.executor(testExecutor({


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* manipulate knowledge works with "score has changed" for Threat actor group, malware, intrusion set

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17752 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
- reproduce this playbook:
https://testing.octi.staging.filigran.io/dashboard/data/processing/automation/22b437ca-853c-41b7-a766-b61712876296
- run your worker
- Update an organization/malware/TA group or IS
- Add label doesn't work on update actions on this entities

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
