### PR TITLE
feat(fds): bump the design-system pin and convert 28 multi-line fields to Textarea (#17926)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -39,7 +39,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=83295d97c9ad95a516e77659538f8d742d84ff2a",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/components/TextareaField.tsx
+++ b/opencti-platform/opencti-front/src/components/TextareaField.tsx
@@ -1,0 +1,74 @@
+import React, { ChangeEvent, FocusEvent, useCallback, useRef } from 'react';
+import { FieldProps, useField } from 'formik';
+import { isNil } from 'ramda';
+import { Textarea } from '@filigran/design-system';
+
+type TextareaProps = React.ComponentProps<typeof Textarea>;
+
+export type TextareaFieldProps = FieldProps<string> & Omit<TextareaProps, 'error' | 'value' | 'onChange'> & {
+  onFocus?: (name: string) => void;
+  onChange?: (name: string, value: string) => void;
+  onSubmit?: (name: string, value: string) => void;
+};
+
+/**
+ * Formik adapter for the design-system Textarea — the multi-line counterpart of
+ * components/TextField.tsx, and the reason the conversion is one component and
+ * not 26 call-site rewrites.
+ *
+ * The error wiring is deliberately identical to TextField.tsx's: an error shows
+ * only once the field is touched or the form has been submitted at least once,
+ * so a pristine form is not painted red. The one difference is forced by the
+ * library contract: Textarea's `error` is a STRING that replaces the helper
+ * text, never a boolean, so the message is passed rather than a flag.
+ */
+const TextareaField = (props: TextareaFieldProps) => {
+  const {
+    form: { setFieldValue, setFieldTouched, submitCount },
+    field: { name, value },
+    onChange,
+    onFocus,
+    onSubmit,
+    helperText,
+    ...rest
+  } = props;
+  const [, meta] = useField(name);
+
+  const initialValueOnFocus = useRef<string | null>(null);
+
+  const internalOnChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    const nextValue = event.target.value;
+    setFieldValue(name, nextValue);
+    if (typeof onChange === 'function') onChange(name, nextValue);
+  }, [onChange, setFieldValue, name]);
+
+  const internalOnFocus = useCallback((event: FocusEvent<HTMLTextAreaElement>) => {
+    initialValueOnFocus.current = event.target.value;
+    if (typeof onFocus === 'function') onFocus(name);
+  }, [onFocus, name]);
+
+  const internalOnBlur = useCallback((event: FocusEvent<HTMLTextAreaElement>) => {
+    const nextValue = event.target.value;
+    setFieldTouched(name, true);
+    if (typeof onSubmit === 'function' && nextValue !== initialValueOnFocus.current) {
+      onSubmit(name, nextValue || '');
+    }
+  }, [onSubmit, setFieldTouched, name]);
+
+  const showError = !isNil(meta.error) && (meta.touched || submitCount > 0);
+
+  return (
+    <Textarea
+      {...rest}
+      name={name}
+      value={value ?? ''}
+      error={showError ? (meta.error as string) : undefined}
+      helperText={helperText}
+      onChange={internalOnChange}
+      onFocus={internalOnFocus}
+      onBlur={internalOnBlur}
+    />
+  );
+};
+
+export default TextareaField;

--- a/opencti-platform/opencti-front/src/private/components/LicenseBanner.tsx
+++ b/opencti-platform/opencti-front/src/private/components/LicenseBanner.tsx
@@ -14,7 +14,8 @@ import useApiMutation from '../../utils/hooks/useApiMutation';
 import { UserContext } from '../../utils/hooks/useAuth';
 import { daysBetweenDates, now } from '../../utils/Time';
 import { RootSettings$data } from '../__generated__/RootSettings.graphql';
-import TextField from '../../components/TextField';
+
+import TextareaField from '../../components/TextareaField';
 
 export const LICENSE_OPTION_TRIAL = 'trial';
 
