### PR TITLE
feat(filters): Add 'revoked' filter for technical views (#10171)

### DIFF
--- a/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
+++ b/opencti-platform/opencti-graphql/src/modules/attributes/stixDomainObject-registrationAttributes.ts
@@ -133,6 +133,7 @@ const stixDomainObjectsAttributes: { [k: string]: Array<AttributeDefinition<any>
     { name: 'x_mitre_permissions_required', label: 'Permissions required', type: 'string', format: 'vocabulary', vocabularyCategory: 'permissions_ov', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
     { name: 'x_mitre_detection', label: 'Detection', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_mitre_id', label: 'External ID', type: 'string', format: 'short', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: false },
+    { ...revoked, isFilterable: true },
   ],
   [ENTITY_TYPE_CAMPAIGN]: [
     aliases,
@@ -185,6 +186,7 @@ const stixDomainObjectsAttributes: { [k: string]: Array<AttributeDefinition<any>
     { name: 'x_mitre_id', label: 'External ID', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_threat_hunting', label: 'Threat hunting', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_opencti_log_sources', label: 'Log sources', type: 'string', format: 'short', mandatoryType: 'no', editDefault: false, multiple: true, upsert: true, isFilterable: true },
+    { ...revoked, isFilterable: true },
   ],
   [ENTITY_TYPE_IDENTITY_INDIVIDUAL]: [
     xOpenctiAliases,

--- a/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataComponent/dataComponent.ts
@@ -9,6 +9,7 @@ import { ABSTRACT_STIX_DOMAIN_OBJECT } from '../../schema/general';
 import type { ModuleDefinition } from '../../schema/module';
 import { registerDefinition } from '../../schema/module';
 import { objectOrganization } from '../../schema/stixRefRelationship';
+import { revoked } from '../../schema/attribute-definition';
 
 const DATA_COMPONENT_DEFINITION: ModuleDefinition<StoreEntityDataComponent, StixDataComponent, Stix2DataComponent> = {
   type: {
@@ -39,6 +40,7 @@ const DATA_COMPONENT_DEFINITION: ModuleDefinition<StoreEntityDataComponent, Stix
   attributes: [
     { name: 'name', label: 'Name', type: 'string', format: 'short', mandatoryType: 'external', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
+    { ...revoked, isFilterable: true },
   ],
   relations: [
     {

--- a/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.ts
+++ b/opencti-platform/opencti-graphql/src/modules/dataSource/dataSource.ts
@@ -8,6 +8,7 @@ import { objectOrganization } from '../../schema/stixRefRelationship';
 import { RELATION_DERIVED_FROM } from '../../schema/stixCoreRelationship';
 import { REL_BUILT_IN } from '../../database/stix';
 import { ENTITY_TYPE_DATA_SOURCE } from '../../schema/stixDomainObject';
+import { revoked } from '../../schema/attribute-definition';
 
 const DATA_SOURCE_DEFINITION: ModuleDefinition<StoreEntityDataSource, StixDataSource, Stix2DataSource> = {
   type: {
@@ -40,6 +41,7 @@ const DATA_SOURCE_DEFINITION: ModuleDefinition<StoreEntityDataSource, StixDataSo
     { name: 'description', label: 'Description', type: 'string', format: 'text', mandatoryType: 'customizable', editDefault: true, multiple: false, upsert: true, isFilterable: true },
     { name: 'x_mitre_platforms', label: 'Platforms', type: 'string', format: 'vocabulary', vocabularyCategory: 'platforms_ov', mandatoryType: 'customizable', editDefault: true, multiple: true, upsert: true, isFilterable: true },
     { name: 'collection_layers', label: 'Layers', type: 'string', format: 'vocabulary', vocabularyCategory: 'collection_layers_ov', mandatoryType: 'customizable', editDefault: true, multiple: true, upsert: true, isFilterable: true },
+    { ...revoked, isFilterable: true },
   ],
   relations: [
     {


### PR DESCRIPTION
### Proposed changes
Add the 'Revoked' filter in the following technical views:
- Attack patterns list
- Courses of action list
- Data components list
- Data sources list

<img width="1839" height="728" alt="image" src="https://github.com/user-attachments/assets/fba85c71-8632-4777-9f86-e2383484f1fa" />


### Related issues
fixes #10171