### PR TITLE
fix(notifications): filter out inactive users in notifications (#16148)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
+++ b/opencti-platform/opencti-graphql/src/manager/notificationManager.ts
@@ -6,7 +6,7 @@ import { type SizedNotifEvent, type StreamProcessor } from '../database/stream/s
 import { fetchRangeNotifications, storeNotificationEvent, createStreamProcessor } from '../database/stream/stream-handler';
 import { redisGetManagerEventState, redisSetManagerEventState } from '../database/redis';
 import { lockResources } from '../lock/master-lock';
-import conf, { booleanConf, logApp } from '../config/conf';
+import conf, { booleanConf, logApp, ACCOUNT_STATUS_ACTIVE } from '../config/conf';
 import { FunctionalError, TYPE_LOCK_ERROR } from '../config/errors';
 import { executionContext, INTERNAL_USERS, isUserCanAccessStixElement, isUserCanAccessStreamUpdateEvent, isUserInPlatformOrganization, SYSTEM_USER } from '../utils/access';
 import type { DataEvent, SseEvent, StreamNotifEvent, UpdateEvent } from '../types/event';
@@ -117,6 +117,15 @@ export const isDigest = (n: ResolvedTrigger): n is ResolvedDigest => {
   return n.trigger.trigger_type === 'digest';
 };
 
+export const isNotificationRecipientActive = (user: AuthUser): boolean => {
+  // Account expiration date reached
+  if (user.account_lock_after_date && utcDate().isAfter(utcDate(user.account_lock_after_date))) {
+    return false;
+  }
+  // Account not active (disabled / inactive / expired status)
+  return user.account_status === ACCOUNT_STATUS_ACTIVE;
+};
+
 const generateAssigneeTrigger = (user: AuthUser) => {
   const filters = {
     mode: 'or',
@@ -182,7 +191,9 @@ const generateRequestAccessAuthorizeTrigger = (user: AuthUser) => {
 
 export const getNotifications = async (context: AuthContext): Promise<Array<ResolvedTrigger>> => {
   const triggers = await getEntitiesListFromCache<BasicStoreEntityTrigger>(context, SYSTEM_USER, ENTITY_TYPE_TRIGGER);
-  const platformUsers = await getEntitiesListFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER);
+  // Exclude inactive/expired/disabled accounts: they must no longer receive any notification.
+  const platformUsers = (await getEntitiesListFromCache<AuthUser>(context, SYSTEM_USER, ENTITY_TYPE_USER))
+    .filter(isNotificationRecipientActive);
   const settings = await getEntityFromCache<BasicStoreSettings>(context, SYSTEM_USER, ENTITY_TYPE_SETTINGS);
   const isAssigneeAutoTriggerEnabled = settings.platform_notifier_auto_trigger_assignee ?? true;
   const notificationTriggers = [];

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/digest-notification-test.ts
@@ -27,6 +27,7 @@ import { collectDigestContent, DEFAULT_MAX_DIGEST_CONTENT_SIZE, handleDigestNoti
 import { getEntitiesListFromCache, getEntityFromCache } from '../../../src/database/cache';
 import { storeNotificationEvent } from '../../../src/database/stream/stream-handler';
 import { ENTITY_TYPE_TRIGGER } from '../../../src/modules/notification/notification-types';
+import { ACCOUNT_STATUS_ACTIVE } from '../../../src/config/conf';
 
 let objSeq = 0;
 const liveEvent = (notificationId: string, userId = 'user-1'): KnowledgeNotificationEvent => {
@@ -148,6 +149,7 @@ describe('handleDigestNotifications', () => {
     groups: [],
     organizations: [],
     personal_notifiers: [],
+    account_status: ACCOUNT_STATUS_ACTIVE,
   } as unknown as AuthUser;
 
   // Feed getDigestNotifications: triggers list resolves the digest, users list resolves its member.

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/notification-recipient-active-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/notification-recipient-active-test.ts
@@ -6,7 +6,7 @@
  * `getNotifications`, which both the live (getLiveNotifications) and digest
  * (getDigestNotifications) pipelines build upon.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthUser } from '../../../src/types/user';
 
 // ─── Cache mock: getNotifications reads triggers/users/settings from cache ─────
@@ -139,5 +139,9 @@ describe('getNotifications — excludes inactive/expired accounts', () => {
     const definedUserIds = new Set((definedResolved?.users ?? []).map((u: AuthUser) => u.id));
     expect(definedUserIds.has('active')).toBe(true);
     expect(definedUserIds.has('disabled')).toBe(false);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/notification-recipient-active-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/notification-recipient-active-test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the notification-recipient account status validation.
+ *
+ * Bug fix: expired / disabled / inactive accounts must stop receiving notifications
+ * (live + digest, email + in-app). Validation is enforced at the single choke point
+ * `getNotifications`, which both the live (getLiveNotifications) and digest
+ * (getDigestNotifications) pipelines build upon.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthUser } from '../../../src/types/user';
+
+// ─── Cache mock: getNotifications reads triggers/users/settings from cache ─────
+const getEntitiesListFromCache = vi.fn();
+const getEntityFromCache = vi.fn();
+
+vi.mock('../../../src/database/cache', () => ({
+  getEntitiesListFromCache: (...args: any[]) => getEntitiesListFromCache(...args),
+  getEntityFromCache: (...args: any[]) => getEntityFromCache(...args),
+}));
+
+import { getNotifications, isNotificationRecipientActive } from '../../../src/manager/notificationManager';
+
+import { ENTITY_TYPE_USER } from '../../../src/schema/internalObject';
+
+import { ACCOUNT_STATUS_ACTIVE, ACCOUNT_STATUS_EXPIRED, ACCOUNT_STATUS_LOCKED } from '../../../src/config/conf';
+
+import { utcDate } from '../../../src/utils/format';
+
+const buildUser = (over: Partial<AuthUser>): AuthUser => ({
+  id: 'user-x',
+  internal_id: 'user-x',
+  account_status: ACCOUNT_STATUS_ACTIVE,
+  account_lock_after_date: undefined,
+  groups: [],
+  organizations: [],
+  personal_notifiers: [],
+  ...over,
+} as unknown as AuthUser);
+
+describe('isNotificationRecipientActive', () => {
+  it('accepts an active, non-expired account', () => {
+    expect(isNotificationRecipientActive(buildUser({ account_status: ACCOUNT_STATUS_ACTIVE }))).toBe(true);
+  });
+
+  it('rejects an account with a non-active status (expired)', () => {
+    expect(isNotificationRecipientActive(buildUser({ account_status: ACCOUNT_STATUS_EXPIRED }))).toBe(false);
+  });
+
+  it('rejects an account with a non-active status (locked/disabled)', () => {
+    expect(isNotificationRecipientActive(buildUser({ account_status: ACCOUNT_STATUS_LOCKED }))).toBe(false);
+  });
+
+  it('rejects an active account whose expiration date is in the past', () => {
+    const past = utcDate().subtract(1, 'day').toISOString();
+    expect(isNotificationRecipientActive(buildUser({ account_status: ACCOUNT_STATUS_ACTIVE, account_lock_after_date: past as any }))).toBe(false);
+  });
+
+  it('accepts an active account whose expiration date is in the future', () => {
+    const future = utcDate().add(1, 'day').toISOString();
+    expect(isNotificationRecipientActive(buildUser({ account_status: ACCOUNT_STATUS_ACTIVE, account_lock_after_date: future as any }))).toBe(true);
+  });
+});
+
+describe('getNotifications — excludes inactive/expired accounts', () => {
+  const context = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEntityFromCache.mockResolvedValue({ platform_notifier_auto_trigger_assignee: true });
+  });
+
+  const collectUserIds = (triggers: Array<{ users: AuthUser[] }>): Set<string> => {
+    const ids = new Set<string>();
+    triggers.forEach((t) => t.users.forEach((u) => ids.add(u.id)));
+    return ids;
+  };
+
+  it('keeps active users and drops inactive / expired ones from native triggers', async () => {
+    const activeUser = buildUser({ id: 'active', internal_id: 'active', account_status: ACCOUNT_STATUS_ACTIVE });
+    const disabledUser = buildUser({ id: 'disabled', internal_id: 'disabled', account_status: ACCOUNT_STATUS_LOCKED });
+    const expiredStatusUser = buildUser({ id: 'expired-status', internal_id: 'expired-status', account_status: ACCOUNT_STATUS_EXPIRED });
+    const expiredDateUser = buildUser({
+      id: 'expired-date',
+      internal_id: 'expired-date',
+      account_status: ACCOUNT_STATUS_ACTIVE,
+      account_lock_after_date: utcDate().subtract(1, 'day').toISOString() as any,
+    });
+
+    getEntitiesListFromCache.mockImplementation((_ctx: any, _user: any, type: string) => {
+      if (type === ENTITY_TYPE_USER) {
+        return Promise.resolve([activeUser, disabledUser, expiredStatusUser, expiredDateUser]);
+      }
+      return Promise.resolve([]); // no defined triggers
+    });
+
+    const triggers = await getNotifications(context);
+    const ids = collectUserIds(triggers);
+
+    expect(ids.has('active')).toBe(true);
+    expect(ids.has('disabled')).toBe(false);
+    expect(ids.has('expired-status')).toBe(false);
+    expect(ids.has('expired-date')).toBe(false);
+  });
+
+  it('produces no triggers at all when every account is inactive', async () => {
+    getEntitiesListFromCache.mockImplementation((_ctx: any, _user: any, type: string) => {
+      if (type === ENTITY_TYPE_USER) {
+        return Promise.resolve([
+          buildUser({ id: 'u1', internal_id: 'u1', account_status: ACCOUNT_STATUS_EXPIRED }),
+          buildUser({ id: 'u2', internal_id: 'u2', account_status: ACCOUNT_STATUS_LOCKED }),
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const triggers = await getNotifications(context);
+    expect(collectUserIds(triggers).size).toBe(0);
+  });
+
+  it('excludes inactive users from a defined trigger targeting them by id', async () => {
+    const activeUser = buildUser({ id: 'active', internal_id: 'active', account_status: ACCOUNT_STATUS_ACTIVE });
+    const disabledUser = buildUser({ id: 'disabled', internal_id: 'disabled', account_status: ACCOUNT_STATUS_LOCKED });
+    const definedTrigger = {
+      internal_id: 'trigger-1',
+      trigger_type: 'live',
+      trigger_scope: 'knowledge',
+      restricted_members: [{ id: 'active' }, { id: 'disabled' }],
+    };
+
+    getEntitiesListFromCache.mockImplementation((_ctx: any, _user: any, type: string) => {
+      if (type === ENTITY_TYPE_USER) {
+        return Promise.resolve([activeUser, disabledUser]);
+      }
+      return Promise.resolve([definedTrigger]); // one defined trigger
+    });
+
+    const triggers = await getNotifications(context);
+    const definedResolved = triggers.find((t: any) => t.trigger.internal_id === 'trigger-1');
+    const definedUserIds = new Set((definedResolved?.users ?? []).map((u: AuthUser) => u.id));
+    expect(definedUserIds.has('active')).toBe(true);
+    expect(definedUserIds.has('disabled')).toBe(false);
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
This pull request addresses a bug where expired, disabled, or inactive user accounts were still receiving notifications (both live and digest, via email and in-app). The fix ensures that only active user accounts receive notifications by adding a centralized validation in the notification pipeline. Unit tests have been added to verify the correct behavior.

**Notification recipient filtering:**

* Added the `isNotificationRecipientActive` function to check if a user account is active and not expired, using both account status and expiration date.
* Updated `getNotifications` to filter out users who are not active, ensuring that inactive, expired, or disabled accounts no longer receive notifications.

**Testing and validation:**

* Introduced comprehensive unit tests in `notification-recipient-active-test.ts` to verify that only active users receive notifications and that various edge cases (expired, disabled, or future expiration) are correctly handled.

**Configuration:**

* Imported `ACCOUNT_STATUS_ACTIVE` from the configuration to support the new recipient validation logic.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #16148

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
