### PR TITLE
fix(redis): support per-node TLS certificates in clusters (#17694)

### DIFF
--- a/docs/docs/deployment/advanced/clustering.md
+++ b/docs/docs/deployment/advanced/clustering.md
@@ -35,6 +35,8 @@ Redis should be turned to cluster mode:
 - "REDIS__HOSTNAMES=[\"node1:6379\", \"node2:6379\", ...]"
 ```
 
+When TLS is enabled, OpenCTI validates each cluster node certificate against the node address by default. Set `REDIS__TLS_SERVERNAME` when every node certificate uses the same Subject Alternative Name (SAN), such as a shared cluster hostname or wildcard.
+
 !!! note "Compatibility"
     
     OpenCTI is also compatible with ElastiCache, MemoryStore and AWS / GCP / Azure native services based on the Redis protocol.

--- a/docs/docs/deployment/configuration.md
+++ b/docs/docs/deployment/configuration.md
@@ -193,6 +193,7 @@ For a detailed list of exposed metrics, please refer to the [Telemetry](../deplo
 | redis:namespace            | REDIS__NAMESPACE            |               | Namespace (to use as prefix)                                                          |
 | redis:hostname             | REDIS__HOSTNAME             | localhost     | Hostname of the Redis Server                                                          |
 | redis:hostnames            | REDIS__HOSTNAMES            |               | Hostnames definition for Redis cluster or sentinel mode: a list of host:port objects. |
+| redis:tls_servername       | REDIS__TLS_SERVERNAME       |               | Optional shared server name used for TLS SNI and certificate validation. In cluster mode, leave empty to validate each node individually. |
 | redis:port                 | REDIS__PORT                 | 6379          | Port of the Redis Server                                                              |
 | redis:sentinel_master_name | REDIS__SENTINEL_MASTER_NAME |               | Name of your Redis Sentinel Master (mandatory in sentinel mode)                       |
 | redis:sentinel_username    | REDIS__SENTINEL_USERNAME    |               | Username to authenticate on Redis Sentinel                                            |

--- a/opencti-platform/opencti-graphql/config/default.json
+++ b/opencti-platform/opencti-graphql/config/default.json
@@ -376,6 +376,7 @@
     "mode": "single",
     "namespace": "",
     "hostname": "localhost",
+    "tls_servername": "",
     "use_ssl": false,
     "ca": [],
     "port": 6379,

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -72,7 +72,7 @@ export const generateNatMap = (mappings: string[]): Record<string, { host: strin
 };
 
 const clusterOptions = async (provider: string): Promise<ClusterOptions> => {
-  const redisOpts = await redisOptions(provider);
+  const redisOpts = await redisOptions(provider, false, conf.get('redis:tls_servername'));
   return {
     keyPrefix: REDIS_PREFIX,
     lazyConnect: true,
@@ -118,7 +118,8 @@ export const createRedisClient = async (provider: string, autoReconnect = false)
     const sentinelOpts = await sentinelOptions(provider, clusterNodes);
     client = new Redis(sentinelOpts);
   } else {
-    const singleOptions = await redisOptions(provider, autoReconnect, conf.get('redis:hostname'));
+    const tlsServername = conf.get('redis:tls_servername') || conf.get('redis:hostname');
+    const singleOptions = await redisOptions(provider, autoReconnect, tlsServername);
     client = new Redis({ ...singleOptions, db: conf.get('redis:database') ?? 0, port: conf.get('redis:port'), host: conf.get('redis:hostname') });
   }
 

--- a/opencti-platform/opencti-graphql/src/database/redis.ts
+++ b/opencti-platform/opencti-graphql/src/database/redis.ts
@@ -25,14 +25,14 @@ const PLAYBOOK_LOG_MAX_SIZE = conf.get('playbook_manager:log_max_size') || 10000
 
 const connectionName = (provider: string) => `${REDIS_PREFIX}${provider.replaceAll(' ', '_')}`;
 
-const redisOptions = async (provider: string, autoReconnect = false): Promise<RedisOptions> => {
+const redisOptions = async (provider: string, autoReconnect = false, tlsServername?: string): Promise<RedisOptions> => {
   const baseAuth = { username: conf.get('redis:username'), password: conf.get('redis:password') };
   const userPasswordAuth = await enrichWithRemoteCredentials('redis', baseAuth);
   return {
     connectionName: connectionName(provider),
     keyPrefix: REDIS_PREFIX,
     ...userPasswordAuth,
-    tls: USE_SSL ? { ...configureCA(REDIS_CA), servername: conf.get('redis:hostname') } : undefined,
+    tls: USE_SSL ? { ...configureCA(REDIS_CA), ...(tlsServername ? { servername: tlsServername } : {}) } : undefined,
     retryStrategy: /* v8 ignore next */ (times) => {
       if (getStoppingState()) {
         return null;
@@ -118,7 +118,7 @@ export const createRedisClient = async (provider: string, autoReconnect = false)
     const sentinelOpts = await sentinelOptions(provider, clusterNodes);
     client = new Redis(sentinelOpts);
   } else {
-    const singleOptions = await redisOptions(provider, autoReconnect);
+    const singleOptions = await redisOptions(provider, autoReconnect, conf.get('redis:hostname'));
     client = new Redis({ ...singleOptions, db: conf.get('redis:database') ?? 0, port: conf.get('redis:port'), host: conf.get('redis:hostname') });
   }
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
@@ -1,4 +1,52 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const redisConfig = vi.hoisted(() => ({
+  mode: 'cluster',
+  hostname: 'redis.example.test',
+  hostnames: ['node-1.example.test:6379', 'node-2.example.test:6379'],
+}));
+
+const redisClientMocks = vi.hoisted(() => {
+  const Redis = vi.fn(function Redis(options) {
+    this.options = options;
+    this.on = vi.fn().mockReturnValue(this);
+  });
+  const Cluster = vi.fn(function Cluster(nodes, options) {
+    this.nodes = nodes;
+    this.options = options;
+    this.on = vi.fn().mockReturnValue(this);
+  });
+  Redis.Cluster = Cluster;
+  return { Redis, Cluster };
+});
+
+vi.mock('ioredis', () => redisClientMocks);
+
+vi.mock('../../../src/config/conf', async (importOriginal) => {
+  const actual = await importOriginal();
+  const redisOverrides = () => ({
+    'redis:mode': redisConfig.mode,
+    'redis:hostname': redisConfig.hostname,
+    'redis:hostnames': redisConfig.hostnames,
+    'redis:ca': [],
+    'redis:database': 0,
+    'redis:port': 6379,
+    'redis:nat_map': [],
+  });
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: (key) => (key in redisOverrides() ? redisOverrides()[key] : actual.default.get(key)),
+    },
+    booleanConf: (key, fallback) => (key === 'redis:use_ssl' ? true : actual.booleanConf(key, fallback)),
+    configureCA: vi.fn(() => ({ ca: ['test-ca'] })),
+  };
+});
+
+vi.mock('../../../src/config/credentials', () => ({
+  enrichWithRemoteCredentials: vi.fn(async (_service, auth) => auth),
+}));
 
 vi.mock('../../../src/schema/schema-relationsRef', () => ({
   schemaRelationsRefDefinition: {
@@ -6,10 +54,37 @@ vi.mock('../../../src/schema/schema-relationsRef', () => ({
   },
 }));
 
-import { removeResolvedRefs } from '../../../src/database/redis';
+import { createRedisClient, removeResolvedRefs } from '../../../src/database/redis';
 import { generateClusterNodes, generateNatMap } from '../../../src/database/redis';
 
 describe('redis', () => {
+  beforeEach(() => {
+    redisConfig.mode = 'cluster';
+    vi.clearAllMocks();
+  });
+
+  it('should not pin the TLS servername in cluster mode', async () => {
+    await createRedisClient('test');
+
+    expect(redisClientMocks.Cluster).toHaveBeenCalledOnce();
+    const [nodes, options] = redisClientMocks.Cluster.mock.calls[0];
+    expect(nodes).toEqual([
+      { host: 'node-1.example.test', port: 6379 },
+      { host: 'node-2.example.test', port: 6379 },
+    ]);
+    expect(options.redisOptions.tls).toEqual({ ca: ['test-ca'] });
+  });
+
+  it('should use the configured hostname as TLS servername in single mode', async () => {
+    redisConfig.mode = 'single';
+
+    await createRedisClient('test');
+
+    expect(redisClientMocks.Redis).toHaveBeenCalledOnce();
+    const [options] = redisClientMocks.Redis.mock.calls[0];
+    expect(options.tls).toEqual({ ca: ['test-ca'], servername: 'redis.example.test' });
+  });
+
   it('should cluster node configuration correctly generated', () => {
     const nodes = generateClusterNodes(['localhost:7000', 'localhost:7001']);
     expect(nodes.length).toBe(2);

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
@@ -5,6 +5,7 @@ const redisConfig = vi.hoisted(() => ({
   mode: 'cluster',
   hostname: 'redis.example.test',
   hostnames: ['node-1.example.test:6379', 'node-2.example.test:6379'],
+  tlsServername: undefined,
 }));
 
 vi.mock('../../../src/config/conf', async (importOriginal) => {
@@ -13,6 +14,7 @@ vi.mock('../../../src/config/conf', async (importOriginal) => {
     'redis:mode': redisConfig.mode,
     'redis:hostname': redisConfig.hostname,
     'redis:hostnames': redisConfig.hostnames,
+    'redis:tls_servername': redisConfig.tlsServername,
     'redis:ca': [],
     'redis:database': 0,
     'redis:port': 6379,
@@ -51,6 +53,7 @@ describe('Redis client creation', () => {
     redisConfig.mode = 'cluster';
     redisConfig.hostname = 'redis.example.test';
     redisConfig.hostnames = ['node-1.example.test:6379', 'node-2.example.test:6379'];
+    redisConfig.tlsServername = undefined;
     vi.clearAllMocks();
   });
 
@@ -73,6 +76,31 @@ describe('Redis client creation', () => {
 
     expect(client).toBeInstanceOf(Redis);
     expect(client.options.tls).toMatchObject({ ca: ['test-ca'], servername: 'redis.example.test' });
+  });
+
+  it('should use an explicit TLS servername for every cluster node', async () => {
+    redisConfig.tlsServername = 'redis-cluster.example.test';
+
+    client = await createRedisClient('test');
+
+    expect(client).toBeInstanceOf(Cluster);
+    expect(client.options.redisOptions.tls).toMatchObject({
+      ca: ['test-ca'],
+      servername: 'redis-cluster.example.test',
+    });
+  });
+
+  it('should override the hostname with an explicit TLS servername in single mode', async () => {
+    redisConfig.mode = 'single';
+    redisConfig.tlsServername = 'redis-service.example.test';
+
+    client = await createRedisClient('test');
+
+    expect(client).toBeInstanceOf(Redis);
+    expect(client.options.tls).toMatchObject({
+      ca: ['test-ca'],
+      servername: 'redis-service.example.test',
+    });
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
@@ -1,26 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Cluster, Redis } from 'ioredis';
 
 const redisConfig = vi.hoisted(() => ({
   mode: 'cluster',
   hostname: 'redis.example.test',
   hostnames: ['node-1.example.test:6379', 'node-2.example.test:6379'],
 }));
-
-const redisClientMocks = vi.hoisted(() => {
-  const Redis = vi.fn(function Redis(options) {
-    this.options = options;
-    this.on = vi.fn().mockReturnValue(this);
-  });
-  const Cluster = vi.fn(function Cluster(nodes, options) {
-    this.nodes = nodes;
-    this.options = options;
-    this.on = vi.fn().mockReturnValue(this);
-  });
-  Redis.Cluster = Cluster;
-  return { Redis, Cluster };
-});
-
-vi.mock('ioredis', () => redisClientMocks);
 
 vi.mock('../../../src/config/conf', async (importOriginal) => {
   const actual = await importOriginal();
@@ -57,58 +42,53 @@ vi.mock('../../../src/schema/schema-relationsRef', () => ({
   },
 }));
 
-import { createRedisClient, removeResolvedRefs } from '../../../src/database/redis';
-import { generateClusterNodes, generateNatMap } from '../../../src/database/redis';
+import { createRedisClient, generateClusterNodes, generateNatMap, removeResolvedRefs } from '../../../src/database/redis';
 
-describe('redis', () => {
+describe('Redis client creation', () => {
+  let client;
+
   beforeEach(() => {
     redisConfig.mode = 'cluster';
+    redisConfig.hostname = 'redis.example.test';
+    redisConfig.hostnames = ['node-1.example.test:6379', 'node-2.example.test:6379'];
     vi.clearAllMocks();
   });
 
-  it('should not pin the TLS servername in cluster mode', async () => {
-    await createRedisClient('test');
+  afterEach(() => {
+    client?.disconnect();
+  });
 
-    expect(redisClientMocks.Cluster).toHaveBeenCalledOnce();
-    const [nodes, options] = redisClientMocks.Cluster.mock.calls[0];
-    expect(nodes).toEqual([
-      { host: 'node-1.example.test', port: 6379 },
-      { host: 'node-2.example.test', port: 6379 },
-    ]);
-    expect(options.redisOptions.tls).toEqual({ ca: ['test-ca'] });
+  it('should not pin the TLS servername in cluster mode', async () => {
+    client = await createRedisClient('test');
+
+    expect(client).toBeInstanceOf(Cluster);
+    expect(client.options.redisOptions.tls).toMatchObject({ ca: ['test-ca'] });
+    expect(client.options.redisOptions.tls).not.toHaveProperty('servername');
   });
 
   it('should use the configured hostname as TLS servername in single mode', async () => {
     redisConfig.mode = 'single';
 
-    await createRedisClient('test');
+    client = await createRedisClient('test');
 
-    expect(redisClientMocks.Redis).toHaveBeenCalledOnce();
-    const [options] = redisClientMocks.Redis.mock.calls[0];
-    expect(options.tls).toEqual({ ca: ['test-ca'], servername: 'redis.example.test' });
+    expect(client).toBeInstanceOf(Redis);
+    expect(client.options.tls).toMatchObject({ ca: ['test-ca'], servername: 'redis.example.test' });
   });
+});
 
+describe('Redis cluster configuration', () => {
   it('should cluster node configuration correctly generated', () => {
-    const nodes = generateClusterNodes(['localhost:7000', 'localhost:7001']);
-    expect(nodes.length).toBe(2);
-    expect(nodes.at(0).host).toBe('localhost');
-    expect(nodes.at(0).port).toBe(7000);
-    expect(nodes.at(1).host).toBe('localhost');
-    expect(nodes.at(1).port).toBe(7001);
+    expect(generateClusterNodes(['localhost:7000', 'localhost:7001'])).toEqual([
+      { host: 'localhost', port: 7000 },
+      { host: 'localhost', port: 7001 },
+    ]);
   });
 
   it('should cluster nat map configuration correctly generated', () => {
-    const nat = generateNatMap(['10.0.1.230:30001>203.0.113.73:30001', '10.0.1.231:30001>203.0.113.73:30002']);
-    const entries = Object.entries(nat);
-    expect(entries.length).toBe(2);
-    const first = entries.at(0);
-    expect(first.at(0)).toBe('10.0.1.230:30001');
-    expect(first.at(1).host).toBe('203.0.113.73');
-    expect(first.at(1).port).toBe(30001);
-    const second = entries.at(1);
-    expect(second.at(0)).toBe('10.0.1.231:30001');
-    expect(second.at(1).host).toBe('203.0.113.73');
-    expect(second.at(1).port).toBe(30002);
+    expect(generateNatMap(['10.0.1.230:30001>203.0.113.73:30001', '10.0.1.231:30001>203.0.113.73:30002'])).toEqual({
+      '10.0.1.230:30001': { host: '203.0.113.73', port: 30001 },
+      '10.0.1.231:30001': { host: '203.0.113.73', port: 30002 },
+    });
   });
 });
 

--- a/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
+++ b/opencti-platform/opencti-graphql/tests/01-unit/database/redis-test.js
@@ -37,7 +37,10 @@ vi.mock('../../../src/config/conf', async (importOriginal) => {
     ...actual,
     default: {
       ...actual.default,
-      get: (key) => (key in redisOverrides() ? redisOverrides()[key] : actual.default.get(key)),
+      get: (key) => {
+        const overrides = redisOverrides();
+        return key in overrides ? overrides[key] : actual.default.get(key);
+      },
     },
     booleanConf: (key, fallback) => (key === 'redis:use_ssl' ? true : actual.booleanConf(key, fallback)),
     configureCA: vi.fn(() => ({ ca: ['test-ca'] })),


### PR DESCRIPTION
## Summary

- validate Redis Cluster TLS certificates against each node address by default
- add `REDIS__TLS_SERVERNAME` for clusters using a shared certificate identity or SNI endpoint
- preserve `REDIS__HOSTNAME` as the default TLS server name in single mode
- document both cluster certificate models and cover them with real lazy ioredis clients



Mode | TLS_SERVERNAME | Result
-- | -- | --
Cluster | unset | Validate each discovered node individually
Cluster | configured | Use one shared SNI/certificate identity
Single | unset | Preserve REDIS__HOSTNAME behavior
Single | configured | Use the explicit override


## Testing

- `yarn test:ci-unit tests/01-unit/database/redis-test.js`
- `yarn eslint --config eslint.config.js src/database/redis.ts tests/01-unit/database/redis-test.js`

`yarn check-ts` is currently blocked by the missing generated `src/__generated__/opencti-manifest.json` file.

Closes #17694