### PR TITLE
feat(build): show build commit hash in settings (#17710)

### DIFF
--- a/opencti-platform/Dockerfile
+++ b/opencti-platform/Dockerfile
@@ -67,6 +67,9 @@ RUN yarn build
 
 FROM base AS app
 
+ARG BUILD_COMMIT
+ENV BUILD_COMMIT="${BUILD_COMMIT}"
+
 RUN <<EOT
   set -euxo pipefail
 

--- a/opencti-platform/Dockerfile_fips
+++ b/opencti-platform/Dockerfile_fips
@@ -84,6 +84,9 @@ RUN yarn build
 
 FROM base AS app
 
+ARG BUILD_COMMIT
+ENV BUILD_COMMIT="${BUILD_COMMIT}"
+
 RUN <<EOT
   set -euxo pipefail
 

--- a/opencti-platform/Dockerfile_ubi9
+++ b/opencti-platform/Dockerfile_ubi9
@@ -72,6 +72,9 @@ RUN yarn build
 
 FROM base AS app
 
+ARG BUILD_COMMIT
+ENV BUILD_COMMIT="${BUILD_COMMIT}"
+
 RUN <<EOT
   set -euxo pipefail
 

--- a/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/Settings.tsx
@@ -41,6 +41,7 @@ import HiddenTypesField from './hidden_types/HiddenTypesField';
 import SettingsAnalytics from './settings_analytics/SettingsAnalytics';
 import SettingsMessages from './settings_messages/SettingsMessages';
 import { useChatbot } from '@components/chatbox/ChatbotContext';
+import { formatOpenCTIVersion } from './SettingsUtils';
 
 const AI_TYPE_MAP: Record<string, string> = {
   mistralai: 'MistralAI',
@@ -118,6 +119,7 @@ const settingsQuery = graphql`
     }
     about {
       version
+      buildCommit
       dependencies {
         name
         version
@@ -214,7 +216,7 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
   };
 
   const modules = settings.platform_modules;
-  const { version, dependencies } = about || { version: '', dependencies: [] };
+  const { version, buildCommit, dependencies } = about || { version: '', buildCommit: null, dependencies: [] };
   const isEnterpriseEditionActivated = settings.platform_enterprise_edition.license_enterprise;
   const isEnterpriseEditionByConfig = settings.platform_enterprise_edition.license_by_configuration;
   const isEnterpriseEditionValid = settings.platform_enterprise_edition.license_validated;
@@ -592,7 +594,7 @@ const SettingsComponent = ({ queryRef }: SettingsComponentProps) => {
                     <ListItem divider={true}>
                       <ListItemText primary={t_i18n('Version')} />
                       <ItemBoolean
-                        neutralLabel={version}
+                        neutralLabel={formatOpenCTIVersion(version, buildCommit)}
                         status={null}
                       />
                     </ListItem>

--- a/opencti-platform/opencti-front/src/private/components/settings/SettingsUtils.test.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/SettingsUtils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { formatOpenCTIVersion } from './SettingsUtils';
+
+describe('formatOpenCTIVersion', () => {
+  it('should append the build commit when present', () => {
+    expect(formatOpenCTIVersion('7.0.0', 'abcdef0')).toBe('7.0.0 (abcdef0)');
+  });
+
+  it('should only display the version when the build commit is absent', () => {
+    expect(formatOpenCTIVersion('7.0.0', null)).toBe('7.0.0');
+  });
+});

--- a/opencti-platform/opencti-front/src/private/components/settings/SettingsUtils.ts
+++ b/opencti-platform/opencti-front/src/private/components/settings/SettingsUtils.ts
@@ -1,0 +1,3 @@
+export const formatOpenCTIVersion = (version: string, buildCommit?: string | null): string => {
+  return buildCommit ? `${version} (${buildCommit})` : version;
+};

--- a/opencti-platform/opencti-front/src/schema/relay.schema.graphql
+++ b/opencti-platform/opencti-front/src/schema/relay.schema.graphql
@@ -289,6 +289,9 @@ type AppInfo {
   """The OpenCTI application version"""
   version: String!
 
+  """The source commit used to build OpenCTI"""
+  buildCommit: String
+
   """The OpenCTI api current memory usage"""
   memory: AppMemory
 

--- a/opencti-platform/opencti-graphql/config/schema/opencti.graphql
+++ b/opencti-platform/opencti-graphql/config/schema/opencti.graphql
@@ -281,6 +281,10 @@ type AppInfo {
   """
   version: String! @auth
   """
+  The source commit used to build OpenCTI
+  """
+  buildCommit: String @auth
+  """
   The OpenCTI api current memory usage
   """
   memory: AppMemory @auth(for: [SETTINGS_SETPARAMETERS])

--- a/opencti-platform/opencti-graphql/src/boot.ts
+++ b/opencti-platform/opencti-graphql/src/boot.ts
@@ -7,11 +7,15 @@ import { initLockFork } from './lock/master-lock';
 import { checkSystemDependencies } from './boot-utils';
 import { startLivenessServer, stopLivenessServer } from './http/httpLiveness';
 import { startEngineHealthMonitor, stopEngineHealthMonitor } from './database/engine-monitoring';
+import { getBuildCommit } from './utils/build-info';
 
 // region platform start and stop
 export const platformStart = async () => {
   const startTime = Date.now();
   logApp.info('[OPENCTI] Starting platform', { environment });
+  if (!getBuildCommit()) {
+    logApp.warn('[OPENCTI] Build commit metadata is unavailable');
+  }
   try {
     // Start the liveness probe first so orchestrators can detect the process is alive
     try {

--- a/opencti-platform/opencti-graphql/src/boot.ts
+++ b/opencti-platform/opencti-graphql/src/boot.ts
@@ -14,7 +14,7 @@ export const platformStart = async () => {
   const startTime = Date.now();
   logApp.info('[OPENCTI] Starting platform', { environment });
   if (!getBuildCommit()) {
-    logApp.warn('[OPENCTI] Build commit metadata is unavailable');
+    logApp.warn('[OPENCTI] Build commit metadata is missing or invalid');
   }
   try {
     // Start the liveness probe first so orchestrators can detect the process is alive

--- a/opencti-platform/opencti-graphql/src/domain/settings.js
+++ b/opencti-platform/opencti-graphql/src/domain/settings.js
@@ -34,6 +34,7 @@ import { findById as findThemeById } from '../modules/theme/theme-domain';
 import { buildAvailableProviders } from './setting-auth';
 import { CguStatus } from '../generated/graphql';
 import { getXtmOneRegistrationVersion } from '../modules/xtm/one/xtm-one';
+import { getBuildCommit } from '../utils/build-info';
 
 export const getMemoryStatistics = () => {
   return { ...process.memoryUsage(), ...getHeapStatistics() };
@@ -41,6 +42,7 @@ export const getMemoryStatistics = () => {
 
 export const getApplicationInfo = () => ({
   version: PLATFORM_VERSION,
+  buildCommit: getBuildCommit(),
   debugStats: {}, // Lazy loaded
 });
 

--- a/opencti-platform/opencti-graphql/src/generated/graphql.ts
+++ b/opencti-platform/opencti-graphql/src/generated/graphql.ts
@@ -651,6 +651,8 @@ export type AppDebugStatistics = {
 /** Retrieve the application information version add dependencies */
 export type AppInfo = {
   __typename?: 'AppInfo';
+  /** The source commit used to build OpenCTI */
+  buildCommit?: Maybe<Scalars['String']['output']>;
   /** The objects statistics */
   debugStats?: Maybe<AppDebugStatistics>;
   /** The list of OpenCTI software dependencies */
@@ -42167,6 +42169,7 @@ export type AppDebugStatisticsResolvers<ContextType = any, ParentType extends Re
 }>;
 
 export type AppInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['AppInfo'] = ResolversParentTypes['AppInfo']> = ResolversObject<{
+  buildCommit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   debugStats?: Resolver<Maybe<ResolversTypes['AppDebugStatistics']>, ParentType, ContextType>;
   dependencies?: Resolver<Array<ResolversTypes['DependencyVersion']>, ParentType, ContextType>;
   memory?: Resolver<Maybe<ResolversTypes['AppMemory']>, ParentType, ContextType>;

--- a/opencti-platform/opencti-graphql/src/resolvers/settings.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/settings.js
@@ -76,7 +76,7 @@ const settingsResolvers = {
     is_authentication_by_env: () => isAuthenticationForcedFromEnv(),
   },
   AppInfo: {
-    memory: getMemoryStatistics(),
+    memory: () => getMemoryStatistics(),
     dependencies: (_, __, context) => getApplicationDependencies(context),
   },
   SettingsMessage: {

--- a/opencti-platform/opencti-graphql/src/utils/build-info.ts
+++ b/opencti-platform/opencti-graphql/src/utils/build-info.ts
@@ -1,0 +1,11 @@
+const GIT_REVISION_PATTERN = /^[0-9a-f]{7,}$/i;
+
+export const normalizeBuildCommit = (value: string | undefined): string | undefined => {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue || !GIT_REVISION_PATTERN.test(trimmedValue)) {
+    return undefined;
+  }
+  return trimmedValue.slice(0, 7);
+};
+
+export const getBuildCommit = (): string | undefined => normalizeBuildCommit(process.env.BUILD_COMMIT);

--- a/opencti-platform/opencti-graphql/tests/01-unit/build-info-startup-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/build-info-startup-test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { platformStart } from '../../src/boot';
+import { logApp } from '../../src/config/conf';
+import * as bootUtils from '../../src/boot-utils';
+
+vi.mock('../../src/boot-utils', () => ({
+  checkSystemDependencies: vi.fn(),
+}));
+vi.mock('../../src/http/httpLiveness', () => ({
+  startLivenessServer: vi.fn(),
+  stopLivenessServer: vi.fn(),
+}));
+vi.mock('../../src/initialization', () => ({
+  default: vi.fn(),
+  checkFeatureFlags: vi.fn(),
+}));
+vi.mock('../../src/manager/cacheManager', () => ({
+  default: {
+    start: vi.fn(),
+    shutdown: vi.fn(),
+  },
+}));
+vi.mock('../../src/managers', () => ({
+  startModules: vi.fn(),
+  shutdownModules: vi.fn(),
+}));
+vi.mock('../../src/lock/master-lock', () => ({
+  initLockFork: vi.fn(),
+}));
+vi.mock('../../src/database/engine-monitoring', () => ({
+  startEngineHealthMonitor: vi.fn(),
+  stopEngineHealthMonitor: vi.fn(),
+}));
+vi.mock('../../src/database/redis', () => ({
+  shutdownRedisClients: vi.fn(),
+}));
+
+describe('Build commit startup warning', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('should warn once when build metadata is absent', async () => {
+    vi.stubEnv('BUILD_COMMIT', '');
+    vi.mocked(bootUtils.checkSystemDependencies).mockResolvedValue(true);
+    const warningSpy = vi.spyOn(logApp, 'warn').mockImplementation(() => logApp);
+
+    await platformStart();
+
+    expect(warningSpy).toHaveBeenCalledOnce();
+    expect(warningSpy).toHaveBeenCalledWith('[OPENCTI] Build commit metadata is unavailable');
+  });
+
+  it('should not warn when build metadata contains a valid commit', async () => {
+    vi.stubEnv('BUILD_COMMIT', '0123456789abcdef');
+    vi.mocked(bootUtils.checkSystemDependencies).mockResolvedValue(true);
+    const warningSpy = vi.spyOn(logApp, 'warn').mockImplementation(() => logApp);
+
+    await platformStart();
+
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+});

--- a/opencti-platform/opencti-graphql/tests/01-unit/build-info-startup-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/build-info-startup-test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { platformStart } from '../../src/boot';
 import { logApp } from '../../src/config/conf';
 import * as bootUtils from '../../src/boot-utils';
@@ -36,6 +36,12 @@ vi.mock('../../src/database/redis', () => ({
 }));
 
 describe('Build commit startup warning', () => {
+  beforeEach(() => {
+    vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`Unexpected process.exit(${code})`);
+    });
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
@@ -49,7 +55,18 @@ describe('Build commit startup warning', () => {
     await platformStart();
 
     expect(warningSpy).toHaveBeenCalledOnce();
-    expect(warningSpy).toHaveBeenCalledWith('[OPENCTI] Build commit metadata is unavailable');
+    expect(warningSpy).toHaveBeenCalledWith('[OPENCTI] Build commit metadata is missing or invalid');
+  });
+
+  it('should warn once when build metadata is malformed', async () => {
+    vi.stubEnv('BUILD_COMMIT', 'not-a-commit');
+    vi.mocked(bootUtils.checkSystemDependencies).mockResolvedValue(true);
+    const warningSpy = vi.spyOn(logApp, 'warn').mockImplementation(() => logApp);
+
+    await platformStart();
+
+    expect(warningSpy).toHaveBeenCalledOnce();
+    expect(warningSpy).toHaveBeenCalledWith('[OPENCTI] Build commit metadata is missing or invalid');
   });
 
   it('should not warn when build metadata contains a valid commit', async () => {

--- a/opencti-platform/opencti-graphql/tests/01-unit/utils/version-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/utils/version-test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { isCompatibleVersionWithMinimal } from '../../../src/utils/version';
+import { normalizeBuildCommit } from '../../../src/utils/build-info';
 
 describe('Version utils Tests', () => {
   it('should test compatible version with minimal', () => {
@@ -11,5 +12,27 @@ describe('Version utils Tests', () => {
     expect(isCompatibleVersionWithMinimal('5.12.15', '5.12.16')).toBeFalsy();
     expect(isCompatibleVersionWithMinimal('5.0.0', '5.12.16')).toBeFalsy();
     expect(isCompatibleVersionWithMinimal('4.12.16', '5.12.16')).toBeFalsy();
+  });
+
+  describe('Build commit normalization', () => {
+    it('should shorten a full commit hash', () => {
+      expect(normalizeBuildCommit('0123456789abcdef0123456789abcdef01234567')).toBe('0123456');
+    });
+
+    it('should preserve a seven-character commit hash', () => {
+      expect(normalizeBuildCommit('abcdef0')).toBe('abcdef0');
+    });
+
+    it('should trim surrounding whitespace', () => {
+      expect(normalizeBuildCommit('  abcdef012345  ')).toBe('abcdef0');
+    });
+
+    it.each([undefined, '', '   '])('should reject a missing or blank commit hash', (value) => {
+      expect(normalizeBuildCommit(value)).toBeUndefined();
+    });
+
+    it.each(['not-a-commit', '123456', 'abcdefg'])('should reject a malformed commit hash', (value) => {
+      expect(normalizeBuildCommit(value)).toBeUndefined();
+    });
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.ts
@@ -1,20 +1,198 @@
 import { describe, expect, it } from 'vitest';
 import gql from 'graphql-tag';
 import { queryAsAdminWithSuccess } from '../../utils/testQueryHelper';
+import { PLATFORM_VERSION } from '../../../src/config/conf';
 
 const ABOUT_QUERY = gql`
   query About {
     about {
+      version
       buildCommit
+      memory {
+        rss
+        heapTotal
+        heapUsed
+        external
+      }
+      dependencies {
+        name
+        version
+      }
+      debugStats {
+        objects {
+          label
+          value
+        }
+        relationships {
+          label
+          value
+        }
+      }
+    }
+  }
+`;
+
+const SETTINGS_QUERY = gql`
+  query Settings {
+    settings {
+      id
+      platform_title
+      platform_type
+      platform_ip_whitelist_enabled
+      platform_session_idle_timeout
+      platform_session_timeout
+      platform_https_enabled
+      caller_ip
+      otp_mandatory
+      password_policy_min_length
+      password_policy_max_length
+      password_policy_min_symbols
+      password_policy_min_numbers
+      password_policy_min_words
+      password_policy_min_lowercase
+      password_policy_min_uppercase
+      password_policy_validity_days
+      platform_notifier_auto_trigger_assignee
+      platform_ai_enabled
+      filigran_chatbot_ai_cgu_status
+      is_authentication_by_env
+    }
+    publicSettings {
+      id
+      platform_title
+      platform_providers {
+        name
+        type
+        provider
+      }
+      platform_enterprise_edition_license_validated
+      playground_enabled
+      password_policy_min_length
+      password_policy_max_length
+      password_policy_min_symbols
+      password_policy_min_numbers
+      password_policy_min_words
+      password_policy_min_lowercase
+      password_policy_min_uppercase
+      password_policy_validity_days
+    }
+  }
+`;
+
+const SETTINGS_CONTEXT_PATCH = gql`
+  mutation SettingsContextPatch($id: ID!, $input: EditContext) {
+    settingsEdit(id: $id) {
+      contextPatch(input: $input) {
+        id
+        editContext {
+          name
+          focusOn
+        }
+      }
+    }
+  }
+`;
+
+const SETTINGS_CONTEXT_CLEAN = gql`
+  mutation SettingsContextClean($id: ID!) {
+    settingsEdit(id: $id) {
+      contextClean {
+        id
+        editContext {
+          name
+          focusOn
+        }
+      }
     }
   }
 `;
 
 describe('Settings resolver', () => {
-  it('should expose a nullable short build commit', async () => {
+  it('should expose application information', async () => {
     const { data } = await queryAsAdminWithSuccess({ query: ABOUT_QUERY });
-    const buildCommit = data.about?.buildCommit;
+    const about = data.about;
 
-    expect(buildCommit === null || /^[0-9a-f]{7}$/i.test(buildCommit)).toBe(true);
+    expect(about?.version).toBe(PLATFORM_VERSION);
+    expect(about?.buildCommit === null || /^[0-9a-f]{7}$/i.test(about?.buildCommit)).toBe(true);
+    expect(about?.memory).toEqual(expect.objectContaining({
+      rss: expect.any(Number),
+      heapTotal: expect.any(Number),
+      heapUsed: expect.any(Number),
+      external: expect.any(Number),
+    }));
+    expect(about?.dependencies).toEqual([
+      { name: 'Search engine', version: expect.any(String) },
+      { name: 'RabbitMQ', version: expect.any(String) },
+      { name: 'Redis', version: expect.any(String) },
+      { name: 'XTM-One', version: expect.any(String) },
+    ]);
+    expect(about?.debugStats?.objects).toEqual(expect.any(Array));
+    expect(about?.debugStats?.relationships).toEqual(expect.any(Array));
+  });
+
+  it('should expose authenticated and public settings consistently', async () => {
+    const { data } = await queryAsAdminWithSuccess({ query: SETTINGS_QUERY });
+    const { settings, publicSettings } = data;
+
+    expect(settings.id).toBe(publicSettings.id);
+    expect(settings.platform_title).toBe(publicSettings.platform_title);
+    expect(['LTS', 'STANDARD']).toContain(settings.platform_type);
+    expect(settings.platform_ip_whitelist_enabled).toEqual(expect.any(Boolean));
+    expect(settings.platform_session_idle_timeout).toEqual(expect.any(Number));
+    expect(settings.platform_session_timeout).toEqual(expect.any(Number));
+    expect(settings.platform_https_enabled).toEqual(expect.any(Boolean));
+    expect(settings.caller_ip).toBeNull();
+    expect(settings.otp_mandatory).toEqual(expect.any(Boolean));
+    expect(settings.platform_notifier_auto_trigger_assignee).toEqual(expect.any(Boolean));
+    expect(settings.platform_ai_enabled).toEqual(expect.any(Boolean));
+    expect(['disabled', 'enabled', 'pending']).toContain(settings.filigran_chatbot_ai_cgu_status);
+    expect(settings.is_authentication_by_env).toEqual(expect.any(Boolean));
+    expect(publicSettings.platform_providers).toEqual(expect.any(Array));
+    expect(publicSettings.platform_enterprise_edition_license_validated).toEqual(expect.any(Boolean));
+    expect(publicSettings.playground_enabled).toEqual(expect.any(Boolean));
+
+    const passwordPolicyFields = [
+      'password_policy_min_length',
+      'password_policy_max_length',
+      'password_policy_min_symbols',
+      'password_policy_min_numbers',
+      'password_policy_min_words',
+      'password_policy_min_lowercase',
+      'password_policy_min_uppercase',
+      'password_policy_validity_days',
+    ];
+    for (const field of passwordPolicyFields) {
+      expect(settings[field]).toEqual(expect.any(Number));
+      expect(publicSettings[field] === null || typeof publicSettings[field] === 'number').toBe(true);
+      if (publicSettings[field] !== null) {
+        expect(publicSettings[field]).toBe(settings[field]);
+      }
+    }
+  });
+
+  it('should patch and clean the settings edit context', async () => {
+    const { data: settingsData } = await queryAsAdminWithSuccess({ query: SETTINGS_QUERY });
+    const settingsId = settingsData.settings.id;
+
+    try {
+      const { data: patchData } = await queryAsAdminWithSuccess({
+        query: SETTINGS_CONTEXT_PATCH,
+        variables: { id: settingsId, input: { focusOn: 'platform_title' } },
+      });
+      const patchedSettings = patchData.settingsEdit.contextPatch;
+
+      expect(patchedSettings.id).toBe(settingsId);
+      expect(patchedSettings.editContext).toEqual(expect.arrayContaining([
+        expect.objectContaining({ focusOn: 'platform_title' }),
+      ]));
+    } finally {
+      const { data: cleanData } = await queryAsAdminWithSuccess({
+        query: SETTINGS_CONTEXT_CLEAN,
+        variables: { id: settingsId },
+      });
+
+      expect(cleanData.settingsEdit.contextClean.id).toBe(settingsId);
+      expect(cleanData.settingsEdit.contextClean.editContext).toEqual([]);
+    }
   });
 });

--- a/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.ts
+++ b/opencti-platform/opencti-graphql/tests/03-integration/02-resolvers/settings-test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import gql from 'graphql-tag';
+import { queryAsAdminWithSuccess } from '../../utils/testQueryHelper';
+
+const ABOUT_QUERY = gql`
+  query About {
+    about {
+      buildCommit
+    }
+  }
+`;
+
+describe('Settings resolver', () => {
+  it('should expose a nullable short build commit', async () => {
+    const { data } = await queryAsAdminWithSuccess({ query: ABOUT_QUERY });
+    const buildCommit = data.about?.buildCommit;
+
+    expect(buildCommit === null || /^[0-9a-f]{7}$/i.test(buildCommit)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Proposed changes

* Persist a CI-agnostic `BUILD_COMMIT` build argument in each final OpenCTI runtime image, normalize it to a seven-character hexadecimal revision in the backend, and expose it through nullable `about.buildCommit` metadata.
* Display the short revision next to the OpenCTI version in Settings when available, while preserving the existing version-only display when metadata is absent. Missing or malformed metadata logs one startup warning and does not block startup.
* Expand settings resolver integration coverage across application metadata, authenticated/public settings, and edit-context lifecycle. This also fixes the existing `AppInfo.memory` resolver so memory statistics are returned instead of `null`.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17710

### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->


* Local: Run command  `BUILD_COMMIT="$(git rev-parse HEAD)" yarn start`
* Docker: Build an image with `--build-arg BUILD_COMMIT=<git-sha>`, 

In all cases, start OpenCTI, and confirm Settings displays `<version> (<first 7 SHA characters>)`. Start without the build argument and confirm Settings displays only `<version>` and startup emits one metadata warning.

Automated coverage includes backend normalization and startup logging tests, application metadata/settings resolver integration coverage, settings edit-context lifecycle coverage, and frontend formatting tests. GraphQL/Relay generation, backend build, type checks, and linting pass.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

The Docker contract is intentionally CI-agnostic. The external build workflow is responsible for passing the checked-out SHA; no CircleCI changes are included.