### PR TITLE
chore(docker): remove the now unused libmagic native dependency (#17911)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     resource_class: medium+
     steps:
       - run:
-          command: apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libmagic libffi-dev curl
+          command: apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libffi-dev curl
       - run:
           command: npm install -g node-gyp
       - attach_workspace:
@@ -172,7 +172,7 @@ jobs:
     resource_class: medium+
     steps:
       - run:
-          command: apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libmagic libffi-dev curl
+          command: apk update && apk upgrade && apk --no-cache add git tini gcc g++ make musl-dev python3 python3-dev postfix postfix-pcre build-base libffi-dev curl
       - run:
           command: npm install -g node-gyp
       - attach_workspace:

--- a/opencti-platform/Dockerfile
+++ b/opencti-platform/Dockerfile
@@ -12,7 +12,7 @@ FROM base AS builder
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add make g++ python3 python3-dev libmagic
+  apk --no-cache add make g++ python3 python3-dev
   rm -f /usr/lib/python*/EXTERNALLY-MANAGED
   python3 -m ensurepip
   npm install -g corepack
@@ -70,7 +70,7 @@ FROM base AS app
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add tini python3 python3-dev libmagic
+  apk --no-cache add tini python3 python3-dev
   rm /var/log/apk.log
   rm -f /usr/lib/python*/EXTERNALLY-MANAGED
   python3 -m ensurepip

--- a/opencti-platform/Dockerfile_fips
+++ b/opencti-platform/Dockerfile_fips
@@ -12,7 +12,7 @@ FROM base AS builder
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add make g++ libmagic gettext-dev
+  apk --no-cache add make g++ gettext-dev
   npm install -g corepack
 EOT
 
@@ -29,7 +29,7 @@ FROM base-nonfips AS builder-nonfips
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add make g++ python3 python3-dev libmagic
+  apk --no-cache add make g++ python3 python3-dev
   rm -f /usr/lib/python*/EXTERNALLY-MANAGED
   python3 -m ensurepip
   npm install -g corepack
@@ -87,7 +87,7 @@ FROM base AS app
 RUN <<EOT
   set -euxo pipefail
 
-  apk --no-cache add tini libmagic
+  apk --no-cache add tini
   rm /var/log/apk.log
 EOT
 

--- a/opencti-worker/Dockerfile
+++ b/opencti-worker/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /opt/opencti-worker
 RUN --mount=type=bind,source=requirements.txt,target=requirements.txt <<EOT
     set -euxo pipefail
 
-    apk --no-cache add libmagic
-
     apk --no-cache add -t .pip_deps git
     pip3 install --no-cache-dir --requirement requirements.txt
     apk del .pip_deps

--- a/opencti-worker/Dockerfile_fips
+++ b/opencti-worker/Dockerfile_fips
@@ -7,8 +7,6 @@ WORKDIR /opt/opencti-worker
 RUN --mount=type=bind,source=requirements.txt,target=requirements.txt <<EOT
     set -euxo pipefail
 
-    apk --no-cache add libmagic
-
     apk --no-cache add -t .pip_deps git
     pip3 install --no-cache-dir --requirement requirements.txt
     apk del .pip_deps

--- a/opencti-worker/Dockerfile_ubi9
+++ b/opencti-worker/Dockerfile_ubi9
@@ -9,7 +9,7 @@ WORKDIR /opt/opencti-worker
 RUN --mount=type=bind,source=requirements.txt,target=requirements.txt <<EOT
     set -euxo pipefail
 
-    microdnf -y --setopt=install_weak_deps=0 -y install python${PYTHON_VERSION} python3-file-magic python${PYTHON_VERSION}-pip git-core
+    microdnf -y --setopt=install_weak_deps=0 -y install python${PYTHON_VERSION} python${PYTHON_VERSION}-pip git-core
     alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 2
     pip${PYTHON_VERSION} install --no-cache-dir --requirement requirements.txt
     microdnf -y remove python${PYTHON_VERSION}-pip git-core


### PR DESCRIPTION
### Proposed changes

* Remove the `libmagic` installation from the platform Docker images (`opencti-platform/Dockerfile`, `opencti-platform/Dockerfile_fips`) in both the builder and the production stages.
* Remove the dedicated `apk --no-cache add libmagic` step from the worker Alpine images (`opencti-worker/Dockerfile`, `opencti-worker/Dockerfile_fips`) and the `python3-file-magic` package from `opencti-worker/Dockerfile_ubi9`.
* Remove `libmagic` from the `apk add` of the `build_platform_musl` and `build_platform_musl_rolling` CircleCI jobs.

`libmagic` was only ever required by the third-party `python-magic` binding that `pycti` used for MIME type detection. That dependency was removed in #13517 in favour of the Python standard library `mimetypes` module, so the native library is now dead weight in every image.

### Related issues

* closes #17911
* follow-up of #13517 / #17374, which removed the `python-magic` usage in client-python

### How to test this PR

The change is purely a removal of an unused build/runtime dependency, so the verification is that everything still builds and runs without it:

1. Build the platform and worker images and confirm they succeed:
   ```
   docker build -f opencti-platform/Dockerfile opencti-platform
   docker build -f opencti-worker/Dockerfile opencti-worker
   ```
2. Start the worker and confirm it connects and consumes messages normally.
3. Upload a file through the platform (import an artifact or attach a document to an entity) and confirm the MIME type is still resolved correctly.

Supporting evidence that nothing depends on it anymore:

* No Python source in the repository imports `magic`; the remaining `magic` matches are the unrelated `magic_number_hex` STIX cyber observable property.
* `python-magic` is absent from `client-python/requirements.txt`, `opencti-worker/requirements.txt` and `opencti-platform/opencti-graphql/src/python/requirements.txt`.
* None of the remaining platform Python dependencies (`parsuricata`, `yara-python`, `pysigma`, `jsonpatch`, `eql`) require `libmagic`.
* The Node.js back-end resolves MIME types with the pure JavaScript `mime-types` package, which has no native dependency.
* `opencti-platform/Dockerfile_ubi9` already builds and runs without any `libmagic`/`file-libs` package, which confirms it is not needed at runtime.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality
