### PR TITLE
feat(filters): Enable dynamic regarding of nested filter update in widgets (#17709)

### DIFF
--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.test.tsx
@@ -1445,6 +1445,48 @@ describe('Function normalizeFilterGroupForFrontend', () => {
     expect(result.filters[0].mode).toEqual('and');
     expect(result.filters[0].values).toEqual(['val1', 'val2']);
   });
+
+  it('should normalize nested filter groups inside dynamicRegardingOf dynamic values', () => {
+    const input = {
+      mode: 'and',
+      filters: [
+        {
+          key: ['dynamicRegardingOf'],
+          operator: 'eq',
+          mode: 'or',
+          values: [
+            { key: 'relationship_type', values: ['targets'] },
+            {
+              key: 'dynamic',
+              values: [
+                {
+                  mode: 'and',
+                  filters: [
+                    { key: ['entity_type'], values: ['Malware'], operator: 'eq', mode: 'or' },
+                  ],
+                  filterGroups: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      filterGroups: [],
+    } as unknown as GqlFilterGroup;
+    const result = normalizeFilterGroupForFrontend(input);
+    expect(result.filters[0].key).toEqual('dynamicRegardingOf');
+    expect(result.filters[0].id).toBeDefined();
+    const values = result.filters[0].values as unknown as Array<{ key: string; values: unknown[] }>;
+    // non-dynamic sub-value is preserved untouched
+    expect(values[0]).toEqual({ key: 'relationship_type', values: ['targets'] });
+    // dynamic sub-value has its nested filter groups normalized (array key -> string key + id added)
+    const dynamicValue = values[1];
+    expect(dynamicValue.key).toEqual('dynamic');
+    const nestedFilterGroup = dynamicValue.values[0] as FilterGroup;
+    expect(nestedFilterGroup.filters[0].key).toEqual('entity_type');
+    expect(nestedFilterGroup.filters[0].id).toBeDefined();
+    expect(typeof nestedFilterGroup.filters[0].id).toBe('string');
+  });
 });
 
 describe('isDraftWorkspaceFilterGroup', () => {

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -583,12 +583,32 @@ export const normalizeFilterGroupForFrontend = (
 ): FilterGroup => {
   return {
     ...filterGroup,
-    filters: filterGroup?.filters?.map((f) => ({
-      ...f,
-      id: uuid(),
-      key: Array.isArray(f.key) ? f.key[0] : f.key,
-      values: f.values.map((v) => v || 'todo: delete this'),
-    })),
+    filters: filterGroup?.filters?.map((f) => {
+      const key = Array.isArray(f.key) ? f.key[0] : f.key;
+      // build values
+      let values: FilterValue[];
+      if (key === 'dynamicRegardingOf') { // add id in dynamic regarding of subfilter for React rendering purposes
+        values = f.values.map((dynamicRegardingOfValue) => {
+          if (dynamicRegardingOfValue.key === 'dynamic') { // values with 'dynamic' key contains filters
+            return {
+              ...dynamicRegardingOfValue,
+              values: dynamicRegardingOfValue.values.map((filterValue) => normalizeFilterGroupForFrontend(filterValue)),
+            };
+          } else {
+            return dynamicRegardingOfValue;
+          }
+        });
+      } else {
+        values = f.values.map((v) => v || 'todo: delete this');
+      }
+      // return the filter with normalized key and values, and add an id
+      return {
+        ...f,
+        id: uuid(),
+        key,
+        values,
+      };
+    }),
     filterGroups: filterGroup?.filterGroups?.map((fg) => normalizeFilterGroupForFrontend(fg)),
   } as FilterGroup;
 };
@@ -609,7 +629,7 @@ export const serializeFilterGroupForBackend = (
 
 /**
  * Parse a filterGroup as given by the backend (backend format, i.e. with array keys),
- * And turns it into the frontend format (single key).²
+ * And turns it into the frontend format (single key).
  * @param filterGroup
  */
 export const deserializeFilterGroupForFrontend = (

--- a/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
+++ b/opencti-platform/opencti-front/src/utils/filters/filtersUtils.tsx
@@ -592,7 +592,7 @@ export const normalizeFilterGroupForFrontend = (
           if (dynamicRegardingOfValue.key === 'dynamic') { // values with 'dynamic' key contains filters
             return {
               ...dynamicRegardingOfValue,
-              values: dynamicRegardingOfValue.values.map((filterValue) => normalizeFilterGroupForFrontend(filterValue)),
+              values: dynamicRegardingOfValue.values.map((filterValue: GqlFilterGroup) => normalizeFilterGroupForFrontend(filterValue)),
             };
           } else {
             return dynamicRegardingOfValue;


### PR DESCRIPTION
### Proposed changes
We should be able to update the nested filter of a 'in regards of (dynamic)' filter inside a widget.

### How to test
- Create a widget with a 'in regards of (dynamic)' filter.
- Update the widget
- Try to update the subfilter of the 'in regards of (dynamic)' filter. The update should be possible.
<img width="1913" height="897" alt="image" src="https://github.com/user-attachments/assets/fd235f61-6380-4f9b-8c1f-f5a8607a87f4" />


### What was the issue
The issue was that, in a widget with a 'in regards of (dynamic)' filter, the subfilter was not updatable. Example: when you clicked on the 'entity type' key of the subfilter in the screenshot below, nothing opens. Now a pop-up opens.
<img width="953" height="442" alt="image" src="https://github.com/user-attachments/assets/18e26148-006d-44d0-82d3-b66453ed608e" />


### Related issues
fixes #17709