### PR TITLE
feat(fds): convert 13 standalone TextField sites to the library Input (#17926)

### DIFF
--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterCreateDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterCreateDialog.tsx
@@ -1,7 +1,6 @@
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import TextField from '@mui/material/TextField';
 import { ChangeEvent, useState } from 'react';
 import { Form, Formik } from 'formik';
 import { graphql } from 'react-relay';
@@ -18,6 +17,7 @@ import { type AuthorizedMembersFieldValue } from '@components/common/form/Author
 import getSavedFilterScopeFilter from './getSavedFilterScopeFilter';
 import SavedFilterSharingSection from './SavedFilterSharingSection';
 import Security from '../../utils/Security';
+import { Input } from '@filigran/design-system';
 
 const savedFilterCreateDialogMutation = graphql`
   mutation SavedFilterCreateDialogMutation($input: SavedFilterAddInput!) {
@@ -125,10 +125,9 @@ const SavedFilterCreateDialog = ({ isOpen, onClose, setCurrentSavedFilter }: Sav
       >
         {({ submitForm }) => (
           <Form>
-            <TextField
+            <Input
               label={t_i18n('Name')}
               placeholder={t_i18n('My saved filter')}
-              fullWidth
               value={filterName}
               onChange={handleChange}
             />

--- a/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
+++ b/opencti-platform/opencti-front/src/components/saved_filters/SavedFilterEditDialog.tsx
@@ -1,7 +1,6 @@
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import TextField from '@mui/material/TextField';
 import { Form, Formik } from 'formik';
 import { graphql } from 'react-relay';
 import { useFormatter } from 'src/components/i18n';
@@ -13,6 +12,7 @@ import { AccessRight, type AuthorizedMemberOption } from '../../utils/authorized
 import { type AuthorizedMembersFieldValue } from '@components/common/form/AuthorizedMembersField';
 import SavedFilterSharingSection from './SavedFilterSharingSection';
 import Security from '../../utils/Security';
+import { Input } from '@filigran/design-system';
 
 const savedFilterFieldPatchMutation = graphql`
   mutation SavedFilterEditDialogFieldPatchMutation($id: ID!, $input: [EditInput!]!) {
@@ -154,10 +154,9 @@ const SavedFilterEditDialog = ({
       >
         {({ submitForm, values, setFieldValue }) => (
           <Form>
-            <TextField
+            <Input
               label={t_i18n('Name')}
               placeholder={t_i18n('My saved filter')}
-              fullWidth
               value={values.name}
               onChange={(e) => setFieldValue('name', e.target.value)}
             />

--- a/opencti-platform/opencti-front/src/private/components/common/lists/FiltersElement.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/lists/FiltersElement.tsx
@@ -1,5 +1,4 @@
 import Grid from '@mui/material/Grid';
-import TextField from '@mui/material/TextField';
 import React, { FunctionComponent } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useFormatter } from '../../../../components/i18n';
@@ -7,6 +6,7 @@ import { FiltersVariant, getFilterDefinitionFromFilterKeysMap, useBuildFilterKey
 import FilterDate from './FilterDate';
 import FilterAutocomplete from './FilterAutocomplete';
 import { HandleAddFilter } from '../../../../utils/hooks/useLocalStorage';
+import { Input } from '@filigran/design-system';
 
 export type FilterElementsInputValue = {
   key: string;
@@ -82,11 +82,8 @@ const FiltersElement: FunctionComponent<FiltersElementProps> = ({
       <Grid container={true} spacing={2}>
         {variant === FiltersVariant.dialog && (
           <Grid item xs={12}>
-            <TextField
+            <Input
               label={t_i18n('Global keyword')}
-              variant="outlined"
-              size="small"
-              fullWidth={true}
               value={keyword}
               onChange={handleChangeKeyword}
               disabled={disabled}

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeOption.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/representations/attributes/CsvMapperRepresentationAttributeOption.tsx
@@ -1,9 +1,9 @@
-import MuiTextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import React from 'react';
 import Alert from '@mui/material/Alert';
 import { FieldProps } from 'formik';
+import { Input } from '@filigran/design-system';
 
 interface CsvMapperRepresentationAttributeOptionProps extends FieldProps<string> {
   placeholder: string;
@@ -24,12 +24,13 @@ const CsvMapperRepresentationAttributeOption = ({
   return (
     <>
       <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px', marginTop: '10px' }}>
-        <MuiTextField
-          style={{ flex: 1 }}
+        <Input
+          className="flex-1"
           type="text"
           value={value ?? ''}
           onChange={(event) => setFieldValue(name, event.target.value)}
           placeholder={placeholder}
+          aria-label={placeholder}
         />
         {tooltip && (
           <Tooltip title={tooltip}>

--- a/opencti-platform/opencti-front/src/private/components/data/forms/FormEdition.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/forms/FormEdition.tsx
@@ -4,7 +4,6 @@ import makeStyles from '@mui/styles/makeStyles';
 import Button from '@common/button/Button';
 import { FormEditionFragment_form$key } from '@components/data/forms/__generated__/FormEditionFragment_form.graphql';
 import { FormCreationQuery } from '@components/data/forms/__generated__/FormCreationQuery.graphql';
-import TextField from '@mui/material/TextField';
 import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { useFormatter } from '../../../../components/i18n';
@@ -16,7 +15,7 @@ import type { FormBuilderData, FormFieldAttribute } from './Form.d';
 import { convertFormBuilderDataToSchema, normalizeDraftAuthorizedMembersDefaults } from './FormUtils';
 import Loader from '../../../../components/Loader';
 import { useTheme } from '@mui/styles';
-import { Textarea } from '@filigran/design-system';
+import { Input, Textarea } from '@filigran/design-system';
 
 const useStyles = makeStyles<Theme>(() => ({
   container: {
@@ -234,10 +233,8 @@ const FormEditionInner: FunctionComponent<FormEditionInnerProps> = ({
   return (
     <div className={classes.container}>
       <div className={classes.topFields}>
-        <TextField
-          variant="standard"
+        <Input
           label={t_i18n('Name')}
-          fullWidth={true}
           value={formName}
           onChange={handleNameChange}
         />

--- a/opencti-platform/opencti-front/src/private/components/data/jsonMapper/representations/attributes/JsonMapperRepresentationAttributeOption.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/jsonMapper/representations/attributes/JsonMapperRepresentationAttributeOption.tsx
@@ -1,9 +1,9 @@
-import MuiTextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import React from 'react';
 import Alert from '@mui/material/Alert';
 import { FieldProps } from 'formik';
+import { Input } from '@filigran/design-system';
 
 interface JsonMapperRepresentationAttributeOptionProps extends FieldProps<string> {
   placeholder: string;
@@ -24,12 +24,13 @@ const JsonMapperRepresentationAttributeOption = ({
   return (
     <>
       <div style={{ display: 'flex', alignItems: 'flex-end', gap: '8px', marginTop: '10px' }}>
-        <MuiTextField
-          style={{ flex: 1 }}
+        <Input
+          className="flex-1"
           type="text"
           value={value ?? ''}
           onChange={(event) => setFieldValue(name, event.target.value)}
           placeholder={placeholder}
+          aria-label={placeholder}
         />
         {tooltip && (
           <Tooltip title={tooltip}>

--- a/opencti-platform/opencti-front/src/private/components/data/jsonMapper/representations/attributes/JsonMapperRepresentationAttributeRefForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/jsonMapper/representations/attributes/JsonMapperRepresentationAttributeRefForm.tsx
@@ -19,6 +19,7 @@ import { resolveTypesForRelationship, resolveTypesForRelationshipRef } from '../
 import { useFormatter } from '../../../../../../components/i18n';
 import { isStixCoreObjects } from '../../../../../../utils/stixTypeUtils';
 import type { Theme } from '../../../../../../components/Theme';
+import { Input } from '@filigran/design-system';
 
 export type RepresentationAttributeForm = JsonMapperRepresentationAttributeFormData | undefined;
 
@@ -271,10 +272,9 @@ const JsonMapperRepresentationAttributeRefForm: FunctionComponent<
                   })}
                 </div>
                 <div>
-                  <MuiTextField
+                  <Input
                     label={t_i18n('JSON Path')}
-                    variant="standard"
-                    style={{ width: '100%' }}
+                    className="w-full"
                     value={identifierValue}
                     onChange={(e) => handleIdentifierChange(rep.id, e.target.value)}
                   />

--- a/opencti-platform/opencti-front/src/private/components/settings/smtp_configuration/SmtpTestDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/smtp_configuration/SmtpTestDialog.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent, useState } from 'react';
 import { graphql } from 'react-relay';
 import Alert from '@mui/material/Alert';
-import TextField from '@mui/material/TextField';
 import { DialogActions } from '@mui/material';
 import Dialog from '@common/dialog/Dialog';
 import Button from '@common/button/Button';
 import { useFormatter } from 'src/components/i18n';
 import useApiMutation from 'src/utils/hooks/useApiMutation';
 import { MESSAGING$ } from 'src/relay/environment';
+import { Input } from '@filigran/design-system';
 
 const smtpConfigurationTestMutation = graphql`
   mutation SmtpTestDialogMutation($email: String!) {
@@ -49,9 +49,8 @@ const SmtpTestDialog: FunctionComponent<SmtpTestDialogProps> = ({ open, onClose 
       <Alert severity="warning" variant="outlined" style={{ marginBottom: 16 }}>
         {t_i18n('This test only confirms the SMTP server accepted the message. It does not guarantee that the email was actually delivered.')}
       </Alert>
-      <TextField
+      <Input
         label={t_i18n('Email address')}
-        fullWidth={true}
         type="email"
         value={email}
         onChange={(event) => setEmail(event.target.value)}

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/custom_views/CustomViewDuplicationDialog.tsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import TextField from '@mui/material/TextField';
 import { useFormatter } from '../../../../../components/i18n';
 import { handleError, MESSAGING$ } from '../../../../../relay/environment';
 import stopEvent from '../../../../../utils/domEvent';
@@ -12,6 +11,7 @@ import useApiMutation from '../../../../../utils/hooks/useApiMutation';
 import { useCustomViewsData } from '../../../custom_views/useCustomViewsData';
 import { CustomViewDuplicationDialog_DuplicateMutation } from './__generated__/CustomViewDuplicationDialog_DuplicateMutation.graphql';
 import { CustomViewDuplicationDialog_Fragment$data, CustomViewDuplicationDialog_Fragment$key } from './__generated__/CustomViewDuplicationDialog_Fragment.graphql';
+import { Input } from '@filigran/design-system';
 
 const customViewDuplicationFragment = graphql`
   fragment CustomViewDuplicationDialog_Fragment on CustomView {
@@ -110,16 +110,12 @@ const CustomViewDuplicationDialog: FunctionComponent<
       size="small"
       title={t_i18n('Duplicate the custom view')}
     >
-      <TextField
-        error={!newName}
+      <Input
+        error={!newName ? t_i18n('This field is required') : undefined}
         autoFocus
-        margin="dense"
         id="duplicated_dashboard_name"
         label={t_i18n('New name')}
         type="text"
-        fullWidth
-        variant="standard"
-        helperText={!newName ? `${t_i18n('This field is required')}` : ''}
         defaultValue={newName}
         onChange={(event) => {
           event.preventDefault();

--- a/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingCustomFields.tsx
+++ b/opencti-platform/opencti-front/src/private/components/settings/sub_types/entity_setting/EntitySettingCustomFields.tsx
@@ -28,6 +28,7 @@ import { CUSTOM_FIELD_NOW_TOKEN } from '../../../../../utils/customFieldDefaults
 import { useSubTypeOutletContext } from '../SubTypeOutletContext';
 import EntitySettingCustomFieldsAddDialog from './EntitySettingCustomFieldsAddDialog';
 import { EntitySettingCustomFieldsQuery, EntitySettingCustomFieldsQuery$data } from './__generated__/EntitySettingCustomFieldsQuery.graphql';
+import { Input } from '@filigran/design-system';
 
 export const entitySettingCustomFieldsQuery = graphql`
   query EntitySettingCustomFieldsQuery {
@@ -181,14 +182,12 @@ const EntitySettingCustomFieldEditDialog: FunctionComponent<EntitySettingCustomF
         );
       case 'integer':
         return (
-          <MuiTextField
+          <Input
             type="number"
-            variant="standard"
-            fullWidth
             label={t_i18n('Default value')}
             value={defaultValue}
             onChange={(event) => setDefaultValue(event.target.value)}
-            style={{ marginTop: 20 }}
+            className="mt-5"
           />
         );
       case 'date': {
@@ -229,13 +228,11 @@ const EntitySettingCustomFieldEditDialog: FunctionComponent<EntitySettingCustomF
         );
       default:
         return (
-          <MuiTextField
-            variant="standard"
-            fullWidth
+          <Input
             label={t_i18n('Default value')}
             value={defaultValue}
             onChange={(event) => setDefaultValue(event.target.value)}
-            style={{ marginTop: 20 }}
+            className="mt-5"
           />
         );
     }

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationDataSelection.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCreationDataSelection.tsx
@@ -1,6 +1,5 @@
 import IconButton from '@common/button/IconButton';
 import { AddOutlined, CancelOutlined } from '@mui/icons-material';
-import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import { InformationOutline } from 'mdi-material-ui';
 import WidgetFilters from '@components/widgets/WidgetFilters';
@@ -14,6 +13,7 @@ import type { WidgetPerspective } from '../../../utils/widget/widget';
 import { getCurrentCategory, getCurrentDataSelectionLimit, isWidgetUsingRelationsAggregation } from '../../../utils/widget/widgetUtils';
 import { useWidgetConfigContext } from './WidgetConfigContext';
 import Alert from '../../../components/Alert';
+import { Input } from '@filigran/design-system';
 
 type StepContainerProps = {
   perspective?: WidgetPerspective | null;
@@ -129,11 +129,10 @@ const WidgetCreationDataSelection = () => {
               </IconButton>
 
               <Stack direction="row" sx={{ width: '100%' }}>
-                <TextField
-                  style={{ flex: 1 }}
+                <Input
+                  className="flex-1"
                   label={`${t_i18n('Label')} (${dataSelection[i].perspective})`}
-                  fullWidth={true}
-                  value={dataSelection[i].label}
+                  value={dataSelection[i].label ?? ''}
                   onChange={(event) => handleChangeDataValidationLabel(i, event.target.value)}
                 />
                 {

--- a/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
+++ b/opencti-platform/opencti-front/src/private/components/workspaces/WorkspaceDuplicationDialog.tsx
@@ -1,7 +1,6 @@
 import Button from '@common/button/Button';
 import Dialog from '@common/dialog/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import TextField from '@mui/material/TextField';
 import { FunctionComponent, UIEvent, useMemo, useState } from 'react';
 import { graphql, useFragment } from 'react-relay';
 import { Link } from 'react-router-dom';
@@ -16,6 +15,7 @@ import {
 } from './__generated__/WorkspaceDuplicationDialogDuplicatedWorkspaceCreationMutation.graphql';
 import { WorkspaceDuplicationDialogFragment$data, WorkspaceDuplicationDialogFragment$key } from './__generated__/WorkspaceDuplicationDialogFragment.graphql';
 import { WorkspacesLinesPaginationQuery$variables } from './__generated__/WorkspacesLinesPaginationQuery.graphql';
+import { Input } from '@filigran/design-system';
 
 const workspaceDuplicationFragment = graphql`
   fragment WorkspaceDuplicationDialogFragment on Workspace {
@@ -120,16 +120,12 @@ const WorkspaceDuplicationDialog: FunctionComponent<
       fullWidth={true}
       title={t_i18n('Duplicate the dashboard')}
     >
-      <TextField
-        error={!newName}
+      <Input
+        error={!newName ? t_i18n('This field is required') : undefined}
         autoFocus
-        margin="dense"
         id="duplicated_dashboard_name"
         label={t_i18n('New name')}
         type="text"
-        fullWidth
-        variant="standard"
-        helperText={!newName ? `${t_i18n('This field is required')}` : ''}
         defaultValue={newName}
         onChange={(event) => {
           event.preventDefault();


### PR DESCRIPTION
Closes part of #17926.

First `Input` adoption in this product. **Depends on the pin bump (#17928)** —
these sites need the design-system commit that carries the Input placeholder fix.

## Scope, and why it is 13 and not 60

Of the 60 standalone MUI `<TextField>` sites (i.e. excluding the 49 that are an
Autocomplete's own `renderInput`), 30 sit in files owned by #17884 or
`fds/buttons-chips-wave1` and are **untouched by file-level frontier**. Of the 30
remaining, 13 are Input material.

Every non-conversion has a stated reason rather than a rewrite:

| Count | Reason |
|---|---|
| 6 | `multiline` → belongs to `Textarea`, converted separately |
| 4 | `<TextField select>` → a Select, not an Input |
| 4 | unresolvable `{...spread}` → the prop set cannot be verified |
| 2 | `slotProps` / `inputProps` → Input exposes no escape hatch |
| 1 | dynamic `type={type}` → outside Input's `text\|password\|number\|email` union |

Also out: `SearchInput` (SearchField territory), `ColorPickerField` (needs an
interactive leading slot the library does not have yet), and
`components/TextField.tsx` — which is the **Formik pivot**, 553 downstream sites,
not a site.

## Mappings

`variant`/`fullWidth`/`size`/`margin` dropped (one style, intrinsic width);
`style={{flex:1}}` → `className="flex-1"`, `{{width:'100%'}}` → `"w-full"`,
`{{marginTop:20}}` → `"mt-5"`; MUI's `error` boolean + `helperText` pair
collapsed into Input's `error` string, which is string-only by arbitration and
replaces the helper. The two placeholder-only mapper fields gained an
`aria-label`, since Input warns on a field with no accessible name and a
placeholder is not one.

The MUI import is **kept** in the 3 files that still render a non-converted
`TextField` (a multiline or a select) and removed from the other 9.

## Audit — on the applied files, re-parsed from disk, not on the diff

- standalone free-file sites **30 → 17**
- in-flight-owned sites **30 → 30, unchanged**
- all 17 survivors carry an explicit reason, **0 unexplained**
- the abandoned `BasicFilterInput.tsx` is **byte-identical to origin** — the
  abort left no partial rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
