### PR TITLE
chore(fds): bump the design-system pin to 83295d9 (#17905)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -39,7 +39,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=fb8c3cc0fd085db0eab1c59ba32945610e4bc6c7",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=83295d97c9ad95a516e77659538f8d742d84ff2a",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/components/fds-tokens.generated.meta.json
+++ b/opencti-platform/opencti-front/src/components/fds-tokens.generated.meta.json
@@ -1,8 +1,8 @@
 {
   "__generated": "GENERATED FILE — do not edit by hand. Regenerate from the filigran-design-system repo: pnpm generate:mui-bridge --product opencti --write-to-product.",
   "product": "opencti",
-  "themeCssHash": "sha256:3c0ef256c9d92003739f590c0d969d3aec1dcc6bcb26e00e9e5db5ca845fa20e",
+  "themeCssHash": "sha256:164d8b4367c80f4e24956aa067ca8177e1d2ddae333e68c873b0c4173df32e52",
   "generator": "@filigran/design-system scripts/generate-mui-bridge.ts",
   "tsFile": "fds-tokens.generated.ts",
-  "tsFileSha256": "sha256:a1fbe12d028ec12290570fc0847d0f02146f8c96d6f5da5eac307e7b01b423a8"
+  "tsFileSha256": "sha256:040942eadd96468546bc9a1092ca727f5f86ce5a0b73fe3d070083f1abc4c88b"
 }

--- a/opencti-platform/opencti-front/src/components/fds-tokens.generated.ts
+++ b/opencti-platform/opencti-front/src/components/fds-tokens.generated.ts
@@ -6,7 +6,7 @@
  * fields. Wiring: fds-migration/TOKEN-MAPPING.md.
  *
  * Source: @filigran/design-system packages/filigran-design-system/src/tokens/theme.css
- * Theme.css content hash: sha256:3c0ef256c9d92003739f590c0d969d3aec1dcc6bcb26e00e9e5db5ca845fa20e
+ * Theme.css content hash: sha256:164d8b4367c80f4e24956aa067ca8177e1d2ddae333e68c873b0c4173df32e52
  * Regenerate (from the filigran-design-system repo, not here):
  *   pnpm generate:mui-bridge --product opencti --write-to-product
  *
@@ -18,7 +18,7 @@
 
 export const FDS_META = {
   product: "opencti",
-  themeCssHash: "sha256:3c0ef256c9d92003739f590c0d969d3aec1dcc6bcb26e00e9e5db5ca845fa20e",
+  themeCssHash: "sha256:164d8b4367c80f4e24956aa067ca8177e1d2ddae333e68c873b0c4173df32e52",
   generator: "@filigran/design-system scripts/generate-mui-bridge.ts",
 } as const;
 
@@ -90,10 +90,10 @@ const colorsDark = {
   "--border-elevation-subtle-soft-layer-0-transparency-15": "#2b4f8d26",
   "--border-elevation-subtle-soft-layer-1": "#2b4f8d",
   "--border-elevation-subtle-soft-layer-1-transparency-15": "#2b4f8d26",
-  "--border-elevation-subtle-soft-layer-2": "#2b4f8d",
-  "--border-elevation-subtle-soft-layer-2-transparency-15": "#2b4f8d26",
-  "--border-elevation-subtle-soft-layer-3": "#2b4f8d",
-  "--border-elevation-subtle-soft-layer-3-transparency-15": "#2b4f8d26",
+  "--border-elevation-subtle-soft-layer-2": "#7a9cd6",
+  "--border-elevation-subtle-soft-layer-2-transparency-15": "#7a9cd626",
+  "--border-elevation-subtle-soft-layer-3": "#7a9cd6",
+  "--border-elevation-subtle-soft-layer-3-transparency-15": "#7a9cd626",
   "--border-input-error": "#f14337",
   "--border-input-focus": "#42caff",
   "--border-input-hover": "#f2f2f3",
@@ -124,6 +124,7 @@ const colorsDark = {
   "--color-feedback-contrast-tertiary": "#ffffff0d",
   "--color-feedback-error-primary": "#f14337",
   "--color-feedback-error-secondary": "#881106",
+  "--color-feedback-error-secondary-transparency-20": "#88110633",
   "--color-feedback-error-secondary-transparency-30": "#8811064d",
   "--color-feedback-error-tertiary": "#f57266",
   "--color-feedback-info-primary": "#42caff",
@@ -147,7 +148,7 @@ const colorsDark = {
   "--color-filigran-brand-primary-transparency-10": "#42caff1a",
   "--color-filigran-brand-primary-transparency-55": "#42caff8c",
   "--color-filigran-brand-secondary": "#a8e7ff",
-  "--color-filigran-brand-tertiary": "#0079a8",
+  "--color-filigran-brand-tertiary": "#009edb",
   "--color-filigran-ia-primary": "#a47af0",
   "--color-filigran-ia-secondary": "#e3d6fa",
   "--color-filigran-ia-secondary-transparency-10": "#e3d6fa1a",
@@ -179,7 +180,7 @@ const colorsDark = {
   "--text-input-label": "#afb0b6",
   "--text-input-placeholder": "#f2f2f3",
   "--text-input-required": "#f2f2f3",
-  "--text-negative-disabled": "#2b4f8d",
+  "--text-negative-disabled": "#62636a",
   "--text-negative-primary": "#18191b",
   "--text-negative-secondary": "#494a50"
 } as const;
@@ -278,6 +279,7 @@ const colorsLight = {
   "--color-feedback-contrast-tertiary": "#0000000d",
   "--color-feedback-error-primary": "#b8180a",
   "--color-feedback-error-secondary": "#f57266",
+  "--color-feedback-error-secondary-transparency-20": "#f5726633",
   "--color-feedback-error-secondary-transparency-30": "#f572664d",
   "--color-feedback-error-tertiary": "#881106",
   "--color-feedback-info-primary": "#0079a8",
@@ -333,7 +335,7 @@ const colorsLight = {
   "--text-input-label": "#494a50",
   "--text-input-placeholder": "#18191b",
   "--text-input-required": "#18191b",
-  "--text-negative-disabled": "#a0b4e3",
+  "--text-negative-disabled": "#95969d",
   "--text-negative-primary": "#f2f2f3",
   "--text-negative-secondary": "#afb0b6"
 } as const;

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -957,9 +957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=fb8c3cc0fd085db0eab1c59ba32945610e4bc6c7":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=83295d97c9ad95a516e77659538f8d742d84ff2a":
   version: 0.1.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=fb8c3cc0fd085db0eab1c59ba32945610e4bc6c7"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=83295d97c9ad95a516e77659538f8d742d84ff2a"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.18"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -980,7 +980,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/ae6cd168eb4891ecfcf3955dac10450bd2980c34f5df3dc75ff1a65254b6450a7c0961be63794a07794da98fea03425a6196c7e96c9fa6dad3c3103542453aa8
+  checksum: 10c0/2e0aac496eec5ccc052a7a1450ad6594a405a0fd4eb072c938e8774a1d2f951c9d13c39ffbfa25d5660fc5c9e94d253afae57205272629dae4f70017780c4e4a
   languageName: node
   linkType: hard
 
@@ -12078,7 +12078,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=fb8c3cc0fd085db0eab1c59ba32945610e4bc6c7"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=83295d97c9ad95a516e77659538f8d742d84ff2a"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
**DO NOT MERGE** — review then merge at your call. Closes #17905.

Pin moves `fb8c3cc` (#152, breadcrumbs) → **`83295d9`** (#165). A deliberate step of its own, not a side effect of a conversion PR.

## Why this is its own PR

The arbitrated Button/Chip conversion needs Chip's `color` prop for the **41 chips whose colour comes from the backend** (label colours, marking colours, draft status). That prop only exists from library PR #154, so the old pin cannot express that decision at all.

Bumping inside the conversion PR would have mixed a dependency move with roughly **1100 call-site edits** in one diff. This is four files.

## What it carries

| library PR | |
|---|---|
| **#154** | Chip data colours (bounded wash) — the one that unblocks the 41 chips |
| #156 | `--icon-*` token bindings |
| **#160** | ButtonGroup / ButtonGroupItem |
| #161 | Button + IconButton measured contrast pairs, glyph bar at 3:1 |
| #162 | `--color-feedback-error-secondary-transparency-20` |
| #163 | Combobox `labelPosition` + required indicator |
| #165 | SearchField × ButtonGroup composition |

## The token bridge, regenerated by the pipeline

`pnpm generate:mui-bridge --product opencti` — never by hand. Every value it moved traces to a merged library PR:

| token | before → after | source |
|---|---|---|
| `--color-filigran-brand-tertiary` | `#0079a8` → **`#009edb`** | #162 — the 3.60:1 dark hover failure, fixed at source |
| `--color-feedback-error-secondary-transparency-20` | *(new, both modes)* | #162 |
| `--border-elevation-subtle-soft-layer-2/3` | `#2b4f8d` → `#7a9cd6` | #156 |
| `--text-negative-disabled` | `#2b4f8d` → `#62636a` (dark), `#a0b4e3` → `#95969d` (light) | #156 |

## Conformity gate — no silent loss

**38 checks before, 38 after, all OK.** Regenerating this gate across a pin bump is a documented failure mode (a previous bump silently dropped a product from 57 checks to 7 and still exited 0), so the count was captured as a baseline before the bump and compared after, rule by rule: `bridge-integrity` 1, `bridge-freshness` 1, `wiring` 2, `forbidden-pattern` 15, `lib-component-usage` 19 — identical on both sides.

One honest caveat about reading it locally: `bridge-freshness` reports STALE while the library resolves from a **sibling checkout** sitting at a different commit than the pin. It reported STALE *before* this change too. With the pinned package actually installed it is **38/38 OK**.

## Verified against the new pin

- `yarn install` resolves the pin and rewrites the lock checksum (`ae6cd1…` → `2e0aac…`).
- The installed package exports `ButtonGroup`, `ButtonGroupItem`, and Chip's `color?: string`.
- Its `dist/tokens/theme.css` carries `brand-tertiary: var(--blue-600)` and the `-20` alpha.
- Relay codegen, then `yarn check-ts` clean and `yarn lint` clean.

## Coordination with the Combobox pilot

#17884 consumes the same pin. Both PRs name this SHA so the two waves land on one dependency state rather than two — a line has been added on that PR pointing here.

## Next

The conversion wave itself follows: raw-MUI IconButtons, static Chips, the 9 Fabs and the `secaondary` typo now; the shared `Button` wrapper rewrite is deliberately held until #17884 merges, so that PR's visual proofs do not go stale under it.
