### PR TITLE
feat(filters): add CURRENT ENTITY option in id filters of 'in regards of (dynamic)' (#16392)

### DIFF
--- a/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterChipPopover.tsx
@@ -250,13 +250,21 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     const getEntitiesOptions = getOptionsFromEntities(entities, searchScope, fKey);
     const optionsValues = subKey ? (filterValues.find((f) => f.key === subKey)?.values ?? []) : filterValues;
 
+    const isIdFilterDefinition = (
+      filterDefinition?: FilterDefinition,
+      subKey?: string,
+    ) => {
+      if (!filterDefinition) return false;
+      return filterDefinition.type === 'id'
+        || (filterDefinition.filterKey === 'regardingOf' && subKey === 'id');
+    };
+
     const completedTypesWithFintelTemplates = typesWithFintelTemplates.concat(['Container', 'Stix-Domain-Object', 'Stix-Core-Object']);
     const shouldAddSelfIdInFintelTemplates = host?.kind === 'fintelTemplate'
-      && (filterDefinition?.type === 'id' || (filterDefinition?.filterKey === 'regardingOf' && subKey === 'id'))
       && (filterDefinition?.elementsForFilterValuesSearch ?? []).every((type) => completedTypesWithFintelTemplates.includes(type));
-    const shouldAddSelfIdInCustomViews = host?.kind === 'custom-view'
-      && (filterDefinition?.type === 'id' || (filterDefinition?.filterKey === 'regardingOf' && subKey === 'id'));
-    const shouldAddSelfId = shouldAddSelfIdInFintelTemplates || shouldAddSelfIdInCustomViews;
+    const shouldAddSelfIdInCustomViews = host?.kind === 'custom-view';
+    const shouldAddSelfId = isIdFilterDefinition(filterDefinition, subKey)
+      && (shouldAddSelfIdInFintelTemplates || shouldAddSelfIdInCustomViews);
 
     const getOptions = shouldAddSelfId
       ? [
@@ -408,6 +416,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
       />
     );
   };
+
   const getSpecificFilter = (fDefinition?: FilterDefinition, subKey?: string, disabled = false): ReactNode => {
     const computedValues = filterValues.find((f) => f.key === fDefinition?.filterKey)?.values ?? filterValues;
     if (fDefinition?.type === 'date') {
@@ -435,6 +444,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
           filterValues={values}
           helpers={helpers}
           disabled={disabled}
+          host={host}
         />
       );
     }
@@ -470,7 +480,7 @@ export const FilterChipPopover: FunctionComponent<FilterChipMenuProps> = ({
     const finalFilterDefinition = useFilterDefinition(fKey, entityTypes, subKey);
     return (
       <>
-        { availableOperators.length > 0 && (
+        {availableOperators.length > 0 && (
           <Select
             labelId="change-operator-select-label"
             id="change-operator-select"

--- a/opencti-platform/opencti-front/src/components/filters/FilterFiltersInput.tsx
+++ b/opencti-platform/opencti-front/src/components/filters/FilterFiltersInput.tsx
@@ -4,9 +4,9 @@ import Box from '@mui/material/Box';
 import { Filter, FilterGroup, handleFilterHelpers } from '../../utils/filters/filtersHelpers-types';
 import { emptyFilterGroup, isFilterGroupNotEmpty, sanitizeFiltersStructure, useAvailableFilterKeysForEntityTypes } from '../../utils/filters/filtersUtils';
 import useFiltersState from '../../utils/filters/useFiltersState';
-
 import FilterIconButton from '../FilterIconButton';
 import { useTheme } from '@mui/material/styles';
+import { WidgetHost } from '../../utils/widget/widget';
 
 interface BasicFilterInputProps {
   filter?: Filter;
@@ -14,6 +14,7 @@ interface BasicFilterInputProps {
   childKey?: string;
   helpers?: handleFilterHelpers;
   filterValues: FilterGroup;
+  host?: WidgetHost;
   disabled?: boolean;
 }
 
@@ -22,6 +23,7 @@ const FilterFiltersInput: FunctionComponent<BasicFilterInputProps> = ({
   childKey,
   helpers,
   filterValues,
+  host,
   disabled = false,
 }) => {
   const theme = useTheme();
@@ -75,6 +77,7 @@ const FilterFiltersInput: FunctionComponent<BasicFilterInputProps> = ({
         helpers={filterHelpers}
         redirection
         searchContext={{ entityTypes: ['Stix-Core-Object'] }}
+        host={host}
       />
     </>
   );


### PR DESCRIPTION
### Proposed changes
In a fintel template widget, in the filters edition panel, in the 'in regards of (dynamic)' filter, if the sub selected filter is of type 'id' (for instance: the 'contains' filter), the 'CURRENT ENTITY' value should be proposed.
Same in custom views widgets.

<img width="1905" height="896" alt="image" src="https://github.com/user-attachments/assets/097b6f2a-fa63-4fd5-af39-6a97320ccbc4" />

### Example = Reproductible step

So we should be able to create this kind of filter in a fintel template widget : 
<img width="1907" height="902" alt="image" src="https://github.com/user-attachments/assets/a6368358-1cb4-416d-9061-4dc98a9670cb" />


### Related issues
closes #16392