### PR TITLE
fix(client-python): preserve report published date on update (#17947)

### DIFF
--- a/client-python/pycti/entities/opencti_report.py
+++ b/client-python/pycti/entities/opencti_report.py
@@ -1042,6 +1042,11 @@ class Report:
                         "opencti_upsert_operations", stix_object
                     )
                 )
+            published = stix_object.get("published")
+            if published is None and update:
+                report = self.read(id=stix_object["id"], customAttributes="published")
+                if report is not None:
+                    published = report.get("published")
             return self.create(
                 stix_id=stix_object["id"],
                 createdBy=(
@@ -1094,9 +1099,7 @@ class Report:
                     if "report_types" in stix_object
                     else None
                 ),
-                published=(
-                    stix_object["published"] if "published" in stix_object else None
-                ),
+                published=published,
                 x_opencti_stix_ids=(
                     stix_object["x_opencti_stix_ids"]
                     if "x_opencti_stix_ids" in stix_object

--- a/client-python/tests/01-unit/entity/test_opencti_report.py
+++ b/client-python/tests/01-unit/entity/test_opencti_report.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+from pycti.entities.opencti_report import Report
+
+
+def opencti_mock(*responses):
+    opencti = MagicMock()
+    opencti.get_attribute_in_extension.return_value = None
+    opencti.process_multiple_fields.side_effect = lambda value: value
+    opencti.stix2.convert_markdown.side_effect = lambda value: value
+    opencti.query.side_effect = responses
+    return opencti
+
+
+def test_update_without_published_reuses_existing_value():
+    opencti = opencti_mock(
+        {"data": {"report": {"published": "1970-01-01T00:00:00.000Z"}}},
+        {"data": {"reportAdd": {"id": "report--internal"}}},
+    )
+
+    result = Report(opencti).import_from_stix2(
+        stixObject={"id": "report--standard", "name": "Epoch report"},
+        update=True,
+    )
+
+    assert result == {"id": "report--internal"}
+    assert opencti.query.call_args_list[1].args[1]["input"]["published"] == (
+        "1970-01-01T00:00:00.000Z"
+    )
+
+
+def test_update_with_published_does_not_read_existing_report():
+    opencti = opencti_mock(
+        {"data": {"reportAdd": {"id": "report--internal"}}},
+    )
+
+    result = Report(opencti).import_from_stix2(
+        stixObject={
+            "id": "report--standard",
+            "name": "Published report",
+            "published": "2026-08-28T00:00:00.000Z",
+        },
+        update=True,
+    )
+
+    assert result == {"id": "report--internal"}
+    assert opencti.query.call_count == 1
+    assert opencti.query.call_args.args[1]["input"]["published"] == (
+        "2026-08-28T00:00:00.000Z"
+    )
+
+
+def test_update_without_published_still_fails_when_report_does_not_exist():
+    opencti = opencti_mock({"data": {"report": None}})
+
+    result = Report(opencti).import_from_stix2(
+        stixObject={"id": "report--missing", "name": "Missing report"},
+        update=True,
+    )
+
+    assert result is None
+    assert opencti.query.call_count == 1


### PR DESCRIPTION
## Summary

- preserve an existing Report's `published` date when a STIX update omits it
- leave new Report creation and explicit `published` updates unchanged
- cover the successful update, no-extra-read, and missing-target paths

Fixes #17947

## Root cause

OpenCTI intentionally omits the epoch placeholder from STIX output, but the
Python Report importer still requires `published` before sending an update.
The importer now reads only the stored `published` value when an update omits
it, so all existing import callers share the same fix.

## Test plan

- `pytest tests/01-unit/entity/test_opencti_report.py -q` (3 passed)
- full `pytest --no-header -vv --disable-warnings --drone` (533 passed, 4 skipped)
- `examples/run_all.sh`
- `isort --check-only`, `black --check`, and `flake8 --ignore E,W`
- scoped `mypy` and `compileall`
- `python -m build`

## Current blockers

- Filigran CLA requires the contributor account holder's acceptance.
- GitHub reports the SSH signature as an unknown key until its public key is
  registered separately as a signing key.
