### PR TITLE
fix(ap): batch nested connections to prevent list view errors (#17226)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainContainer.tsx
+++ b/opencti-platform/opencti-front/src/private/components/common/stix_domain_objects/StixDomainObjectAttackPatternsKillChainContainer.tsx
@@ -113,16 +113,6 @@ export const stixDomainObjectAttackPatternsKillChainContainerFragment = graphql`
               }
             }
           }
-          parentAttackPatterns {
-            edges {
-              node {
-                id
-                name
-                description
-                x_mitre_id
-              }
-            }
-          }
           subAttackPatterns {
             edges {
               node {
@@ -138,10 +128,6 @@ export const stixDomainObjectAttackPatternsKillChainContainerFragment = graphql`
             kill_chain_name
             phase_name
             x_opencti_order
-          }
-          creators {
-            id
-            name
           }
           objectMarking {
             id

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -558,15 +558,23 @@ export const loadEntityThroughRelationsPaginated = async <T extends BasicStoreEn
 export const batchEntitiesThroughRelations = async <T extends BasicStoreEntity>(
   context: AuthContext,
   user: AuthUser,
-  parentIds: string[],
+  targetIds: string[],
   relationType: string,
   fromType: string,
 ): Promise<BasicConnection<T>[]> => {
-  const relations = await fullRelationsList<BasicStoreRelation>(context, user, relationType, { toId: parentIds, fromTypes: [fromType], baseData: true });
+  const relations: { fromId: string; toId: string }[] = [];
+  await fullRelationsList<BasicStoreRelation>(context, user, relationType, {
+    toId: targetIds,
+    fromTypes: [fromType],
+    baseData: true,
+    callback: async (page) => {
+      page.forEach((relation) => relations.push({ fromId: relation.fromId, toId: relation.toId }));
+    },
+  });
   const entitiesById = await internalFindByIdsMapped<T>(context, user, R.uniq(relations.map((relation) => relation.fromId)), { type: fromType });
-  const relationsByParentId = R.groupBy((relation) => relation.toId, relations);
-  return parentIds.map((id) => {
-    const nodes = (relationsByParentId[id] ?? [])
+  const relationsByTargetId = R.groupBy((relation) => relation.toId, relations);
+  return targetIds.map((id) => {
+    const nodes = (relationsByTargetId[id] ?? [])
       .map((relation) => entitiesById[relation.fromId])
       .filter((node): node is T => !!node);
     return buildPagination(0, null, nodes.map((node) => ({ node })), nodes.length);

--- a/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
+++ b/opencti-platform/opencti-graphql/src/database/middleware-loader.ts
@@ -555,6 +555,24 @@ export const loadEntityThroughRelationsPaginated = async <T extends BasicStoreEn
   return pagination.edges[0]?.node;
 };
 
+export const batchEntitiesThroughRelations = async <T extends BasicStoreEntity>(
+  context: AuthContext,
+  user: AuthUser,
+  parentIds: string[],
+  relationType: string,
+  fromType: string,
+): Promise<BasicConnection<T>[]> => {
+  const relations = await fullRelationsList<BasicStoreRelation>(context, user, relationType, { toId: parentIds, fromTypes: [fromType], baseData: true });
+  const entitiesById = await internalFindByIdsMapped<T>(context, user, R.uniq(relations.map((relation) => relation.fromId)), { type: fromType });
+  const relationsByParentId = R.groupBy((relation) => relation.toId, relations);
+  return parentIds.map((id) => {
+    const nodes = (relationsByParentId[id] ?? [])
+      .map((relation) => entitiesById[relation.fromId])
+      .filter((node): node is T => !!node);
+    return buildPagination(0, null, nodes.map((node) => ({ node })), nodes.length);
+  });
+};
+
 export const countAllThings = async <T extends BasicStoreCommon>(context: AuthContext, user: AuthUser, args: ListFilter<T> = {}) => {
   const { indices = READ_DATA_INDICES } = args;
   return elCount(context, user, indices, args);

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 import { createEntity } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
 import { notify } from '../database/redis';
-import { isEmptyField, READ_INDEX_STIX_DOMAIN_OBJECTS, READ_INDEX_STIX_META_OBJECTS } from '../database/utils';
+import { buildPagination, isEmptyField, READ_INDEX_STIX_DOMAIN_OBJECTS, READ_INDEX_STIX_META_OBJECTS } from '../database/utils';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION, ENTITY_TYPE_DATA_COMPONENT } from '../schema/stixDomainObject';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
 import { RELATION_DETECTS, RELATION_MITIGATES, RELATION_SUBTECHNIQUE_OF } from '../schema/stixCoreRelationship';
@@ -13,12 +13,13 @@ import {
   findEntitiesIdsWithRelations,
   fullEntitiesList,
   fullRelationsList,
+  internalFindByIdsMapped,
   pageEntitiesConnection,
   pageRegardingEntitiesConnection,
   storeLoadById,
 } from '../database/middleware-loader';
 import type { AuthContext, AuthUser } from '../types/user';
-import type { BasicStoreCommon, BasicStoreRelation } from '../types/store';
+import type { BasicStoreCommon, BasicStoreEntity, BasicStoreRelation } from '../types/store';
 import { type AttackPatternAddInput, FilterMode } from '../generated/graphql';
 
 export const findById = (context: AuthContext, user: AuthUser, attackPatternId: string) => {
@@ -59,8 +60,35 @@ export const batchIsSubAttackPattern = async (context: AuthContext, user: AuthUs
   });
 };
 
+const batchEntitiesFromRelations = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[], relationType: string, fromType: string) => {
+  const relations = await fullRelationsList<BasicStoreRelation>(context, user, relationType, { toId: attackPatternsIds, fromTypes: [fromType] });
+  const entitiesById = await internalFindByIdsMapped<BasicStoreEntity>(context, user, R.uniq(relations.map((relation) => relation.fromId)), { type: fromType });
+  const nodesByAttackPatternId = new Map<string, BasicStoreEntity[]>();
+  for (const relation of relations) {
+    const node = entitiesById[relation.fromId];
+    if (node) {
+      if (!nodesByAttackPatternId.has(relation.toId)) {
+        nodesByAttackPatternId.set(relation.toId, []);
+      }
+      nodesByAttackPatternId.get(relation.toId)!.push(node);
+    }
+  }
+  return attackPatternsIds.map((id) => {
+    const nodes = nodesByAttackPatternId.get(id) ?? [];
+    return buildPagination(0, null, nodes.map((node) => ({ node })), nodes.length);
+  });
+};
+
+export const batchSubAttackPatterns = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[]) => {
+  return batchEntitiesFromRelations(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN);
+};
+
 export const coursesOfActionPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
   return pageRegardingEntitiesConnection(context, user, attackPatternId, RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION, true, args);
+};
+
+export const batchCoursesOfAction = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[]) => {
+  return batchEntitiesFromRelations(context, user, attackPatternsIds, RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION);
 };
 
 export const dataComponentsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {

--- a/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
+++ b/opencti-platform/opencti-graphql/src/domain/attackPattern.ts
@@ -2,18 +2,18 @@ import * as R from 'ramda';
 import { createEntity } from '../database/middleware';
 import { BUS_TOPICS } from '../config/conf';
 import { notify } from '../database/redis';
-import { buildPagination, isEmptyField, READ_INDEX_STIX_DOMAIN_OBJECTS, READ_INDEX_STIX_META_OBJECTS } from '../database/utils';
+import { isEmptyField, READ_INDEX_STIX_DOMAIN_OBJECTS, READ_INDEX_STIX_META_OBJECTS } from '../database/utils';
 import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION, ENTITY_TYPE_DATA_COMPONENT } from '../schema/stixDomainObject';
 import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../schema/general';
 import { RELATION_DETECTS, RELATION_MITIGATES, RELATION_SUBTECHNIQUE_OF } from '../schema/stixCoreRelationship';
 import { ENTITY_TYPE_KILL_CHAIN_PHASE } from '../schema/stixMetaObject';
 import { RELATION_KILL_CHAIN_PHASE } from '../schema/stixRefRelationship';
 import {
+  batchEntitiesThroughRelations,
   type EntityOptions,
   findEntitiesIdsWithRelations,
   fullEntitiesList,
   fullRelationsList,
-  internalFindByIdsMapped,
   pageEntitiesConnection,
   pageRegardingEntitiesConnection,
   storeLoadById,
@@ -60,27 +60,8 @@ export const batchIsSubAttackPattern = async (context: AuthContext, user: AuthUs
   });
 };
 
