### PR TITLE
fix(ui-sc-overview): removed option to update or delete from list of vulnerabilities (#14716)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
@@ -230,7 +230,7 @@ const SecurityCoverageAttackPatternsComponent = ({
                         primary={(
                           <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
                             <Typography variant="body2" component="span" noWrap sx={{ flex: '1 1 10%' }}>{attackPattern?.name}</Typography>
-                            <Box sx={{ flex: '1 1 auto', display: 'flex', justifyContent: 'center' }}>
+                            <Box sx={{ flex: '1 1 auto', display: 'flex', justifyContent: 'end' }}>
                               <SecurityCoverageScores
                                 coverage_information={coverage}
                                 variant="header"

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageAttackPatterns.tsx
@@ -6,9 +6,8 @@ import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import React, { useEffect, useMemo, useState } from 'react';
-import { createRefetchContainer, graphql, RelayRefetchProp, useFragment } from 'react-relay';
+import { createFragmentContainer, graphql, useFragment } from 'react-relay';
 import ListItem from '@mui/material/ListItem';
-import StixCoreRelationshipPopover from '@components/common/stix_core_relationships/StixCoreRelationshipPopover';
 import { Box, IconButton, ListItemButton, Stack, Tooltip } from '@mui/material';
 import { Link } from 'react-router-dom';
 import ListItemIcon from '@mui/material/ListItemIcon';
@@ -49,13 +48,11 @@ const securityCoverageKillChainPhasesFragment = graphql`
 interface SecurityCoverageAttackPatternsProps {
   securityCoverage: SecurityCoverageAttackPatternsFragment$data;
   dataKillChains: SecurityCoverageAttackPatternsKillChainPhasesFragment$key;
-  relay: RelayRefetchProp;
 }
 
 const SecurityCoverageAttackPatternsComponent = ({
   securityCoverage,
   dataKillChains,
-  relay,
 }: SecurityCoverageAttackPatternsProps) => {
   const { t_i18n } = useFormatter();
   const [searchTerm, setSearchTerm] = useState('');
@@ -220,14 +217,6 @@ const SecurityCoverageAttackPatternsComponent = ({
                     dense={true}
                     divider={true}
                     disablePadding={true}
-                    secondaryAction={(
-                      <StixCoreRelationshipPopover
-                        objectId={securityCoverage.id}
-                        stixCoreRelationshipId={attackPatternEntity.relationship_id}
-                        onDelete={() => relay.refetch({ id: securityCoverage.id })}
-                        isCoverage={true}
-                      />
-                    )}
                   >
                     <ListItemButton
                       component={Link}
@@ -262,7 +251,7 @@ const SecurityCoverageAttackPatternsComponent = ({
   );
 };
 
-const SecurityCoverageAttackPatterns = createRefetchContainer(
+const SecurityCoverageAttackPatterns = createFragmentContainer(
   SecurityCoverageAttackPatternsComponent,
   {
     securityCoverage: graphql`
@@ -292,13 +281,6 @@ const SecurityCoverageAttackPatterns = createRefetchContainer(
       }
     `,
   },
-  graphql`
-    query SecurityCoverageAttackPatternsRefetchQuery($id: String!) {
-      securityCoverage(id: $id) {
-        ...SecurityCoverageAttackPatternsFragment
-      }
-    }
-  `,
 );
 
 export default SecurityCoverageAttackPatterns;

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageVulnerabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageVulnerabilities.tsx
@@ -5,7 +5,7 @@ import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { Link } from 'react-router-dom';
-import { createRefetchContainer, graphql, RelayRefetchProp } from 'react-relay';
+import { createFragmentContainer, graphql } from 'react-relay';
 import { Box, ListItemButton, Tooltip } from '@mui/material';
 import { InformationOutline } from 'mdi-material-ui';
 import type { Theme } from '../../../../components/Theme';
@@ -15,7 +15,6 @@ import { SecurityCoverageVulnerabilities_securityCoverage$data } from './__gener
 import SecurityCoverageScores from './SecurityCoverageScores';
 import SecurityCoverageCoveredList from './SecurityCoverageCoveredList';
 import ItemIcon from '../../../../components/ItemIcon';
-import StixCoreRelationshipPopover from '../../common/stix_core_relationships/StixCoreRelationshipPopover';
 import Label from '../../../../components/common/label/Label';
 import Alert from '../../../../components/Alert';
 import { dedupeCoveredEntities } from './securityCoverageAggregation';
@@ -24,12 +23,10 @@ const MAX_VULNERABILITIES = 5000;
 
 interface SecurityCoverageVulnerabilitiesProps {
   securityCoverage: SecurityCoverageVulnerabilities_securityCoverage$data;
-  relay: RelayRefetchProp;
 }
 
 const SecurityCoverageVulnerabilitiesComponent: FunctionComponent<SecurityCoverageVulnerabilitiesProps> = ({
   securityCoverage,
-  relay,
 }) => {
   const { t_i18n } = useFormatter();
   const theme = useTheme<Theme>();
@@ -71,14 +68,6 @@ const SecurityCoverageVulnerabilitiesComponent: FunctionComponent<SecurityCovera
                 dense={true}
                 divider={true}
                 disablePadding={true}
-                secondaryAction={(
-                  <StixCoreRelationshipPopover
-                    objectId={securityCoverage.id}
-                    stixCoreRelationshipId={vulnerabilityEntity.relationship_id}
-                    onDelete={() => relay.refetch({ id: securityCoverage.id })}
-                    isCoverage={true}
-                  />
-                )}
               >
                 <ListItemButton
                   component={Link}
@@ -111,15 +100,11 @@ const SecurityCoverageVulnerabilitiesComponent: FunctionComponent<SecurityCovera
   );
 };
 
-const SecurityCoverageVulnerabilities = createRefetchContainer(
+const SecurityCoverageVulnerabilities = createFragmentContainer(
   SecurityCoverageVulnerabilitiesComponent,
   {
     securityCoverage: graphql`
       fragment SecurityCoverageVulnerabilities_securityCoverage on SecurityCoverage {
-        id
-        name
-        parent_types
-        entity_type
         vulnerabilities: coveredVulnerabilities(
           orderBy: created_at
           orderMode: asc
@@ -143,13 +128,6 @@ const SecurityCoverageVulnerabilities = createRefetchContainer(
       }
     `,
   },
-  graphql`
-    query SecurityCoverageVulnerabilitiesRefetchQuery($id: String!) {
-      securityCoverage(id: $id) {
-        ...SecurityCoverageVulnerabilities_securityCoverage
-      }
-    }
-  `,
 );
 
 export default SecurityCoverageVulnerabilities;

--- a/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageVulnerabilities.tsx
+++ b/opencti-platform/opencti-front/src/private/components/analyses/security_coverages/SecurityCoverageVulnerabilities.tsx
@@ -81,7 +81,7 @@ const SecurityCoverageVulnerabilitiesComponent: FunctionComponent<SecurityCovera
                     primary={(
                       <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
                         <Typography variant="body2" component="span" noWrap sx={{ flex: '1 1 10%' }}>{vulnerability?.name}</Typography>
-                        <Box sx={{ flex: '1 1 auto', display: 'flex', justifyContent: 'center' }}>
+                        <Box sx={{ flex: '1 1 auto', display: 'flex', justifyContent: 'end' }}>
                           <SecurityCoverageScores
                             coverage_information={coverage}
                             variant="header"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Removed the secondary options
* Removed unused code => no need to refetch anymore so replaced createRefetchContainer with createFragmentContainer and removed unused refetch query

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->


### How to test this PR
<!-- please give example or instruction for the reviewer to test this PR -->
Create a SC with tested vulnerabilities
You should see them on the overview tab but not be able to update or delete them from that screen :
<img width="711" height="171" alt="Capture d’écran 2026-08-28 à 11 50 08" src="https://github.com/user-attachments/assets/96ff3223-98f2-4b0d-b80e-2c1d67168134" />


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

<!-- _NOTE: Test coverage is, by default, mandatory. It will help us improve the stability of the platform. If you consider tests are not relevant for this PR, reach out and explain why._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
