### PR TITLE
fix(chatbot): keep the panel from crashing and unmask upstream error text (#17956, #17964)

### DIFF
--- a/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
+++ b/opencti-platform/opencti-front/src/private/components/chatbox/AskArianePanel.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useIntl } from 'react-intl';
 import { ChatPanel, ChatMode } from '@filigran/chatbot';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '@mui/styles';
@@ -35,6 +36,15 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
   const location = useLocation();
   const theme = useTheme<Theme>();
   const { t_i18n } = useFormatter();
+  const intl = useIntl();
+
+  // The widget's `t` is a lookup: it must return the sentence with its
+  // `{placeholder}` slots intact, because the panel splices the values in
+  // itself. `t_i18n` would ICU-format it and throw on an unfilled slot.
+  const tChatbot = useCallback((key: string) => {
+    const message = intl.messages[key];
+    return typeof message === 'string' ? message : key;
+  }, [intl]);
   const { me, bannerSettings: { bannerHeightNumber } } = useAuth();
   const settingsMessagesBannerHeight = useSettingsMessagesBannerHeight();
   const { height: topBannerHeight } = useTopBanner();
@@ -156,7 +166,7 @@ const AskArianePanel: React.FC<AskArianePanelProps> = ({
       }}
       user={{ firstName }}
       disableFileManagement={false}
-      t={t_i18n}
+      t={tChatbot}
       accentColor={accentColor}
       logoIcon={logoIcon}
       agentDashboardUrl={xtmOneUrl || undefined}

--- a/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
+++ b/opencti-platform/opencti-graphql/src/http/httpChatbotProxy.ts
@@ -52,6 +52,19 @@ const AI_AGENTS_REFRESH_TIMEOUT_SECONDS = Math.floor(AI_AGENTS_REFRESH_TIMEOUT_M
 // arbitrary strings out of the upstream URL path.
 const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
+// XTM One reports a refusal as `{detail: {code, message}}` as often as a bare
+// string, and an object interpolated into the SSE error line reaches the chat
+// bubble as "[object Object]".
+const detailToText = (detail: unknown, fallback: string): string => {
+  if (typeof detail === 'string' && detail.trim()) return detail.trim();
+  if (detail && typeof detail === 'object') {
+    const { message, detail: nested } = detail as { message?: unknown; detail?: unknown };
+    if (typeof message === 'string' && message.trim()) return message.trim();
+    if (typeof nested === 'string' && nested.trim()) return nested.trim();
+  }
+  return fallback;
+};
+
 // ── HTTP client (proxy-aware) ────────────────────────────────────────────
 const getXtmClient = (responseType: 'json' | 'stream', headers?: Record<string, string>) => {
   return getHttpClient({
@@ -500,9 +513,10 @@ export const postChatbotMessage = async (req: Express.Request, res: Express.Resp
       res.setHeader('Connection', 'keep-alive');
       res.status(200);
 
+      const detailText = detailToText(detail, message);
       const errorContent = code === 429
-        ? `⚠️ **Quota exceeded** — ${detail}`
-        : `⚠️ **Error** — ${detail}`;
+        ? `⚠️ **Quota exceeded** — ${detailText}`
+        : `⚠️ **Error** — ${detailText}`;
 
       res.write(`data: ${JSON.stringify({ type: 'error', content: errorContent, code })}\n\n`);
       res.end();
@@ -1041,7 +1055,7 @@ export const postAgentMessageStream = async (req: Express.Request, res: Express.
       res.setHeader('Content-Type', 'text/event-stream');
       res.setHeader('Cache-Control', 'no-cache, no-transform');
       res.status(200);
-      res.write(`data: ${JSON.stringify({ type: 'error', content: `⚠️ **Error** — ${detail}` })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'error', content: `⚠️ **Error** — ${detailToText(detail, message)}` })}\n\n`);
       res.end();
     } else {
       const userMessage = 'XTM One is unreachable';

--- a/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
+++ b/opencti-platform/opencti-graphql/tests/01-unit/http/httpChatbotProxy-test.ts
@@ -331,6 +331,26 @@ describe('httpChatbotProxy: postAgentMessageStream', () => {
     expect(res.end).toHaveBeenCalled();
   });
 
+  it('should extract the message when the upstream detail is an object', async () => {
+    // XTM One refuses with `{detail: {code, message}}`; interpolating that
+    // object reached the chat bubble as "[object Object]".
+    const httpError = new Error('Request failed with status code 403') as any;
+    httpError.response = { status: 403, data: { detail: { code: 'ai_disabled', message: 'AI is disabled on this deployment.' } } };
+    mockPost.mockRejectedValue(httpError);
+
+    const req = buildReq({ agent_slug: 'test-agent', content: 'hello' });
+
+    await postAgentMessageStream(req, res);
+
+    expect(res.write).toHaveBeenCalledWith(
+      expect.stringContaining('AI is disabled on this deployment.'),
+    );
+    expect(res.write).not.toHaveBeenCalledWith(
+      expect.stringContaining('[object Object]'),
+    );
+    expect(res.end).toHaveBeenCalled();
+  });
+
   it('should fall back to error message when HTTP response has no detail', async () => {
     const httpError = new Error('Server error') as any;
     httpError.response = { status: 500, data: {} };


### PR DESCRIPTION
### Proposed changes

* `AskArianePanel` hands `<ChatPanel>` a raw-lookup `t` (`intl.messages[key]`, key as fallback) instead of `t_i18n`, so `{placeholder}` slots reach the widget, which splices the values in itself. `t_i18n` ICU-formats and throws on an unfilled slot, taking the dashboard into the auth error boundary.
* `httpChatbotProxy` pulls the text out of the upstream `detail` before writing the SSE error line. XTM One refuses with `{code, message}`, which the template stringified to `[object Object]`, losing the reason.

Both date from #15109 and are independent of each other.

### Related issues

* closes #17956
* closes #17964

### How to test this PR

1. EE with XTM One configured and the chatbot enabled.
2. Click *Ask Ariane*: the panel opens and the greeting reads *"How can {agent} help you, {name}?"* with both names spliced in, in the UI language. On master the dashboard is replaced by *"An unknown error occurred"*.
3. Point at an XTM One running `PLATFORM_MODE=ai_disabled` and send a message: the bubble reads *"⚠️ Error — AI is disabled on this deployment."* On master it reads *"⚠️ Error — [object Object]"*.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant use cases (coverage and e2e)
- [ ] I added/updated the relevant documentation (either on GitHub or on Notion)
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

`httpChatbotProxy-test.ts` gains a case asserting the object detail is unwrapped; it fails on the old code with the `[object Object]` line. The front adapter has no unit test — it is three lines inside the component and asserting it means rendering `ChatPanel` against a real locale table — so it was verified in the browser instead (greeting in `fr-fr`, zero react-intl errors), on both 3.9.1 and a local 3.9.2 build.

Vibe coded.
