### PR TITLE
fix(ui): in light mode, there is no header in drawers (#17236)

### DIFF
--- a/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
+++ b/opencti-platform/opencti-front/src/components/common/drawer/DrawerHeader.tsx
@@ -17,7 +17,7 @@ const DrawerHeader = ({ title, onClose, endContent }: DrawerHeaderProps) => {
     <Stack
       direction="row"
       sx={{
-        backgroundColor: theme.palette.background.secondary,
+        backgroundColor: theme.palette.mode === 'light' ? theme.palette.background.default : theme.palette.background.nav,
         paddingX: 3,
         paddingY: 2,
         alignItems: 'center',


### PR DESCRIPTION
### Proposed changes

* Add a ternary to check if theme light or dark and apply the correct style

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes: https://github.com/OpenCTI-Platform/opencti/issues/17236

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
