### PR TITLE
feat(docker): adopt the FIPS 140-3 validated base image (#17908)

### DIFF
--- a/docs/docs/deployment/installation.md
+++ b/docs/docs/deployment/installation.md
@@ -56,9 +56,9 @@ There is one SBOM asset per Docker image base (for example: standard, FIPS, and 
 
 OpenCTI can be deployed using the *docker-compose* command.
 
-!!! note "Deploy FIPS 140-2 compliant components"
+!!! note "Deploy FIPS 140-3 compliant components"
 
-    We provide FIPS 140-2 compliant images. Please read the [dedicated documentation](../reference/fips.md) to understand how to deploy OpenCTI in FIPS-compliant mode.
+    We provide FIPS 140-3 compliant images. The [dedicated documentation](../reference/fips.md) explains how to deploy OpenCTI in FIPS 140-3 compliant mode and describes the exact compliance posture of these images.
 
 ### Pre-requisites
 

--- a/docs/docs/reference/fips.md
+++ b/docs/docs/reference/fips.md
@@ -1,12 +1,26 @@
-# SSL FIPS 140-2 deployment
+# FIPS 140-3 deployment
 
 ## Introduction
 
-For organizations that need to deploy OpenCTI in a SSL FIPS 140-2 compliant environment, we provide FIPS compliant OpenCTI images for all components of the platform. Please note that you will also need to deploy dependencies (ElasticSearch / OpenSearch, Redis, etc.) with FIPS 140-2 SSL to have the full compliant OpenCTI technological stack.
+For organizations that need to deploy OpenCTI in a FIPS 140-3 compliant environment, we provide FIPS 140-3 compliant OpenCTI images for all components of the platform. Please note that you will also need to deploy the dependencies (ElasticSearch / OpenSearch, Redis, etc.) with FIPS 140-3 compliant cryptography to have a fully compliant OpenCTI technological stack.
 
-!!! note "OpenCTI SSL FIPS 140-2 compliant builds"
+!!! note "OpenCTI FIPS 140-3 compliant builds"
 
-    The OpenCTI platform, workers and connectors SSL FIPS 140-2 compliant images are based on packaged [Alpine Linux with OpenSSL 3 and FIPS mode enabled](https://github.com/FiligranHQ/docker-python-nodejs-fips) maintened by the Filigran engineering team.
+    The OpenCTI platform, workers and connectors FIPS 140-3 compliant images are based on [Alpine Linux with the OpenSSL FIPS provider enabled](https://github.com/FiligranHQ/docker-python-nodejs-fips), maintained by the Filigran engineering team.
+
+## Compliance posture
+
+All cryptography in the OpenCTI FIPS 140-3 images goes through the **OpenSSL FIPS provider 3.1.2**, the module validated under **CMVP certificate #4985**, valid until 10 March 2030. FIPS mode is active by default: no flag, environment variable or configuration step is required to deploy in it.
+
+The module is built from the validated source distribution, unmodified, by the procedure documented in its Security Policy for integrators embedding the module in their own product, with integrity verification and the required self-tests enabled. Non-approved algorithms are refused rather than substituted.
+
+The images therefore support these claims:
+
+* They perform cryptography through the OpenSSL FIPS provider 3.1.2, validated under CMVP certificate #4985.
+* The module is built from the validated source distribution, unmodified, by the procedure documented in its Security Policy, with integrity verification and self-tests enabled.
+* FIPS mode is enforced: non-approved algorithms are refused, not substituted.
+
+The full posture is described in [`FIPS.md`](https://github.com/FiligranHQ/docker-python-nodejs-fips/blob/main/FIPS.md), in the base image repository.
 
 ## Dependencies
 
@@ -21,36 +35,36 @@ It is important to remind that OpenCTI is fully compatible with AWS native servi
 
 ### ElasticSearch / OpenSearch
 
-ElasticSearch is known to be compatible with FIPS 140-2 SSL using the proper JVM. There is a [comprehensive guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/fips-140-compliance.html) in the Elastic documentation.
+ElasticSearch supports FIPS 140-3 from version 9.4, and from 8.19.15 in the 8.x line, using the Bouncy Castle FIPS 2.x libraries as the Java security provider. Earlier versions support FIPS 140-2 with the Bouncy Castle 1.x libraries. There is a [comprehensive guide](https://www.elastic.co/docs/deploy-manage/security/fips-es) in the Elastic documentation.
 
 Alternatively, please note that Elastic is also providing an [ElasticSearch FedRAMP authorized cloud offering](https://www.elastic.co/industries/public-sector/fedramp).  
 
 ### Redis
 
-Redis does not provide FIPS 140-2 SSL compliant Docker images but supports very well custom [tls-ciphersuites](https://github.com/redis/redis/issues/7802) that can be configured to use the system FIPS 140-2 OpenSSL library. 
+Redis does not provide FIPS 140 compliant Docker images but supports very well custom [tls-ciphersuites](https://github.com/redis/redis/issues/7802) that can be configured to use the system OpenSSL library in FIPS mode. 
 
 Alternatively, you can use a [Stunnel](https://www.stunnel.org/) TLS endpoint to ensure encrypted communication between OpenCTI and Redis. There are a few examples available, [here](https://github.com/kientv/redis-stunnel) or [here](https://github.com/Runnable/redis-stunnel).
 
 ### RabbitMQ
 
-RabbitMQ does not provide FIPS 140-2 SSL compliant Docker images but, as Redis, supports [custom cipher suites](https://www.rabbitmq.com/docs/ssl#cipher-suites). Also, it is confirmed since RabbitMQ version 3.12.5, the associated Erlang build (> 26.1), [supports FIPS mode on OpenSSL 3](https://www.rabbitmq.com/docs/which-erlang).
+RabbitMQ does not provide FIPS 140 compliant Docker images but, as Redis, supports [custom cipher suites](https://www.rabbitmq.com/docs/ssl#cipher-suites). Also, it is confirmed since RabbitMQ version 3.12.5, the associated Erlang build (> 26.1), [supports FIPS mode on OpenSSL 3](https://www.rabbitmq.com/docs/which-erlang).
 
 Alternatively, you can use a [Stunnel](https://www.stunnel.org/) TLS endpoint to ensure encrypted communication between OpenCTI and RabbitMQ.
 
 ### S3 Bucket / MinIO
 
-If you cannot use an S3 endpoint already deployed in your FIPS 140-2 SSL compliant environment, MinIO provides [FIPS 140-2 SSL compliant Docker images](https://hub.docker.com/r/minio/minio/tags?page=1&name=fips) which then are very easy to deploy within your environment.
+If you cannot use an S3 endpoint already deployed in your FIPS 140 compliant environment, MinIO provides [FIPS 140 compliant Docker images](https://hub.docker.com/r/minio/minio/tags?page=1&name=fips) which then are very easy to deploy within your environment.
 
 ## OpenCTI stack
 
 ### Platform
 
-For the platform, we provide [FIPS 140-2 SSL compliant Docker images](https://hub.docker.com/r/opencti/platform/tags?page=1&name=fips). Just use the appropriate tag to ensure you are deploying the FIPS compliant version and follow the [standard Docker deployment](../deployment/installation.md) procedure. 
+For the platform, we provide [FIPS 140-3 compliant Docker images](https://hub.docker.com/r/opencti/platform/tags?page=1&name=fips). Just use the appropriate tag to ensure you are deploying the FIPS 140-3 compliant version and follow the [standard Docker deployment](../deployment/installation.md) procedure. 
 
 ### Worker
 
-For the worker, we provide [FIPS 140-2 SSL compliant Docker images](https://hub.docker.com/r/opencti/worker/tags?page=1&name=fips). Just use the appropriate tag to ensure you are deploying the FIPS compliant version and follow the [standard Docker deployment](../deployment/installation.md) procedure.
+For the worker, we provide [FIPS 140-3 compliant Docker images](https://hub.docker.com/r/opencti/worker/tags?page=1&name=fips). Just use the appropriate tag to ensure you are deploying the FIPS 140-3 compliant version and follow the [standard Docker deployment](../deployment/installation.md) procedure.
 
 ### Connectors
 
-All connectors have FIPS 140-2 SSL compliant Docker images. For each connector you need to deploy, please use the tag `{version}-fips` instead of `{version}` and  follow the [standard deployment](../deployment/connectors.md) procedure. An example is available on [Docker Hub](https://hub.docker.com/r/opencti/connector-export-file-stix/tags?page=1&name=fips). 
+All connectors have FIPS 140-3 compliant Docker images. For each connector you need to deploy, please use the tag `{version}-fips` instead of `{version}` and  follow the [standard deployment](../deployment/connectors.md) procedure. An example is available on [Docker Hub](https://hub.docker.com/r/opencti/connector-export-file-stix/tags?page=1&name=fips). 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -290,7 +290,7 @@ nav:
       - Data Streaming: reference/streaming.md
     - Deployment and stack:
         - Usage telemetry: reference/usage-telemetry.md
-        - FIPS 140-2 installation: reference/fips.md
+        - FIPS 140-3 installation: reference/fips.md
   - Development:
     - Prerequisites:
       - Ubuntu: development/environment_ubuntu.md

--- a/opencti-platform/Dockerfile_fips
+++ b/opencti-platform/Dockerfile_fips
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.26
-FROM filigran/python-nodejs-fips:latest AS base
+FROM filigran/alpine-python-nodejs-fips:python3.12-nodejs24 AS base
 FROM node:22-alpine3.23 AS base-nonfips
 
 
@@ -12,7 +12,7 @@ FROM base AS builder
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add make g++ gettext-dev
+  apk --no-cache add make g++ npm python3-dev
   npm install -g corepack
 EOT
 
@@ -87,7 +87,7 @@ FROM base AS app
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add tini
+  apk --no-cache add tini python3-dev
   rm /var/log/apk.log
 EOT
 

--- a/opencti-worker/Dockerfile_fips
+++ b/opencti-worker/Dockerfile_fips
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.26
-FROM filigran/python-fips:latest
+FROM filigran/alpine-python-fips:python3.12
 
 COPY src /opt/opencti-worker
 WORKDIR /opt/opencti-worker


### PR DESCRIPTION
### Proposed changes

* `opencti-platform/Dockerfile_fips`: switch to the renamed base image, install `npm` and `python3-dev` explicitly instead of relying on side effects of the previous image's source-built Python, and drop `gettext-dev`, which those side effects were the only reason for.
* `opencti-worker/Dockerfile_fips`: switch to the renamed base image.
* `docs/docs/reference/fips.md`: state the FIPS 140-3 compliance posture of the images.
* `docs/docs/deployment/installation.md`, `docs/mkdocs.yml`: align the FIPS wording with the above.

This adopts the reworked FIPS base images ([FiligranHQ/docker-python-nodejs-fips#45](https://github.com/FiligranHQ/docker-python-nodejs-fips/pull/45)), whose OpenSSL FIPS provider is built from FIPS 140-3 validated sources under CMVP certificate #4985. This matters beyond the version number: certificate #4282, covering the FIPS 140-2 validated sources, moves to the CMVP *Historical* list on 21 September 2026.

They are renamed in the process:

| before | after |
|---|---|
| `filigran/python-nodejs-fips:latest` | [`filigran/alpine-python-nodejs-fips`](https://hub.docker.com/r/filigran/alpine-python-nodejs-fips)`:python3.12-nodejs24` |
| `filigran/python-fips:latest` | [`filigran/alpine-python-fips`](https://hub.docker.com/r/filigran/alpine-python-fips)`:python3.12` |

Both are now referenced by their versioned tag rather than `latest`, so the Python and Node.js lines the images build on are stated in the Dockerfiles instead of following wherever `latest` moves. Those tags are republished by the base image's daily rebuild, so Alpine security updates still reach us — the pin fixes the language versions, not the patch level.

The previous names stay published from a legacy branch as a migration window, but their FIPS provider is built from the same sources as the OpenSSL libraries and so carries no CMVP certificate — which is what the new images fix. That legacy workflow is meant to be deleted, so remaining on the old names is not an option.

The new images also install OpenSSL, Python and Node.js from Alpine packages rather than compiling them, which is what keeps its advertised versions honest. Three side effects of the previous source build disappear as a result — `npm`/`yarn`, the Python headers, and `python3-config` — and `Dockerfile_fips` depends on all three implicitly, so they are now installed explicitly.

The non-FIPS `opencti-platform/Dockerfile` already installs `python3-dev` in both its builder and app stages for the same reason, so this brings the two files in line: the FIPS builder becomes `make g++ npm python3-dev` against its `make g++ python3 python3-dev`, differing only where the base images do — the FIPS base ships `python3` but not `npm`.

`gettext-dev` goes the other way. The source-built CPython advertised `-lintl` in `python3-config --libs`, which the `node-calls-python` link step then required, and musl provides no `libintl` of its own. Alpine's `libpython3.12.so` is not linked against `libintl` and its `python3-config --libs` is just `-ldl -lm`, so nothing needs the package any more — confirmed by building `node-calls-python` and `re2` without it. Nothing else in the tree uses gettext either: no `.po`/`.pot` files, no `msgfmt`, no `libintl` references.

The worker image needs the rename only: it just uses `pip3`, which the new base image still provides.

Note that the Node.js major version is unchanged. Alpine 3.23 already shipped Node.js 24, so the base image's previous `nodejs22` tag did not reflect its contents; the reworked image now asserts the version at build time.

### Related issues

* closes #17908

### How to test this PR

The renamed base images are published, so no local base build is needed. Build and start the FIPS platform image:

```bash
docker build --pull -f opencti-platform/Dockerfile_fips -t opencti-platform-fips:test opencti-platform
docker run --rm opencti-platform-fips:test node build/back.mjs
```

The platform must reach `[CHECK] Python is alive` — which exercises the Node/Python bridge through `node-calls-python` — before failing on the absent Redis, RabbitMQ and search engine. On `master`, the build fails at `npm install -g corepack`; with only `npm` added, it fails at `node-calls-python@npm:1.13.0 couldn't be built successfully`; with only the builder stage fixed, it builds but exits on startup with `python3-config: not found` and `status: 127`.

FIPS enforcement is unaffected, which can be checked on the resulting image:

```bash
docker run --rm --entrypoint sh opencti-platform-fips:test -c '
  openssl list -providers
  echo test | openssl dgst -md5 || echo "MD5 refused, as expected"
  node -e "try { require(\"crypto\").createHash(\"md5\") } catch (e) { console.log(\"node MD5 refused, as expected\") }"
  python3 -c "import cryptography, ssl; print(cryptography.__version__, ssl.OPENSSL_VERSION)"
'
```

The FIPS provider reports 3.1.2 while the library reports the Alpine version — expected, since the validated module is the provider and it is supported across OpenSSL library releases. `cryptography` remains the one built from source in the base image: installing `src/python/requirements.txt` does not pull a wheel over it, so it stays linked against the system OpenSSL.

The images also feed the SBOM that `generate-sbom` produces with Syft, and this change alters what that SBOM can see:

```bash
syft opencti-platform-fips:test -o cyclonedx-json \
  | jq -r '.components[] | select(.name|test("openssl|python|nodejs|cryptography|fips")) | "\(.name) \(.version)"'
```

`openssl`, `python3` and `nodejs` should now be reported with the versions Alpine ships, because the base image installs them as packages: under the previous base they were compiled into `/usr/local` and the apk database knew nothing about them, so the SBOM could not report them accurately. `fips.so` belongs to no package, so whether it appears depends on Syft's binary cataloguer — worth confirming whether it is listed at all and, if it is, that the version reads 3.1.2, the module's own, and not the OpenSSL library version.

The worker image is the rename only, and can be checked the same way:

```bash
docker build --pull -f opencti-worker/Dockerfile_fips -t opencti-worker-fips:test opencti-worker
docker run --rm --entrypoint sh opencti-worker-fips:test -c '
  openssl list -providers
  echo test | openssl dgst -md5 || echo "MD5 refused, as expected"
  python3 -c "import pycti, cryptography, ssl; print(cryptography.__version__, ssl.OPENSSL_VERSION)"
'
```

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [x] I added/updated the relevant documentation (either on GitHub or on Notion)
- [ ] Where necessary, I refactored code to improve the overall quality

### Further comments

**No merge-order constraint.** [FiligranHQ/docker-python-nodejs-fips#45](https://github.com/FiligranHQ/docker-python-nodejs-fips/pull/45) is merged and both renamed images are published, so this pull request can merge whenever it is ready.

The rename is what removes the hazard. Had the images kept their names, the two changes would have been strictly coupled in both directions: the new base image breaks the current `Dockerfile_fips`, and this `Dockerfile_fips` breaks against the old base image, since the `gettext-dev` removal leaves `python3-config --libs` emitting `-lintl` with no `/usr/lib/libintl.so` to link against. Because the new content lives under new names, each `Dockerfile_fips` only ever resolves to a base image it works with.

No automated test is added: the changes are Dockerfile package installations, and the existing `cd-check-images-on-pr.yml` workflow already builds the FIPS images on every pull request — against the renamed base images as of this change, so CI exercises it directly.

Two points found while testing, left out as unrelated to this fix:

* The platform runs `node` without `--enable-fips`, so `crypto.getFips()` reports `0`. Algorithm fetches are still confined to the FIPS provider by the OpenSSL configuration, so MD5 is refused either way, and this behaviour is unchanged by this PR — but the flag is missing if `getFips()` is expected to report accurately.
* The dependency sections describe each product's own posture rather than OpenCTI's, so they keep their own standard version: FIPS 140-2 for ElasticSearch, whose linked Elastic guide states it, and the unqualified FIPS 140 family for Redis, RabbitMQ and MinIO, where naming a revision would assert something on their behalf.
* Two dependency findings worth a follow-up, out of scope here. ElasticSearch has supported FIPS 140-3 since 9.4 — backported to 8.19.15 — using Bouncy Castle 2.x, so that section could recommend it rather than 140-2. And MinIO's community `.fips` tags have not been published since `RELEASE.2024-12-18`, while ordinary releases continued to `RELEASE.2025-09-07`, so the Docker Hub link in the MinIO section now points at unmaintained images; FIPS moved to the commercial AIStor edition.


