### PR TITLE
fix(sync): handle oversized sync attachment payloads (#17778)

### DIFF
--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -36,6 +36,73 @@ const FILE_FETCH_TIMEOUT = conf.get('sync_manager:file_fetch_timeout') || 300_00
 
 const waitLoopTimer = new InterruptibleTimer();
 
+const isStringTooLongError = (error) => {
+  const errorMessage = error?.message ?? '';
+  return error?.code === 'ERR_STRING_TOO_LONG'
+    || errorMessage.includes('Cannot create a string longer than');
+};
+
+const dropAttachedFilesData = (syncData) => {
+  const files = syncData?.extensions?.[STIX_EXT_OCTI]?.files;
+  if (!Array.isArray(files) || files.length === 0) {
+    return [];
+  }
+
+  const droppedFiles = [];
+  for (let index = 0; index < files.length; index += 1) {
+    const file = files[index];
+    if (typeof file?.data === 'string' && file.data.length > 0) {
+      droppedFiles.push({
+        fileUri: file.uri,
+        dataLength: file.data.length,
+      });
+      delete file.data;
+    }
+  }
+  return droppedFiles;
+};
+
+const encodeEventPayloadToBase64 = (payload) => Buffer.from(payload, 'utf-8').toString('base64');
+
+const buildSyncEventContent = ({
+  syncId,
+  lastEventId,
+  eventType,
+  syncData,
+  eventContext,
+  encodeToBase64 = encodeEventPayloadToBase64,
+  logger = logApp,
+}) => {
+  const buildPayload = () => JSON.stringify({
+    id: lastEventId,
+    type: eventType,
+    data: syncData,
+    context: eventContext,
+  });
+  try {
+    return encodeToBase64(buildPayload());
+  } catch (encodingError) {
+    if (!isStringTooLongError(encodingError)) {
+      throw encodingError;
+    }
+    const droppedFiles = dropAttachedFilesData(syncData);
+    if (droppedFiles.length === 0) {
+      throw encodingError;
+    }
+    logger.error('[OPENCTI] Sync: Event payload too large, dropping attached files data and retrying.', {
+      id: syncId,
+      eventId: lastEventId,
+      entityId: syncData?.extensions?.[STIX_EXT_OCTI]?.id,
+      entityType: syncData?.extensions?.[STIX_EXT_OCTI]?.type,
+      droppedFilesCount: droppedFiles.length,
+      droppedFiles,
+      code: encodingError.code,
+      message: encodingError.message,
+    });
+    return encodeToBase64(buildPayload());
+  }
+};
+
 const hasEmbeddedStorageRef = (markdown) => {
   return markdown.includes('embedded/')
     || markdown.includes('/storage/get/embedded/')
@@ -164,7 +231,25 @@ export const transformDataWithReverseIdAndFilesData = async (sync, httpClient, d
         continue;
       }
       const response = await httpClient.get(fetchUri);
-      entityFile.data = Buffer.from(response.data).toString('base64');
+      try {
+        entityFile.data = Buffer.from(response.data).toString('base64');
+      } catch (encodingError) {
+        if (isStringTooLongError(encodingError)) {
+          const attachmentByteLength = Buffer.isBuffer(response?.data)
+            ? response.data.length
+            : response?.data?.byteLength;
+          logApp.error('[OPENCTI] Sync: Attached file too large to encode, skipping file data.', {
+            fileUri,
+            entityId: markdownEntityContext.entityId,
+            entityType: markdownEntityContext.entityType,
+            attachmentByteLength,
+            code: encodingError.code,
+            message: encodingError.message,
+          });
+          continue;
+        }
+        throw encodingError;
+      }
     } catch (e) {
       logApp.warn('[OPENCTI] Sync: Error when trying to get file from storage. Skipping file.', { fileUri, message: e.message });
     }
@@ -361,8 +446,13 @@ const syncManagerInstance = (syncId) => {
             while (!processed && running) {
               try {
                 const { data: syncData, previous_standard } = await transformDataWithReverseIdAndFilesData(sync, httpClient, stixData, eventContext);
-                const enrichedEvent = JSON.stringify({ id: lastEventId, type: eventType, data: syncData, context: eventContext });
-                const content = Buffer.from(enrichedEvent, 'utf-8').toString('base64');
+                const content = buildSyncEventContent({
+                  syncId,
+                  lastEventId,
+                  eventType,
+                  syncData,
+                  eventContext,
+                });
                 await pushBundleToWorker(context, SYSTEM_USER, sync.internal_id, {
                   type: 'event',
                   event_id,
@@ -500,4 +590,5 @@ const initSyncManager = () => {
 };
 const syncManager = initSyncManager();
 
+export { isStringTooLongError, dropAttachedFilesData, buildSyncEventContent };
 export default syncManager;

--- a/opencti-platform/opencti-graphql/src/manager/syncManager.js
+++ b/opencti-platform/opencti-graphql/src/manager/syncManager.js
@@ -39,7 +39,10 @@ const waitLoopTimer = new InterruptibleTimer();
 const isStringTooLongError = (error) => {
   const errorMessage = error?.message ?? '';
   return error?.code === 'ERR_STRING_TOO_LONG'
-    || errorMessage.includes('Cannot create a string longer than');
+    || errorMessage.includes('Cannot create a string longer than')
+    // JSON.stringify throws a plain RangeError with this message (no error code) when the
+    // resulting string would exceed Node's max string length.
+    || (error instanceof RangeError && errorMessage.includes('Invalid string length'));
 };
 
 const dropAttachedFilesData = (syncData) => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-large-payload-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-large-payload-test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { STIX_EXT_OCTI } from '../../../src/types/stix-2-1-extensions';
+import { buildSyncEventContent, dropAttachedFilesData, isStringTooLongError } from '../../../src/manager/syncManager';
+
+describe('syncManager large payload safeguards', () => {
+  it('detects Node string-too-long errors', () => {
+    expect(isStringTooLongError({ code: 'ERR_STRING_TOO_LONG' })).toBe(true);
+    expect(isStringTooLongError(new Error('Cannot create a string longer than 0x1fffffe8 characters'))).toBe(true);
+    expect(isStringTooLongError(new Error('another error'))).toBe(false);
+  });
+
+  it('drops attached files data and returns dropped files details', () => {
+    const syncData: Record<string, any> = {
+      extensions: {
+        [STIX_EXT_OCTI]: {
+          files: [
+            { uri: '/storage/get/a', data: 'A'.repeat(32) },
+            { uri: '/storage/get/b' },
+            { uri: '/storage/get/c', data: 'C'.repeat(8) },
+          ],
+        },
+      },
+    };
+
+    const droppedFiles = dropAttachedFilesData(syncData);
+
+    expect(droppedFiles).toEqual([
+      { fileUri: '/storage/get/a', dataLength: 32 },
+      { fileUri: '/storage/get/c', dataLength: 8 },
+    ]);
+    expect(syncData.extensions[STIX_EXT_OCTI].files[0]).not.toHaveProperty('data');
+    expect(syncData.extensions[STIX_EXT_OCTI].files[1]).not.toHaveProperty('data');
+    expect(syncData.extensions[STIX_EXT_OCTI].files[2]).not.toHaveProperty('data');
+  });
+
+  it('retries payload encoding after dropping attachment data on ERR_STRING_TOO_LONG', () => {
+    const syncData: Record<string, any> = {
+      extensions: {
+        [STIX_EXT_OCTI]: {
+          id: 'entity-id',
+          type: 'Report',
+          files: [{ uri: '/storage/get/huge', data: 'H'.repeat(64) }],
+        },
+      },
+    };
+    const logger = { error: vi.fn() };
+    const encodeToBase64 = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        const error = new Error('Cannot create a string longer than 0x1fffffe8 characters');
+        (error as any).code = 'ERR_STRING_TOO_LONG';
+        throw error;
+      })
+      .mockImplementation((payload: string) => `encoded:${payload.length}`);
+
+    const content = buildSyncEventContent({
+      syncId: 'sync-id',
+      lastEventId: 'event-id',
+      eventType: 'create',
+      syncData,
+      eventContext: { user_id: 'u-1' },
+      encodeToBase64,
+      logger,
+    });
+
+    expect(content).toMatch(/^encoded:/);
+    expect(encodeToBase64).toHaveBeenCalledTimes(2);
+    const firstPayload = JSON.parse(encodeToBase64.mock.calls[0][0]);
+    const secondPayload = JSON.parse(encodeToBase64.mock.calls[1][0]);
+    expect(firstPayload.data.extensions[STIX_EXT_OCTI].files[0].data).toBeDefined();
+    expect(secondPayload.data.extensions[STIX_EXT_OCTI].files[0].data).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows ERR_STRING_TOO_LONG when no attachment data can be dropped', () => {
+    const syncData: Record<string, any> = {
+      extensions: {
+        [STIX_EXT_OCTI]: {
+          files: [{ uri: '/storage/get/no-data' }],
+        },
+      },
+    };
+    const encodeToBase64 = vi.fn(() => {
+      const error = new Error('Cannot create a string longer than 0x1fffffe8 characters');
+      (error as any).code = 'ERR_STRING_TOO_LONG';
+      throw error;
+    });
+
+    expect(() => buildSyncEventContent({
+      syncId: 'sync-id',
+      lastEventId: 'event-id',
+      eventType: 'create',
+      syncData,
+      eventContext: {},
+      encodeToBase64,
+    })).toThrowError(/Cannot create a string longer than/);
+    expect(encodeToBase64).toHaveBeenCalledTimes(1);
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-large-payload-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-large-payload-test.ts
@@ -6,7 +6,9 @@ describe('syncManager large payload safeguards', () => {
   it('detects Node string-too-long errors', () => {
     expect(isStringTooLongError({ code: 'ERR_STRING_TOO_LONG' })).toBe(true);
     expect(isStringTooLongError(new Error('Cannot create a string longer than 0x1fffffe8 characters'))).toBe(true);
+    expect(isStringTooLongError(new RangeError('Invalid string length'))).toBe(true);
     expect(isStringTooLongError(new Error('another error'))).toBe(false);
+    expect(isStringTooLongError(new Error('Invalid string length'))).toBe(false);
   });
 
   it('drops attached files data and returns dropped files details', () => {
@@ -68,6 +70,41 @@ describe('syncManager large payload safeguards', () => {
     const firstPayload = JSON.parse(encodeToBase64.mock.calls[0][0]);
     const secondPayload = JSON.parse(encodeToBase64.mock.calls[1][0]);
     expect(firstPayload.data.extensions[STIX_EXT_OCTI].files[0].data).toBeDefined();
+    expect(secondPayload.data.extensions[STIX_EXT_OCTI].files[0].data).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries payload encoding after dropping attachment data on JSON.stringify RangeError', () => {
+    const syncData: Record<string, any> = {
+      extensions: {
+        [STIX_EXT_OCTI]: {
+          id: 'entity-id',
+          type: 'Report',
+          files: [{ uri: '/storage/get/huge', data: 'H'.repeat(64) }],
+        },
+      },
+    };
+    const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), query: vi.fn(), _log: vi.fn(), debug: vi.fn() };
+    const encodeToBase64 = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new RangeError('Invalid string length');
+      })
+      .mockImplementation((payload: string) => `encoded:${payload.length}`);
+
+    const content = buildSyncEventContent({
+      syncId: 'sync-id',
+      lastEventId: 'event-id',
+      eventType: 'create',
+      syncData,
+      eventContext: { user_id: 'u-1' },
+      encodeToBase64,
+      logger,
+    });
+
+    expect(content).toMatch(/^encoded:/);
+    expect(encodeToBase64).toHaveBeenCalledTimes(2);
+    const secondPayload = JSON.parse(encodeToBase64.mock.calls[1][0]);
     expect(secondPayload.data.extensions[STIX_EXT_OCTI].files[0].data).toBeUndefined();
     expect(logger.error).toHaveBeenCalledTimes(1);
   });

--- a/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-large-payload-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/manager/syncManager-large-payload-test.ts
@@ -43,7 +43,7 @@ describe('syncManager large payload safeguards', () => {
         },
       },
     };
-    const logger = { error: vi.fn() };
+    const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), query: vi.fn(), _log: vi.fn(), debug: vi.fn() };
     const encodeToBase64 = vi
       .fn()
       .mockImplementationOnce(() => {


### PR DESCRIPTION
### Proposed changes

* During Sync, on the receiving end, catches (`ERR_STRING_TOO_LONG`) exceptions (`Cannot create a string longer than`) when stringifying to base-64 attached files. When it happens, logs an errors and retries without the attached file. Also treated the case when the `JSON.stringify` could fail because the total payload exceeds 500~MB; throwing a `RangeError: Invalid string length`.

* Cases handled:
  * A single file is larger than the limit for `Buffer#toString('base64')` (`ERR_STRING_TOO_LONG`)
  * The base-64 encoding of the total payload exceeds the same limit (`ERR_STRING_TOO_LONG`)
  * The stringification of the total payload is larger than the JSON.stringify limit (`RangeError: Invalid string length`)
 
* This is a mitigation while working on a better solution.

### Related issues

* closes #17778

### How to test this PR

* Set up a sync between two platforms: on the source go to "Data Sharing" and create a public Stream. On the target, go to "Integrations" and create a "OpenCTI Streams" built-in connector (make sure you enter the admin token of source). Select "Perfect stream" option.
* Create a new Note entity with a large attached file that when base-64 encoded gets larger than 500MB by using the following command: `head -c 351000000 /dev/zero > ~/Downloads/sync-err-string-too-long-351MB.bin`.
* Witness the Note arriving on the receiving end and the sync process NOT being blocked (i.e. you can continue sending other entities).

Repeat the process with another case: attach multiple files with the sum larger than 500MB (ex: 5 x 150MB). You should fall in the `RangeError: Invalid string length` case.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
