### PR TITLE
feat(ingestion): add stream feed logs (#17531)

### DIFF
--- a/opencti-platform/opencti-front/lang/back/de.json
+++ b/opencti-platform/opencti-front/lang/back/de.json
@@ -188,7 +188,6 @@
   "Current State": "Aktueller Stand",
   "Current state cursor": "Aktueller Status Cursor",
   "Current state date": "Aktuelles Statusdatum",
-  "Current stated date": "Aktuell angegebenes Datum",
   "Current_state_hash": "Aktueller_Zustand_Hash",
   "Custom field values": "Werte für benutzerdefinierte Felder",
   "CVSS2 Access Complexity (AC)": "CVSS2 Zugriffskomplexität (AC)",

--- a/opencti-platform/opencti-front/lang/back/en.json
+++ b/opencti-platform/opencti-front/lang/back/en.json
@@ -188,7 +188,6 @@
   "Current State": "Current State",
   "Current state cursor": "Current state cursor",
   "Current state date": "Current state date",
-  "Current stated date": "Current stated date",
   "Current_state_hash": "Current_state_hash",
   "Custom field values": "Custom field values",
   "CVSS2 Access Complexity (AC)": "CVSS2 Access Complexity (AC)",

--- a/opencti-platform/opencti-front/lang/back/es.json
+++ b/opencti-platform/opencti-front/lang/back/es.json
@@ -188,7 +188,6 @@
   "Current State": "Estado actual",
   "Current state cursor": "Cursor de estado actual",
   "Current state date": "Fecha de estado actual",
-  "Current stated date": "Fecha actual",
   "Current_state_hash": "Estado_actual",
   "Custom field values": "Valores de campos personalizados",
   "CVSS2 Access Complexity (AC)": "Complejidad de acceso CVSS2 (AC)",

--- a/opencti-platform/opencti-front/lang/back/fr.json
+++ b/opencti-platform/opencti-front/lang/back/fr.json
@@ -188,7 +188,6 @@
   "Current State": "État actuel",
   "Current state cursor": "Curseur d'état actuel",
   "Current state date": "Date de l'état actuel",
-  "Current stated date": "Current stated date",
   "Current_state_hash": "État actuel",
   "Custom field values": "Valeurs des champs personnalisés",
   "CVSS2 Access Complexity (AC)": "Complexité d'accès CVSS2 (AC)",

--- a/opencti-platform/opencti-front/lang/back/it.json
+++ b/opencti-platform/opencti-front/lang/back/it.json
@@ -188,7 +188,6 @@
   "Current State": "Stato attuale",
   "Current state cursor": "Cursore dello stato corrente",
   "Current state date": "Data dello stato corrente",
-  "Current stated date": "Data dichiarata corrente",
   "Current_state_hash": "Hash dello stato corrente",
   "Custom field values": "Valori dei campi personalizzati",
   "CVSS2 Access Complexity (AC)": "Complessità di accesso CVSS2 (AC)",

--- a/opencti-platform/opencti-front/lang/back/ja.json
+++ b/opencti-platform/opencti-front/lang/back/ja.json
@@ -188,7 +188,6 @@
   "Current State": "現在の状態",
   "Current state cursor": "ヘッダー",
   "Current state date": "摂取実行",
-  "Current stated date": "現在の記載日",
   "Current_state_hash": "現在の状態_ハッシュ",
   "Custom field values": "カスタムフィールドの値",
   "CVSS2 Access Complexity (AC)": "CVSS2 アクセス複雑度 (AC)",

--- a/opencti-platform/opencti-front/lang/back/ko.json
+++ b/opencti-platform/opencti-front/lang/back/ko.json
@@ -188,7 +188,6 @@
   "Current State": "현재 상태",
   "Current state cursor": "현재 상태 커서",
   "Current state date": "현재 상태 날짜",
-  "Current stated date": "현재 명시된 날짜",
   "Current_state_hash": "현재 상태 해시",
   "Custom field values": "사용자 정의 필드 값",
   "CVSS2 Access Complexity (AC)": "CVSS2 액세스 복잡성(AC)",

--- a/opencti-platform/opencti-front/lang/back/ru.json
+++ b/opencti-platform/opencti-front/lang/back/ru.json
@@ -188,7 +188,6 @@
   "Current State": "Текущее состояние",
   "Current state cursor": "Курсор текущего состояния",
   "Current state date": "Текущая дата состояния",
-  "Current stated date": "Текущая заявленная дата",
   "Current_state_hash": "Текущее_состояние_хэша",
   "Custom field values": "Значения пользовательских полей",
   "CVSS2 Access Complexity (AC)": "CVSS2 Access Complexity (AC)",

--- a/opencti-platform/opencti-front/lang/back/zh.json
+++ b/opencti-platform/opencti-front/lang/back/zh.json
@@ -188,7 +188,6 @@
   "Current State": "当前状态",
   "Current state cursor": "当前状态游标",
   "Current state date": "当前状态日期",
-  "Current stated date": "当前状态日期",
   "Current_state_hash": "当前状态哈希值",
   "Custom field values": "自定义字段值",
   "CVSS2 Access Complexity (AC)": "CVSS2 访问复杂性 (AC)",

--- a/opencti-platform/opencti-front/lang/front/de.json
+++ b/opencti-platform/opencti-front/lang/front/de.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "Agenten werden geladen...",
   "Loading current message count...": "Laden der aktuellen Nachrichtenanzahl...",
   "Loading image…": "Bild wird geladen…",
+  "Loading synchronizer logs...": "Synchronizer-Protokolle werden geladen...",
   "Local": "Lokal",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "Die lokale Authentifizierung kann nicht geändert werden, wenn die Authentifizierung über die Umgebungskonfiguration verwaltet wird",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "Die lokale Authentifizierung kann nicht deaktiviert werden, wenn kein anderer Authentifizierungsanbieter aktiviert ist",

--- a/opencti-platform/opencti-front/lang/front/en.json
+++ b/opencti-platform/opencti-front/lang/front/en.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "Loading agents...",
   "Loading current message count...": "Loading current message count...",
   "Loading image…": "Loading image…",
+  "Loading synchronizer logs...": "Loading synchronizer logs...",
   "Local": "Local",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "Local authentication cannot be changed when authentication is managed by environment configuration",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "Local authentication cannot be disabled when no other authentication provider is enabled",

--- a/opencti-platform/opencti-front/lang/front/es.json
+++ b/opencti-platform/opencti-front/lang/front/es.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "Cargando agentes...",
   "Loading current message count...": "Cargando recuento de mensajes actual...",
   "Loading image…": "Cargando imagen…",
+  "Loading synchronizer logs...": "Cargando registros del sincronizador...",
   "Local": "Local",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "La autenticación local no se puede cambiar cuando la autenticación se gestiona mediante la configuración del entorno",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "La autenticación local no se puede deshabilitar cuando no hay otro proveedor de autenticación habilitado",

--- a/opencti-platform/opencti-front/lang/front/fr.json
+++ b/opencti-platform/opencti-front/lang/front/fr.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "Chargement des agents...",
   "Loading current message count...": "Chargement du nombre de messages en cours...",
   "Loading image…": "Chargement de l’image…",
+  "Loading synchronizer logs...": "Chargement des logs du synchroniseur...",
   "Local": "Local",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "L'authentification locale ne peut pas être modifiée lorsque l'authentification est gérée par la configuration de l'environnement",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "L'authentification locale ne peut pas être désactivée lorsqu'aucun autre fournisseur d'authentification n'est activé",

--- a/opencti-platform/opencti-front/lang/front/it.json
+++ b/opencti-platform/opencti-front/lang/front/it.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "Caricamento agenti in corso...",
   "Loading current message count...": "Caricamento del numero di messaggi attuali...",
   "Loading image…": "Caricamento immagine in corso…",
+  "Loading synchronizer logs...": "Caricamento dei log del sincronizzatore in corso...",
   "Local": "Locale",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "L'autenticazione locale non può essere modificata quando l'autenticazione è gestita dalla configurazione dell'ambiente",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "L'autenticazione locale non può essere disabilitata se nessun altro provider di autenticazione è abilitato",

--- a/opencti-platform/opencti-front/lang/front/ja.json
+++ b/opencti-platform/opencti-front/lang/front/ja.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "エージェントを読み込み中...",
   "Loading current message count...": "現在のメッセージ数をロード中...",
   "Loading image…": "画像を読み込み中…",
+  "Loading synchronizer logs...": "シンクロナイザーログを読み込み中...",
   "Local": "ローカル",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "認証が環境設定で管理されている場合、ローカル認証は変更できない",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "他の認証プロバイダーが有効になっていない場合、ローカル認証を無効にすることはできません",

--- a/opencti-platform/opencti-front/lang/front/ko.json
+++ b/opencti-platform/opencti-front/lang/front/ko.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "에이전트를 불러오는 중...",
   "Loading current message count...": "현재 메시지 수 로드 중...",
   "Loading image…": "이미지 불러오는 중…",
+  "Loading synchronizer logs...": "동기화 로그를 불러오는 중...",
   "Local": "로컬",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "환경 구성으로 인증이 관리되는 경우 로컬 인증을 변경할 수 없습니다",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "다른 인증 공급자가 활성화되어 있지 않으면 로컬 인증을 비활성화할 수 없습니다",

--- a/opencti-platform/opencti-front/lang/front/ru.json
+++ b/opencti-platform/opencti-front/lang/front/ru.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "Загрузка агентов...",
   "Loading current message count...": "Загрузка текущего количества сообщений...",
   "Loading image…": "Загрузка изображения…",
+  "Loading synchronizer logs...": "Загрузка журналов синхронизатора...",
   "Local": "Локальный",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "Локальная аутентификация не может быть изменена, если аутентификация управляется конфигурацией среды",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "Локальная аутентификация не может быть отключена, если не включен другой провайдер аутентификации",

--- a/opencti-platform/opencti-front/lang/front/zh.json
+++ b/opencti-platform/opencti-front/lang/front/zh.json
@@ -2874,6 +2874,7 @@
   "Loading agents...": "正在加载代理...",
   "Loading current message count...": "正在加载当前信息数...",
   "Loading image…": "正在加载图片……",
+  "Loading synchronizer logs...": "正在加载同步器日志...",
   "Local": "本地",
   "Local authentication cannot be changed when authentication is managed by environment configuration": "当身份验证由环境配置管理时，不能更改本地身份验证",
   "Local authentication cannot be disabled when no other authentication provider is enabled": "当未启用其他身份验证提供程序时，无法禁用本地身份验证",

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncLogsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncLogsTab.tsx
@@ -1,0 +1,93 @@
+import React, { Suspense, useEffect, useState } from 'react';
+import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { RefreshOutlined } from '@mui/icons-material';
+import { useFormatter } from '../../../../components/i18n';
+import type { SyncLogsTabQuery } from './__generated__/SyncLogsTabQuery.graphql';
+import IngestionLogTab from '../IngestionLogTab';
+
+export const syncLogsTabQuery = graphql`
+  query SyncLogsTabQuery($id: String!) {
+    synchronizerLogs(id: $id) {
+      timestamp
+      level
+      type
+      identifier
+      message
+      meta
+    }
+  }
+`;
+
+interface SyncLogsTabProps {
+  feedId: string;
+  feedName: string;
+}
+
+const SyncLogsTabBody: React.FC<{
+  queryRef: PreloadedQuery<SyncLogsTabQuery>;
+  feedName: string;
+}> = ({ queryRef, feedName }) => {
+  const data = usePreloadedQuery(syncLogsTabQuery, queryRef);
+  const logs = (data?.synchronizerLogs ?? []).filter((e): e is NonNullable<typeof e> => e != null);
+  return <IngestionLogTab name={feedName} logHistory={logs} />;
+};
+
+const SyncLogsTab: React.FC<SyncLogsTabProps> = ({ feedId, feedName }) => {
+  const { t_i18n } = useFormatter();
+  const [queryRef, loadQuery] = useQueryLoader<SyncLogsTabQuery>(syncLogsTabQuery);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    loadQuery({ id: feedId }, { fetchPolicy: 'network-only' });
+  }, [feedId, loadQuery]);
+
+  useEffect(() => {
+    setRefreshing(false);
+  }, [queryRef]);
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    loadQuery({ id: feedId }, { fetchPolicy: 'network-only' });
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="flex-end" sx={{ mb: 1 }}>
+        <Tooltip title={t_i18n('Refresh')}>
+          <span>
+            <IconButton
+              size="small"
+              onClick={handleRefresh}
+              disabled={refreshing || !queryRef}
+              aria-label={t_i18n('Refresh')}
+            >
+              <RefreshOutlined fontSize="small" sx={{ opacity: refreshing ? 0.6 : 1 }} />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Stack>
+      {queryRef ? (
+        <Suspense
+          fallback={(
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={32} />
+            </Box>
+          )}
+        >
+          <SyncLogsTabBody queryRef={queryRef} feedName={feedName} />
+        </Suspense>
+      ) : (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={32} />
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default SyncLogsTab;

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncLogsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncLogsTab.tsx
@@ -74,7 +74,7 @@ const SyncLogsTab: React.FC<SyncLogsTabProps> = ({ feedId, feedName }) => {
         <Suspense
           fallback={(
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <Spinner size="xl" label={t_i18n('Loading')} />
+              <Spinner size="xl" label={t_i18n('Loading synchronizer logs...')} />
             </Box>
           )}
         >
@@ -82,7 +82,7 @@ const SyncLogsTab: React.FC<SyncLogsTabProps> = ({ feedId, feedName }) => {
         </Suspense>
       ) : (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-          <Spinner size="xl" label={t_i18n('Loading')} />
+          <Spinner size="xl" label={t_i18n('Loading synchronizer logs...')} />
         </Box>
       )}
     </Box>

--- a/opencti-platform/opencti-front/src/private/components/data/sync/SyncLogsTab.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/sync/SyncLogsTab.tsx
@@ -2,9 +2,7 @@ import React, { Suspense, useEffect, useState } from 'react';
 import { graphql, PreloadedQuery, usePreloadedQuery, useQueryLoader } from 'react-relay';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
-import CircularProgress from '@mui/material/CircularProgress';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
+import { IconButton, Spinner, Tooltip, TooltipContent, TooltipTrigger } from '@filigran/design-system';
 import { RefreshOutlined } from '@mui/icons-material';
 import { useFormatter } from '../../../../components/i18n';
 import type { SyncLogsTabQuery } from './__generated__/SyncLogsTabQuery.graphql';
@@ -58,24 +56,25 @@ const SyncLogsTab: React.FC<SyncLogsTabProps> = ({ feedId, feedName }) => {
   return (
     <Box>
       <Stack direction="row" justifyContent="flex-end" sx={{ mb: 1 }}>
-        <Tooltip title={t_i18n('Refresh')}>
-          <span>
+        <Tooltip>
+          <TooltipTrigger asChild>
             <IconButton
-              size="small"
+              size="sm"
+              priority="tertiary"
               onClick={handleRefresh}
               disabled={refreshing || !queryRef}
               aria-label={t_i18n('Refresh')}
-            >
-              <RefreshOutlined fontSize="small" sx={{ opacity: refreshing ? 0.6 : 1 }} />
-            </IconButton>
-          </span>
+              icon={<RefreshOutlined fontSize="small" sx={{ opacity: refreshing ? 0.6 : 1 }} aria-hidden />}
+            />
+          </TooltipTrigger>
+          <TooltipContent>{t_i18n('Refresh')}</TooltipContent>
         </Tooltip>
       </Stack>
       {queryRef ? (
         <Suspense
           fallback={(
             <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-              <CircularProgress size={32} />
+              <Spinner size="xl" label={t_i18n('Loading')} />
             </Box>
           )}
         >
@@ -83,7 +82,7 @@ const SyncLogsTab: React.FC<SyncLogsTabProps> = ({ feedId, feedName }) => {
         </Suspense>
       ) : (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-          <CircularProgress size={32} />
+          <Spinner size="xl" label={t_i18n('Loading')} />
         </Box>
       )}
     </Box>

--- a/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
+++ b/opencti-platform/opencti-front/src/private/components/integrations/feeds/FeedDetail.tsx
@@ -18,6 +18,7 @@ import { BuiltInIntegrationKind, getBuiltInIntegration, isBuiltInIntegrationKind
 import IngestionTaxiiLogsTab from '@components/data/ingestionTaxii/IngestionTaxiiLogsTab';
 import IngestionCsvLogsTab from '@components/data/ingestionCsv/IngestionCsvLogsTab';
 import IngestionJsonLogsTab from '@components/data/ingestionJson/IngestionJsonLogsTab';
+import SyncLogsTab from '@components/data/sync/SyncLogsTab';
 import { ConnectorWorksSection } from '@components/data/connectors/Connector';
 import { connectorIdFromIngestId } from '@components/integrations/deployed/useDeployedIntegrations';
 import useHelper from '../../../../utils/hooks/useHelper';
@@ -46,6 +47,7 @@ const feedDetailSyncQuery = graphql`
       stream_id
       running
       current_state_date
+      last_execution_status
       listen_deletion
       no_dependencies
       ssl_verify
@@ -199,6 +201,7 @@ export interface FeedDetailNode {
   queue_messages?: number | null;
   added_after_start?: string | null;
   current_state_date?: string | null;
+  last_execution_status?: string | null;
   current_state_cursor?: string | null;
   current_state_hash?: string | null;
   last_execution_date?: string | null;
@@ -289,9 +292,11 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
   const { setTitle } = useConnectedDocumentModifier();
   const { isFeatureEnable } = useHelper();
   const definition = getBuiltInIntegration(kind);
-  // Only TAXII, CSV, RSS and JSON feeds get the Overview / Works / Logs tabs,
-  // mirroring the connector detail page. Other feed kinds keep single-page layout.
-  const hasTabs = kind === 'taxii' || kind === 'csv' || kind === 'rss' || kind === 'json';
+  // TAXII, CSV, RSS, JSON and stream feeds get tabs. Stream feeds don't expose
+  // works, so they only display Overview + Logs.
+  const hasTabs = kind === 'taxii' || kind === 'csv' || kind === 'rss' || kind === 'json' || kind === 'sync';
+  const hasWorksTab = hasTabs && kind !== 'sync';
+  const logsTabIndex = hasWorksTab ? 2 : 1;
   const [tabValue, setTabValue] = useState(0);
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
@@ -425,7 +430,7 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tabs value={tabValue} onChange={handleTabChange}>
             <Tab label={t_i18n('Overview')} />
-            <Tab label={t_i18n('Works')} disabled={!isConnectorReader} />
+            {hasWorksTab && <Tab label={t_i18n('Works')} disabled={!isConnectorReader} />}
             {isIngestionFeedLogsEnabled && <Tab label={t_i18n('Logs')} />}
           </Tabs>
         </Box>
@@ -572,13 +577,14 @@ const FeedDetailContent = ({ kind, queryRef }: FeedDetailContentProps) => {
           completed), exactly like the connector detail pages. Synchronizers
           consume streams directly and never register works. For tabbed feeds
           this now lives in its own "Works" tab instead of the single page. */}
-      {isConnectorReader && kind !== 'sync' && (!hasTabs || tabValue === 1) && (
+      {isConnectorReader && hasWorksTab && (!hasTabs || tabValue === 1) && (
         <ConnectorWorksSection connectorId={connectorIdFromIngestId(node.id)} />
       )}
 
-      {/* "Logs" tab content for TAXII, CSV, RSS and JSON feeds. */}
-      {isIngestionFeedLogsEnabled && hasTabs && tabValue === 2 && (
+      {/* "Logs" tab content for TAXII, CSV, RSS, JSON and stream feeds. */}
+      {isIngestionFeedLogsEnabled && hasTabs && tabValue === logsTabIndex && (
         <>
+          {kind === 'sync' && <SyncLogsTab feedId={node.id} feedName={node.name} />}
           {kind === 'taxii' && <IngestionTaxiiLogsTab feedId={node.id} feedName={node.name} />}
           {kind === 'csv' && <IngestionCsvLogsTab feedId={node.id} feedName={node.name} />}
           {kind === 'rss' && <IngestionRssLogsTab feedId={node.id} feedName={node.name} />}

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -713,6 +713,9 @@ type Synchronizer {
   user: Creator
   running: Boolean!
   current_state_date: DateTime
+  last_execution_date: DateTime
+  last_execution_status: String
+  ingestionLogs: [IngestionEntry]
   listen_deletion: Boolean!
   no_dependencies: Boolean!
   ssl_verify: Boolean
@@ -9305,6 +9308,7 @@ type Query {
   rules: [Rule]
   ruleManagerInfo: RuleManager
   synchronizer(id: String!): Synchronizer
+  synchronizerLogs(id: String!): [IngestionEntry]
   synchronizerAddInputFromImport(file: Upload!): SynchronizerAddInputFromImport!
   synchronizers(first: Int, after: ID, orderBy: SynchronizersOrdering, orderMode: OrderingMode, search: String): SynchronizerConnection
   synchronizerFetch(input: SynchronizerFetchInput): [RemoteStreamCollection]

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -5580,6 +5580,7 @@ enum ThreatActorsOrdering {
   updated_at
   x_opencti_workflow_id
   confidence
+  x_opencti_score
   sophistication
   resource_level
   _score
@@ -5690,6 +5691,7 @@ type ThreatActorGroup implements BasicObject & StixObject & StixCoreObject & Sti
   metrics: [Metric]
   representative: Representative!
   x_opencti_stix_ids: [StixId]
+  x_opencti_score: Int
   is_inferred: Boolean!
   spec_version: String!
   created_at: DateTime!

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -5580,7 +5580,6 @@ enum ThreatActorsOrdering {
   updated_at
   x_opencti_workflow_id
   confidence
-  x_opencti_score
   sophistication
   resource_level
   _score
@@ -5691,7 +5690,6 @@ type ThreatActorGroup implements BasicObject & StixObject & StixCoreObject & Sti
   metrics: [Metric]
   representative: Representative!
   x_opencti_stix_ids: [StixId]
-  x_opencti_score: Int
   is_inferred: Boolean!
   spec_version: String!
   created_at: DateTime!

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -669,6 +669,9 @@ type Synchronizer {
   user: Creator
   running: Boolean!
   current_state_date: DateTime
+  last_execution_date: DateTime
+  last_execution_status: String
+  ingestionLogs: [IngestionEntry] @ff(flags: ["INGESTION_FEED_LOGS"])
   listen_deletion: Boolean!
   no_dependencies: Boolean!
   ssl_verify: Boolean
@@ -14682,6 +14685,7 @@ type Query {
   rules: [Rule] @auth(for: [KNOWLEDGE, SETTINGS_SETCUSTOMIZATION])
   ruleManagerInfo: RuleManager @auth(for: [SETTINGS_SETCUSTOMIZATION])
   synchronizer(id: String!): Synchronizer @auth(for: [INGESTION])
+  synchronizerLogs(id: String!): [IngestionEntry] @auth(for: [INGESTION]) @ff(flags: ["INGESTION_FEED_LOGS"])
   synchronizerAddInputFromImport(file: Upload!): SynchronizerAddInputFromImport! @auth(for: [CONNECTORAPI])
 
   synchronizers(

--- a/opencti-platform/opencti-graphql/src/domain/connector.ts
+++ b/opencti-platform/opencti-graphql/src/domain/connector.ts
@@ -544,7 +544,14 @@ export const unregisterConnectorForIngestion = async (context: AuthContext, id: 
   await connectorDelete(context, SYSTEM_USER, connectorId);
 };
 
-export const patchSync = async (context: AuthContext, user: AuthUser, id: string, patch: { running: boolean }) => {
+type SynchronizerPatch = {
+  running?: boolean;
+  current_state_date?: Date | string;
+  last_execution_date?: Date | string;
+  last_execution_status?: string;
+};
+
+export const patchSync = async (context: AuthContext, user: AuthUser, id: string, patch: SynchronizerPatch) => {
   const patched = await patchAttribute(context, user, id, ENTITY_TYPE_SYNC, patch);
   return patched.element;
 };

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15998,7 +15998,6 @@ export type Malware = BasicObject & StixCoreObject & StixDomainObject & StixObje
   x_opencti_graph_data?: Maybe<Scalars['String']['output']>;
   x_opencti_inferences?: Maybe<Array<Maybe<Inference>>>;
   x_opencti_modified_at?: Maybe<Scalars['DateTime']['output']>;
-  x_opencti_score?: Maybe<Scalars['Int']['output']>;
   x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
 };
 
@@ -16198,7 +16197,6 @@ export type MalwareAddInput = {
   update?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   x_opencti_modified_at?: InputMaybe<Scalars['DateTime']['input']>;
-  x_opencti_score?: InputMaybe<Scalars['Int']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
   x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -16571,7 +16569,6 @@ export enum MalwaresOrdering {
   ObjectLabel = 'objectLabel',
   ObjectMarking = 'objectMarking',
   UpdatedAt = 'updated_at',
-  XOpenctiScore = 'x_opencti_score',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
@@ -47575,7 +47572,6 @@ export type MalwareResolvers<ContextType = any, ParentType extends ResolversPare
   x_opencti_graph_data?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
   x_opencti_modified_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  x_opencti_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -15998,6 +15998,7 @@ export type Malware = BasicObject & StixCoreObject & StixDomainObject & StixObje
   x_opencti_graph_data?: Maybe<Scalars['String']['output']>;
   x_opencti_inferences?: Maybe<Array<Maybe<Inference>>>;
   x_opencti_modified_at?: Maybe<Scalars['DateTime']['output']>;
+  x_opencti_score?: Maybe<Scalars['Int']['output']>;
   x_opencti_stix_ids?: Maybe<Array<Maybe<Scalars['StixId']['output']>>>;
 };
 
@@ -16197,6 +16198,7 @@ export type MalwareAddInput = {
   update?: InputMaybe<Scalars['Boolean']['input']>;
   upsertOperations?: InputMaybe<Array<EditInput>>;
   x_opencti_modified_at?: InputMaybe<Scalars['DateTime']['input']>;
+  x_opencti_score?: InputMaybe<Scalars['Int']['input']>;
   x_opencti_stix_ids?: InputMaybe<Array<InputMaybe<Scalars['StixId']['input']>>>;
   x_opencti_workflow_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -16569,6 +16571,7 @@ export enum MalwaresOrdering {
   ObjectLabel = 'objectLabel',
   ObjectMarking = 'objectMarking',
   UpdatedAt = 'updated_at',
+  XOpenctiScore = 'x_opencti_score',
   XOpenctiWorkflowId = 'x_opencti_workflow_id'
 }
 
@@ -47572,6 +47575,7 @@ export type MalwareResolvers<ContextType = any, ParentType extends ResolversPare
   x_opencti_graph_data?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   x_opencti_inferences?: Resolver<Maybe<Array<Maybe<ResolversTypes['Inference']>>>, ParentType, ContextType>;
   x_opencti_modified_at?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  x_opencti_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   x_opencti_stix_ids?: Resolver<Maybe<Array<Maybe<ResolversTypes['StixId']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -25048,6 +25048,7 @@ export type Query = {
   synchronizer?: Maybe<Synchronizer>;
   synchronizerAddInputFromImport: SynchronizerAddInputFromImport;
   synchronizerFetch?: Maybe<Array<Maybe<RemoteStreamCollection>>>;
+  synchronizerLogs?: Maybe<Array<Maybe<IngestionEntry>>>;
   synchronizers?: Maybe<SynchronizerConnection>;
   system?: Maybe<System>;
   systemMembers?: Maybe<MemberConnection>;
@@ -27996,6 +27997,11 @@ export type QuerySynchronizerAddInputFromImportArgs = {
 
 export type QuerySynchronizerFetchArgs = {
   input?: InputMaybe<SynchronizerFetchInput>;
+};
+
+
+export type QuerySynchronizerLogsArgs = {
+  id: Scalars['String']['input'];
 };
 
 
@@ -33761,6 +33767,9 @@ export type Synchronizer = {
   consumer_metrics?: Maybe<StreamCollectionConsumer>;
   current_state_date?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['ID']['output'];
+  ingestionLogs?: Maybe<Array<Maybe<IngestionEntry>>>;
+  last_execution_date?: Maybe<Scalars['DateTime']['output']>;
+  last_execution_status?: Maybe<Scalars['String']['output']>;
   listen_deletion: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   no_dependencies: Scalars['Boolean']['output'];
@@ -50331,6 +50340,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   synchronizer?: Resolver<Maybe<ResolversTypes['Synchronizer']>, ParentType, ContextType, RequireFields<QuerySynchronizerArgs, 'id'>>;
   synchronizerAddInputFromImport?: Resolver<ResolversTypes['SynchronizerAddInputFromImport'], ParentType, ContextType, RequireFields<QuerySynchronizerAddInputFromImportArgs, 'file'>>;
   synchronizerFetch?: Resolver<Maybe<Array<Maybe<ResolversTypes['RemoteStreamCollection']>>>, ParentType, ContextType, Partial<QuerySynchronizerFetchArgs>>;
+  synchronizerLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['IngestionEntry']>>>, ParentType, ContextType, RequireFields<QuerySynchronizerLogsArgs, 'id'>>;
   synchronizers?: Resolver<Maybe<ResolversTypes['SynchronizerConnection']>, ParentType, ContextType, Partial<QuerySynchronizersArgs>>;
   system?: Resolver<Maybe<ResolversTypes['System']>, ParentType, ContextType, Partial<QuerySystemArgs>>;
   systemMembers?: Resolver<Maybe<ResolversTypes['MemberConnection']>, ParentType, ContextType>;
@@ -52252,6 +52262,9 @@ export type SynchronizerResolvers<ContextType = any, ParentType extends Resolver
   consumer_metrics?: Resolver<Maybe<ResolversTypes['StreamCollectionConsumer']>, ParentType, ContextType>;
   current_state_date?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  ingestionLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['IngestionEntry']>>>, ParentType, ContextType>;
+  last_execution_date?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  last_execution_status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   listen_deletion?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   no_dependencies?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/ingestionManager.ts
@@ -282,14 +282,10 @@ export const rssExecutor = async (context: AuthContext, turndownService: Turndow
         ingestionLogger.info('Feed execution started', { uri: ingestion.uri });
         const ingestionPromise = rssDataHandler(context, httpGet, turndownService, ingestion)
           .then(async () => {
-            try {
-              await patchRssIngestion(context, SYSTEM_USER, ingestion.internal_id, {
-                last_execution_status: 'success',
-                last_execution_date: now(),
-              });
-            } catch (patchErr) {
-              logApp.warn('[OPENCTI-MODULE] Failed to patch rss ingestion success status', { cause: patchErr });
-            }
+            await patchRssIngestion(context, SYSTEM_USER, ingestion.internal_id, {
+              last_execution_status: 'success',
+              last_execution_date: now(),
+            });
             await ingestionLogger.success('Feed execution succeeded');
           })
           .catch((e) => {

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -21,6 +21,7 @@ import { EVENT_CURRENT_VERSION } from '../database/stream/stream-utils';
 import { clearSyncConsumerMetrics, storeSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
 import { createParser } from 'eventsource-parser';
 import { InterruptibleTimer } from './interruptible-timer';
+import { buildIngestionErrorMeta, createIngestionLogger } from './ingestionManager/ingestionManagerUtils';
 import {
   ALLOWED_EMBEDDED_IMAGE_MIME_TYPE_SET,
   extractMarkdownImageReferences,
@@ -306,6 +307,8 @@ const syncManagerInstance = (syncId) => {
       running = true;
       logApp.info(`[OPENCTI] Sync ${syncId}: starting manager`);
       const sync = await storeLoadById(context, SYSTEM_USER, syncId, ENTITY_TYPE_SYNC);
+      const syncLogger = createIngestionLogger(sync.internal_id, sync.name, 'sync');
+      syncLogger.info('Feed execution started');
       const synchronized = sync.synchronized ?? false;
       const { ssl_verify: ssl = false } = sync;
       const token = await decryptSynchronizerCredential(sync.token);
@@ -333,6 +336,13 @@ const syncManagerInstance = (syncId) => {
               connectionId = connectedData.connectionId;
               connectedAt = new Date().toISOString();
               logApp.info(`[OPENCTI] Sync ${syncId}: listening ${sseUri} with id ${connectionId}`);
+              await patchSync(context, SYSTEM_USER, syncId, {
+                last_execution_date: new Date().toISOString(),
+                last_execution_status: 'success',
+              });
+              await syncLogger.success('Feed execution succeeded', {
+                connection_id: connectionId,
+              });
               continue;
             }
             // Handle heartbeat - just save state, no data to process
@@ -378,6 +388,11 @@ const syncManagerInstance = (syncId) => {
                 logApp.error('[OPENCTI-MODULE] Sync manager event handling error, retrying...', {
                   cause: processingError, id: syncId, manager: 'SYNC_MANAGER',
                 });
+                await patchSync(context, SYSTEM_USER, syncId, {
+                  last_execution_date: new Date().toISOString(),
+                  last_execution_status: 'error',
+                });
+                await syncLogger.error('Feed execution failed', buildIngestionErrorMeta(processingError));
                 await wait(5000);
               }
             }
@@ -391,6 +406,11 @@ const syncManagerInstance = (syncId) => {
           logApp.warn('[OPENCTI] Sync stream error, reconnecting...', {
             id: syncId, manager: 'SYNC_MANAGER', cause: streamError,
           });
+          await patchSync(context, SYSTEM_USER, syncId, {
+            last_execution_date: new Date().toISOString(),
+            last_execution_status: 'error',
+          });
+          await syncLogger.error('Feed execution failed', buildIngestionErrorMeta(streamError));
           await wait(5000);
         }
       }

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -561,6 +561,8 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition<any>> 
     { name: 'stream_id', label: 'Stream id', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: false },
     { name: 'running', label: 'Running', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'current_state_date', label: 'Current stated date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'last_execution_date', label: 'Last execution date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'last_execution_status', label: 'Last execution status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'listen_deletion', label: 'Listen deletion', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
     { name: 'no_dependencies', label: 'No dependencies', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },
   ],

--- a/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/internalObject-registrationAttributes.ts
@@ -560,7 +560,7 @@ const internalObjectsAttributes: { [k: string]: Array<AttributeDefinition<any>> 
     { name: 'token', label: 'Token', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: false },
     { name: 'stream_id', label: 'Stream id', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: false },
     { name: 'running', label: 'Running', type: 'boolean', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
-    { name: 'current_state_date', label: 'Current stated date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
+    { name: 'current_state_date', label: 'Current state date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'last_execution_date', label: 'Last execution date', type: 'date', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'last_execution_status', label: 'Last execution status', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: false, isFilterable: true },
     { name: 'listen_deletion', label: 'Listen deletion', type: 'boolean', mandatoryType: 'external', editDefault: true, multiple: false, upsert: false, isFilterable: true },

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -73,6 +73,7 @@ import { ConnectorPriorityGroup } from '../generated/graphql';
 import { assessConnectorMigration, migrateConnectorToManaged } from '../domain/connector-migration';
 import { loadCreator } from '../database/members';
 import { readSyncConsumerMetrics } from '../graphql/syncConsumerMetrics';
+import { findIngestionLogsForFeed } from '../modules/ingestion/ingestion-common';
 
 export const PLATFORM_VERSION = pjson.version;
 
@@ -90,6 +91,10 @@ const connectorResolvers = {
     work: (_, { id }, context) => findById(context, context.user, id),
     isWorkAlive: (_, { id }, context) => isWorkAlive(context, context.user, id),
     synchronizer: (_, { id }, context) => findSyncById(context, context.user, id),
+    synchronizerLogs: async (_, { id }, context) => {
+      await findSyncById(context, context.user, id);
+      return findIngestionLogsForFeed(id);
+    },
     synchronizerAddInputFromImport: (_, { file }) => syncAddInputFromImport(file),
     synchronizers: (_, args, context) => findSyncPaginated(context, context.user, args),
     synchronizerFetch: (_, { input }, context) => fetchRemoteStreams(context, context.user, input),
@@ -144,6 +149,7 @@ const connectorResolvers = {
     queue_messages: async (sync, _, context) => getConnectorQueueSize(context, context.user, sync.id),
     toConfigurationExport: (synchronizer) => synchronizerExport(synchronizer),
     consumer_metrics: (sync) => readSyncConsumerMetrics(sync.id),
+    ingestionLogs: (sync) => findIngestionLogsForFeed(sync.internal_id ?? sync.id),
   },
   Mutation: {
     deleteConnector: (_, { id }, context) => connectorDelete(context, context.user, id),

--- a/opencti-platform/opencti-graphql/src/resolvers/connector.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/connector.js
@@ -92,8 +92,8 @@ const connectorResolvers = {
     isWorkAlive: (_, { id }, context) => isWorkAlive(context, context.user, id),
     synchronizer: (_, { id }, context) => findSyncById(context, context.user, id),
     synchronizerLogs: async (_, { id }, context) => {
-      await findSyncById(context, context.user, id);
-      return findIngestionLogsForFeed(id);
+      const sync = await findSyncById(context, context.user, id);
+      return findIngestionLogsForFeed(sync.internal_id ?? sync.id);
     },
     synchronizerAddInputFromImport: (_, { file }) => syncAddInputFromImport(file),
     synchronizers: (_, args, context) => findSyncPaginated(context, context.user, args),

--- a/opencti-platform/opencti-graphql/src/types/connector.d.ts
+++ b/opencti-platform/opencti-graphql/src/types/connector.d.ts
@@ -39,7 +39,9 @@ export interface BasicStoreEntitySynchronizer extends BasicStoreEntity {
   token?: string | null;
   stream_id: string;
   running: boolean;
-  current_state_date: Date;
+  current_state_date?: Date;
+  last_execution_date?: Date;
+  last_execution_status?: string;
   listen_deletion: boolean;
   no_dependencies: boolean;
   ssl_verify: boolean;

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-sync-logs-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-sync-logs-test.ts
@@ -1,11 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
 import { createEntity, deleteElementById } from '../../../src/database/middleware';
-import {
-  getClientBase,
-  redisDeleteIngestionLogHistory,
-  redisPushIngestionLog,
-} from '../../../src/database/redis';
+import { getClientBase, redisDeleteIngestionLogHistory, redisPushIngestionLog } from '../../../src/database/redis';
 import { ENTITY_TYPE_SYNC } from '../../../src/schema/internalObject';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import { queryAsAdmin, queryAsAdminWithSuccess } from '../../utils/testQueryHelper';

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-sync-logs-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-sync-logs-test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { createEntity, deleteElementById } from '../../../src/database/middleware';
+import {
+  getClientBase,
+  redisDeleteIngestionLogHistory,
+  redisPushIngestionLog,
+} from '../../../src/database/redis';
+import { ENTITY_TYPE_SYNC } from '../../../src/schema/internalObject';
+import { ADMIN_USER, testContext } from '../../utils/testQuery';
+import { queryAsAdmin, queryAsAdminWithSuccess } from '../../utils/testQueryHelper';
+
+const READ_SYNC_LOGS_QUERY = gql`
+  query readSynchronizerLogs($id: String!) {
+    synchronizerLogs(id: $id) {
+      level
+      message
+      type
+      identifier
+      meta
+    }
+  }
+`;
+
+const READ_SYNC_LOGS_FIELD_QUERY = gql`
+  query readSynchronizerLogsField($id: String!) {
+    synchronizer(id: $id) {
+      id
+      ingestionLogs {
+        level
+        message
+      }
+    }
+  }
+`;
+
+describe('Connector resolver - stream logs', () => {
+  let synchronizerId: string;
+  const synchronizerName = 'sync-logs-test';
+
+  beforeAll(async () => {
+    const creationResult = await createEntity(testContext, ADMIN_USER, {
+      name: synchronizerName,
+      uri: 'http://localhost:4242',
+      token: 'token',
+      stream_id: 'stream--sync-logs-test',
+      running: false,
+      listen_deletion: true,
+      no_dependencies: false,
+      ssl_verify: false,
+      synchronized: false,
+      user_id: ADMIN_USER.id,
+    }, ENTITY_TYPE_SYNC, { complete: true });
+    const synchronizer = 'element' in creationResult ? creationResult.element : creationResult;
+    synchronizerId = synchronizer.id;
+    expect(synchronizerId).toBeDefined();
+  });
+
+  afterAll(async () => {
+    if (synchronizerId) {
+      await redisDeleteIngestionLogHistory(synchronizerId);
+      await deleteElementById(testContext, ADMIN_USER, synchronizerId, ENTITY_TYPE_SYNC);
+    }
+  });
+
+  it('should resolve logs from synchronizerLogs query and ingestionLogs field', async () => {
+    await redisDeleteIngestionLogHistory(synchronizerId);
+    await redisPushIngestionLog(synchronizerId, {
+      level: 'info',
+      type: 'sync',
+      identifier: synchronizerName,
+      message: 'info-log',
+      meta: { step: 1 },
+    });
+    await redisPushIngestionLog(synchronizerId, {
+      level: 'success',
+      type: 'sync',
+      identifier: synchronizerName,
+      message: 'success-log',
+      meta: { step: 2 },
+    });
+    await redisPushIngestionLog(synchronizerId, {
+      level: 'warn',
+      type: 'sync',
+      identifier: synchronizerName,
+      message: 'warn-log',
+      meta: { step: 3 },
+    });
+    await redisPushIngestionLog(synchronizerId, {
+      level: 'error',
+      type: 'sync',
+      identifier: synchronizerName,
+      message: 'error-log',
+      meta: { step: 4 },
+    });
+
+    const queryLogsResult = await queryAsAdminWithSuccess({
+      query: READ_SYNC_LOGS_QUERY,
+      variables: { id: synchronizerId },
+    });
+    expect(queryLogsResult.data?.synchronizerLogs).toHaveLength(4);
+    expect(queryLogsResult.data?.synchronizerLogs.map((l: { level: string }) => l.level)).toEqual(['error', 'warn', 'success', 'info']);
+    expect(queryLogsResult.data?.synchronizerLogs[0].message).toBe('error-log');
+
+    const fieldLogsResult = await queryAsAdminWithSuccess({
+      query: READ_SYNC_LOGS_FIELD_QUERY,
+      variables: { id: synchronizerId },
+    });
+    expect(fieldLogsResult.data?.synchronizer.ingestionLogs).toHaveLength(4);
+    expect(fieldLogsResult.data?.synchronizer.ingestionLogs.map((l: { level: string }) => l.level)).toEqual(['error', 'warn', 'success', 'info']);
+  });
+
+  it('should fail when encountering an unknown log level', async () => {
+    await redisDeleteIngestionLogHistory(synchronizerId);
+    await getClientBase().lpush(`ingestion-log-${synchronizerId}-history`, JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: 'unknown_level',
+      type: 'sync',
+      identifier: synchronizerName,
+      message: 'bad-level',
+      meta: {},
+    }));
+
+    const result = await queryAsAdmin({
+      query: READ_SYNC_LOGS_QUERY,
+      variables: { id: synchronizerId },
+    });
+    expect(result.errors).toBeDefined();
+    if (result.errors) {
+      expect(result.errors[0].message).toContain('Unknown ingestion log level');
+    }
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-sync-logs-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/connector-sync-logs-test.ts
@@ -109,7 +109,7 @@ describe('Connector resolver - stream logs', () => {
   it('should fail when encountering an unknown log level', async () => {
     await redisDeleteIngestionLogHistory(synchronizerId);
     await getClientBase().lpush(`ingestion-log-${synchronizerId}-history`, JSON.stringify({
-      timestamp: new Date().toISOString(),
+      timestamp: Date.now(),
       level: 'unknown_level',
       type: 'sync',
       identifier: synchronizerName,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

- Added stream feed logs support, aligned with CSV/RSS/JSON behavior.
- Exposed synchronizer logs in GraphQL (`synchronizerLogs` + `ingestionLogs` on `Synchronizer`).
- Tracked stream execution status/date (`last_execution_status`, `last_execution_date`).
- Instrumented sync manager to write info/success/error log entries.
- Added a dedicated stream logs tab in Feed Detail (Overview + Logs for sync).
- Added integration tests for query/field logs resolution and unknown log level handling.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17531 

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