-const batchEntitiesFromRelations = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[], relationType: string, fromType: string) => {
-  const relations = await fullRelationsList<BasicStoreRelation>(context, user, relationType, { toId: attackPatternsIds, fromTypes: [fromType] });
-  const entitiesById = await internalFindByIdsMapped<BasicStoreEntity>(context, user, R.uniq(relations.map((relation) => relation.fromId)), { type: fromType });
-  const nodesByAttackPatternId = new Map<string, BasicStoreEntity[]>();
-  for (const relation of relations) {
-    const node = entitiesById[relation.fromId];
-    if (node) {
-      if (!nodesByAttackPatternId.has(relation.toId)) {
-        nodesByAttackPatternId.set(relation.toId, []);
-      }
-      nodesByAttackPatternId.get(relation.toId)!.push(node);
-    }
-  }
-  return attackPatternsIds.map((id) => {
-    const nodes = nodesByAttackPatternId.get(id) ?? [];
-    return buildPagination(0, null, nodes.map((node) => ({ node })), nodes.length);
-  });
-};
-
 export const batchSubAttackPatterns = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[]) => {
-  return batchEntitiesFromRelations(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN);
+  return batchEntitiesThroughRelations<BasicStoreEntity>(context, user, attackPatternsIds, RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN);
 };
 
 export const coursesOfActionPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {
@@ -88,7 +69,7 @@ export const coursesOfActionPaginated = async (context: AuthContext, user: AuthU
 };
 
 export const batchCoursesOfAction = async (context: AuthContext, user: AuthUser, attackPatternsIds: string[]) => {
-  return batchEntitiesFromRelations(context, user, attackPatternsIds, RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION);
+  return batchEntitiesThroughRelations<BasicStoreEntity>(context, user, attackPatternsIds, RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION);
 };
 
 export const dataComponentsPaginated = async (context: AuthContext, user: AuthUser, attackPatternId: string, args: EntityOptions<BasicStoreCommon>) => {

--- a/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
+++ b/opencti-platform/opencti-graphql/src/http/httpAuthenticatedContext.js
@@ -10,7 +10,7 @@ import { batchStixDomainObjects } from '../domain/stixDomainObject';
 import { batchFileMarkingDefinitions, batchFileWorks } from '../domain/file';
 import { batchGlobalStatusesByType, batchRequestAccessStatusesByType } from '../domain/status';
 import { batchEntitySettingsByType } from '../modules/entitySetting/entitySetting-domain';
-import { batchIsSubAttackPattern } from '../domain/attackPattern';
+import { batchIsSubAttackPattern, batchCoursesOfAction, batchSubAttackPatterns } from '../domain/attackPattern';
 import { executionContext, isBypassUser, isUserInPlatformOrganization, SYSTEM_USER } from '../utils/access';
 import { getEnterpriseEditionInfo, IS_LTS_PLATFORM } from '../modules/settings/licensing';
 import { batchContextDataForLog } from '../database/data-changes';
@@ -36,6 +36,8 @@ export const computeLoaders = (executeContext, user) => {
     requestAccessStatusBatchLoader: batchLoader(batchRequestAccessStatusesByType, executeContext, user),
     entitySettingsBatchLoader: batchLoader(batchEntitySettingsByType, executeContext, user),
     isSubAttachPatternBatchLoader: batchLoader(batchIsSubAttackPattern, executeContext, user),
+    subAttackPatternsBatchLoader: batchLoader(batchSubAttackPatterns, executeContext, user),
+    coursesOfActionBatchLoader: batchLoader(batchCoursesOfAction, executeContext, user),
   };
 };
 

--- a/opencti-platform/opencti-graphql/src/resolvers/attackPattern.js
+++ b/opencti-platform/opencti-graphql/src/resolvers/attackPattern.js
@@ -20,6 +20,8 @@ import { ENTITY_TYPE_ATTACK_PATTERN } from '../schema/stixDomainObject';
 import { loadThroughDenormalized } from './stix';
 import { INPUT_KILLCHAIN } from '../schema/general';
 
+const hasArguments = (args) => Object.values(args ?? {}).some((value) => value !== undefined && value !== null);
+
 const attackPatternResolvers = {
   Query: {
     attackPattern: (_, { id }, context) => findById(context, context.user, id),
@@ -28,9 +30,15 @@ const attackPatternResolvers = {
   },
   AttackPattern: {
     killChainPhases: (attackPattern, _, context) => loadThroughDenormalized(context, context.user, attackPattern, INPUT_KILLCHAIN, { sortBy: 'phase_name' }),
-    coursesOfAction: (attackPattern, args, context) => coursesOfActionPaginated(context, context.user, attackPattern.id, args),
+    coursesOfAction: (attackPattern, args, context) => {
+      if (hasArguments(args)) return coursesOfActionPaginated(context, context.user, attackPattern.id, args);
+      return context.batch.coursesOfActionBatchLoader.load(attackPattern.id);
+    },
+    subAttackPatterns: (attackPattern, args, context) => {
+      if (hasArguments(args)) return childAttackPatternsPaginated(context, context.user, attackPattern.id, args);
+      return context.batch.subAttackPatternsBatchLoader.load(attackPattern.id);
+    },
     parentAttackPatterns: (attackPattern, args, context) => parentAttackPatternsPaginated(context, context.user, attackPattern.id, args),
-    subAttackPatterns: (attackPattern, args, context) => childAttackPatternsPaginated(context, context.user, attackPattern.id, args),
     dataComponents: (attackPattern, args, context) => dataComponentsPaginated(context, context.user, attackPattern.id, args),
     isSubAttackPattern: (attackPattern, _, context) => context.batch.isSubAttachPatternBatchLoader.load(attackPattern.id),
   },

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/attackPattern-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/attackPattern-test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as middlewareLoader from '../../../src/database/middleware-loader';
-import { getAttackPatternsMatrix } from '../../../src/domain/attackPattern';
-import { RELATION_SUBTECHNIQUE_OF } from '../../../src/schema/stixCoreRelationship';
+import { batchCoursesOfAction, batchSubAttackPatterns, childAttackPatternsPaginated, coursesOfActionPaginated, getAttackPatternsMatrix } from '../../../src/domain/attackPattern';
+import attackPatternResolvers from '../../../src/resolvers/attackPattern';
+import { RELATION_MITIGATES, RELATION_SUBTECHNIQUE_OF } from '../../../src/schema/stixCoreRelationship';
 import { RELATION_KILL_CHAIN_PHASE } from '../../../src/schema/stixRefRelationship';
+import { ENTITY_TYPE_ATTACK_PATTERN, ENTITY_TYPE_COURSE_OF_ACTION } from '../../../src/schema/stixDomainObject';
+import { emptyPaginationResult } from '../../../src/database/utils';
 import { ADMIN_USER, testContext } from '../../utils/testQuery';
 import type { BasicStoreEntity, BasicStoreRelation } from '../../../src/types/store';
 
@@ -271,5 +274,103 @@ describe('Function getAttackPatternsMatrix()', () => {
       expect(mitrePhasResult?.attackPatterns[0].attack_pattern_id).toBe('ap-mitre');
       expect(customPhaseResult?.attackPatterns[0].attack_pattern_id).toBe('ap-custom');
     });
+  });
+});
+
+describe('Attack pattern nested connections batching', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockRelations = (relations: Partial<BasicStoreRelation>[], entities: Partial<BasicStoreEntity>[]) => {
+    const relationsSpy = vi.spyOn(middlewareLoader, 'fullRelationsList').mockResolvedValue(relations as BasicStoreRelation[]);
+    vi.spyOn(middlewareLoader, 'internalFindByIdsMapped')
+      .mockResolvedValue(Object.fromEntries(entities.map((entity) => [entity.id, entity])) as any);
+    return relationsSpy;
+  };
+
+  it('should load, in a single query, the relations of the whole batch for the expected relation and target type', async () => {
+    const relationsSpy = mockRelations([], []);
+
+    await batchSubAttackPatterns(testContext, ADMIN_USER, ['ap-1', 'ap-2']);
+    await batchCoursesOfAction(testContext, ADMIN_USER, ['ap-1', 'ap-2']);
+
+    expect(relationsSpy).toHaveBeenCalledTimes(2);
+    expect(relationsSpy).toHaveBeenNthCalledWith(1, testContext, ADMIN_USER, RELATION_SUBTECHNIQUE_OF, { toId: ['ap-1', 'ap-2'], fromTypes: [ENTITY_TYPE_ATTACK_PATTERN] });
+    expect(relationsSpy).toHaveBeenNthCalledWith(2, testContext, ADMIN_USER, RELATION_MITIGATES, { toId: ['ap-1', 'ap-2'], fromTypes: [ENTITY_TYPE_COURSE_OF_ACTION] });
+  });
+
+  it('should return one connection per requested id, in order, skipping targets the user cannot read', async () => {
+    mockRelations(
+      [
+        { fromId: 'sub-a', toId: 'ap-1' },
+        { fromId: 'sub-restricted', toId: 'ap-1' },
+        { fromId: 'sub-c', toId: 'ap-3' },
+      ],
+      [{ id: 'sub-a', name: 'Sub A' }, { id: 'sub-c', name: 'Sub C' }],
+    );
+
+    const [ap1, ap2, ap3] = await batchSubAttackPatterns(testContext, ADMIN_USER, ['ap-1', 'ap-2', 'ap-3']);
+
+    expect(ap1.edges.map((edge: any) => edge.node.id)).toEqual(['sub-a']);
+    expect(ap1.pageInfo).toMatchObject({ globalCount: 1, hasNextPage: false });
+    expect(ap2.edges).toEqual([]);
+    expect(ap2.pageInfo.globalCount).toBe(0);
+    expect(ap3.edges.map((edge: any) => edge.node.id)).toEqual(['sub-c']);
+  });
+
+  it('should keep resolving per attack pattern when explicit connection arguments are given', async () => {
+    const connectionSpy = vi.spyOn(middlewareLoader, 'pageRegardingEntitiesConnection').mockResolvedValue(emptyPaginationResult());
+
+    await childAttackPatternsPaginated(testContext, ADMIN_USER, 'ap-1', { first: 5 });
+    await coursesOfActionPaginated(testContext, ADMIN_USER, 'ap-1', { first: 5 });
+
+    expect(connectionSpy).toHaveBeenNthCalledWith(1, testContext, ADMIN_USER, 'ap-1', RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, true, { first: 5 });
+    expect(connectionSpy).toHaveBeenNthCalledWith(2, testContext, ADMIN_USER, 'ap-1', RELATION_MITIGATES, ENTITY_TYPE_COURSE_OF_ACTION, true, { first: 5 });
+  });
+});
+
+describe('Attack pattern resolvers batching routing ', () => {
+  const { AttackPattern } = attackPatternResolvers as any;
+  const attackPattern = { id: 'ap-1' };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const buildContext = () => ({
+    user: ADMIN_USER,
+    batch: {
+      subAttackPatternsBatchLoader: { load: vi.fn().mockResolvedValue('BATCHED_SUB') },
+      coursesOfActionBatchLoader: { load: vi.fn().mockResolvedValue('BATCHED_COA') },
+    },
+  });
+
+  it.each([undefined, {}])('should use the batch loaders when no connection argument is given (%o)', async (args) => {
+    const connectionSpy = vi.spyOn(middlewareLoader, 'pageRegardingEntitiesConnection');
+    const context = buildContext();
+
+    expect(await AttackPattern.subAttackPatterns(attackPattern, args, context)).toBe('BATCHED_SUB');
+    expect(await AttackPattern.coursesOfAction(attackPattern, args, context)).toBe('BATCHED_COA');
+    expect(context.batch.subAttackPatternsBatchLoader.load).toHaveBeenCalledWith('ap-1');
+    expect(context.batch.coursesOfActionBatchLoader.load).toHaveBeenCalledWith('ap-1');
+    expect(connectionSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { first: 5 },
+    { after: 'cursor' },
+    { orderBy: 'name' },
+    { orderMode: 'asc' },
+    { filters: { mode: 'and', filters: [], filterGroups: [] } },
+    { search: 'foo' },
+  ])('should bypass the batch loaders as soon as a connection argument is given (%o)', async (args) => {
+    const connectionSpy = vi.spyOn(middlewareLoader, 'pageRegardingEntitiesConnection').mockResolvedValue(emptyPaginationResult());
+    const context = buildContext();
+
+    await AttackPattern.subAttackPatterns(attackPattern, args, context);
+
+    expect(context.batch.subAttackPatternsBatchLoader.load).not.toHaveBeenCalled();
+    expect(connectionSpy).toHaveBeenCalledWith(context, ADMIN_USER, 'ap-1', RELATION_SUBTECHNIQUE_OF, ENTITY_TYPE_ATTACK_PATTERN, true, args);
   });
 });

--- a/opencti-platform/opencti-graphql/tests/01-unit/domain/attackPattern-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/domain/attackPattern-test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as middlewareLoader from '../../../src/database/middleware-loader';
+import * as engine from '../../../src/database/engine';
 import { batchCoursesOfAction, batchSubAttackPatterns, childAttackPatternsPaginated, coursesOfActionPaginated, getAttackPatternsMatrix } from '../../../src/domain/attackPattern';
 import attackPatternResolvers from '../../../src/resolvers/attackPattern';
 import { RELATION_MITIGATES, RELATION_SUBTECHNIQUE_OF } from '../../../src/schema/stixCoreRelationship';
@@ -283,8 +284,13 @@ describe('Attack pattern nested connections batching', () => {
   });
 
   const mockRelations = (relations: Partial<BasicStoreRelation>[], entities: Partial<BasicStoreEntity>[]) => {
-    const relationsSpy = vi.spyOn(middlewareLoader, 'fullRelationsList').mockResolvedValue(relations as BasicStoreRelation[]);
-    vi.spyOn(middlewareLoader, 'internalFindByIdsMapped')
+    // fullRelationsList streams pages through the `callback` option (see batchEntitiesThroughRelations),
+    // so the mock must invoke it, like the real engine would for a single page.
+    const relationsSpy = vi.spyOn(engine, 'elList').mockImplementation(async (_context, _user, _indexName, opts: any) => {
+      await opts?.callback?.(relations);
+      return relations as BasicStoreRelation[];
+    });
+    vi.spyOn(engine, 'elFindByIds')
       .mockResolvedValue(Object.fromEntries(entities.map((entity) => [entity.id, entity])) as any);
     return relationsSpy;
   };
@@ -296,8 +302,20 @@ describe('Attack pattern nested connections batching', () => {
     await batchCoursesOfAction(testContext, ADMIN_USER, ['ap-1', 'ap-2']);
 
     expect(relationsSpy).toHaveBeenCalledTimes(2);
-    expect(relationsSpy).toHaveBeenNthCalledWith(1, testContext, ADMIN_USER, RELATION_SUBTECHNIQUE_OF, { toId: ['ap-1', 'ap-2'], fromTypes: [ENTITY_TYPE_ATTACK_PATTERN] });
-    expect(relationsSpy).toHaveBeenNthCalledWith(2, testContext, ADMIN_USER, RELATION_MITIGATES, { toId: ['ap-1', 'ap-2'], fromTypes: [ENTITY_TYPE_COURSE_OF_ACTION] });
+    expect(relationsSpy.mock.calls[0][3]).toMatchObject({
+      types: [RELATION_SUBTECHNIQUE_OF],
+      filters: { filters: expect.arrayContaining([
+        { key: ['toId'], values: ['ap-1', 'ap-2'] },
+        { key: ['fromTypes'], values: [ENTITY_TYPE_ATTACK_PATTERN] },
+      ]) },
+    });
+    expect(relationsSpy.mock.calls[1][3]).toMatchObject({
+      types: [RELATION_MITIGATES],
+      filters: { filters: expect.arrayContaining([
+        { key: ['toId'], values: ['ap-1', 'ap-2'] },
+        { key: ['fromTypes'], values: [ENTITY_TYPE_COURSE_OF_ACTION] },
+      ]) },
+    });
   });
 
   it('should return one connection per requested id, in order, skipping targets the user cannot read', async () => {


### PR DESCRIPTION
### Proposed changes
`subAttackPatterns` and `coursesOfAction` were resolved once per node, issuing ~2N concurrent engine queries per page. On entities with hundreds of attack patterns some of them failed and Relay rejected the whole response with "An unknown error occurred".

- Both fields now go through per-request data loaders: 2 engine calls whatever the page size
- Calls providing `first`/`after`/`orderBy`/`orderMode`/`filters`/`search` keep the previous per-node resolution untouched, since a data loader batches by id only.
- Removed `parentAttackPatterns` and `creators` from the kill chain fragment, neither was rendered.

### Related issues
<!-- Please attach your PR to related issues in the Development widget on the right or use closes keyword-->
* closes #17226 

### How to test this PR
1. Open an intrusion set with 500+ attack patterns → `Knowledge` > `Attack patterns`.
2. Toggle matrix ↔ list view a few times: both must load without error

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality
