### PR TITLE
docs(fds-migration): record the Combobox reconnaissance and its blockers

### DIFF
--- a/fds-migration/IMPLEMENTATION-LOG.md
+++ b/fds-migration/IMPLEMENTATION-LOG.md
@@ -836,3 +836,118 @@ symbol.
 Both grafts are test-only. The rendered bar at this head is identical to the one
 measured above, so the checkpoint was not re-run: there is nothing new to look
 at, and re-photographing an unchanged bar would only look like evidence.
+
+## 2026-08-20 — Combobox reconnaissance: measured, nothing converted
+
+Session goal was to adopt the library `Combobox` on the `AutocompleteField`
+pivot and the direct MUI sites. **No product component code was written**: the
+session stopped twice on the conditions it was given, and the library work is
+now sequenced first. What follows is the measurement, so the next session does
+not repeat it.
+
+Measured with a TypeScript AST pass (not a grep) on a fresh worktree at
+`origin/design-system/current` @ `4a2007398d`, resolving the `@common/*` and
+`@components/*` aliases, including `.jsx`/`.js` and `src/public`, and resolving
+Formik `component=`/`as=`/`render=` to the component actually mounted. The
+library API was read on the `dist/` actually installed at pin `f86e76e`, not on
+the library's source.
+
+### The real numbers
+
+| axis | measured | note |
+|---|---|---|
+| `AutocompleteField` pivot | **54 sites / 46 files** | |
+| business wrappers delegating to it | 46 modules, **692 mount points** / 207 files | 32 of them live in `common/form/` (669 mounts / 194 files) |
+| direct MUI `<Autocomplete>` | **49 sites / 29 files** | 47 in scope: one is the pivot's own element, one is `AutocompleteFreeSoloField.jsx` (out of scope) |
+| wrappers over a direct MUI site | 27 modules, 59 mount points | |
+| authored sites in scope | **101** | 54 pivot call sites + 47 direct |
+
+The 49/29 figure agrees, independently, with the count the library's own
+`Combobox.rfc.md` recorded for OpenCTI on 2026-08-11 ("49 in 29 files").
+
+**Eleven files carrying a direct MUI Autocomplete were missing from the brief's
+list of sixteen** — 13 in-scope sites. They are the same family of entity and
+option pickers as the listed ones, not search fields and not `Select`s:
+
+```
+private/components/common/lists/FilterAutocomplete.tsx                                  1
+private/components/common/lists/ListFilters.tsx                                         1
+private/components/data/csvMapper/representations/CsvMapperConditionalEntityMapping.tsx  2
+private/components/data/csvMapper/representations/CsvMapperRepresentationForm.tsx        1
+private/components/data/csvMapper/.../CsvMapperRepresentationAttributeForm.tsx           1
+private/components/data/csvMapper/.../CsvMapperRepresentationAttributeRefForm.tsx        2
+private/components/data/jsonMapper/representations/JsonMapperRepresentationForm.tsx      1
+private/components/data/jsonMapper/.../JsonMapperRepresentationAttributeRefForm.tsx      1
+private/components/settings/custom_fields/CustomFieldCreation.tsx                        1
+private/components/settings/custom_fields/CustomFieldEdition.tsx                         1
+private/components/settings/users/edition/ConfidenceOverrideField.tsx                    1
+```
+
+Ten of those thirteen carry `selectOnFocus`, so under the current arbitration
+only one of them would convert today anyway — the omission cost little in
+delivery and a lot in confidence.
+
+### The two blockers
+
+1. **The pivot cannot convert while `selectOnFocus` sends a site back to MUI.**
+   `AutocompleteField` sets `selectOnFocus` unconditionally on its own MUI
+   element (`components/AutocompleteField.tsx:150`) and no call site overrides
+   it, so all 54 sites — and the 692 mount points behind them — inherit a
+   behaviour the library does not offer. `LIBRARY-FEEDBACK.md` entry 41.
+2. **The value chips cannot carry the product's data colour**, which is the
+   pivot's default rendering, not an option. `LIBRARY-FEEDBACK.md` entry 40,
+   with the contrast measurements and the reason the existing 20 %-composite
+   pattern is transposable.
+
+Entry 42 carries the remaining six gaps and the delivery table: 7 of the 101
+sites convert today, 49 once entry 41 is closed, 101 with everything closed.
+
+### Two defects found in this repository's own tooling
+
+**The conformity analyser is blind to JSX written with type parameters.**
+`fds-migration/scripts/lib/jsx-opening-tags.mjs` matches `<Name` only when the
+next character is whitespace, `/` or `>`; a site written
+`<MUIAutocomplete<CsvMapperRepresentationFormData, true>` therefore never
+matches. Measured on this surface: the product analyser sees **40 sites / 22
+files** where the AST sees **49 / 29** — 9 sites and 7 files invisible, in
+`AIInsights.tsx`, `ResponseDialog.tsx`, `ConfidenceOverrideField.tsx`,
+`JsonMapperRepresentationForm.tsx`, `JsonMapperRepresentationAttributeRefForm.tsx`,
+`CsvMapperRepresentationForm.tsx` and `CsvMapperRepresentationAttributeRefForm.tsx`.
+Reproduce by counting `<Autocomplete` sites with both implementations over
+`opencti-front/src`.
+
+The same shape is in the library's own template, so it affects every product:
+fixed upstream in `filigran-design-system` PR #131, with the failing case proven
+red first — the guard did not merely miss a generic site, it reported `DRIFT`
+("declared adoption site renders none of the component") on a file that renders
+it.
+
+**This product's `check-fds-conformity.mjs` has diverged from the template it
+declares itself a verbatim copy of, and regenerating would silently drop
+coverage.** The header says "GENERATED TEMPLATE, copied verbatim … Do not
+hand-edit here", but the local copy imports a product-only
+`scripts/lib/jsx-opening-tags.mjs` the generator never ships, and implements a
+bespoke `paper` check (`openingTags` + `reDeclaresPadding`, driven by
+`migration-state.json`'s `paperPattern`). The template has since generalised
+that into a `lib-component-usage` check driven by a `libComponentUsage` section —
+which this product's `migration-state.json` does not have.
+
+Consequence, measured by generating to a scratch directory and diffing
+(`--out-dir`, no product write): a regeneration overwrites `AGENTS.md` (84
+diverging lines), `COMPONENT-MAPPING.md` (34) and
+`scripts/check-fds-conformity.mjs` (430), and keeps `IMPLEMENTATION-LOG.md`,
+`IMPLEMENTATION-ROADMAP.md` and `migration-state.json` (scaffold-once files).
+So it would replace the working Paper padding check with a generic one that is
+**inert until `libComponentUsage` is declared** — losing Paper coverage without
+a single red gate.
+
+**Regenerate only together with a `libComponentUsage` entry for Paper in the
+same change set.** That pairing is a mission of its own; it was not done here.
+
+### Also stale, not fixed here
+
+`fds-migration/AGENTS.md` rule 5 still reads "This phase is TOKENS ONLY … do not
+start it here unless explicitly asked". The library's template replaced that
+rule with "The component phase has started — declare every adoption" some time
+ago; three component pilots have shipped since. The file is generated, so the
+fix is the regeneration above, not an edit.

--- a/fds-migration/LIBRARY-FEEDBACK.md
+++ b/fds-migration/LIBRARY-FEEDBACK.md
@@ -16,6 +16,10 @@ library pin `56f7e59823cae7d815a451206e3cb4cb1d31022d`, then re-checked at
 pin `486cec92c3abf006997ac269d34ff0fcc23f178f` (2026-08-06) and at pin
 `5960966216533f620393a2174213c666f57af7dd` (2026-08-11, the token pass).
 
+Then re-opened for the Combobox reconnaissance at pin
+`f86e76e192bccaecb88cece466a02221070bf656` (2026-08-20) — entries 40 to 42,
+measured on the Autocomplete surface, no conversion written.
+
 Closed so far: entries 5 and 12, both at the 2026-08-11 pin. Every other entry
 was re-checked against that pin's source and its removal condition is still
 unmet — the compensations stay, with the reason stated in each entry.
@@ -1347,3 +1351,164 @@ scale the host happens to apply around it.
 
 **Removal test.** Render the chip inside a container at 20px, inspect the chip
 root: its computed `font-size` must be the chip's own value, not 20px.
+
+## 40. `ComboboxChips` gives the value chips no tone at all, and a per-value colour is what OpenCTI's field is *for*
+
+**This is the blocking entry for the Combobox adoption in this product.** Not a
+polish item: the colour is the product's own data, rendered today by default on
+the largest Autocomplete surface here.
+
+**Needed.** A selected value's chip carries a colour that comes from the
+database. Labels (`label.color`), marking definitions
+(`markingDefinition.x_opencti_color`), workflow statuses
+(`status.template.color`) and kill-chain phases all store a free-form hex an
+administrator picks in Settings. Nothing about it is decorative: on a marking
+chip the colour *is* the classification.
+
+**How the product does it today.** `components/common/tag/Tag.tsx`, reached
+through `AutocompleteField`'s own `defaultRenderTags` — so it is the DEFAULT of
+the pivot field, not something a call site opts into:
+
+- background: `alpha(color, 0.2)` — the data colour never contributes more than
+  20 % of the composited background;
+- text: **never set**, inherited from the theme;
+- invalid input: `alpha()` throwing is caught and falls back to the neutral.
+
+**Measured, and this is the part worth carrying into the library's design.** The
+legibility guarantee comes from the 20 % ceiling, not from any computation on
+the colour. Sweeping the entire RGB cube against the real surfaces
+(`#ffffff` light, `#0d172b` dark):
+
+| pair | light | dark |
+|---|---|---|
+| label text over `alpha(data, 0.2)` — **worst case over the whole cube** | **10.78:1** | **9.57:1** |
+| same, best case | 17.59:1 | 16.67:1 |
+
+So an arbitrary colour capped at 20 % over a known surface cannot fail 4.5:1 —
+the minimum is computable once per (surface token, text token) pair and holds
+for every colour a user can enter. That is a gate-able property, not a
+per-value check.
+
+**Three parts of the same product pattern that must NOT be copied**, measured
+the same way:
+
+| what | light | dark |
+|---|---|---|
+| the chip with **no** data colour: neutral at full opacity | **3.25:1** | **2.95:1** |
+| the decorative chip icon, tinted with the raw colour at full strength | worst **1.00:1** | worst **1.00:1** |
+| the delete icon, hardcoded `#F2F2F3` (not a token) | worst **1.00:1** | 8.55:1 |
+
+The uncoloured chip is the one that fails today, which is the opposite of what
+one expects going in.
+
+**Today, library side.** `ComboboxChips` renders
+`<Chip label={getOptionLabel(option)} onDelete deleteTabIndex={-1} disabled />`
+and nothing else. There is no render prop, no per-value hook, and no way to
+reach `ChipProps.severity` or `ChipProps.entity`. **Even mapping a value onto
+one of the 16 tones the library already ships is impossible** — that half needs
+no colour arbitration at all.
+
+**Count.** 32 sites need a tone on their chips: 15 pivot call sites in
+multiple mode whose module builds a colour (structural — the pivot's default
+tag renderer reads `option.color`), and 17 direct MUI sites by the same test
+(upper bound: a module may build a colour for something other than its chips).
+26 of the 40 modules that mount an Autocomplete here construct a colour key.
+Behind those sites sit the 692 mount points the business wrappers shield.
+
+**Asked.** Two things, separable and worth separating:
+
+1. a way to select a chip's tone per value from the tones the library already
+   defines — no new colour, no contrast question;
+2. for a genuinely arbitrary hex: a documented ceiling mechanism (the 20 %
+   composite above is the measured, transposable one) so the library can accept
+   a data colour *and* keep its own contrast guarantee.
+
+**Removal test.** Render a `Combobox multiple` whose selected values carry
+`#000000` and `#ffffff` — the two extremes of the cube — in both modes.
+Every chip label must measure ≥ 4.5:1 against its own rendered background, and
+the two chips must be visually distinguishable from an uncoloured one. Then
+delete the product's `Tag`-based `renderTags` from `AutocompleteField` and check
+that no marking, label or status chip loses its colour.
+
+## 41. No way to select the input text when the field takes focus
+
+**Needed.** Focusing a filled field and typing replaces the previous value
+instead of appending to it. In this product it is not a per-site choice:
+`AutocompleteField` sets `selectOnFocus` unconditionally on its own MUI element,
+so every one of its call sites has always behaved that way, and no call site
+overrides it.
+
+**Today.** Absent from the shipped API — verified on the installed build at pin
+`f86e76e`, not on the source: `selectOnFocus`, `openOnFocus` and `autoSelect`
+appear nowhere in `index.d.ts`.
+
+**Consequence.** 86 sites are affected: the 54 pivot call sites, which inherit
+it, and 32 of the 47 direct MUI sites. It is the **sole** blocker on 42 of them,
+so it is the single highest-leverage gap on this surface: closing it alone takes
+the wave from 7 convertible sites to 49.
+
+**Not a workaround the product should invent.** `ComboboxInput` is typed
+`Omit<ComponentPropsWithoutRef<"input">, "value" | "onChange" | "role" | "type">`,
+so it forwards `onFocus`, and `onFocus={(e) => e.currentTarget.select()}` is
+expressible through the public API. It is deliberately NOT used here: MUI's
+behaviour is entangled with blur handling and with resetting the input value, so
+a one-line imitation would silently differ. The product waits for the library.
+
+**Asked.** A prop on `Combobox` for selecting the field's text on focus. While
+the question is open, `openOnFocus` sits on the same 10 sites (all 10 also carry
+`selectOnFocus`) and belongs to the same arbitration.
+
+**Removal test.** With the prop on, focus a field holding a value and type one
+character: the field must contain that character alone. With it off, the same
+keystroke must append. Then delete the `selectOnFocus` line from
+`AutocompleteField` and confirm the 54 call sites keep the behaviour.
+
+## 42. The rest of the Autocomplete gap list, so one library session can close it in one pass
+
+Recorded together on purpose: this surface was measured once, exhaustively, and
+splitting six small gaps across six sessions is what the measurement was meant
+to avoid. Counts are over the 101 authored sites in scope (54 pivot call sites +
+47 direct MUI sites) at `design-system/current` @ `4a2007398d`.
+
+| gap | sites | what is lost | can a site do without it? |
+|---|---|---|---|
+| create-on-the-fly affordance in the field line | 8 (pivot) | the `+` control that opens a creation form for a label, external reference or status without leaving the field. The pivot renders it as an absolutely-positioned `IconButton` over the field | no — no slot exists |
+| custom chip content | 6 | composed chips (icon, tooltip, own layout) — MUI's `renderTags` | no equivalent |
+| free text / value absent from the list | 3 | typing a value that does not exist yet. Already deferred to v2 in `Combobox.rfc.md` §7 | no |
+| an adornment slot in the field line | 2 (pivot) | an entity-type selector rendered *inside* the field, and a creation button | structurally `ComboboxControls`/`ComboboxField` accept children, but the drawn 24/48px geometry does not plan for a third control — a design question more than an API one |
+| `disablePortal`, `clearOnEscape`, inline `autoComplete` | 3 | one non-portalled panel, one Escape-clears, one inline completion | yes, individually negligible |
+| empty-string normalisation | — | Formik initialises a multi-value field to `''`; the engine maps a non-array to `[value]`, so `''` becomes one empty chip where MUI plus the pivot's own guard produce none | one line, library side |
+
+**Three candidates that measurement removed** — worth stating so the next
+session does not re-add them:
+
+- `autoSelect`: 7 sites, **all passing `false`**, which is MUI's own default. A
+  no-op.
+- the pivot's non-array crash guard: the engine already normalises `null` and
+  `undefined` to `[]`, so only the `''` case above remains.
+- `renderInput` (47 sites), `noOptionsText` (70 → `emptyMessage`),
+  `disableClearable` (11 → `clearable`, including the 27 sites that hid the
+  clear control through `classes={{ clearIndicator: { display: 'none' } }}`),
+  `getOptionDisabled` (4 → `isOptionDisabled`), `handleHomeEndKeys` (3),
+  `autoHighlight` (35, native and unconditional), `slotProps.listbox`
+  (→ `listClassName`), `sx`/`style` (→ `className`): all already paired.
+
+**What the wave delivers**, same 101 sites, each line closing one more gap:
+
+| state | sites delivered |
+|---|---|
+| today | **7** (and 0 of the 54 pivot call sites) |
+| + entry 41 | 49 |
+| + entry 40 | 73 |
+| + `openOnFocus` | 82 |
+| + create affordance | 90 |
+| + the remaining four rows above | **101** |
+
+**Not a library gap, but it will cost the product session** — recorded here so
+it is not rediscovered as a surprise: 84 `renderOption` bodies must be
+rewritten, because 82 of them build their own `<li>`/`ListItem` and 68 spread
+MUI's `{...props}` onto it, while the library keeps the row and takes only its
+content. Five of those bodies render their own `Checkbox`, which would collide
+with the one the library places in multiple mode. `variant: 'standard'` on 47
+sites and `size="small"` on 28 meet a single 36px field (`--spacing-9`), a
+density delta to measure in the DOM on a converted screen.


### PR DESCRIPTION
## What

Documentation only, two Markdown files under `fds-migration/`. **No component
code changed, nothing converted, no pin touched.** The Combobox adoption is
sequenced behind library work; this keeps the reconnaissance so the next session
starts from it.

## Why

The conversion stopped on its own conditions: the census disagreed with the
brief by more than the tolerance on the axis that defines the work list, and the
pivot turned out to be blocked by the same rule that sends a site back to MUI.
Both are now filed with their counts and their removal tests, and the library
gaps are on the table before the library session opens.

## Gate verdict

`node fds-migration/scripts/check-fds-conformity.mjs` — 54 checks, 0 issues
(52 OK, 2 SKIPPED) on this SHA. No build, test or type-check surface is touched.

## Known limits

Nothing is converted and no workaround marker is placed, because no file was
converted. The label and helper-text DOM delta is not measured — it needs a
converted screen. Two tooling defects are recorded rather than fixed here: this
product's JSX analyser is blind to type-parameterised call sites (fixed upstream
in `XTM-Foundation/filigran-design-system#131`, not in this product's forked
copy), and regenerating `fds-migration/` would drop Paper coverage unless paired
with a `libComponentUsage` declaration.

## Where to read

`fds-migration/IMPLEMENTATION-LOG.md`, entry dated 2026-08-20 — the numbers, the
two blockers, the two tooling defects. `fds-migration/LIBRARY-FEEDBACK.md`
entries 40 (data colour on the value chips, the blocking one), 41
(select-on-focus) and 42 (the remaining gaps and the delivery table).

## Arbitrations required

The PR title needs an issue number to satisfy this repo's title convention
(`type(scope): description (#issue)`), and no Combobox issue exists yet — the
four earlier design-system PRs reference #17539, the Paper one #17728.