### PR TITLE
fix(stream): properly encode fetchUri in syncManager (#17489)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -61,7 +61,31 @@ const extractStorageRelativePath = (candidateUri) => {
   return normalizedUri.substring(pathIndex).replace(/^\/+/, '');
 };
 
-const buildSyncStorageFetchUri = (syncUri, storageUri, options = {}) => {
+// Percent-encode each segment of a relative storage path so that reserved characters
+// present in filenames (e.g. '#', '?', ...) are not interpreted as URL fragment/query
+// delimiters by the HTTP client. Idempotent: already-encoded segments are not double-encoded.
+export const encodeStorageRelativePath = (relativePath) => {
+  return relativePath
+    .split('/')
+    .map((segment) => {
+      if (segment === '') {
+        return segment;
+      }
+      // Decode first so that already-encoded input is not double-encoded,
+      // then re-encode reserved characters consistently.
+      let decodedSegment;
+      try {
+        decodedSegment = decodeURIComponent(segment);
+      } catch {
+        // Malformed percent-sequence (e.g. a literal '%'): keep the raw segment as-is.
+        decodedSegment = segment;
+      }
+      return encodeURIComponent(decodedSegment);
+    })
+    .join('/');
+};
+
+export const buildSyncStorageFetchUri = (syncUri, storageUri, options = {}) => {
   if (typeof storageUri !== 'string') {
     return null;
   }
@@ -78,7 +102,7 @@ const buildSyncStorageFetchUri = (syncUri, storageUri, options = {}) => {
       const normalizedPath = decodeURIComponent((parsedUri.pathname || '').replace(/^\/+/, ''));
       if (normalizedPath.startsWith('embedded/')) {
         const resolvedEmbeddedPath = resolveEmbeddedStoragePathWithContext(normalizedPath, { entityType, entityId });
-        return `${httpBase(syncUri)}storage/get/${resolvedEmbeddedPath}`;
+        return `${httpBase(syncUri)}storage/get/${encodeStorageRelativePath(resolvedEmbeddedPath)}`;
       }
       return null;
     } catch {
@@ -88,13 +112,13 @@ const buildSyncStorageFetchUri = (syncUri, storageUri, options = {}) => {
 
   const extractedPath = extractStorageRelativePath(trimmedStorageUri);
   if (extractedPath) {
-    return `${httpBase(syncUri)}${extractedPath}`;
+    return `${httpBase(syncUri)}${encodeStorageRelativePath(extractedPath)}`;
   }
 
   const normalizedPath = decodeURIComponent(trimmedStorageUri.replace(/^\/+/, ''));
   if (normalizedPath.startsWith('embedded/')) {
     const resolvedEmbeddedPath = resolveEmbeddedStoragePathWithContext(normalizedPath, { entityType, entityId });
-    return `${httpBase(syncUri)}storage/get/${resolvedEmbeddedPath}`;
+    return `${httpBase(syncUri)}storage/get/${encodeStorageRelativePath(resolvedEmbeddedPath)}`;
   }
 
   return null;

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-storage-uri-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-storage-uri-test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { buildSyncStorageFetchUri, encodeStorageRelativePath } from '../../../src/manager/syncManager';
+
+describe('syncManager storage fetch URI encoding', () => {
+  describe('encodeStorageRelativePath', () => {
+    it('encodes reserved characters in a filename segment', () => {
+      const input = 'storage/get/import/Case-Incident/bb58de87/#s18bfbad0ee7d0_-endpoint.csv';
+      const output = encodeStorageRelativePath(input);
+      expect(output).toBe('storage/get/import/Case-Incident/bb58de87/%23s18bfbad0ee7d0_-endpoint.csv');
+      // slashes are preserved as path separators
+      expect(output.split('/').length).toBe(input.split('/').length);
+    });
+
+    it('encodes other reserved characters (?, space, %23 already encoded stays stable)', () => {
+      expect(encodeStorageRelativePath('a/b c/d?e.csv')).toBe('a/b%20c/d%3Fe.csv');
+      // idempotent: already-encoded input is not double-encoded
+      expect(encodeStorageRelativePath('a/%23file.csv')).toBe('a/%23file.csv');
+      expect(encodeStorageRelativePath(encodeStorageRelativePath('a/#file.csv'))).toBe('a/%23file.csv');
+    });
+
+    it('keeps malformed percent-sequences untouched instead of throwing', () => {
+      expect(encodeStorageRelativePath('a/100%done.csv')).toBe('a/100%25done.csv');
+    });
+  });
+
+  describe('buildSyncStorageFetchUri', () => {
+    const syncUri = 'https://instance-a.example.com';
+
+    it('encodes a # in the filename of a relative storage path (regression)', () => {
+      const fileUri = '/storage/get/import/Case-Incident/bb58de87-908e-4fcb-af80-339562208b8c/#s18bfbad0ee7d0_-endpoint-allow_operation.csv';
+      const fetchUri = buildSyncStorageFetchUri(syncUri, fileUri);
+      expect(fetchUri).toBe(
+        'https://instance-a.example.com/storage/get/import/Case-Incident/bb58de87-908e-4fcb-af80-339562208b8c/%23s18bfbad0ee7d0_-endpoint-allow_operation.csv',
+      );
+      // the '#' must not survive raw (it would be treated as a URL fragment by the HTTP client)
+      expect(fetchUri).not.toContain('/#');
+    });
+
+    it('builds a valid URL whose path (after host) no longer contains a raw fragment delimiter', () => {
+      const fileUri = '/storage/get/import/Report/abc/weird#name?x.csv';
+      const fetchUri = buildSyncStorageFetchUri(syncUri, fileUri);
+      const parsed = new URL(fetchUri);
+      expect(parsed.hash).toBe('');
+      expect(parsed.search).toBe('');
+      expect(parsed.pathname.endsWith('weird%23name%3Fx.csv')).toBe(true);
+    });
+
+    it('returns null for a non-string storage uri', () => {
+      expect(buildSyncStorageFetchUri(syncUri, null)).toBeNull();
+      expect(buildSyncStorageFetchUri(syncUri, undefined)).toBeNull();
+    });
+
+    it('returns null when the storage uri does not point to a known storage path', () => {
+      expect(buildSyncStorageFetchUri(syncUri, '/not/a/storage/path.csv')).toBeNull();
+    });
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-storage-uri-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-storage-uri-test.ts
@@ -38,7 +38,7 @@ describe('syncManager storage fetch URI encoding', () => {
 
     it('builds a valid URL whose path (after host) no longer contains a raw fragment delimiter', () => {
       const fileUri = '/storage/get/import/Report/abc/weird#name?x.csv';
-      const fetchUri = buildSyncStorageFetchUri(syncUri, fileUri);
+      const fetchUri = buildSyncStorageFetchUri(syncUri, fileUri) as string;
       const parsed = new URL(fetchUri);
       expect(parsed.hash).toBe('');
       expect(parsed.search).toBe('');


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
This pull request improves the handling of storage file paths in the sync manager by ensuring that reserved characters in filenames (such as `#`, `?`, and spaces) are properly percent-encoded when constructing fetch URIs. This prevents issues where these characters could be misinterpreted as URL fragments or queries by HTTP clients. Additionally, comprehensive unit tests have been added to verify correct encoding and URI construction.

**Encoding and URI Construction Improvements:**

* Added a new function `encodeStorageRelativePath` to percent-encode each segment of a storage path, ensuring reserved characters in filenames are safely included in URLs and not misinterpreted by HTTP clients. The function is idempotent and handles malformed percent sequences gracefully. (`opencti-platform/opencti-graphql/src/manager/syncManager.js`, [opencti-platform/opencti-graphql/src/manager/syncManager.jsL64-R88](diffhunk://#diff-702f3e33ced9a2bdb1fe429d119c906d2c6d637f0f0dc3259ddd42d3d4b44e76L64-R88))
* Updated the `buildSyncStorageFetchUri` function to use `encodeStorageRelativePath` when constructing fetch URIs, ensuring all generated URLs are safe and correct. (`opencti-platform/opencti-graphql/src/manager/syncManager.js`, [[1]](diffhunk://#diff-702f3e33ced9a2bdb1fe429d119c906d2c6d637f0f0dc3259ddd42d3d4b44e76L81-R105) [[2]](diffhunk://#diff-702f3e33ced9a2bdb1fe429d119c906d2c6d637f0f0dc3259ddd42d3d4b44e76L91-R121)

**Testing Enhancements:**

* Added a new unit test suite for `encodeStorageRelativePath` and `buildSyncStorageFetchUri`, covering reserved character encoding, idempotency, handling of malformed percent sequences, and correct construction of fetch URIs. (`opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-storage-uri-test.ts`, [opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-storage-uri-test.tsR1-R57](diffhunk://#diff-a41ac3586d6d766dffe13ac86a05c204b69a38960c8c8c879a2ea09bee723cb3R1-R57))

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17489

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