@@ -168,12 +169,9 @@ const LicenseBanner = () => {
           {({ submitForm, isSubmitting, resetForm }) => (
             <Form>
               <Field
-                component={TextField}
+                component={TextareaField}
                 name="message"
-                variant="standard"
-                multiline={true}
                 label={t_i18n('Your message')}
-                fullWidth={true}
                 minRows={5}
               />
               <DialogActions>

--- a/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
+++ b/opencti-platform/opencti-front/src/private/components/LtsLicenseRoot.tsx
@@ -20,7 +20,6 @@ import CssBaseline from '@mui/material/CssBaseline';
 import makeStyles from '@mui/styles/makeStyles';
 import Alert from '@mui/material/Alert';
 import FormGroup from '@mui/material/FormGroup';
-import TextField from '@mui/material/TextField';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
@@ -36,6 +35,7 @@ import useApiMutation from '../../utils/hooks/useApiMutation';
 import Message from '../../components/Message';
 import { isEmptyField } from '../../utils/utils';
 import ItemCopy from '../../components/ItemCopy';
+import { Textarea } from '@filigran/design-system';
 
 const useStyles = makeStyles<Theme>(() => ({
   container: {
@@ -120,13 +120,10 @@ const LicenseComponent: FunctionComponent<LicenseProps> = ({ settings }) => {
           </Alert>
           {isNoLicenseByConfig ? (
             <FormGroup style={{ marginTop: 15 }}>
-              <TextField
+              <Textarea
                 onChange={(event) => setEnterpriseLicense(event.target.value)}
-                multiline={true}
-                fullWidth={true}
                 minRows={10}
                 placeholder={t_i18n('Paste your Filigran OpenCTI LTS license')}
-                variant="outlined"
               />
             </FormGroup>
           ) : (

--- a/opencti-platform/opencti-front/src/private/components/SearchBulkContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/SearchBulkContainer.tsx
@@ -1,6 +1,5 @@
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
@@ -15,6 +14,7 @@ import DataTableWithoutFragment from '../../components/dataGrid/DataTableWithout
 import { DataTableProps } from '../../components/dataGrid/dataTableTypes';
 import useDebounceCallback from '../../utils/hooks/useDebounceCallback';
 import { splitIntoLines } from '../../utils/String';
+import { Textarea } from '@filigran/design-system';
 
 const SearchBulkContainer = () => {
   const { t_i18n } = useFormatter();
@@ -55,7 +55,7 @@ const SearchBulkContainer = () => {
     setCurrentTab(value);
   };
 
-  const handleChangeTextField = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleChangeTextField = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = event.target;
     const text = splitIntoLines(value);
     setTextFieldValue(text);
@@ -91,14 +91,11 @@ const SearchBulkContainer = () => {
         style={{ marginBottom: 20, marginTop: 0 }}
       >
         <Grid item xs={2} style={{ marginTop: -20 }}>
-          <TextField
+          <Textarea
             onChange={handleChangeTextField}
             value={textFieldValue}
-            multiline={true}
-            fullWidth={true}
             minRows={20}
             placeholder={t_i18n('One keyword by line or separated by commas')}
-            variant="outlined"
           />
         </Grid>
         <Grid item xs={10}>

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisCreation.tsx
@@ -30,6 +30,7 @@ import {
   MalwareAnalysisCreationMutation,
   MalwareAnalysisCreationMutation$variables as MalwareAnalysisMutationVariables,
 } from './__generated__/MalwareAnalysisCreationMutation.graphql';
+import TextareaField from '../../../../components/TextareaField';
 
 const malwareAnalysisMutation = graphql`
   mutation MalwareAnalysisCreationMutation($input: MalwareAnalysisAddInput!) {
@@ -328,14 +329,12 @@ export const MalwareAnalysisCreationForm: FunctionComponent<
             style={fieldSpacingContainerStyle}
           />
           <Field
-            component={TextField}
+            component={TextareaField}
             name="modules"
             required={mandatoryAttributes.includes('modules')}
             label={t_i18n('Modules (1 / line)')}
-            fullWidth
-            multiline
             rows="4"
-            style={fieldSpacingContainerStyle}
+            className="mt-5"
           />
           <FormButtonContainer>
             <Button

--- a/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/malware_analyses/MalwareAnalysisEditionDetails.tsx
@@ -27,6 +27,7 @@ import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { parse } from '../../../../utils/Time';
 import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeConditionalRequired } from '../../../../utils/hooks/useEntitySettings';
 import type { Theme } from '../../../../components/Theme';
+import TextareaField from '../../../../components/TextareaField';
 
 const malwareAnalysisMutationFieldPatch = graphql`
     mutation MalwareAnalysisEditionDetailsFieldPatchMutation(
@@ -300,14 +301,12 @@ const MalwareAnalysisEditionDetails: FunctionComponent<
             }
           />
           <Field
-            component={TextField}
+            component={TextareaField}
             name="modules"
             label={t_i18n('Modules (1 / line)')}
             required={(mandatoryAttributes.includes('modules'))}
-            fullWidth
-            multiline
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitModules}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/arsenal/vulnerabilities/VulnerabilityEditionOverview.jsx
@@ -22,6 +22,7 @@ import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForE
 import SwitchField from '../../../../components/fields/SwitchField';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { buildDate, formatDate } from '../../../../utils/Time';
+import TextareaField from '../../../../components/TextareaField';
 
 const vulnerabilityMutationFieldPatch = graphql`
   mutation VulnerabilityEditionOverviewFieldPatchMutation(
@@ -371,14 +372,11 @@ const VulnerabilityEditionOverviewComponent = (props) => {
             )}
           />
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="x_opencti_cwe"
             label={t_i18n('Associated CWE(s) (one by line)')}
-            fullWidth={true}
-            multiline={true}
             rows="3"
-            style={fieldSpacingContainerStyle}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={(

--- a/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionAgreement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/entreprise_edition/EnterpriseEditionAgreement.tsx
@@ -3,12 +3,12 @@ import Dialog from '@common/dialog/Dialog';
 import Alert from '@mui/material/Alert';
 import DialogActions from '@mui/material/DialogActions';
 import FormGroup from '@mui/material/FormGroup';
-import TextField from '@mui/material/TextField';
 import { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import { isEmptyField } from '../../../../utils/utils';
+import { Textarea } from '@filigran/design-system';
 
 const EnterpriseEditionAgreementMutationFieldPatch = graphql`
   mutation EnterpriseEditionAgreementMutation($id: ID!, $input: [EditInput]!) {
@@ -64,13 +64,10 @@ const EnterpriseEditionAgreement: FunctionComponent<
       </Alert>
 
       <FormGroup style={{ marginTop: 15 }}>
-        <TextField
+        <Textarea
           onChange={(event) => setEnterpriseLicense(event.target.value)}
-          multiline={true}
-          fullWidth={true}
           minRows={10}
           placeholder={t_i18n('Paste your Filigran OpenCTI Enterprise Edition license')}
-          variant="outlined"
         />
       </FormGroup>
 

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormCreation.tsx
@@ -16,6 +16,7 @@ import { insertNode } from '../../../../utils/store';
 import { FormAddInput, FormBuilderData, FormFieldAttribute } from './Form.d';
 import FormSchemaEditor from './FormSchemaEditor';
 import { convertFormBuilderDataToSchema, normalizeDraftAuthorizedMembersDefaults } from './FormUtils';
+import TextareaField from '../../../../components/TextareaField';
 
 const formCreationMutation = graphql`
   mutation FormCreationMutation($input: FormAddInput!) {
@@ -238,14 +239,11 @@ const FormCreation: FunctionComponent<FormCreationProps> = ({
               fullWidth={true}
             />
             <Field
-              component={TextField}
-              variant="standard"
+              component={TextareaField}
               name="description"
               label={t_i18n('Description')}
-              fullWidth={true}
-              multiline={true}
               rows={3}
-              style={{ marginTop: 20 }}
+              className="mt-5"
             />
             <Field
               component={SwitchField}

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormEdition.tsx
@@ -16,6 +16,7 @@ import type { FormBuilderData, FormFieldAttribute } from './Form.d';
 import { convertFormBuilderDataToSchema, normalizeDraftAuthorizedMembersDefaults } from './FormUtils';
 import Loader from '../../../../components/Loader';
 import { useTheme } from '@mui/styles';
+import { Textarea } from '@filigran/design-system';
 
 const useStyles = makeStyles<Theme>(() => ({
   container: {
@@ -217,7 +218,7 @@ const FormEditionInner: FunctionComponent<FormEditionInnerProps> = ({
     setFormName(event.target.value);
   };
 
-  const handleDescriptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleDescriptionChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setFormDescription(event.target.value);
   };
 
@@ -240,12 +241,9 @@ const FormEditionInner: FunctionComponent<FormEditionInnerProps> = ({
           value={formName}
           onChange={handleNameChange}
         />
-        <TextField
-          variant="standard"
+        <Textarea
           label={t_i18n('Description')}
-          fullWidth={true}
-          style={{ marginTop: 20 }}
-          multiline={true}
+          className="mt-5"
           rows={2}
           value={formDescription}
           onChange={handleDescriptionChange}

--- a/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/view/FormView.tsx
@@ -38,6 +38,7 @@ import { FormFieldRendererProps } from './FormFieldRenderer';
 import FormFields from './FormFields';
 import { convertFormSchemaToYupSchema, formatFormDataForSubmission } from './FormViewUtils';
 import { FormViewQuery } from './__generated__/FormViewQuery.graphql';
+import TextareaField from '../../../../../components/TextareaField';
 
 // Styles
 const useStyles = makeStyles<Theme>(() => ({
@@ -630,17 +631,13 @@ const FormViewInner: FunctionComponent<FormViewInnerProps> = ({ queryRef, embedd
                         <>
                           {schema.mainEntityParseField === 'textarea' ? (
                             <Field
-                              component={TextField}
-                              className={classes.parsedField}
+                              component={TextareaField}
+                              className={`${classes.parsedField} mt-5`}
                               name="mainEntityParsed"
                               placeholder={t_i18n(schema.mainEntityParseMode === 'line'
                                 ? 'Enter values separated by new lines'
                                 : 'Enter values separated by commas')}
                               rows={10}
-                              multiline={true}
-                              fullWidth={true}
-                              variant="standard"
-                              style={{ marginTop: 20 }}
                               helperText={helperText}
                             />
                           ) : (
@@ -795,17 +792,13 @@ const FormViewInner: FunctionComponent<FormViewInnerProps> = ({ queryRef, embedd
                                 <>
                                   {additionalEntity.parseField === 'textarea' ? (
                                     <Field
-                                      component={TextField}
-                                      className={classes.parsedField}
+                                      component={TextareaField}
+                                      className={`${classes.parsedField} mt-5`}
                                       name={fieldName}
                                       placeholder={t_i18n(additionalEntity.parseMode === 'line'
                                         ? 'Enter values separated by new lines'
                                         : 'Enter values separated by commas')}
                                       rows={10}
-                                      multiline={true}
-                                      fullWidth={true}
-                                      variant="standard"
-                                      style={{ marginTop: 20 }}
                                       helperText={helperText}
                                     />
                                   ) : (

--- a/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/individuals/IndividualEditionOverview.jsx
@@ -19,6 +19,7 @@ import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeCon
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const individualMutationFieldPatch = graphql`
   mutation IndividualEditionOverviewFieldPatchMutation(
@@ -233,15 +234,12 @@ const IndividualEditionOverviewComponent = (props) => {
             variant="edit"
           />
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="contact_information"
             label={t_i18n('Contact information')}
             required={(mandatoryAttributes.includes('contact_information'))}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/organizations/OrganizationEditionOverview.tsx
@@ -22,6 +22,7 @@ import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEdito
 import { FieldOption, fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useFormatter } from '../../../../components/i18n';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 export const organizationEditionOverviewFragment = graphql`
   fragment OrganizationEditionOverview_organization on Organization {
@@ -286,14 +287,11 @@ const OrganizationEditionOverview: FunctionComponent<OrganizationEditionOverview
             variant="edit"
           />
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="contact_information"
             label={t_i18n('Contact information')}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={fieldSpacingContainerStyle}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/entities/systems/SystemEditionOverview.jsx
@@ -19,6 +19,7 @@ import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeCon
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const systemMutationFieldPatch = graphql`
   mutation SystemEditionOverviewFieldPatchMutation(
@@ -230,15 +231,12 @@ const SystemEditionOverviewComponent = (props) => {
             variant="edit"
           />
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="contact_information"
             label={t_i18n('Contact information')}
             required={(mandatoryAttributes.includes('contact_information'))}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/events/incidents/IncidentEditionDetails.tsx
@@ -20,6 +20,7 @@ import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForE
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import type { Theme } from '../../../../components/Theme';
 import { FieldOption } from '../../../../utils/field';
+import TextareaField from '../../../../components/TextareaField';
 
 const incidentMutationFieldPatch = graphql`
   mutation IncidentEditionDetailsFieldPatchMutation(
@@ -245,15 +246,12 @@ const IncidentEditionDetails: FunctionComponent<
             }
           />
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="objective"
             required={(mandatoryAttributes.includes('objective'))}
             label={t_i18n('Objective')}
-            fullWidth={true}
-            multiline={true}
             rows={4}
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
+++ b/opencti-platform/opencti-front/src/private/components/observations/indicators/IndicatorEditionOverview.tsx
@@ -27,6 +27,7 @@ import { GenericContext } from '@components/common/model/GenericContextModel';
 import { IndicatorEditionOverview_indicator$data } from '@components/observations/indicators/__generated__/IndicatorEditionOverview_indicator.graphql';
 import { ExternalReferencesValues } from '@components/common/form/ExternalReferencesField';
 import { FormikConfig } from 'formik/dist/types';
+import TextareaField from '../../../../components/TextareaField';
 
 const indicatorMutationFieldPatch = graphql`
   mutation IndicatorEditionOverviewFieldPatchMutation(
@@ -300,15 +301,12 @@ const IndicatorEditionOverviewComponent: FunctionComponent<IndicatorEditionOverv
             variant="edit"
           />
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="pattern"
             label={t_i18n('Indicator pattern')}
             required={(mandatoryAttributes.includes('pattern'))}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/settings/custom_fields/CustomFieldEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/custom_fields/CustomFieldEdition.tsx
@@ -10,6 +10,7 @@ import { useFormatter } from '../../../../components/i18n';
 import { commitMutation, handleError } from '../../../../relay/environment';
 import TextField from '../../../../components/TextField';
 import { CustomFieldEdition_customFieldDefinition$key } from './__generated__/CustomFieldEdition_customFieldDefinition.graphql';
+import TextareaField from '../../../../components/TextareaField';
 
 export const CustomFieldEditionFragment = graphql`
   fragment CustomFieldEdition_customFieldDefinition on CustomFieldDefinition {
@@ -161,14 +162,11 @@ const CustomFieldEdition: FunctionComponent<CustomFieldEditionProps> = ({
             />
           )}
           <Field
-            component={TextField}
-            variant="standard"
+            component={TextareaField}
             name="description"
             label={t_i18n('Description')}
-            fullWidth={true}
-            multiline={true}
             rows={2}
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onSubmit={handleSubmitField}
           />
         </Form>

--- a/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/organizations/SettingsOrganizationEdition.tsx
@@ -22,6 +22,7 @@ import { SettingsOrganization_organization$data } from './__generated__/Settings
 import SettingsOrganizationHiddenTypesField from './SettingsOrganizationHiddenTypesField';
 import useEnterpriseEdition from '../../../../utils/hooks/useEnterpriseEdition';
 import EditEntityControlledDial from '../../../../components/EditEntityControlledDial';
+import TextareaField from '../../../../components/TextareaField';
 
 const organizationMutationFieldPatch = graphql`
   mutation SettingsOrganizationEditionMutation(
@@ -257,14 +258,11 @@ const SettingsOrganizationEdition = ({
                 containerStyle={fieldSpacingContainerStyle}
               />
               <Field
-                component={TextField}
-                variant="standard"
+                component={TextareaField}
                 name="contact_information"
                 label={t_i18n('Contact information')}
-                fullWidth={true}
-                multiline={true}
                 rows="4"
-                style={{ marginTop: 20 }}
+                className="mt-5"
                 onFocus={editor.changeFocus}
                 onSubmit={handleSubmitField}
                 helperText={(

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/CertStrategyForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/CertStrategyForm.tsx
@@ -20,6 +20,7 @@ import AuthProviderOrganizationsFields from './AuthProviderOrganizationsFields';
 import AuthProviderUserInfoFields from './AuthProviderUserInfoFields';
 import type { CertStrategyFormQuery } from './__generated__/CertStrategyFormQuery.graphql';
 import type { CertStrategyFormMutation } from './__generated__/CertStrategyFormMutation.graphql';
+import TextareaField from '../../../../components/TextareaField';
 
 const certStrategyFormQuery = graphql`
   query CertStrategyFormQuery {
@@ -298,14 +299,11 @@ const CertStrategyForm = ({ onCancel }: CertStrategyFormProps) => {
                 )}
               </Box>
               <Field
-                component={TextField}
-                variant="standard"
+                component={TextareaField}
                 name="description"
                 label={t_i18n('Description')}
-                fullWidth
-                multiline
                 rows={3}
-                style={{ marginTop: 20 }}
+                className="mt-5"
               />
               <AuthProviderUserInfoFields
                 fieldPrefix="user_info_mapping"

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/HeaderStrategyForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/HeaderStrategyForm.tsx
@@ -22,6 +22,7 @@ import AuthProviderOrganizationsFields from './AuthProviderOrganizationsFields';
 import AuthProviderUserInfoFields from './AuthProviderUserInfoFields';
 import type { HeaderStrategyFormQuery } from './__generated__/HeaderStrategyFormQuery.graphql';
 import type { HeaderStrategyFormMutation } from './__generated__/HeaderStrategyFormMutation.graphql';
+import TextareaField from '../../../../components/TextareaField';
 
 const headerStrategyFormQuery = graphql`
   query HeaderStrategyFormQuery {
@@ -291,14 +292,11 @@ const HeaderStrategyForm = ({ onCancel }: HeaderStrategyFormProps) => {
                 containerstyle={{ marginTop: 20 }}
               />
               <Field
-                component={TextField}
-                variant="standard"
+                component={TextareaField}
                 name="description"
                 label={t_i18n('Description')}
-                fullWidth
-                multiline
                 rows={3}
-                style={{ marginTop: 20 }}
+                className="mt-5"
               />
               <AuthProviderUserInfoFields fieldPrefix="user_info_mapping" />
               <Field

--- a/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/IpWhitelistSettings.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sso_definitions/IpWhitelistSettings.tsx
@@ -11,7 +11,7 @@ import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import { groupSetDefaultGroupForIngestionUsersQuery } from '@components/settings/groups/GroupSetDefaultGroupForIngestionUsers';
 import SwitchField from '../../../../components/fields/SwitchField';
-import TextField from '../../../../components/TextField';
+
 import { useFormatter } from '../../../../components/i18n';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import useAuth from '../../../../utils/hooks/useAuth';
@@ -23,6 +23,7 @@ import { FieldOption } from '../../../../utils/field';
 import { IpWhitelistSettingsQuery } from './__generated__/IpWhitelistSettingsQuery.graphql';
 import type { GroupSetDefaultGroupForIngestionUsersQuery$data } from '@components/settings/groups/__generated__/GroupSetDefaultGroupForIngestionUsersQuery.graphql';
 import { OPENCTI_ADMIN_UUID } from 'src/utils/hooks/useGranted';
+import TextareaField from '../../../../components/TextareaField';
 
 const ipWhitelistSettingsQuery = graphql`
   query IpWhitelistSettingsQuery {
@@ -254,13 +255,10 @@ const IpWhitelistSettingsContent = () => {
                           {' '}{t_i18n('Excluded users, groups, or organizations bypass the IP check.')}
                         </Alert>
                         <Field
-                          component={TextField}
-                          variant="standard"
-                          style={{ marginTop: 20 }}
+                          component={TextareaField}
+                          className="mt-5"
                           name="platform_ip_whitelist"
                           label={t_i18n('Allowed IP addresses (one per line, e.g. 192.168.1.0/24)')}
-                          fullWidth={true}
-                          multiline={true}
                           rows={6}
                         />
 

--- a/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/attack_patterns/AttackPatternEditionDetails.jsx
@@ -7,7 +7,7 @@ import { useTheme } from '@mui/styles';
 import { attackPatternMutationRelationAdd, attackPatternMutationRelationDelete } from './AttackPatternEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
 import { SubscriptionFocus } from '../../../../components/Subscription';
-import TextField from '../../../../components/TextField';
+
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { adaptFieldValue } from '../../../../utils/String';
@@ -15,6 +15,7 @@ import CommitMessage from '../../common/form/CommitMessage';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const attackPatternMutationFieldPatch = graphql`
   mutation AttackPatternEditionDetailsFieldPatchMutation(
@@ -180,13 +181,11 @@ const AttackPatternEditionDetailsComponent = (props) => {
             editContext={context}
           />
           <Field
-            component={TextField}
+            component={TextareaField}
             name="x_mitre_detection"
             label={t_i18n('Detection')}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={(

--- a/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
+++ b/opencti-platform/opencti-front/src/private/components/techniques/courses_of_action/CourseOfActionEditionOverview.jsx
@@ -18,6 +18,7 @@ import { useDynamicSchemaEditionValidation, useIsMandatoryAttribute, yupShapeCon
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const courseOfActionMutationFieldPatch = graphql`
   mutation CourseOfActionEditionOverviewFieldPatchMutation(
@@ -276,14 +277,12 @@ const CourseOfActionEditionOverviewComponent = (props) => {
             )}
           />
           <Field
-            component={TextField}
+            component={TextareaField}
             name="x_opencti_log_sources"
             label={t_i18n('Log sources (1 / line)')}
             required={(mandatoryAttributes.includes('x_opencti_log_sources'))}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={editor.changeFocus}
             onSubmit={handleSubmitField}
             helperText={(

--- a/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/campaigns/CampaignEditionDetails.jsx
@@ -6,7 +6,7 @@ import * as R from 'ramda';
 import { useTheme } from '@mui/styles';
 import { campaignEditionOverviewFocus, campaignMutationRelationAdd, campaignMutationRelationDelete } from './CampaignEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
-import TextField from '../../../../components/TextField';
+
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import { commitMutation } from '../../../../relay/environment';
 import { buildDate, parse } from '../../../../utils/Time';
@@ -16,6 +16,7 @@ import DateTimePickerField from '../../../../components/DateTimePickerField';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const campaignMutationFieldPatch = graphql`
   mutation CampaignEditionDetailsFieldPatchMutation(
@@ -194,13 +195,11 @@ const CampaignEditionDetailsComponent = (props) => {
             }}
           />
           <Field
-            component={TextField}
+            component={TextareaField}
             name="objective"
             label={t_i18n('Objective')}
-            fullWidth={true}
-            multiline={true}
             rows={4}
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/intrusion_sets/IntrusionSetEditionDetails.jsx
@@ -10,7 +10,7 @@ import { SubscriptionFocus } from '../../../../components/Subscription';
 import { commitMutation } from '../../../../relay/environment';
 import { buildDate, parse } from '../../../../utils/Time';
 import OpenVocabField from '../../common/form/OpenVocabField';
-import TextField from '../../../../components/TextField';
+
 import CommitMessage from '../../common/form/CommitMessage';
 import { adaptFieldValue } from '../../../../utils/String';
 import DateTimePickerField from '../../../../components/DateTimePickerField';
@@ -18,6 +18,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const intrusionSetMutationFieldPatch = graphql`
   mutation IntrusionSetEditionDetailsFieldPatchMutation(
@@ -263,13 +264,11 @@ const IntrusionSetEditionDetailsComponent = (props) => {
             editContext={context}
           />
           <Field
-            component={TextField}
+            component={TextareaField}
             name="goals"
             label={t_i18n('Goals (1 / line)')}
-            fullWidth={true}
-            multiline={true}
             rows="4"
-            style={{ marginTop: 20 }}
+            className="mt-5"
             onFocus={handleChangeFocus}
             onSubmit={handleSubmitField}
             helperText={

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionDetails.jsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_group/ThreatActorGroupEditionDetails.jsx
@@ -6,7 +6,7 @@ import { Field, Form, Formik } from 'formik';
 import { useTheme } from '@mui/styles';
 import { ThreatActorGroupEditionOverviewFocus, ThreatActorGroupMutationRelationAdd, ThreatActorGroupMutationRelationDelete } from './ThreatActorGroupEditionOverview';
 import { useFormatter } from '../../../../components/i18n';
-import TextField from '../../../../components/TextField';
+
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import { commitMutation } from '../../../../relay/environment';
 import OpenVocabField from '../../common/form/OpenVocabField';
@@ -18,6 +18,7 @@ import { fieldSpacingContainerStyle } from '../../../../utils/field';
 import { useSchemaEditionValidation } from '../../../../utils/hooks/useEntitySettings';
 import useFormEditor from '../../../../utils/hooks/useFormEditor';
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
+import TextareaField from '../../../../components/TextareaField';
 
 const ThreatActorGroupMutationFieldPatch = graphql`
   mutation ThreatActorGroupEditionDetailsFieldPatchMutation(
@@ -300,13 +301,11 @@ const ThreatActorGroupEditionDetailsComponent = ({
                 editContext={context}
               />
               <Field
-                component={TextField}
+                component={TextareaField}
                 name="goals"
                 label={t_i18n('Goals (1 / line)')}
-                fullWidth={true}
-                multiline={true}
                 rows="4"
-                style={{ marginTop: 20 }}
+                className="mt-5"
                 onFocus={handleChangeFocus}
                 onSubmit={handleSubmitField}
                 helperText={

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualCreation.tsx
@@ -14,7 +14,7 @@ import Tab from '@mui/material/Tab';
 import CountryField from '@components/common/form/CountryField';
 import { useFormatter } from '../../../../components/i18n';
 import { handleErrorInForm } from '../../../../relay/environment';
-import TextField from '../../../../components/TextField';
+
 import ObjectLabelField from '../../common/form/ObjectLabelField';
 import CreatedByField from '../../common/form/CreatedByField';
 import ObjectMarkingField from '../../common/form/ObjectMarkingField';
@@ -47,6 +47,7 @@ import BulkTextModalButton from '../../../../components/fields/BulkTextField/Bul
 import BulkTextField from '../../../../components/fields/BulkTextField/BulkTextField';
 import CreateEntityControlledDial from '../../../../components/CreateEntityControlledDial';
 import FormButtonContainer from '../../../../components/common/form/FormButtonContainer';
+import TextareaField from '../../../../components/TextareaField';
 
 interface ErrorBadgeProps extends BadgeProps {
   errors?: FormikErrors<ThreatActorIndividualAddInput>;
@@ -545,14 +546,12 @@ export const ThreatActorIndividualCreationForm: FunctionComponent<
                 multiple={true}
               />
               <Field
-                component={TextField}
+                component={TextareaField}
                 name="goals"
                 label={t_i18n('Goals (1 / line)')}
                 required={(mandatoryAttributes.includes('goals'))}
-                fullWidth={true}
-                multiline={true}
                 rows="4"
-                style={{ marginTop: 20 }}
+                className="mt-5"
               />
             </Box>
             <Box sx={{ display: currentTab === 2 ? 'block' : 'none' }}>

--- a/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDetails.tsx
+++ b/opencti-platform/opencti-front/src/private/components/threats/threat_actors_individual/ThreatActorIndividualEditionDetails.tsx
@@ -10,7 +10,7 @@ import {
 import { useTheme } from '@mui/styles';
 import { GenericContext } from '../../common/model/GenericContextModel';
 import { isNone, useFormatter } from '../../../../components/i18n';
-import TextField from '../../../../components/TextField';
+
 import { SubscriptionFocus } from '../../../../components/Subscription';
 import OpenVocabField from '../../common/form/OpenVocabField';
 import { parse } from '../../../../utils/Time';
@@ -25,6 +25,7 @@ import useFormEditor, { GenericData } from '../../../../utils/hooks/useFormEdito
 import AlertConfidenceForEntity from '../../../../components/AlertConfidenceForEntity';
 import useApiMutation from '../../../../utils/hooks/useApiMutation';
 import type { Theme } from '../../../../components/Theme';
+import TextareaField from '../../../../components/TextareaField';
 
 const threatActorIndividualMutationFieldPatch = graphql`
   mutation ThreatActorIndividualEditionDetailsFieldPatchMutation(
@@ -369,14 +370,12 @@ const ThreatActorIndividualEditionDetailsComponent: FunctionComponent<
                 editContext={context}
               />
               <Field
-                component={TextField}
+                component={TextareaField}
                 name="goals"
                 label={t_i18n('Goals (1 / line)')}
                 required={(mandatoryAttributes.includes('goals'))}
-                fullWidth={true}
-                multiline={true}
                 rows="4"
-                style={{ marginTop: 20 }}
+                className="mt-5"
                 onFocus={handleChangeFocus}
                 onSubmit={handleSubmitGoals}
                 helperText={

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -957,9 +957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=83295d97c9ad95a516e77659538f8d742d84ff2a":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c":
   version: 0.1.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=83295d97c9ad95a516e77659538f8d742d84ff2a"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.18"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -980,7 +980,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/2e0aac496eec5ccc052a7a1450ad6594a405a0fd4eb072c938e8774a1d2f951c9d13c39ffbfa25d5660fc5c9e94d253afae57205272629dae4f70017780c4e4a
+  checksum: 10c0/3642b6fc864059600ac0d5f8b76cf824b1f3f556999b487a97d4d8efeea347cedc0f53f7d20916c83d2defdbc0b7e50602c0c41c7adec996a43dd062cffb0601
   languageName: node
   linkType: hard
 
@@ -12078,7 +12078,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=83295d97c9ad95a516e77659538f8d742d84ff2a"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
Closes part of #17926.

## What

Design-system pin `83295d9` → `359ab8c`. Brings the Input placeholder fix
(#172), the packaging change #171, Textarea (#170), FileSelect (#157), the
ButtonGroup fix (#168) and IconButton `asChild` (#167).

No product file is touched. This PR exists so the pin move is reviewable on its
own, separately from the conversions that depend on it.

## Install proof

The packaging change (#171) was the risk, so this was measured rather than
assumed. Cache purged, lockfile **re-resolved by yarn** (checksum regenerated,
not hand-edited), full linked install:

| Check | Result |
|---|---|
| dist | **529 files, 7.4 MB**, at `packages/filigran-design-system/dist` |
| #171's shape | `dist/components/input/`, `dist/components/textarea/` — per-component modules, not one bundled index |
| #172 in the shipped bytes | `placeholder:text-default-secondary` present in `dist/components/input/Input.mjs` |
| Real ESM import | `Input`, `Textarea`, `FileSelect` all resolve through the package entry |

**One trap documented in the commit**, because it cost me a false alarm: this
repo sets `enableScripts: false` and does not list `@filigran/design-system` in
`dependenciesMeta`, so the package's own `prepare` never runs at link time. The
dist is present anyway because yarn builds a git dependency during the **fetch**
step, before that gate applies — and it lives one level down, not at a top-level
`dist/`. Checking the wrong place looks exactly like a broken install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Second commit — 28 multi-line sites → `Textarea`

One adapter, not 28 rewrites: **26 of the 32 convertible sites are Formik
`<Field component={TextField} multiline>`**, so this adds
`components/TextareaField.tsx` — the multi-line counterpart of the existing
`components/TextField.tsx` pivot — and repoints them at it. Same error wiring as
that pivot (error shows only once touched or after a submit attempt), with the
one difference the library forces: `Textarea`'s `error` is a **string** replacing
the helper text, not a boolean.

**Four sites deliberately not converted**, each with a reason:

| Site | Reason |
|---|---|
| `StixCoreObjectContent.jsx:577`, `WorkflowTransitions.tsx:289` | `slotProps` — no escape hatch on Textarea |
| `DisseminationListForm.tsx:87` | `style={{ marginTop: theme.spacing(2) }}` — a theme function is not something to guess a class for |
| `PlaybookFlowFieldString.tsx:34` | `multiline` is a **prop**, not a literal: the wrapper serves both shapes and Textarea cannot |

That last one is worth reading. An earlier pass of this branch converted it and
**silently dropped the conditional behaviour** — callers passing
`multiline={false}` would have got a textarea. Lint surfaced it only as an unused
variable; the real fault was semantic. It is reverted byte-identical, and I swept
for the pattern: exactly two sites in the product have a non-literal `multiline`,
and the other belongs to another branch.

The **20** multiline sites in files owned by #17884 / `fds/buttons-chips-wave1`
are untouched, by file-level frontier.

### Audit — applied files, not the diff

- free multiline sites **32 → 4**, owned **20 → 20 unchanged**
- every survivor carries an explicit reason, 0 unexplained
- **typecheck against the real installed library**: 85 non-Relay errors
  project-wide, **none in any file this branch touches** — down from 89 before
  four defects of this pass were fixed (regex import insertion landing inside
  multi-line imports, 9 unused pivot imports, a duplicate `className`, two
  handlers still typed for `HTMLInputElement`)
- lint clean on all 28 changed files apart from pre-existing
  `import/no-unresolved` on Relay artifacts, absent because `relay-compiler` has
  not run in this worktree