### PR TITLE
feat(fds): bump the pin and convert the horizontal Radio groups (#17804)

### DIFF
--- a/opencti-platform/opencti-front/package.json
+++ b/opencti-platform/opencti-front/package.json
@@ -39,7 +39,7 @@
     "@cfworker/json-schema": "4.1.1",
     "@filigran/chatbot": "3.7.4",
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2",
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c",
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=bd076e8f49dfb678469be0638562ea0c85b06a6c",
     "@filigran/rich-text-editor": "1.2.0",
     "@fontsource/geologica": "5.3.0",
     "@fontsource/ibm-plex-sans": "5.3.0",

--- a/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/csvMapper/CsvMapperForm.tsx
@@ -3,16 +3,14 @@ import { Field, FieldArray, Form, Formik } from 'formik';
 import Button from '@common/button/Button';
 import makeStyles from '@mui/styles/makeStyles';
 import * as Yup from 'yup';
-import { IconButton, Radio, RadioGroup, Typography } from '@mui/material';
+import { IconButton, Typography } from '@mui/material';
 import { Add } from '@mui/icons-material';
 import { InformationOutline } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
 import { FormikHelpers } from 'formik/dist/types';
-import { SelectChangeEvent } from '@mui/material/Select';
 import CsvMapperRepresentationForm, { RepresentationFormEntityOption } from '@components/data/csvMapper/representations/CsvMapperRepresentationForm';
 import { CsvMapperFormData } from '@components/data/csvMapper/CsvMapper';
 import classNames from 'classnames';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import { formDataToCsvMapper } from '@components/data/csvMapper/CsvMapperUtils';
 import { CsvMapperProvider } from '@components/data/csvMapper/CsvMapperContext';
 import type { Theme } from '../../../../components/Theme';
@@ -23,6 +21,7 @@ import useAuth from '../../../../utils/hooks/useAuth';
 import { representationInitialization } from './representations/RepresentationUtils';
 import CsvMapperTestDialog from './CsvMapperTestDialog';
 import FormButtonContainer from '@common/form/FormButtonContainer';
+import { Radio, RadioGroup } from '@filigran/design-system';
 
 // Deprecated - https://mui.com/system/styles/basics/
 // Do not use it for new code.
@@ -197,25 +196,13 @@ const CsvMapperForm: FunctionComponent<CsvMapperFormProps> = ({ csvMapper, onSub
                   <RadioGroup
                     aria-label="CSV separator"
                     name="separator"
-                    style={{ flexDirection: 'row' }}
+                    orientation="horizontal"
                     value={values.separator}
-                    onChange={(event: SelectChangeEvent) => setFieldValue('separator', event.target.value)}
+                    onValueChange={(value) => setFieldValue('separator', value)}
                   >
-                    <FormControlLabel
-                      value=","
-                      control={<Radio />}
-                      label={t_i18n('Comma')}
-                    />
-                    <FormControlLabel
-                      value=";"
-                      control={<Radio />}
-                      label={t_i18n('Semicolon')}
-                    />
-                    <FormControlLabel
-                      value="|"
-                      control={<Radio />}
-                      label={t_i18n('Pipe')}
-                    />
+                    <Radio value="," label={t_i18n('Comma')} />
+                    <Radio value=";" label={t_i18n('Semicolon')} />
+                    <Radio value="|" label={t_i18n('Pipe')} />
                   </RadioGroup>
                 </div>
               </div>

--- a/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvInlineMapperForm.tsx
+++ b/opencti-platform/opencti-front/src/private/components/data/ingestionCsv/IngestionCsvInlineMapperForm.tsx
@@ -1,15 +1,13 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Field, FieldArray, Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import { IconButton, Radio, RadioGroup, Typography } from '@mui/material';
+import { IconButton, Typography } from '@mui/material';
 import { Add } from '@mui/icons-material';
 import { InformationOutline } from 'mdi-material-ui';
 import Tooltip from '@mui/material/Tooltip';
 import { FormikHelpers } from 'formik/dist/types';
-import { SelectChangeEvent } from '@mui/material/Select';
 import CsvMapperRepresentationForm, { RepresentationFormEntityOption } from '@components/data/csvMapper/representations/CsvMapperRepresentationForm';
 import { CsvMapperFormData } from '@components/data/csvMapper/CsvMapper';
-import FormControlLabel from '@mui/material/FormControlLabel';
 import { CsvMapperProvider } from '@components/data/csvMapper/CsvMapperContext';
 import Box from '@mui/material/Box';
 import { csvFeedCsvMapperToFormData } from '@components/data/ingestionCsv/IngestionCSVFeedUtils';
@@ -19,6 +17,7 @@ import SwitchField from '../../../../components/fields/SwitchField';
 import useAuth from '../../../../utils/hooks/useAuth';
 import { representationInitialization } from '../csvMapper/representations/RepresentationUtils';
 import { CsvMapperAddInput, formDataToCsvMapper } from '../csvMapper/CsvMapperUtils';
+import { Radio, RadioGroup } from '@filigran/design-system';
 
 const csvMapperValidation = (t_i18n: (s: string) => string) => Yup.object().shape({
   has_header: Yup.boolean().required(t_i18n('This field is required')),
@@ -189,25 +188,13 @@ const IngestionCsvInlineMapperForm: FunctionComponent<CsvMapperFormProps> = ({ c
                   <RadioGroup
                     aria-label="CSV separator"
                     name="separator"
-                    style={{ flexDirection: 'row' }}
+                    orientation="horizontal"
                     value={values.separator}
-                    onChange={(event: SelectChangeEvent) => setFieldValue('separator', event.target.value)}
+                    onValueChange={(value) => setFieldValue('separator', value)}
                   >
-                    <FormControlLabel
-                      value=","
-                      control={<Radio />}
-                      label={t_i18n('Comma')}
-                    />
-                    <FormControlLabel
-                      value=";"
-                      control={<Radio />}
-                      label={t_i18n('Semicolon')}
-                    />
-                    <FormControlLabel
-                      value="|"
-                      control={<Radio />}
-                      label={t_i18n('Pipe')}
-                    />
+                    <Radio value="," label={t_i18n('Comma')} />
+                    <Radio value=";" label={t_i18n('Semicolon')} />
+                    <Radio value="|" label={t_i18n('Pipe')} />
                   </RadioGroup>
                 </Box>
               </Box>

--- a/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttributesColumnsInput.tsx
+++ b/opencti-platform/opencti-front/src/private/components/widgets/WidgetCustomAttributesColumnsInput.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
-import { Box, Checkbox, FormControlLabel, IconButton, List, ListItem, ListItemIcon, ListItemText, Radio, RadioGroup, Typography } from '@mui/material';
+import { Box, Checkbox, IconButton, List, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import { Close, DragIndicatorOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/styles';
@@ -10,6 +10,7 @@ import { useFormatter } from 'src/components/i18n';
 import type { WidgetColumn } from 'src/utils/widget/widget';
 import { Accordion, AccordionSummary } from 'src/components/Accordion';
 import useWidgetColumnsCustomization from './useWidgetColumnsCustomization';
+import { Radio, RadioGroup } from '@filigran/design-system';
 
 export type WidgetColumnsLayout = '1' | '2';
 
@@ -207,12 +208,13 @@ const WidgetCustomAttributesColumnsInput: FunctionComponent<WidgetCustomAttribut
           <Box sx={{ marginBottom: theme.spacing(2) }}>
             <Typography variant="h4">{t_i18n('Layout')}</Typography>
             <RadioGroup
-              row
+              aria-label={t_i18n('Layout')}
+              orientation="horizontal"
               value={layout}
-              onChange={(e) => onLayoutChange(e.target.value as WidgetColumnsLayout)}
+              onValueChange={(value) => onLayoutChange(value as WidgetColumnsLayout)}
             >
-              <FormControlLabel value="1" control={<Radio size="small" />} label={t_i18n('1 column')} />
-              <FormControlLabel value="2" control={<Radio size="small" />} label={t_i18n('2 columns')} />
+              <Radio value="1" label={t_i18n('1 column')} />
+              <Radio value="2" label={t_i18n('2 columns')} />
             </RadioGroup>
           </Box>
         )}

--- a/opencti-platform/opencti-front/yarn.lock
+++ b/opencti-platform/opencti-front/yarn.lock
@@ -957,9 +957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c":
+"@filigran/design-system@XTM-Foundation/filigran-design-system#commit=bd076e8f49dfb678469be0638562ea0c85b06a6c":
   version: 0.1.0
-  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c"
+  resolution: "@filigran/design-system@https://github.com/XTM-Foundation/filigran-design-system.git#commit=bd076e8f49dfb678469be0638562ea0c85b06a6c"
   dependencies:
     "@radix-ui/react-accordion": "npm:^1.2.18"
     "@radix-ui/react-checkbox": "npm:^1.3.11"
@@ -980,7 +980,7 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/3642b6fc864059600ac0d5f8b76cf824b1f3f556999b487a97d4d8efeea347cedc0f53f7d20916c83d2defdbc0b7e50602c0c41c7adec996a43dd062cffb0601
+  checksum: 10c0/d08e8c0982df213aa350702f8d7afa144a9a0c3030158e0fac99bc6935eb87d311d3f3a7e2901b739fe3e6e467ac092f25256dcaaef9fb779ebb1f7437965451
   languageName: node
   linkType: hard
 
@@ -12078,7 +12078,7 @@ __metadata:
     "@faker-js/faker": "npm:10.5.0"
     "@filigran/chatbot": "npm:3.7.4"
     "@filigran/chatbot-legacy": "npm:@filigran/chatbot@1.1.2"
-    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=359ab8c44c9f61574d6e922483f9ebd93aad3f8c"
+    "@filigran/design-system": "XTM-Foundation/filigran-design-system#commit=bd076e8f49dfb678469be0638562ea0c85b06a6c"
     "@filigran/rich-text-editor": "npm:1.2.0"
     "@fontsource/geologica": "npm:5.3.0"
     "@fontsource/ibm-plex-sans": "npm:5.3.0"


### PR DESCRIPTION
Closes part of #17804.

## What

Pin `359ab8c` → `bd076e8f` (Radio horizontal #175, bundle gate #174, Combobox fix
#176), and the **3 groups that were waiting on the variant** — all three were
faking the axis before:

| File | Was |
|---|---|
| `data/csvMapper/CsvMapperForm.tsx` | `style={{flexDirection:'row'}}` |
| `data/ingestionCsv/IngestionCsvInlineMapperForm.tsx` | `style={{flexDirection:'row'}}` |
| `widgets/WidgetCustomAttributesColumnsInput.tsx` | `row` |

Each becomes `<RadioGroup orientation="horizontal">` with the library's
integrated label, so **8 `FormControlLabel` wrappers disappear**. `onChange(event)`
→ `onValueChange(value)`. `<Radio size="small" />` loses a size the library does
not have (one size in Figma).

**One accessibility gain worth naming:** `WidgetCustomAttributesColumnsInput` had
**no accessible name** on its group — the visible "Layout" heading was doing that
work visually only. It now carries `aria-label={t_i18n('Layout')}`, taken from
that heading rather than invented.

## Install proof

Cache purged, lockfile re-resolved by yarn, full linked install: **529 files** at
`packages/filigran-design-system/dist`, and **`aria-orientation` present in the
shipped `dist/components/radio/Radio.mjs`** — #175's fix is in these bytes.

## The bump introduced nothing else

Typecheck against the installed library: **85 non-Relay errors project-wide — the
exact same 85** measured on the previous pin, and **none** in any file this PR
touches. Lint clean on all three. So the pin move changed no other rendering path
or type.

## Before / after

Both themes, painted with the design system's own built `theme.css` and
`index.css` from the installed package:
https://claude.ai/code/artifact/bbfebc97-8b85-4577-bcbc-bc4834040a51

Control 20px → 16px, label 16px → 14px, item gap now the node's `Gap/gap-md`
(16px) instead of MUI's `9px` padding plus a `−11px` label offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Radio census — the component is NOT fully converted

Re-counted with the compiler on this branch. **11 of 14 Radio sites are now on the
library; 3 remain, and both files that hold them are OFF LIMITS to me.**

| | sites | files |
|---|---|---|
| Converted here (`RadioGroup` + `Radio`) | 11 | 3 |
| **Remaining on MUI** | **3** | **2** |

The 3 remaining, with why each is blocked — **not my call to make**:

| Site | Blocker 1 — frontier | Blocker 2 — structural |
|---|---|---|
| `StixCoreObjectAskAI.tsx:325` | file is in **#17884**'s diff | ungrouped radio, rendered as a `<ListItem secondaryAction>` |
| `StixCoreObjectAskAI.tsx:345` | file is in **#17884**'s diff | same |
| `DataTableToolBar.jsx:2988` | file is in **#17884**'s diff | ungrouped radio, one per data-table row |

**Frontier:** both files appear in the open #17884 (Combobox) diff, so the
file-level rule says I do not touch them.

**Structural:** all three are *ungrouped* — each carries its own `checked` +
`onChange` with no `<RadioGroup>` ancestor. The library's `Radio` derives its state
from the group's value and has no `checked` prop by design (the Figma component
note is explicit: "Coded Radio Fields are grouped and the value of the field
indicates its state"). Converting them means wrapping a `RadioGroup` around a
`<List>` whose items each contribute one radio via `secondaryAction`, and around
data-table rows — a restructuring of the surrounding markup, not a swap. This is
exactly the case `Radio.rfc.md` §2.4 flagged.

**For arbitration:** (a) wait for #17884 to merge, then restructure both into real
groups; (b) leave them on MUI and close Radio as "converted except 3 ungrouped
legacy sites"; (c) something else. I have not chosen.