### PR TITLE
fix(filters): disable client filtering in object members field (#15082)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
@@ -2,6 +2,7 @@ import { graphql } from 'react-relay';
 import makeStyles from '@mui/styles/makeStyles';
 import React, { FunctionComponent, useState } from 'react';
 import { Field } from 'formik';
+import { createFilterOptions } from '@mui/material/Autocomplete';
 import type { Theme } from '../../../../components/Theme';
 import { fetchQuery } from '../../../../relay/environment';
 import { useFormatter } from '../../../../components/i18n';
@@ -47,6 +48,9 @@ export interface OptionMember extends FieldOption {
 }
 
 type MemberType = 'Group' | 'Organization' | 'User';
+
+// Filter on the full label: AutocompleteField's default getOptionLabel truncates it, which broke matching on long names
+const filterOptions = createFilterOptions<OptionMember>({ stringify: (option) => option.label });
 
 interface ObjectMembersFieldProps {
   name: string;
@@ -155,6 +159,7 @@ const ObjectMembersField: FunctionComponent<ObjectMembersFieldProps> = ({
         style={style}
         noOptionsText={t_i18n('No available options')}
         options={members}
+        filterOptions={filterOptions}
         groupBy={(option: OptionMember) => option.type}
         onInputChange={searchMembers}
         renderOption={(

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
@@ -155,6 +155,7 @@ const ObjectMembersField: FunctionComponent<ObjectMembersFieldProps> = ({
         style={style}
         noOptionsText={t_i18n('No available options')}
         options={members}
+        filterOptions={(options) => options}
         groupBy={(option: OptionMember) => option.type}
         onInputChange={searchMembers}
         renderOption={(

--- a/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/form/ObjectMembersField.tsx
@@ -127,7 +127,7 @@ const ObjectMembersField: FunctionComponent<ObjectMembersFieldProps> = ({
           value: n?.node.id,
           type: n?.node.entity_type,
         })).sort((a, b) => (b.type ? -b.type.localeCompare(a.type) : 0));
-        const templateValues = [...members, ...NewMembers];
+        const templateValues = [...dynamicMembers, ...NewMembers];
         // Keep only the unique list of options
         const uniqTemplates = templateValues.filter((item, index) => {
           return (
@@ -155,7 +155,6 @@ const ObjectMembersField: FunctionComponent<ObjectMembersFieldProps> = ({
         style={style}
         noOptionsText={t_i18n('No available options')}
         options={members}
-        filterOptions={(options) => options}
         groupBy={(option: OptionMember) => option.type}
         onInputChange={searchMembers}
         renderOption={(


### PR DESCRIPTION
### Proposed changes

- Restored client-side filtering in `ObjectMembersField` using `createFilterOptions` with a custom `stringify` that matches against the **full** member label, instead of relying on `AutocompleteField`'s default `getOptionLabel`, which truncates labels to 40 characters before MUI's filtering runs. This was the root cause: valid backend results were discarded client-side whenever the matching text fell outside the first 40 characters.
- Filtering therefore stays enabled (not disabled like the initial approach) — it now simply matches against the untruncated label, so short-name filtering behavior (e.g. dynamic options like "Author", "Creators") is preserved while long names are no longer wrongly hidden.
- Kept the `[...dynamicMembers, ...NewMembers]` merge (instead of `[...members, ...NewMembers]`) so the options list stays aligned with the latest backend response instead of accumulating stale entries from every previous keystroke's search.
- Display is unaffected: `renderOption` already used the untruncated `option.label`, only the filtering logic was broken.

### Related issues

- closes #15082

### How to test this PR

1. Create (or use) a User, Group, or Organization with a name longer than 40 characters, with a space before the distinguishing part (e.g. `"Something TOTO"`).
2. Go to Data → Data sharing → Live Streams (or TAXII collections / CSV feeds).
3. Edit an existing item and open the "Accessible for" field.
4. Type a substring located after the first 40 characters (e.g. `TOTO`).
5. Verify the entity is shown in the dropdown and can be selected.

Note: substrings in the middle of a single unbroken word (no spaces) still won't match — that's an Elasticsearch tokenization limitation, unrelated to this fix and out of scope for #15082.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality